### PR TITLE
Allow picker to be set to tray or popover via a prop

### DIFF
--- a/packages/@react-spectrum/picker/docs/Picker.mdx
+++ b/packages/@react-spectrum/picker/docs/Picker.mdx
@@ -397,3 +397,12 @@ function Example() {
   );
 }
 ```
+### Display Items In
+Picker normally chooses whether to display items as a tray or popover. This allows you to override that decision.
+```tsx example
+<Picker label="Choose frequency" displayItemsIn='tray'>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
+</Picker>
+```

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -55,7 +55,8 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     isRequired,
     necessityIndicator,
     menuWidth,
-    name
+	name,
+	displayItemsIn
   } = props;
 
   let {styleProps} = useStyleProps(props);
@@ -134,9 +135,10 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   }, [scale, isMobile, triggerRef, state.selectedKey]);
 
   let overlay;
-  if (isMobile) {
+  let useTray = displayItemsIn ? displayItemsIn === 'tray' : isMobile;
+  if (useTray) {
     overlay = (
-      <Tray isOpen={state.isOpen} onClose={state.close} shouldCloseOnBlur>
+      <Tray isOpen={state.isOpen} onClose={state.close} shouldCloseOnBlur data-testid="picker-tray" >
         {listbox}
       </Tray>
     );
@@ -153,6 +155,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
 
     overlay = (
       <Popover
+		data-testid="picker-popup"
         isOpen={state.isOpen}
         UNSAFE_style={style}
         UNSAFE_className={classNames(styles, 'spectrum-Dropdown-popover', {'spectrum-Dropdown-popover--quiet': isQuiet})}

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -49,7 +49,6 @@ let withSection = [
   ]}
 ];
 
-
 storiesOf('Picker', module)
   .add(
     'default',
@@ -476,8 +475,30 @@ storiesOf('Picker', module)
     'async loading',
     () => (
       <AsyncLoadingExample />
-    )
-  );
+	)
+  )
+	.add(
+		'force tray or popover',
+		() => (
+			<div>
+				<Picker label="Force Tray" onSelectionChange={(action('selectionChange'))} displayItemsIn='tray'>
+					<Item key="One">One</Item>
+					<Item key="Two">Two</Item>
+					<Item key="Three">Three</Item>
+				</Picker>
+				<Picker label="Force Popup" onSelectionChange={(action('selectionChange'))} displayItemsIn='popover'>
+					<Item key="One">One</Item>
+					<Item key="Two">Two</Item>
+					<Item key="Three">Three</Item>
+				</Picker>
+				<Picker label="Picker Decides" onSelectionChange={(action('selectionChange'))}>
+					<Item key="One">One</Item>
+					<Item key="Two">Two</Item>
+					<Item key="Three">Three</Item>
+				</Picker>
+			</div>
+		)
+	) ;
 
 function AsyncLoadingExample() {
   interface Pokemon {

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1722,4 +1722,48 @@ describe('Picker', function () {
       expect(document.activeElement).not.toBe(picker);
     });
   });
+  describe('force tray or popover', function () {
+    it('open as tray', function () {
+      let {getByRole, queryByTestId} = render(
+        <Provider theme={theme}>
+          <Picker label="Test" displayItemsIn="tray">
+            <Item>One</Item>
+            <Item>Two</Item>
+            <Item>Three</Item>
+          </Picker>
+        </Provider>
+		);
+
+      let picker = getByRole('button');
+			// make sure to run through mousedown AND mouseup, like would really happen, otherwise a mouseup listener
+			// sits around until the component is unmounted
+      act(() => { triggerPress(picker); });
+      act(() => jest.runAllTimers());
+
+      expect(queryByTestId('tray')).toBeVisible();
+      expect(queryByTestId('popover')).not.toBeInTheDocument();
+    });
+	
+    it('open as popover', function () {
+      let {getByRole, queryByTestId} = render(
+        <Provider theme={theme}>
+          <Picker label="Test" displayItemsIn="popover">
+            <Item>One</Item>
+            <Item>Two</Item>
+            <Item>Three</Item>
+          </Picker>
+        </Provider>
+		);
+
+      let picker = getByRole('button');
+		// make sure to run through mousedown AND mouseup, like would really happen, otherwise a mouseup listener
+		// sits around until the component is unmounted
+      act(() => { triggerPress(picker); });
+      act(() => jest.runAllTimers());
+
+
+      expect(queryByTestId('tray')).not.toBeInTheDocument();
+      expect(queryByTestId('popover')).toBeVisible();
+    });
+  });
 });

--- a/packages/@react-types/select/src/index.d.ts
+++ b/packages/@react-types/select/src/index.d.ts
@@ -60,4 +60,9 @@ export interface SpectrumPickerProps<T> extends AriaSelectProps<T>, SpectrumLabe
    * The name of the Picker input, used when submitting an HTML form.
    */
   name?: string
+  /**
+   * If set to 'tray', the items will open in a tray. If 'popover', as a popover.
+   * If not defined, Picker will make its best guess based on window max-width.
+   */
+	displayItemsIn?: 'tray' | 'popover',
 }


### PR DESCRIPTION
Closes 989
https://github.com/adobe/react-spectrum/issues/989

## 📝 Test Instructions:

You can run `yarn run test Picker` to run the unit test, or you can look at the storyboard.

You can create a Picker and then try it with the prop `displayItemsIn` set to `tray` or `popover` or without the prop.

## 🧢 Your Project:

Adobe, Inc./Report Builder 2.0
