### PR TITLE
Revert "Fix double open menu"

### DIFF
--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -29,48 +29,65 @@ interface InteractOutsideProps {
 export function useInteractOutside(props: InteractOutsideProps) {
   let {ref, onInteractOutside} = props;
   let stateRef = useRef({
+    isPointerDown: false,
     ignoreEmulatedMouseEvents: false
   });
   let state = stateRef.current;
 
   useEffect(() => {
-    if (!onInteractOutside) {
-      return;
-    }
     let onPointerDown = (e) => {
-      if (state.ignoreEmulatedMouseEvents) {
-        state.ignoreEmulatedMouseEvents = false;
-        return;
-      }
       if (isValidEvent(e, ref)) {
-        onInteractOutside(e);
+        state.isPointerDown = true;
       }
     };
 
     // Use pointer events if available. Otherwise, fall back to mouse and touch events.
     if (typeof PointerEvent !== 'undefined') {
+      let onPointerUp = (e) => {
+        if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
+          state.isPointerDown = false;
+          onInteractOutside(e);
+        }
+      };
+
       document.addEventListener('pointerdown', onPointerDown, false);
+      document.addEventListener('pointerup', onPointerUp, false);
 
       return () => {
         document.removeEventListener('pointerdown', onPointerDown, false);
+        document.removeEventListener('pointerup', onPointerUp, false);
       };
     } else {
-      let onTouchStart = (e) => {
-        if (isValidEvent(e, ref)) {
-          state.ignoreEmulatedMouseEvents = true;
+      let onMouseUp = (e) => {
+        if (state.ignoreEmulatedMouseEvents) {
+          state.ignoreEmulatedMouseEvents = false;
+        } else if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
+          state.isPointerDown = false;
+          onInteractOutside(e);
+        }
+      };
+
+      let onTouchEnd = (e) => {
+        state.ignoreEmulatedMouseEvents = true;
+        if (onInteractOutside && state.isPointerDown && isValidEvent(e, ref)) {
+          state.isPointerDown = false;
           onInteractOutside(e);
         }
       };
 
       document.addEventListener('mousedown', onPointerDown, false);
-      document.addEventListener('touchstart', onTouchStart, false);
+      document.addEventListener('mouseup', onMouseUp, false);
+      document.addEventListener('touchstart', onPointerDown, false);
+      document.addEventListener('touchend', onTouchEnd, false);
 
       return () => {
         document.removeEventListener('mousedown', onPointerDown, false);
+        document.removeEventListener('mouseup', onMouseUp, false);
         document.removeEventListener('touchstart', onPointerDown, false);
+        document.removeEventListener('touchend', onTouchEnd, false);
       };
     }
-  }, [onInteractOutside, ref, state]);
+  }, [onInteractOutside, ref, state.ignoreEmulatedMouseEvents, state.isPointerDown]);
 }
 
 function isValidEvent(event, ref) {

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -29,8 +29,8 @@ interface OverlayProps {
   /** Whether the overlay should close when focus is lost or moves outside it. */
   shouldCloseOnBlur?: boolean,
 
-  /**
-   * Whether pressing the escape key to close the overlay should be disabled.
+  /** 
+   * Whether pressing the escape key to close the overlay should be disabled. 
    * @default false
    */
   isKeyboardDismissDisabled?: boolean,
@@ -38,7 +38,7 @@ interface OverlayProps {
   /**
    * When user interacts with the argument element outside of the overlay ref,
    * return true if onClose should be called.  This gives you a chance to filter
-   * out interaction with elements that should not dismiss the overlay.
+   * out interaction with elements that should not dismiss the overlay.  
    * By default, onClose will always be called on interaction outside the overlay ref.
    */
   shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
@@ -95,7 +95,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   };
 
   // Handle clicking outside the overlay to close it
-  useInteractOutside({ref, onInteractOutside: isDismissable && isOpen ? onInteractOutside : undefined});
+  useInteractOutside({ref, onInteractOutside: isDismissable ? onInteractOutside : null});
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,

--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -82,7 +82,7 @@ export function useSelect<T>(props: AriaSelectOptions<T>, state: SelectState<T>,
   });
 
   let domProps = filterDOMProps(props, {labelable: true});
-  let triggerProps = mergeProps(menuTriggerProps, fieldProps, typeSelectProps);
+  let triggerProps = mergeProps(mergeProps(menuTriggerProps, fieldProps), typeSelectProps);
   let valueId = useId();
 
   return {

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -73,8 +73,6 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
     </FocusScope>
   );
 
-  let shouldCloseOnInteractOutside = (element) => !menuTriggerRef.current?.contains(element);
-
   // On small screen devices, the menu is rendered in a tray, otherwise a popover.
   let overlay;
   if (isMobile) {
@@ -92,8 +90,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
         placement={placement}
         hideArrow
         onClose={state.close}
-        shouldCloseOnBlur
-        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}>
+        shouldCloseOnBlur>
         {contents}
       </Popover>
     );

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -19,7 +19,6 @@ import Blower from '@spectrum-icons/workflow/Blower';
 import Book from '@spectrum-icons/workflow/Book';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
