### PR TITLE
Workaround for iOS hover events bug

### DIFF
--- a/packages/@react-aria/interactions/test/useHover.test.js
+++ b/packages/@react-aria/interactions/test/useHover.test.js
@@ -31,6 +31,10 @@ function pointerEvent(type, opts) {
 }
 
 describe('useHover', function () {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
   it('does not handle hover events if disabled', function () {
     let events = [];
     let addEvent = (e) => events.push(e);
@@ -111,6 +115,75 @@ describe('useHover', function () {
       expect(events).toEqual([]);
     });
 
+    it('ignores emulated mouse events following touch events', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onHoverStart={addEvent}
+          onHoverEnd={addEvent}
+          onHoverChange={isHovering => addEvent({type: 'hoverchange', isHovering})} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent(el, pointerEvent('pointerdown', {pointerType: 'touch'}));
+      fireEvent(el, pointerEvent('pointerover', {pointerType: 'touch'}));
+      fireEvent(el, pointerEvent('pointerout', {pointerType: 'touch'}));
+      fireEvent(el, pointerEvent('pointerup', {pointerType: 'touch'}));
+
+      // Safari on iOS has a bug that fires a pointer event with pointerType="mouse" on focus.
+      // See https://bugs.webkit.org/show_bug.cgi?id=214609.
+      fireEvent(el, pointerEvent('pointerover', {pointerType: 'mouse'}));
+      fireEvent(el, pointerEvent('pointerout', {pointerType: 'mouse'}));
+
+      expect(events).toEqual([]);
+    });
+
+    it('ignores supports mouse events following touch events after a delay', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onHoverStart={addEvent}
+          onHoverEnd={addEvent}
+          onHoverChange={isHovering => addEvent({type: 'hoverchange', isHovering})} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent(el, pointerEvent('pointerdown', {pointerType: 'touch'}));
+      fireEvent(el, pointerEvent('pointerover', {pointerType: 'touch'}));
+      fireEvent(el, pointerEvent('pointerout', {pointerType: 'touch'}));
+      fireEvent(el, pointerEvent('pointerup', {pointerType: 'touch'}));
+
+      jest.advanceTimersByTime(100);
+
+      // Safari on iOS has a bug that fires a pointer event with pointerType="mouse" on focus.
+      // See https://bugs.webkit.org/show_bug.cgi?id=214609.
+      fireEvent(el, pointerEvent('pointerover', {pointerType: 'mouse'}));
+      fireEvent(el, pointerEvent('pointerout', {pointerType: 'mouse'}));
+
+      expect(events).toEqual([
+        {
+          type: 'hoverstart',
+          target: el,
+          pointerType: 'mouse'
+        },
+        {
+          type: 'hoverchange',
+          isHovering: true
+        },
+        {
+          type: 'hoverend',
+          target: el,
+          pointerType: 'mouse'
+        },
+        {
+          type: 'hoverchange',
+          isHovering: false
+        }
+      ]);
+    });
+
     it('should visually change component with pointer events', function () {
       let res = render(
         <Example />
@@ -186,6 +259,75 @@ describe('useHover', function () {
 
       fireEvent.mouseLeave(el);
       expect(el.textContent).toBe('test');
+    });
+
+    it('ignores emulated mouse events following touch events', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onHoverStart={addEvent}
+          onHoverEnd={addEvent}
+          onHoverChange={isHovering => addEvent({type: 'hoverchange', isHovering})} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent.touchStart(el);
+      fireEvent.mouseEnter(el);
+      fireEvent.mouseLeave(el);
+      fireEvent.touchEnd(el);
+
+      // Safari on iOS has a bug that fires a mouse event on focus.
+      // See https://bugs.webkit.org/show_bug.cgi?id=214609.
+      fireEvent.mouseEnter(el);
+      fireEvent.mouseLeave(el);
+
+      expect(events).toEqual([]);
+    });
+
+    it('ignores supports mouse events following touch events after a delay', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onHoverStart={addEvent}
+          onHoverEnd={addEvent}
+          onHoverChange={isHovering => addEvent({type: 'hoverchange', isHovering})} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent.touchStart(el);
+      fireEvent.mouseEnter(el);
+      fireEvent.mouseLeave(el);
+      fireEvent.touchEnd(el);
+
+      jest.advanceTimersByTime(100);
+
+      // Safari on iOS has a bug that fires a mouse event on focus.
+      // See https://bugs.webkit.org/show_bug.cgi?id=214609.
+      fireEvent.mouseEnter(el);
+      fireEvent.mouseLeave(el);
+
+      expect(events).toEqual([
+        {
+          type: 'hoverstart',
+          target: el,
+          pointerType: 'mouse'
+        },
+        {
+          type: 'hoverchange',
+          isHovering: true
+        },
+        {
+          type: 'hoverend',
+          target: el,
+          pointerType: 'mouse'
+        },
+        {
+          type: 'hoverchange',
+          isHovering: false
+        }
+      ]);
     });
   });
 


### PR DESCRIPTION
This works around a bug in iOS Safari that fires the `onPointerEnter` and `onMouseEnter` between the `onPointerUp` and `onFocus` events. This caused `onPointerEnter` to be fired twice: once on touch and once before focus, which meant that `useHover` fired a hover event even though you're on a touch device. Webkit bug filed here: https://bugs.webkit.org/show_bug.cgi?id=214609.

The workaround is to register a global event listener for the `pointerup`/`touched` event, which sets a flag and unsets it after a quick timeout (after the `onFocus` event). This handles two scenarios: the iOS case where `onPointerEnter` is fired prior to focus, and the non-iOS case where this event is not fired. In that case, we do not want to leave the flag hanging, because if the user switched to a mouse after touching the element, the hover event would not fire. The short delay to reset this fixes that.

The event is global due to another iOS quirk: focus events (and the prior `onPointerEnter`) are dispatched even when you didn't touch directly on the element, but somewhere nearby. iOS seems to be doing some magic to move focus to the closest element. This means we cannot use a touch event handler on the element itself to determine if there's a preceding touch, we need to listen on the document instead.