### PR TITLE
Add useSingleSelectListState

### DIFF
--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1398,7 +1398,8 @@ describe('Picker', function () {
       expect(document.activeElement).toBe(items[1]);
 
       act(() => triggerPress(items[1]));
-      expect(onSelectionChange).not.toHaveBeenCalled();
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onSelectionChange).toHaveBeenCalledWith('two');
       act(() => jest.runAllTimers());
       expect(listbox).not.toBeInTheDocument();
 

--- a/packages/@react-stately/list/src/index.ts
+++ b/packages/@react-stately/list/src/index.ts
@@ -3,7 +3,7 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
@@ -11,3 +11,4 @@
  */
 
 export * from './useListState';
+export * from './useSingleSelectListState';

--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {CollectionBase, SingleSelection} from '@react-types/shared';
+import {Key, useMemo} from 'react';
+import {ListState, useListState} from './useListState';
+import {Node} from '@react-types/shared';
+import {SelectProps} from '@react-types/select';
+import {useControlledState} from '@react-stately/utils';
+
+export interface SingleSelectListProps<T> extends CollectionBase<T>, SingleSelection {}
+export interface SingleSelectListState<T> extends ListState<T> {
+  /** The key for the currently selected item. */
+  readonly selectedKey: Key,
+
+  /** Sets the selected key. */
+  setSelectedKey(key: Key): void,
+
+  /** The value of the currently selected item. */
+  readonly selectedItem: Node<T>,
+}
+
+/**
+ * Provides state management for list-like components with single selection.
+ * Handles building a collection of items from props, and manages selection state.
+ */
+export function useSingleSelectListState<T extends object>(props: SelectProps<T>): SingleSelectListState<T>  {
+  let [selectedKey, setSelectedKey] = useControlledState(props.selectedKey, props.defaultSelectedKey, props.onSelectionChange);
+  let selectedKeys = useMemo(() => selectedKey != null ? [selectedKey] : [], [selectedKey]);
+  let {collection, disabledKeys, selectionManager} = useListState({
+    ...props,
+    selectionMode: 'single',
+    disallowEmptySelection: true,
+    selectedKeys,
+    onSelectionChange: (keys: Set<Key>) => {
+      let key = keys.values().next().value;
+
+      // Always fire onSelectionChange, even if the key is the same
+      // as the current key (useControlledState does not).
+      if (key === selectedKey && props.onSelectionChange) {
+        props.onSelectionChange(key);
+      }
+
+      setSelectedKey(key);
+    }
+  });
+
+  let selectedItem = selectedKey
+    ? collection.getItem(selectedKey)
+    : null;
+
+  return {
+    collection,
+    disabledKeys,
+    selectionManager,
+    selectedKey,
+    setSelectedKey,
+    selectedItem
+  };
+}

--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -14,7 +14,6 @@ import {CollectionBase, SingleSelection} from '@react-types/shared';
 import {Key, useMemo} from 'react';
 import {ListState, useListState} from './useListState';
 import {Node} from '@react-types/shared';
-import {SelectProps} from '@react-types/select';
 import {useControlledState} from '@react-stately/utils';
 
 export interface SingleSelectListProps<T> extends CollectionBase<T>, SingleSelection {}
@@ -33,7 +32,7 @@ export interface SingleSelectListState<T> extends ListState<T> {
  * Provides state management for list-like components with single selection.
  * Handles building a collection of items from props, and manages selection state.
  */
-export function useSingleSelectListState<T extends object>(props: SelectProps<T>): SingleSelectListState<T>  {
+export function useSingleSelectListState<T extends object>(props: SingleSelectListProps<T>): SingleSelectListState<T>  {
   let [selectedKey, setSelectedKey] = useControlledState(props.selectedKey, props.defaultSelectedKey, props.onSelectionChange);
   let selectedKeys = useMemo(() => selectedKey != null ? [selectedKey] : [], [selectedKey]);
   let {collection, disabledKeys, selectionManager} = useListState({

--- a/packages/@react-stately/select/src/useSelectState.ts
+++ b/packages/@react-stately/select/src/useSelectState.ts
@@ -12,7 +12,7 @@
 
 import {MenuTriggerState, useMenuTriggerState} from '@react-stately/menu';
 import {SelectProps} from '@react-types/select';
-import {useSingleSelectListState, SingleSelectListState} from '@react-stately/list';
+import {SingleSelectListState, useSingleSelectListState} from '@react-stately/list';
 import {useState} from 'react';
 
 export interface SelectState<T> extends SingleSelectListState<T>, MenuTriggerState {


### PR DESCRIPTION
This refactors some of the logic currently in `useSelectState` into a `useSingleSelectListState` hook that's more reusable. This hook handles mapping the props for components supporting single selection to the internal state which is stored as a set of one key. This should allow reuse in other components that support only single selection, e.g. combo box, tabs, and accordion.

One difference that was introduced: `onSelectionChange` is now always fired, regardless of whether the key actually changed. This was to ensure that the picker closes when selecting the same item, but I think there are other use cases to know when a user selected the same item as before and this matches what happens with multiple selection more closely (`new Set() !== new Set()`).