### PR TITLE
Slider component for @react-stately and @react-aria

### DIFF
--- a/packages/@react-aria/slider/index.ts
+++ b/packages/@react-aria/slider/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './src';

--- a/packages/@react-aria/slider/package.json
+++ b/packages/@react-aria/slider/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@react-aria/slider",
+  "version": "3.0.2",
+  "description": "Slider",
+  "license": "Apache-2.0",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
+  "source": "src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/react-spectrum"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.6.2",
+    "@react-aria/focus": "^3.0.2",
+    "@react-aria/i18n": "^3.0.2",
+    "@react-aria/interactions": "^3.0.2",
+    "@react-aria/label": "^3.0.2",
+    "@react-aria/utils": "^3.0.2",
+    "@react-stately/radio": "^3.0.2",
+    "@react-stately/slider": "3.0.2",
+    "@react-types/radio": "^3.0.2",
+    "@react-types/slider": "3.0.2"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-aria/slider/src/index.ts
+++ b/packages/@react-aria/slider/src/index.ts
@@ -10,5 +10,5 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './useMultiSlider';
+export * from './useSlider';
 export * from './useSliderThumb';

--- a/packages/@react-aria/slider/src/index.ts
+++ b/packages/@react-aria/slider/src/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './useMultiSlider';
+export * from './useSliderThumb';

--- a/packages/@react-aria/slider/src/useMultiSlider.ts
+++ b/packages/@react-aria/slider/src/useMultiSlider.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {computeOffsetToValue} from './utils';
+import {HTMLAttributes, useRef} from 'react';
+import {mergeProps, useDrag1D} from '@react-aria/utils';
+import {MultiSliderProps} from '@react-types/slider';
+import {MultiSliderState} from '@react-stately/slider';
+import {useLabel} from '@react-aria/label';
+
+interface MultiSliderAria {
+  /** Props for the label element. */
+  labelProps: HTMLAttributes<HTMLElement>;
+
+  /** Props for the root element of the slider component; groups slider inputs. */
+  containerProps: HTMLAttributes<HTMLElement>;
+
+  /** Props for the track element. */
+  trackProps: HTMLAttributes<HTMLElement>;
+
+  /** Label ID for labling slider inputs. Should be passed on in `useSliderThumb`. */
+  labelId: string;
+}
+
+/**
+ * Provides behavior and accessibility for a slider component.
+ * 
+ * @param props Props for the slider.
+ * @param state State for the slider, as returned by `useMultiSliderState`.
+ * @param trackRef Ref for the "track" element.  The width of this element provides the "length"
+ * of the track -- the span of one dimensional space that the slider thumb can be.  It also
+ * accepts click and drag motions, so that the closest thumb will follow clicks and drags on
+ * the track.
+ */
+export function useMultiSlider(
+  props: MultiSliderProps, 
+  state: MultiSliderState, 
+  trackRef: React.RefObject<HTMLElement>
+): MultiSliderAria {
+  const {labelProps, fieldProps} = useLabel(props);
+
+  // When the user clicks or drags the track, we want the motion to set and drag the 
+  // closest thumb.  Hence we also need to install useDrag1D() on the track element.
+  // Here, we keep track of which index is the "closest" to the drag start point.
+  // It is set onMouseDown; see trackProps below.
+  const realTimeTrackDraggingIndex = useRef<number | undefined>(undefined);
+  const draggableProps = useDrag1D({
+    containerRef: trackRef as any,
+    reverse: false,
+    orientation: 'horizontal',
+    onDrag: (dragging) => {
+      if (realTimeTrackDraggingIndex.current !== undefined) {
+        state.setDragging(realTimeTrackDraggingIndex.current, dragging);
+      }
+    },
+    onPositionChange: (position) => {
+      if (realTimeTrackDraggingIndex.current !== undefined) {
+        state.setValue(realTimeTrackDraggingIndex.current, computeOffsetToValue(position, props, trackRef));
+      }
+    }
+  });
+
+  return {
+    labelProps,
+
+    // The root element of the Slider will have role="group" to group together
+    // all the thumb inputs in the Slider.  The label of the Slider will
+    // be used to label the group.
+    containerProps: {
+      role: 'group',
+      ...fieldProps
+    },
+    trackProps: mergeProps({
+      onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
+        // We only trigger track-dragging if the user clicks on the track itself.
+        if (trackRef.current && trackRef.current === e.target) {
+          // Find the closest thumb
+          const trackPosition = trackRef.current.getBoundingClientRect().left;
+          const clickPosition = e.clientX;
+          const offset = clickPosition - trackPosition;
+          const value = computeOffsetToValue(offset, props, trackRef);
+          const minDiff = Math.min(...state.values.map(v => Math.abs(v - value)));
+          const index = state.values.findIndex(v => Math.abs(v - value) === minDiff);
+          if (index >= 0) {
+            // Don't unfocus anything
+            e.preventDefault();
+
+            realTimeTrackDraggingIndex.current = index;
+            state.setFocusedIndex(index);
+          }
+        }
+      }
+    }, draggableProps),
+    labelId: (labelProps.id ?? fieldProps.id)!
+  };
+}

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -13,7 +13,7 @@
 import {computeOffsetToValue} from './utils';
 import {HTMLAttributes, useRef} from 'react';
 import {mergeProps, useDrag1D} from '@react-aria/utils';
-import {SliderProps} from '@react-types/slider';
+import {SliderProps, CommonSliderThumbProps} from '@react-types/slider';
 import {SliderState} from '@react-stately/slider';
 import {useLabel} from '@react-aria/label';
 
@@ -27,8 +27,9 @@ interface SliderAria {
   /** Props for the track element. */
   trackProps: HTMLAttributes<HTMLElement>;
 
-  /** Label ID for labling slider inputs. Should be passed on in `useSliderThumb`. */
-  labelId: string;
+  /** Partial props that should be passed into `useSliderThumb` for all thumbs.  
+   * Includes the Label ID for labeling slider inputs. */
+  commonThumbProps: CommonSliderThumbProps;
 }
 
 /**
@@ -100,6 +101,8 @@ export function useSlider(
         }
       }
     }, draggableProps),
-    labelId: (labelProps.id ?? fieldProps.id)!
+    commonThumbProps: {
+      labelId: (labelProps.id ?? fieldProps.id)!
+    }
   };
 }

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -88,7 +88,8 @@ export function useSlider(
           const trackPosition = trackRef.current.getBoundingClientRect().left;
           const clickPosition = e.clientX;
           const offset = clickPosition - trackPosition;
-          const value = computeOffsetToValue(offset, props, trackRef);
+          const percent = offset / trackRef.current.offsetWidth;
+          const value = state.getPercentValue(percent);
           const minDiff = Math.min(...state.values.map(v => Math.abs(v - value)));
           const index = state.values.findIndex(v => Math.abs(v - value) === minDiff);
           if (index >= 0) {

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -97,6 +97,15 @@ export function useSlider(
 
             realTimeTrackDraggingIndex.current = index;
             state.setFocusedIndex(index);
+
+            // We immediately toggle state to dragging and set the value on mouse down.
+            // We set the value now, instead of waiting for onDrag, so that the thumb 
+            // is updated while you're still holding the mouse button down.  And we 
+            // set dragging on now, so that onChangeEnd() won't fire yet when we set
+            // the value.  Dragging state will be reset to false in onDrag above, even
+            // if no dragging actually occurs.
+            state.setDragging(realTimeTrackDraggingIndex.current, true);
+            state.setValue(index, value);
           }
         }
       }

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -13,11 +13,11 @@
 import {computeOffsetToValue} from './utils';
 import {HTMLAttributes, useRef} from 'react';
 import {mergeProps, useDrag1D} from '@react-aria/utils';
-import {MultiSliderProps} from '@react-types/slider';
-import {MultiSliderState} from '@react-stately/slider';
+import {SliderProps} from '@react-types/slider';
+import {SliderState} from '@react-stately/slider';
 import {useLabel} from '@react-aria/label';
 
-interface MultiSliderAria {
+interface SliderAria {
   /** Props for the label element. */
   labelProps: HTMLAttributes<HTMLElement>;
 
