### PR TITLE
Change clear button to be non-focusable

### DIFF
--- a/packages/@react-aria/searchfield/src/useSearchField.ts
+++ b/packages/@react-aria/searchfield/src/useSearchField.ts
@@ -61,6 +61,7 @@ export function useSearchField(
     },
     clearButtonProps: {
       'aria-label': formatMessage('Clear search'),
+      tabIndex: -1,
       onPress: chain(onClearButtonClick, props.onClear)
     }
   };

--- a/packages/@react-aria/searchfield/test/useSearchField.test.js
+++ b/packages/@react-aria/searchfield/test/useSearchField.test.js
@@ -102,6 +102,11 @@ describe('useSearchField hook', () => {
       expect(clearButtonProps['aria-label']).toBe(expectedIntl);
     });
 
+    it('clear button should not be focusable', () => {
+      let {clearButtonProps} = renderSearchHook({});
+      expect(clearButtonProps.tabIndex).toBe(-1);
+    });
+
     describe('with specific onPress behavior', () => {
       let mockEvent = {blah: 1};
       it('sets the state to "" and focuses the search field', () => {


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1408

## ✅ Pull Request Checklist:

- [x ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [x ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [x ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

- Run Storybook 
- Searchfield -> Default story
- Click in search field
- Type a value
- Press tab
- Note that focus goes past the clear button to the next item on the page

## 🧢 Your Team:

Accessibility