### PR TITLE
Add shouldCloseOnInteractOutside prop to useOverlay()

### DIFF
--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -99,8 +99,10 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,
-    onBlurWithin: () => {
-      onClose();
+    onBlurWithin: (e) => {
+      if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.relatedTarget as HTMLElement)) {
+        onClose();
+      }
     }
   });
 

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -80,11 +80,11 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
     }
   };
 
-  let onInteractOutside = isDismissable ? (e: SyntheticEvent<HTMLElement>) => {
+  let onInteractOutside = (e: SyntheticEvent<HTMLElement>) => {
     if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as HTMLElement)) {
       onHide();
     }
-  } : null;
+  };
 
   // Handle the escape key
   let onKeyDown = (e) => {
@@ -95,7 +95,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   };
 
   // Handle clicking outside the overlay to close it
-  useInteractOutside({ref, onInteractOutside});
+  useInteractOutside({ref, onInteractOutside: isDismissable ? onInteractOutside : null});
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {HTMLAttributes, RefObject, useEffect} from 'react';
+import {HTMLAttributes, RefObject, SyntheticEvent, useEffect} from 'react';
 import {useFocusWithin, useInteractOutside} from '@react-aria/interactions';
 
 interface OverlayProps {
@@ -33,7 +33,15 @@ interface OverlayProps {
    * Whether pressing the escape key to close the overlay should be disabled. 
    * @default false
    */
-  isKeyboardDismissDisabled?: boolean
+  isKeyboardDismissDisabled?: boolean,
+
+  /**
+   * When user interacts with the argument element outside of the overlay ref,
+   * return true if onClose should be called.  This gives you a chance to filter
+   * out interaction with elements that should not dismiss the overlay.  
+   * By default, onClose will always be called on interaction outside the overlay ref.
+   */
+  shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
 }
 
 interface OverlayAria {
@@ -49,7 +57,7 @@ const visibleOverlays: RefObject<HTMLElement>[] = [];
  * or optionally, on blur. Only the top-most overlay will close at once.
  */
 export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): OverlayAria {
-  let {onClose, shouldCloseOnBlur, isOpen, isDismissable = false, isKeyboardDismissDisabled = false} = props;
+  let {onClose, shouldCloseOnBlur, isOpen, isDismissable = false, isKeyboardDismissDisabled = false, shouldCloseOnInteractOutside} = props;
 
   // Add the overlay ref to the stack of visible overlays on mount, and remove on unmount.
   useEffect(() => {
@@ -72,6 +80,12 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
     }
   };
 
+  let onInteractOutside = isDismissable ? (e: SyntheticEvent<HTMLElement>) => {
+    if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as HTMLElement)) {
+      onHide();
+    }
+  } : null;
+
   // Handle the escape key
   let onKeyDown = (e) => {
     if (e.key === 'Escape' && !isKeyboardDismissDisabled) {
@@ -81,7 +95,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   };
 
   // Handle clicking outside the overlay to close it
-  useInteractOutside({ref, onInteractOutside: isDismissable ? onHide : null});
+  useInteractOutside({ref, onInteractOutside});
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,

--- a/packages/@react-aria/overlays/test/useOverlay.test.js
+++ b/packages/@react-aria/overlays/test/useOverlay.test.js
@@ -40,7 +40,7 @@ describe('useOverlay', function () {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('should not hide the overlay when clicking outside if shouldCloseOnInteractOutside returns true', function () {
+  it('should hide the overlay when clicking outside if shouldCloseOnInteractOutside returns true', function () {
     let onClose = jest.fn();
     render(<Example isOpen onClose={onClose} isDismissable shouldCloseOnInteractOutside={target => target === document.body} />);
     fireEvent.mouseDown(document.body);

--- a/packages/@react-aria/overlays/test/useOverlay.test.js
+++ b/packages/@react-aria/overlays/test/useOverlay.test.js
@@ -40,6 +40,22 @@ describe('useOverlay', function () {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should not hide the overlay when clicking outside if shouldCloseOnInteractOutside returns true', function () {
+    let onClose = jest.fn();
+    render(<Example isOpen onClose={onClose} isDismissable shouldCloseOnInteractOutside={target => target === document.body} />);
+    fireEvent.mouseDown(document.body);
+    fireEvent.mouseUp(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not hide the overlay when clicking outside if shouldCloseOnInteractOutside returns false', function () {
+    let onClose = jest.fn();
+    render(<Example isOpen onClose={onClose} isDismissable shouldCloseOnInteractOutside={target => target !== document.body} />);
+    fireEvent.mouseDown(document.body);
+    fireEvent.mouseUp(document.body);
+    expect(onClose).toHaveBeenCalledTimes(0);
+  });
+
   it('should not hide the overlay when clicking outside if isDismissable is false', function () {
     let onClose = jest.fn();
     render(<Example isOpen onClose={onClose} isDismissable={false} />);


### PR DESCRIPTION
Allows you to filter overlay dismissal by the outside element that was
interacted with.

Closes #892 

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 🧢 Your Project:

[Plasmic](https://plasmic.app)
