### PR TITLE
use default font-families

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -29,7 +29,7 @@ governing permissions and limitations under the License.
   --spectrum-textfield-multiline-padding-bottom: var(--spectrum-textfield-padding-bottom);
 
   /* Todo: DNA uses incorrect font family "Adobe Clean" */;
-  --spectrum-textfield-text-font-family-fixed: adobe-clean, Helvetica, Arial, sans-serif;
+  --spectrum-textfield-text-font-family-fixed: var(--spectrum-font-family-base);
 }
 
 .spectrum-Textfield {


### PR DESCRIPTION
* use --spectrum-font-family-base fonts


Closes #847

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

I looked at the current for TextField and could find any tests for fonts. So I tested this manually the StoryBook using the web-developer tools in Firefox

Result in current main-branch:
<img width="1583" alt="baseline" src="https://user-images.githubusercontent.com/52631/89402147-b5f1da80-d716-11ea-996d-eb53dc957515.png">

Result with above fix applied:
<img width="1583" alt="fix" src="https://user-images.githubusercontent.com/52631/89402221-ce61f500-d716-11ea-847e-d5bb5dc577a7.png">


## 🧢 Your Project:

<!--- Company/project for pull request -->
