### PR TITLE
Add missing ref to useButton in useSelect example

### DIFF
--- a/packages/@react-aria/select/docs/useSelect.mdx
+++ b/packages/@react-aria/select/docs/useSelect.mdx
@@ -149,7 +149,7 @@ function Select(props) {
   } = useSelect(props, state, ref);
 
   // Get props for the button based on the trigger props from useSelect
-  let {buttonProps} = useButton(triggerProps);
+  let {buttonProps} = useButton(triggerProps, ref);
 
   return (
     <div style={{position: 'relative', display: 'inline-block'}}>

--- a/packages/@react-stately/collections/docs/collections.mdx
+++ b/packages/@react-stately/collections/docs/collections.mdx
@@ -235,7 +235,7 @@ let [sections, setSections] = useState([
 
 <Picker items={sections}>
   {section =>
-    <Section key={item.name} title={section.name} items={section.items}>
+    <Section key={section.name} title={section.name} items={section.items}>
       {item => <Item key={item.name}>{item.name}</Item>}
     </Section>
   }


### PR DESCRIPTION
Closes #870

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

N/A
