### PR TITLE
Prevent Default for onClick

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -224,10 +224,8 @@ export function usePress(props: PressHookProps): PressResult {
       },
       onClick(e) {
         if (e && e.button === 0) {
+          e.preventDefault();
           e.stopPropagation();
-          if (isDisabled) {
-            e.preventDefault();
-          }
 
           // If triggered from a screen reader or by using element.click(),
           // trigger as if it were a keyboard click.


### PR DESCRIPTION
We should be consistent with the other event handlers here. This may be a pretty big change.
May need to be merged with https://github.com/adobe/react-spectrum/pull/904 and is likely the reason that PR doesn't need to call submit for onClick in addition to the key handlers
Discovered while discussing usePress events in https://github.com/adobe/react-spectrum/issues/963

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
