### PR TITLE
Fix placeholder hover styles in Picker

### DIFF
--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -34,7 +34,7 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef<HTMLBu
 
   let domRef = useFocusableRef(ref);
   let {buttonProps, isPressed} = useButton(props, domRef);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);
   let isTextOnly = React.Children.toArray(props.children).every(c => !React.isValidElement(c));
 

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -41,7 +41,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
   } = props;
   let domRef = useFocusableRef(ref);
   let {buttonProps, isPressed} = useButton(props, domRef);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);
 
   let buttonVariant = variant;

--- a/packages/@react-spectrum/button/src/ClearButton.tsx
+++ b/packages/@react-spectrum/button/src/ClearButton.tsx
@@ -32,11 +32,12 @@ function ClearButton(props: ClearButtonProps, ref: FocusableRef<HTMLButtonElemen
     focusClassName,
     variant,
     autoFocus,
+    isDisabled,
     ...otherProps
   } = props;
   let domRef = useFocusableRef(ref);
   let {buttonProps, isPressed} = useButton(props, domRef);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);
 
   return (

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -39,7 +39,7 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
   } = props;
   let domRef = useFocusableRef(ref) as RefObject<HTMLButtonElement>;
   let {buttonProps, isPressed} = useButton(props, domRef);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);
 
   return (

--- a/packages/@react-spectrum/button/src/LogicButton.tsx
+++ b/packages/@react-spectrum/button/src/LogicButton.tsx
@@ -32,7 +32,7 @@ function LogicButton(props: SpectrumLogicButtonProps, ref: FocusableRef<HTMLButt
   } = props;
   let domRef = useFocusableRef(ref);
   let {buttonProps, isPressed} = useButton(props, domRef);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let {styleProps} = useStyleProps(otherProps);
 
   return (

--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -34,7 +34,7 @@ function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelEleme
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   let inputRef = useRef<HTMLInputElement>(null);
   let domRef = useFocusableRef(ref, inputRef);

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -42,7 +42,7 @@ export function DatePicker(props: SpectrumDatePickerProps) {
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let state = useDatePickerState(props);
   let {comboboxProps, fieldProps, buttonProps, dialogProps} = useDatePicker(props, state);
   let {value, setValue, selectDate, isOpen, setOpen} = state;

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -41,7 +41,7 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let state = useDateRangePickerState(props);
   let {comboboxProps, buttonProps, dialogProps, startFieldProps, endFieldProps} = useDateRangePicker(props, state);
   let {value, setDate, selectDateRange, isOpen, setOpen} = state;

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -68,10 +68,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
     state,
     ref
   );
-  let {hoverProps, isHovered} = useHover({
-    ...props,
-    isDisabled
-  });
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   let contents = typeof rendered === 'string'
     ? <Text>{rendered}</Text>

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -26,6 +26,7 @@ import {ListBoxBase, useListBoxLayout} from '@react-spectrum/listbox';
 import {mergeProps} from '@react-aria/utils';
 import {Placement} from '@react-types/overlays';
 import {Popover, Tray} from '@react-spectrum/overlays';
+import {PressResponder, useHover} from '@react-aria/interactions';
 import {ProgressCircle} from '@react-spectrum/progress';
 import React, {ReactElement, useLayoutEffect, useRef, useState} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
@@ -82,6 +83,8 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     shouldFlip: shouldFlip,
     isOpen: state.isOpen
   });
+
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   // Update position once the ListBox has rendered. This ensures that
   // it flips properly when it doesn't fit in the available space.
@@ -185,43 +188,45 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         triggerRef={unwrapDOMRef(triggerRef)}
         label={label}
         name={name} />
