### PR TITLE
Adjust search padding for large scale

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/search/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/search/index.css
@@ -12,6 +12,14 @@ governing permissions and limitations under the License.
 
 @import '../commons/index.css';
 
+/* override DNA variables to use ones that change in large scale instead of staying static */
+:root {
+  --spectrum-search-padding-left: var(--spectrum-global-dimension-size-450);
+  --spectrum-search-padding-right: var(--spectrum-global-dimension-size-350);
+  --spectrum-search-quiet-padding-left: var(--spectrum-global-dimension-size-300);
+  --spectrum-search-quiet-padding-right: var(--spectrum-global-dimension-size-350);
+}
+
 .spectrum-Search {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
Reverts #135 which changed the positioning of the search icon and text more drastically. This only adjusts the padding on large scale to how medium scale works. It uses the global vars with the same values in medium scale as before, but which scale up on large scale.