### PR TITLE
[RSP-1459] Don't use <label> element for progressbar/meter/radiogroup labels

### DIFF
--- a/packages/@react-aria/label/src/useLabel.ts
+++ b/packages/@react-aria/label/src/useLabel.ts
@@ -1,18 +1,23 @@
 import {DOMProps, LabelableProps} from '@react-types/shared';
-import {HTMLAttributes, LabelHTMLAttributes} from 'react';
+import {ElementType, HTMLAttributes, LabelHTMLAttributes} from 'react';
 import {useId, useLabels} from '@react-aria/utils';
+
+interface LabelAriaProps extends LabelableProps, DOMProps {
+  labelElementType?: ElementType
+}
 
 interface LabelAria {
   labelProps: LabelHTMLAttributes<HTMLLabelElement>,
   fieldProps: HTMLAttributes<HTMLElement>
 }
 
-export function useLabel(props: LabelableProps & DOMProps): LabelAria {
+export function useLabel(props: LabelAriaProps): LabelAria {
   let {
     id,
     label,
     'aria-labelledby': ariaLabelledby,
-    'aria-label': ariaLabel
+    'aria-label': ariaLabel,
+    labelElementType = 'label'
   } = props;
 
   id = useId(id);
@@ -22,7 +27,7 @@ export function useLabel(props: LabelableProps & DOMProps): LabelAria {
     ariaLabelledby = ariaLabelledby ? `${ariaLabelledby} ${labelId}` : labelId;
     labelProps = {
       id: labelId,
-      htmlFor: id
+      htmlFor: labelElementType === 'label' ? id : undefined
     };
   } else if (!ariaLabelledby && !ariaLabel) {
     console.warn('If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility');

--- a/packages/@react-aria/label/test/useLabel.test.js
+++ b/packages/@react-aria/label/test/useLabel.test.js
@@ -60,4 +60,12 @@ describe('useLabel hook', () => {
     renderLabelHook({});
     expect(spyWarn).toHaveBeenCalledWith('If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility');
   });
+
+  it('should not return a `for` attribute when the label element type is not <label>', () => {
+    let {labelProps, fieldProps} = renderLabelHook({label: 'Test', labelElementType: 'span'});
+    expect(labelProps.id).toBeDefined();
+    expect(fieldProps.id).toBeDefined();
+    expect(labelProps.id).toBe(fieldProps['aria-labelledby']);
+    expect(labelProps.htmlFor).toBeUndefined();
+  });
 });

--- a/packages/@react-aria/progress/src/useProgressBar.ts
+++ b/packages/@react-aria/progress/src/useProgressBar.ts
@@ -26,7 +26,12 @@ export function useProgressBar(props: ProgressBarAriaProps): ProgressBarAria {
     }
   } = props;
 
-  let {labelProps, fieldProps} = useLabel(props);
+  let {labelProps, fieldProps} = useLabel({
+    ...props,
+    // Progress bar is not an HTML input element so it 
+    // shouldn't be labeled by a <label> element.
+    labelElementType: 'span'
+  });
 
   value = clamp(value, minValue, maxValue);
   let percentage = (value - minValue) / (maxValue - minValue);

--- a/packages/@react-aria/progress/test/useProgressBar.test.js
+++ b/packages/@react-aria/progress/test/useProgressBar.test.js
@@ -24,8 +24,8 @@ describe('useProgressBar', function () {
 
   it('supports labeling', () => {
     let {progressBarProps, labelProps} = renderProgressBarHook({label: 'Test'});
-    expect(progressBarProps.id).toBeDefined();
-    expect(labelProps.htmlFor).toBe(progressBarProps.id);
+    expect(labelProps.id).toBeDefined();
+    expect(progressBarProps['aria-labelledby']).toBe(labelProps.id);
   });
 
   it('with value of 25%', () => {

--- a/packages/@react-spectrum/label/src/Label.tsx
+++ b/packages/@react-spectrum/label/src/Label.tsx
@@ -18,6 +18,7 @@ function Label(props: SpectrumLabelProps, ref: DOMRef<HTMLLabelElement>) {
     necessityIndicator = isRequired != null ? 'icon' : null,
     htmlFor,
     for: labelFor,
+    elementType: ElementType = 'label',
     ...otherProps
   } = props;
 
@@ -43,12 +44,12 @@ function Label(props: SpectrumLabelProps, ref: DOMRef<HTMLLabelElement>) {
   );
 
   return (
-    <label
+    <ElementType
       {...filterDOMProps(otherProps)}
       {...styleProps}
       ref={domRef}
       className={labelClassNames}
-      htmlFor={labelFor || htmlFor}>
+      htmlFor={ElementType === 'label' ? labelFor || htmlFor : undefined}>
       {children}
       {necessityIndicator && ' \u200b'}
       {/* necessityLabel is hidden to screen readers if the field is required because 
@@ -56,7 +57,7 @@ function Label(props: SpectrumLabelProps, ref: DOMRef<HTMLLabelElement>) {
         * so no need to duplicate it here. If optional, we do want it to be announced here. */}
       {necessityIndicator === 'label' && <span aria-hidden={isRequired}>{necessityLabel}</span>}
       {necessityIndicator === 'icon' && isRequired && icon}
-    </label>
+    </ElementType>
   );
 }
 

--- a/packages/@react-spectrum/progress/src/ProgressBarBase.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressBarBase.tsx
@@ -68,11 +68,11 @@ function ProgressBarBase(props: ProgressBarBaseProps, ref: DOMRef<HTMLDivElement
         )
       }>
       {label &&
-        <label
+        <span
           {...labelProps}
           className={classNames(styles, 'spectrum-BarLoader-label')}>
             {label}
-        </label>
+        </span>
       }
       {showValueLabel &&
         <div className={classNames(styles, 'spectrum-BarLoader-percentage')}>

--- a/packages/@react-spectrum/radio/src/RadioGroup.tsx
+++ b/packages/@react-spectrum/radio/src/RadioGroup.tsx
@@ -74,6 +74,7 @@ export const RadioGroup = forwardRef((props: SpectrumRadioGroupProps, ref: DOMRe
       {label && 
         <Label
           {...labelProps}
+          elementType="span"
           labelPosition={labelPosition}
           labelAlign={labelAlign}
           isRequired={isRequired}

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -264,6 +264,5 @@ describe('Radios', function () {
     expect(labelId).toBeDefined();
     let label = document.getElementById(labelId);
     expect(label).toHaveTextContent('Favorite Pet');
-    expect(label).toHaveAttribute('for', radioGroup.id);
   });
 });

--- a/packages/@react-types/label/src/index.d.ts
+++ b/packages/@react-types/label/src/index.d.ts
@@ -1,10 +1,11 @@
 import {Alignment, DOMProps, LabelPosition, NecessityIndicator, StyleProps} from '@react-types/shared';
-import {ReactNode} from 'react';
+import {ElementType, ReactNode} from 'react';
 
 export interface LabelProps {
   children?: ReactNode,
   htmlFor?: string, // for compatibility with React
-  for?: string
+  for?: string,
+  elementType?: ElementType
 }
 
 export interface SpectrumLabelProps extends LabelProps, DOMProps, StyleProps {


### PR DESCRIPTION
Per @jnurthen, the <label> element can only label HTML form elements
