### PR TITLE
Allow arbitrary number of prop objects to be passed to mergeProps

### DIFF
--- a/packages/@react-aria/utils/docs/mergeProps.mdx
+++ b/packages/@react-aria/utils/docs/mergeProps.mdx
@@ -38,7 +38,7 @@ This can be useful when you need to combine the results of multiple react-aria h
 element. For example, both hooks may return the same event handlers, class names, or ids, and only
 one of these can be applied. `mergeProps` handles combining these props together so that multiple
 event handlers will be chained, multiple classes will be combined, and ids will be deduplicated.
-For all other props, the second props object overrides the first.
+For all other props, the last prop object overrides all previous ones.
 
 ## Example
 

--- a/packages/@react-aria/utils/src/mergeProps.ts
+++ b/packages/@react-aria/utils/src/mergeProps.ts
@@ -18,42 +18,67 @@ interface Props {
   [key: string]: any
 }
 
+// taken from: https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379
+type TupleTypes<T> = { [P in keyof T]: T[P] } extends { [key: number]: infer V }
+  ? V
+  : never;
+type UnionToIntersection<U> = (U extends any
+  ? (k: U) => void
+  : never) extends ((k: infer I) => void)
+  ? I
+  : never;
+
 /**
  * Merges multiple props objects together. Event handlers are chained,
  * classNames are combined, and ids are deduplicated. For all other props,
- * the second props object overrides the first.
+ * the last prop object overrides all previous ones.
  * @param a - The first set of props to merge.
- * @param b - The second set of props to merge.
+ * @param rest - The remaining sets of props to merge.
  */
