### PR TITLE
Fix double open menu

### DIFF
--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -80,11 +80,11 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
     }
   };
 
-  let onInteractOutside = isDismissable && isOpen ? (e: SyntheticEvent<HTMLElement>) => {
+  let onInteractOutside = (e: SyntheticEvent<HTMLElement>) => {
     if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as HTMLElement)) {
       onHide();
     }
-  } : undefined;
+  };
 
   // Handle the escape key
   let onKeyDown = (e) => {
@@ -95,7 +95,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   };
 
   // Handle clicking outside the overlay to close it
-  useInteractOutside({ref, onInteractOutside});
+  useInteractOutside({ref, onInteractOutside: isDismissable && isOpen ? onInteractOutside : undefined});
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -29,8 +29,8 @@ interface OverlayProps {
   /** Whether the overlay should close when focus is lost or moves outside it. */
   shouldCloseOnBlur?: boolean,
 
-  /** 
-   * Whether pressing the escape key to close the overlay should be disabled. 
+  /**
+   * Whether pressing the escape key to close the overlay should be disabled.
    * @default false
    */
   isKeyboardDismissDisabled?: boolean,
@@ -38,7 +38,7 @@ interface OverlayProps {
   /**
    * When user interacts with the argument element outside of the overlay ref,
    * return true if onClose should be called.  This gives you a chance to filter
-   * out interaction with elements that should not dismiss the overlay.  
+   * out interaction with elements that should not dismiss the overlay.
    * By default, onClose will always be called on interaction outside the overlay ref.
    */
   shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
@@ -80,11 +80,11 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
     }
   };
 
-  let onInteractOutside = (e: SyntheticEvent<HTMLElement>) => {
+  let onInteractOutside = isDismissable && isOpen ? (e: SyntheticEvent<HTMLElement>) => {
     if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as HTMLElement)) {
       onHide();
     }
-  };
+  } : undefined;
 
   // Handle the escape key
   let onKeyDown = (e) => {
@@ -95,7 +95,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   };
 
   // Handle clicking outside the overlay to close it
-  useInteractOutside({ref, onInteractOutside: isDismissable ? onInteractOutside : null});
+  useInteractOutside({ref, onInteractOutside});
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,

--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -81,7 +81,7 @@ export function useSelect<T>(props: AriaSelectOptions<T>, state: SelectState<T>,
   });
 
   let domProps = filterDOMProps(props, {labelable: true});
-  let triggerProps = mergeProps(mergeProps(menuTriggerProps, fieldProps), typeSelectProps);
+  let triggerProps = mergeProps(menuTriggerProps, fieldProps, typeSelectProps);
   let valueId = useId();
 
   return {

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -73,6 +73,13 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
     </FocusScope>
   );
 
+  let shouldCloseOnInteractOutside = (element) => {
+    if (menuTriggerRef.current && menuTriggerRef.current.contains(element)) {
+      return false;
+    }
+    return true;
+  };
+
   // On small screen devices, the menu is rendered in a tray, otherwise a popover.
   let overlay;
   if (isMobile) {
@@ -90,7 +97,8 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
         placement={placement}
         hideArrow
         onClose={state.close}
-        shouldCloseOnBlur>
+        shouldCloseOnBlur
+        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}>
         {contents}
       </Popover>
     );

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -74,10 +74,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
   );
 
   let shouldCloseOnInteractOutside = (element) => {
-    if (menuTriggerRef.current && menuTriggerRef.current.contains(element)) {
-      return false;
-    }
-    return true;
+    return !(menuTriggerRef.current?.contains(element));
   };
 
   // On small screen devices, the menu is rendered in a tray, otherwise a popover.

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -73,9 +73,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
     </FocusScope>
   );
 
-  let shouldCloseOnInteractOutside = (element) => {
-    return !(menuTriggerRef.current?.contains(element));
-  };
+  let shouldCloseOnInteractOutside = (element) => !menuTriggerRef.current?.contains(element);
 
   // On small screen devices, the menu is rendered in a tray, otherwise a popover.
   let overlay;

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -500,7 +500,7 @@ storiesOf('MenuTrigger', module)
         {defaultMenu}
       </MenuTrigger>
     </Flex>
-  );
+  ));
 
 
 let customMenuItem = (item) => {

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -479,30 +479,28 @@ storiesOf('MenuTrigger', module)
       </>
     )
   )
