### PR TITLE
Adding disabled attribute to HiddenInput

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -27,6 +27,9 @@ interface HiddenSelectProps<T> {
 
   /** HTML form input name. */
   name?: string
+
+  /** Sets the disabled state of the select and input */
+  isDisabled?: boolean
 }
 
 /**
@@ -34,7 +37,7 @@ interface HiddenSelectProps<T> {
  * form autofill, mobile form navigation, and native form submission.
  */
 export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
-  let {state, triggerRef, label, name} = props;
+  let {state, triggerRef, label, name, isDisabled} = props;
   let modality = useInteractionModality();
 
   // If used in a <form>, use a hidden input so the value can be submitted to a server.
@@ -65,11 +68,14 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
           type="text"
           tabIndex={modality == null || state.isFocused || state.isOpen ? -1 : 0}
           style={{fontSize: 16}}
-          onFocus={() => triggerRef.current.focus()} />
+          onFocus={() => triggerRef.current.focus()} 
+          disabled={isDisabled}
+          />
         <label>
           {label}
           <select
             tabIndex={-1}
+            disabled={isDisabled}
             name={name}
             size={state.collection.size}
             value={state.selectedKey}
@@ -95,6 +101,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
       <input
         type="hidden"
         name={name}
+        disabled={isDisabled}
         value={state.selectedKey} />
     );
   }

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -28,7 +28,7 @@ interface HiddenSelectProps<T> {
   /** HTML form input name. */
   name?: string
 
-  /** Sets the disabled state of the select and input */
+  /** Sets the disabled state of the select and input. */
   isDisabled?: boolean
 }
 
@@ -69,8 +69,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
           tabIndex={modality == null || state.isFocused || state.isOpen ? -1 : 0}
           style={{fontSize: 16}}
           onFocus={() => triggerRef.current.focus()} 
-          disabled={isDisabled}
-          />
+          disabled={isDisabled} />
         <label>
           {label}
           <select

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -180,6 +180,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         )
       }>
       <HiddenSelect
+        isDisabled={isDisabled}
         state={state}
         triggerRef={unwrapDOMRef(triggerRef)}
         label={label}

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1624,4 +1624,38 @@ describe('Picker', function () {
       expect(progressbar).not.toBeInTheDocument();
     });
   });