-export function mergeProps<T extends Props, U extends Props>(a: T, b: U): T & U {
-  let res: Props = {};
-  for (let key in a) {
-    // Chain events
-    if (/^on[A-Z]/.test(key) && typeof a[key] === 'function' && typeof b[key] === 'function') {
-      res[key] = chain(a[key], b[key]);
+export function mergeProps<T extends Props, U extends Props[]>(
+  a: T,
+  ...rest: U
+): T & UnionToIntersection<TupleTypes<U>> {
+  let result: Props = { ...a };
+  for (let b of rest) {
+    for (let key in result) {
+      // Chain events
+      if (
+        /^on[A-Z]/.test(key) &&
+        typeof result[key] === "function" &&
+        typeof b[key] === "function"
+      ) {
+        result[key] = chain(result[key], b[key]);
 
-    // Merge classnames, sometimes classNames are empty string which eval to false, so we just need to do a type check
-    } else if (key === 'className' && typeof a.className === 'string' && typeof b.className === 'string') {
-      res[key] = classNames(a.className, b.className);
+        // Merge classnames, sometimes classNames are empty string which eval to false, so we just need to do a type check
+      } else if (
+        key === "className" &&
+        typeof result.className === "string" &&
+        typeof b.className === "string"
+      ) {
+        result[key] = classNames(result.className, b.className);
+      } else if (
+        key === "UNSAFE_className" &&
+        typeof result.UNSAFE_className === "string" &&
+        typeof b.UNSAFE_className === "string"
+      ) {
+        result[key] = classNames(result.UNSAFE_className, b.UNSAFE_className);
+      } else if (key === "id" && result.id && b.id) {
+        result.id = mergeIds(result.id, b.id);
 
-    } else if (key === 'UNSAFE_className' && typeof a.UNSAFE_className === 'string' && typeof b.UNSAFE_className === 'string') {
-      res[key] = classNames(a.UNSAFE_className, b.UNSAFE_className);
+        // Override others
+      } else {
+        result[key] = b[key] !== undefined ? b[key] : result[key];
+      }
+    }
 
-    } else if (key === 'id' && a.id && b.id) {
-      res.id = mergeIds(a.id, b.id);
-
-    // Override others
-    } else {
-      res[key] = b[key] !== undefined ? b[key] : a[key];
+    // Add props from b that are not in a
+    for (let key in b) {
+      if (result[key] === undefined) {
+        result[key] = b[key];
+      }
     }
   }
 
-  // Add props from b that are not in a
-  for (let key in b) {
-    if (a[key] === undefined) {
-      res[key] = b[key];
-    }
-  }
-
-  return res as T & U;
+  return result as T & UnionToIntersection<TupleTypes<U>>;
 }

--- a/packages/@react-aria/utils/src/mergeProps.ts
+++ b/packages/@react-aria/utils/src/mergeProps.ts
@@ -1,11 +1,11 @@
 /*
  * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */

--- a/packages/@react-aria/utils/src/mergeProps.ts
+++ b/packages/@react-aria/utils/src/mergeProps.ts
@@ -1,11 +1,11 @@
 /*
  * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * This file is licensed to you under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
@@ -39,31 +39,31 @@ export function mergeProps<T extends Props, U extends Props[]>(
   a: T,
   ...rest: U
 ): T & UnionToIntersection<TupleTypes<U>> {
-  let result: Props = { ...a };
+  let result: Props = {...a};
   for (let b of rest) {
     for (let key in result) {
       // Chain events
       if (
         /^on[A-Z]/.test(key) &&
-        typeof result[key] === "function" &&
-        typeof b[key] === "function"
+        typeof result[key] === 'function' &&
+        typeof b[key] === 'function'
       ) {
         result[key] = chain(result[key], b[key]);
 
         // Merge classnames, sometimes classNames are empty string which eval to false, so we just need to do a type check
       } else if (
-        key === "className" &&
-        typeof result.className === "string" &&
-        typeof b.className === "string"
+        key === 'className' &&
+        typeof result.className === 'string' &&
+        typeof b.className === 'string'
       ) {
         result[key] = classNames(result.className, b.className);
       } else if (
-        key === "UNSAFE_className" &&
-        typeof result.UNSAFE_className === "string" &&
-        typeof b.UNSAFE_className === "string"
+        key === 'UNSAFE_className' &&
+        typeof result.UNSAFE_className === 'string' &&
+        typeof b.UNSAFE_className === 'string'
       ) {
         result[key] = classNames(result.UNSAFE_className, b.UNSAFE_className);
-      } else if (key === "id" && result.id && b.id) {
+      } else if (key === 'id' && result.id && b.id) {
         result.id = mergeIds(result.id, b.id);
         // Override others
       } else {

--- a/packages/@react-aria/utils/src/mergeProps.ts
+++ b/packages/@react-aria/utils/src/mergeProps.ts
@@ -19,65 +19,55 @@ interface Props {
 }
 
 // taken from: https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379
-type TupleTypes<T> = { [P in keyof T]: T[P] } extends { [key: number]: infer V }
-  ? V
-  : never;
-type UnionToIntersection<U> = (U extends any
-  ? (k: U) => void
-  : never) extends ((k: infer I) => void)
-  ? I
-  : never;
+type TupleTypes<T> = { [P in keyof T]: T[P] } extends { [key: number]: infer V } ? V : never;
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
 
 /**
  * Merges multiple props objects together. Event handlers are chained,
  * classNames are combined, and ids are deduplicated. For all other props,
  * the last prop object overrides all previous ones.
- * @param a - The first set of props to merge.
- * @param rest - The remaining sets of props to merge.
+ * @param args - Multiple sets of props to merge together.
  */
-export function mergeProps<T extends Props, U extends Props[]>(
-  a: T,
-  ...rest: U
-): T & UnionToIntersection<TupleTypes<U>> {
-  let result: Props = {...a};
-  for (let b of rest) {
+export function mergeProps<T extends Props[]>(...args: T): UnionToIntersection<TupleTypes<T>> {
+  let result: Props = {};
+  for (let props of args) {
     for (let key in result) {
       // Chain events
       if (
         /^on[A-Z]/.test(key) &&
         typeof result[key] === 'function' &&
-        typeof b[key] === 'function'
+        typeof props[key] === 'function'
       ) {
-        result[key] = chain(result[key], b[key]);
+        result[key] = chain(result[key], props[key]);
 
         // Merge classnames, sometimes classNames are empty string which eval to false, so we just need to do a type check
       } else if (
         key === 'className' &&
         typeof result.className === 'string' &&
-        typeof b.className === 'string'
+        typeof props.className === 'string'
       ) {
-        result[key] = classNames(result.className, b.className);
+        result[key] = classNames(result.className, props.className);
       } else if (
         key === 'UNSAFE_className' &&
         typeof result.UNSAFE_className === 'string' &&
-        typeof b.UNSAFE_className === 'string'
+        typeof props.UNSAFE_className === 'string'
       ) {
-        result[key] = classNames(result.UNSAFE_className, b.UNSAFE_className);
-      } else if (key === 'id' && result.id && b.id) {
-        result.id = mergeIds(result.id, b.id);
+        result[key] = classNames(result.UNSAFE_className, props.UNSAFE_className);
+      } else if (key === 'id' && result.id && props.id) {
+        result.id = mergeIds(result.id, props.id);
         // Override others
       } else {
-        result[key] = b[key] !== undefined ? b[key] : result[key];
+        result[key] = props[key] !== undefined ? props[key] : result[key];
       }
     }
 
     // Add props from b that are not in a
-    for (let key in b) {
+    for (let key in props) {
       if (result[key] === undefined) {
-        result[key] = b[key];
+        result[key] = props[key];
       }
     }
   }
 
-  return result as T & UnionToIntersection<TupleTypes<U>>;
+  return result as UnionToIntersection<TupleTypes<T>>;
 }

--- a/packages/@react-aria/utils/src/mergeProps.ts
+++ b/packages/@react-aria/utils/src/mergeProps.ts
@@ -65,7 +65,6 @@ export function mergeProps<T extends Props, U extends Props[]>(
         result[key] = classNames(result.UNSAFE_className, b.UNSAFE_className);
       } else if (key === "id" && result.id && b.id) {
         result.id = mergeIds(result.id, b.id);
-
         // Override others
       } else {
         result[key] = b[key] !== undefined ? b[key] : result[key];

--- a/packages/@react-aria/utils/test/mergeProps.test.js
+++ b/packages/@react-aria/utils/test/mergeProps.test.js
@@ -27,43 +27,43 @@ describe('mergeProps', function () {
   });
 
   it('combines callbacks', function () {
-    console.log = jest.fn();
+    let mockFn = jest.fn();
     let message1 = 'click1';
     let message2 = 'click2';
     let message3 = 'click3';
     let mergedProps = mergeProps(
-      {onClick: () => console.log(message1)},
-      {onClick: () => console.log(message2)},
-      {onClick: () => console.log(message3)}
+      {onClick: () => mockFn(message1)},
+      {onClick: () => mockFn(message2)},
+      {onClick: () => mockFn(message3)}
     );
     mergedProps.onClick();
-    expect(console.log).toHaveBeenNthCalledWith(1, message1);
-    expect(console.log).toHaveBeenNthCalledWith(2, message2);
-    expect(console.log).toHaveBeenNthCalledWith(3, message3);
-    expect(console.log).toHaveBeenCalledTimes(3);
+    expect(mockFn).toHaveBeenNthCalledWith(1, message1);
+    expect(mockFn).toHaveBeenNthCalledWith(2, message2);
+    expect(mockFn).toHaveBeenNthCalledWith(3, message3);
+    expect(mockFn).toHaveBeenCalledTimes(3);
   });
 
   it('merges props with different keys', function () {
-    console.log = jest.fn();
+    let mockFn = jest.fn();
     let click1 = 'click1';
     let click2 = 'click2';
     let hover = 'hover';
     let focus = 'focus';
     let margin = 2;
     const mergedProps = mergeProps(
-      {onClick: () => console.log(click1)},
-      {onHover: () => console.log(hover), styles: {margin}},
-      {onClick: () => console.log(click2), onFocus: () => console.log(focus)}
+      {onClick: () => mockFn(click1)},
+      {onHover: () => mockFn(hover), styles: {margin}},
+      {onClick: () => mockFn(click2), onFocus: () => mockFn(focus)}
     );
 
     mergedProps.onClick();
-    expect(console.log).toHaveBeenNthCalledWith(1, click1);
-    expect(console.log).toHaveBeenNthCalledWith(2, click2);
+    expect(mockFn).toHaveBeenNthCalledWith(1, click1);
+    expect(mockFn).toHaveBeenNthCalledWith(2, click2);
     mergedProps.onFocus();
-    expect(console.log).toHaveBeenNthCalledWith(3, focus);
+    expect(mockFn).toHaveBeenNthCalledWith(3, focus);
     mergedProps.onHover();
-    expect(console.log).toHaveBeenNthCalledWith(4, hover);
-    expect(console.log).toHaveBeenCalledTimes(4);
+    expect(mockFn).toHaveBeenNthCalledWith(4, hover);
+    expect(mockFn).toHaveBeenCalledTimes(4);
     expect(mergedProps.styles.margin).toBe(margin);
   });
 

--- a/packages/@react-aria/utils/test/mergeProps.test.js
+++ b/packages/@react-aria/utils/test/mergeProps.test.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import classNames from 'classnames';
+import {mergeIds} from '../src/useId';
+import {mergeProps} from '../';
+
+
+describe('mergeProps', function () {
+  it('handles one argument', function () {
+    let onClick = () => {};
+    let classname = 'primary';
+    let id = 'test_id';
+    let mergedProps = mergeProps({onClick, classname, id});
+    expect(mergedProps.onClick).toBe(onClick);
+    expect(mergedProps.classname).toBe(classname);
+    expect(mergedProps.id).toBe(id);
+  });
+
+  it('combines callbacks', function () {
+    console.log = jest.fn();
+    let message1 = 'click1';
+    let message2 = 'click2';
+    let message3 = 'click3';
+
+    let a = {onClick: () => console.log(message1)};
+    let b = {onClick: () => console.log(message2)};
+    let c = {onClick: () => console.log(message3)};
+    let mergedProps = mergeProps(a, b, c);
+    mergedProps.onClick();
+    expect(console.log).toHaveBeenCalledWith(message1);
+    expect(console.log).toHaveBeenCalledWith(message2);
+    expect(console.log).toHaveBeenCalledWith(message3);
+    expect(console.log).toHaveBeenCalledTimes(3);
+  });
+
+  it('combines classNames', function () {
+    let className1 = 'primary';
+    let className2 = 'hover';
+    let className3 = 'hover';
+    let mergedProps = mergeProps({className: className1}, {className: className2}, {className: className3});
+    let mergedClassNames = classNames(className1, className2, className3);
+    expect(mergedProps.className).toBe(mergedClassNames);
+  });
+
+  it('combines ids', function () {
+    let id1 = 'id1';
+    let id2 = 'id2';
+    let id3 = 'id3';
+    let mergedProps = mergeProps({id: id1}, {id: id2}, {id: id3});
+    let mergedIds = mergeIds(mergeIds(id1, id2), id3);
+    expect(mergedProps.id).toBe(mergedIds);
+  });
+});

--- a/packages/@react-aria/utils/test/mergeProps.test.js
+++ b/packages/@react-aria/utils/test/mergeProps.test.js
@@ -43,6 +43,29 @@ describe('mergeProps', function () {
     expect(console.log).toHaveBeenCalledTimes(3);
   });
 
+  it('merges props with different keys', function () {
+    console.log = jest.fn();
+    let click1 = 'click1';
+    let click2 = 'click2';
+    let hover = 'hover';
+    let focus = 'focus';
+    let margin = 2;
+    const mergedProps = mergeProps(
+      {onClick: () => console.log(click1)},
+      {onHover: () => console.log(hover), styles: {margin}},
+      {onClick: () => console.log(click2), onFocus: () => console.log(focus)}
+    );
+    mergedProps.onClick();
+    mergedProps.onFocus();
+    mergedProps.onHover();
+    expect(console.log).toHaveBeenCalledWith(click1);
+    expect(console.log).toHaveBeenCalledWith(click2);
+    expect(console.log).toHaveBeenCalledWith(hover);
+    expect(console.log).toHaveBeenCalledWith(focus);
+    expect(console.log).toHaveBeenCalledTimes(4);
+    expect(mergedProps.styles.margin).toBe(margin);
+  });
+
   it('combines classNames', function () {
     let className1 = 'primary';
     let className2 = 'hover';

--- a/packages/@react-aria/utils/test/mergeProps.test.js
+++ b/packages/@react-aria/utils/test/mergeProps.test.js
@@ -18,11 +18,11 @@ import {mergeProps} from '../';
 describe('mergeProps', function () {
   it('handles one argument', function () {
     let onClick = () => {};
-    let classname = 'primary';
+    let className = 'primary';
     let id = 'test_id';
-    let mergedProps = mergeProps({onClick, classname, id});
+    let mergedProps = mergeProps({onClick, className, id});
     expect(mergedProps.onClick).toBe(onClick);
-    expect(mergedProps.classname).toBe(classname);
+    expect(mergedProps.className).toBe(className);
     expect(mergedProps.id).toBe(id);
   });
 
@@ -31,15 +31,15 @@ describe('mergeProps', function () {
     let message1 = 'click1';
     let message2 = 'click2';
     let message3 = 'click3';
-
-    let a = {onClick: () => console.log(message1)};
-    let b = {onClick: () => console.log(message2)};
-    let c = {onClick: () => console.log(message3)};
-    let mergedProps = mergeProps(a, b, c);
+    let mergedProps = mergeProps(
+      {onClick: () => console.log(message1)},
+      {onClick: () => console.log(message2)},
+      {onClick: () => console.log(message3)}
+    );
     mergedProps.onClick();
-    expect(console.log).toHaveBeenCalledWith(message1);
-    expect(console.log).toHaveBeenCalledWith(message2);
-    expect(console.log).toHaveBeenCalledWith(message3);
+    expect(console.log).toHaveBeenNthCalledWith(1, message1);
+    expect(console.log).toHaveBeenNthCalledWith(2, message2);
+    expect(console.log).toHaveBeenNthCalledWith(3, message3);
     expect(console.log).toHaveBeenCalledTimes(3);
   });
 
@@ -55,13 +55,14 @@ describe('mergeProps', function () {
       {onHover: () => console.log(hover), styles: {margin}},
       {onClick: () => console.log(click2), onFocus: () => console.log(focus)}
     );
+
     mergedProps.onClick();
+    expect(console.log).toHaveBeenNthCalledWith(1, click1);
+    expect(console.log).toHaveBeenNthCalledWith(2, click2);
     mergedProps.onFocus();
+    expect(console.log).toHaveBeenNthCalledWith(3, focus);
     mergedProps.onHover();
-    expect(console.log).toHaveBeenCalledWith(click1);
-    expect(console.log).toHaveBeenCalledWith(click2);
-    expect(console.log).toHaveBeenCalledWith(hover);
-    expect(console.log).toHaveBeenCalledWith(focus);
+    expect(console.log).toHaveBeenNthCalledWith(4, hover);
     expect(console.log).toHaveBeenCalledTimes(4);
     expect(mergedProps.styles.margin).toBe(margin);
   });
@@ -69,7 +70,7 @@ describe('mergeProps', function () {
   it('combines classNames', function () {
     let className1 = 'primary';
     let className2 = 'hover';
-    let className3 = 'hover';
+    let className3 = 'focus';
     let mergedProps = mergeProps({className: className1}, {className: className2}, {className: className3});
     let mergedClassNames = classNames(className1, className2, className3);
     expect(mergedProps.className).toBe(mergedClassNames);


### PR DESCRIPTION
Currently `mergeProps` only allows 2 arguments to be passed in at a time, which results in extra nesting whenever there are more than 2 prop objects that need to be merged, as seen in [this example](https://codesandbox.io/s/playing-with-react-aria-wvcjd?file=/src/App.js:1346-1417).

So instead of:
```js
let props = mergeProps(mergeProps(buttonProps, hoverProps), focusProps)
```

You can just do:
```js
let props = mergeProps(buttonProps, hoverProps, focusProps)
```

@devongovett [mentioned on twitter](https://twitter.com/devongovett/status/1283881587516424192) that the team ran into issues with TypeScript handling an arbitrary number.

I was able to [find a solution on stackoverflow](https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379) that helped me solve this, which I cited in the source code.

Please let me know if any more testing needs to be done or if there are any other steps I should take on this PR.
