### PR TITLE
Fix more toggle button states

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -556,9 +556,15 @@ governing permissions and limitations under the License.
       border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-key-focus);
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus);
 
+      &:hover {
+        /* change 1px of focus ring blue to match the rest of the hover state */
+        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-emphasized-border-color-selected-hover);
+      }
+
       &.is-active {
         /* change 1px of focus ring blue to match the rest of the active state */
         box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-emphasized-border-color-selected-down);
+        border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-down);
       }
 
       .spectrum-Icon {
@@ -635,16 +641,16 @@ governing permissions and limitations under the License.
     border-color: var(--spectrum-actionbutton-quiet-border-color-selected);
     color: var(--spectrum-actionbutton-quiet-text-color-selected);
 
-    &:focus-ring {
-      background-color: var(--spectrum-actionbutton-quiet-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-quiet-border-color-selected-key-focus);
-      color: var(--spectrum-actionbutton-quiet-text-color-selected-key-focus);
-    }
-
     &:hover {
       background-color: var(--spectrum-actionbutton-quiet-background-color-selected-hover);
       border-color: var(--spectrum-actionbutton-quiet-border-color-selected-hover);
       color: var(--spectrum-actionbutton-quiet-text-color-selected-hover);
+    }
+
+    &:focus-ring {
+      background-color: var(--spectrum-actionbutton-quiet-background-color-selected-key-focus);
+      border-color: var(--spectrum-actionbutton-quiet-border-color-selected-key-focus);
+      color: var(--spectrum-actionbutton-quiet-text-color-selected-key-focus);
     }
 
     &.is-active {

--- a/packages/@react-spectrum/button/chromatic/ToggleButton.chromatic.tsx
+++ b/packages/@react-spectrum/button/chromatic/ToggleButton.chromatic.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {classNames} from '@react-spectrum/utils';
+import {Grid, repeat} from '@adobe/react-spectrum';
+import {mergeProps} from '@react-aria/utils';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
+import {ToggleButton} from '../';
+
+let states = [
+  {isQuiet: true},
+  {isEmphasized: true},
+  {isSelected: true},
+  {isDisabled: true},
+  {UNSAFE_className: classNames(styles, 'is-active')},
+  {UNSAFE_className: classNames(styles, 'is-hovered')},
+  {UNSAFE_className: classNames(styles, 'focus-ring')}
+];
+
+// Generate a powerset of the options
+let combinations: any[] = [{}];
+for (let i = 0; i < states.length; i++) {
+  let len = combinations.length;
+  for (let j = 0; j < len; j++) {
+    let merged = mergeProps(combinations[j], states[i]);
+
+    // Ignore disabled combined with interactive states.
+    if (merged.isDisabled && merged.UNSAFE_className) {
+      continue;
+    }
+
+    combinations.push(merged);
+  }
+}
+
+storiesOf('Button/ToggleButton', module)
+  .addParameters({providerSwitcher: {status: 'positive'}})
+  .add('all possible states', () => (
+    <Grid columns={repeat(states.length, '1fr')} autoFlow="row" gap="size-300">
+      {combinations.map(c => <ToggleButton {...c}>Button</ToggleButton>)}
+    </Grid>
+  ));


### PR DESCRIPTION
The following states were broken:

* emphasized + selected + focus-ring + active
* emphasized + selected + focus-ring + hovered
* quiet + selected + focus-ring + hovered

Also added a story to chromatic that creates a powerset of all possible states so we can easily catch regressions.