@@ -35,17 +35,17 @@ interface MultiSliderAria {
  * Provides behavior and accessibility for a slider component.
  * 
  * @param props Props for the slider.
- * @param state State for the slider, as returned by `useMultiSliderState`.
+ * @param state State for the slider, as returned by `useSliderState`.
  * @param trackRef Ref for the "track" element.  The width of this element provides the "length"
  * of the track -- the span of one dimensional space that the slider thumb can be.  It also
  * accepts click and drag motions, so that the closest thumb will follow clicks and drags on
  * the track.
  */
-export function useMultiSlider(
-  props: MultiSliderProps, 
-  state: MultiSliderState, 
+export function useSlider(
+  props: SliderProps, 
+  state: SliderState, 
   trackRef: React.RefObject<HTMLElement>
-): MultiSliderAria {
+): SliderAria {
   const {labelProps, fieldProps} = useLabel(props);
 
   // When the user clicks or drags the track, we want the motion to set and drag the 

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -29,7 +29,7 @@ interface SliderAria {
 
   /** Partial props that should be passed into `useSliderThumb` for all thumbs.  
    * Includes the Label ID for labeling slider inputs. */
-  commonThumbProps: CommonSliderThumbProps
+  thumbProps: CommonSliderThumbProps
 }
 
 /**
@@ -60,12 +60,12 @@ export function useSlider(
     orientation: 'horizontal',
     onDrag: (dragging) => {
       if (realTimeTrackDraggingIndex.current !== undefined) {
-        state.setDragging(realTimeTrackDraggingIndex.current, dragging);
+        state.setThumbDragging(realTimeTrackDraggingIndex.current, dragging);
       }
     },
     onPositionChange: (position) => {
       if (realTimeTrackDraggingIndex.current !== undefined) {
-        state.setValue(realTimeTrackDraggingIndex.current, computeOffsetToValue(position, props, trackRef));
+        state.setThumbValue(realTimeTrackDraggingIndex.current, computeOffsetToValue(position, props, trackRef));
       }
     }
   });
@@ -96,7 +96,7 @@ export function useSlider(
             e.preventDefault();
 
             realTimeTrackDraggingIndex.current = index;
-            state.setFocusedIndex(index);
+            state.setFocusedThumb(index);
 
             // We immediately toggle state to dragging and set the value on mouse down.
             // We set the value now, instead of waiting for onDrag, so that the thumb 
@@ -104,13 +104,13 @@ export function useSlider(
             // set dragging on now, so that onChangeEnd() won't fire yet when we set
             // the value.  Dragging state will be reset to false in onDrag above, even
             // if no dragging actually occurs.
-            state.setDragging(realTimeTrackDraggingIndex.current, true);
-            state.setValue(index, value);
+            state.setThumbDragging(realTimeTrackDraggingIndex.current, true);
+            state.setThumbValue(index, value);
           }
         }
       }
     }, draggableProps),
-    commonThumbProps: {
+    thumbProps: {
       labelId: (labelProps.id ?? fieldProps.id)!
     }
   };

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -10,26 +10,26 @@
  * governing permissions and limitations under the License.
  */
 
+import {CommonSliderThumbProps, SliderProps} from '@react-types/slider';
 import {computeOffsetToValue} from './utils';
 import {HTMLAttributes, useRef} from 'react';
 import {mergeProps, useDrag1D} from '@react-aria/utils';
-import {SliderProps, CommonSliderThumbProps} from '@react-types/slider';
 import {SliderState} from '@react-stately/slider';
 import {useLabel} from '@react-aria/label';
 
 interface SliderAria {
   /** Props for the label element. */
-  labelProps: HTMLAttributes<HTMLElement>;
+  labelProps: HTMLAttributes<HTMLElement>,
 
   /** Props for the root element of the slider component; groups slider inputs. */
-  containerProps: HTMLAttributes<HTMLElement>;
+  containerProps: HTMLAttributes<HTMLElement>,
 
   /** Props for the track element. */
-  trackProps: HTMLAttributes<HTMLElement>;
+  trackProps: HTMLAttributes<HTMLElement>,
 
   /** Partial props that should be passed into `useSliderThumb` for all thumbs.  
    * Includes the Label ID for labeling slider inputs. */
-  commonThumbProps: CommonSliderThumbProps;
+  commonThumbProps: CommonSliderThumbProps
 }
 
 /**

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -1,7 +1,7 @@
 import {BaseSliderProps, SliderThumbProps} from '@react-types/slider';
 import {chain, focusWithoutScrolling, mergeProps, useDrag1D} from '@react-aria/utils';
 import {computeOffsetToValue} from './utils';
-import {DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE, DEFAULT_STEP_VALUE, MultiSliderState} from '@react-stately/slider';
+import {DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE, DEFAULT_STEP_VALUE, SliderState} from '@react-stately/slider';
 import {HTMLAttributes, useCallback, useEffect} from 'react';
 import {useFocusable} from '@react-aria/focus';
 import {useLabel} from '@react-aria/label';
@@ -22,14 +22,14 @@ interface SliderThumbAria {
  * 
  * @param sliderProps Props used for the Slider component.
  * @param thumbProps Props used for this specific thumb.
- * @param state Slider state, created via `useMultiSliderState`.
+ * @param state Slider state, created via `useSliderState`.
  * @param trackRef Ref for the track element.
  * @param inputRef Ref for the range input element.
  */
 export function useSliderThumb(
   sliderProps: BaseSliderProps,
   thumbProps: SliderThumbProps,
-  state: MultiSliderState,
+  state: SliderState,
   trackRef: React.RefObject<HTMLElement>,
   inputRef: React.RefObject<HTMLInputElement>
 ): SliderThumbAria {

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -1,27 +1,27 @@
 import {BaseSliderProps, SliderThumbProps} from '@react-types/slider';
-import {chain, focusWithoutScrolling, mergeProps, useDrag1D} from '@react-aria/utils';
+import {ChangeEvent, HTMLAttributes, useCallback, useEffect} from 'react';
 import {computeOffsetToValue} from './utils';
 import {DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE, DEFAULT_STEP_VALUE, SliderState} from '@react-stately/slider';
-import {HTMLAttributes, useCallback, useEffect, ChangeEvent} from 'react';
+import {focusWithoutScrolling, mergeProps, useDrag1D} from '@react-aria/utils';
 import {useFocusable} from '@react-aria/focus';
 import {useLabel} from '@react-aria/label';
 
 interface SliderThumbAria {
   /** Props for the range input. */
-  inputProps: HTMLAttributes<HTMLElement>;
+  inputProps: HTMLAttributes<HTMLElement>,
 
   /** Props for the root thumb element; handles the dragging motion. */
-  thumbProps: HTMLAttributes<HTMLElement>;
+  thumbProps: HTMLAttributes<HTMLElement>,
   
   /** Props for the label element for this thumb. */
-  labelProps: HTMLAttributes<HTMLElement>;
+  labelProps: HTMLAttributes<HTMLElement>
 }
 
 interface SliderThumbOptions {
-  sliderProps: BaseSliderProps;
-  thumbProps: SliderThumbProps;
-  trackRef: React.RefObject<HTMLElement>;
-  inputRef: React.RefObject<HTMLInputElement>;
+  sliderProps: BaseSliderProps,
+  thumbProps: SliderThumbProps,
+  trackRef: React.RefObject<HTMLElement>,
+  inputRef: React.RefObject<HTMLInputElement>
 }
 
 /**
@@ -128,9 +128,9 @@ export function useSliderThumb(
     thumbProps: allowDrag ? mergeProps({
       onMouseDown: draggableProps.onMouseDown,
       onMosueEnter: draggableProps.onMouseEnter,
-      onMouseOut: draggableProps.onMouseOut,
+      onMouseOut: draggableProps.onMouseOut
     }, {
-      onMouseDown: focusInput,
+      onMouseDown: focusInput
     }) : {},
     labelProps
   };

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -17,6 +17,13 @@ interface SliderThumbAria {
   labelProps: HTMLAttributes<HTMLElement>;
 }
 
+interface SliderThumbOptions {
+  sliderProps: BaseSliderProps;
+  thumbProps: SliderThumbProps;
+  trackRef: React.RefObject<HTMLElement>;
+  inputRef: React.RefObject<HTMLInputElement>;
+}
+
 /**
  * Provides behavior and accessibility for a thumb of a slider component.
  * 
@@ -27,12 +34,10 @@ interface SliderThumbAria {
  * @param inputRef Ref for the range input element.
  */
 export function useSliderThumb(
-  sliderProps: BaseSliderProps,
-  thumbProps: SliderThumbProps,
+  opts: SliderThumbOptions,
   state: SliderState,
-  trackRef: React.RefObject<HTMLElement>,
-  inputRef: React.RefObject<HTMLInputElement>
 ): SliderThumbAria {
+  const {sliderProps, thumbProps, trackRef, inputRef} = opts;
   const {
     maxValue = DEFAULT_MAX_VALUE,
     minValue = DEFAULT_MIN_VALUE,

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -1,0 +1,124 @@
+import {BaseSliderProps, SliderThumbProps} from '@react-types/slider';
+import {chain, focusWithoutScrolling, mergeProps, useDrag1D} from '@react-aria/utils';
+import {computeOffsetToValue} from './utils';
+import {DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE, DEFAULT_STEP_VALUE, MultiSliderState} from '@react-stately/slider';
+import {HTMLAttributes, useCallback, useEffect} from 'react';
+import {useFocusable} from '@react-aria/focus';
+import {useLabel} from '@react-aria/label';
+
+interface SliderThumbAria {
+  /** Props for the range input. */
+  inputProps: HTMLAttributes<HTMLElement>;
+
+  /** Props for the root thumb element; handles the dragging motion. */
+  thumbProps: HTMLAttributes<HTMLElement>;
+  
+  /** Props for the label element for this thumb. */
+  labelProps: HTMLAttributes<HTMLElement>;
+}
+
+/**
+ * Provides behavior and accessibility for a thumb of a slider component.
+ * 
+ * @param sliderProps Props used for the Slider component.
+ * @param thumbProps Props used for this specific thumb.
+ * @param state Slider state, created via `useMultiSliderState`.
+ * @param trackRef Ref for the track element.
+ * @param inputRef Ref for the range input element.
+ */
+export function useSliderThumb(
+  sliderProps: BaseSliderProps,
+  thumbProps: SliderThumbProps,
+  state: MultiSliderState,
+  trackRef: React.RefObject<HTMLElement>,
+  inputRef: React.RefObject<HTMLInputElement>
+): SliderThumbAria {
+  const {
+    maxValue = DEFAULT_MAX_VALUE,
+    minValue = DEFAULT_MIN_VALUE,
+    step = DEFAULT_STEP_VALUE,
+    isReadOnly: isSliderReadOnly,
+    isDisabled: isSliderDisabled
+  } = sliderProps;
+
+  const {
+    index,
+    isRequired,
+    isDisabled,
+    isReadOnly,
+    validationState,
+    labelId
+  } = thumbProps;
+
+  const {labelProps, fieldProps} = useLabel({
+    ...thumbProps,
+    'aria-labelledby': `${labelId} ${thumbProps['aria-labelledby'] ?? ''}`.trim()
+  });
+
+  const value = state.values[index];
+  const allowDrag = !(isSliderDisabled || isSliderReadOnly || isDisabled || isReadOnly);
+
+  const focusInput = useCallback(() => {
+    if (inputRef.current) {
+      focusWithoutScrolling(inputRef.current);
+    }
+  }, [inputRef]);
+
+  const isFocused = state.focusedIndex === index;
+
+  useEffect(() => {
+    if (isFocused) {
+      focusInput();
+    }
+  }, [isFocused, focusInput]);
+
+  const draggableProps = useDrag1D({
+    containerRef: trackRef as any,
+    reverse: false,
+    orientation: 'horizontal',
+    onDrag: (dragging) => {
+      state.setDragging(index, dragging);
+      console.log('THUMB FOCUS');
+      focusInput();
+    },
+    onPositionChange: (position) => {
+      state.setValue(index, computeOffsetToValue(position, sliderProps, trackRef));
+    },
+    onIncrement: () => state.setValue(index, value + step),
+    onDecrement: () => state.setValue(index, value - step),
+    onIncrementToMax: () => state.setValue(index, maxValue),
+    onDecrementToMin: () => state.setValue(index, minValue)
+  });
+
+  const {focusableProps} = useFocusable(
+    mergeProps(thumbProps, {
+      onFocus: () => state.setFocusedIndex(index),
+      onBlur: () => state.setFocusedIndex(undefined)
+    }),
+    inputRef
+  );
+
+  return {
+    inputProps: mergeProps(focusableProps, fieldProps, {
+      type: 'range',
+      tabIndex: allowDrag ? 0 : undefined,
+      'aria-valuenow': value,
+      'aria-valuemin': state.getMinValueForIndex(index),
+      'aria-valuemax': state.getMaxValueForIndex(index),
+      'aria-readonly': isReadOnly || undefined,
+      'aria-disabled': isDisabled || undefined,
+      'aria-orientation': 'horizontal',
+      'aria-valuetext': state.getValueLabelForIndex(index),
+      'aria-required': isRequired || undefined,
+      'aria-invalid': validationState === 'invalid' || undefined,
+      'aria-errormessage': thumbProps['aria-errormessage'],
+      onKeyDown: allowDrag ? draggableProps.onKeyDown : undefined
+    }),
+    thumbProps: {
+      onMouseDown: allowDrag ? chain(draggableProps.onMouseDown, () => focusInput()) : undefined,
+      onMouseEnter: allowDrag ? draggableProps.onMouseEnter : undefined,
+      onMouseOut: allowDrag ? draggableProps.onMouseOut : undefined
+    },
+    labelProps
+  };
+}

--- a/packages/@react-aria/slider/src/utils.ts
+++ b/packages/@react-aria/slider/src/utils.ts
@@ -1,0 +1,12 @@
+import {BaseSliderProps} from '@react-types/slider';
+
+export function computeOffsetToValue(offset: number, props: BaseSliderProps, trackRef: React.RefObject<HTMLElement>) {
+  const {minValue = 0, maxValue = 100, step = 1} = props;
+  if (!trackRef.current) {
+    return minValue;
+  }
+
+  const containerSize = trackRef.current.offsetWidth;
+  const val = offset / containerSize * (maxValue - minValue) + minValue;
+  return Math.round((val - minValue) / step) * step + minValue;
+}

--- a/packages/@react-aria/slider/stories/Slider.stories.tsx
+++ b/packages/@react-aria/slider/stories/Slider.stories.tsx
@@ -12,6 +12,10 @@ storiesOf('Slider', module)
     () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
   )
   .add(
+    'single with big steps',
+    () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} step={10} />
+  )
+  .add(
     'single with origin',
     () => <StorySlider label="Exposure" origin={0} minValue={-5} maxValue={5} step={0.1} onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
   )

--- a/packages/@react-aria/slider/stories/Slider.stories.tsx
+++ b/packages/@react-aria/slider/stories/Slider.stories.tsx
@@ -1,0 +1,90 @@
+import {action} from '@storybook/addon-actions';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {StoryMultiSlider, StoryThumb} from './StoryMultiSlider';
+import {StoryRangeSlider} from './StoryRangeSlider';
+import {StorySlider} from './StorySlider';
+
+
+storiesOf('Slider', module)
+  .add(
+    'single',
+    () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
+  )
+  .add(
+    'single with origin',
+    () => <StorySlider label="Exposure" origin={0} minValue={-5} maxValue={5} step={0.1} onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
+  )
+  .add(
+    'single with aria label',
+    () => <StorySlider aria-label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
+  )
+  .add(
+    'range',
+    () => (<StoryRangeSlider 
+      label="Temperature" 
+      defaultValue={[25, 75]} 
+      onChange={action('onChange')} 
+      onChangeEnd={action('onChangeEnd')} 
+      formatOptions={{
+        style: 'unit',
+        unit: 'celsius',
+        unitDisplay: 'narrow'
+      } as any} />)
+  )
+  .add(
+    'range with aria-label',
+    () => (<StoryRangeSlider 
+      aria-label="Temperature"
+      defaultValue={[25, 75]} 
+      onChange={action('onChange')} 
+      onChangeEnd={action('onChangeEnd')} 
+      formatOptions={{
+        style: 'unit',
+        unit: 'celsius',
+        unitDisplay: 'narrow'
+      } as any} />)
+  )
+  .add(
+    '3 thumbs',
+    () => (
+      <StoryMultiSlider 
+        label="Ticks" 
+        onChange={action('onChange')} 
+        onChangeEnd={action('onChangeEnd')}
+        defaultValue={[10, 40, 80]}>
+        <StoryThumb label="A" />
+        <StoryThumb label="B" />
+        <StoryThumb label="C" />
+      </StoryMultiSlider>
+    )
+  )
+  .add(
+    '3 thumbs with disabled',
+    () => (
+      <StoryMultiSlider 
+        label="Ticks" 
+        onChange={action('onChange')} 
+        onChangeEnd={action('onChangeEnd')}
+        defaultValue={[10, 40, 80]}>
+        <StoryThumb label="A" />
+        <StoryThumb label="B" isDisabled />
+        <StoryThumb label="C" />
+      </StoryMultiSlider>
+    )
+  )
+  .add(
+    '3 thumbs with aria-label',
+    () => (
+      <StoryMultiSlider 
+        aria-label="Ticks"
+        onChange={action('onChange')} 
+        onChangeEnd={action('onChangeEnd')}
+        defaultValue={[10, 40, 80]}>
+        <StoryThumb aria-label="A" />
+        <StoryThumb aria-label="B" />
+        <StoryThumb aria-label="C" />
+      </StoryMultiSlider>
+    )
+  )
+  ;

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -68,12 +68,14 @@ export function StoryThumb(props: StoryThumbProps) {
   
   const {label, isDisabled} = props;
   const context = (props as any).__context as SliderStateContext;
-  const {index, state, commonThumbProps} = context;
-
+  const {index, state, commonThumbProps, sliderProps} = context;
   const inputRef = React.useRef<HTMLInputElement>(null);
   const {inputProps, thumbProps, labelProps} = useSliderThumb({
-    sliderProps: context.sliderProps,
-    thumbProps: {...props, index, ...commonThumbProps},
+    index, 
+    ...props,
+    ...commonThumbProps,
+    isReadOnly: sliderProps.isReadOnly || props.isReadOnly,
+    isDisabled: sliderProps.isDisabled || props.isDisabled,
     trackRef: context.trackRef,
     inputRef
   }, state);

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -17,7 +17,7 @@ export function StoryMultiSlider(props: StoryMultiSliderProps) {
   const trackRef = React.useRef<HTMLDivElement>(null);
   const state = useSliderState(props);
   const {
-    trackProps, labelProps, commonThumbProps, containerProps
+    trackProps, labelProps, thumbProps: commonThumbProps, containerProps
   } = useSlider(props, state, trackRef);
 
   const numThumbs = React.Children.count(children);
@@ -84,7 +84,7 @@ export function StoryThumb(props: StoryThumbProps) {
         {...thumbProps} 
         className={classNames(styles, 'thumb', {thumbDisabled: isDisabled})}
         style={{
-          'left': `${state.getOffsetPercentForIndex(index) * 100}%`
+          'left': `${state.getThumbPercent(index) * 100}%`
         }}>
         <VisuallyHidden isFocusable><input className={styles.input} ref={inputRef} {...inputProps} /></VisuallyHidden>
         {label && <label {...labelProps}>{label}</label>}

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -71,8 +71,12 @@ export function StoryThumb(props: StoryThumbProps) {
   const {index, state, commonThumbProps} = context;
 
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const {inputProps, thumbProps, labelProps} = useSliderThumb(
-    context.sliderProps, {...props, index, ...commonThumbProps}, state, context.trackRef, inputRef);
+  const {inputProps, thumbProps, labelProps} = useSliderThumb({
+    sliderProps: context.sliderProps,
+    thumbProps: { ...props, index, ...commonThumbProps },
+    trackRef: context.trackRef,
+    inputRef
+  }, state);
 
   return (
     <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -1,6 +1,6 @@
 import {classNames} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
-import {SliderProps, SliderThumbProps} from '@react-types/slider';
+import {SliderProps, SliderThumbProps, CommonSliderThumbProps} from '@react-types/slider';
 import {SliderState, useSliderState} from '@react-stately/slider';
 import React from 'react';
 import styles from './story-slider.css';
@@ -17,7 +17,7 @@ export function StoryMultiSlider(props: StoryMultiSliderProps) {
   const trackRef = React.useRef<HTMLDivElement>(null);
   const state = useSliderState(props);
   const {
-    trackProps, labelProps, labelId, containerProps
+    trackProps, labelProps, commonThumbProps, containerProps
   } = useSlider(props, state, trackRef);
 
   const numThumbs = React.Children.count(children);
@@ -41,7 +41,7 @@ export function StoryMultiSlider(props: StoryMultiSliderProps) {
               state,
               trackRef,
               index,
-              labelId
+              commonThumbProps
             }
           } as any)))}
       </div>
@@ -58,7 +58,7 @@ interface SliderStateContext {
   state: SliderState;
   trackRef: React.RefObject<HTMLElement>;
   index: number;
-  labelId: string;
+  commonThumbProps: CommonSliderThumbProps;
 }
 
 export function StoryThumb(props: StoryThumbProps) {
@@ -68,11 +68,11 @@ export function StoryThumb(props: StoryThumbProps) {
   
   const {label, isDisabled} = props;
   const context = (props as any).__context as SliderStateContext;
-  const {index, state} = context;
+  const {index, state, commonThumbProps} = context;
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const {inputProps, thumbProps, labelProps} = useSliderThumb(
-    context.sliderProps, {...props, index, labelId: context.labelId}, state, context.trackRef, inputRef);
+    context.sliderProps, {...props, index, ...commonThumbProps}, state, context.trackRef, inputRef);
 
   return (
     <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -1,0 +1,90 @@
+import {classNames} from '@react-spectrum/utils';
+import {FocusRing} from '@react-aria/focus';
+import {MultiSliderProps, SliderThumbProps} from '@react-types/slider';
+import {MultiSliderState, useMultiSliderState} from '@react-stately/slider';
+import React from 'react';
+import styles from './story-slider.css';
+import {useMultiSlider, useSliderThumb} from '@react-aria/slider';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
+
+
+interface StoryMultiSliderProps extends MultiSliderProps {
+  children: React.ReactNode;
+}
+
+export function StoryMultiSlider(props: StoryMultiSliderProps) {
+  const {children} = props;
+  const trackRef = React.useRef<HTMLDivElement>(null);
+  const state = useMultiSliderState(props);
+  const {
+    trackProps, labelProps, labelId, containerProps
+  } = useMultiSlider(props, state, trackRef);
+
+  const numThumbs = React.Children.count(children);
+  if (numThumbs !== state.values.length) {
+    throw new Error('You must have the same number of StoryThumb as the number of values in `defaultValue` or `value`.');
+  }
+
+  return (
+    <div {...containerProps} className={styles.slider}>
+      <div className={styles.sliderLabel}>
+        {props.label && <label {...labelProps} className={styles.label}>{props.label}</label>}
+        <div className={styles.value}>{JSON.stringify(state.values)}</div>
+      </div>
+      <div className={styles.trackContainer}>
+        <div className={styles.rail} />
+        <div {...trackProps} ref={trackRef} className={styles.track} />
+        {React.Children.map(children, ((child, index) => 
+          React.cloneElement(child as React.ReactElement, {
+            __context: {
+              sliderProps: props,
+              state,
+              trackRef,
+              index,
+              labelId
+            }
+          } as any)))}
+      </div>
+    </div>
+  );
+}
+
+
+interface StoryThumbProps extends Omit<SliderThumbProps, 'index'|'labelId'> {
+}
+
+interface SliderStateContext {
+  sliderProps: StoryMultiSliderProps;
+  state: MultiSliderState;
+  trackRef: React.RefObject<HTMLElement>;
+  index: number;
+  labelId: string;
+}
+
+export function StoryThumb(props: StoryThumbProps) {
+  if (!(props as any).__context) {
+    throw new Error('Cannot use StoryThumb outside of a StoryMultiSlider!');
+  }
+  
+  const {label, isDisabled} = props;
+  const context = (props as any).__context as SliderStateContext;
+  const {index, state} = context;
+
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const {inputProps, thumbProps, labelProps} = useSliderThumb(
+    context.sliderProps, {...props, index, labelId: context.labelId}, state, context.trackRef, inputRef);
+
+  return (
+    <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+      <div 
+        {...thumbProps} 
+        className={classNames(styles, 'thumb', {thumbDisabled: isDisabled})}
+        style={{
+          'left': `${state.getOffsetPercentForIndex(index) * 100}%`
+        }}>
+        <VisuallyHidden isFocusable><input className={styles.input} ref={inputRef} {...inputProps} /></VisuallyHidden>
+        {label && <label {...labelProps}>{label}</label>}
+      </div>
+    </FocusRing>
+  );
+}

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -1,24 +1,24 @@
 import {classNames} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
-import {MultiSliderProps, SliderThumbProps} from '@react-types/slider';
-import {MultiSliderState, useMultiSliderState} from '@react-stately/slider';
+import {SliderProps, SliderThumbProps} from '@react-types/slider';
+import {SliderState, useSliderState} from '@react-stately/slider';
 import React from 'react';
 import styles from './story-slider.css';
-import {useMultiSlider, useSliderThumb} from '@react-aria/slider';
+import {useSlider, useSliderThumb} from '@react-aria/slider';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 
-interface StoryMultiSliderProps extends MultiSliderProps {
+interface StoryMultiSliderProps extends SliderProps {
   children: React.ReactNode;
 }
 
 export function StoryMultiSlider(props: StoryMultiSliderProps) {
   const {children} = props;
   const trackRef = React.useRef<HTMLDivElement>(null);
-  const state = useMultiSliderState(props);
+  const state = useSliderState(props);
   const {
     trackProps, labelProps, labelId, containerProps
-  } = useMultiSlider(props, state, trackRef);
+  } = useSlider(props, state, trackRef);
 
   const numThumbs = React.Children.count(children);
   if (numThumbs !== state.values.length) {
@@ -55,7 +55,7 @@ interface StoryThumbProps extends Omit<SliderThumbProps, 'index'|'labelId'> {
 
 interface SliderStateContext {
   sliderProps: StoryMultiSliderProps;
-  state: MultiSliderState;
+  state: SliderState;
   trackRef: React.RefObject<HTMLElement>;
   index: number;
   labelId: string;

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -1,15 +1,15 @@
 import {classNames} from '@react-spectrum/utils';
+import {CommonSliderThumbProps, SliderProps, SliderThumbProps} from '@react-types/slider';
 import {FocusRing} from '@react-aria/focus';
-import {SliderProps, SliderThumbProps, CommonSliderThumbProps} from '@react-types/slider';
-import {SliderState, useSliderState} from '@react-stately/slider';
 import React from 'react';
+import {SliderState, useSliderState} from '@react-stately/slider';
 import styles from './story-slider.css';
 import {useSlider, useSliderThumb} from '@react-aria/slider';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 
 interface StoryMultiSliderProps extends SliderProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 export function StoryMultiSlider(props: StoryMultiSliderProps) {
@@ -54,11 +54,11 @@ interface StoryThumbProps extends Omit<SliderThumbProps, 'index'|'labelId'> {
 }
 
 interface SliderStateContext {
-  sliderProps: StoryMultiSliderProps;
-  state: SliderState;
-  trackRef: React.RefObject<HTMLElement>;
-  index: number;
-  commonThumbProps: CommonSliderThumbProps;
+  sliderProps: StoryMultiSliderProps,
+  state: SliderState,
+  trackRef: React.RefObject<HTMLElement>,
+  index: number,
+  commonThumbProps: CommonSliderThumbProps
 }
 
 export function StoryThumb(props: StoryThumbProps) {
@@ -73,7 +73,7 @@ export function StoryThumb(props: StoryThumbProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const {inputProps, thumbProps, labelProps} = useSliderThumb({
     sliderProps: context.sliderProps,
-    thumbProps: { ...props, index, ...commonThumbProps },
+    thumbProps: {...props, index, ...commonThumbProps},
     trackRef: context.trackRef,
     inputRef
   }, state);

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -1,0 +1,78 @@
+import {FocusRing} from '@react-aria/focus';
+import {MultiSliderProps} from '@react-types/slider';
+import React from 'react';
+import styles from './story-slider.css';
+import {useMultiSlider, useSliderThumb} from '@react-aria/slider';
+import {useMultiSliderState} from '@react-stately/slider';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
+
+
+interface StoryRangeSliderProps extends MultiSliderProps {
+  minLabel?: string;
+  maxLabel?: string;
+}
+
+export function StoryRangeSlider(props: StoryRangeSliderProps) {
+  const {minLabel, maxLabel} = props;
+  const trackRef = React.useRef<HTMLDivElement>(null);
+  const minInputRef = React.useRef<HTMLInputElement>(null);
+  const maxInputRef = React.useRef<HTMLInputElement>(null);
+  const state = useMultiSliderState(props);
+
+  if (state.values.length !== 2) {
+    throw new Error('Must specify an array of two numbers');
+  }
+
+  const {
+    trackProps, labelProps, labelId, containerProps
+  } = useMultiSlider(props, state, trackRef);
+
+  const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb(
+    props, {...props, index: 0, labelId, 'aria-label': minLabel ?? 'Minimum'}, state, trackRef, minInputRef);
+
+  const {thumbProps: maxThumbProps, inputProps: maxInputProps} = useSliderThumb(
+    props, {...props, index: 1, labelId, 'aria-label': maxLabel ?? 'Maximum'}, state, trackRef, maxInputRef);
+
+  return (
+    <div {...containerProps} className={styles.slider}>
+      <div className={styles.sliderLabel}>
+        {props.label && <label {...labelProps} className={styles.label}>{props.label}</label>}
+        <div className={styles.value}>
+          {state.getValueLabelForIndex(0)}
+          {' to '}
+          {state.getValueLabelForIndex(1)}
+        </div>
+      </div>
+      <div className={styles.trackContainer}>
+        <div className={styles.rail} />
+        <div 
+          className={styles.filledRail} 
+          style={{
+            left: `${state.getOffsetPercentForIndex(0) * 100}%`,
+            width: `${(state.getOffsetPercentForIndex(1) - state.getOffsetPercentForIndex(0)) * 100}%`
+          }} />
+        <div {...trackProps} ref={trackRef} className={styles.track} />
+        <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+          <div 
+            {...minThumbProps} 
+            className={styles.thumb}
+            style={{
+              'left': `${state.getOffsetPercentForIndex(0) * 100}%`
+            }}>
+            <VisuallyHidden isFocusable><input className={styles.input} ref={minInputRef} {...minInputProps} /></VisuallyHidden>
+          </div>
+        </FocusRing>
+        <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+          <div 
+            {...maxThumbProps} 
+            className={styles.thumb}
+            style={{
+              'left': `${state.getOffsetPercentForIndex(1) * 100}%`
+            }}>
+            <VisuallyHidden isFocusable><input className={styles.input} ref={maxInputRef} {...maxInputProps} /></VisuallyHidden>
+          </div>
+        </FocusRing>
+      </div>
+    </div>
+  );
+}

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -24,7 +24,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
   }
 
   const {
-    trackProps, labelProps, commonThumbProps, containerProps
+    trackProps, labelProps, thumbProps: commonThumbProps, containerProps
   } = useSlider(props, state, trackRef);
 
   const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb({
@@ -46,9 +46,9 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
       <div className={styles.sliderLabel}>
         {props.label && <label {...labelProps} className={styles.label}>{props.label}</label>}
         <div className={styles.value}>
-          {state.getValueLabelForIndex(0)}
+          {state.getThumbValueLabel(0)}
           {' to '}
-          {state.getValueLabelForIndex(1)}
+          {state.getThumbValueLabel(1)}
         </div>
       </div>
       <div className={styles.trackContainer}>
@@ -56,8 +56,8 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
         <div 
           className={styles.filledRail} 
           style={{
-            left: `${state.getOffsetPercentForIndex(0) * 100}%`,
-            width: `${(state.getOffsetPercentForIndex(1) - state.getOffsetPercentForIndex(0)) * 100}%`
+            left: `${state.getThumbPercent(0) * 100}%`,
+            width: `${(state.getThumbPercent(1) - state.getThumbPercent(0)) * 100}%`
           }} />
         <div {...trackProps} ref={trackRef} className={styles.track} />
         <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
@@ -65,7 +65,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
             {...minThumbProps} 
             className={styles.thumb}
             style={{
-              'left': `${state.getOffsetPercentForIndex(0) * 100}%`
+              'left': `${state.getThumbPercent(0) * 100}%`
             }}>
             <VisuallyHidden isFocusable><input className={styles.input} ref={minInputRef} {...minInputProps} /></VisuallyHidden>
           </div>
@@ -75,7 +75,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
             {...maxThumbProps} 
             className={styles.thumb}
             style={{
-              'left': `${state.getOffsetPercentForIndex(1) * 100}%`
+              'left': `${state.getThumbPercent(1) * 100}%`
             }}>
             <VisuallyHidden isFocusable><input className={styles.input} ref={maxInputRef} {...maxInputProps} /></VisuallyHidden>
           </div>

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -24,14 +24,14 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
   }
 
   const {
-    trackProps, labelProps, labelId, containerProps
+    trackProps, labelProps, commonThumbProps, containerProps
   } = useSlider(props, state, trackRef);
 
   const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb(
-    props, {...props, index: 0, labelId, 'aria-label': minLabel ?? 'Minimum'}, state, trackRef, minInputRef);
+    props, {...props, index: 0, 'aria-label': minLabel ?? 'Minimum', ...commonThumbProps}, state, trackRef, minInputRef);
 
   const {thumbProps: maxThumbProps, inputProps: maxInputProps} = useSliderThumb(
-    props, {...props, index: 1, labelId, 'aria-label': maxLabel ?? 'Maximum'}, state, trackRef, maxInputRef);
+    props, {...props, index: 1, 'aria-label': maxLabel ?? 'Maximum', ...commonThumbProps}, state, trackRef, maxInputRef);
 
   return (
     <div {...containerProps} className={styles.slider}>

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -1,6 +1,6 @@
 import {FocusRing} from '@react-aria/focus';
-import {SliderProps} from '@react-types/slider';
 import React from 'react';
+import {SliderProps} from '@react-types/slider';
 import styles from './story-slider.css';
 import {useSlider, useSliderThumb} from '@react-aria/slider';
 import {useSliderState} from '@react-stately/slider';
@@ -8,8 +8,8 @@ import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 
 interface StoryRangeSliderProps extends SliderProps {
-  minLabel?: string;
-  maxLabel?: string;
+  minLabel?: string,
+  maxLabel?: string
 }
 
 export function StoryRangeSlider(props: StoryRangeSliderProps) {

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -27,11 +27,19 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
     trackProps, labelProps, commonThumbProps, containerProps
   } = useSlider(props, state, trackRef);
 
-  const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb(
-    props, {...props, index: 0, 'aria-label': minLabel ?? 'Minimum', ...commonThumbProps}, state, trackRef, minInputRef);
+  const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb({
+    sliderProps: props,
+    thumbProps: {...props, index: 0, 'aria-label': minLabel ?? 'Minimum', ...commonThumbProps},
+    trackRef,
+    inputRef: minInputRef
+  }, state);
 
-  const {thumbProps: maxThumbProps, inputProps: maxInputProps} = useSliderThumb(
-    props, {...props, index: 1, 'aria-label': maxLabel ?? 'Maximum', ...commonThumbProps}, state, trackRef, maxInputRef);
+  const {thumbProps: maxThumbProps, inputProps: maxInputProps} = useSliderThumb({
+    sliderProps: props,
+    thumbProps: {...props, index: 1, 'aria-label': maxLabel ?? 'Maximum', ...commonThumbProps},
+    trackRef,
+    inputRef: maxInputRef
+  }, state);
 
   return (
     <div {...containerProps} className={styles.slider}>

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -28,15 +28,21 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
   } = useSlider(props, state, trackRef);
 
   const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb({
-    sliderProps: props,
-    thumbProps: {...props, index: 0, 'aria-label': minLabel ?? 'Minimum', ...commonThumbProps},
+    index: 0, 
+    'aria-label': minLabel ?? 'Minimum', 
+    ...commonThumbProps,
+    isReadOnly: props.isReadOnly,
+    isDisabled: props.isDisabled,
     trackRef,
     inputRef: minInputRef
   }, state);
 
   const {thumbProps: maxThumbProps, inputProps: maxInputProps} = useSliderThumb({
-    sliderProps: props,
-    thumbProps: {...props, index: 1, 'aria-label': maxLabel ?? 'Maximum', ...commonThumbProps},
+    index: 1, 
+    'aria-label': maxLabel ?? 'Maximum', 
+    ...commonThumbProps,
+    isReadOnly: props.isReadOnly,
+    isDisabled: props.isDisabled,
     trackRef,
     inputRef: maxInputRef
   }, state);

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -1,13 +1,13 @@
 import {FocusRing} from '@react-aria/focus';
-import {MultiSliderProps} from '@react-types/slider';
+import {SliderProps} from '@react-types/slider';
 import React from 'react';
 import styles from './story-slider.css';
-import {useMultiSlider, useSliderThumb} from '@react-aria/slider';
-import {useMultiSliderState} from '@react-stately/slider';
+import {useSlider, useSliderThumb} from '@react-aria/slider';
+import {useSliderState} from '@react-stately/slider';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 
-interface StoryRangeSliderProps extends MultiSliderProps {
+interface StoryRangeSliderProps extends SliderProps {
   minLabel?: string;
   maxLabel?: string;
 }
@@ -17,7 +17,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
   const trackRef = React.useRef<HTMLDivElement>(null);
   const minInputRef = React.useRef<HTMLInputElement>(null);
   const maxInputRef = React.useRef<HTMLInputElement>(null);
-  const state = useMultiSliderState(props);
+  const state = useSliderState(props);
 
   if (state.values.length !== 2) {
     throw new Error('Must specify an array of two numbers');
@@ -25,7 +25,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
 
   const {
     trackProps, labelProps, labelId, containerProps
-  } = useMultiSlider(props, state, trackRef);
+  } = useSlider(props, state, trackRef);
 
   const {thumbProps: minThumbProps, inputProps: minInputProps} = useSliderThumb(
     props, {...props, index: 0, labelId, 'aria-label': minLabel ?? 'Minimum'}, state, trackRef, minInputRef);

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -27,11 +27,11 @@ export function StorySlider(props: StorySliderProps) {
 
   const state = useSliderState(multiProps);
   const {
-    trackProps, labelProps, labelId
+    trackProps, labelProps, commonThumbProps
   } = useSlider(multiProps, state, trackRef);
 
   const {thumbProps, inputProps} = useSliderThumb(
-    props, {...props, index: 0, labelId}, state, trackRef, inputRef);
+    props, {...props, index: 0, ...commonThumbProps}, state, trackRef, inputRef);
 
   const value = state.values[0];
 

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -1,9 +1,9 @@
-import {BaseSliderProps, MultiSliderProps} from '@react-types/slider';
-import {DEFAULT_MIN_VALUE, useMultiSliderState} from '@react-stately/slider';
+import {BaseSliderProps, SliderProps} from '@react-types/slider';
+import {DEFAULT_MIN_VALUE, useSliderState} from '@react-stately/slider';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';
 import styles from './story-slider.css';
-import {useMultiSlider, useSliderThumb} from '@react-aria/slider';
+import {useSlider, useSliderThumb} from '@react-aria/slider';
 import {ValueBase} from '@react-types/shared';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
@@ -17,7 +17,7 @@ export function StorySlider(props: StorySliderProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const origin = props.origin ?? props.minValue ?? DEFAULT_MIN_VALUE;
 
-  const multiProps: MultiSliderProps = {
+  const multiProps: SliderProps = {
     ...props,
     value: props.value == null ? undefined :  [props.value],
     defaultValue: props.defaultValue == null ? undefined : [props.defaultValue],
@@ -25,10 +25,10 @@ export function StorySlider(props: StorySliderProps) {
     onChangeEnd: props.onChangeEnd == null ? undefined : (vals: number[]) => props.onChangeEnd(vals[0])
   };
 
-  const state = useMultiSliderState(multiProps);
+  const state = useSliderState(multiProps);
   const {
     trackProps, labelProps, labelId
-  } = useMultiSlider(multiProps, state, trackRef);
+  } = useSlider(multiProps, state, trackRef);
 
   const {thumbProps, inputProps} = useSliderThumb(
     props, {...props, index: 0, labelId}, state, trackRef, inputRef);

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -8,8 +8,8 @@ import {ValueBase} from '@react-types/shared';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 interface StorySliderProps extends BaseSliderProps, ValueBase<number> {
-  origin?: number;
-  onChangeEnd?: (value: number) => void;
+  origin?: number,
+  onChangeEnd?: (value: number) => void
 }
 
 export function StorySlider(props: StorySliderProps) {

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -31,8 +31,10 @@ export function StorySlider(props: StorySliderProps) {
   } = useSlider(multiProps, state, trackRef);
 
   const {thumbProps, inputProps} = useSliderThumb({
-    sliderProps: props,
-    thumbProps: {...props, index: 0, ...commonThumbProps},
+    index: 0,
+    ...commonThumbProps,
+    isReadOnly: props.isReadOnly,
+    isDisabled: props.isDisabled,
     trackRef,
     inputRef
   }, state);

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -1,0 +1,66 @@
+import {BaseSliderProps, MultiSliderProps} from '@react-types/slider';
+import {DEFAULT_MIN_VALUE, useMultiSliderState} from '@react-stately/slider';
+import {FocusRing} from '@react-aria/focus';
+import React from 'react';
+import styles from './story-slider.css';
+import {useMultiSlider, useSliderThumb} from '@react-aria/slider';
+import {ValueBase} from '@react-types/shared';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
+
+interface StorySliderProps extends BaseSliderProps, ValueBase<number> {
+  origin?: number;
+  onChangeEnd?: (value: number) => void;
+}
+
+export function StorySlider(props: StorySliderProps) {
+  const trackRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const origin = props.origin ?? props.minValue ?? DEFAULT_MIN_VALUE;
+
+  const multiProps: MultiSliderProps = {
+    ...props,
+    value: props.value == null ? undefined :  [props.value],
+    defaultValue: props.defaultValue == null ? undefined : [props.defaultValue],
+    onChange: props.onChange == null ? undefined : (vals: number[]) => props.onChange(vals[0]),
+    onChangeEnd: props.onChangeEnd == null ? undefined : (vals: number[]) => props.onChangeEnd(vals[0])
+  };
+
+  const state = useMultiSliderState(multiProps);
+  const {
+    trackProps, labelProps, labelId
+  } = useMultiSlider(multiProps, state, trackRef);
+
+  const {thumbProps, inputProps} = useSliderThumb(
+    props, {...props, index: 0, labelId}, state, trackRef, inputRef);
+
+  const value = state.values[0];
+
+  return (
+    <div className={styles.slider}>
+      <div className={styles.sliderLabel}>
+        {props.label && <label {...labelProps} className={styles.label}>{props.label}</label>}
+        <div className={styles.value}>{state.getValueLabelForIndex(0)}</div>
+      </div>
+      <div className={styles.trackContainer}>
+        <div className={styles.rail} />
+        <div 
+          className={styles.filledRail} 
+          style={{
+            left: `${state.getOffsetPercentForValue(Math.min(value, origin)) * 100}%`,
+            width: `${(state.getOffsetPercentForValue(Math.max(value, origin)) - state.getOffsetPercentForValue(Math.min(value, origin))) * 100}%`
+          }} />
+        <div {...trackProps} ref={trackRef} className={styles.track} />
+        <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+          <div 
+            {...thumbProps} 
+            className={styles.thumb}
+            style={{
+              'left': `${state.getOffsetPercentForIndex(0) * 100}%`
+            }}>
+            <VisuallyHidden isFocusable><input className={styles.input} ref={inputRef} {...inputProps} /></VisuallyHidden>
+          </div>
+        </FocusRing>
+      </div>
+    </div>
+  );
+}

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -27,7 +27,7 @@ export function StorySlider(props: StorySliderProps) {
 
   const state = useSliderState(multiProps);
   const {
-    trackProps, labelProps, commonThumbProps
+    trackProps, labelProps, thumbProps: commonThumbProps
   } = useSlider(multiProps, state, trackRef);
 
   const {thumbProps, inputProps} = useSliderThumb({
@@ -43,15 +43,15 @@ export function StorySlider(props: StorySliderProps) {
     <div className={styles.slider}>
       <div className={styles.sliderLabel}>
         {props.label && <label {...labelProps} className={styles.label}>{props.label}</label>}
-        <div className={styles.value}>{state.getValueLabelForIndex(0)}</div>
+        <div className={styles.value}>{state.getThumbValueLabel(0)}</div>
       </div>
       <div className={styles.trackContainer}>
         <div className={styles.rail} />
         <div 
           className={styles.filledRail} 
           style={{
-            left: `${state.getOffsetPercentForValue(Math.min(value, origin)) * 100}%`,
-            width: `${(state.getOffsetPercentForValue(Math.max(value, origin)) - state.getOffsetPercentForValue(Math.min(value, origin))) * 100}%`
+            left: `${state.getValuePercent(Math.min(value, origin)) * 100}%`,
+            width: `${(state.getValuePercent(Math.max(value, origin)) - state.getValuePercent(Math.min(value, origin))) * 100}%`
           }} />
         <div {...trackProps} ref={trackRef} className={styles.track} />
         <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
@@ -59,7 +59,7 @@ export function StorySlider(props: StorySliderProps) {
             {...thumbProps} 
             className={styles.thumb}
             style={{
-              'left': `${state.getOffsetPercentForIndex(0) * 100}%`
+              'left': `${state.getThumbPercent(0) * 100}%`
             }}>
             <VisuallyHidden isFocusable><input className={styles.input} ref={inputRef} {...inputProps} /></VisuallyHidden>
           </div>

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -30,8 +30,12 @@ export function StorySlider(props: StorySliderProps) {
     trackProps, labelProps, commonThumbProps
   } = useSlider(multiProps, state, trackRef);
 
-  const {thumbProps, inputProps} = useSliderThumb(
-    props, {...props, index: 0, ...commonThumbProps}, state, trackRef, inputRef);
+  const {thumbProps, inputProps} = useSliderThumb({
+    sliderProps: props,
+    thumbProps: {...props, index: 0, ...commonThumbProps},
+    trackRef,
+    inputRef
+  }, state);
 
   const value = state.values[0];
 

--- a/packages/@react-aria/slider/stories/story-slider.css
+++ b/packages/@react-aria/slider/stories/story-slider.css
@@ -1,0 +1,83 @@
+.slider {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 300px;
+}
+
+.sliderLabel {
+  display: flex;
+  align-self: stretch;
+}
+
+.label {
+  color: #8b8b8b;
+}
+
+.value {
+  color: #585858;
+  margin-left: auto;
+}
+
+.thumb {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #707070;
+  box-sizing: border-box;
+  background-color: #f5f5f5;
+  box-shadow: 0 0 0 4px #f5f5f5;
+  top: 4px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.thumbFocusVisible {
+  box-shadow: 0 0 0 2px #f5f5f5, 0 0 0 4px #2c83eb;
+}
+
+.thumbFocused {
+  border-color: #2c83eb;
+}
+
+.thumbDisabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.thumbDisabled label {
+  cursor: inherit;
+}
+
+.rail {
+  position: absolute;
+  background-color: #e4e4e4;
+  height: 3px;
+  top: 13px;
+  width: 100%;
+}
+
+.filledRail {
+  position: absolute;
+  height: 3px;
+  background-color: #707070;
+  top: 13px;
+  height: 3px;
+  top: 13px;
+  left: 0;
+}
+
+.track {
+  position: relative;
+  height: 30px;
+  width: 100%;
+}
+
+.trackContainer {
+  position: relative;
+  width: 100%;
+}

--- a/packages/@react-aria/slider/test/useSlider.test.js
+++ b/packages/@react-aria/slider/test/useSlider.test.js
@@ -1,0 +1,114 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import * as React from 'react';
+import {renderHook} from '@testing-library/react-hooks';
+import {useRef} from 'react';
+import {useSlider} from '../src';
+import {useSliderState} from '@react-stately/slider';
+
+describe('useSlider', () => {
+  describe('aria labels', () => {
+    function renderUseSlider(sliderProps) {
+      return renderHook(() => {
+        let trackRef = useRef(null);
+        let state = useSliderState(sliderProps);
+        let props = useSlider(sliderProps, state, trackRef);
+        return {state, props, trackRef};
+      }).result;
+    }
+  
+    it('should have the right labels when setting label', () => {
+      let result = renderUseSlider({
+        defaultValue: [0],
+        label: 'Slider'
+      });
+  
+      let {labelProps, containerProps, thumbProps} = result.current.props;
+  
+      expect(labelProps.id).toBe(thumbProps.labelId);
+      expect(containerProps.role).toBe('group');
+      expect(containerProps.id).toBe(labelProps.htmlFor);
+    });
+  
+    it('should have the right labels when setting aria-label', () => {
+      let result = renderUseSlider({
+        defaultValue: [0],
+        'aria-label': 'Slider'
+      });
+  
+      let {labelProps, containerProps, thumbProps} = result.current.props;
+  
+      expect(labelProps).toEqual({});
+      expect(containerProps.id).toBe(thumbProps.labelId);
+      expect(containerProps.role).toBe('group');
+      expect(containerProps['aria-label']).toBe('Slider');
+    });
+  });
+
+  describe('interactions on track', () => {
+    let widthStub;
+    beforeAll(() => {
+      widthStub = jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 100);
+    });
+    afterAll(() => {
+      widthStub.mockReset();
+    });
+
+    let stateRef = React.createRef();
+
+    function Example(props) {
+      let trackRef = useRef(null);
+      let state = useSliderState(props);
+      stateRef.current = state;
+      let {trackProps} = useSlider(props, state, trackRef);
+      return <div data-testid="track" ref={trackRef} {...trackProps} />;
+    }
+
+    it('should allow you to set value of closest thumb by clicking on track', () => {
+      let onChangeSpy = jest.fn();
+      let onChangeEndSpy = jest.fn();
+      render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10, 80]} />);
+
+      let track = screen.getByTestId('track');
+      fireEvent.mouseDown(track, {clientX: 20});
+      fireEvent.mouseUp(track, {clientX: 20});
+
+      expect(onChangeSpy).toHaveBeenLastCalledWith([20, 80]);
+      expect(onChangeEndSpy).toHaveBeenLastCalledWith([20, 80]);
+      expect(stateRef.current.values).toEqual([20, 80]);
+
+      track = screen.getByTestId('track');
+      fireEvent.mouseDown(track, {clientX: 90});
+      fireEvent.mouseUp(track, {clientX: 90});
+
+      expect(onChangeSpy).toHaveBeenLastCalledWith([20, 90]);
+      expect(onChangeEndSpy).toHaveBeenLastCalledWith([20, 90]);
+      expect(stateRef.current.values).toEqual([20, 90]);
+    });
+
+    it('should allow you to set value of closest thumb by dragging on track', () => {
+      let onChangeSpy = jest.fn();
+      let onChangeEndSpy = jest.fn();
+      render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10, 80]} />);
+
+      let track = screen.getByTestId('track');
+      fireEvent.mouseDown(track, {clientX: 20});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([20, 80]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([20, 80]);
+      
+      fireEvent.mouseMove(track, {clientX: 30});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([30, 80]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([30, 80]);
+
+      fireEvent.mouseMove(track, {clientX: 40});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([40, 80]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([40, 80]);
+
+      fireEvent.mouseUp(track, {clientX: 40});
+      expect(onChangeEndSpy).toHaveBeenLastCalledWith([40, 80]);
+      expect(stateRef.current.values).toEqual([40, 80]);
+    });
+  });
+});

--- a/packages/@react-aria/slider/test/useSliderThumb.test.js
+++ b/packages/@react-aria/slider/test/useSliderThumb.test.js
@@ -1,0 +1,207 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import * as React from 'react';
+import {renderHook} from '@testing-library/react-hooks';
+import {useRef} from 'react';
+import {useSlider, useSliderThumb} from '../src';
+import {useSliderState} from '@react-stately/slider';
+
+describe('useSliderThumb', () => {
+  describe('aria labels', () => {
+    it('should have the right labels with Slider-level label', () => {
+      let result = renderHook(() => {
+        let trackRef = React.createRef(null);
+        let inputRef = React.createRef(null);
+        let sliderProps = {
+          label: 'slider',
+          defaultValue: [50],
+          minValue: 10,
+          maxValue: 200,
+          step: 2
+        };
+        let state = useSliderState(sliderProps);
+        let {thumbProps: commonThumbProps} = useSlider(sliderProps, state, trackRef);
+        let props = useSliderThumb({
+          sliderProps,
+          thumbProps: {
+            index: 0, ...commonThumbProps
+          },
+          trackRef,
+          inputRef
+        }, state);
+        return {props, labelId: commonThumbProps.labelId};
+      }).result;
+      
+      let {inputProps} = result.current.props;
+      let labelId = result.current.labelId;
+      expect(inputProps).toMatchObject({type: 'range', step: 2, value: 50, min: 10, max: 200, 'aria-labelledby': `${labelId}`});
+    });
+    it('should have the right labels with Slider thumb label', () => {
+      let result = renderHook(() => {
+        let trackRef = React.createRef(null);
+        let inputRef = React.createRef(null);
+        let sliderProps = {
+          'aria-label': 'slider',
+          defaultValue: [50],
+          minValue: 10,
+          maxValue: 200,
+          step: 2
+        };
+        let state = useSliderState(sliderProps);
+        let {thumbProps: commonThumbProps} = useSlider(sliderProps, state, trackRef);
+        let props = useSliderThumb({
+          sliderProps,
+          thumbProps: {
+            index: 0, 
+            label: 'thumb',
+            ...commonThumbProps
+          },
+          trackRef,
+          inputRef
+        }, state);
+        return {props, labelId: commonThumbProps.labelId};
+      }).result;
+      
+      let {inputProps, labelProps} = result.current.props;
+      let labelId = result.current.labelId;
+      expect(inputProps).toMatchObject({type: 'range', step: 2, value: 50, min: 10, max: 200, 'aria-labelledby': `${labelId} ${labelProps.id}`, id: labelProps.htmlFor});
+    });
+    it('should have the right labels with Slider thumb aria-label', () => {
+      let result = renderHook(() => {
+        let trackRef = React.createRef(null);
+        let inputRef = React.createRef(null);
+        let sliderProps = {
+          'aria-label': 'slider',
+          defaultValue: [50, 70],
+          minValue: 10,
+          maxValue: 200,
+          step: 2
+        };
+        let state = useSliderState(sliderProps);
+        let {thumbProps: commonThumbProps} = useSlider(sliderProps, state, trackRef);
+        let props0 = useSliderThumb({
+          sliderProps,
+          thumbProps: {
+            index: 0, 
+            'aria-label': 'thumb0',
+            ...commonThumbProps
+          },
+          trackRef,
+          inputRef
+        }, state);
+        let props1 = useSliderThumb({
+          sliderProps,
+          thumbProps: {
+            index: 1, 
+            'aria-label': 'thumb1',
+            ...commonThumbProps
+          },
+          trackRef,
+          inputRef
+        }, state);
+        return {props0, props1, labelId: commonThumbProps.labelId};
+      }).result;
+      
+      let {inputProps: inputProps0} = result.current.props0;
+      let {inputProps: inputProps1} = result.current.props1;
+      let labelId = result.current.labelId;
+      expect(inputProps0).toMatchObject({type: 'range', step: 2, value: 50, min: 10, max: 70, 'aria-labelledby': `${labelId} ${inputProps0.id}`});
+      expect(inputProps1).toMatchObject({type: 'range', step: 2, value: 70, min: 50, max: 200, 'aria-labelledby': `${labelId} ${inputProps1.id}`});
+    });
+  });
+
+  describe('interactions on thumbs', () => {
+    let widthStub;
+    beforeAll(() => {
+      widthStub = jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 100);
+    });
+    afterAll(() => {
+      widthStub.mockReset();
+    });
+
+    let stateRef = React.createRef();
+
+    function RangeExample(props) {
+      let trackRef = useRef(null);
+      let input0Ref = useRef(null);
+      let input1Ref = useRef(null);
+      let state = useSliderState(props);
+      stateRef.current = state;
+      let {trackProps, thumbProps: commonThumbProps} = useSlider(props, state, trackRef);
+      let {inputProps: input0Props, thumbProps: thumb0Props} = useSliderThumb({
+        sliderProps: props, 
+        thumbProps: {...commonThumbProps, 'aria-label': 'Min', index: 0},
+        trackRef,
+        inputRef: input0Ref
+      }, state);
+      let {inputProps: input1Props, thumbProps: thumb1Props} = useSliderThumb({
+        sliderProps: props, 
+        thumbProps: {...commonThumbProps, 'aria-label': 'Max', index: 1},
+        trackRef,
+        inputRef: input1Ref
+      }, state);
+      return (
+        <div data-testid="track" ref={trackRef} {...trackProps}>
+          <div data-testid="thumb0" {...thumb0Props}>
+            <input {...input0Props} />
+          </div>
+          <div data-testid="thumb1" {...thumb1Props}>
+            <input {...input1Props} />
+          </div>
+        </div>
+      );
+    }
+
+    it('can be moved by dragging', () => {
+      let onChangeSpy = jest.fn();
+      let onChangeEndSpy = jest.fn();
+      render(<RangeExample onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10, 80]} />);
+
+      // Drag thumb0
+      let thumb0 = screen.getByTestId('thumb0');
+      fireEvent.mouseDown(thumb0, {clientX: 10});
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([10, 80]);
+
+      fireEvent.mouseMove(thumb0, {clientX: 20});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([20, 80]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([20, 80]);
+
+      fireEvent.mouseMove(thumb0, {clientX: 30});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([30, 80]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([30, 80]);
+
+      fireEvent.mouseUp(thumb0, {clientX: 40});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([40, 80]);
+      expect(onChangeEndSpy).toHaveBeenLastCalledWith([40, 80]);
+      expect(stateRef.current.values).toEqual([40, 80]);
+
+      onChangeSpy.mockClear();
+      onChangeEndSpy.mockClear();
+      
+      // Drag thumb1 past thumb0
+      let thumb1 = screen.getByTestId('thumb1');
+      fireEvent.mouseDown(thumb1, {clientX: 80});
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([40, 80]);
+      
+      fireEvent.mouseMove(thumb1, {clientX: 60});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([40, 60]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([40, 60]);
+      
+      fireEvent.mouseMove(thumb1, {clientX: 30});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([40, 40]);
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([40, 40]);
+      
+      fireEvent.mouseUp(thumb1, {clientX: 30});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([40, 40]);
+      expect(onChangeEndSpy).toHaveBeenLastCalledWith([40, 40]);
+      expect(stateRef.current.values).toEqual([40, 40]);
+    });
+  });
+});

--- a/packages/@react-aria/slider/test/useSliderThumb.test.js
+++ b/packages/@react-aria/slider/test/useSliderThumb.test.js
@@ -21,10 +21,8 @@ describe('useSliderThumb', () => {
         let state = useSliderState(sliderProps);
         let {thumbProps: commonThumbProps} = useSlider(sliderProps, state, trackRef);
         let props = useSliderThumb({
-          sliderProps,
-          thumbProps: {
-            index: 0, ...commonThumbProps
-          },
+          index: 0,
+          ...commonThumbProps,
           trackRef,
           inputRef
         }, state);
@@ -49,12 +47,9 @@ describe('useSliderThumb', () => {
         let state = useSliderState(sliderProps);
         let {thumbProps: commonThumbProps} = useSlider(sliderProps, state, trackRef);
         let props = useSliderThumb({
-          sliderProps,
-          thumbProps: {
-            index: 0, 
-            label: 'thumb',
-            ...commonThumbProps
-          },
+          index: 0, 
+          label: 'thumb',
+          ...commonThumbProps,
           trackRef,
           inputRef
         }, state);
@@ -79,22 +74,16 @@ describe('useSliderThumb', () => {
         let state = useSliderState(sliderProps);
         let {thumbProps: commonThumbProps} = useSlider(sliderProps, state, trackRef);
         let props0 = useSliderThumb({
-          sliderProps,
-          thumbProps: {
-            index: 0, 
-            'aria-label': 'thumb0',
-            ...commonThumbProps
-          },
+          index: 0, 
+          'aria-label': 'thumb0',
+          ...commonThumbProps,
           trackRef,
           inputRef
         }, state);
         let props1 = useSliderThumb({
-          sliderProps,
-          thumbProps: {
-            index: 1, 
-            'aria-label': 'thumb1',
-            ...commonThumbProps
-          },
+          index: 1, 
+          'aria-label': 'thumb1',
+          ...commonThumbProps,
           trackRef,
           inputRef
         }, state);
@@ -128,14 +117,16 @@ describe('useSliderThumb', () => {
       stateRef.current = state;
       let {trackProps, thumbProps: commonThumbProps} = useSlider(props, state, trackRef);
       let {inputProps: input0Props, thumbProps: thumb0Props} = useSliderThumb({
-        sliderProps: props, 
-        thumbProps: {...commonThumbProps, 'aria-label': 'Min', index: 0},
+        ...commonThumbProps, 
+        'aria-label': 'Min', 
+        index: 0,
         trackRef,
         inputRef: input0Ref
       }, state);
       let {inputProps: input1Props, thumbProps: thumb1Props} = useSliderThumb({
-        sliderProps: props, 
-        thumbProps: {...commonThumbProps, 'aria-label': 'Max', index: 1},
+        ...commonThumbProps, 
+        'aria-label': 'Max', 
+        index: 1,
         trackRef,
         inputRef: input1Ref
       }, state);

--- a/packages/@react-aria/utils/src/useDrag1D.ts
+++ b/packages/@react-aria/utils/src/useDrag1D.ts
@@ -97,10 +97,10 @@ export function useDrag1D(props: UseDrag1DProps): HTMLAttributes<HTMLElement> {
   };
 
   let onKeyDown = (e) => {
-    e.preventDefault();
     switch (e.key) {
       case 'Left':
       case 'ArrowLeft':
+        e.preventDefault();
         if (orientation === 'horizontal') {
           if (onDecrement && !reverse) {
             onDecrement();
@@ -111,6 +111,7 @@ export function useDrag1D(props: UseDrag1DProps): HTMLAttributes<HTMLElement> {
         break;
       case 'Up':
       case 'ArrowUp':
+        e.preventDefault();
         if (orientation === 'vertical') {
           if (onDecrement && !reverse) {
             onDecrement();
@@ -121,6 +122,7 @@ export function useDrag1D(props: UseDrag1DProps): HTMLAttributes<HTMLElement> {
         break;
       case 'Right':
       case 'ArrowRight':
+        e.preventDefault();
         if (orientation === 'horizontal') {
           if (onIncrement && !reverse) {
             onIncrement();
@@ -131,6 +133,7 @@ export function useDrag1D(props: UseDrag1DProps): HTMLAttributes<HTMLElement> {
         break;
       case 'Down':
       case 'ArrowDown':
+        e.preventDefault();
         if (orientation === 'vertical') {
           if (onIncrement && !reverse) {
             onIncrement();
@@ -140,16 +143,19 @@ export function useDrag1D(props: UseDrag1DProps): HTMLAttributes<HTMLElement> {
         }
         break;
       case 'Home':
+        e.preventDefault();
         if (onDecrementToMin) {
           onDecrementToMin();
         }
         break;
       case 'End':
+        e.preventDefault();
         if (onIncrementToMax) {
           onIncrementToMax();
         }
         break;
       case 'Enter':
+        e.preventDefault();
         if (onCollapseToggle) {
           onCollapseToggle();
         }

--- a/packages/@react-stately/slider/index.ts
+++ b/packages/@react-stately/slider/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './src';

--- a/packages/@react-stately/slider/package.json
+++ b/packages/@react-stately/slider/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@react-stately/slider",
+  "version": "3.0.2",
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
+  "source": "src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/react-spectrum"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.6.2",
+    "@react-aria/i18n": "3.0.2",
+    "@react-aria/utils": "^3.0.2",
+    "@react-stately/utils": "^3.0.2",
+    "@react-types/slider": "^3.0.2"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "devDependencies": {
+    "react": "^16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-stately/slider/src/index.ts
+++ b/packages/@react-stately/slider/src/index.ts
@@ -10,4 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './useMultiSliderState';
+export * from './useSliderState';

--- a/packages/@react-stately/slider/src/index.ts
+++ b/packages/@react-stately/slider/src/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './useMultiSliderState';

--- a/packages/@react-stately/slider/src/useMultiSliderState.ts
+++ b/packages/@react-stately/slider/src/useMultiSliderState.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {clamp} from '@react-aria/utils';
+import {MultiSliderProps} from '@react-types/slider';
+import {useControlledState} from '@react-stately/utils';
+import {useNumberFormatter} from '@react-aria/i18n';
+import {useRef, useState} from 'react';
+
+export interface MultiSliderState {
+  // Values managed by the slider
+  readonly values: number[];
+  setValue: (index: number, value: number) => void;
+
+  // Whether a specific index is being dragged
+  isDragging: (index: number) => boolean;
+  setDragging: (index: number, dragging: boolean) => void;
+
+  // Currently-focused index
+  readonly focusedIndex: number | undefined;
+  setFocusedIndex: (index: number | undefined) => void;
+
+  // Returns the value offset as a percentage from 0 to 1.
+  getOffsetPercentForIndex: (index: number) => number;
+  getOffsetPercentForValue: (value: number) => number;
+
+  // Returns the string label for the value, per props.formatOptions
+  getValueLabelForIndex: (index: number) => string;
+  getValueLabelForValue: (value: number) => string;
+
+  // Returns the min and max values for the index
+  getMinValueForIndex: (index: number) => number;
+  getMaxValueForIndex: (index: number) => number;
+}
+
+export const DEFAULT_MIN_VALUE = 0;
+export const DEFAULT_MAX_VALUE = 100;
+export const DEFAULT_STEP_VALUE = 1;
+
+export function useMultiSliderState(props: MultiSliderProps): MultiSliderState {
+  let {isReadOnly, isDisabled, minValue = DEFAULT_MIN_VALUE, maxValue = DEFAULT_MAX_VALUE, formatOptions} = props;
+
+  const [values, setValues] = useControlledState<number[]>(
+    props.value as any,
+    props.defaultValue ?? [minValue] as any,
+    props.onChange as any
+  );
+  const [isDraggings, setDraggings] = useState<boolean[]>(new Array(values.length).fill(false));
+  const [focusedIndex, setFocusedIndex] = useState<number|undefined>(undefined);
+  const realTimeDragging = useRef(false);
+  const formatter = useNumberFormatter(formatOptions);
+
+  function getOffsetPercentForValue(value: number) {
+    return (value - minValue) / (maxValue - minValue);
+  }
+
+  function getMinValueForIndex(index: number) {
+    return index === 0 ? minValue : values[index - 1];
+  }
+  function getMaxValueForIndex(index: number) {
+    return index === values.length - 1 ? maxValue : values[index + 1];
+  }
+
+  function updateValue(index: number, value: number) {
+    if (isReadOnly || isDisabled) {
+      return;
+    }
+    const thisMin = getMinValueForIndex(index);
+    const thisMax = getMaxValueForIndex(index);
+    value = clamp(value, thisMin, thisMax);
+    const newValues = replaceIndex(values, index, value);
+    setValues(newValues);
+
+    if (props.onChangeEnd && !realTimeDragging.current) {
+      // If not in the middle of dragging, call onChangeEnd
+      props.onChangeEnd(newValues);
+    }
+  }
+
+  function updateDragging(index: number, dragging: boolean) {
+    setDraggings(replaceIndex(isDraggings, index, dragging));
+    realTimeDragging.current = dragging;
+  }
+
+  function getValueLabelForValue(value: number) {
+    return formatter.format(value);
+  }
+
+  return {
+    values: values,
+    setValue: updateValue,
+    isDragging: (index: number) => isDraggings[index],
+    setDragging: updateDragging,
+    focusedIndex,
+    setFocusedIndex,
+    getOffsetPercentForIndex: (index: number) => getOffsetPercentForValue(values[index]),
+    getOffsetPercentForValue,
+    getValueLabelForIndex: (index: number) => getValueLabelForValue(values[index]),
+    getValueLabelForValue,
+    getMinValueForIndex,
+    getMaxValueForIndex
+  };
+}
+
+function replaceIndex<T>(array: T[], index: number, value: T) {
+  return [...array.slice(0, index), value, ...array.slice(index + 1)];
+}

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -18,28 +18,28 @@ import {useRef, useState} from 'react';
 
 export interface SliderState {
   // Values managed by the slider
-  readonly values: number[];
-  setValue: (index: number, value: number) => void;
+  readonly values: number[],
+  setValue: (index: number, value: number) => void,
 
   // Whether a specific index is being dragged
-  isDragging: (index: number) => boolean;
-  setDragging: (index: number, dragging: boolean) => void;
+  isDragging: (index: number) => boolean,
+  setDragging: (index: number, dragging: boolean) => void,
 
   // Currently-focused index
-  readonly focusedIndex: number | undefined;
-  setFocusedIndex: (index: number | undefined) => void;
+  readonly focusedIndex: number | undefined,
+  setFocusedIndex: (index: number | undefined) => void,
 
   // Returns the value offset as a percentage from 0 to 1.
-  getOffsetPercentForIndex: (index: number) => number;
-  getOffsetPercentForValue: (value: number) => number;
+  getOffsetPercentForIndex: (index: number) => number,
+  getOffsetPercentForValue: (value: number) => number,
 
   // Returns the string label for the value, per props.formatOptions
-  getValueLabelForIndex: (index: number) => string;
-  getValueLabelForValue: (value: number) => string;
+  getValueLabelForIndex: (index: number) => string,
+  getValueLabelForValue: (value: number) => string,
 
   // Returns the min and max values for the index
-  getMinValueForIndex: (index: number) => number;
-  getMaxValueForIndex: (index: number) => number;
+  getMinValueForIndex: (index: number) => number,
+  getMaxValueForIndex: (index: number) => number
 }
 
 export const DEFAULT_MIN_VALUE = 0;

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -87,8 +87,9 @@ export function useSliderState(props: SliderProps): SliderState {
   }
 
   function updateDragging(index: number, dragging: boolean) {
-    setDraggings(replaceIndex(isDraggings, index, dragging));
-    realTimeDragging.current = dragging;
+    const newDraggings = replaceIndex(isDraggings, index, dragging);
+    setDraggings(newDraggings);
+    realTimeDragging.current = newDraggings.some(Boolean);
   }
 
   function getValueLabelForValue(value: number) {

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -11,12 +11,12 @@
  */
 
 import {clamp} from '@react-aria/utils';
-import {MultiSliderProps} from '@react-types/slider';
+import {SliderProps} from '@react-types/slider';
 import {useControlledState} from '@react-stately/utils';
 import {useNumberFormatter} from '@react-aria/i18n';
 import {useRef, useState} from 'react';
 
-export interface MultiSliderState {
+export interface SliderState {
   // Values managed by the slider
   readonly values: number[];
   setValue: (index: number, value: number) => void;
@@ -46,7 +46,7 @@ export const DEFAULT_MIN_VALUE = 0;
 export const DEFAULT_MAX_VALUE = 100;
 export const DEFAULT_STEP_VALUE = 1;
 
-export function useMultiSliderState(props: MultiSliderProps): MultiSliderState {
+export function useSliderState(props: SliderProps): SliderState {
   let {isReadOnly, isDisabled, minValue = DEFAULT_MIN_VALUE, maxValue = DEFAULT_MAX_VALUE, formatOptions} = props;
 
   const [values, setValues] = useControlledState<number[]>(

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -19,27 +19,28 @@ import {useRef, useState} from 'react';
 export interface SliderState {
   // Values managed by the slider
   readonly values: number[],
-  setValue: (index: number, value: number) => void,
+  getThumbValue: (index: number) => number,
+  setThumbValue: (index: number, value: number) => void,
 
   // Whether a specific index is being dragged
-  isDragging: (index: number) => boolean,
-  setDragging: (index: number, dragging: boolean) => void,
+  isThumbDragging: (index: number) => boolean,
+  setThumbDragging: (index: number, dragging: boolean) => void,
 
   // Currently-focused index
-  readonly focusedIndex: number | undefined,
-  setFocusedIndex: (index: number | undefined) => void,
+  readonly focusedThumb: number | undefined,
+  setFocusedThumb: (index: number | undefined) => void,
 
   // Returns the value offset as a percentage from 0 to 1.
-  getOffsetPercentForIndex: (index: number) => number,
-  getOffsetPercentForValue: (value: number) => number,
+  getThumbPercent: (index: number) => number,
+  getValuePercent: (value: number) => number,
 
   // Returns the string label for the value, per props.formatOptions
-  getValueLabelForIndex: (index: number) => string,
-  getValueLabelForValue: (value: number) => string,
+  getThumbValueLabel: (index: number) => string,
+  getFormattedValue: (value: number) => string,
 
   // Returns the min and max values for the index
-  getMinValueForIndex: (index: number) => number,
-  getMaxValueForIndex: (index: number) => number
+  getThumbMinValue: (index: number) => number,
+  getThumbMaxValue: (index: number) => number
 }
 
 export const DEFAULT_MIN_VALUE = 0;
@@ -59,14 +60,14 @@ export function useSliderState(props: SliderProps): SliderState {
   const realTimeDragging = useRef(false);
   const formatter = useNumberFormatter(formatOptions);
 
-  function getOffsetPercentForValue(value: number) {
+  function getValuePercent(value: number) {
     return (value - minValue) / (maxValue - minValue);
   }
 
-  function getMinValueForIndex(index: number) {
+  function getThumbMinValue(index: number) {
     return index === 0 ? minValue : values[index - 1];
   }
-  function getMaxValueForIndex(index: number) {
+  function getThumbMaxValue(index: number) {
     return index === values.length - 1 ? maxValue : values[index + 1];
   }
 
@@ -74,8 +75,8 @@ export function useSliderState(props: SliderProps): SliderState {
     if (isReadOnly || isDisabled) {
       return;
     }
-    const thisMin = getMinValueForIndex(index);
-    const thisMax = getMaxValueForIndex(index);
+    const thisMin = getThumbMinValue(index);
+    const thisMax = getThumbMaxValue(index);
     value = clamp(value, thisMin, thisMax);
     const newValues = replaceIndex(values, index, value);
     setValues(newValues);
@@ -92,23 +93,24 @@ export function useSliderState(props: SliderProps): SliderState {
     realTimeDragging.current = newDraggings.some(Boolean);
   }
 
-  function getValueLabelForValue(value: number) {
+  function getFormattedValue(value: number) {
     return formatter.format(value);
   }
 
   return {
     values: values,
-    setValue: updateValue,
-    isDragging: (index: number) => isDraggings[index],
-    setDragging: updateDragging,
-    focusedIndex,
-    setFocusedIndex,
-    getOffsetPercentForIndex: (index: number) => getOffsetPercentForValue(values[index]),
-    getOffsetPercentForValue,
-    getValueLabelForIndex: (index: number) => getValueLabelForValue(values[index]),
-    getValueLabelForValue,
-    getMinValueForIndex,
-    getMaxValueForIndex
+    getThumbValue: (index: number) => values[index],
+    setThumbValue: updateValue,
+    isThumbDragging: (index: number) => isDraggings[index],
+    setThumbDragging: updateDragging,
+    focusedThumb: focusedIndex,
+    setFocusedThumb: setFocusedIndex,
+    getThumbPercent: (index: number) => getValuePercent(values[index]),
+    getValuePercent,
+    getThumbValueLabel: (index: number) => getFormattedValue(values[index]),
+    getFormattedValue,
+    getThumbMinValue,
+    getThumbMaxValue
   };
 }
 

--- a/packages/@react-stately/slider/test/useSliderState.test.js
+++ b/packages/@react-stately/slider/test/useSliderState.test.js
@@ -8,6 +8,7 @@ describe('useSliderState', () => {
       defaultValue: [50],
       minValue: 10,
       maxValue: 200,
+      step: 10,
       formatOptions: {
         style: 'currency',
         currency: 'USD'
@@ -33,6 +34,15 @@ describe('useSliderState', () => {
     expect(result.current.getThumbValue(0)).toBe(10);
     expect(result.current.getThumbPercent(0)).toBe(0);
     expect(result.current.getThumbValueLabel(0)).toBe('$10.00');
+    
+    act(() => result.current.setThumbValue(0, 7));
+    expect(result.current.getThumbValue(0)).toBe(10);
+    expect(result.current.getThumbPercent(0)).toBe(0);
+    expect(result.current.getThumbValueLabel(0)).toBe('$10.00');
+
+    act(() => result.current.setThumbPercent(0, 0.13));
+    expect(result.current.getThumbValue(0)).toBe(30);
+    expect(result.current.getThumbPercent(0)).toBe(20 / 190);
   });
 
   it('should enforce maxValue and minValue for multiple thumbs', () => {

--- a/packages/@react-stately/slider/test/useSliderState.test.js
+++ b/packages/@react-stately/slider/test/useSliderState.test.js
@@ -1,0 +1,93 @@
+
+import {act, renderHook} from '@testing-library/react-hooks';
+import {useSliderState} from '../';
+
+describe('useSliderState', () => {
+  it('should allow setting and reading values, percentages, and labels', () => {
+    let result = renderHook(() => useSliderState({
+      defaultValue: [50],
+      minValue: 10,
+      maxValue: 200,
+      formatOptions: {
+        style: 'currency',
+        currency: 'USD'
+      }
+    })).result;
+
+    expect(result.current.getThumbValue(0)).toBe(50);
+    expect(result.current.getThumbPercent(0)).toBe(40 / 190);
+    expect(result.current.getValuePercent(50)).toBe(40 / 190);
+    expect(result.current.getThumbValueLabel(0)).toBe('$50.00');
+    
+    act(() => result.current.setThumbValue(0, 100));
+    expect(result.current.getThumbValue(0)).toBe(100);
+    expect(result.current.getThumbPercent(0)).toBe(90 / 190);
+    expect(result.current.getThumbValueLabel(0)).toBe('$100.00');
+    
+    act(() => result.current.setThumbValue(0, 500));
+    expect(result.current.getThumbValue(0)).toBe(200);
+    expect(result.current.getThumbPercent(0)).toBe(1);
+    expect(result.current.getThumbValueLabel(0)).toBe('$200.00');
+    
+    act(() => result.current.setThumbValue(0, 0));
+    expect(result.current.getThumbValue(0)).toBe(10);
+    expect(result.current.getThumbPercent(0)).toBe(0);
+    expect(result.current.getThumbValueLabel(0)).toBe('$10.00');
+  });
+
+  it('should enforce maxValue and minValue for multiple thumbs', () => {
+    let result = renderHook(() => useSliderState({
+      defaultValue: [50, 70, 90],
+      minValue: 10,
+      maxValue: 200
+    })).result;
+
+    expect(result.current.values).toEqual([50, 70, 90]);
+
+    expect(result.current.getThumbMinValue(0)).toBe(10);
+    expect(result.current.getThumbMaxValue(0)).toBe(70);
+
+    expect(result.current.getThumbMinValue(1)).toBe(50);
+    expect(result.current.getThumbMaxValue(1)).toBe(90);
+
+    expect(result.current.getThumbMinValue(2)).toBe(70);
+    expect(result.current.getThumbMaxValue(2)).toBe(200);
+
+    act(() => result.current.setThumbValue(1, 80));
+    expect(result.current.values).toEqual([50, 80, 90]);
+    expect(result.current.getThumbMinValue(2)).toBe(80);
+    
+    act(() => result.current.setThumbValue(1, 100));
+    expect(result.current.values).toEqual([50, 90, 90]);
+    expect(result.current.getThumbMinValue(2)).toBe(90);
+  });
+
+  it('should call onChange and onChangeEnd appropriately', () => {
+    let onChangeEndSpy = jest.fn();
+    let onChangeSpy = jest.fn();
+    let result = renderHook(() => useSliderState({
+      onChangeEnd: onChangeEndSpy,
+      onChange: onChangeSpy
+    })).result;
+
+    expect(result.current.values).toEqual([0]);
+    act(() => result.current.setThumbValue(0, 50));
+    expect(onChangeSpy).toHaveBeenLastCalledWith([50]);
+    expect(onChangeEndSpy).toHaveBeenLastCalledWith([50]);
+    
+    onChangeEndSpy.mockClear();
+    
+    act(() => result.current.setThumbDragging(0, true));
+    expect(result.current.isThumbDragging(0)).toBe(true);
+    act(() => result.current.setThumbValue(0, 55));
+    expect(onChangeSpy).toHaveBeenLastCalledWith([55]);
+    expect(onChangeEndSpy).not.toHaveBeenCalled();
+    act(() => result.current.setThumbValue(0, 60));
+    expect(onChangeSpy).toHaveBeenLastCalledWith([60]);
+    expect(onChangeEndSpy).not.toHaveBeenCalled();
+    act(() => result.current.setThumbDragging(0, false));
+    act(() => result.current.setThumbValue(0, 65));
+    expect(onChangeSpy).toHaveBeenLastCalledWith([65]);
+    expect(onChangeEndSpy).toHaveBeenLastCalledWith([65]);
+  });
+});

--- a/packages/@react-types/slider/README.md
+++ b/packages/@react-types/slider/README.md
@@ -1,0 +1,3 @@
+# @react-types/radio
+
+This package is part of [react-spectrum](https://github.com/adobe/react-spectrum). See the repo for more details.

--- a/packages/@react-types/slider/README.md
+++ b/packages/@react-types/slider/README.md
@@ -1,3 +1,3 @@
-# @react-types/radio
+# @react-types/slider
 
 This package is part of [react-spectrum](https://github.com/adobe/react-spectrum). See the repo for more details.

--- a/packages/@react-types/slider/package.json
+++ b/packages/@react-types/slider/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@react-types/slider",
+  "version": "3.0.2",
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "types": "src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/react-spectrum"
+  },
+  "dependencies": {
+    "@react-types/shared": "^3.0.2"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -17,7 +17,6 @@ export interface CommonSliderThumbProps {
   labelId: string;
 }
 
-
 export interface SliderThumbProps extends CommonSliderThumbProps, AriaLabelingProps, FocusableDOMProps, FocusableProps, Validation, AriaValidationProps, LabelableProps {
   isReadOnly?: boolean;
   isDisabled?: boolean;

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -10,10 +10,16 @@ export interface SliderProps extends BaseSliderProps, ValueBase<number[]> {
   onChangeEnd?: (value: number[]) => void;
 }
 
+/**
+ * Subset of SliderThumbProps that should have the same value for all slider thumbs
+ */
+export interface CommonSliderThumbProps {
+  labelId: string;
+}
 
-export interface SliderThumbProps extends AriaLabelingProps, FocusableDOMProps, FocusableProps, Validation, AriaValidationProps, LabelableProps {
+
+export interface SliderThumbProps extends CommonSliderThumbProps, AriaLabelingProps, FocusableDOMProps, FocusableProps, Validation, AriaValidationProps, LabelableProps {
   isReadOnly?: boolean;
   isDisabled?: boolean;
   index: number;
-  labelId: string;
 }

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -1,0 +1,19 @@
+import {AriaLabelingProps, AriaValidationProps, FocusableDOMProps, FocusableProps, LabelableProps, RangeInputBase, Validation, ValueBase} from '@react-types/shared';
+
+export interface BaseSliderProps extends RangeInputBase<number>, LabelableProps, AriaLabelingProps {
+  isReadOnly?: boolean;
+  isDisabled?: boolean;
+  formatOptions?: Intl.NumberFormatOptions;
+}
+
+export interface MultiSliderProps extends BaseSliderProps, ValueBase<number[]> {
+  onChangeEnd?: (value: number[]) => void;
+}
+
+
+export interface SliderThumbProps extends AriaLabelingProps, FocusableDOMProps, FocusableProps, Validation, AriaValidationProps, LabelableProps {
+  isReadOnly?: boolean;
+  isDisabled?: boolean;
+  index: number;
+  labelId: string;
+}

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -6,7 +6,7 @@ export interface BaseSliderProps extends RangeInputBase<number>, LabelableProps,
   formatOptions?: Intl.NumberFormatOptions;
 }
 
-export interface MultiSliderProps extends BaseSliderProps, ValueBase<number[]> {
+export interface SliderProps extends BaseSliderProps, ValueBase<number[]> {
   onChangeEnd?: (value: number[]) => void;
 }
 

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -1,24 +1,24 @@
 import {AriaLabelingProps, AriaValidationProps, FocusableDOMProps, FocusableProps, LabelableProps, RangeInputBase, Validation, ValueBase} from '@react-types/shared';
 
 export interface BaseSliderProps extends RangeInputBase<number>, LabelableProps, AriaLabelingProps {
-  isReadOnly?: boolean;
-  isDisabled?: boolean;
-  formatOptions?: Intl.NumberFormatOptions;
+  isReadOnly?: boolean,
+  isDisabled?: boolean,
+  formatOptions?: Intl.NumberFormatOptions
 }
 
 export interface SliderProps extends BaseSliderProps, ValueBase<number[]> {
-  onChangeEnd?: (value: number[]) => void;
+  onChangeEnd?: (value: number[]) => void
 }
 
 /**
- * Subset of SliderThumbProps that should have the same value for all slider thumbs
+ * Subset of SliderThumbProps that should have the same value for all slider thumbs.
  */
 export interface CommonSliderThumbProps {
-  labelId: string;
+  labelId: string
 }
 
 export interface SliderThumbProps extends CommonSliderThumbProps, AriaLabelingProps, FocusableDOMProps, FocusableProps, Validation, AriaValidationProps, LabelableProps {
-  isReadOnly?: boolean;
-  isDisabled?: boolean;
-  index: number;
+  isReadOnly?: boolean,
+  isDisabled?: boolean,
+  index: number
 }


### PR DESCRIPTION
This creates:

* `useMultiSliderState` for @react-stately/slider for managing slider state for multiple values
* `useMultiSlider` for @react-aria/slider for managing interactions and accessibility for slider components

Includes some Storybook stories and toy components using the above hooks to build sliders.

Does _not_ include slider implementations for @react-aria/spectrum.

Closes #763

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

For now, just visual tests on Storybook under the "Slider" group, starting here: http://localhost:9003/?path=/story/slider--single

## 🧢 Your Project:

[Plasmic](https://plasmic.app)
