### PR TITLE
Fix useKeyboard example

### DIFF
--- a/packages/@react-aria/interactions/docs/useKeyboard.mdx
+++ b/packages/@react-aria/interactions/docs/useKeyboard.mdx
@@ -71,7 +71,7 @@ function Example() {
     onKeyDown: e => setEvents(
       events => [`key down: ${e.key}`, ...events]
     ),
-    onKeyDown: e => setEvents(
+    onKeyUp: e => setEvents(
       events => [`key up: ${e.key}`, ...events]
     )
   });


### PR DESCRIPTION
In the `useKeyboard` doc it has an example using both the `onKeyDown` and `onKeyUp` handlers, but both were actually using `onKeyDown`. I've changed the second handler to `onKeyUp` since it seems that was intended.

```tsx example
  let {keyboardProps} = useKeyboard({
    onKeyDown: e => setEvents(
      events => [`key down: ${e.key}`, ...events]
    ),
    onKeyUp: e => setEvents(
      events => [`key up: ${e.key}`, ...events]
    )
  });
```