### PR TITLE
Add hooks versions of VisuallyHidden and HiddenSelect

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -13,15 +13,9 @@
 import React, {ReactNode, RefObject} from 'react';
 import {SelectState} from '@react-stately/select';
 import {useInteractionModality} from '@react-aria/interactions';
-import {VisuallyHidden} from '@react-aria/visually-hidden';
+import {useVisuallyHidden} from '@react-aria/visually-hidden';
 
-interface HiddenSelectProps<T> {
-  /** State for the select. */
-  state: SelectState<T>,
-
-  /** A ref to the trigger element. */
-  triggerRef: RefObject<HTMLElement>,
-
+interface AriaHiddenSelectProps<T> {
   /** The text label for the select. */
   label?: ReactNode,
 
@@ -32,53 +26,83 @@ interface HiddenSelectProps<T> {
   isDisabled?: boolean
 }
 
+interface HiddenSelectProps<T> extends AriaHiddenSelectProps<T> {
+  /** State for the select. */
+  state: SelectState<T>,
+
+  /** A ref to the trigger element. */
+  triggerRef: RefObject<HTMLElement>
+}
+
+/**
+ * Provides the behavior and accessibility implementation for a hidden `<select>` element, which
+ * can be used in combination with `useSelect` to support browser form autofill, mobile form
+ * navigation, and native HTML form submission.
+ */
+function useHiddenSelect<T>(props: AriaHiddenSelectProps<T>, state: SelectState<T>, triggerRef: RefObject<HTMLElement>) {
+  let {name, isDisabled} = props;
+  let modality = useInteractionModality();
+  let {visuallyHiddenProps} = useVisuallyHidden();
+
+  // In Safari, the <select> cannot have `display: none` or `hidden` for autofill to work.
+  // In Firefox, there must be a <label> to identify the <select> whereas other browsers
+  // seem to identify it just by surrounding text.
+  // The solution is to use <VisuallyHidden> to hide the elements, which clips the elements to a
+  // 1px rectangle. In addition, we hide from screen readers with aria-hidden, and make the <select>
+  // non tabbable with tabIndex={-1}.
+  //
+  // In mobile browsers, there are next/previous buttons above the software keyboard for navigating
+  // between fields in a form. These only support native form inputs that are tabbable. In order to
+  // support those, an additional hidden input is used to marshall focus to the button. It is tabbable
+  // except when the button is focused, so that shift tab works properly to go to the actual previous
+  // input in the form. Using the <select> for this also works, but Safari on iOS briefly flashes
+  // the native menu on focus, so this isn't ideal. A font-size of 16px or greater is required to
+  // prevent Safari from zooming in on the input when it is focused.
+  //
+  // If the current interaction modality is null, then the user hasn't interacted with the page yet.
+  // In this case, we set the tabIndex to -1 on the input element so that automated accessibility
+  // checkers don't throw false-positives about focusable elements inside an aria-hidden parent.
+  return {
+    containerProps: {
+      ...visuallyHiddenProps,
+      'aria-hidden': true
+    },
+    inputProps: {
+      type: 'text',
+      tabIndex: modality == null || state.isFocused || state.isOpen ? -1 : 0,
+      style: {fontSize: 16},
+      onFocus: () => triggerRef.current.focus(),
+      disabled: isDisabled
+    },
+    selectProps: {
+      tabIndex: -1,
+      disabled: isDisabled,
+      name,
+      size: state.collection.size,
+      value: state.selectedKey,
+      onChange: e => state.setSelectedKey(e.target.value)
+    }
+  }
+}
+
 /**
  * Renders a hidden native `<select>` element, which can be used to support browser
  * form autofill, mobile form navigation, and native form submission.
  */
 export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
   let {state, triggerRef, label, name, isDisabled} = props;
-  let modality = useInteractionModality();
+  let {containerProps, inputProps, selectProps} = useHiddenSelect(props, state, triggerRef);
 
   // If used in a <form>, use a hidden input so the value can be submitted to a server.
   // If the collection isn't too big, use a hidden <select> element for this so that browser
   // autofill will work. Otherwise, use an <input type="hidden">.
   if (state.collection.size <= 300) {
-    // In Safari, the <select> cannot have `display: none` or `hidden` for autofill to work.
-    // In Firefox, there must be a <label> to identify the <select> whereas other browsers
-    // seem to identify it just by surrounding text.
-    // The solution is to use <VisuallyHidden> to hide the elements, which clips the elements to a
-    // 1px rectangle. In addition, we hide from screen readers with aria-hidden, and make the <select>
-    // non tabbable with tabIndex={-1}.
-    //
-    // In mobile browsers, there are next/previous buttons above the software keyboard for navigating
-    // between fields in a form. These only support native form inputs that are tabbable. In order to
-    // support those, an additional hidden input is used to marshall focus to the button. It is tabbable
-    // except when the button is focused, so that shift tab works properly to go to the actual previous
-    // input in the form. Using the <select> for this also works, but Safari on iOS briefly flashes
-    // the native menu on focus, so this isn't ideal. A font-size of 16px or greater is required to
-    // prevent Safari from zooming in on the input when it is focused.
-    //
-    // If the current interaction modality is null, then the user hasn't interacted with the page yet.
-    // In this case, we set the tabIndex to -1 on the input element so that automated accessibility
-    // checkers don't throw false-positives about focusable elements inside an aria-hidden parent.
     return (
-      <VisuallyHidden aria-hidden="true">
-        <input
-          type="text"
-          tabIndex={modality == null || state.isFocused || state.isOpen ? -1 : 0}
-          style={{fontSize: 16}}
-          onFocus={() => triggerRef.current.focus()}
-          disabled={isDisabled} />
+      <div {...containerProps}>
+        <input {...inputProps} />
         <label>
           {label}
-          <select
-            tabIndex={-1}
-            disabled={isDisabled}
-            name={name}
-            size={state.collection.size}
-            value={state.selectedKey}
-            onChange={e => state.setSelectedKey(e.target.value)}>
+          <select {...selectProps}>
             {[...state.collection.getKeys()].map(key => {
               let item = state.collection.getItem(key);
               if (item.type === 'item') {
@@ -93,7 +117,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
             })}
           </select>
         </label>
-      </VisuallyHidden>
+      </div>
     );
   } else if (name) {
     return (

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -82,7 +82,7 @@ function useHiddenSelect<T>(props: AriaHiddenSelectProps<T>, state: SelectState<
       value: state.selectedKey,
       onChange: e => state.setSelectedKey(e.target.value)
     }
-  }
+  };
 }
 
 /**

--- a/packages/@react-aria/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/@react-aria/visually-hidden/src/VisuallyHidden.tsx
@@ -16,7 +16,7 @@ import {useFocus} from '@react-aria/interactions';
 
 interface VisuallyHiddenProps extends HTMLAttributes<HTMLElement> {
   /** The content to visually hide. */
-  children: ReactNode,
+  children?: ReactNode,
 
   /**
    * The element type for the container.
@@ -41,17 +41,18 @@ const styles: CSSProperties = {
   whiteSpace: 'nowrap'
 };
 
+interface VisuallyHiddenAria {
+  visuallyHiddenProps: HTMLAttributes<HTMLElement>
+}
+
 /**
- * VisuallyHidden hides its children visually, while keeping content visible
- * to screen readers.
+ * Provides props for an element that hides its children visually
+ * but keeps content visible to assistive technology.
  */
-export function VisuallyHidden(props: VisuallyHiddenProps) {
+export function useVisuallyHidden(props: VisuallyHiddenProps = {}): VisuallyHiddenAria {
   let {
-    children,
     style,
-    elementType: Element = 'div',
-    isFocusable,
-    ...otherProps
+    isFocusable
   } = props;
 
   let [isFocused, setFocused] = useState(false);
@@ -71,10 +72,25 @@ export function VisuallyHidden(props: VisuallyHiddenProps) {
     }
   }, [isFocused]);
 
+  return {
+    visuallyHiddenProps: {
+      ...focusProps,
+      style: combinedStyles
+    }
+  };
+}
+
+/**
+ * VisuallyHidden hides its children visually, while keeping content visible
+ * to screen readers.
+ */
+export function VisuallyHidden(props: VisuallyHiddenProps) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let {children, elementType: Element = 'div', isFocusable, style, ...otherProps} = props;
+  let {visuallyHiddenProps} = useVisuallyHidden(props);
+
   return (
-    <Element
-      {...mergeProps(otherProps, focusProps)}
-      style={combinedStyles}>
+    <Element {...mergeProps(otherProps, visuallyHiddenProps)}>
       {children}
     </Element>
   );


### PR DESCRIPTION
Closes #857. Depends on #911.

This adds `useVisuallyHidden` and `useHiddenSelect` hooks of the corresponding components, which may be useful for users with alternative renderers than React. Users of the hooks versions are responsible for rendering the actual elements and spreading props onto them.