### PR TITLE
RSP-1686: WIP - add isPending prop to <Button />

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -23,6 +23,9 @@ governing permissions and limitations under the License.
       box-shadow: 0 0 0 var(--spectrum-button-primary-focus-ring-size-key-focus) var(--spectrum-button-primary-focus-ring-color-key-focus);
     }
   }
+  &.is-pending {
+    pointer-events: none;
+  }
 }
 
 .spectrum-ClearButton {

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -35,6 +35,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
   let {
     elementType = 'button',
     isDisabled,
+    isPending,
     onPress,
     onPressStart,
     onPressEnd,
@@ -65,7 +66,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
     onPressEnd,
     onPressChange,
     onPress,
-    isDisabled,
+    isDisabled: isDisabled || isPending,
     ref
   });
 
@@ -80,6 +81,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
       'aria-expanded': props['aria-expanded'],
       'aria-controls': props['aria-controls'],
       'aria-pressed': props['aria-pressed'],
+      'aria-disabled': isPending || undefined,
       disabled: isDisabled,
       type,
       ...(additionalProps || {}),

--- a/packages/@react-aria/label/src/useLabel.ts
+++ b/packages/@react-aria/label/src/useLabel.ts
@@ -20,6 +20,7 @@ interface LabelAriaProps extends LabelableProps, DOMProps, AriaLabelingProps {
    * @default 'label'
    */
   labelElementType?: ElementType
+  'aria-hidden'?: boolean,
 }
 
 interface LabelAria {
@@ -40,6 +41,7 @@ export function useLabel(props: LabelAriaProps): LabelAria {
     label,
     'aria-labelledby': ariaLabelledby,
     'aria-label': ariaLabel,
+    'aria-hidden': ariaHidden,
     labelElementType = 'label'
   } = props;
 
@@ -52,7 +54,7 @@ export function useLabel(props: LabelAriaProps): LabelAria {
       id: labelId,
       htmlFor: labelElementType === 'label' ? id : undefined
     };
-  } else if (!ariaLabelledby && !ariaLabel) {
+  } else if (!ariaLabelledby && !ariaLabel && !ariaHidden) {
     console.warn('If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility');
   }
 

--- a/packages/@react-aria/label/src/useLabel.ts
+++ b/packages/@react-aria/label/src/useLabel.ts
@@ -19,8 +19,8 @@ interface LabelAriaProps extends LabelableProps, DOMProps, AriaLabelingProps {
    * The HTML element used to render the label, e.g. 'label', or 'span'.
    * @default 'label'
    */
-  labelElementType?: ElementType
-  'aria-hidden'?: boolean,
+  labelElementType?: ElementType,
+  'aria-hidden'?: boolean
 }
 
 interface LabelAria {

--- a/packages/@react-aria/progress/src/useProgressBar.ts
+++ b/packages/@react-aria/progress/src/useProgressBar.ts
@@ -40,7 +40,7 @@ export function useProgressBar(props: AriaProgressBarProps): ProgressBarAria {
     }
   } = props;
 