+
+  describe('disabled', function () {
+    it('enables the hidden select when isDisabled is false', function () {
+      let {getByRole, rerender, debug} = render(
+        <Provider theme={theme}>
+          <Picker isDisabled={false} label="Test" onSelectionChange={onSelectionChange}>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
+          </Picker>
+        </Provider>
+      );
+
+      let select = getByRole('textbox', {hidden: true});
+
+      expect(select).not.toBeDisabled()
+    })
+
+    it('disables the hidden select when isDisabled is true', function () {
+      let {getByRole, rerender, debug} = render(
+        <Provider theme={theme}>
+          <Picker isDisabled={true} label="Test" onSelectionChange={onSelectionChange}>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
+          </Picker>
+        </Provider>
+      );
+
+      let select = getByRole('textbox', {hidden: true});
+
+      expect(select).toBeDisabled()
+    })
+  })
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1627,7 +1627,7 @@ describe('Picker', function () {
 
   describe('disabled', function () {
     it('enables the hidden select when isDisabled is false', function () {
-      let {getByRole, rerender, debug} = render(
+      let {getByRole} = render(
         <Provider theme={theme}>
           <Picker isDisabled={false} label="Test" onSelectionChange={onSelectionChange}>
             <Item key="one">One</Item>
@@ -1639,13 +1639,13 @@ describe('Picker', function () {
 
       let select = getByRole('textbox', {hidden: true});
 
-      expect(select).not.toBeDisabled()
-    })
+      expect(select).not.toBeDisabled();
+    });
 
     it('disables the hidden select when isDisabled is true', function () {
-      let {getByRole, rerender, debug} = render(
+      let {getByRole} = render(
         <Provider theme={theme}>
-          <Picker isDisabled={true} label="Test" onSelectionChange={onSelectionChange}>
+          <Picker isDisabled label="Test" onSelectionChange={onSelectionChange}>
             <Item key="one">One</Item>
             <Item key="two">Two</Item>
             <Item key="three">Three</Item>
@@ -1655,7 +1655,7 @@ describe('Picker', function () {
 
       let select = getByRole('textbox', {hidden: true});
 
-      expect(select).toBeDisabled()
-    })
-  })
+      expect(select).toBeDisabled();
+    });
+  });
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1628,7 +1628,7 @@ describe('Picker', function () {
     });
   });
 
-  describe('disabled', function () {
+  describe.only('disabled', function () {
     it('disables the hidden select when isDisabled is true', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
@@ -1643,6 +1643,59 @@ describe('Picker', function () {
       let select = getByRole('textbox', {hidden: true});
 
       expect(select).toBeDisabled();
+    });
+
+    it('does not open on mouse down when isDisabled is true', function () {
+      let onOpenChange = jest.fn();
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <Picker isDisabled label="Test" onOpenChange={onOpenChange}>
+            <Item>One</Item>
+            <Item>Two</Item>
+            <Item>Three</Item>
+          </Picker>
+        </Provider>
+      );
+
+      expect(() => getByRole('listbox')).toThrow();
+
+      let picker = getByRole('button');
+      act(() => {triggerPress(picker);});
+      act(() => jest.runAllTimers());
+
+      expect(() => getByRole('listbox')).toThrow();
+
+      expect(onOpenChange).toBeCalledTimes(0);
+
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
+      expect(document.activeElement).not.toBe(picker);
+    });
+
+    it('does not open on Space key press when isDisabled is true', function () {
+      let onOpenChange = jest.fn();
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <Picker isDisabled label="Test" onOpenChange={onOpenChange}>
+            <Item>One</Item>
+            <Item>Two</Item>
+            <Item>Three</Item>
+          </Picker>
+        </Provider>
+      );
+
+      expect(() => getByRole('listbox')).toThrow();
+
+      let picker = getByRole('button');
+      act(() => {fireEvent.keyDown(picker, {key: ' '});});
+      act(() => {fireEvent.keyUp(picker, {key: ' '});});
+      act(() => jest.runAllTimers());
+
+      expect(() => getByRole('listbox')).toThrow();
+
+      expect(onOpenChange).toBeCalledTimes(0);
+
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
+      expect(document.activeElement).not.toBe(picker);
     });
   });
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1628,7 +1628,7 @@ describe('Picker', function () {
     });
   });
 
-  describe.only('disabled', function () {
+  describe('disabled', function () {
     it('disables the hidden select when isDisabled is true', function () {
       let {getByRole} = render(
         <Provider theme={theme}>

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -52,6 +52,9 @@ describe('Picker', function () {
       </Provider>
     );
 
+    let select = getByRole('textbox', {hidden: true});
+    expect(select).not.toBeDisabled();
+
     let picker = getByRole('button');
     expect(picker).toHaveAttribute('aria-haspopup', 'listbox');
     expect(picker).toHaveAttribute('data-testid', 'test');
@@ -1626,22 +1629,6 @@ describe('Picker', function () {
   });
 
   describe('disabled', function () {
-    it('enables the hidden select when isDisabled is false', function () {
-      let {getByRole} = render(
-        <Provider theme={theme}>
-          <Picker isDisabled={false} label="Test" onSelectionChange={onSelectionChange}>
-            <Item key="one">One</Item>
-            <Item key="two">Two</Item>
-            <Item key="three">Three</Item>
-          </Picker>
-        </Provider>
-      );
-
-      let select = getByRole('textbox', {hidden: true});
-
-      expect(select).not.toBeDisabled();
-    });
-
     it('disables the hidden select when isDisabled is true', function () {
       let {getByRole} = render(
         <Provider theme={theme}>


### PR DESCRIPTION
Closes #786 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

You can test this PR by running the new tests in `Picket.test.js`. You can also manually test this PR by going to the Picker docs in storybook and looking at the disabled section. Found [here](http://localhost:1234/react-spectrum/Picker.html#disabled). You can then inspect the input and find the hidden input in the DOM. You can see that they now have `disabled` DOM attribute on them when previously they didn't.