### PR TITLE
RSP-1382: ProgressBar valueLabel story

### DIFF
--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -53,8 +53,8 @@ storiesOf('Progress/ProgressBar', module)
     }
   )
   .add(
-    'valueLabel: 1 of 4',
-    () => render({value: 25, valueLabel: '1 of 4'})
+    'valueLabel: Loading 1 of 4',
+    () => render({value: 25, valueLabel: 'Loading 1 of 4'})
   )
   .add(
     'Using number formatOptions with currency style',


### PR DESCRIPTION
labels that start with number and are not localized will reorder incorrectly

example of localized label:

![localized](https://user-images.githubusercontent.com/28627218/70546936-60a5ff00-1b70-11ea-8df9-d965b5365c55.PNG)

![notlocalized](https://user-images.githubusercontent.com/28627218/70546951-64398600-1b70-11ea-8c6a-33e2942eca85.PNG)


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product is this pull request for? (i.e. Photoshop) -->
