### PR TITLE
Expose offset and crossOffset in TooltipTrigger

### DIFF
--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -19,10 +19,15 @@ import {useOverlayPosition} from '@react-aria/overlays';
 import {useTooltipTrigger} from '@react-aria/tooltip';
 import {useTooltipTriggerState} from '@react-stately/tooltip';
 
+const DEFAULT_OFFSET = 7;
+const DEFAULT_CROSS_OFFSET = 0;
+
 function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
   let {
     children,
-    isDisabled
+    crossOffset = DEFAULT_CROSS_OFFSET,
+    isDisabled,
+    offset = DEFAULT_OFFSET
   } = props;
 
   let [trigger, tooltip] = React.Children.toArray(children);
@@ -40,6 +45,8 @@ function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
     placement: props.placement || 'top',
     targetRef: tooltipTriggerRef,
     overlayRef,
+    offset,
+    crossOffset,
     isOpen: state.isOpen
   });
 

--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -19,7 +19,7 @@ import {useOverlayPosition} from '@react-aria/overlays';
 import {useTooltipTrigger} from '@react-aria/tooltip';
 import {useTooltipTriggerState} from '@react-stately/tooltip';
 
-const DEFAULT_OFFSET = 7;
+const DEFAULT_OFFSET = 7; // Closest visual match to Spectrum's mocks
 const DEFAULT_CROSS_OFFSET = 0;
 
 function TooltipTrigger(props: SpectrumTooltipTriggerProps) {

--- a/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
+++ b/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
@@ -43,6 +43,14 @@ storiesOf('TooltipTrigger', module)
     () => render({placement: 'bottom'})
   )
   .add(
+    'placement: top with offset',
+    () => render({placement: 'top', offset: 50})
+  )
+  .add(
+    'placement: bottom with crossOffset',
+    () => render({placement: 'bottom', crossOffset: 50})
+  )
+  .add(
     'isDisabled',
     () => render({placement: 'start', isDisabled: true})
   )

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -16,7 +16,9 @@ import {ReactElement, ReactNode} from 'react';
 
 export interface TooltipTriggerProps extends OverlayTriggerProps {
   isDisabled?: boolean,
-  delay?: number
+  delay?: number,
+  offset?: number,
+  crossOffset?: number
 }
 
 export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, PositionProps {

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -17,7 +17,17 @@ import {ReactElement, ReactNode} from 'react';
 export interface TooltipTriggerProps extends OverlayTriggerProps {
   isDisabled?: boolean,
   delay?: number,
+  /**
+   * The additional offset applied along the main axis between the element and its
+   * anchor element.
+   * @default 7
+   */
   offset?: number,
+  /**
+   * The additional offset applied along the cross axis between the element and its
+   * anchor element.
+   * @default 0
+   */
   crossOffset?: number
 }
 


### PR DESCRIPTION
Closes #941

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
1. Go to the storybook
2. Select **TooltipTrigger** > _placement: top_
3. Inspect gap between tooltip and button. If the gap is wide enough, the test passes.
4. Select _placement: top with offset_
5. Inspect gap between tooltip and button. If the gap is large (about 50px), the test passes.
6. Select _placement: bottom with crossOffset_
7. Verify that the tooltip is anchored at the bottom right corner of the button.

## 🧢 Your Project:
RSP
