### PR TITLE
Workaround search field css issue

### DIFF
--- a/packages/@react-spectrum/icon/docs/workflow-icons.mdx
+++ b/packages/@react-spectrum/icon/docs/workflow-icons.mdx
@@ -16,8 +16,8 @@ import packageData from '@react-spectrum/icon/package.json';
 import workflowIconPackageData from '@spectrum-icons/workflow/package.json';
 
 ```jsx import
-import {Icon} from '@react-spectrum/icon';
-import IconTable from './IconTable';
+// import {Icon} from '@react-spectrum/icon';
+// import IconTable from './IconTable';
 ```
 
 ---
@@ -74,6 +74,9 @@ import LockClosed from '@spectrum-icons/workflow/LockClosed';
 
 ## Available Icons
 
-```tsx snippet
+A [searchable list of workflow icons](https://spectrum.adobe.com/page/icons/) is available on the Spectrum website.
+The name of the icon without any whitespace matches the import in React Spectrum.
+
+<!-- ```tsx snippet
 <IconTable iconPackage="workflow" />
-```
+``` -->


### PR DESCRIPTION
Removes the icon table for now. Likely a parcel issue where the css for textfield wasn't getting placed in the correct bundle groups. Luckily, Spectrum already has an icon page we can link to in the meantime.