### PR TITLE
Update script to bump versions of packages

### DIFF
--- a/scripts/bumpVersions.js
+++ b/scripts/bumpVersions.js
@@ -16,6 +16,8 @@ const fetch = require('node-fetch');
 const semver = require('semver');
 const readline = require("readline");
 const chalk = require('chalk');
+const http = require('http');
+const qs = require('querystring');
 
 let levels = {
   alpha: 1,
@@ -24,305 +26,339 @@ let levels = {
   released: 4
 };
 
-// Packages to release
-let publicPackages = {
-  '@adobe/react-spectrum': 'released',
-  '@react-spectrum/actiongroup': 'released',
-  '@react-spectrum/breadcrumbs' : 'released',
-  '@react-spectrum/button': 'released',
-  '@react-spectrum/buttongroup': 'released',
-  '@react-spectrum/checkbox': 'released',
-  '@react-spectrum/dialog': 'released',
-  '@react-spectrum/divider': 'released',
-  '@react-spectrum/form': 'released',
-  '@react-spectrum/icon': 'released',
-  '@react-spectrum/illustratedmessage': 'released',
-  '@react-spectrum/image': 'released',
-  '@react-spectrum/label': 'released',
-  '@react-spectrum/layout': 'released',
-  '@react-spectrum/link': 'released',
-  '@react-spectrum/listbox': 'released',
-  '@react-spectrum/menu': 'released',
-  '@react-spectrum/meter': 'released',
-  '@react-spectrum/overlays': 'released',
-  '@react-spectrum/picker': 'released',
-  '@react-spectrum/progress': 'released',
-  '@react-spectrum/provider': 'released',
-  '@react-spectrum/radio': 'released',
-  '@react-spectrum/searchfield': 'released',
-  '@react-spectrum/statuslight': 'released',
-  '@react-spectrum/switch': 'released',
-  '@react-spectrum/table': 'alpha',
-  '@react-types/table': 'rc',
-  '@react-spectrum/text': 'released',
-  '@react-spectrum/textfield': 'released',
-  '@react-spectrum/theme-dark': 'released',
-  '@react-spectrum/theme-default': 'released',
-  '@react-spectrum/utils': 'released',
-  '@react-spectrum/view': 'released',
-  '@react-spectrum/well': 'released',
-  '@spectrum-icons/color': 'released',
-  '@spectrum-icons/workflow': 'released',
-  '@spectrum-icons/illustrations': 'released',
-  '@react-stately/data': 'released',
-  '@react-aria/aria-modal-polyfill': 'released'
-};
-
 // Packages never to release
 let excludedPackages = new Set([
   '@adobe/spectrum-css-temp',
   '@react-spectrum/test-utils',
-  '@spectrum-icons/build-tools'
+  '@spectrum-icons/build-tools',
+  '@react-spectrum/docs'
 ]);
 
-// Get dependency tree from yarn workspaces, and build full list of packages to release
-// based on dependencies of the public packages.
-let info = JSON.parse(exec('yarn workspaces info --json').toString().split('\n').slice(1, -2).join('\n'));
-let releasedPackages = new Map();
-
-// If releasing an individual package, bump that package and all packages that depend on it.
-// Otherwise, add all public packages and their dependencies.
-let arg = process.argv[process.argv.length - 1];
-let bump = /^(major|minor|patch)$/.test(arg) ? arg : 'patch';
-if (arg.startsWith('@')) {
-  if (!info[arg]) {
-    throw new Error('Invalid package ' + arg);
+class VersionManager {
+  constructor() {
+    // Get dependency tree from yarn workspaces
+    this.workspacePackages = JSON.parse(exec('yarn workspaces info --json').toString().split('\n').slice(1, -2).join('\n'));
+    this.existingPackages = new Set();
+    this.changedPackages = new Set();
+    this.versionBumps = {};
+    this.releasedPackages = new Map();
   }
 
-  let addPackage = (pkg, status) => {
-    if (excludedPackages.has(pkg)) {
-      return;
-    }
+  async run() {
+    await this.getExistingPackages();
+    this.getChangedPackages();
 
-    let filePath = info[pkg].location + '/package.json';
-    let pkgJSON = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    if (pkgJSON.private) {
-      return;
-    }
-
-    if (releasedPackages.has(pkg)) {
-      let cur = releasedPackages.get(pkg);
-      if (levels[status] > levels[cur.level]) {
-        cur.status = status;
-      }
-
-      return;
-    }
-
-    releasedPackages.set(pkg, {
-      location: info[pkg].location,
-      status
-    });
-
-    for (let p in info) {
-      if (releasedPackages.has(p)) {
+    await this.getVersionBumps();
+    for (let pkg in this.versionBumps) {
+      let bump = this.versionBumps[pkg];
+      if (bump === 'unreleased' || bump === 'unchanged') {
         continue;
       }
 
-      if (info[p].workspaceDependencies.includes(pkg)) {
-        addPackage(p, status);
-      }
+      this.addReleasedPackage(pkg, bump);
     }
-  };
 
-  addPackage(arg, publicPackages[arg]);
+    let versions = this.getVersions();
+    await this.promptVersions(versions);
+    this.bumpVersions(versions);
+    this.commit(versions);
+  }
 
-  for (let pkg in info) {
-    if (!releasedPackages.has(pkg)) {
-      excludedPackages.add(pkg);
+  async getExistingPackages() {
+    // Find what packages already exist on npm
+    let promises = [];
+    for (let name in this.workspacePackages) {
+      promises.push(
+        fetch(`https://registry.npmjs.com/${name}`, {method: 'HEAD'})
+          .then(res => {
+            if (res.ok) {
+              this.existingPackages.add(name);
+            }
+          })
+      );
+    }
+
+    await Promise.all(promises);
+  }
+
+  getChangedPackages() {
+    let res = exec("git diff $(git describe --tags --abbrev=0)..HEAD --name-only packages ':!**/dev/**' ':!**/docs/**' ':!**/test/**' ':!**/stories/**' ':!**/chromatic/**'", {encoding: 'utf8'});
+
+    for (let line of res.trim().split('\n')) {
+      let parts = line.split('/');
+      let name = parts.slice(1, 3).join('/');
+      let pkg = JSON.parse(fs.readFileSync(`packages/${name}/package.json`, 'utf8'));
+      this.changedPackages.add(name);
     }
   }
-} else {
-  let addPackage = (pkg, status) => {
-    if (excludedPackages.has(pkg)) {
+
+  async getVersionBumps() {
+    return new Promise((resolve) => {
+      let server = http.createServer(async (req, res) => {
+        if (req.method === 'POST') {
+          await this.serveVersionBumps(req, res);
+          server.close();
+          req.connection.destroy();
+          resolve();
+        } else {
+          this.serveChangedPackages(res);
+        }
+      });
+
+      server.listen(9000, () => {
+        exec('open http://localhost:9000');
+      });
+    });
+  }
+
+  serveChangedPackages(res) {
+    res.setHeader('Content-Type', 'text/html');
+    res.end(`
+      <!doctype html>
+      <html style="color-scheme: dark light">
+        <body>
+          <form method="post">
+            <h1>Changed packages</h1>
+            <table>
+              ${[...this.changedPackages].filter(pkg => !excludedPackages.has(pkg) && !this.existingPackages.has(pkg)).map(pkg => `
+              <tr>
+                <td><code>${pkg}</code></td>
+                <td>
+                  <select name="${pkg}">
+                    <option>unreleased</option>
+                    <option>alpha</option>
+                    <option>beta</option>
+                    <option>rc</option>
+                    <option>released</option>
+                  </select>
+                </td>
+              </tr>
+            `).join('\n')}
+              ${[...this.changedPackages].filter(pkg => !excludedPackages.has(pkg) && this.existingPackages.has(pkg)).map(pkg => {
+                let json = JSON.parse(fs.readFileSync(`packages/${pkg}/package.json`, 'utf8'));
+                let version = semver.parse(json.version);
+                return `
+                  <tr>
+                    <td><code>${pkg}</code></td>
+                    <td>
+                      <select name="${pkg}">
+                        <option>unchanged</option>
+                        <option ${version.prerelease[0] === 'alpha' ? 'selected' : ''}>alpha</option>
+                        <option ${version.prerelease[0] === 'beta' ? 'selected' : ''}>beta</option>
+                        <option ${version.prerelease[0] === 'rc' ? 'selected' : ''}>rc</option>
+                        <option>patch</option>
+                        <option ${version.prerelease.length === 0 ? 'selected' : ''}>minor</option>
+                        <option>major</option>
+                      </select>
+                    </td>
+                  </tr>
+                `;
+              }).join('\n')}
+            </table>
+            <input type="submit" />
+          </form>
+        </body>
+      </html>
+    `);
+  }
+
+  serveVersionBumps(req, res) {
+    return new Promise((resolve) => {
+      let body = '';
+      req.on('data', (data) => {
+        body += data;
+      });
+
+      req.on('end', () => {
+        this.versionBumps = qs.parse(body);
+        res.setHeader('Content-Type', 'text/html');
+        res.end('<html style="color-scheme: dark light"><body>Done!</body></html>', () => {
+          resolve();
+        });
+      });
+    });
+  }
+
+  addReleasedPackage(pkg, bump, isDep = false) {
+    bump = this.versionBumps[pkg] || bump;
+    if (excludedPackages.has(pkg) || bump === 'unpublished' || bump === 'unchanged') {
       return;
     }
 
-    if (releasedPackages.has(pkg)) {
-      let cur = releasedPackages.get(pkg);
-      if (levels[status] > levels[cur.level] && !publicPackages[pkg]) {
+    let status = bump === 'alpha' || bump === 'beta' || bump === 'rc' ? bump : 'released';
+
+    if (this.releasedPackages.has(pkg)) {
+      let cur = this.releasedPackages.get(pkg);
+      if (!isDep || levels[status] > levels[cur.status]) {
         cur.status = status;
+        cur.bump = bump;
+      } else {
+        status = cur.status;
+        bump = cur.bump;
       }
-
-      return;
-    }
-
-    releasedPackages.set(pkg, {
-      location: info[pkg].location,
-      status: publicPackages[pkg] || status
-    });
-
-    for (let dep of info[pkg].workspaceDependencies) {
-      addPackage(dep, status);
-    }
-  };
-
-  for (let pkg in publicPackages) {
-    addPackage(pkg, publicPackages[pkg]);
-  }
-}
-
-run();
-
-async function run() {
-  let existingPackages = await getExistingPackages();
-  let versions = getVersions(existingPackages);
-  await promptVersions(versions);
-  bumpVersions(versions);
-  commit(versions);
-}
-
-async function getExistingPackages() {
-  // Find what packages already exist on npm
-  let existing = new Set();
-  let promises = [];
-  for (let [name, {location}] of releasedPackages) {
-    promises.push(
-      fetch(`https://registry.npmjs.com/${name}`, {method: 'HEAD'})
-        .then(res => {
-          if (res.ok) {
-            existing.add(name);
-          }
-        })
-    );
-  }
-
-  await Promise.all(promises);
-  return existing;
-}
-
-function getVersions(existingPackages) {
-  let versions = new Map();
-  for (let [name, {location, status}] of releasedPackages) {
-    let filePath = location + '/package.json';
-    let pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-
-    // If the package already exists on npm, then increment the version
-    // number to the correct status. If it's a new package, then ensure
-    // the package.json version is correct according to the status.
-    if (existingPackages.has(name)) {
-      let newVersion = status === 'released'
-        ? semver.inc(pkg.version, bump)
-        : semver.inc(pkg.version, 'prerelease', status)
-      versions.set(name, [pkg.version, newVersion, pkg.private]);
     } else {
-      let parsed = semver.parse(pkg.version);
-      let newVersion = pkg.version;
-      if (parsed.prerelease.length > 0) {
-        if (status === 'released') {
-          newVersion = semver.inc(pkg.version, bump);
-        } else if (parsed.prerelease[0] !== status) {
-          newVersion = semver.inc(pkg.version, 'prerelease', status);
-        } else {
-          parsed.prerelease[1] = 0;
-          newVersion = parsed.format();
+      this.releasedPackages.set(pkg, {
+        location: this.workspacePackages[pkg].location,
+        status,
+        bump
+      });
+    }
+
+    // Bump anything that depends on this package if it's a prerelease
+    // because dependencies will be pinned rather than caret ranges.
+    if (status !== 'released') {
+      for (let p in this.workspacePackages) {
+        if (this.releasedPackages.has(p)) {
+          continue;
         }
-      } else {
-        if (status === 'released') {
-          newVersion = '3.0.0';
-        } else {
-          newVersion = semver.inc(pkg.version, 'prerelease', status);
+
+        if (this.workspacePackages[p].workspaceDependencies.includes(pkg)) {
+          if (this.existingPackages.has(p)) {
+            this.addReleasedPackage(p, bump, true);
+          }
         }
       }
+    }
 
-      versions.set(name, [pkg.version, newVersion, pkg.private]);
+    // Ensure all dependencies of this package are published and up to date
+    for (let dep of this.workspacePackages[pkg].workspaceDependencies) {
+      if (!this.existingPackages.has(dep) || this.changedPackages.has(dep)) {
+        this.addReleasedPackage(dep, bump);
+      }
     }
   }
 
-  return versions;
-}
-
-async function promptVersions(versions) {
-  console.log('');
-  for (let [name, [oldVersion, newVersion, private]] of versions) {
-    if (newVersion !== oldVersion || private) {
-      console.log(`${name}: ${chalk.blue(oldVersion)}${private ? chalk.red(' (private)') : ''} => ${chalk.green(newVersion)}`);
-    }
-  }
-
-  let loggedSpace = false;
-  for (let name in info) {
-    if (!releasedPackages.has(name) && !excludedPackages.has(name)) {
-      let filePath = info[name].location + '/package.json';
+  getVersions() {
+    let versions = new Map();
+    for (let [name, {location, status, bump}] of this.releasedPackages) {
+      let filePath = this.workspacePackages[name].location + '/package.json';
       let pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-      if (!pkg.private) {
-        if (!loggedSpace) {
-          console.log('');
-          loggedSpace = true;
+
+      if (!bump || bump === 'unreleased' || bump === 'unchanged') {
+        versions.set(name, [pkg.version, pkg.version, pkg.private]);
+        continue;
+      }
+
+      // If the package already exists on npm, then increment the version
+      // number to the correct status. If it's a new package, then ensure
+      // the package.json version is correct according to the status.
+      if (this.existingPackages.has(name)) {
+        let newVersion = status === 'released'
+          ? semver.inc(pkg.version, bump)
+          : semver.inc(pkg.version, 'prerelease', status)
+        versions.set(name, [pkg.version, newVersion, pkg.private]);
+      } else {
+        let newVersion = '3.0.0';
+        if (status !== 'released') {
+          newVersion += `-${status}.0`;
         }
 
-        console.warn(chalk.red(`${name} will change from public to private`));
+        versions.set(name, [pkg.version, newVersion, pkg.private]);
       }
     }
+
+    return versions;
   }
 
-  console.log('');
-
-  let rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  });
-
-  return new Promise((resolve, reject) => {
-    rl.question('Do you want to continue? (y/n) ', function(c) {
-      rl.close();
-      if (c === 'n') {
-        reject('Not continuing');
-      } else if (c === 'y') {
-        resolve();
-      } else {
-        reject('Invalid answer');
+  async promptVersions(versions) {
+    console.log('');
+    for (let [name, [oldVersion, newVersion, isPrivate]] of versions) {
+      if (newVersion !== oldVersion || isPrivate) {
+        console.log(`${name}: ${chalk.blue(oldVersion)}${isPrivate ? chalk.red(' (private)') : ''} => ${chalk.green(newVersion)}`);
       }
+    }
+
+    let loggedSpace = false;
+    for (let name in this.workspacePackages) {
+      if (!this.releasedPackages.has(name) && !excludedPackages.has(name) && !this.existingPackages.has(name)) {
+        let filePath = this.workspacePackages[name].location + '/package.json';
+        let pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        if (!pkg.private) {
+          if (!loggedSpace) {
+            console.log('');
+            loggedSpace = true;
+          }
+
+          console.warn(chalk.red(`${name} will change from public to private`));
+        }
+      }
+    }
+
+    console.log('');
+
+    let rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
     });
-  });
-}
 
-function bumpVersions(versions) {
-  for (let [name, {location}] of releasedPackages) {
-    let filePath = location + '/package.json';
-    let pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    pkg.version = versions.get(name)[1];
-
-    if (pkg.private) {
-      delete pkg.private;
-    }
-
-    for (let dep in pkg.dependencies) {
-      if (versions.has(dep)) {
-        let {status} = releasedPackages.get(dep);
-        pkg.dependencies[dep] = (status === 'released' ? '^' : '') + versions.get(dep)[1];
-      }
-    }
-
-    fs.writeFileSync(filePath, JSON.stringify(pkg, false, 2) + '\n');
+    return new Promise((resolve, reject) => {
+      rl.question('Do you want to continue? (y/n) ', function(c) {
+        rl.close();
+        if (c === 'n') {
+          reject('Not continuing');
+        } else if (c === 'y') {
+          resolve();
+        } else {
+          reject('Invalid answer');
+        }
+      });
+    });
   }
 
-  for (let name in info) {
-    if (!releasedPackages.has(name) && !excludedPackages.has(name)) {
-      let filePath = info[name].location + '/package.json';
+  bumpVersions(versions) {
+    for (let [name, {location}] of this.releasedPackages) {
+      let filePath = location + '/package.json';
       let pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-      if (!pkg.private) {
-        pkg = insertKey(pkg, 'license', 'private', true);
+      pkg.version = versions.get(name)[1];
+
+      if (pkg.private) {
+        delete pkg.private;
       }
 
       for (let dep in pkg.dependencies) {
         if (versions.has(dep)) {
-          let {status} = releasedPackages.get(dep);
+          let {status} = this.releasedPackages.get(dep);
           pkg.dependencies[dep] = (status === 'released' ? '^' : '') + versions.get(dep)[1];
         }
       }
 
       fs.writeFileSync(filePath, JSON.stringify(pkg, false, 2) + '\n');
     }
+
+    for (let name in this.workspacePackages) {
+      if (!this.releasedPackages.has(name)) {
+        let filePath = this.workspacePackages[name].location + '/package.json';
+        let pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+        // Mark package as private if it wasn't already published.
+        if (!pkg.private && !excludedPackages.has(name) && !this.existingPackages.has(name)) {
+          pkg = insertKey(pkg, 'license', 'private', true);
+        }
+
+        // Ensure pinned dependencies of unpublished packages in the monorepo are updated.
+        for (let dep in pkg.dependencies) {
+          if (versions.has(dep)) {
+            let {status} = this.releasedPackages.get(dep);
+            if (status !== 'released') {
+              pkg.dependencies[dep] = versions.get(dep)[1];
+            }
+          }
+        }
+
+        fs.writeFileSync(filePath, JSON.stringify(pkg, false, 2) + '\n');
+      }
+    }
+  }
+
+  commit(versions) {
+    exec('git commit -a -m "Publish"', {stdio: 'inherit'});
+    for (let [name, [, newVersion]] of versions) {
+      exec(`git tag ${name}@${newVersion}`, {stdio: 'inherit'});
+    }
   }
 }
 
-function commit(versions) {
-  exec('git commit -a -m "Publish"', {stdio: 'inherit'});
-  for (let [name, [, newVersion]] of versions) {
-    exec(`git tag ${name}@${newVersion}`, {stdio: 'inherit'});
-  }
-}
+new VersionManager().run();
 
 function insertKey(obj, afterKey, key, value) {
   let res = {};


### PR DESCRIPTION
This updates the script to bump versions of packages to have a UI for selecting _how_ to bump the version for each package (e.g. alpha, patch, minor, major, etc.). It starts a simple web server and triggers your browser to open to a page listing all of the changed packages.

<img width="1326" alt="Screen Shot 2020-08-14 at 1 07 28 PM" src="https://user-images.githubusercontent.com/19409/90301604-d710a480-de55-11ea-9fb4-e037558669b7.png">

It then propagates these version selections as necessary to dependent packages. Specifically, if the version is a prerelease, then it propagates the version bump upwards to anything that has a dependency on the package being published. This is so that the dependent packages get the updated pinned version. Additionally, we also propagate the version bump downward to all packages that the package depends on, to ensure that all dependencies are published and up to date.

For now, the rest of the script works as it did, with a prompt for the new versions in the terminal. Eventually I'd like to make that part of the web UI as well.