### PR TITLE
Fix hover styles

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -101,6 +101,9 @@ governing permissions and limitations under the License.
     max-block-size: 100%;
     flex-shrink: 0;
     order: 0; /* always be before the label, regardless of DOM order */
+
+    transition: background var(--spectrum-global-animation-duration-100) ease-out,
+                color var(--spectrum-global-animation-duration-100) ease-out;
   }
 
 }

--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -72,7 +72,8 @@ governing permissions and limitations under the License.
   line-height: var(--spectrum-textfield-text-line-height);
   text-overflow: ellipsis;
 
-  transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out, box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
+  transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out,
+              box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
 
   outline: none;
 
@@ -188,6 +189,7 @@ governing permissions and limitations under the License.
   position: absolute;
   padding-inline-end: calc(var(--spectrum-textfield-padding-x, var(--spectrum-global-dimension-size-150)) / 2);
   pointer-events: all;
+  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
 
   .spectrum-Textfield--quiet & {
     padding-inline-end: 0;
@@ -215,6 +217,7 @@ governing permissions and limitations under the License.
   width: var(--spectrum-icon-info-medium-width);
   inset-inline-start: var(--spectrum-global-dimension-size-100);
   top: var(--spectrum-global-dimension-size-85);
+  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
 }
 
 /* styles the textfield properly if the left icon is provided */

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -16,7 +16,7 @@ import {classNames, unwrapDOMRef, useDOMRef, useStyleProps} from '@react-spectru
 import {DOMProps, DOMRef, Node, StyleProps} from '@react-types/shared';
 import {ListState, useListState} from '@react-stately/list';
 import {mergeProps} from '@react-aria/utils';
-import {PressResponder} from '@react-aria/interactions';
+import {PressResponder, useHover} from '@react-aria/interactions';
 import {Provider} from '@react-spectrum/provider';
 import React, {forwardRef, Key, ReactElement, useRef} from 'react';
 import {SpectrumActionGroupProps} from '@react-types/actiongroup';
@@ -100,6 +100,7 @@ function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, onAction}: A
   let {buttonProps} = useActionGroupItem({key: item.key}, state, unwrapDOMRef(ref));
   isDisabled = isDisabled || state.disabledKeys.has(item.key);
   let isSelected = state.selectionManager.isSelected(item.key);
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   if (onAction && !isDisabled) {
     buttonProps = mergeProps(buttonProps, {
@@ -110,7 +111,7 @@ function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, onAction}: A
   let button = (
     // Use a PressResponder to send DOM props through.
     // ActionButton doesn't allow overriding the role by default.
-    <PressResponder {...buttonProps}>
+    <PressResponder {...mergeProps(buttonProps, hoverProps)}>
       <ActionButton
         ref={ref}
         UNSAFE_className={
@@ -118,7 +119,8 @@ function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, onAction}: A
             styles,
             'spectrum-ActionGroup-item',
             {
-              'is-selected': isSelected
+              'is-selected': isSelected,
+              'is-hovered': isHovered
             },
             classNames(
               buttonStyles,


### PR DESCRIPTION
Missed a hover style in ActionGroup
Add transitions to hover for icons in buttons and textfields

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
