### PR TITLE
RSP-1863 [Docs][A11y] Improve permalink labeling

### DIFF
--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -41,7 +41,7 @@ const mdxComponents = {
       <h2 {...props} className={classNames(typographyStyles['spectrum-Heading3'], docStyles['sectionHeader'], docStyles['docsHeader'])}>
         {children}
         <span className={classNames(docStyles['headingAnchor'])}>
-          <a className={classNames(linkStyle['spectrum-Link'], docStyles.link, docStyles.anchor)} href={`#${props.id}`}>#</a>
+          <a className={classNames(linkStyle['spectrum-Link'], docStyles.link, docStyles.anchor)} href={`#${props.id}`} aria-label={`Direct link to ${children}`}>#</a>
         </span>
       </h2>
       <Divider marginBottom="33px" />
@@ -51,7 +51,7 @@ const mdxComponents = {
     <h3 {...props} className={classNames(typographyStyles['spectrum-Heading4'], docStyles['sectionHeader'], docStyles['docsHeader'])}>
       {children}
       <span className={docStyles['headingAnchor']}>
-        <a className={classNames(linkStyle['spectrum-Link'], docStyles.link, docStyles.anchor)} href={`#${props.id}`} aria-label="§">#</a>
+        <a className={classNames(linkStyle['spectrum-Link'], docStyles.link, docStyles.anchor)} href={`#${props.id}`} aria-label={`Direct link to ${children}`}>#</a>
       </span>
     </h3>
   ),


### PR DESCRIPTION
Provide unique label names for permalink links in documentation.


Closes [RSP-1863](https://jira.corp.adobe.com/browse/RSP-1863)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [RSP-1863](https://jira.corp.adobe.com/browse/RSP-1863).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Run yarn start:docs, open http://localhost:1234/react-aria/useListBox.html
2. Verify that each permalink within each heading has a unique label like: "Direct link to Features"

## 🧢 Your Project:

Accessibility
