### PR TITLE
Add releases section and update docs for latest release

### DIFF
--- a/packages/@react-aria/interactions/docs/useHover.mdx
+++ b/packages/@react-aria/interactions/docs/useHover.mdx
@@ -83,21 +83,19 @@ with focus events in order to expose the content to keyboard users.
 ## Example
 
 This example shows a simple target that handles hover events with `useHover` and logs them to a
-list below. It also tracks the `isHovered` state using `onHoverChange` to adjust the background
+list below. It also uses the `isHovered` state to adjust the background
 color when the target is hovered.
 
 ```tsx example
 function Example() {
   let [events, setEvents] = React.useState([]);
-  let [isHovered, setHovered] = React.useState(false);
-  let {hoverProps} = useHover({
+  let {hoverProps, isHovered} = useHover({
     onHoverStart: e => setEvents(
       events => [...events, `hover start with ${e.pointerType}`]
     ),
     onHoverEnd: e => setEvents(
       events => [...events, `hover end with ${e.pointerType}`]
-    ),
-    onHoverChange: setHovered
+    )
   });
 
   return (
@@ -126,33 +124,3 @@ function Example() {
   );
 }
 ```
-
-<!-- (disabled until release)
-
-Also, you can track `isHovered` state by simply destructuring the `useHover` call.
-
-```tsx example
-function Example() {
-  let {hoverProps, isHovered} = useHover({});
-
-  return (
-    <>
-      <div
-        {...hoverProps}
-        style={{
-          background: isHovered ? 'darkgreen' : 'green',
-          color: 'white',
-          display: 'inline-block',
-          padding: 4,
-          cursor: 'pointer'
-        }}
-        role="button"
-        tabIndex={0}>
-        Hover me!
-      </div>
-    </>
-  );
-}
-```
-
--->

