### PR TITLE
Fix usePress user-select not removed on HTML element

### DIFF
--- a/packages/@react-aria/interactions/src/textSelection.ts
+++ b/packages/@react-aria/interactions/src/textSelection.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {runAfterTransition} from '@react-aria/utils';
+
+// Safari on iOS starts selecting text on long press. The only way to avoid this, it seems,
+// is to add user-select: none to the entire page. Adding it to the pressable element prevents
+// that element from being selected, but nearby elements may still receive selection. We add
+// user-select: none on touch start, and remove it again on touch end to prevent this.
+// This must be implemented using global state to avoid race conditions between multiple elements.
+
+// There are three possible states due to the delay before removing user-select: none after
+// pointer up. The 'default' state always transitions to the 'disabled' state, which transitions
+// to 'restoring'. The 'restoring' state can either transition back to 'disabled' or 'default'.
+type State = 'default' | 'disabled' | 'restoring';
+
+let state: State = 'default';
+let savedUserSelect = '';
+
+export function disableTextSelection() {
+  if (state === 'default') {
+    savedUserSelect = document.documentElement.style.webkitUserSelect;
+    document.documentElement.style.webkitUserSelect = 'none';
+  }
+
+  state = 'disabled';
+}
+
+export function restoreTextSelection() {
+  // If the state is already default, there's nothing to do.
+  // If it is restoring, then there's no need to queue a second restore.
+  if (state !== 'disabled') {
+    return;
+  }
+
+  state = 'restoring';
+
+  // There appears to be a delay on iOS where selection still might occur
+  // after pointer up, so wait a bit before removing user-select.
+  setTimeout(() => {
+    // Wait for any CSS transitions to complete so we don't recompute style
+    // for the whole page in the middle of the animation and cause jank.
+    runAfterTransition(() => {
+      // Avoid race conditions
+      if (state === 'restoring') {
+        if (document.documentElement.style.webkitUserSelect === 'none') {
+          document.documentElement.style.webkitUserSelect = savedUserSelect || '';
+        }
+
+        savedUserSelect = '';
+        state = 'default';
+      }
+    });
+  }, 300);
+}

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -273,6 +273,12 @@ export function usePress(props: PressHookProps): PressResult {
     // that element from being selected, but nearby elements may still receive selection. We add
     // user-select: none on touch start, and remove it again on touch end to prevent this.
     let disableTextSelection = () => {
+      // restoreTextSelection logic is always called after 300ms delay, so there is chance
+      // when multiple press events fired within 300ms, at that time this function is called
+      // and set state.userSelect to none. in order to avoid that, following guard is added
+      if (document.documentElement.style.webkitUserSelect === 'none') {
+        return;
+      }
       state.userSelect = document.documentElement.style.webkitUserSelect;
       document.documentElement.style.webkitUserSelect = 'none';
     };

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -15,7 +15,8 @@
 // NOTICE file in the root directory of this source tree.
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
-import {focusWithoutScrolling, mergeProps, runAfterTransition} from '@react-aria/utils';
+import {disableTextSelection, restoreTextSelection} from './textSelection';
+import {focusWithoutScrolling, mergeProps} from '@react-aria/utils';
 import {HTMLAttributes, RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {isVirtualClick} from './utils';
 import {PointerType, PressEvents} from '@react-types/shared';
@@ -115,11 +116,11 @@ export function usePress(props: PressHookProps): PressResult {
   let addGlobalListener = useCallback((eventTarget, type, listener, options) => {
     globalListeners.current.set(listener, {type, eventTarget, options});
     eventTarget.addEventListener(type, listener, options);
-  }, [globalListeners.current]);
+  }, []);
   let removeGlobalListener = useCallback((eventTarget, type, listener, options) => {
     eventTarget.removeEventListener(type, listener, options);
     globalListeners.current.delete(listener);
-  }, [globalListeners.current]);
+  }, []);
 
   let pressProps = useMemo(() => {
     let state = ref.current;
@@ -266,37 +267,6 @@ export function usePress(props: PressHookProps): PressResult {
           state.target.click();
         }
       }
-    };
-
-    // Safari on iOS starts selecting text on long press. The only way to avoid this, it seems,
-    // is to add user-select: none to the entire page. Adding it to the pressable element prevents
-    // that element from being selected, but nearby elements may still receive selection. We add
-    // user-select: none on touch start, and remove it again on touch end to prevent this.
-    let disableTextSelection = () => {
-      // restoreTextSelection logic is always called after 300ms delay, so there is chance
-      // when multiple press events fired within 300ms, at that time this function is called
-      // and set state.userSelect to none. in order to avoid that, following guard is added
-      if (document.documentElement.style.webkitUserSelect === 'none') {
-        return;
-      }
-      state.userSelect = document.documentElement.style.webkitUserSelect;
-      document.documentElement.style.webkitUserSelect = 'none';
-    };
-
-    let restoreTextSelection = () => {
-      // There appears to be a delay on iOS where selection still might occur
-      // after pointer up, so wait a bit before removing user-select.
-      setTimeout(() => {
-        // Wait for any CSS transitions to complete so we don't recompute style
-        // for the whole page in the middle of the animation and cause jank.
-        runAfterTransition(() => {
-          // Avoid race conditions
-          if (!state.isPressed && document.documentElement.style.webkitUserSelect === 'none') {
-            document.documentElement.style.webkitUserSelect = state.userSelect || '';
-            state.userSelect = null;
-          }
-        });
-      }, 300);
     };
 
     if (typeof PointerEvent !== 'undefined') {
@@ -570,7 +540,7 @@ export function usePress(props: PressHookProps): PressResult {
     }
 
     return pressProps;
-  }, [onPress, onPressStart, onPressEnd, onPressChange, onPressUp, isDisabled]);
+  }, [isDisabled, onPressStart, onPressChange, onPressEnd, onPress, onPressUp, addGlobalListener, preventFocusOnPress, removeGlobalListener]);
 
   // eslint-disable-next-line arrow-body-style
   useEffect(() => {
@@ -579,7 +549,7 @@ export function usePress(props: PressHookProps): PressResult {
         removeGlobalListener(value.eventTarget, value.type, key, value.options);
       });
     };
