### PR TITLE
Fix ListBox typeahead spacebar issue

### DIFF
--- a/packages/@react-aria/selection/src/useTypeSelect.ts
+++ b/packages/@react-aria/selection/src/useTypeSelect.ts
@@ -52,6 +52,15 @@ export function useTypeSelect(options: TypeSelectOptions): TypeSelectAria {
       return;
     }
 
+    // Do not propagate the Spacebar event if it's meant to be part of the search.
+    // When we time out, the search term becomes empty, hence the check on length.
+    // Trimming is to account for the case of pressing the Spacebar more than once,
+    // which should cycle through the selection/deselection of the focused item.
+    if (character === ' ' && state.search.trim().length > 0) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
     state.search += character;
 
     // Use the delegate to find a key to focus.
@@ -76,7 +85,9 @@ export function useTypeSelect(options: TypeSelectOptions): TypeSelectAria {
 
   return {
     typeSelectProps: {
-      onKeyDown: keyboardDelegate.getKeyForSearch ? onKeyDown : null
+      // Using a capturing listener to catch the keydown event before
+      // other hooks in order to handle the Spacebar event. 
+      onKeyDownCapture: keyboardDelegate.getKeyForSearch ? onKeyDown : null
     }
   };
 }

--- a/packages/@react-aria/sidenav/test/useSideNav.test.js
+++ b/packages/@react-aria/sidenav/test/useSideNav.test.js
@@ -33,7 +33,7 @@ describe('useSideNav', function () {
     expect(navProps.role).toBe('navigation');
     expect(listProps).toBeDefined();
     expect(listProps.role).toBe('list');
-    expect(typeof listProps.onKeyDown).toBe('function');
+    expect(typeof listProps.onKeyDownCapture).toBe('function');
     expect(typeof listProps.onFocus).toBe('function');
     expect(typeof listProps.onBlur).toBe('function');
   });
@@ -55,7 +55,7 @@ describe('useSideNav', function () {
     expect(listProps).toBeDefined();
     expect(listProps.role).toBe('list');
     expect(listProps['aria-labelledby']).toBe('test-aria-labelledby');
-    expect(typeof listProps.onKeyDown).toBe('function');
+    expect(typeof listProps.onKeyDownCapture).toBe('function');
     expect(typeof listProps.onFocus).toBe('function');
     expect(typeof listProps.onBlur).toBe('function');
   });

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -28,6 +28,10 @@ let withSection = [
   {name: 'Heading 2', children: [
     {name: 'Blah'},
     {name: 'Bleh'}
+  ]},
+  {name: 'Heading 3', children: [
+    {name: 'Foo Bar'},
+    {name: 'Foo Baz'}
   ]}
 ];
 
