### PR TITLE
Cleanup for Menu Trigger split button and Illustrated Message

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/illustratedmessage/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/illustratedmessage/index.css
@@ -27,22 +27,22 @@ governing permissions and limitations under the License.
   justify-content: center;
 
   text-align: center;
-}
 
-.spectrum-IllustratedMessage-illustration {
-  margin-bottom: var(--spectrum-illustrated-message-illustration-margin-bottom);
-}
+  .spectrum-IllustratedMessage-illustration {
+    margin-bottom: var(--spectrum-illustrated-message-illustration-margin-bottom);
+  }
 
-.spectrum-IllustratedMessage-heading {
-  max-width: var(--spectrum-illustrated-message-heading-max-width);
-  margin: var(--spectrum-illustrated-message-heading-margin);
-}
+  .spectrum-IllustratedMessage-heading {
+    max-width: var(--spectrum-illustrated-message-heading-max-width);
+    margin: var(--spectrum-illustrated-message-heading-margin);
+  }
 
-.spectrum-IllustratedMessage-description {
-  max-width: var(--spectrum-illustrated-message-description-max-width);
-  margin: var(--spectrum-illustrated-message-description-margin);
+  .spectrum-IllustratedMessage-description {
+    max-width: var(--spectrum-illustrated-message-description-max-width);
+    margin: var(--spectrum-illustrated-message-description-margin);
 
-  font-style: italic;
+    font-style: italic;
+  }
 }
 
 .spectrum-IllustratedMessage--cta {

--- a/packages/@react-spectrum/menu-trigger/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu-trigger/stories/MenuTrigger.stories.tsx
@@ -1,5 +1,5 @@
 import {action} from '@storybook/addon-actions';
-import {ActionButton} from '@react-spectrum/button';
+import {ActionButton, Button} from '@react-spectrum/button';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
 import {classNames} from '@react-spectrum/utils';
 import {Menu} from '../';
@@ -79,7 +79,8 @@ storiesOf('MenuTrigger', module)
     'more than 2 children (split button)',
     () => (
       <div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>
-        <ActionButton
+        <Button
+          variant="primary"
           onPress={action('press 1')}
           onPressStart={action('pressstart 1')}
           onPressEnd={action('pressend 1')}
@@ -88,9 +89,10 @@ storiesOf('MenuTrigger', module)
             'spectrum-SplitButton-action'
           )}>
           Hi
-        </ActionButton>
+        </Button>
         <MenuTrigger onOpenChange={action('onOpenChange')}>
-          <ActionButton
+          <Button
+            variant="primary"
             onPress={action('press 2')}
             onPressStart={action('pressstart 2')}
             onPressEnd={action('pressend 2')}
@@ -99,7 +101,7 @@ storiesOf('MenuTrigger', module)
               'spectrum-SplitButton-trigger'
             )}>
             <ChevronDownMedium />
-          </ActionButton>
+          </Button>
           <Menu>
             <li>MenuItem1111111111111111</li>
             <li>MenuItem22222222222222222</li>
@@ -109,7 +111,7 @@ storiesOf('MenuTrigger', module)
       </div>
     )
   );
-  
+
 function render(props = {}, menuProps = {}) {
   return (
     <div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>


### PR DESCRIPTION
MenuTrigger SplitButton should look marginally like it'll end up looking, so it's now a Button variant primary.
IllustratedMessage description had a CSS specificity issue where font-style was fighting with spectrum-Body-secondary and was losing. By giving it a higher specificity, we can ensure it'll be correct.

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product is this pull request for? (i.e. Photoshop) -->
