### PR TITLE
Use selection manager isSelected method to check if menuitem is selected

### DIFF
--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -48,7 +48,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
     key
   } = item;
 
-  let isSelected = state.selectionManager.selectedKeys.has(key);
+  let isSelected = state.selectionManager.isSelected(key);
   let isDisabled = state.disabledKeys.has(key);
 
   let ref = useRef<HTMLLIElement>();

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -696,4 +696,15 @@ describe('MenuTrigger', function () {
       expect(buttonRef.current.UNSAFE_getDOMNode()).toBe(getByRole('button'));
     });
   });
+
+  it('should not show checkmarks if selectionMode not defined', function () {
+    let {queryByRole} = render(
+      <Menu selectedKeys={['alpha']}>
+        <Item key="alpha">Alpha</Item>
+        <Item key="bravo">Bravo</Item>
+      </Menu>
+    );
+    let checkmark = queryByRole('img', {hidden: true});
+    expect(checkmark).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Create a menu with `selectedKeys` defined but no `selectionMode` prop and see that no items are selected

## 🧢 Your Project:

Adobe
