### PR TITLE
Reduced to one icon size for workflow icons

### DIFF
--- a/packages/@react-spectrum/icon/src/Icon.tsx
+++ b/packages/@react-spectrum/icon/src/Icon.tsx
@@ -30,14 +30,14 @@ export function Icon({
   }
   if (color === undefined) {
     color = pcolor;
-  } 
-  
+  }
+
   // Use user specified size, falling back to provider scale if size is undef
   let iconSize = size ? size : scale;
 
   return React.cloneElement(children, {
     ...props,
-    scale,
+    scale: 'M',
     color,
     focusable: 'false',
     'aria-label': props['aria-label'] || alt,


### PR DESCRIPTION
We only have one scale of icons now, set it to 'M' so we use the correct viewbox

All workflow icons will now be the 18px size. They still obey tshirt sizes and the css dictated scaling factor to large. They no longer need to swap paths though, so we are setting the scale to 'M' for what's been distributed to us.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product is this pull request for? (i.e. Photoshop) -->
