### PR TITLE
(RSP-1443 followup) Adding long label examples to Switch and Checkbox stories

### DIFF
--- a/packages/@react-spectrum/checkbox/stories/Checkbox.stories.tsx
+++ b/packages/@react-spectrum/checkbox/stories/Checkbox.stories.tsx
@@ -65,6 +65,15 @@ storiesOf('Checkbox', module)
     () => renderCustomLabel()
   )
   .add(
+    'long label',
+    () => (
+      <Checkbox
+        onChange={action('change')}>
+        Super long checkbox label. Sample text. Arma virumque cano, Troiae qui primus ab oris. Italiam, fato profugus, Laviniaque venit.
+      </Checkbox>
+    )
+  )
+  .add(
     'no label',
     () => renderNoLabel({'aria-label': 'This checkbox has no visible label'})
   );

--- a/packages/@react-spectrum/switch/stories/Switch.stories.tsx
+++ b/packages/@react-spectrum/switch/stories/Switch.stories.tsx
@@ -45,6 +45,15 @@ storiesOf('Switch', module)
     () => renderCustomLabel()
   )
   .add(
+    'long label',
+    () => (
+      <Switch
+        onChange={action('change')}>
+        Super long checkbox label. Sample text. Arma virumque cano, Troiae qui primus ab oris. Italiam, fato profugus, Laviniaque venit.
+      </Switch>
+    )
+  )
+  .add(
     'no label',
     () => renderNoLabel({'aria-label': 'This switch has no visible label'})
   );


### PR DESCRIPTION
As per a request from Kyle in https://github.com/adobe/react-spectrum-v3/pull/125, adding long label stories to Switch and Checkbox