### PR TITLE
RSP-1502: Hover style overriding focus for ButtonGroup/ActionButton

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -388,16 +388,6 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-icon-color-selected);
     }
 
-    &:focus-ring {
-      background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-border-color-selected-key-focus);
-      color: var(--spectrum-actionbutton-text-color-selected-key-focus);
-
-      .spectrum-Icon {
-        color: var(--spectrum-actionbutton-icon-color-selected-key-focus);
-      }
-    }
-
     &:hover {
       background-color: var(--spectrum-actionbutton-background-color-selected-hover);
       border-color: var(--spectrum-actionbutton-border-color-selected-hover);
@@ -405,6 +395,16 @@ governing permissions and limitations under the License.
 
       .spectrum-Icon {
         color: var(--spectrum-actionbutton-icon-color-selected-hover);
+      }
+    }
+
+    &:focus-ring {
+      background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
+      border-color: var(--spectrum-actionbutton-border-color-selected-key-focus);
+      color: var(--spectrum-actionbutton-text-color-selected-key-focus);
+
+      .spectrum-Icon {
+        color: var(--spectrum-actionbutton-icon-color-selected-key-focus);
       }
     }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->
JIRA: https://jira.corp.adobe.com/browse/RSP-1502

ActionButton should be selected and focused, then hover over it.
Focus border should not change the size.

`&:hover` selector should be before `&:focus-ring` selector


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exist for this component).
- [ ] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product is this pull request for? (i.e. Photoshop) -->
