### PR TITLE
Allow to parametrize a bunch of event-related types with concrete HTMLElement

### DIFF
--- a/packages/@react-aria/focus/src/useFocusable.ts
+++ b/packages/@react-aria/focus/src/useFocusable.ts
@@ -11,6 +11,7 @@
  */
 
 import {FocusableDOMProps, FocusableProps} from '@react-types/shared';
+import {HTMLAttributes} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {RefObject, useEffect} from 'react';
 import {useFocus, useKeyboard} from '@react-aria/interactions';
@@ -20,12 +21,17 @@ interface FocusableOptions extends FocusableProps, FocusableDOMProps {
   isDisabled?: boolean
 }
 
+interface FocusableResult<T extends HTMLElement = HTMLElement> {
+  /** Props to spread onto the target element. */
+  focusableProps: HTMLAttributes<T>
+}
+
 /**
  * Used to make an element focusable and capable of auto focus.
  */
-export function useFocusable(props: FocusableOptions, domRef: RefObject<HTMLElement>) {
-  let {focusProps} = useFocus(props);
-  let {keyboardProps} = useKeyboard(props);
+export function useFocusable<T extends HTMLElement = HTMLElement>(props: FocusableOptions, domRef: RefObject<T>): FocusableResult<T> {
+  let {focusProps} = useFocus<T>(props);
+  let {keyboardProps} = useKeyboard<T>(props);
   let interactions = mergeProps(focusProps, keyboardProps);
 
   useEffect(() => {

--- a/packages/@react-aria/interactions/src/useFocus.ts
+++ b/packages/@react-aria/interactions/src/useFocus.ts
@@ -23,23 +23,23 @@ interface FocusProps extends FocusEvents {
   isDisabled?: boolean
 }
 
-interface FocusResult {
+interface FocusResult<T extends HTMLElement = HTMLElement> {
   /** Props to spread onto the target element. */
-  focusProps: HTMLAttributes<HTMLElement>
+  focusProps: HTMLAttributes<T>
 }
 
 /**
  * Handles focus events for the immediate target.
  * Focus events on child elements will be ignored.
  */
-export function useFocus(props: FocusProps): FocusResult {
+export function useFocus<T extends HTMLElement = HTMLElement>(props: FocusProps): FocusResult<T> {
   if (props.isDisabled) {
     return {focusProps: {}};
   }
 
   let onFocus, onBlur;
   if (props.onFocus || props.onFocusChange) {
-    onFocus = (e: FocusEvent) => {
+    onFocus = (e: FocusEvent<T>) => {
       if (e.target === e.currentTarget) {
         if (props.onFocus) {
           props.onFocus(e);
@@ -53,7 +53,7 @@ export function useFocus(props: FocusProps): FocusResult {
   }
 
   if (props.onBlur || props.onFocusChange) {
-    onBlur = (e: FocusEvent) => {
+    onBlur = (e: FocusEvent<T>) => {
       if (e.target === e.currentTarget) {
         if (props.onBlur) {
           props.onBlur(e);

--- a/packages/@react-aria/interactions/src/useKeyboard.ts
+++ b/packages/@react-aria/interactions/src/useKeyboard.ts
@@ -19,15 +19,15 @@ export interface KeyboardProps extends KeyboardEvents {
   isDisabled?: boolean
 }
 
-interface KeyboardResult {
+interface KeyboardResult<T extends HTMLElement = HTMLElement> {
   /** Props to spread onto the target element. */
-  keyboardProps: HTMLAttributes<HTMLElement>
+  keyboardProps: HTMLAttributes<T>
 }
 
 /**
  * Handles keyboard interactions for a focusable element.
  */
-export function useKeyboard(props: KeyboardProps): KeyboardResult {
+export function useKeyboard<T extends HTMLElement = HTMLElement>(props: KeyboardProps): KeyboardResult<T> {
   return {
     keyboardProps: props.isDisabled ? {} : {
       onKeyDown: createEventHandler(props.onKeyDown),

--- a/packages/@react-aria/label/src/useLabel.ts
+++ b/packages/@react-aria/label/src/useLabel.ts
@@ -22,11 +22,11 @@ interface LabelAriaProps extends LabelableProps, DOMProps, AriaLabelingProps {
   labelElementType?: ElementType
 }
 
-interface LabelAria {
+interface LabelAria<T extends HTMLElement = HTMLElement> {
   /** Props to apply to the label container element. */
   labelProps: LabelHTMLAttributes<HTMLLabelElement>,
   /** Props to apply to the field container element being labeled. */
-  fieldProps: HTMLAttributes<HTMLElement>
+  fieldProps: HTMLAttributes<T>
 }
 
 /**
@@ -34,7 +34,7 @@ interface LabelAria {
  * Labels provide context for user inputs.
  * @param props - The props for labels and fields.
  */
-export function useLabel(props: LabelAriaProps): LabelAria {
+export function useLabel<T extends HTMLElement = HTMLElement>(props: LabelAriaProps): LabelAria<T> {
   let {
     id,
     label,

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -120,7 +120,7 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState,
   }, [inputId, isReadOnly, isDisabled, decrement, increment]);
 
   let domProps = filterDOMProps(props, {labelable: true});
-  let {labelProps, inputProps} = useTextField(mergeProps(spinButtonProps, {
+  let {labelProps, inputProps} = useTextField<HTMLInputElement>(mergeProps(spinButtonProps, {
     autoFocus,
     value: '' + value,
     onChange: state.setValue,

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -16,9 +16,9 @@ import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {useFocusable} from '@react-aria/focus';
 import {useLabel} from '@react-aria/label';
 
-interface TextFieldAria {
+interface TextFieldAria<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement | HTMLTextAreaElement> {
   /** Props for the input element. */
-  inputProps: InputHTMLAttributes<HTMLInputElement & HTMLTextAreaElement>,
+  inputProps: InputHTMLAttributes<T>,
   /** Props for the text field's visible label element (if any). */
   labelProps: LabelHTMLAttributes<HTMLLabelElement>
 }
@@ -28,10 +28,10 @@ interface TextFieldAria {
  * @param props - Props for the text field.
  * @param ref - Ref to the HTML input element.
  */
-export function useTextField(
-  props: AriaTextFieldProps,
-  ref: RefObject<HTMLInputElement>
-): TextFieldAria {
+export function useTextField<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement | HTMLTextAreaElement>(
+  props: AriaTextFieldProps<T>,
+  ref: RefObject<T>
+): TextFieldAria<T> {
   let {
     inputElementType = 'input',
     isDisabled = false,
@@ -42,7 +42,7 @@ export function useTextField(
     onChange = () => {}
   } = props;
   let {focusableProps} = useFocusable(props, ref);
-  let {labelProps, fieldProps} = useLabel(props);
+  let {labelProps, fieldProps} = useLabel<T>(props);
   let domProps = filterDOMProps(props, {labelable: true});
 
   const inputOnlyProps = {
@@ -66,7 +66,7 @@ export function useTextField(
         'aria-haspopup': props['aria-haspopup'],
         value: props.value,
         defaultValue: props.value ? undefined : props.defaultValue,
-        onChange: (e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+        onChange: (e: ChangeEvent<T>) => onChange(e.target.value),
         autoComplete: props.autoComplete,
         maxLength: props.maxLength,
         minLength: props.minLength,

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, FocusableDOMProps, FocusableProps, PressEvents, StyleProps} from '@react-types/shared';
 import {JSXElementConstructor, ReactNode} from 'react';
 
-interface ButtonProps extends PressEvents, FocusableProps {
+interface ButtonProps extends PressEvents, FocusableProps<HTMLButtonElement> {
   /** Whether the button is disabled. */
   isDisabled?: boolean,
   /** The content to display in the button. */

--- a/packages/@react-types/shared/src/events.d.ts
+++ b/packages/@react-types/shared/src/events.d.ts
@@ -24,7 +24,7 @@ export type BaseEvent<T extends SyntheticEvent> = T & {
   continuePropagation(): void
 }
 
-export type KeyboardEvent = BaseEvent<ReactKeyboardEvent<any>>;
+export type KeyboardEvent<T extends HTMLElement = HTMLElement> = BaseEvent<ReactKeyboardEvent<T>>;
 
 export type PointerType = 'mouse' | 'pen' | 'touch' | 'keyboard' | 'virtual';
 
@@ -52,18 +52,18 @@ export interface HoverEvent {
   target: HTMLElement
 }
 
-export interface KeyboardEvents {
+export interface KeyboardEvents<T extends HTMLElement = HTMLElement> {
   /** Handler that is called when a key is pressed. */
-  onKeyDown?: (e: KeyboardEvent) => void,
+  onKeyDown?: (e: KeyboardEvent<T>) => void,
   /** Handler that is called when a key is released. */
-  onKeyUp?: (e: KeyboardEvent) => void
+  onKeyUp?: (e: KeyboardEvent<T>) => void
 }
 
-export interface FocusEvents {
+export interface FocusEvents<T extends HTMLElement = HTMLElement> {
   /** Handler that is called when the element receives focus. */
-  onFocus?: (e: FocusEvent) => void,
+  onFocus?: (e: FocusEvent<T>) => void,
   /** Handler that is called when the element loses focus. */
-  onBlur?: (e: FocusEvent) => void,
+  onBlur?: (e: FocusEvent<T>) => void,
   /** Handler that is called when the element's focus status changes. */
   onFocusChange?: (isFocused: boolean) => void
 }
@@ -96,7 +96,6 @@ export interface PressEvents {
   onPressUp?: (e: PressEvent) => void
 }
 
-export interface FocusableProps extends FocusEvents, KeyboardEvents {
-  /** Whether the element should receive focus on render. */
+export interface FocusableProps<T extends HTMLElement = HTMLElement> extends FocusEvents<T>, KeyboardEvents<T> {
   autoFocus?: boolean
 }

--- a/packages/@react-types/textfield/src/index.d.ts
+++ b/packages/@react-types/textfield/src/index.d.ts
@@ -27,9 +27,9 @@ import {
 } from '@react-types/shared';
 import {ElementType, ReactElement} from 'react';
 
-export interface TextFieldProps extends InputBase, Validation, FocusableProps, TextInputBase, ValueBase<string>, LabelableProps {}
+export interface TextFieldProps<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement | HTMLTextAreaElement> extends InputBase, Validation, FocusableProps<T>, TextInputBase, ValueBase<string>, LabelableProps {}
 
-export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, FocusableDOMProps, TextInputDOMProps, AriaValidationProps {
+export interface AriaTextFieldProps<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement | HTMLTextAreaElement> extends TextFieldProps<T>, AriaLabelingProps, FocusableDOMProps, TextInputDOMProps, AriaValidationProps {
   // https://www.w3.org/TR/wai-aria-1.2/#textbox
   /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
   'aria-activedescendant'?: string,
@@ -50,7 +50,7 @@ export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, F
   inputElementType?: ElementType
 }
 
-export interface SpectrumTextFieldProps extends AriaTextFieldProps, SpectrumLabelableProps, StyleProps {
+export interface SpectrumTextFieldProps<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement | HTMLTextAreaElement> extends AriaTextFieldProps<T>, SpectrumLabelableProps, StyleProps {
   /** An icon to display at the start of the textfield. */
   icon?: ReactElement,
   /** Whether the textfield should be displayed with a quiet style. */


### PR DESCRIPTION
This change improves the interop with external code expecting concrete handlers etc. If a library expects `FocusEvent<HTMLButtonElement>` then it won't accept just `FocusEvent<HTMLElement>`. Without this change, one has to cast quite a lot of things instead of providing the appropriate generic parameter once.

I don't expect this PR to solve this particular problem entirely. Most probably more places will need adjusting in the future but those are the ones that I have found so far.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

`yarn check-types`
