### PR TITLE
Change icon transition from color to fill

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -103,7 +103,7 @@ governing permissions and limitations under the License.
     order: 0; /* always be before the label, regardless of DOM order */
 
     transition: background var(--spectrum-global-animation-duration-100) ease-out,
-                color var(--spectrum-global-animation-duration-100) ease-out;
+                fill var(--spectrum-global-animation-duration-100) ease-out;
   }
 
 }

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -30,22 +30,38 @@ governing permissions and limitations under the License.
 
   color: var(--spectrum-clearbutton-medium-icon-color);
 
+  .spectrum-Icon {
+    fill: var(--spectrum-clearbutton-medium-icon-color);
+  }
+
   &:hover {
     background-color: var(--spectrum-clearbutton-medium-background-color-hover);
 
     color: var(--spectrum-clearbutton-medium-icon-color-hover);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-clearbutton-medium-icon-color-hover);
+    }
   }
 
   &.is-active {
     background-color: var(--spectrum-clearbutton-medium-background-color-down);
 
     color: var(--spectrum-clearbutton-medium-icon-color-down);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-clearbutton-medium-icon-color-down);
+    }
   }
 
   &:focus-ring {
     background-color: var(--spectrum-clearbutton-medium-background-color-key-focus);
 
     color: var(--spectrum-clearbutton-medium-icon-color-key-focus);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-clearbutton-medium-icon-color-key-focus);
+    }
   }
 
   &:disabled,
@@ -53,6 +69,10 @@ governing permissions and limitations under the License.
     background-color: var(--spectrum-clearbutton-medium-background-color-disabled);
 
     color: var(--spectrum-clearbutton-medium-icon-color-disabled);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-clearbutton-medium-icon-color-disabled);
+    }
   }
 }
 
@@ -320,11 +340,11 @@ governing permissions and limitations under the License.
   color: var(--spectrum-actionbutton-text-color);
 
   .spectrum-Icon {
-    color: var(--spectrum-actionbutton-icon-color);
+    fill: var(--spectrum-actionbutton-icon-color);
   }
 
   .spectrum-ActionButton-hold {
-    color: var(--spectrum-actionbutton-hold-icon-color);
+    fill: var(--spectrum-actionbutton-hold-icon-color);
   }
 
   &:hover {
@@ -333,11 +353,11 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-text-color-hover);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-icon-color-hover);
+      fill: var(--spectrum-actionbutton-icon-color-hover);
     }
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-hold-icon-color-hover);
+      fill: var(--spectrum-actionbutton-hold-icon-color-hover);
     }
   }
 
@@ -348,11 +368,11 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-text-color-key-focus);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-icon-color-key-focus);
+      fill: var(--spectrum-actionbutton-icon-color-key-focus);
     }
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-hold-icon-color-key-focus);
+      fill: var(--spectrum-actionbutton-hold-icon-color-key-focus);
     }
   }
 
@@ -362,7 +382,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-text-color-down);
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-hold-icon-color-down);
+      fill: var(--spectrum-actionbutton-hold-icon-color-down);
     }
   }
 
@@ -373,11 +393,11 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-text-color-disabled);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-icon-color-disabled);
+      fill: var(--spectrum-actionbutton-icon-color-disabled);
     }
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-hold-icon-color-disabled);
+      fill: var(--spectrum-actionbutton-hold-icon-color-disabled);
     }
   }
 
@@ -387,7 +407,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-text-color-selected);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-icon-color-selected);
+      fill: var(--spectrum-actionbutton-icon-color-selected);
     }
 
     &:hover {
@@ -396,7 +416,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-text-color-selected-hover);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-icon-color-selected-hover);
+        fill: var(--spectrum-actionbutton-icon-color-selected-hover);
       }
     }
 
@@ -406,7 +426,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-text-color-selected-key-focus);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-icon-color-selected-key-focus);
+        fill: var(--spectrum-actionbutton-icon-color-selected-key-focus);
       }
     }
 
@@ -416,7 +436,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-text-color-selected-down);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-icon-color-selected-down);
+        fill: var(--spectrum-actionbutton-icon-color-selected-down);
       }
     }
 
@@ -427,7 +447,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-text-color-selected-disabled);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-icon-color-selected-disabled);
+        fill: var(--spectrum-actionbutton-icon-color-selected-disabled);
       }
     }
   }
@@ -439,21 +459,21 @@ governing permissions and limitations under the License.
   color: var(--spectrum-actionbutton-emphasized-text-color);
 
   .spectrum-Icon {
-    color: var(--spectrum-actionbutton-emphasized-icon-color);
+    fill: var(--spectrum-actionbutton-emphasized-icon-color);
   }
 
   .spectrum-ActionButton-hold {
-    color: var(--spectrum-actionbutton-emphasized-hold-icon-color);
+    fill: var(--spectrum-actionbutton-emphasized-hold-icon-color);
   }
 
   &.is-selected {
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-emphasized-hold-icon-color-selected);
+      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-selected);
     }
 
     &:hover {
       .spectrum-ActionButton-hold {
-        color: var(--spectrum-actionbutton-emphasized-text-color-selected-hover);
+        fill: var(--spectrum-actionbutton-emphasized-text-color-selected-hover);
       }
     }
   }
@@ -465,11 +485,11 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-emphasized-text-color-hover);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-emphasized-icon-color-hover);
+      fill: var(--spectrum-actionbutton-emphasized-icon-color-hover);
     }
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-emphasized-hold-icon-color-hover);
+      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-hover);
     }
   }
 
@@ -480,11 +500,11 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-emphasized-text-color-key-focus);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-emphasized-icon-color-key-focus);
+      fill: var(--spectrum-actionbutton-emphasized-icon-color-key-focus);
     }
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-emphasized-hold-icon-color-key-focus);
+      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-key-focus);
     }
   }
 
