### PR TITLE
fixed a command to start storybook in contributing docs

### DIFF
--- a/packages/dev/docs/pages/contribute.mdx
+++ b/packages/dev/docs/pages/contribute.mdx
@@ -87,7 +87,7 @@ yarn install
 
 You can then run the storybook and browse to [http://localhost:9003](http://localhost:9003) with:
 ```bash
-yarn run
+yarn start
 ```
 
 Or run the documentation and browse to [http://localhost:1234/](http://localhost:1234/) with:


### PR DESCRIPTION
no jira/issue

## 📝 Test Instructions:

goto the contributing page in the docs
confirm the instructions to start storybook are `yarn start`

## 🧢 Your Project:
RSP