### PR TITLE
Add blog to website

### DIFF
--- a/packages/dev/docs/pages/blog/PostListing.js
+++ b/packages/dev/docs/pages/blog/PostListing.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import classNames from 'classnames';
+import docStyles from '@react-spectrum/docs/src/docs.css';
+import linkStyle from '@adobe/spectrum-css-temp/components/link/vars.css';
+import {PageContext, renderHTMLfromMarkdown, Time} from '@react-spectrum/docs';
+import React from 'react';
+import typographyStyles from '@adobe/spectrum-css-temp/components/typography/vars.css';
+
+export function PostListing() {
+  let {pages} = React.useContext(PageContext);
+  let blogPages = pages
+    .filter(page => page.name.startsWith('blog/') && !page.name.endsWith('index.html'))
+    .sort((a, b) => a.date < b.date ? 1 : -1);
+
+  return (
+    <>
+      {blogPages.map(page => <BlogPost {...page} />)}
+    </>
+  );
+}
+
+function BlogPost({name, title, url, description, date}) {
+  return (
+    <article className={classNames(typographyStyles['spectrum-Typography'], docStyles.blogArticle)}>
+      <header className={docStyles.blogHeader}>
+        <h2 className={typographyStyles['spectrum-Heading3']}><a href={url} className={linkStyle['spectrum-Link']}>{title}</a></h2>
+        <Time date={date} />
+      </header>
+      <p className={typographyStyles['spectrum-Body3']}>
+        {renderHTMLfromMarkdown(description)}
+      </p>
+    </article>
+  );
+}

--- a/packages/dev/docs/pages/blog/index.mdx
+++ b/packages/dev/docs/pages/blog/index.mdx
@@ -1,0 +1,20 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {PostListing} from './PostListing';
+import {BlogLayout} from '@react-spectrum/docs';
+export default BlogLayout;
+
+---
+category: Foundation
+---
+
+# Blog
+
+<PostListing />

