### PR TITLE
Move docs dev dependency to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@actions/core": "^1.1.0",
     "@actions/github": "^1.1.0",
+    "@adobe/spectrum-css-workflow-icons": "^1.0.0",
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.4.5",

--- a/packages/@react-spectrum/icon/package.json
+++ b/packages/@react-spectrum/icon/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1",
-    "@adobe/spectrum-css-workflow-icons": "^1.0.0",
     "@spectrum-icons/workflow": "^3.0.0"
   },
   "peerDependencies": {

--- a/scripts/buildWebsite.js
+++ b/scripts/buildWebsite.js
@@ -42,7 +42,8 @@ async function build() {
           name === 'parcel' ||
           name === 'patch-package' ||
           name.startsWith('@spectrum-css') ||
-          name.startsWith('postcss')
+          name.startsWith('postcss') ||
+          name.startsWith('@adobe')
         )
     ),
     dependencies: {},


### PR DESCRIPTION
Dev dependencies won't be installed from published packages when building the docs for production