### PR TITLE
Add inputElementType in TextArea

### DIFF
--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -12,6 +12,7 @@
 
 import {AriaTextFieldProps} from '@react-types/textfield';
 import {ChangeEvent, InputHTMLAttributes, LabelHTMLAttributes, RefObject} from 'react';
+import {ElementType} from 'react';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {useFocusable} from '@react-aria/focus';
 import {useLabel} from '@react-aria/label';
@@ -23,13 +24,23 @@ interface TextFieldAria {
   labelProps: LabelHTMLAttributes<HTMLLabelElement>
 }
 
+interface AriaTextFieldOptions extends AriaTextFieldProps {
+  /**
+   * The HTML element used to render the input, e.g. 'input', or 'textarea'.
+   * It determines whether certain HTML attributes will be included in `inputProps`.
+   * For example, [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-type).
+   * @default 'input'
+   */
+  inputElementType?: ElementType
+}
+
 /**
  * Provides the behavior and accessibility implementation for a text field.
  * @param props - Props for the text field.
  * @param ref - Ref to the HTML input element.
  */
 export function useTextField(
-  props: AriaTextFieldProps,
+  props: AriaTextFieldOptions,
   ref: RefObject<HTMLInputElement>
 ): TextFieldAria {
   let {

--- a/packages/@react-spectrum/textfield/src/TextArea.tsx
+++ b/packages/@react-spectrum/textfield/src/TextArea.tsx
@@ -51,7 +51,8 @@ function TextArea(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
 
   let {labelProps, inputProps} = useTextField({
     ...props,
-    onChange: chain(onChange, setInputValue)
+    onChange: chain(onChange, setInputValue),
+    inputElementType: 'textarea'
   }, inputRef);
 
   return (

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -73,7 +73,11 @@ describe('Shared TextField behavior', () => {
     expect(input.value).toBe('');
     act(() => {userEvent.type(input, inputText);});
     expect(input.value).toBe(inputText);
-    expect(input).toHaveAttribute('type', expectedType);
+    if (Name === 'v3 TextArea') {
+      expect(input).not.toHaveAttribute('type');
+    } else {
+      expect(input).toHaveAttribute('type', expectedType);
+    }
     expect(input.tagName).toBe(expectedTagName);
   });
 

--- a/packages/@react-types/textfield/src/index.d.ts
+++ b/packages/@react-types/textfield/src/index.d.ts
@@ -25,7 +25,7 @@ import {
   Validation,
   ValueBase
 } from '@react-types/shared';
-import {ElementType, ReactElement} from 'react';
+import {ReactElement} from 'react';
 
 export interface TextFieldProps extends InputBase, Validation, FocusableProps, TextInputBase, ValueBase<string>, LabelableProps {}
 
@@ -40,15 +40,7 @@ export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, F
   'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both',
   /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
 
-  'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog',
-
-  /**
-   * The HTML element used to render the input, e.g. 'input', or 'textarea'.
-   * It determines whether certain HTML attributes will be included in `inputProps`.
-   * For example, [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-type).
-   * @default 'input'
-   */
-  inputElementType?: ElementType
+  'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog'
 }
 
 export interface SpectrumTextFieldProps extends AriaTextFieldProps, SpectrumLabelableProps, StyleProps {


### PR DESCRIPTION
Adds the `inputElementType` option added to `useTextArea` in #831 to the spectrum TextArea component. Also moved the option to be specific to aria and not exposed as a prop to Spectrum, where you can't actually change the element type we render.