### PR TITLE
Fix Search Icon during hover

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/search/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/search/skin.css
@@ -15,12 +15,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Search-input {
-  &:disabled {
-    & ~ .spectrum-Search-icon {
-      color: var(--spectrum-textfield-text-color-disabled);
-    }
-  }
-
   /* The value of color is identical for hover/active/focus-ring, but we repeat it here in case one is changed in the future */
   &:hover {
     & ~ .spectrum-Search-icon {
@@ -37,6 +31,12 @@ governing permissions and limitations under the License.
   &:focus-ring {
     & ~ .spectrum-Search-icon {
       color: var(--spectrum-search-icon-color-key-focus);
+    }
+  }
+
+  &:disabled {
+    & ~ .spectrum-Search-icon {
+      color: var(--spectrum-textfield-text-color-disabled);
     }
   }
 }


### PR DESCRIPTION
This fixes the issue where a disabled textfield still get a hover color for the magnifier because order matters when specificity collides


Closes https://jira.corp.adobe.com/browse/RSP-1461

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product is this pull request for? (i.e. Photoshop) -->