-  }, [globalListeners.current]);
+  }, [removeGlobalListener]);
 
   return {
     isPressed: isPressedProp || isPressed,

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -32,6 +32,20 @@ function pointerEvent(type, opts) {
 }
 
 describe('usePress', function () {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+    window.requestAnimationFrame.mockRestore();
+  });
+
+  afterEach(() => {
+    jest.runAllTimers();
+  });
+
   // TODO: JSDOM doesn't yet support pointer events. Once they do, convert these tests.
   // https://github.com/jsdom/jsdom/issues/2527
   describe('pointer events', function () {
@@ -1657,15 +1671,10 @@ describe('usePress', function () {
     let mockUserSelect = 'contain';
     let oldUserSelect = document.documentElement.style.webkitUserSelect;
 
-    beforeAll(() => {
-      jest.useFakeTimers();
-      jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
-    });
     afterAll(() => {
-      jest.useRealTimers();
-      window.requestAnimationFrame.mockRestore();
       handler.mockClear();
     });
+
     beforeEach(() => {
       document.documentElement.style.webkitUserSelect = mockUserSelect;
     });
@@ -1673,35 +1682,29 @@ describe('usePress', function () {
       document.documentElement.style.webkitUserSelect = oldUserSelect;
     });
 
-    it('should add user-select:none to html element when press start', function () {
-      let {getByText, baseElement} = render(
+    it('should add user-select: none to html element when press start', function () {
+      let {getByText} = render(
         <Example
           onPressStart={handler}
           onPressEnd={handler}
           onPressChange={handler}
           onPress={handler}
-          onPressUp={handler} />,
-        {
-          baseElement: document.documentElement
-        }
+          onPressUp={handler} />
       );
 
       let el = getByText('test');
       fireEvent.touchStart(el, {targetTouches: [{identifier: 1}]});
-      expect(baseElement.style.webkitUserSelect).toBe('none');
+      expect(document.documentElement.style.webkitUserSelect).toBe('none');
     });
 
-    it('should remove user-select:none to html element when press end', function () {
-      let {getByText, baseElement} = render(
+    it('should remove user-select: none to html element when press end', function () {
+      let {getByText} = render(
         <Example
           onPressStart={handler}
           onPressEnd={handler}
           onPressChange={handler}
           onPress={handler}
-          onPressUp={handler} />,
-        {
-          baseElement: document.documentElement
-        }
+          onPressUp={handler} />
       );
 
       let el = getByText('test');
@@ -1710,7 +1713,7 @@ describe('usePress', function () {
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1}]});
 
       jest.advanceTimersByTime(300);
-      expect(baseElement.style.webkitUserSelect).toBe(mockUserSelect);
+      expect(document.documentElement.style.webkitUserSelect).toBe(mockUserSelect);
 
       // Checkbox doesn't remove `user-select: none;` style from HTML Element issue
       // see https://github.com/adobe/react-spectrum/issues/862
@@ -1722,7 +1725,43 @@ describe('usePress', function () {
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 100, clientY: 100}]});
       jest.advanceTimersByTime(300);
 
-      expect(baseElement.style.webkitUserSelect).toBe(mockUserSelect);
+      expect(document.documentElement.style.webkitUserSelect).toBe(mockUserSelect);
+    });
+
+    it('should not remove user-select: none when pressing two different elements quickly', function () {
+      let {getAllByText} = render(
+        <>
+          <Example
+            onPressStart={handler}
+            onPressEnd={handler}
+            onPressChange={handler}
+            onPress={handler}
+            onPressUp={handler} />
+          <Example
+            onPressStart={handler}
+            onPressEnd={handler}
+            onPressChange={handler}
+            onPress={handler}
+            onPressUp={handler} />
+        </>
+      );
+
+      let els = getAllByText('test');
+
+      fireEvent.touchStart(els[0], {targetTouches: [{identifier: 1}]});
+      fireEvent.touchEnd(els[0], {changedTouches: [{identifier: 1}]});
+
+      expect(document.documentElement.style.webkitUserSelect).toBe('none');
+
+      fireEvent.touchStart(els[1], {targetTouches: [{identifier: 1}]});
+
+      jest.advanceTimersByTime(300);
+      expect(document.documentElement.style.webkitUserSelect).toBe('none');
+
+      fireEvent.touchEnd(els[1], {changedTouches: [{identifier: 1}]});
+
+      jest.advanceTimersByTime(300);
+      expect(document.documentElement.style.webkitUserSelect).toBe(mockUserSelect);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/862

Fix the user-select not removed on HTML element issue, add tests for it.


## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

quickly and repeatedly toggling a checkbox and then move the cursor away from the checkbox component and let go, `user-select:none` on html element is always removed. can check this on document site, I've tested it.

`yarn test usePress`

## 🧢 Your Project:

<!--- Company/project for pull request -->
