### PR TITLE
Fix Textarea height on Firefox on windows

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -41,6 +41,7 @@ governing permissions and limitations under the License.
   &.spectrum-Textfield--quiet.spectrum-Textfield--multiline .spectrum-Textfield-input {
     height: var(--spectrum-textfield-height);
     min-height: var(--spectrum-textfield-height);
+    overflow-x: hidden;
   }
 }
 


### PR DESCRIPTION
Height is 52 on Firefox windows but 39 on Firefox OSX. Difference seems to be scrollbars (even if not visible)