### PR TITLE
Check is window exists in setupGlobalFocusEvents

### DIFF
--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -105,7 +105,7 @@ function handleWindowBlur() {
  * Setup global event listeners to control when keyboard focus style should be visible.
  */
 function setupGlobalFocusEvents() {
-  if (hasSetupGlobalListeners) {
+  if ( window === 'undefined' || hasSetupGlobalListeners) {
     return;
   }
 

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -105,7 +105,7 @@ function handleWindowBlur() {
  * Setup global event listeners to control when keyboard focus style should be visible.
  */
 function setupGlobalFocusEvents() {
-  if ( window === 'undefined' || hasSetupGlobalListeners) {
+  if (typeof window === 'undefined' || hasSetupGlobalListeners) {
     return;
   }
 


### PR DESCRIPTION
`setupGlobalFocusEvents` should check if window exists to prevent crash on server side.

cc @Skona27

Closes #767 