### PR TITLE
(RSP-1380) Fixing DialogTrigger tray in RTL locales

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -8,6 +8,7 @@
 }
 
 .spectrum-Tray-wrapper {
+  inset-inline-start: 0;
   /* Positioned at the bottom of the window */
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1380

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

1. Using any of the DialogTrigger type: tray stories, trigger the tray to appear and switch to a RTL locale. Note that the tray doesn't disappear