-      <FieldButton
-        {...triggerProps}
-        ref={triggerRef}
-        isActive={state.isOpen}
-        isQuiet={isQuiet}
-        isDisabled={isDisabled}
-        validationState={validationState}
-        UNSAFE_className={classNames(styles, 'spectrum-Dropdown-trigger')}>
-        <SlotProvider
-          slots={{
-            icon: {UNSAFE_className: classNames(styles, 'spectrum-Icon'), size: 'S'},
-            text: {
-              ...valueProps,
-              UNSAFE_className: classNames(
-                styles,
-                'spectrum-Dropdown-label',
-                {'is-placeholder': !state.selectedItem}
-              )
-            },
-            description: {
-              isHidden: true
-            }
-          }}>
-          {contents}
-        </SlotProvider>
-        {isLoadingInitial &&
-          <ProgressCircle
-            isIndeterminate
-            size="S"
-            aria-label={formatMessage('loading')}
-            UNSAFE_className={classNames(styles, 'spectrum-Dropdown-progressCircle')} />
-        }
-        {validationState === 'invalid' && !isLoadingInitial &&
-          <AlertMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-invalidIcon')} />
-        }
-        <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-chevron')} />
-      </FieldButton>
+      <PressResponder {...hoverProps}>
+        <FieldButton
+          {...triggerProps}
+          ref={triggerRef}
+          isActive={state.isOpen}
+          isQuiet={isQuiet}
+          isDisabled={isDisabled}
+          validationState={validationState}
+          UNSAFE_className={classNames(styles, 'spectrum-Dropdown-trigger', {'is-hovered': isHovered})}>
+          <SlotProvider
+            slots={{
+              icon: {UNSAFE_className: classNames(styles, 'spectrum-Icon'), size: 'S'},
+              text: {
+                ...valueProps,
+                UNSAFE_className: classNames(
+                  styles,
+                  'spectrum-Dropdown-label',
+                  {'is-placeholder': !state.selectedItem}
+                )
+              },
+              description: {
+                isHidden: true
+              }
+            }}>
+            {contents}
+          </SlotProvider>
+          {isLoadingInitial &&
+            <ProgressCircle
+              isIndeterminate
+              size="S"
+              aria-label={formatMessage('loading')}
+              UNSAFE_className={classNames(styles, 'spectrum-Dropdown-progressCircle')} />
+          }
+          {validationState === 'invalid' && !isLoadingInitial &&
+            <AlertMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-invalidIcon')} />
+          }
+          <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-chevron')} />
+        </FieldButton>
+      </PressResponder>
       {state.collection.size === 0 ? null : overlay}
     </div>
   );

--- a/packages/@react-spectrum/radio/src/Radio.tsx
+++ b/packages/@react-spectrum/radio/src/Radio.tsx
@@ -28,7 +28,7 @@ function Radio(props: SpectrumRadioProps, ref: FocusableRef<HTMLLabelElement>) {
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   let inputRef = useRef<HTMLInputElement>(null);
   let domRef = useFocusableRef(ref, inputRef);

--- a/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
@@ -40,10 +40,7 @@ export function SideNavItem<T>(props: SpectrumSideNavItemProps<T>) {
   );
 
   let {listItemProps, listItemLinkProps} = useSideNavItem(props, state, ref);
-  let {hoverProps, isHovered} = useHover({
-    ...props,
-    isDisabled
-  });
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   return (
     <div

--- a/packages/@react-spectrum/switch/src/Switch.tsx
+++ b/packages/@react-spectrum/switch/src/Switch.tsx
@@ -31,7 +31,7 @@ function Switch(props: SpectrumSwitchProps, ref: FocusableRef<HTMLLabelElement>)
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   let inputRef = useRef<HTMLInputElement>(null);
   let domRef = useFocusableRef(ref, inputRef);

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -30,7 +30,7 @@ export const Tag = ((props: SpectrumTagProps) => {
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   const {
     isDisabled: isGroupDisabled,
     isRemovable: isGroupRemovable,

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -50,6 +50,7 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
     validationState,
     icon,
     isQuiet = false,
+    isDisabled,
     multiLine,
     autoFocus,
     inputClassName,
@@ -59,7 +60,7 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
     inputRef,
     ...otherProps
   } = props;
-  let {hoverProps, isHovered} = useHover(props);
+  let {hoverProps, isHovered} = useHover({isDisabled});
   let domRef = useRef<HTMLDivElement>(null);
   let defaultInputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
   inputRef = inputRef || defaultInputRef;


### PR DESCRIPTION
Also prevent unintentionally passing through undocumented hover event props by passing props directly to `useHover`. We only need to pass through `isDisabled`.