--- a/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
+++ b/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
@@ -1,0 +1,168 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import heroNarrow from 'url:../assets/ReactAria_Mobile_976x1025_1x.png';
+import heroNarrow2x from 'url:../assets/ReactAria_Mobile_976x1025_2x.png';
+import heroNarrowWebp from 'url:../assets/ReactAria_Mobile_976x1025_1x.webp';
+import heroNarrow2xWebp from 'url:../assets/ReactAria_Mobile_976x1025_2x.webp';
+import heroWide from 'url:../assets/ReactAria_976x445_1x.png';
+import heroWide2x from 'url:../assets/ReactAria_976x445_2x.png';
+import heroWideWebp from 'url:../assets/ReactAria_976x445_1x.webp';
+import heroWide2xWebp from 'url:../assets/ReactAria_976x445_2x.webp';
+
+import {BlogPostLayout, Hero} from '@react-spectrum/docs';
+export default BlogPostLayout;
+
+```tsx import
+import {Picker, Item, Section} from '@react-spectrum/picker';
+import {Text} from '@react-spectrum/text';
+import Book from '@spectrum-icons/workflow/Book';
+import BulkEditUsers from '@spectrum-icons/workflow/BulkEditUsers';
+import Draw from '@spectrum-icons/workflow/Draw';
+import {useSwitch} from '@react-aria/switch';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
+import {useToggleState} from '@react-stately/toggle';
+import {useFocusRing} from '@react-aria/focus';
+```
+
+---
+keywords: [react stately, react aria, react spectrum, hooks, react, spectrum]
+description: Today, we’re excited to announce [React Spectrum](https://react-spectrum.adobe.com/), a collection of libraries and tools that help you build adaptive, accessible, and robust user experiences. Check it out on [Github](https://github.com/adobe/react-spectrum)!
+date: 2020-07-14
+image: ../assets/ReactAria_976x445_2x.png
+---
+
+# Introducing React Spectrum
+
+Today, we’re excited to announce [React Spectrum](https://react-spectrum.adobe.com/), a collection of libraries and tools that help you build adaptive, accessible, and robust user experiences. Check it out on [Github](https://github.com/adobe/react-spectrum)!
+
+- **React Spectrum** — A React implementation of Spectrum, Adobe’s design system.
+- **React Aria** — A library of React Hooks that provides accessible UI primitives for your design system.
+- **React Stately** — A library of React Hooks that provides cross-platform state management and core logic for your design system.
+
+We’ve been working on React Spectrum for several years now. Adobe is a large company with thousands of engineers working on hundreds of products, which must meet high standards for UI consistency, accessibility, internationalization, and usability. Meeting these standards at our scale has been a challenge, and we’re excited to share what we’ve learned with the community and raise the bar for web applications together.
+
+<Hero
+  narrow={heroNarrow}
+  narrow2x={heroNarrow2x}
+  narrowWebp={heroNarrowWebp}
+  narrow2xWebp={heroNarrow2xWebp}
+  wide={heroWide}
+  wide2x={heroWide2x}
+  wideWebp={heroWideWebp}
+  wide2xWebp={heroWide2xWebp}
+  alt="React Aria hero image" />
+
+## Features
+
+- ♿️ [**Accessible**](https://react-spectrum.adobe.com/react-aria/accessibility.html) – Accessibility and behavior is implemented according to [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/), including full screen reader and keyboard navigation support. All components have been tested across a wide variety of screen readers and devices to ensure the best experience possible for all users.
+- 📱 [**Adaptive**](https://react-spectrum.adobe.com/react-aria/interactions.html) – All components are designed to work with mouse, touch, and keyboard interactions. They’re built with responsive design principles to deliver a great experience, no matter the device.
+- 🌍 [**International**](https://react-spectrum.adobe.com/react-aria/internationalization.html) – Support for over 30 languages is included out of the box, including support for right-to-left languages, date and number formatting, and more.
+- 🎨 [**Customizable**](https://react-spectrum.adobe.com/react-spectrum/theming.html) – React Spectrum components support custom themes, and automatically adapt for dark mode. For even more customizability, you can build your own components with your own DOM structure and stying using the [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) and [React Stately](https://react-spectrum.adobe.com/react-stately/index.html) hooks to provide behavior, accessibility, and interactions.
+
+## Motivation
+
+Design systems are now more popular than ever, and many companies both large and small are implementing their own component libraries from scratch. Modern view libraries like React allow teams to build and maintain these components more easily than ever before, but it is still **extraordinarily difficult** to do so in a fully accessible way with interactions that work across many types of devices. This represents **millions of dollars** of investment for each company to **duplicate work** that could have been shared.
+
+While each design system is unique, there is often more in common between components than different. Most components typically found in a design system, like buttons, checkboxes, selects, and even tables, usually have very similar behavior and logic. The [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/) describe how many of the most common components should behave in terms of [accessibility semantics](https://www.w3.org/TR/wai-aria-1.2/) and [keyboard interactions](https://www.w3.org/TR/wai-aria-practices-1.2/). The main difference between design systems is styling.
+
+Unfortunately, many companies and teams don't have the resources or time to prioritize features like accessibility, internationalization, full keyboard navigation, and touch interactions. This leads to many web apps having sub-par accessibility and interactions, and contributes to the perception of the web as an inferior app platform compared to native apps.
+
+We believe there is an opportunity to share much of the behavior and component logic between design systems and across platforms. For example, user interactions, accessibility, internationalization, and behavior can be reused, while allowing custom styling and rendering to live within individual design systems. This has the potential to improve the overall quality of applications, while saving companies money and time, and reducing duplicated effort across the industry.
+
+## Architecture
+
+In order to allow reusing component behavior between design systems, React Spectrum splits each component into three parts: state, behavior, and the rendered component. This architecture is made possible by [React Hooks](https://reactjs.org/docs/hooks-intro.html), which enable the ability to reuse behavior between multiple components.
+
+### React Stately
+
+[React Stately](https://react-spectrum.adobe.com/react-stately/index.html) is a collection of hooks that provide state management and core logic for each component. They make no assumptions about the platform they are running on, and have no theme or design system specific logic.
+
+React Stately hooks accept common props from the component and provide state management. They implement the core logic for the component and return an interface for reading and updating the component state.
+
+React Stately can be used independently in your own components, or paired with React Aria hooks to get more of the behavior and user interactions for web applications out of the box. Learn more about React Stately, and how to [get started](https://react-spectrum.adobe.com/react-stately/getting-started.html) by reading the docs.
+
+### React Aria
+
+[React Aria](https://react-spectrum.adobe.com/react-aria/index.html) implements behavior and [accessibility](https://react-spectrum.adobe.com/react-aria/accessibility.html) for the web according to the [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/). It includes full screen reader and keyboard navigation support, along with mouse and touch [interactions](https://react-spectrum.adobe.com/react-aria/interactions.html) that have been tested across a wide variety of devices and browsers. It also implements [internationalization](https://react-spectrum.adobe.com/react-aria/internationalization.html) for over 30 languages, including right-to-left specific behavior, localized date and number formatting, and more.
+
+React Aria includes no design system specific styling or logic. It implements event handling, accessibility, internationalization, etc. — all the parts of a component that could be shared across multiple design systems. It returns DOM props that can be spread onto the elements rendered by the component. These include semantic properties like [ARIA](https://www.w3.org/TR/wai-aria-1.2/), and event handlers. The event handlers in turn call methods on the state interface to implement the behavior for the component.
+
+React Aria gives you complete control over the rendering and styling of your components, but rather than building everything from scratch, you start with higher level primitives that have semantic meaning, behavior, and interactions built in. This allows you to **build components more quickly**, and ensures that they work well across devices and assistive technology.
+
+Building a component with React Aria and React Stately looks like this. Call the hooks, and spread the resulting props onto the appropriate DOM elements.
+
+```tsx example
+function Switch(props) {
+  let state = useToggleState(props);
+  let {inputProps} = useSwitch(props, state);
+  let {isFocusVisible, focusProps} = useFocusRing();
+
+  return (
+    <label style={{display: 'flex', alignItems: 'center'}}>
+      <VisuallyHidden>
+        <input {...inputProps} {...focusProps} />
+      </VisuallyHidden>
+      <svg width={40} height={24} aria-hidden="true" style={{marginRight: 4}}>
+        <rect x={4} y={4} width={32} height={16} rx={8} fill={state.isSelected ? 'orange' : 'gray'} />
+        <circle cx={state.isSelected ? 28 : 12} cy={12} r={5} fill="white" />
+        {isFocusVisible &&
+          <rect x={1} y={1} width={38} height={22} rx={11} fill="none" stroke="orange" strokeWidth={2} />
+        }
+      </svg>
+      {props.children}
+    </label>
+  );
+}
+
+<Switch>Test</Switch>
+```
+
+[Read more](https://react-spectrum.adobe.com/react-aria/why.html) about React Aria and the problems it solves, and check out the docs to [get started](https://react-spectrum.adobe.com/react-aria/getting-started.html) building your own design system.
+
+### React Spectrum
+
+[React Spectrum](https://react-spectrum.adobe.com/react-spectrum/index.html) puts all of these pieces together and implements the Adobe-specific styling. It's designed to be adaptive, and works across mouse, touch, and keyboard interactions, on devices of any screen size. It supports [theming](https://react-spectrum.adobe.com/react-spectrum/theming.html), including automatic support for dark mode, and responsive scaling for large hit targets on touch devices.
+
+If you’re integrating with Adobe software or would like an end-to-end component library to use in your project, then React Spectrum is a great place to start. ***INSERT ADOBE STUFF HERE*** [Get started](https://react-spectrum.adobe.com/react-spectrum/getting-started.html) building an application with React Spectrum, and check out the docs for each component to learn more.
+
+We’ve designed the APIs in React Spectrum to be easy to use. The following example shows how simple it is to create a select element with support for sections and complex options.
+
+```tsx example
+<Picker label="Options">
+  <Section title="Permission">
+    <Item textValue="Read">
+      <Book size="S" />
+      <Text>Read</Text>
+      <Text slot="description">Read Only</Text>
+    </Item>
+    <Item textValue="Write">
+      <Draw size="S" />
+      <Text>Write</Text>
+      <Text slot="description">Read and Write Only</Text>
+    </Item>
+    <Item textValue="Admin">
+      <BulkEditUsers size="S" />
+      <Text>Admin</Text>
+      <Text slot="description">Full access</Text>
+    </Item>
+  </Section>
+</Picker>
+```
+
+If you’re building your own components, React Spectrum is a good example of how to use React Aria and React Stately to build a full design system.
+
+## Try it out!
+
+We’re really excited to see how you use React Aria, React Stately, and React Spectrum in your own applications! We’ve started with an initial set of components, and many more will be added in the coming months.
+
+Check out [our documentation](https://react-spectrum.adobe.com/) to learn more. We’ve put a huge amount of effort into making it easy to get started, with API docs and examples for each component, and a clear list of all of the functionality we handle out of the box.
+
+- [Website](https://react-spectrum.adobe.com/)
+- [Github](https://github.com/adobe/react-spectrum)

--- a/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
+++ b/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
@@ -34,19 +34,17 @@ import {useFocusRing} from '@react-aria/focus';
 ---
 keywords: [react stately, react aria, react spectrum, hooks, react, spectrum]
 description: Today, we’re excited to announce [React Spectrum](https://react-spectrum.adobe.com/), a collection of libraries and tools that help you build adaptive, accessible, and robust user experiences. Check it out on [Github](https://github.com/adobe/react-spectrum)!
-date: 2020-07-14
+date: 2020-07-15
 image: ../assets/ReactAria_976x445_2x.png
 ---
 
 # Introducing React Spectrum
 
-Today, we’re excited to announce [React Spectrum](https://react-spectrum.adobe.com/), a collection of libraries and tools that help you build adaptive, accessible, and robust user experiences. Check it out on [Github](https://github.com/adobe/react-spectrum)!
+We’re excited to announce [React Spectrum](https://react-spectrum.adobe.com/index.html), a collection of libraries and tools that help you build adaptive, accessible, and robust user experiences. [Check it out on Github](https://github.com/adobe/react-spectrum)! React Spectrum includes three libraries:
 
 - **React Spectrum** — A React implementation of Spectrum, Adobe’s design system.
 - **React Aria** — A library of React Hooks that provides accessible UI primitives for your design system.
 - **React Stately** — A library of React Hooks that provides cross-platform state management and core logic for your design system.
-
-We’ve been working on React Spectrum for several years now. Adobe is a large company with thousands of engineers working on hundreds of products, which must meet high standards for UI consistency, accessibility, internationalization, and usability. Meeting these standards at our scale has been a challenge, and we’re excited to share what we’ve learned with the community and raise the bar for web applications together.
 
 <Hero
   narrow={heroNarrow}
@@ -63,12 +61,14 @@ We’ve been working on React Spectrum for several years now. Adobe is a large c
 
 - ♿️ [**Accessible**](https://react-spectrum.adobe.com/react-aria/accessibility.html) – Accessibility and behavior is implemented according to [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/), including full screen reader and keyboard navigation support. All components have been tested across a wide variety of screen readers and devices to ensure the best experience possible for all users.
 - 📱 [**Adaptive**](https://react-spectrum.adobe.com/react-aria/interactions.html) – All components are designed to work with mouse, touch, and keyboard interactions. They’re built with responsive design principles to deliver a great experience, no matter the device.
-- 🌍 [**International**](https://react-spectrum.adobe.com/react-aria/internationalization.html) – Support for over 30 languages is included out of the box, including support for right-to-left languages, date and number formatting, and more.
+- 🌍 [**International**](https://react-spectrum.adobe.com/react-aria/internationalization.html) – Support for more than 30 languages is included out of the box, including support for right-to-left languages, date and number formatting, and more.
 - 🎨 [**Customizable**](https://react-spectrum.adobe.com/react-spectrum/theming.html) – React Spectrum components support custom themes, and automatically adapt for dark mode. For even more customizability, you can build your own components with your own DOM structure and stying using the [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) and [React Stately](https://react-spectrum.adobe.com/react-stately/index.html) hooks to provide behavior, accessibility, and interactions.
+
+Adobe is a large company with thousands of engineers working on hundreds of products, which must all meet high standards for UI consistency, accessibility, internationalization, and usability. Meeting these standards at our scale has been a challenge, and we’re excited to share what we’ve learned with the community and raise the bar for web applications together.
 
 ## Motivation
 
-Design systems are now more popular than ever, and many companies both large and small are implementing their own component libraries from scratch. Modern view libraries like React allow teams to build and maintain these components more easily than ever before, but it is still **extraordinarily difficult** to do so in a fully accessible way with interactions that work across many types of devices. This represents **millions of dollars** of investment for each company to **duplicate work** that could have been shared.
+Design systems are now more popular than ever, and many companies both large and small are implementing their own component libraries from scratch. Modern view libraries like React allow teams to build and maintain these components more easily than ever before, but it is still **extraordinarily difficult** to do so in a fully accessible way with interactions that work across many types of devices. This represents **millions of dollars** of investment for each company as they **duplicate work** that could have been shared.
 
 While each design system is unique, there is often more in common between components than different. Most components typically found in a design system, like buttons, checkboxes, selects, and even tables, usually have very similar behavior and logic. The [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/) describe how many of the most common components should behave in terms of [accessibility semantics](https://www.w3.org/TR/wai-aria-1.2/) and [keyboard interactions](https://www.w3.org/TR/wai-aria-practices-1.2/). The main difference between design systems is styling.
 
@@ -78,7 +78,7 @@ We believe there is an opportunity to share much of the behavior and component l
 
 ## Architecture
 
-In order to allow reusing component behavior between design systems, React Spectrum splits each component into three parts: state, behavior, and the rendered component. This architecture is made possible by [React Hooks](https://reactjs.org/docs/hooks-intro.html), which enable the ability to reuse behavior between multiple components.
+To enable reusing component behavior between design systems, React Spectrum splits each component into three parts: state, behavior, and the rendered component. This architecture is made possible by [React Hooks](https://reactjs.org/docs/hooks-intro.html), which enable the ability to reuse behavior between multiple components.
 
 ### React Stately
 
@@ -130,7 +130,7 @@ function Switch(props) {
 
 [React Spectrum](https://react-spectrum.adobe.com/react-spectrum/index.html) puts all of these pieces together and implements the Adobe-specific styling. It's designed to be adaptive, and works across mouse, touch, and keyboard interactions, on devices of any screen size. It supports [theming](https://react-spectrum.adobe.com/react-spectrum/theming.html), including automatic support for dark mode, and responsive scaling for large hit targets on touch devices.
 
-If you’re integrating with Adobe software or would like an end-to-end component library to use in your project, then React Spectrum is a great place to start. ***INSERT ADOBE STUFF HERE*** [Get started](https://react-spectrum.adobe.com/react-spectrum/getting-started.html) building an application with React Spectrum, and check out the docs for each component to learn more.
+If you’re integrating with Adobe software or would like an end-to-end component library to use in your project, then React Spectrum is a great place to start. Save time by using [Project Firefly](https://www.adobe.io/apis/experienceplatform/project-firefly.html), our complete framework for building custom cloud-native Adobe apps. Enterprise customers and partners can extend the functionality of Adobe Experience Platform and Adobe Experience Cloud solutions in a custom app that solves specific business and workflow needs. [Sign up](https://adobeio.typeform.com/to/obqgRm) to get access to Project Firefly developer preview.
 
 We’ve designed the APIs in React Spectrum to be easy to use. The following example shows how simple it is to create a select element with support for sections and complex options.
 
@@ -156,7 +156,7 @@ We’ve designed the APIs in React Spectrum to be easy to use. The following exa
 </Picker>
 ```
 
-If you’re building your own components, React Spectrum is a good example of how to use React Aria and React Stately to build a full design system.
+[Get started](https://react-spectrum.adobe.com/react-spectrum/getting-started.html) building an application with React Spectrum, and check out the docs for each component to learn more. In addition, if you’re building your own component library, React Spectrum is a good example of how to use React Aria and React Stately to build a full design system.
 
 ## Try it out!
 

--- a/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
+++ b/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
@@ -61,7 +61,7 @@ We’re excited to announce [React Spectrum](https://react-spectrum.adobe.com/in
 
 - ♿️ [**Accessible**](https://react-spectrum.adobe.com/react-aria/accessibility.html) – Accessibility and behavior is implemented according to [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/), including full screen reader and keyboard navigation support. All components have been tested across a wide variety of screen readers and devices to ensure the best experience possible for all users.
 - 📱 [**Adaptive**](https://react-spectrum.adobe.com/react-aria/interactions.html) – All components are designed to work with mouse, touch, and keyboard interactions. They’re built with responsive design principles to deliver a great experience, no matter the device.
-- 🌍 [**International**](https://react-spectrum.adobe.com/react-aria/internationalization.html) – Support for more than 30 languages is included out of the box, including support for right-to-left languages, date and number formatting, and more.
+- 🌍 [**International**](https://react-spectrum.adobe.com/react-aria/internationalization.html) – Support for more than 30 languages is included out of the box, with support for right-to-left languages, date and number formatting, and more.
 - 🎨 [**Customizable**](https://react-spectrum.adobe.com/react-spectrum/theming.html) – React Spectrum components support custom themes, and automatically adapt for dark mode. For even more customizability, you can build your own components with your own DOM structure and stying using the [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) and [React Stately](https://react-spectrum.adobe.com/react-stately/index.html) hooks to provide behavior, accessibility, and interactions.
 
 Adobe is a large company with thousands of engineers working on hundreds of products, which must all meet high standards for UI consistency, accessibility, internationalization, and usability. Meeting these standards at our scale has been a challenge, and we’re excited to share what we’ve learned with the community and raise the bar for web applications together.
@@ -82,7 +82,7 @@ To enable reusing component behavior between design systems, React Spectrum spli
 
 ### React Stately
 
-[React Stately](https://react-spectrum.adobe.com/react-stately/index.html) is a collection of hooks that provide state management and core logic for each component. They make no assumptions about the platform they are running on, and have no theme or design system specific logic.
+[React Stately](https://react-spectrum.adobe.com/react-stately/index.html) is a collection of hooks that provide state management and core logic for each component. They make no assumptions about the platform they are running on, and have no theme or design system-specific logic.
 
 React Stately hooks accept common props from the component and provide state management. They implement the core logic for the component and return an interface for reading and updating the component state.
 
@@ -90,13 +90,13 @@ React Stately can be used independently in your own components, or paired with R
 
 ### React Aria
 
-[React Aria](https://react-spectrum.adobe.com/react-aria/index.html) implements behavior and [accessibility](https://react-spectrum.adobe.com/react-aria/accessibility.html) for the web according to the [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/). It includes full screen reader and keyboard navigation support, along with mouse and touch [interactions](https://react-spectrum.adobe.com/react-aria/interactions.html) that have been tested across a wide variety of devices and browsers. It also implements [internationalization](https://react-spectrum.adobe.com/react-aria/internationalization.html) for over 30 languages, including right-to-left specific behavior, localized date and number formatting, and more.
+[React Aria](https://react-spectrum.adobe.com/react-aria/index.html) implements behavior and [accessibility](https://react-spectrum.adobe.com/react-aria/accessibility.html) for the web according to the [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/). It includes full screen reader and keyboard navigation support, along with mouse and touch [interactions](https://react-spectrum.adobe.com/react-aria/interactions.html) that have been tested across a wide variety of devices and browsers. It also implements [internationalization](https://react-spectrum.adobe.com/react-aria/internationalization.html) for over 30 languages, with right-to-left specific behavior, localized date and number formatting, and more.
 
-React Aria includes no design system specific styling or logic. It implements event handling, accessibility, internationalization, etc. — all the parts of a component that could be shared across multiple design systems. It returns DOM props that can be spread onto the elements rendered by the component. These include semantic properties like [ARIA](https://www.w3.org/TR/wai-aria-1.2/), and event handlers. The event handlers in turn call methods on the state interface to implement the behavior for the component.
+React Aria does not contain any design system specific styling or logic. It implements event handling, accessibility, internationalization, etc. — all the parts of a component that could be shared across multiple design systems. It returns DOM props that can be spread onto the elements rendered by the component. These include semantic properties like [ARIA](https://www.w3.org/TR/wai-aria-1.2/), and event handlers. The event handlers in turn call methods on the state interface to implement the behavior for the component.
 
 React Aria gives you complete control over the rendering and styling of your components, but rather than building everything from scratch, you start with higher level primitives that have semantic meaning, behavior, and interactions built in. This allows you to **build components more quickly**, and ensures that they work well across devices and assistive technology.
 
-Building a component with React Aria and React Stately looks like this. Call the hooks, and spread the resulting props onto the appropriate DOM elements.
+Building a component with React Aria and React Stately looks like this: call the hooks, and spread the resulting props onto the appropriate DOM elements.
 
 ```tsx example
 function Switch(props) {
@@ -130,7 +130,7 @@ function Switch(props) {
 
 [React Spectrum](https://react-spectrum.adobe.com/react-spectrum/index.html) puts all of these pieces together and implements the Adobe-specific styling. It's designed to be adaptive, and works across mouse, touch, and keyboard interactions, on devices of any screen size. It supports [theming](https://react-spectrum.adobe.com/react-spectrum/theming.html), including automatic support for dark mode, and responsive scaling for large hit targets on touch devices.
 
-If you’re integrating with Adobe software or would like an end-to-end component library to use in your project, then React Spectrum is a great place to start. Save time by using [Project Firefly](https://www.adobe.io/apis/experienceplatform/project-firefly.html), our complete framework for building custom cloud-native Adobe apps. Enterprise customers and partners can extend the functionality of Adobe Experience Platform and Adobe Experience Cloud solutions in a custom app that solves specific business and workflow needs. [Sign up](https://adobeio.typeform.com/to/obqgRm) to get access to Project Firefly developer preview.
+If you’re integrating with Adobe software or would like an end-to-end component library to use in your project, then React Spectrum is a great place to start. Save time by using [Project Firefly](https://www.adobe.io/apis/experienceplatform/project-firefly.html), our complete framework for building custom cloud-native Adobe apps. Enterprise customers and partners can extend the functionality of Adobe Experience Platform and Adobe Experience Cloud solutions in a custom app that solves specific business and workflow needs. [Sign up](https://adobeio.typeform.com/to/obqgRm) to get access to the Project Firefly developer preview.
 
 We’ve designed the APIs in React Spectrum to be easy to use. The following example shows how simple it is to create a select element with support for sections and complex options.
 

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -97,7 +97,7 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
   let description = stripMarkdown(currentPage.description) || `Documentation for ${currentPage.title} in the ${pageSection} package.`;
   let title = currentPage.title + (!/index\.html$/.test(currentPage.name) || isBlog ? ` – ${pageSection}` : '');
   let hero = (parts.length > 1 ? HERO[parts[0]] : '') || heroImageHome;
-  let heroUrl = `https://${TLD}/${currentPage.image || path.basename(hero)}`
+  let heroUrl = `https://${TLD}/${currentPage.image || path.basename(hero)}`;
 
   return (
     <html

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -97,6 +97,7 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
   let description = stripMarkdown(currentPage.description) || `Documentation for ${currentPage.title} in the ${pageSection} package.`;
   let title = currentPage.title + (!/index\.html$/.test(currentPage.name) || isBlog ? ` – ${pageSection}` : '');
   let hero = (parts.length > 1 ? HERO[parts[0]] : '') || heroImageHome;
+  let heroUrl = `https://${TLD}/${currentPage.image || path.basename(hero)}`
 
   return (
     <html
@@ -164,11 +165,11 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
         <meta name="description" content={description} />
         <meta name="keywords" content={keywords} />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content={`https://${TLD}${heroImage}`} />
+        <meta name="twitter:image" content={heroUrl} />
         <meta property="og:title" content={currentPage.title} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={`https://${TLD}${currentPage.url}`} />
-        <meta property="og:image" content={`https://${TLD}/${currentPage.image || path.basename(hero)}`} />
+        <meta property="og:image" content={heroUrl} />
         <meta property="og:description" content={description} />
         <meta property="og:locale" content="en_US" />
         <script
@@ -180,7 +181,7 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
               author: 'Adobe Inc',
               headline: currentPage.title,
               description: description,
-              image: `https://${TLD}${heroImage}`,
+              image: heroUrl,
               publisher: {
                 '@type': 'Organization',
                 url: 'https://www.adobe.com',

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -15,7 +15,10 @@ import classNames from 'classnames';
 import {Divider} from '@react-spectrum/divider';
 import docStyles from './docs.css';
 import {getAnchorProps} from './utils';
-import heroImage from 'url:../pages/assets/ReactSpectrum_976x445_2x.png';
+import heroImageAria from 'url:../pages/assets/ReactAria_976x445_2x.png';
+import heroImageHome from 'url:../pages/assets/ReactSpectrumHome_976x445_2x.png';
+import heroImageSpectrum from 'url:../pages/assets/ReactSpectrum_976x445_2x.png';
+import heroImageStately from 'url:../pages/assets/ReactStately_976x445_2x.png';
 import highlightCss from './syntax-highlight.css';
 import {ImageContext} from './Image';
 import {LinkProvider} from './types';
@@ -30,6 +33,11 @@ import {ToC} from './ToC';
 import typographyStyles from '@adobe/spectrum-css-temp/components/typography/vars.css';
 
 const TLD = 'react-spectrum.adobe.com';
+const HERO = {
+  'react-spectrum': heroImageSpectrum,
+  'react-aria': heroImageAria,
+  'react-stately': heroImageStately
+};
 
 const mdxComponents = {
   h1: ({children, ...props}) => (
@@ -77,8 +85,9 @@ function stripMarkdown(description) {
 }
 
 function Page({children, currentPage, publicUrl, styles, scripts}) {
-  let isBlog = currentPage.name.startsWith('blog/');
-  let isSubpage = currentPage.name.split('/').length > 1 && !/index\.html$/.test(currentPage.name);
+  let parts = currentPage.name.split('/');
+  let isBlog = parts[0] === 'blog';
+  let isSubpage = parts.length > 1 && !/index\.html$/.test(currentPage.name);
   let pageSection = isSubpage ? dirToTitle(currentPage.name) : 'React Spectrum';
   if (isBlog && isSubpage) {
     pageSection = 'React Spectrum Blog';
@@ -87,6 +96,7 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
   let keywords = [...new Set(currentPage.keywords.concat([currentPage.category, currentPage.title, pageSection]).filter(k => !!k))];
   let description = stripMarkdown(currentPage.description) || `Documentation for ${currentPage.title} in the ${pageSection} package.`;
   let title = currentPage.title + (!/index\.html$/.test(currentPage.name) || isBlog ? ` – ${pageSection}` : '');
+  let hero = (parts.length > 1 ? HERO[parts[0]] : '') || heroImageHome;
 
   return (
     <html
@@ -158,7 +168,7 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
         <meta property="og:title" content={currentPage.title} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={`https://${TLD}${currentPage.url}`} />
-        <meta property="og:image" content={`https://${TLD}/${currentPage.image || path.basename(heroImage)}`} />
+        <meta property="og:image" content={`https://${TLD}/${currentPage.image || path.basename(hero)}`} />
         <meta property="og:description" content={description} />
         <meta property="og:locale" content="en_US" />
         <script

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -80,7 +80,7 @@ html, body {
   .example {
     background-color: var(--spectrum-global-color-gray-100);
   }
-  article pre  {
+  .article pre  {
     --hljs-background:  #212121; /* between gray-100 and gray-200 */
     background-color: var(--hljs-background);
   }
@@ -105,6 +105,10 @@ html, body {
     max-width: 100%;
     border-radius: 4px;
   }
+}
+
+.inCategory .heroImage {
+  padding-bottom: 0;
 }
 
 .homeLinks {
@@ -238,7 +242,7 @@ main {
   align-items: center;
 }
 
-article {
+.article {
   max-width: 967px;
   flex: 1;
   padding-bottom: 40px;
@@ -317,7 +321,7 @@ footer li:last-child:after {
   }
 }
 
-article h1.articleHeader {
+.article h1.articleHeader {
   margin-top: 0 !important;
   /* scale font size between 32px and 58px
    * 10vw is 32px at 320px viewport size. */
@@ -328,19 +332,19 @@ article h1.articleHeader {
   max-width: 100%;
 }
 
-article h1.articleHeader + p {
+.article h1.articleHeader + p {
   font-size: var(--spectrum-body-2-text-size);
 }
 
-article.inCategory h1.articleHeader + p {
+.article.inCategory h1.articleHeader + p {
   max-width: 75%;
 }
 
-article.inCategory h2.sectionHeader.docsHeader {
+.article.inCategory h2.sectionHeader.docsHeader {
   margin-top: 80px;
 }
 
-article.inCategory h2.sectionHeader + hr {
+.article.inCategory h2.sectionHeader + hr {
   margin-bottom: 33px;
 }
 
@@ -360,7 +364,7 @@ article.inCategory h2.sectionHeader + hr {
   font-family: inherit !important;
 }
 
-article pre {
+.article pre {
   background: var(--spectrum-global-color-gray-75);
   padding: 18px;
   border-radius: 4px;
@@ -368,18 +372,18 @@ article pre {
   white-space: pre-wrap;
 }
 
-article pre:global(.example) {
+.article pre:global(.example) {
   border-radius: 4px 4px 0 0;
   margin-bottom: 0;
 }
 
 /* Display large width code examples by default */
-article pre:global(.small),
-article pre:global(.medium) {
+.article pre:global(.small),
+.article pre:global(.medium) {
   display: none;
 }
 
-article pre + div > .example {
+.article pre + div > .example {
   border-radius: 0 0 4px 4px;
 }
 
@@ -396,7 +400,7 @@ code {
   font-size: var(--spectrum-global-dimension-static-font-size-150);
 }
 
-article > code {
+.article > code {
   display: block;
 }
 
@@ -575,6 +579,29 @@ h2.sectionHeader {
   text-decoration-style: double;
 }
 
+.blogArticle {
+  margin: 40px 0;
+  max-width: 800px;
+}
+
+.blogHeader {
+  margin-bottom: 24px;
+}
+
+.blogArticle .blogHeader {
+  margin-bottom: 12px;
+}
+
+.blogHeader h1,
+.blogHeader h2 {
+  margin-top: 0;
+  margin-bottom: 0 !important;
+}
+
+.blogArticle p {
+  margin-bottom: 0;
+}
+
 @media (max-width: 750px) {
   .float {
     float: none;
@@ -713,17 +740,17 @@ h2.sectionHeader {
   }
 
   /* Expand the component description to full width */
-  article h1 + p {
+  .article h1 + p {
     max-width: initial !important;
   }
 
   /* Swap to displaying the medium width code examples */
-  article pre:global(.small),
-  article pre:global(.large) {
+  .article pre:global(.small),
+  .article pre:global(.large) {
     display: none;
   }
 
-  article pre:global(.medium) {
+  .article pre:global(.medium) {
     display: block;
   }
 
@@ -732,7 +759,7 @@ h2.sectionHeader {
     padding: 14px;
   }
 
-  article pre {
+  .article pre {
     padding: 8px;
   }
 
@@ -741,12 +768,12 @@ h2.sectionHeader {
 
 @media (max-width: 500px) {
   /* Swap to displaying the small width code examples */
-  article pre:global(.medium),
-  article pre:global(.large) {
+  .article pre:global(.medium),
+  .article pre:global(.large) {
     display: none;
   }
 
-  article pre:global(.small) {
+  .article pre:global(.small) {
     display: block;
   }
 

--- a/packages/dev/parcel-optimizer-ssg/SSGOptimizer.js
+++ b/packages/dev/parcel-optimizer-ssg/SSGOptimizer.js
@@ -36,7 +36,11 @@ module.exports = new Optimizer({
           url: urlJoin(b.target.publicUrl, rename(b)),
           name: rename(b),
           title: meta.title,
-          category: meta.category
+          category: meta.category,
+          description: meta.description,
+          keywords: meta.keywords,
+          date: meta.date,
+          image: getImageURL(meta.image, bundleGraph, b)
         });
       }
     });
@@ -58,7 +62,9 @@ module.exports = new Optimizer({
           title: mainAsset.meta.title,
           url: urlJoin(bundle.target.publicUrl, name),
           description: mainAsset.meta.description,
-          keywords: mainAsset.meta.keywords
+          keywords: mainAsset.meta.keywords,
+          date: mainAsset.meta.date,
+          image: getImageURL(mainAsset.meta.image, bundleGraph, bundle)
         },
         toc: mainAsset.meta.toc,
         publicUrl: bundle.target.publicUrl
@@ -74,4 +80,22 @@ module.exports = new Optimizer({
 
 function rename(bundle) {
   return bundle.name.slice(0, -bundle.type.length) + 'html';
+}
+
+function getImageURL(image, bundleGraph, bundle) {
+  if (!image) {
+    return '';
+  }
+
+  let dep = bundle.getMainEntry().getDependencies().find(d => d.id === image);
+  if (!dep) {
+    return '';
+  }
+
+  let resolved = bundleGraph.getReferencedBundle(dep, bundle);
+  if (!resolved) {
+    return '';
+  }
+
+  return resolved.name;
 }

--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -122,6 +122,8 @@ module.exports = new Transformer({
     let category = '';
     let keywords = [];
     let description = '';
+    let date = '';
+    let image = '';
     const extractToc = (options) => {
       const settings = options || {};
       const depth = settings.maxDepth || 6;
@@ -174,6 +176,13 @@ module.exports = new Transformer({
           category = yamlData.category || '';
           keywords = yamlData.keywords || [];
           description = yamlData.description || '';
+          date = yamlData.date || '';
+          if (yamlData.image) {
+            image = asset.addDependency({
+              moduleSpecifier: yamlData.image,
+              isURL: true
+            });
+          }
         }
 
         return node;
@@ -231,6 +240,8 @@ module.exports = new Transformer({
     asset.meta.category = category;
     asset.meta.description = description;
     asset.meta.keywords = keywords;
+    asset.meta.date = date;
+    asset.meta.image = image;
     asset.meta.isMDX = true;
     asset.isSplittable = false;
 


### PR DESCRIPTION
Depends on #733.

This adds a blog section to the website, along with the first post. The blog works slightly different from other sections of the site. Rather than listing the posts in the sidebar, the blog lives at the root of the site. There's a separate post listing page that can be used to navigate to one of the individual blog post pages. Each post works similarly to our existing pages. The only addition is a date property in the metadata which is used to display the post date in both the listing and individual pages. Finally, there's an `image` meta property which is used to generate the `og:image` meta tag for social sharing.