-  let domProps = filterDOMProps(props, {labelable: true});
+  let domProps = filterDOMProps(props, {labelable: true, propNames: new Set(['aria-hidden'])});
   let {labelProps, fieldProps} = useLabel({
     ...props,
     // Progress bar is not an HTML input element so it

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -32,30 +32,19 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-<<<<<<< HEAD
     "@react-aria/button": "^3.2.0",
     "@react-aria/focus": "^3.2.0",
     "@react-aria/interactions": "^3.2.0",
     "@react-aria/utils": "^3.2.0",
+    "@react-aria/visually-hidden": "^3.2.0",
+    "@react-spectrum/progress": "^3.1.0",
     "@react-spectrum/text": "^3.1.0",
     "@react-spectrum/utils": "^3.2.0",
     "@react-stately/toggle": "^3.2.0",
     "@react-types/button": "^3.2.0",
+    "@react-types/progress": "^3.1.0",
     "@react-types/shared": "^3.2.0",
     "@spectrum-icons/ui": "^3.1.0"
-=======
-    "@react-aria/button": "3.0.0-rc.3",
-    "@react-aria/focus": "3.0.0-rc.3",
-    "@react-aria/utils": "3.0.0-rc.3",
-    "@react-aria/visually-hidden": "^3.0.0-rc.0",
-    "@react-spectrum/progress": "^3.0.0-rc.3",
-    "@react-spectrum/text": "3.0.0-rc.0",
-    "@react-spectrum/utils": "3.0.0-rc.3",
-    "@react-types/button": "3.0.0-rc.3",
-    "@react-types/progress": "3.0.0-rc.3",
-    "@react-types/shared": "3.0.0-rc.3",
-    "@spectrum-icons/ui": "3.0.0-rc.3"
->>>>>>> RSP-1686: Add `isPending` prop to @react-spectrum/Button
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1",

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+<<<<<<< HEAD
     "@react-aria/button": "^3.2.0",
     "@react-aria/focus": "^3.2.0",
     "@react-aria/interactions": "^3.2.0",
@@ -42,14 +43,27 @@
     "@react-types/button": "^3.2.0",
     "@react-types/shared": "^3.2.0",
     "@spectrum-icons/ui": "^3.1.0"
+=======
+    "@react-aria/button": "3.0.0-rc.3",
+    "@react-aria/focus": "3.0.0-rc.3",
+    "@react-aria/utils": "3.0.0-rc.3",
+    "@react-aria/visually-hidden": "^3.0.0-rc.0",
+    "@react-spectrum/progress": "^3.0.0-rc.3",
+    "@react-spectrum/text": "3.0.0-rc.0",
+    "@react-spectrum/utils": "3.0.0-rc.3",
+    "@react-types/button": "3.0.0-rc.3",
+    "@react-types/progress": "3.0.0-rc.3",
+    "@react-types/shared": "3.0.0-rc.3",
+    "@spectrum-icons/ui": "3.0.0-rc.3"
+>>>>>>> RSP-1686: Add `isPending` prop to @react-spectrum/Button
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1",
     "@react-spectrum/test-utils": "^3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0-rc.1",
+    "react": "^16.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -10,17 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, SlotProvider, useFocusableRef, useIndeterminate, useSlotProps, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
+import {ProgressCircle} from '@react-spectrum/progress';
 import React from 'react';
 import {SpectrumButtonProps} from '@react-types/button';
+import {SpectrumProgressCircleProps} from '@react-types/progress';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {Text} from '@react-spectrum/text';
 import {useButton} from '@react-aria/button';
 import {useHover} from '@react-aria/interactions';
 import {useProviderProps} from '@react-spectrum/provider';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 // todo: CSS hasn't caught up yet, map
 let VARIANT_MAPPING = {
@@ -35,6 +38,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
     children,
     variant,
     isQuiet,
+    isPending,
     isDisabled,
     autoFocus,
     ...otherProps
@@ -43,11 +47,20 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
   let {buttonProps, isPressed} = useButton(props, domRef);
   let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);
+  let {isIndeterminate} = useIndeterminate({isPending});
+  let progressCircleProps: SpectrumProgressCircleProps = {
+    isIndeterminate: true,
+    size: 'S',
+    ...variant === 'overBackground' && {variant: 'overBackground'}
+  };
 
   let buttonVariant = variant;
   if (VARIANT_MAPPING[variant]) {
     buttonVariant = VARIANT_MAPPING[variant];
   }
+
+  // TODO: preserve width of hidden children, append localized "loading"
+  children = isIndeterminate ? <VisuallyHidden>{children}</VisuallyHidden> : children;
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
@@ -62,9 +75,15 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
             `spectrum-Button--${buttonVariant}`,
             {
               'spectrum-Button--quiet': isQuiet,
+<<<<<<< HEAD
               'is-disabled': isDisabled,
               'is-active': isPressed,
               'is-hovered': isHovered
+=======
+              'is-disabled': isDisabled || isIndeterminate,
+              'is-active': isPressed,
+              'is-pending': isPending
+>>>>>>> RSP-1686: Add `isPending` prop to @react-spectrum/Button
             },
             styleProps.className
           )
@@ -82,6 +101,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
           {typeof children === 'string'
             ? <Text>{children}</Text>
             : children}
+          {isIndeterminate && <ProgressCircle {...progressCircleProps} />}
         </SlotProvider>
       </ElementType>
     </FocusRing>

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -51,6 +51,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
   let progressCircleProps: SpectrumProgressCircleProps = {
     isIndeterminate: true,
     size: 'S',
+    'aria-hidden': true,
     ...variant === 'overBackground' && {variant: 'overBackground'}
   };
 

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -78,8 +78,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
               'spectrum-Button--quiet': isQuiet,
               'is-disabled': isDisabled || isIndeterminate,
               'is-active': isPressed,
-              'is-hovered': isHovered
-              'is-disabled': isDisabled || isIndeterminate,
+              'is-hovered': isHovered,
               'is-active': isPressed,
               'is-pending': isPending,
               'is-hovered': isHovered

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -76,15 +76,13 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
             `spectrum-Button--${buttonVariant}`,
             {
               'spectrum-Button--quiet': isQuiet,
-<<<<<<< HEAD
-              'is-disabled': isDisabled,
-              'is-active': isPressed,
-              'is-hovered': isHovered
-=======
               'is-disabled': isDisabled || isIndeterminate,
               'is-active': isPressed,
-              'is-pending': isPending
->>>>>>> RSP-1686: Add `isPending` prop to @react-spectrum/Button
+              'is-hovered': isHovered
+              'is-disabled': isDisabled || isIndeterminate,
+              'is-active': isPressed,
+              'is-pending': isPending,
+              'is-hovered': isHovered
             },
             styleProps.className
           )

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -85,7 +85,7 @@ storiesOf('Button', module)
   .add(
     'element: a, rel: \'noopener noreferrer\'',
     () => render({elementType: 'a', href: '//example.com', rel: 'noopener noreferrer', variant: 'primary'})
-  ),
+  )
   .add(
     'is pending',
     () => {

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -14,9 +14,10 @@ import {action} from '@storybook/addon-actions';
 import Bell from '@spectrum-icons/workflow/Bell';
 import {Button} from '../';
 import {Flex} from '@react-spectrum/layout';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
+import {View} from '@react-spectrum/view';
 
 storiesOf('Button', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -59,11 +60,7 @@ storiesOf('Button', module)
   )
   .add(
     'variant: overBackground',
-    () => (
-      <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
-        {render({variant: 'overBackground'})}
-      </div>
-    )
+    () => render({variant: 'overBackground'})
   )
   .add(
     'variant: primary',
@@ -88,36 +85,74 @@ storiesOf('Button', module)
   .add(
     'element: a, rel: \'noopener noreferrer\'',
     () => render({elementType: 'a', href: '//example.com', rel: 'noopener noreferrer', variant: 'primary'})
+  ),
+  .add(
+    'is pending',
+    () => {
+      let timeout = useRef<ReturnType<typeof setTimeout>>();
+      let [isPending, setPending] = useState(false);
+      let handlePress = (e) => {
+        setPending(true);
+        action('press')(e);
+
+        timeout.current = setTimeout(() => {
+          setPending(false);
+        }, 3000);
+      };
+
+      useEffect(() => () => clearTimeout(timeout.current), []);
+
+      let variants = ['cta', 'primary', 'secondary', 'negative', 'overBackground'];
+
+      return (
+        <Flex direction="column">
+          {variants.map(variant =>
+            render({
+              onPress: handlePress,
+              variant,
+              isPending
+            }, {
+              key: variant,
+              padding: 'size-300'
+            })
+          )}
+        </Flex>
+      );
+    }
   );
 
-function render(props: any = {}) {
+function render(props: any = {}, viewProps: any = {}) {
+  let backgroundProps = {...props.variant === 'overBackground' && {backgroundColor: 'blue-700', padding: 'size-400'}};
+
   return (
-    <Flex gap="size-200">
-      <Button
-        onPress={action('press')}
-        onPressStart={action('pressstart')}
-        onPressEnd={action('pressend')}
-        {...props}>
-        Default
-      </Button>
-      <Button
-        onPress={action('press')}
-        onPressStart={action('pressstart')}
-        onPressEnd={action('pressend')}
-        isDisabled
-        {...props}>
-        Disabled
-      </Button>
-      {props.variant !== 'cta' && (
-      <Button
-        onPress={action('press')}
-        onPressStart={action('pressstart')}
-        onPressEnd={action('pressend')}
-        isQuiet
-        {...props}>
-        Quiet
-      </Button>
-      )}
-    </Flex>
+    <View {...backgroundProps} {...viewProps}>
+      <Flex gap="size-200">
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          {...props}>
+          Default
+        </Button>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isDisabled
+          {...props}>
+          Disabled
+        </Button>
+        {props.variant !== 'cta' && (
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isQuiet
+          {...props}>
+          Quiet
+        </Button>
+        )}
+      </Flex>
+    </View>
   );
 }

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import {act, fireEvent, render} from '@testing-library/react';
 import {ActionButton, Button, ClearButton, LogicButton} from '../';
-import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 import {triggerPress} from '@react-spectrum/test-utils';
 import V2Button from '@react/react-spectrum/Button';
@@ -216,5 +216,34 @@ describe('Button', function () {
 
     let button = getByRole('button');
     expect(document.activeElement).toBe(button);
+  });
+
+  it.each`
+    Name                | Component | props
+    ${'Button'}         | ${Button} | ${{onPress: onPressSpy, isPending: true}}
+  `('$Name supports isPending', async function ({Component, props}) {
+    let {getByRole, rerender} = render(<Component {...props}>Click me</Component>);
+
+    let button = getByRole('button');
+
+    expect(button).toBeEnabled();
+    expect(button).toHaveAttribute('aria-disabled');
+
+    triggerPress(button);
+    expect(onPressSpy).toHaveBeenCalledTimes(0);
+
+    await act(async () => new Promise((c) => setTimeout(c, 1000))); // Enter intermediate state
+
+    // TODO: verify that label is visible only to screen readers
+    triggerPress(button);
+    expect(button.textContent).toEqual('Click me');
+    expect(onPressSpy).toHaveBeenCalledTimes(0);
+
+    rerender(<Component {...props} isPending={false} />);
+
+    expect(button).not.toHaveAttribute('aria-disabled');
+
+    triggerPress(button);
+    expect(onPressSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@react-spectrum/progress/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressCircle.tsx
@@ -28,6 +28,7 @@ function ProgressCircle(props: SpectrumProgressCircleProps, ref: DOMRef<HTMLDivE
     isIndeterminate = false,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
+    'aria-hidden': ariaHidden,
     ...otherProps
   } = props;
   let domRef = useDOMRef(ref);
@@ -52,7 +53,7 @@ function ProgressCircle(props: SpectrumProgressCircleProps, ref: DOMRef<HTMLDivE
     }
   }
 
-  if (!ariaLabel && !ariaLabelledby) {
+  if (!ariaLabel && !ariaLabelledby && !ariaHidden) {
     console.warn('ProgressCircle requires an aria-label or aria-labelledby attribute for accessibility');
   }
 

--- a/packages/@react-spectrum/utils/src/index.ts
+++ b/packages/@react-spectrum/utils/src/index.ts
@@ -20,4 +20,4 @@ export * from './styleProps';
 export * from './Slots';
 export * from './useHasChild';
 export * from './useResizeObserver';
-
+export * from './useIndeterminate';

--- a/packages/@react-spectrum/utils/src/useIndeterminate.ts
+++ b/packages/@react-spectrum/utils/src/useIndeterminate.ts
@@ -1,0 +1,45 @@
+import {useEffect, useRef, useState} from 'react';
+
+export interface PendingHookProps {
+  /** Whether the element is in a pending state (e.g. press events are disabled but the element is not disabled). */
+  isPending: boolean,
+  /** Timeout before the element enters an indeterminate state. */
+  timeoutMs?: number
+}
+
+export interface PendingResult {
+  /** Whether the element is in an indeterminate state (e.g. conveys indeterminate progress). Only pending elements can be indeterminate. */
+  isIndeterminate: boolean
+}
+
+/**
+ * Handles indeterminate state. When an element becomes pending, starts a timer for it to transition to an indeterminate state. When an indeterminate element is no longer pending, exit the indeterminate state.
+ */
+export function useIndeterminate(props: PendingHookProps): PendingResult {
+  let {isPending, timeoutMs = 1000} = props;
+  let [isIndeterminate, setIndeterminate] = useState(false);
+  let timeout = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    // Start timer when isPending is set to true.
+    if (isPending) {
+      timeout.current = setTimeout(() => {
+        setIndeterminate(true);
+        timeout.current = null;
+      }, timeoutMs);
+    // Exit indeterminate state when isPending is set to false. */
+    } else {
+      setIndeterminate(false);
+    }
+
+    return () => {
+      // Clean up on unmount or when user removes isPending prop before entering indeterminate state.
+      clearTimeout(timeout.current);
+      timeout.current = null;
+    };
+  }, [isPending, timeoutMs]);
+
+  return {
+    isIndeterminate
+  };
+}

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -59,14 +59,19 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
   type?: 'button' | 'submit' | 'reset'
 }
 
-export interface AriaButtonProps extends ButtonProps, LinkButtonProps, AriaBaseButtonProps {}
+export interface AriaButtonProps extends ButtonProps, LinkButtonProps, AriaBaseButtonProps {
+  /** Whether the button should have press events temporarily disabled. */
+  isPending?: boolean
+}
 export interface AriaToggleButtonProps extends ToggleButtonProps, AriaBaseButtonProps {}
 
 export interface SpectrumButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */
   variant: 'cta' | 'overBackground' | 'primary' | 'secondary' | 'negative',
   /** Whether the button should be displayed with a quiet style. */
-  isQuiet?: boolean
+  isQuiet?: boolean,
+  /** Whether the button should have press events temporarily disabled. */
+  isPending?: boolean
 }
 
 export interface SpectrumActionButtonProps extends AriaBaseButtonProps, ButtonProps, StyleProps {

--- a/packages/@react-types/progress/src/index.d.ts
+++ b/packages/@react-types/progress/src/index.d.ts
@@ -63,7 +63,12 @@ export interface ProgressCircleProps extends ProgressBaseProps {
   isIndeterminate?: boolean
 }
 
-export interface AriaProgressCircleProps extends ProgressCircleProps, DOMProps, AriaLabelingProps {}
+export interface AriaProgressCircleProps extends ProgressCircleProps, DOMProps, AriaLabelingProps {
+  /**
+   * Whether the ProgressCircle should be hidden from assistive technology.
+   */
+  'aria-hidden'?: boolean
+}
 export interface SpectrumProgressCircleProps extends AriaProgressCircleProps, StyleProps {
   /**
    * What the ProgressCircle's diameter should be.


### PR DESCRIPTION
- [x] Expose `isPending` prop that blocks press events/styles
- [x] Add `usePending` hook to manage delay from `isPending` to `isPending + isIndeterminate`
- [x] Visually hide label and show progress circle when `isIndeterminate`
- [ ] Add i18n'd "Loading" label when pending
- [ ] Preserve button width when pending
- [ ] Docs

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [JIRA ticket](https://jira.corp.adobe.com/browse/RSP-1686).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

View the new "isPending" Button story.

## 🧢 Your Team:

RSP, AEP
