### PR TITLE
Docs: keepIndividualImport

### DIFF
--- a/packages/dev/docs/pages/react-spectrum/versioning.mdx
+++ b/packages/dev/docs/pages/react-spectrum/versioning.mdx
@@ -65,7 +65,7 @@ import {Button} from '@adobe/react-spectrum';
 
 with:
 
-```tsx
+```tsx keepIndividualImports
 import {Button} from '@react-spectrum/button';
 ```
 
@@ -79,7 +79,7 @@ to ensure your application works correctly and avoids bloat.
 You must manage versioning yourself. Unlike the mono-package, individually
 versioned packages must be manually upgraded to ensure compatibility between
 components. Upgrading a component that depends on another component may require
-that component to also be updated to ensure compatibility. We suggest using a 
+that component to also be updated to ensure compatibility. We suggest using a
 lock file to ensure versions of dependencies between components are controlled.
 See [yarn lockfiles](https://classic.yarnpkg.com/en/docs/yarn-lock/) or
 [NPM lockfiles](https://docs.npmjs.com/configuring-npm/package-locks.html).

--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -362,7 +362,7 @@ function transformExample(node) {
       },
       Program: {
         exit(path) {
-          if (specifiers.length > 0) {
+          if (specifiers.length > 0 && !(node.meta && node.meta.split(' ').includes('keepIndividualImports'))) {
             let literal =  t.stringLiteral('@adobe/react-spectrum');
             literal.raw = "'@adobe/react-spectrum'";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17754,7 +17754,7 @@ prismjs@~1.17.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
-private@^0.1.8, private@~0.1.5:
+private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==


### PR DESCRIPTION
Closes #765 

Add `keepIndividualImports` tag to retain the individual package imports for specific code samples.

	```tsx keepIndividualImports
	import {Button} from '@react-spectrum/button';
	```

-> https://reactspectrum.blob.core.windows.net/reactspectrum/aa4130204964a98a4b8d99a3fed05e217bb1e88a/docs/react-spectrum/versioning.html#using-individual-packages