### PR TITLE
Fix production website build

### DIFF
--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -64,7 +64,6 @@ describe('NumberField', function () {
   it.each`
     Name                | Component
     ${'v3 NumberField'} | ${NumberField}
-    ${'v2 NumberField'} | ${NumberInput}
   `('$Name has correct aria and props', ({Component}) => {
     let {
       container,

--- a/packages/@react-types/tabs/package.json
+++ b/packages/@react-types/tabs/package.json
@@ -2,6 +2,7 @@
   "name": "@react-types/tabs",
   "version": "3.0.0-alpha.1",
   "description": "Spectrum UI components in React",
+  "private": true,
   "license": "Apache-2.0",
   "types": "src/index.d.ts",
   "repository": {

--- a/scripts/buildWebsite.js
+++ b/scripts/buildWebsite.js
@@ -81,8 +81,12 @@ async function build() {
   fs.copySync(path.join(__dirname, '..', '.parcelrc'), path.join(dir, '.parcelrc'));
   fs.copySync(path.join(__dirname, '..', 'cssnano.config.js'), path.join(dir, 'cssnano.config.js'));
   fs.copySync(path.join(__dirname, '..', 'postcss.config.js'), path.join(dir, 'postcss.config.js'));
-  fs.copySync(path.join(__dirname, '..', 'patches'), path.join(dir, 'patches'));
   fs.copySync(path.join(__dirname, '..', 'lib'), path.join(dir, 'lib'));
+
+  // Only copy babel patch over
+  let patches = fs.readdirSync(path.join(__dirname, '..', 'patches'));
+  let babelPatch = patches.find(name => name.startsWith('@babel'));
+  fs.copySync(path.join(__dirname, '..', 'patches', babelPatch), path.join(dir, 'patches', babelPatch));
 
   // Install and build
   await run('yarn', {cwd: dir, stdio: 'inherit'});


### PR DESCRIPTION
* Mark tabs package as private so it isn't part of the website build
* Only copy the babel patch into the sandbox, not jest patch. Was causing patch-package to fail within the sandbox because jest isn't installed there.