@@ -75,7 +79,7 @@ describe('ListBox', function () {
     expect(listbox).toHaveAttribute('aria-labelledby', 'label');
 
     let sections = within(listbox).getAllByRole('group');
-    expect(sections.length).toBe(2);
+    expect(sections.length).toBe(withSection.length);
 
     for (let section of sections) {
       expect(section).toHaveAttribute('aria-labelledby');
@@ -85,10 +89,10 @@ describe('ListBox', function () {
     }
 
     let dividers = within(listbox).getAllByRole('separator');
-    expect(dividers.length).toBe(1);
+    expect(dividers.length).toBe(withSection.length - 1);
 
     let items = within(listbox).getAllByRole('option');
-    expect(items.length).toBe(5);
+    expect(items.length).toBe(withSection.reduce((acc, curr) => (acc + curr.children.length), 0));
     let i = 1;
     for (let item of items) {
       expect(item).toHaveAttribute('tabindex');
@@ -487,6 +491,89 @@ describe('ListBox', function () {
 
       fireEvent.keyDown(listbox, {key: 'E'});
       expect(document.activeElement).toBe(options[4]);
+    });
+
+    it('supports the space character in a search', function () {
+      let tree = renderComponent({autoFocus: 'first'});
+      let listbox = tree.getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: 'F'});
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: 'O'});
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: 'O'});
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: ' '});
+      expect(document.activeElement).toBe(options[5]);
+
+      fireEvent.keyDown(listbox, {key: 'B'});
+      expect(document.activeElement).toBe(options[5]);
+
+      fireEvent.keyDown(listbox, {key: 'A'});
+      expect(document.activeElement).toBe(options[5]);
+
+      fireEvent.keyDown(listbox, {key: 'Z'});
+      expect(document.activeElement).toBe(options[6]);
+    });
+
+    it('supports item selection using the Spacebar after search times out', function () {
+      let tree = renderComponent({autoFocus: 'first', onSelectionChange, selectionMode: 'single'});
+      let listbox = tree.getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: 'F'});
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: 'O'});
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: 'O'});
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyDown(listbox, {key: ' '});
+      expect(document.activeElement).toBe(options[5]);
+
+      // Verify no selection was made
+      expect(document.activeElement).toHaveAttribute('aria-selected', 'false');
+
+      // Verify there are no checkmarks on the active element
+      let checkmark = within(document.activeElement).queryByRole('img', {hidden: true});
+      expect(checkmark).toBeFalsy();
+
+      // Verify there are no checkmarks in the entire listbox
+      let checkmarks = tree.queryAllByRole('img', {hidden: true});
+      expect(checkmarks.length).toBe(0);
+
+      // Verify onSelectionChange was not called
+      expect(onSelectionChange).toBeCalledTimes(0);
+
+      // Continue the search
+      fireEvent.keyDown(listbox, {key: 'B'});
+      expect(document.activeElement).toBe(options[5]);
+
+      // Advance the timers so we can select using the Spacebar
+      jest.runAllTimers();
+
+      fireEvent.keyDown(document.activeElement, {key: ' ', code: 32, charCode: 32});
+
+      // Verify the selection
+      expect(document.activeElement).toHaveAttribute('aria-selected', 'true');
+      checkmark = within(document.activeElement).getByRole('img', {hidden: true});
+      expect(checkmark).toBeTruthy();
+
+      // Verify there is only a single checkmark in the entire listbox
+      checkmarks = tree.getAllByRole('img', {hidden: true});
+      expect(checkmarks.length).toBe(1);
+
+      // Verify onSelectionChange is called
+      expect(onSelectionChange).toBeCalledTimes(1);
+      expect(onSelectionChange.mock.calls[0][0].has('Foo Bar')).toBeTruthy();
     });
 
     it('resets the search text after a timeout', function () {

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -188,9 +188,8 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         triggerRef={unwrapDOMRef(triggerRef)}
         label={label}
         name={name} />
-      <PressResponder {...hoverProps}>
+      <PressResponder {...mergeProps(hoverProps, triggerProps)}>
         <FieldButton
-          {...triggerProps}
           ref={triggerRef}
           isActive={state.isOpen}
           isQuiet={isQuiet}


### PR DESCRIPTION
Closes #851

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
1. Go to storybook
2. Go to **ListBox > ListBox w/ many sections and selection**
3. Make sure the listbox is in focus
4. Type in an item name including the space character; e.g. `Section 8`
5. If the item is highlighted without being selected, tests 1/2 pass ✅ 
6. Wait about a second or so (to clear the typeahead timeout), then press the *Spacebar* on your keyboard
7. If the item is selected, tests 2/2 pass ✅ 
8. Everything is fine, nothing is ruined
## 🧢 Your Project:
Adobe React-Spectrum
![rsp](https://camo.githubusercontent.com/108ee104a4c31bdb1a0e24d1cfe1ade874f6a955/68747470733a2f2f6d65646961312e74656e6f722e636f6d2f696d616765732f65336438363934316262633433633264393963653866616465386663616362332f74656e6f722e6769663f6974656d69643d34363831363735)