--- a/packages/@react-stately/list/docs/useSingleSelectListState.mdx
+++ b/packages/@react-stately/list/docs/useSingleSelectListState.mdx
@@ -1,0 +1,38 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/list';
+import {HeaderInfo, TypeContext, InterfaceType, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '@react-stately/list/package.json';
+
+---
+category: Collections
+keywords: [lists, state]
+---
+
+# useSingleSelectListState
+
+<p>{docs.exports.useSingleSelectListState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useSingleSelectListState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useSingleSelectListState} links={docs.links} />
+
+## Interface
+
+<TypeContext.Provider value={docs.links}>
+  <InterfaceType properties={docs.links[docs.exports.useSingleSelectListState.return.base.id].properties} />
+</TypeContext.Provider>

--- a/packages/dev/docs/pages/blog/index.mdx
+++ b/packages/dev/docs/pages/blog/index.mdx
@@ -12,6 +12,7 @@ export default BlogLayout;
 
 ---
 category: Foundation
+description: React Spectrum blog
 ---
 
 # Blog

--- a/packages/dev/docs/pages/releases/2020-07-23.mdx
+++ b/packages/dev/docs/pages/releases/2020-07-23.mdx
@@ -11,13 +11,13 @@ import {BlogPostLayout, Hero} from '@react-spectrum/docs';
 export default BlogPostLayout;
 
 ---
-description: A new minor has landed! The response to our release last week has been incredible. Thank you to all of the amazing contributors! This release contains some bug fixes, updates to how we handle hover state in React Spectrum, and documentation improvements.
+description: A new release has landed! The response to our release last week has been incredible. Thank you to all of the amazing contributors! This release contains some bug fixes, updates to how we handle hover state in React Spectrum, and documentation improvements.
 date: 2020-07-23
 ---
 
 # July 23, 2020 Release
 
-A new minor has landed! The response to our release last week has been incredible. Thank you to all of the amazing contributors!
+A new release has landed! The response to our release last week has been incredible. Thank you to all of the amazing contributors!
 This release contains some bug fixes, updates to how we handle hover state in React Spectrum, and documentation improvements.
 See below for details, as well as the package versions included in this release.
 

--- a/packages/dev/docs/pages/releases/2020-07-23.mdx
+++ b/packages/dev/docs/pages/releases/2020-07-23.mdx
@@ -1,0 +1,167 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {BlogPostLayout, Hero} from '@react-spectrum/docs';
+export default BlogPostLayout;
+
+---
+description: A new minor has landed! The response to our release last week has been incredible. Thank you to all of the amazing contributors! This release contains some bug fixes, updates to how we handle hover state in React Spectrum, and documentation improvements.
+date: 2020-07-23
+---
+
+# July 23, 2020 Release
+
+A new minor has landed! The response to our release last week has been incredible. Thank you to all of the amazing contributors!
+This release contains some bug fixes, updates to how we handle hover state in React Spectrum, and documentation improvements.
+See below for details, as well as the package versions included in this release.
+
+## Added
+
+- Replace `:hover` CSS pseudo class with [useHover](../../react-aria/useHover.html) hook across all components for improved touch/hybrid device support - [@so99ynoodles](https://github.com/so99ynoodles) - [PR](https://github.com/adobe/react-spectrum/pull/775)
+- Allow no props to be given to [useToggleState](../../react-stately/useToggleState.html) - [@Andarist](https://github.com/Andarist) - [PR](https://github.com/adobe/react-spectrum/pull/687)
+- Allow arbitrary number of prop objects to be passed to mergeProps - [@brokslybrand](https://github.com/brokslybrand) - [PR](https://github.com/adobe/react-spectrum/pull/776)
+- Add [useSingleSelectListState](../../react-stately/useSingleSelectListState.html) hook to `@react-stately/list` - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/802)
+- Add active state to textfield for mobile - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/823)
+
+## Fixed
+
+- Add check for SSR environment to [useFocusVisible](../../react-aria/useFocusVisible.html) - [@RafalFilipek](https://github.com/RafalFilipek) - [PR](https://github.com/adobe/react-spectrum/pull/769)
+- Ignore selected keys when `selectionMode=``"``none``"` in menu - [@jluyau](https://github.com/jluyau) - [PR](https://github.com/adobe/react-spectrum/pull/783)
+- Fix tabbing to a disabled Picker in HiddenInput - [@gavinhenderson](https://github.com/gavinhenderson) - [PR](https://github.com/adobe/react-spectrum/pull/787)
+- Fix typescript build errors/warnings - [@mischnic](https://github.com/mischnic) - [PR](https://github.com/adobe/react-spectrum/pull/713)
+- Update lint rules - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/747)
+- Workaround for iOS hover events bug - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/815)
+- Fix hover and active styles for Radio invalid state - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/819)
+- Fix hover transition for icons in Safari - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/821)
+- Ensure react is a peer dependency instead of a dependency - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/824)
+
+## Docs
+
+- Fix `useKeyboard` example - [@spbyrne](https://github.com/spbyrne) - [PR](https://github.com/adobe/react-spectrum/pull/759)
+- Fix package imports for React Aria/React Stately packages - [@DeMoorJasper](https://github.com/DeMoorJasper) - [PR](https://github.com/adobe/react-spectrum/pull/761)
+- JSDocs eslint - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/662)
+- fix: some typos of react-aria - [@grgr-dkrk](https://github.com/grgr-dkrk) - [PR](https://github.com/adobe/react-spectrum/pull/774)
+- Fix individual import in versioning docs - [@mischnic](https://github.com/mischnic) - [PR](https://github.com/adobe/react-spectrum/pull/792)
+- Fix typo in ListBox docs - [@evargast](https://github.com/evargast) - [PR](https://github.com/adobe/react-spectrum/pull/795)
+
+## Released packages
+
+```
+- @adobe/react-spectrum@3.1.0
+- @react-aria/actiongroup@3.1.0
+- @react-aria/aria-modal-polyfill@3.1.0
+- @react-aria/breadcrumbs@3.1.0
+- @react-aria/button@3.1.0
+- @react-aria/checkbox@3.1.0
+- @react-aria/dialog@3.1.0
+- @react-aria/focus@3.1.0
+- @react-aria/i18n@3.1.0
+- @react-aria/interactions@3.1.0
+- @react-aria/label@3.1.0
+- @react-aria/link@3.1.0
+- @react-aria/listbox@3.1.0
+- @react-aria/menu@3.1.0
+- @react-aria/meter@3.1.0
+- @react-aria/overlays@3.1.0
+- @react-aria/progress@3.1.0
+- @react-aria/radio@3.1.0
+- @react-aria/searchfield@3.1.0
+- @react-aria/select@3.1.0
+- @react-aria/selection@3.1.0
+- @react-aria/separator@3.1.0
+- @react-aria/switch@3.1.0
+- @react-aria/table@3.0.0-alpha.5
+- @react-aria/textfield@3.1.0
+- @react-aria/toggle@3.1.0
+- @react-aria/utils@3.1.0
+- @react-aria/virtualizer@3.1.0
+- @react-aria/visually-hidden@3.1.0
+- @react-spectrum/actiongroup@3.1.0
+- @react-spectrum/breadcrumbs@3.1.0
+- @react-spectrum/button@3.1.0
+- @react-spectrum/buttongroup@3.1.0
+- @react-spectrum/checkbox@3.1.0
+- @react-spectrum/dialog@3.1.0
+- @react-spectrum/divider@3.1.0
+- @react-spectrum/form@3.1.0
+- @react-spectrum/icon@3.1.0
+- @react-spectrum/illustratedmessage@3.1.0
+- @react-spectrum/image@3.1.0
+- @react-spectrum/label@3.1.0
+- @react-spectrum/layout@3.1.0
+- @react-spectrum/link@3.1.0
+- @react-spectrum/listbox@3.1.0
+- @react-spectrum/menu@3.1.0
+- @react-spectrum/meter@3.1.0
+- @react-spectrum/overlays@3.1.0
+- @react-spectrum/picker@3.1.0
+- @react-spectrum/progress@3.1.0
+- @react-spectrum/provider@3.1.0
+- @react-spectrum/radio@3.1.0
+- @react-spectrum/searchfield@3.1.0
+- @react-spectrum/statuslight@3.1.0
+- @react-spectrum/switch@3.1.0
+- @react-spectrum/table@3.0.0-alpha.5
+- @react-spectrum/text@3.1.0
+- @react-spectrum/textfield@3.1.0
+- @react-spectrum/theme-dark@3.1.0
+- @react-spectrum/theme-default@3.1.0
+- @react-spectrum/utils@3.1.0
+- @react-spectrum/view@3.1.0
+- @react-spectrum/well@3.1.0
+- @react-stately/collections@3.1.0
+- @react-stately/data@3.1.0
+- @react-stately/layout@3.1.0
+- @react-stately/list@3.1.0
+- @react-stately/menu@3.1.0
+- @react-stately/overlays@3.1.0
+- @react-stately/radio@3.1.0
+- @react-stately/searchfield@3.1.0
+- @react-stately/select@3.1.0
+- @react-stately/selection@3.1.0
+- @react-stately/table@3.0.0-alpha.5
+- @react-stately/toggle@3.1.0
+- @react-stately/tree@3.1.0
+- @react-stately/utils@3.1.0
+- @react-stately/virtualizer@3.1.0
+- @react-types/actiongroup@3.1.0
+- @react-types/breadcrumbs@3.1.0
+- @react-types/button@3.1.0
+- @react-types/buttongroup@3.1.0
+- @react-types/checkbox@3.1.0
+- @react-types/dialog@3.1.0
+- @react-types/divider@3.1.0
+- @react-types/form@3.1.0
+- @react-types/illustratedmessage@3.1.0
+- @react-types/image@3.1.0
+- @react-types/label@3.1.0
+- @react-types/layout@3.1.0
+- @react-types/link@3.1.0
+- @react-types/listbox@3.1.0
+- @react-types/menu@3.1.0
+- @react-types/meter@3.1.0
+- @react-types/overlays@3.1.0
+- @react-types/progress@3.1.0
+- @react-types/provider@3.1.0
+- @react-types/radio@3.1.0
+- @react-types/searchfield@3.1.0
+- @react-types/select@3.1.0
+- @react-types/shared@3.1.0
+- @react-types/statuslight@3.1.0
+- @react-types/switch@3.1.0
+- @react-types/table@3.0.0-rc.4
+- @react-types/text@3.1.0
+- @react-types/textfield@3.1.0
+- @react-types/view@3.1.0
+- @react-types/well@3.1.0
+- @spectrum-icons/color@3.1.0
+- @spectrum-icons/illustrations@3.1.0
+- @spectrum-icons/ui@3.1.0
+- @spectrum-icons/workflow@3.1.0
+```

--- a/packages/dev/docs/pages/releases/index.mdx
+++ b/packages/dev/docs/pages/releases/index.mdx
@@ -12,6 +12,7 @@ export default BlogLayout;
 
 ---
 category: Foundation
+description: React Spectrum releases
 ---
 
 # Releases

--- a/packages/dev/docs/pages/releases/index.mdx
+++ b/packages/dev/docs/pages/releases/index.mdx
@@ -14,6 +14,6 @@ export default BlogLayout;
 category: Foundation
 ---
 
-# Blog
+# Releases
 
-<PostListing type="blog" />
+<PostListing type="releases" />

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -72,6 +72,11 @@ const mdxComponents = {
   kbd: ({children, ...props}) => <kbd {...props} className={docStyles['keyboard']}>{children}</kbd>
 };
 
+const sectionTitles = {
+  blog: 'React Spectrum Blog',
+  releases: 'React Spectrum Releases'
+};
+
 function dirToTitle(dir) {
   return dir
     .split('/')[0]
@@ -84,13 +89,17 @@ function stripMarkdown(description) {
   return (description || '').replace(/\[(.*?)\]\(.*?\)/g, '$1');
 }
 
+function isBlogSection(section) {
+  return section === 'blog' || section === 'releases';
+}
+
 function Page({children, currentPage, publicUrl, styles, scripts}) {
   let parts = currentPage.name.split('/');
-  let isBlog = parts[0] === 'blog';
+  let isBlog = isBlogSection(parts[0]);
   let isSubpage = parts.length > 1 && !/index\.html$/.test(currentPage.name);
   let pageSection = isSubpage ? dirToTitle(currentPage.name) : 'React Spectrum';
   if (isBlog && isSubpage) {
-    pageSection = 'React Spectrum Blog';
+    pageSection = sectionTitles[parts[0]];
   }
 
   let keywords = [...new Set(currentPage.keywords.concat([currentPage.category, currentPage.title, pageSection]).filter(k => !!k))];
@@ -222,7 +231,8 @@ const CATEGORY_ORDER = [
 function Nav({currentPageName, pages}) {
   let isIndex = /index\.html$/;
   let currentParts = currentPageName.split('/');
-  let isBlog = currentParts[0] === 'blog';
+  let isBlog = isBlogSection(currentParts[0]);
+  let blogIndex = currentParts[0] + '/index.html';
   if (isBlog) {
     currentParts.shift();
   }
@@ -232,7 +242,7 @@ function Nav({currentPageName, pages}) {
   pages = pages.filter(p => {
     let pageParts = p.name.split('/');
     let pageDir = pageParts[0];
-    if (pageDir === 'blog') {
+    if (isBlogSection(pageDir)) {
       return currentParts.length === 1 && pageParts[pageParts.length - 1] === 'index.html';
     }
 
@@ -306,7 +316,7 @@ function Nav({currentPageName, pages}) {
   function SideNavItem({name, url, title}) {
     const isCurrentPage = !currentPageIsIndex && name === currentPageName;
     return (
-      <li className={classNames(sideNavStyles['spectrum-SideNav-item'], {[sideNavStyles['is-selected']]: isCurrentPage || (name === 'blog/index.html' && isBlog)})}>
+      <li className={classNames(sideNavStyles['spectrum-SideNav-item'], {[sideNavStyles['is-selected']]: isCurrentPage || (name === blogIndex && isBlog)})}>
         <a
           className={classNames(sideNavStyles['spectrum-SideNav-itemLink'], docStyles.sideNavItem)}
           href={url}

--- a/packages/dev/docs/src/PostListing.js
+++ b/packages/dev/docs/src/PostListing.js
@@ -17,10 +17,10 @@ import {PageContext, renderHTMLfromMarkdown, Time} from '@react-spectrum/docs';
 import React from 'react';
 import typographyStyles from '@adobe/spectrum-css-temp/components/typography/vars.css';
 
-export function PostListing() {
+export function PostListing({type}) {
   let {pages} = React.useContext(PageContext);
   let blogPages = pages
-    .filter(page => page.name.startsWith('blog/') && !page.name.endsWith('index.html'))
+    .filter(page => page.name.startsWith(type) && !page.name.endsWith('index.html'))
     .sort((a, b) => a.date < b.date ? 1 : -1);
 
   return (

--- a/packages/dev/docs/src/index.js
+++ b/packages/dev/docs/src/index.js
@@ -20,3 +20,4 @@ export * from './types';
 export * from './FunctionAPI';
 export * from './TypeLink';
 export * from './ClassAPI';
+export * from './PostListing';


### PR DESCRIPTION
Adds a releases section to the top-level nav. It's structured similar to the blog, with a page for each release and a listing page showing the latest one at the top. Also added docs for the new `useSingleSelectListState` hook, and updated `useHover` for the added `isHovered` return value.