### PR TITLE
A few tweaks and fixes to slider:

### DIFF
--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {computeOffsetToValue, sliderIds} from './utils';
 import {HTMLAttributes, useRef} from 'react';
 import {mergeProps, useDrag1D} from '@react-aria/utils';
+import {sliderIds} from './utils';
 import {SliderProps} from '@react-types/slider';
 import {SliderState} from '@react-stately/slider';
 import {useLabel} from '@react-aria/label';
@@ -53,7 +53,7 @@ export function useSlider(
   // Here, we keep track of which index is the "closest" to the drag start point.
   // It is set onMouseDown; see trackProps below.
   const realTimeTrackDraggingIndex = useRef<number | undefined>(undefined);
-  const draggableProps = useDrag1D({
+  const {onMouseDown, onMouseEnter, onMouseOut} = useDrag1D({
     containerRef: trackRef as any,
     reverse: false,
     orientation: 'horizontal',
@@ -61,10 +61,21 @@ export function useSlider(
       if (realTimeTrackDraggingIndex.current !== undefined) {
         state.setThumbDragging(realTimeTrackDraggingIndex.current, dragging);
       }
+      if (!dragging) {
+        state.setTrackDragging(false);
+      }
     },
     onPositionChange: (position) => {
-      if (realTimeTrackDraggingIndex.current !== undefined) {
-        state.setThumbValue(realTimeTrackDraggingIndex.current, computeOffsetToValue(position, props, trackRef));
+      if (realTimeTrackDraggingIndex.current !== undefined && trackRef.current) {
+        const percent = position / trackRef.current.offsetWidth;
+        state.setThumbPercent(realTimeTrackDraggingIndex.current, percent);
+
+        // When track-dragging ends, onDrag is called before a final onPositionChange is
+        // called, so we can't reset realTimeTrackDraggingIndex until onPositionChange,
+        // as we still needed to update the thumb position one last time.
+        if (!state.isTrackDragging()) {
+          realTimeTrackDraggingIndex.current = undefined;
+        }
       }
     }
   });
@@ -82,16 +93,18 @@ export function useSlider(
     trackProps: mergeProps({
       onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
         // We only trigger track-dragging if the user clicks on the track itself.
-        if (trackRef.current && trackRef.current === e.target) {
+        if (trackRef.current) {
           // Find the closest thumb
           const trackPosition = trackRef.current.getBoundingClientRect().left;
           const clickPosition = e.clientX;
           const offset = clickPosition - trackPosition;
           const percent = offset / trackRef.current.offsetWidth;
           const value = state.getPercentValue(percent);
-          const minDiff = Math.min(...state.values.map(v => Math.abs(v - value)));
+
+          // Only compute the diff for thumbs that are editable, as only they can be dragged
+          const minDiff = Math.min(...state.values.map((v, index) => state.isThumbEditable(index) ? Math.abs(v - value) : Number.POSITIVE_INFINITY));
           const index = state.values.findIndex(v => Math.abs(v - value) === minDiff);
-          if (index >= 0) {
+          if (minDiff !== Number.POSITIVE_INFINITY && index >= 0) {
             // Don't unfocus anything
             e.preventDefault();
 
@@ -105,10 +118,15 @@ export function useSlider(
             // the value.  Dragging state will be reset to false in onDrag above, even
             // if no dragging actually occurs.
             state.setThumbDragging(realTimeTrackDraggingIndex.current, true);
+            state.setTrackDragging(true);
             state.setThumbValue(index, value);
+          } else {
+            realTimeTrackDraggingIndex.current = undefined;
           }
         }
       }
-    }, draggableProps)
+    }, {
+      onMouseDown, onMouseEnter, onMouseOut
+    })
   };
 }

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -55,6 +55,7 @@ export function useSlider(
   // Here, we keep track of which index is the "closest" to the drag start point.
   // It is set onMouseDown; see trackProps below.
   const realTimeTrackDraggingIndex = useRef<number | undefined>(undefined);
+  const isTrackDragging = useRef(false);
   const {onMouseDown, onMouseEnter, onMouseOut} = useDrag1D({
     containerRef: trackRef as any,
     reverse: false,
@@ -63,9 +64,7 @@ export function useSlider(
       if (realTimeTrackDraggingIndex.current !== undefined) {
         state.setThumbDragging(realTimeTrackDraggingIndex.current, dragging);
       }
-      if (!dragging) {
-        state.setTrackDragging(false);
-      }
+      isTrackDragging.current = dragging;
     },
     onPositionChange: (position) => {
       if (realTimeTrackDraggingIndex.current !== undefined && trackRef.current) {
@@ -74,8 +73,9 @@ export function useSlider(
 
         // When track-dragging ends, onDrag is called before a final onPositionChange is
         // called, so we can't reset realTimeTrackDraggingIndex until onPositionChange,
-        // as we still needed to update the thumb position one last time.
-        if (!state.isTrackDragging()) {
+        // as we still needed to update the thumb position one last time.  Hence we
+        // track whether we're dragging, and the actual dragged index, separately.
+        if (!isTrackDragging.current) {
           realTimeTrackDraggingIndex.current = undefined;
         }
       }
@@ -120,7 +120,6 @@ export function useSlider(
             // the value.  Dragging state will be reset to false in onDrag above, even
             // if no dragging actually occurs.
             state.setThumbDragging(realTimeTrackDraggingIndex.current, true);
-            state.setTrackDragging(true);
             state.setThumbValue(index, value);
           } else {
             realTimeTrackDraggingIndex.current = undefined;

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -45,6 +45,8 @@ export function useSlider(
 ): SliderAria {
   const {labelProps, fieldProps} = useLabel(props);
 
+  const isSliderEditable = !(props.isDisabled || props.isReadOnly);
+
   // Attach id of the label to the state so it can be accessed by useSliderThumb.
   sliderIds.set(state, labelProps.id ?? fieldProps.id);
 
@@ -93,7 +95,7 @@ export function useSlider(
     trackProps: mergeProps({
       onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
         // We only trigger track-dragging if the user clicks on the track itself.
-        if (trackRef.current) {
+        if (trackRef.current && isSliderEditable) {
           // Find the closest thumb
           const trackPosition = trackRef.current.getBoundingClientRect().left;
           const clickPosition = e.clientX;

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -70,19 +70,10 @@ export function useSliderThumb(
     reverse: false,
     orientation: 'horizontal',
     onDrag: (dragging) => {
-      if (state.isTrackDragging()) {
-        // If the track's drag handlers are already handling the drag event,
-        // that means this thumb must be a child of the track.  Just let the
-        // track's drag handlers handle it.
-        return;
-      }
       state.setThumbDragging(index, dragging);
       focusInput();
     },
     onPositionChange: (position) => {
-      if (state.isTrackDragging()) {
-        return;
-      }
       const percent = position / trackRef.current.offsetWidth;
       state.setThumbPercent(index, percent);
     }

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -1,4 +1,4 @@
-import {ChangeEvent, HTMLAttributes, useCallback, useEffect, useLayoutEffect} from 'react';
+import {ChangeEvent, HTMLAttributes, useCallback, useEffect} from 'react';
 import {focusWithoutScrolling, mergeProps, useDrag1D} from '@react-aria/utils';
 import {sliderIds} from './utils';
 import {SliderState} from '@react-stately/slider';
@@ -88,10 +88,8 @@ export function useSliderThumb(
     }
   });
 
-  // Use useLayoutEffect to immediately register editability with the state
-  useLayoutEffect(() => {
-    state.setThumbEditable(index, isEditable);
-  }, [index, isEditable, state]);
+  // Immediately register editability with the state
+  state.setThumbEditable(index, isEditable);
 
   const {focusableProps} = useFocusable(
     mergeProps(opts, {

--- a/packages/@react-aria/slider/src/utils.ts
+++ b/packages/@react-aria/slider/src/utils.ts
@@ -1,15 +1,3 @@
-import {BaseSliderProps} from '@react-types/slider';
 import {SliderState} from '@react-stately/slider';
 
 export const sliderIds = new WeakMap<SliderState, string>();
-
-export function computeOffsetToValue(offset: number, props: BaseSliderProps, trackRef: React.RefObject<HTMLElement>) {
-  const {minValue = 0, maxValue = 100, step = 1} = props;
-  if (!trackRef.current) {
-    return minValue;
-  }
-
-  const containerSize = trackRef.current.offsetWidth;
-  const val = offset / containerSize * (maxValue - minValue) + minValue;
-  return Math.round((val - minValue) / step) * step + minValue;
-}

--- a/packages/@react-aria/slider/stories/Slider.stories.tsx
+++ b/packages/@react-aria/slider/stories/Slider.stories.tsx
@@ -9,19 +9,19 @@ import {StorySlider} from './StorySlider';
 storiesOf('Slider', module)
   .add(
     'single',
-    () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
+    () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} showTip />
   )
   .add(
     'single with big steps',
-    () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} step={10} />
+    () => <StorySlider label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} step={10} showTip />
   )
   .add(
     'single with origin',
-    () => <StorySlider label="Exposure" origin={0} minValue={-5} maxValue={5} step={0.1} onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
+    () => <StorySlider label="Exposure" origin={0} minValue={-5} maxValue={5} step={0.1} onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} showTip />
   )
   .add(
     'single with aria label',
-    () => <StorySlider aria-label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} />
+    () => <StorySlider aria-label="Size" onChange={action('onChange')} onChangeEnd={action('onChangeEnd')} showTip />
   )
   .add(
     'range',
@@ -30,6 +30,7 @@ storiesOf('Slider', module)
       defaultValue={[25, 75]} 
       onChange={action('onChange')} 
       onChangeEnd={action('onChangeEnd')} 
+      showTip
       formatOptions={{
         style: 'unit',
         unit: 'celsius',
@@ -43,6 +44,7 @@ storiesOf('Slider', module)
       defaultValue={[25, 75]} 
       onChange={action('onChange')} 
       onChangeEnd={action('onChangeEnd')} 
+      showTip
       formatOptions={{
         style: 'unit',
         unit: 'celsius',

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -31,9 +31,13 @@ export function StoryMultiSlider(props: StoryMultiSliderProps) {
         {props.label && <label {...labelProps} className={styles.label}>{props.label}</label>}
         <div className={styles.value}>{JSON.stringify(state.values)}</div>
       </div>
-      <div className={styles.trackContainer}>
+      {
+        // We make rail and all thumbs children of the trackRef.  That means dragging on the thumb
+        // will also trigger the dragging handlers on the track, so we need to make sure we don't
+        // double-handle these events.
+      }
+      <div ref={trackRef} className={styles.track} {...trackProps}>
         <div className={styles.rail} />
-        <div {...trackProps} ref={trackRef} className={styles.track} />
         {React.Children.map(children, ((child, index) =>
           React.cloneElement(child as React.ReactElement, {
             __context: {
@@ -81,7 +85,7 @@ export function StoryThumb(props: StoryThumbProps) {
     <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
       <div
         {...thumbProps}
-        className={classNames(styles, 'thumb', {thumbDisabled: isDisabled})}
+        className={classNames(styles, 'thumb', 'thumbHandle', {thumbDisabled: isDisabled})}
         style={{
           'left': `${state.getThumbPercent(index) * 100}%`
         }}>

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -9,7 +9,8 @@ import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 interface StoryRangeSliderProps extends SliderProps {
   minLabel?: string,
-  maxLabel?: string
+  maxLabel?: string,
+  showTip?: boolean
 }
 
 export function StoryRangeSlider(props: StoryRangeSliderProps) {
@@ -56,31 +57,46 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
         </div>
       </div>
       <div className={styles.trackContainer}>
-        <div className={styles.rail} />
-        <div
-          className={styles.filledRail}
-          style={{
-            left: `${state.getThumbPercent(0) * 100}%`,
-            width: `${(state.getThumbPercent(1) - state.getThumbPercent(0)) * 100}%`
-          }} />
-        <div {...trackProps} ref={trackRef} className={styles.track} />
+        {
+          // We make rail and filledRail children of track. User can click on the track, the 
+          // rail, or the filledRail to drag by track
+        }
+        <div ref={trackRef} className={styles.track} {...trackProps}>
+          <div className={styles.rail} />
+          <div
+            className={styles.filledRail}
+            style={{
+              left: `${state.getThumbPercent(0) * 100}%`,
+              width: `${(state.getThumbPercent(1) - state.getThumbPercent(0)) * 100}%`
+            }} />
+        </div>
         <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
           <div
-            {...minThumbProps}
             className={styles.thumb}
             style={{
               'left': `${state.getThumbPercent(0) * 100}%`
             }}>
+            {
+              // We put thumbProps on thumbHandle, so that you cannot drag by the tip 
+            }
+            <div {...minThumbProps} className={styles.thumbHandle} />
+            {props.showTip && <div className={styles.tip}>{state.getThumbValueLabel(0)}</div>}
             <VisuallyHidden isFocusable><input className={styles.input} ref={minInputRef} {...minInputProps} /></VisuallyHidden>
           </div>
         </FocusRing>
         <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
           <div
-            {...maxThumbProps}
             className={styles.thumb}
+            {...maxThumbProps}
             style={{
               'left': `${state.getThumbPercent(1) * 100}%`
             }}>
+            {
+              // For fun, we put the thumbProps on the thumb container instead of just the handle.  
+              // This means you can drag the max thumb by the tip.
+            }
+            <div className={styles.thumbHandle} />
+            {props.showTip && <div className={styles.tip}>{state.getThumbValueLabel(1)} (can drag by tip)</div>}
             <VisuallyHidden isFocusable><input className={styles.input} ref={maxInputRef} {...maxInputProps} /></VisuallyHidden>
           </div>
         </FocusRing>

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -9,7 +9,8 @@ import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 interface StorySliderProps extends BaseSliderProps, ValueBase<number> {
   origin?: number,
-  onChangeEnd?: (value: number) => void
+  onChangeEnd?: (value: number) => void,
+  showTip?: boolean
 }
 
 export function StorySlider(props: StorySliderProps) {
@@ -49,6 +50,10 @@ export function StorySlider(props: StorySliderProps) {
         <div className={styles.value}>{state.getThumbValueLabel(0)}</div>
       </div>
       <div className={styles.trackContainer}>
+        {
+          // We make rail, filledRail, and track siblings in the DOM, so that trackRef has no children.
+          // User must click on the trackRef to drag by track, and so it comes last in the DOM.
+        }
         <div className={styles.rail} />
         <div
           className={styles.filledRail}
@@ -56,14 +61,16 @@ export function StorySlider(props: StorySliderProps) {
             left: `${state.getValuePercent(Math.min(value, origin)) * 100}%`,
             width: `${(state.getValuePercent(Math.max(value, origin)) - state.getValuePercent(Math.min(value, origin))) * 100}%`
           }} />
-        <div {...trackProps} ref={trackRef} className={styles.track} />
+        <div ref={trackRef} className={styles.track} {...trackProps} />
         <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
           <div
-            {...thumbProps}
             className={styles.thumb}
             style={{
               'left': `${state.getThumbPercent(0) * 100}%`
             }}>
+            {/* We put thumbProps on thumbHandle, so that you cannot drag by the tip */}
+            <div {...thumbProps} className={styles.thumbHandle} />
+            {props.showTip && <div className={styles.tip}>{state.getThumbValueLabel(0)}</div>}
             <VisuallyHidden isFocusable><input className={styles.input} ref={inputRef} {...inputProps} /></VisuallyHidden>
           </div>
         </FocusRing>

--- a/packages/@react-aria/slider/stories/story-slider.css
+++ b/packages/@react-aria/slider/stories/story-slider.css
@@ -22,6 +22,14 @@
 
 .thumb {
   position: absolute;
+  top: 4px;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.thumbHandle {
   width: 20px;
   height: 20px;
   border-radius: 50%;
@@ -29,14 +37,12 @@
   box-sizing: border-box;
   background-color: #f5f5f5;
   box-shadow: 0 0 0 4px #f5f5f5;
-  top: 4px;
-  transform: translateX(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.thumbFocusVisible {
+.thumbFocusVisible .thumbHandle {
   box-shadow: 0 0 0 2px #f5f5f5, 0 0 0 4px #2c83eb;
 }
 
@@ -80,4 +86,8 @@
 .trackContainer {
   position: relative;
   width: 100%;
+}
+
+.tip {
+  margin-top: 8px;
 }

--- a/packages/@react-aria/slider/test/useSlider.test.js
+++ b/packages/@react-aria/slider/test/useSlider.test.js
@@ -108,5 +108,27 @@ describe('useSlider', () => {
       expect(onChangeEndSpy).toHaveBeenLastCalledWith([40, 80]);
       expect(stateRef.current.values).toEqual([40, 80]);
     });
+
+    it('should not allow you to set value if disabled', () => {
+      let onChangeSpy = jest.fn();
+      let onChangeEndSpy = jest.fn();
+      render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10, 80]} isDisabled />);
+
+      let track = screen.getByTestId('track');
+      fireEvent.mouseDown(track, {clientX: 20});
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([10, 80]);
+
+      fireEvent.mouseMove(track, {clientX: 30});
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([10, 80]);
+      
+      fireEvent.mouseUp(track, {clientX: 40});
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onChangeEndSpy).not.toHaveBeenCalled();
+      expect(stateRef.current.values).toEqual([10, 80]);
+    });
   });
 });

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -74,7 +74,7 @@ export function useSliderState(props: SliderProps): SliderState {
     props.onChange as any
   );
   const [isDraggings, setDraggings] = useState<boolean[]>(new Array(values.length).fill(false));
-  const [isEditables, setEditables] = useState<boolean[]>(new Array(values.length).fill(true));
+  const isEditablesRef = useRef<boolean[]>(new Array(values.length).fill(true));
   const [focusedIndex, setFocusedIndex] = useState<number|undefined>(undefined);
   const [isTrackDragging, setTrackDragging] = useState(false);
 
@@ -97,13 +97,11 @@ export function useSliderState(props: SliderProps): SliderState {
   }
 
   function isThumbEditable(index: number) {
-    return isEditables[index];
+    return isEditablesRef.current[index];
   }
 
   function setThumbEditable(index: number, editable: boolean) {
-    if (isEditables[index] !== editable) {
-      setEditables(replaceIndex(isEditables, index, editable));
-    }
+    isEditablesRef.current[index] = editable;
   }
 
   function updateValue(index: number, value: number) {

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -31,8 +31,6 @@ export interface SliderState {
   // Whether a specific index is being dragged
   isThumbDragging: (index: number) => boolean,
   setThumbDragging: (index: number, dragging: boolean) => void,
-  isTrackDragging: () => boolean,
-  setTrackDragging: (dragging: boolean) => void,
 
   // Currently-focused index
   readonly focusedThumb: number | undefined,
@@ -76,13 +74,11 @@ export function useSliderState(props: SliderProps): SliderState {
   const [isDraggings, setDraggings] = useState<boolean[]>(new Array(values.length).fill(false));
   const isEditablesRef = useRef<boolean[]>(new Array(values.length).fill(true));
   const [focusedIndex, setFocusedIndex] = useState<number|undefined>(undefined);
-  const [isTrackDragging, setTrackDragging] = useState(false);
 
   // We keep some of the dragging state on refs as well, because they are read by event
   // handlers.  In useDrag1D, the same drag event handler is used for the entire drag motion,
   // so the state object within their closure is already stale.
   const realTimeDragging = useRef(false);
-  const realTimeTrackDragging = useRef(false);
   const formatter = useNumberFormatter(formatOptions);
 
   function getValuePercent(value: number) {
@@ -156,11 +152,6 @@ export function useSliderState(props: SliderProps): SliderState {
     setThumbPercent,
     isThumbDragging: (index: number) => isDraggings[index],
     setThumbDragging: updateDragging,
-    isTrackDragging: () => isTrackDragging || realTimeTrackDragging.current,
-    setTrackDragging: (dragging: boolean) => {
-      realTimeTrackDragging.current = dragging;
-      setTrackDragging(dragging);
-    },
     focusedThumb: focusedIndex,
     setFocusedThumb: setFocusedIndex,
     getThumbPercent: (index: number) => getValuePercent(values[index]),

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -31,6 +31,8 @@ export interface SliderState {
   // Whether a specific index is being dragged
   isThumbDragging: (index: number) => boolean,
   setThumbDragging: (index: number, dragging: boolean) => void,
+  isTrackDragging: () => boolean,
+  setTrackDragging: (dragging: boolean) => void,
 
   // Currently-focused index
   readonly focusedThumb: number | undefined,
@@ -51,6 +53,10 @@ export interface SliderState {
   // Converts a percent along track (between 0 and 1) to the corresponding value
   getPercentValue: (percent: number) => number,
 
+  // editable
+  isThumbEditable: (index: number) => boolean,
+  setThumbEditable: (index: number, editable: boolean) => void,
+
   // The step amount for the slider
   readonly step: number
 }
@@ -68,8 +74,15 @@ export function useSliderState(props: SliderProps): SliderState {
     props.onChange as any
   );
   const [isDraggings, setDraggings] = useState<boolean[]>(new Array(values.length).fill(false));
+  const [isEditables, setEditables] = useState<boolean[]>(new Array(values.length).fill(true));
   const [focusedIndex, setFocusedIndex] = useState<number|undefined>(undefined);
+  const [isTrackDragging, setTrackDragging] = useState(false);
+
+  // We keep some of the dragging state on refs as well, because they are read by event
+  // handlers.  In useDrag1D, the same drag event handler is used for the entire drag motion,
+  // so the state object within their closure is already stale.
   const realTimeDragging = useRef(false);
+  const realTimeTrackDragging = useRef(false);
   const formatter = useNumberFormatter(formatOptions);
 
   function getValuePercent(value: number) {
@@ -83,8 +96,18 @@ export function useSliderState(props: SliderProps): SliderState {
     return index === values.length - 1 ? maxValue : values[index + 1];
   }
 
+  function isThumbEditable(index: number) {
+    return isEditables[index];
+  }
+
+  function setThumbEditable(index: number, editable: boolean) {
+    if (isEditables[index] !== editable) {
+      setEditables(replaceIndex(isEditables, index, editable));
+    }
+  }
+
   function updateValue(index: number, value: number) {
-    if (isReadOnly || isDisabled) {
+    if (isReadOnly || isDisabled || !isThumbEditable(index)) {
       return;
     }
     const thisMin = getThumbMinValue(index);
@@ -103,6 +126,9 @@ export function useSliderState(props: SliderProps): SliderState {
   }
 
   function updateDragging(index: number, dragging: boolean) {
+    if (isReadOnly || isDisabled || !isThumbEditable(index)) {
+      return;
+    }
     const newDraggings = replaceIndex(isDraggings, index, dragging);
     setDraggings(newDraggings);
     realTimeDragging.current = newDraggings.some(Boolean);
@@ -132,6 +158,11 @@ export function useSliderState(props: SliderProps): SliderState {
     setThumbPercent,
     isThumbDragging: (index: number) => isDraggings[index],
     setThumbDragging: updateDragging,
+    isTrackDragging: () => isTrackDragging || realTimeTrackDragging.current,
+    setTrackDragging: (dragging: boolean) => {
+      realTimeTrackDragging.current = dragging;
+      setTrackDragging(dragging);
+    },
     focusedThumb: focusedIndex,
     setFocusedThumb: setFocusedIndex,
     getThumbPercent: (index: number) => getValuePercent(values[index]),
@@ -141,6 +172,8 @@ export function useSliderState(props: SliderProps): SliderState {
     getThumbMinValue,
     getThumbMaxValue,
     getPercentValue,
+    isThumbEditable,
+    setThumbEditable,
     step
   };
 }


### PR DESCRIPTION
Fixing a few issues:

* `SliderState` needs to know which thumbs are editable, so that it can block edits to uneditable thumbs by track-dragging
* Make track-dragging less fragile to different DOM structures.  Previously, it only handles drag events on itself, not its children; you are expected to place the track DOM by itself, with no children, so that the drag events on the track element and the thumb elements don't conflict.  Now, we keep track of whether we are dragging by track; if so, the thumb drag events won't do anything.  This makes how you structure your DOM less strict; you can put the trackProps on an element by itself, or on the container of the thumbs.  The Story*Slider components have been updated to show the different variations.
* Removed unnecessary `computeOffsetToValue()`
* Don't install key handlers on the track element, which was blocking key events from going into the range input if you had put the thumbs inside the track element.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Track the different sliders in Storybook:

* For each slider, make sure dragging by track or by thumb results in only a single onChangeEnd fired.
* For the single slider, can drag by the thumb but not by the thumb tip
* For the range slider, can drag by the tip for the max thumb

## 🧢 Your Project:

[Plasmic](https://plasmic.app)