-import {Flex} from '@react-spectrum/layout';
 import {Item, Menu, MenuTrigger, Section} from '../';
 import {Keyboard, Text} from '@react-spectrum/text';
 import Paste from '@spectrum-icons/workflow/Paste';
@@ -478,30 +477,7 @@ storiesOf('MenuTrigger', module)
         </div>
       </>
     )
-  )
-  .add('double menu', () => (
-    <Flex gap="size-100">
-      <MenuTrigger>
-        <ActionButton
-          onPressStart={action('1onPressStart')}
-          onPressEnd={action('1onPressEnd')}
-          onPress={action('1onPress')}>
-          Menu Button 1
-        </ActionButton>
-        {defaultMenu}
-      </MenuTrigger>
-      <MenuTrigger>
-        <ActionButton
-          onPressStart={action('2onPressStart')}
-          onPressEnd={action('2onPressEnd')}
-          onPress={action('2onPress')}>
-          Menu Button 2
-        </ActionButton>
-        {defaultMenu}
-      </MenuTrigger>
-    </Flex>
-  ));
-
+  );
 
 let customMenuItem = (item) => {
   let Icon = iconMap[item.icon];

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -221,7 +221,7 @@ describe('MenuTrigger', function () {
 
     menu = tree.getByRole('menu');
     expect(menu).toBeTruthy();
-    expect(onOpenChange).toBeCalledTimes(1);
+    expect(onOpenChange).toBeCalledTimes(2); // once for press, once for blur :/
   });
 
   // New functionality in v3

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -28,8 +28,7 @@ interface PopoverWrapperProps extends HTMLAttributes<HTMLElement> {
   isOpen?: boolean,
   onClose?: () => void,
   shouldCloseOnBlur?: boolean,
-  isKeyboardDismissDisabled?: boolean,
-  shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
+  isKeyboardDismissDisabled?: boolean
 }
 
 /**
@@ -47,7 +46,7 @@ let arrowPlacement = {
 };
 
 function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
-  let {children, placement, arrowProps, onClose, shouldCloseOnBlur, hideArrow, isKeyboardDismissDisabled, shouldCloseOnInteractOutside, ...otherProps} = props;
+  let {children, placement, arrowProps, onClose, shouldCloseOnBlur, hideArrow, isKeyboardDismissDisabled, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let {styleProps} = useStyleProps(props);
 
@@ -61,8 +60,7 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
         onClose={onClose}
         shouldCloseOnBlur={shouldCloseOnBlur}
         isKeyboardDismissDisabled={isKeyboardDismissDisabled}
-        hideArrow={hideArrow}
-        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}>
+        hideArrow={hideArrow}>
         {children}
       </PopoverWrapper>
     </Overlay>
@@ -71,7 +69,7 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
 
 const PopoverWrapper = forwardRef((props: PopoverWrapperProps, ref: RefObject<HTMLDivElement>) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let {children, placement = 'bottom', arrowProps, isOpen, hideArrow, shouldCloseOnBlur, isKeyboardDismissDisabled, shouldCloseOnInteractOutside, ...otherProps} = props;
+  let {children, placement = 'bottom', arrowProps, isOpen, hideArrow, shouldCloseOnBlur, isKeyboardDismissDisabled, ...otherProps} = props;
   let {overlayProps} = useOverlay({...props, isDismissable: true}, ref);
   let {modalProps} = useModal();
 

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -151,8 +151,6 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       minWidth: isQuiet ? `calc(${buttonWidth}px + calc(2 * var(--spectrum-dropdown-quiet-offset)))` : buttonWidth
     };
 
-    let shouldCloseOnInteractOutside = (element) => !triggerRef.current?.UNSAFE_getDOMNode()?.contains(element);
-
     overlay = (
       <Popover
         isOpen={state.isOpen}
@@ -162,8 +160,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         placement={placement}
         hideArrow
         shouldCloseOnBlur
-        onClose={state.close}
-        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}>
+        onClose={state.close}>
         {listbox}
       </Popover>
     );

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -54,7 +54,7 @@ storiesOf('Picker', module)
   .add(
     'default',
     () => (
-      <Picker label="Test" onOpenChange={action('openchange')} onSelectionChange={action('selectionChange')}>
+      <Picker label="Test" onSelectionChange={action('selectionChange')}>
         <Item key="One">One</Item>
         <Item key="Two">Two</Item>
         <Item key="Three">Three</Item>

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -23,7 +23,6 @@ import React from 'react';
 import {Text} from '@react-spectrum/text';
 import {theme} from '@react-spectrum/theme-default';
 import {triggerPress} from '@react-spectrum/test-utils';
-import userEvent from '@testing-library/user-event';
 
 describe('Picker', function () {
   let offsetWidth, offsetHeight;
@@ -366,7 +365,7 @@ describe('Picker', function () {
       expect(() => getByRole('listbox')).toThrow();
 
       let picker = getByRole('button');
-      act(() => userEvent.click(picker));
+      act(() => triggerPress(picker));
       act(() => jest.runAllTimers());
 
       let listbox = getByRole('listbox');
@@ -376,7 +375,7 @@ describe('Picker', function () {
       expect(picker).toHaveAttribute('aria-expanded', 'true');
       expect(picker).toHaveAttribute('aria-controls', listbox.id);
 
-      act(() => userEvent.click(picker));
+      act(() => triggerPress(picker));
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();

--- a/packages/@react-stately/overlays/src/useOverlayTriggerState.ts
+++ b/packages/@react-stately/overlays/src/useOverlayTriggerState.ts
@@ -40,7 +40,7 @@ export function useOverlayTriggerState(props: OverlayTriggerProps): OverlayTrigg
       setOpen(false);
     },
     toggle() {
-      setOpen(prev => !prev);
+      setOpen(!isOpen);
     }
   };
 }

--- a/packages/@react-types/overlays/src/index.d.ts
+++ b/packages/@react-types/overlays/src/index.d.ts
@@ -89,8 +89,7 @@ export interface PopoverProps extends StyleProps, OverlayProps {
   hideArrow?: boolean,
   isOpen?: boolean,
   onClose?: () => void,
-  shouldCloseOnBlur?: boolean,
-  shouldCloseOnInteractOutside?: (element: HTMLElement) => boolean
+  shouldCloseOnBlur?: boolean
 }
 
 export interface TrayProps extends StyleProps, OverlayProps {


### PR DESCRIPTION
Reverts adobe/react-spectrum#925

Found a couple issues. I think we'll need to revisit the behavior of whether we open/close on mouse down or mouse up. Reverting for the release and we can come back to this.