### PR TITLE
keep package name for everything except react-spectrum

### DIFF
--- a/packages/dev/docs/src/HeaderInfo.js
+++ b/packages/dev/docs/src/HeaderInfo.js
@@ -28,7 +28,7 @@ export function HeaderInfo(props) {
   } = props;
 
   let importName = packageData.name;
-  if (process.env.DOCS_ENV === 'production') {
+  if (importName.startsWith('@react-spectrum') && process.env.DOCS_ENV === 'production') {
     importName = '@adobe/react-spectrum';
   }
 


### PR DESCRIPTION
Hey,

Was just trying out react-aria and noticed the docs have an incorrect import in the usage section.
This PR attempts to fix that.

Current Behaviour:

![Screenshot 2020-07-15 at 22 20 57](https://user-images.githubusercontent.com/2175521/87592147-ab30c080-c6e9-11ea-90c1-e4a15fe58913.png)

Expected behaviour (I think, not sure):
![Screenshot 2020-07-15 at 22 21 05](https://user-images.githubusercontent.com/2175521/87592192-c00d5400-c6e9-11ea-94a6-3514a3403831.png)

There's not really a github issue for this and didn't really wanna open one as I might as well just fix it right away :)

Congrats on the release and looking forward to using react-aria a lot in the future

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