-  .add('double menu', () => {
-    return (
-      <Flex gap="size-100">
-        <MenuTrigger>
-          <ActionButton
-            onPressStart={action('1onPressStart')}
-            onPressEnd={action('1onPressEnd')}
-            onPress={action('1onPress')}>
-            Menu Button 1
-          </ActionButton>
-          {defaultMenu}
-        </MenuTrigger>
-        <MenuTrigger>
-          <ActionButton
-            onPressStart={action('2onPressStart')}
-            onPressEnd={action('2onPressEnd')}
-            onPress={action('2onPress')}>
-            Menu Button 2
-          </ActionButton>
-          {defaultMenu}
-        </MenuTrigger>
-      </Flex>
-    );
-  });
+  .add('double menu', () => (
+    <Flex gap="size-100">
+      <MenuTrigger>
+        <ActionButton
+          onPressStart={action('1onPressStart')}
+          onPressEnd={action('1onPressEnd')}
+          onPress={action('1onPress')}>
+          Menu Button 1
+        </ActionButton>
+        {defaultMenu}
+      </MenuTrigger>
+      <MenuTrigger>
+        <ActionButton
+          onPressStart={action('2onPressStart')}
+          onPressEnd={action('2onPressEnd')}
+          onPress={action('2onPress')}>
+          Menu Button 2
+        </ActionButton>
+        {defaultMenu}
+      </MenuTrigger>
+    </Flex>
+  );
 
 
 let customMenuItem = (item) => {

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -19,6 +19,7 @@ import Blower from '@spectrum-icons/workflow/Blower';
 import Book from '@spectrum-icons/workflow/Book';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
+import {Flex} from '@react-spectrum/layout';
 import {Item, Menu, MenuTrigger, Section} from '../';
 import {Keyboard, Text} from '@react-spectrum/text';
 import Paste from '@spectrum-icons/workflow/Paste';
@@ -477,7 +478,32 @@ storiesOf('MenuTrigger', module)
         </div>
       </>
     )
-  );
+  )
+  .add('double menu', () => {
+    return (
+      <Flex gap="size-100">
+        <MenuTrigger>
+          <ActionButton
+            onPressStart={action('1onPressStart')}
+            onPressEnd={action('1onPressEnd')}
+            onPress={action('1onPress')}>
+            Menu Button 1
+          </ActionButton>
+          {defaultMenu}
+        </MenuTrigger>
+        <MenuTrigger>
+          <ActionButton
+            onPressStart={action('2onPressStart')}
+            onPressEnd={action('2onPressEnd')}
+            onPress={action('2onPress')}>
+            Menu Button 2
+          </ActionButton>
+          {defaultMenu}
+        </MenuTrigger>
+      </Flex>
+    );
+  });
+
 
 let customMenuItem = (item) => {
   let Icon = iconMap[item.icon];

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -221,7 +221,7 @@ describe('MenuTrigger', function () {
 
     menu = tree.getByRole('menu');
     expect(menu).toBeTruthy();
-    expect(onOpenChange).toBeCalledTimes(2); // once for press, once for blur :/
+    expect(onOpenChange).toBeCalledTimes(1);
   });
 
   // New functionality in v3

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -28,7 +28,8 @@ interface PopoverWrapperProps extends HTMLAttributes<HTMLElement> {
   isOpen?: boolean,
   onClose?: () => void,
   shouldCloseOnBlur?: boolean,
-  isKeyboardDismissDisabled?: boolean
+  isKeyboardDismissDisabled?: boolean,
+  shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
 }
 
 /**
@@ -46,7 +47,7 @@ let arrowPlacement = {
 };
 
 function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
-  let {children, placement, arrowProps, onClose, shouldCloseOnBlur, hideArrow, isKeyboardDismissDisabled, ...otherProps} = props;
+  let {children, placement, arrowProps, onClose, shouldCloseOnBlur, hideArrow, isKeyboardDismissDisabled, shouldCloseOnInteractOutside, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let {styleProps} = useStyleProps(props);
 
@@ -60,7 +61,8 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
         onClose={onClose}
         shouldCloseOnBlur={shouldCloseOnBlur}
         isKeyboardDismissDisabled={isKeyboardDismissDisabled}
-        hideArrow={hideArrow}>
+        hideArrow={hideArrow}
+        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}>
         {children}
       </PopoverWrapper>
     </Overlay>
@@ -69,7 +71,7 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
 
 const PopoverWrapper = forwardRef((props: PopoverWrapperProps, ref: RefObject<HTMLDivElement>) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let {children, placement = 'bottom', arrowProps, isOpen, hideArrow, shouldCloseOnBlur, isKeyboardDismissDisabled, ...otherProps} = props;
+  let {children, placement = 'bottom', arrowProps, isOpen, hideArrow, shouldCloseOnBlur, isKeyboardDismissDisabled, shouldCloseOnInteractOutside, ...otherProps} = props;
   let {overlayProps} = useOverlay({...props, isDismissable: true}, ref);
   let {modalProps} = useModal();
 

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -149,10 +149,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       minWidth: isQuiet ? `calc(${buttonWidth}px + calc(2 * var(--spectrum-dropdown-quiet-offset)))` : buttonWidth
     };
 
-    let shouldCloseOnInteractOutside = (element) => {
-      return !(triggerRef.current?.UNSAFE_getDOMNode()?.contains(element));
-    };
-
+    let shouldCloseOnInteractOutside = (element) => !triggerRef.current?.UNSAFE_getDOMNode()?.contains(element);
 
     overlay = (
       <Popover

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -149,6 +149,14 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       minWidth: isQuiet ? `calc(${buttonWidth}px + calc(2 * var(--spectrum-dropdown-quiet-offset)))` : buttonWidth
     };
 
+    let shouldCloseOnInteractOutside = (element) => {
+      if (triggerRef.current && triggerRef.current?.UNSAFE_getDOMNode().contains(element)) {
+        return false;
+      }
+      return true;
+    };
+
+
     overlay = (
       <Popover
         isOpen={state.isOpen}
@@ -158,7 +166,8 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         placement={placement}
         hideArrow
         shouldCloseOnBlur
-        onClose={state.close}>
+        onClose={state.close}
+        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}>
         {listbox}
       </Popover>
     );

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -150,10 +150,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     };
 
     let shouldCloseOnInteractOutside = (element) => {
-      if (triggerRef.current && triggerRef.current?.UNSAFE_getDOMNode().contains(element)) {
-        return false;
-      }
-      return true;
+      return !(triggerRef.current?.UNSAFE_getDOMNode()?.contains(element));
     };
 
 

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -54,7 +54,7 @@ storiesOf('Picker', module)
   .add(
     'default',
     () => (
-      <Picker label="Test" onSelectionChange={action('selectionChange')}>
+      <Picker label="Test" onOpenChange={action('openchange')} onSelectionChange={action('selectionChange')}>
         <Item key="One">One</Item>
         <Item key="Two">Two</Item>
         <Item key="Three">Three</Item>

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -23,6 +23,7 @@ import React from 'react';
 import {Text} from '@react-spectrum/text';
 import {theme} from '@react-spectrum/theme-default';
 import {triggerPress} from '@react-spectrum/test-utils';
+import userEvent from '@testing-library/user-event';
 
 describe('Picker', function () {
   let offsetWidth, offsetHeight;
@@ -365,7 +366,7 @@ describe('Picker', function () {
       expect(() => getByRole('listbox')).toThrow();
 
       let picker = getByRole('button');
-      act(() => triggerPress(picker));
+      act(() => userEvent.click(picker));
       act(() => jest.runAllTimers());
 
       let listbox = getByRole('listbox');
@@ -375,7 +376,7 @@ describe('Picker', function () {
       expect(picker).toHaveAttribute('aria-expanded', 'true');
       expect(picker).toHaveAttribute('aria-controls', listbox.id);
 
-      act(() => triggerPress(picker));
+      act(() => userEvent.click(picker));
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();

--- a/packages/@react-stately/overlays/src/useOverlayTriggerState.ts
+++ b/packages/@react-stately/overlays/src/useOverlayTriggerState.ts
@@ -40,7 +40,7 @@ export function useOverlayTriggerState(props: OverlayTriggerProps): OverlayTrigg
       setOpen(false);
     },
     toggle() {
-      setOpen(!isOpen);
+      setOpen(prev => !prev);
     }
   };
 }

--- a/packages/@react-types/overlays/src/index.d.ts
+++ b/packages/@react-types/overlays/src/index.d.ts
@@ -89,7 +89,8 @@ export interface PopoverProps extends StyleProps, OverlayProps {
   hideArrow?: boolean,
   isOpen?: boolean,
   onClose?: () => void,
-  shouldCloseOnBlur?: boolean
+  shouldCloseOnBlur?: boolean,
+  shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
 }
 
 export interface TrayProps extends StyleProps, OverlayProps {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/850
This moves useInteractOutside to fire on mouse down instead of on up, this means menus won't reopen after they've been closed by the blur
It also takes advantage of shouldCloseOnInteractOutside, which lets us detect if the the interaction was on the trigger, which will automatically toggle the menu when clicked. If we couldn't filter that event out, then the menu would just be closed from outside interaction and toggled open again immediately
cleans up trigger toggle state so it always uses the latest state

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
