### PR TITLE
Move isRequired from LabelableProps to SpectrumLabelableProps

### DIFF
--- a/packages/@react-types/shared/src/labelable.d.ts
+++ b/packages/@react-types/shared/src/labelable.d.ts
@@ -18,9 +18,7 @@ export type NecessityIndicator = 'icon' | 'label';
 
 export interface LabelableProps {
   /** The content to display as the label. */
-  label?: ReactNode,
-  /** Whether the label is labeling a required field or group. */
-  isRequired?: boolean
+  label?: ReactNode
 }
 
 export interface SpectrumLabelableProps extends LabelableProps {
@@ -38,5 +36,9 @@ export interface SpectrumLabelableProps extends LabelableProps {
    * Whether the required state should be shown as an icon or text.
    * @default 'icon'
    */
-  necessityIndicator?: NecessityIndicator
+  necessityIndicator?: NecessityIndicator,
+  /**
+   * Whether the label is labeling a required field or group.
+   */
+  isRequired?: boolean
 }


### PR DESCRIPTION
Related to: https://github.com/adobe/react-spectrum/pull/868#discussion_r464361906

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->