@@ -495,7 +515,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-emphasized-text-color-down);
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-emphasized-hold-icon-color-down);
+      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-down);
     }
   }
 
@@ -506,11 +526,11 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-emphasized-text-color-disabled);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-emphasized-icon-color-disabled);
+      fill: var(--spectrum-actionbutton-emphasized-icon-color-disabled);
     }
 
     .spectrum-ActionButton-hold {
-      color: var(--spectrum-actionbutton-emphasized-hold-icon-color-disabled);
+      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-disabled);
     }
   }
 
@@ -521,7 +541,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-actionbutton-emphasized-text-color-selected);
 
     .spectrum-Icon {
-      color: var(--spectrum-actionbutton-emphasized-icon-color-selected);
+      fill: var(--spectrum-actionbutton-emphasized-icon-color-selected);
     }
 
     &:focus-ring {
@@ -530,7 +550,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-emphasized-icon-color-selected-key-focus);
+        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-key-focus);
       }
     }
 
@@ -540,7 +560,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-hover);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-emphasized-icon-color-selected-hover);
+        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-hover);
       }
     }
 
@@ -550,7 +570,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-down);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-emphasized-icon-color-selected-down);
+        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-down);
       }
     }
 
@@ -561,7 +581,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-disabled);
 
       .spectrum-Icon {
-        color: var(--spectrum-actionbutton-emphasized-icon-color-selected-disabled);
+        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-disabled);
       }
     }
   }
@@ -753,7 +773,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-fieldbutton-text-color-disabled);
 
     & .spectrum-Icon {
-      color: var(--spectrum-fieldbutton-icon-color-disabled);
+        fill: var(--spectrum-fieldbutton-icon-color-disabled);
     }
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/search/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/search/index.css
@@ -69,7 +69,7 @@ governing permissions and limitations under the License.
   inset-inline-start: 12px;
   top: calc(calc(var(--spectrum-textfield-height) / 2) - calc(var(--spectrum-global-dimension-size-200) / 2));
 
-  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
+  transition: fill var(--spectrum-global-animation-duration-100) ease-in-out;
 
   pointer-events: none;
 }

--- a/packages/@adobe/spectrum-css-temp/components/search/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/search/skin.css
@@ -11,32 +11,32 @@ governing permissions and limitations under the License.
 */
 
 .spectrum-Search-icon {
-  color: var(--spectrum-textfield-icon-color);
+  fill: var(--spectrum-textfield-icon-color);
 }
 
 .spectrum-Search-input {
   /* The value of color is identical for hover/active/focus-ring, but we repeat it here in case one is changed in the future */
   &:hover {
     & ~ .spectrum-Search-icon {
-      color: var(--spectrum-search-icon-color-hover);
+      fill: var(--spectrum-search-icon-color-hover);
     }
   }
 
   &:active {
     & ~ .spectrum-Search-icon {
-      color: var(--spectrum-search-icon-color-down);
+      fill: var(--spectrum-search-icon-color-down);
     }
   }
 
   &:focus-ring {
     & ~ .spectrum-Search-icon {
-      color: var(--spectrum-search-icon-color-key-focus);
+      fill: var(--spectrum-search-icon-color-key-focus);
     }
   }
 
   &:disabled {
     & ~ .spectrum-Search-icon {
-      color: var(--spectrum-textfield-text-color-disabled);
+      fill: var(--spectrum-textfield-text-color-disabled);
     }
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -217,7 +217,7 @@ governing permissions and limitations under the License.
   width: var(--spectrum-icon-info-medium-width);
   inset-inline-start: var(--spectrum-global-dimension-size-100);
   top: var(--spectrum-global-dimension-size-85);
-  transition: color var(--spectrum-global-animation-duration-100) ease-in-out;
+  transition: fill var(--spectrum-global-animation-duration-100) ease-in-out;
 }
 
 /* styles the textfield properly if the left icon is provided */

--- a/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
@@ -28,7 +28,7 @@ governing permissions and limitations under the License.
     }
 
     & ~ .spectrum-Textfield-icon {
-      color: var(--spectrum-textfield-placeholder-text-color-hover);
+      fill: var(--spectrum-textfield-placeholder-text-color-hover);
     }
   }
 
@@ -145,19 +145,19 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Textfield-icon {
-  color: var(--spectrum-textfield-icon-color);
+  fill: var(--spectrum-textfield-icon-color);
 
   &.disabled {
-    color: var(--spectrum-textfield-text-color-disabled);
+    fill: var(--spectrum-textfield-text-color-disabled);
   }
 }
 
 .spectrum-Textfield-validationIcon {
   .spectrum-Textfield.is-valid & {
-    color: var(--spectrum-alert-success-icon-color);
+    fill: var(--spectrum-alert-success-icon-color);
   }
 
   .spectrum-Textfield.is-invalid & {
-    color: var(--spectrum-alert-error-icon-color);
+    fill: var(--spectrum-alert-error-icon-color);
   }
 }

--- a/packages/@react-spectrum/button/src/ClearButton.tsx
+++ b/packages/@react-spectrum/button/src/ClearButton.tsx
@@ -28,7 +28,7 @@ interface ClearButtonProps extends ButtonProps, DOMProps, StyleProps {
 
 function ClearButton(props: ClearButtonProps, ref: FocusableRef<HTMLButtonElement>) {
   let {
-    children = <CrossSmall />,
+    children = <CrossSmall UNSAFE_className={styles['spectrum-Icon']} />,
     focusClassName,
     variant,
     autoFocus,


### PR DESCRIPTION
can't transition color in svg's on safari, use fill instead


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
