### PR TITLE
Cleanup from typography&types

### DIFF
--- a/packages/@react-spectrum/alert/stories/Alert.stories.js
+++ b/packages/@react-spectrum/alert/stories/Alert.stories.js
@@ -7,35 +7,35 @@ import {storiesOf} from '@storybook/react';
 storiesOf('Alert', module)
   .add(
     'header',
-    () => render({header: 'info', variant: 'info'})
+    () => render({title: 'info', variant: 'info'})
   )
   .add(
     'variant: info',
-    () => render({header: 'info', variant: 'info'})
+    () => render({title: 'info', variant: 'info'})
   )
   .add(
     'variant: help',
-    () => render({header: 'help', variant: 'help'})
+    () => render({title: 'help', variant: 'help'})
   )
   .add(
     'variant: success',
-    () => render({header: 'success', variant: 'success'})
+    () => render({title: 'success', variant: 'success'})
   )
   .add(
     'variant: error',
-    () => render({header: 'error', variant: 'error'})
+    () => render({title: 'error', variant: 'error'})
   )
   .add(
     'variant: warning',
-    () => render({header: 'warning', variant: 'warning'})
+    () => render({title: 'warning', variant: 'warning'})
   )
   .add(
     'aria-live: polite',
-    () => render({header: 'error', variant: 'error', 'aria-live': 'polite'})
+    () => render({title: 'error', variant: 'error', 'aria-live': 'polite'})
   )
   .add(
     'aria-live: off',
-    () => render({header: 'error', variant: 'error', 'aria-live': 'off'})
+    () => render({title: 'error', variant: 'error', 'aria-live': 'off'})
   );
 
 function render(props = {}, children = 'This is a React Spectrum alert') {

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -7,7 +7,7 @@ import {ModalProvider, useModalProvider} from '@react-aria/dialog';
 import {ProviderContext, ProviderProps} from '@react-types/provider';
 import React, {useContext, useEffect} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/page/vars.css';
-import typographyStyles from '@adobe/spectrum-css-temp/components/typography/font.css';
+import typographyStyles from '@adobe/spectrum-css-temp/components/typography/index.css';
 import {useColorScheme, useScale} from './mediaQueries';
 // @ts-ignore
 import {version} from '../package.json';
@@ -110,7 +110,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper({children, ...
   );
 
   return (
-    <div 
+    <div
       {...filterDOMProps(otherProps)}
       {...styleProps}
       {...modalProviderProps}


### PR DESCRIPTION
Alert was changed to use title instead of header
We were missing some global styles


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product is this pull request for? (i.e. Photoshop) -->
