### PR TITLE
Disabling textfield icon active style if textfield is disabled

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
@@ -41,7 +41,7 @@ governing permissions and limitations under the License.
       color: var(--spectrum-textfield-placeholder-text-color-down);
     }
 
-    & ~ .spectrum-Textfield-icon {
+    &:not([disabled]) ~ .spectrum-Textfield-icon {
       fill: var(--spectrum-textfield-icon-color-down);
     }
   }
@@ -70,6 +70,7 @@ governing permissions and limitations under the License.
     &::placeholder {
       color: var(--spectrum-textfield-placeholder-text-color-disabled);
     }
+
   }
 
   &:invalid,

--- a/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
@@ -70,7 +70,6 @@ governing permissions and limitations under the License.
     &::placeholder {
       color: var(--spectrum-textfield-placeholder-text-color-disabled);
     }
-
   }
 
   &:invalid,


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
