### PR TITLE
SSR compatibility patch for useId(...)

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -63,7 +63,8 @@
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-syntax-class-properties",
     "transform-glob-import",
-    "babel-plugin-macros"
+    "babel-plugin-macros",
+    "./lib/babel-plugin-package-json-version"
   ],
   "sourceType": "unambiguous"
 }

--- a/lib/babel-plugin-package-json-version.js
+++ b/lib/babel-plugin-package-json-version.js
@@ -1,0 +1,38 @@
+const { resolve, sep, dirname } = require('path');
+const { existsSync } = require('fs');
+
+const PACKAGE_JSON = 'package.json';
+
+// returns path to closest package.json file while traversing up from given filepath
+// this is compatible with a yarn/lerna workspaces environment
+const resolvePackageJsonPath = (filepath) => {
+  let packageJsonPath = resolve(dirname(filepath), PACKAGE_JSON);
+  // while the parent directory does not have package.json and not at root of path
+  while (!existsSync(packageJsonPath)) {
+    const prevPackageJsonPath = packageJsonPath;
+    // step up into parent directory
+    packageJsonPath = resolve(dirname(dirname(packageJsonPath)), PACKAGE_JSON);
+    // ensure not already at root
+    if (packageJsonPath === prevPackageJsonPath) {
+      throw new Error(`could not resolve ${PACKAGE_JSON} from ${filepath}`);
+    }
+  }
+  // found a package.json file
+  return packageJsonPath;
+}
+
+module.exports = function versionTransform() {
+  return {
+    visitor: {
+      Identifier(path, { filename }) {
+        if (path.node.name === '__PACKAGE_JSON_VERSION__') {
+          // find nearest package.json file
+          const packagePath = resolvePackageJsonPath(filename);
+          // replace reference with version string
+          const { version } = require(packagePath);          
+          path.replaceWithSourceString('"' + version + '"');
+        }
+      },
+    },
+  };
+};

--- a/packages/@react-aria/utils/package.json
+++ b/packages/@react-aria/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-aria/utils",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Spectrum UI components in React",
   "license": "Apache-2.0",
   "main": "dist/main.js",

--- a/packages/@react-aria/utils/src/useId.ts
+++ b/packages/@react-aria/utils/src/useId.ts
@@ -15,9 +15,10 @@ import {useLayoutEffect, useMemo, useState} from 'react';
 let map: Map<string, (v: string) => void> = new Map();
 
 let id = 0;
-// don't want to conflict with ids from v2, this will guarantee something unique
+// don't want to conflict with ids from other instances of this module, this will *mostly* guarantee something unique
 // plus we'll know how many instances of this module are loaded on a page if there are more than one number ;)
-let randomInstanceNumber = Math.round(Math.random() * 10000000000);
+// NOTE: __PACKAGE_JSON_VERSION__ is injected by <root>/lib/babel-plugin-package-json-version.js during babel transpilation
+let packageVersion = __PACKAGE_JSON_VERSION__;
 
 /**
  * If a default is not provided, generate an id.
@@ -25,7 +26,7 @@ let randomInstanceNumber = Math.round(Math.random() * 10000000000);
  */
 export function useId(defaultId?: string): string {
   let [value, setValue] = useState(defaultId);
-  let res = useMemo(() => value || `react-aria-${randomInstanceNumber}-${++id}`, [value]);
+  let res = useMemo(() => value || `react-aria-utils-${packageVersion}-${++id}`, [value]);
   map.set(res, setValue);
   return res;
 }


### PR DESCRIPTION
I'm evaluating `@react-aria` for use in NerdWallet's frontend stack.

First, I'd like to complement you all.  This project is incredible.  The semantics of the hooks have me hooked.  The documentation for this project is incredibly valuable: https://react-spectrum.adobe.com/react-aria

We need SSR support in order to use this package. When I came across the following comment, it made me want to test the waters of how responsive this project is to external contributions. If y'all are receptive, we'd love to contribute more patches for SSR compatibility.

> Hey thanks for reporting this! SSR support is an area we’re actively working on. We’ve just started a test suite to ensure we catch all of these issues that result from running in a non-DOM environment. See #835. If you’d like to contribute tests/fixes for these issues it would be greatly appreciated! 😃

https://github.com/adobe/react-spectrum/issues/842#issuecomment-663893152

---
This PR patches the `useId(id)` hook to be SSR compatible. It removes the use of `Math.random()` to seed the ids it generates in order to keep the generated id consistent between server-response and client hydration.  It replaces the random number with the current package version of @react-aria/utils, in order to keep the spirit from the comment in that file of having something visible for devs to see that multiple instances of the module are in use.

I hooked up a local babel plugin to inject the package version during babel transpilation

This patch solves ~60% of the ssr tests that are currently failing.

`yarn test:ssr` before:
```
Test Suites: 26 failed, 9 passed, 35 total
Tests:       29 failed, 9 passed, 38 total
Snapshots:   0 total
Time:        135.882s
```

`yarn test:ssr` after:
```
Test Suites: 12 failed, 23 passed, 35 total
Tests:       12 failed, 26 passed, 38 total
Snapshots:   0 total
Time:        74.253s, estimated 129s
```

P.S. for anyone else reading, the discussion concerning `isomorphic ids` in this react issue helped with context of this kind of issue. https://github.com/facebook/react/issues/5867

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

`yarn test:ssr`


## Related Issues:

https://github.com/adobe/react-spectrum/issues/760
https://github.com/adobe/react-spectrum/pull/835
https://github.com/adobe/react-spectrum/pull/899
https://github.com/adobe/react-spectrum/issues/842