### PR TITLE
DialogTrigger in popover should accept function as 2nd child

### DIFF
--- a/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
+++ b/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
@@ -155,7 +155,7 @@ function PopoverTrigger({state, targetRef, trigger, content, hideArrow, isKeyboa
       arrowProps={arrowProps}
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}
       hideArrow={hideArrow}>
-      {content}
+      {typeof content === 'function' ? content(state.close) : content}
     </Popover>
   );
 

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -278,7 +278,7 @@ storiesOf('DialogTrigger', module)
     () => renderPopover({type: 'popover', placement: 'bottom', width: 'calc(100vh - 100px)', containerPadding: 20})
   )
   .add(
-    'contents of function render',
+    'Close function with button: popover',
     () => (
       <div style={{display: 'flex', margin: '100px 0'}}>
         <DialogTrigger type="popover" onOpenChange={action('open change')}>

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -278,6 +278,27 @@ storiesOf('DialogTrigger', module)
     () => renderPopover({type: 'popover', placement: 'bottom', width: 'calc(100vh - 100px)', containerPadding: 20})
   )
   .add(
+    'contents of function render',
+    () => (
+      <div style={{display: 'flex', margin: '100px 0'}}>
+        <DialogTrigger type="popover" onOpenChange={action('open change')}>
+          <ActionButton>Trigger</ActionButton>
+          {(close) => (
+            <Dialog>
+              <Heading>The Heading</Heading>
+              <Header>The Header</Header>
+              <Divider />
+              <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
+              <ButtonGroup>
+                <Button variant="secondary" onPress={chain(close, action('cancel'))}>Cancel</Button>
+              </ButtonGroup>
+            </Dialog>
+          )}
+        </DialogTrigger>
+      </div>
+    )
+  )
+  .add(
     'targetRef',
     () => (<TriggerWithRef type="popover" />)
   )
@@ -314,17 +335,12 @@ function renderPopover({width = 'auto', ...props}) {
     <div style={{display: 'flex', width, margin: '100px 0'}}>
       <DialogTrigger {...props} onOpenChange={action('open change')}>
         <ActionButton>Trigger</ActionButton>
-        {(close) => (
-          <Dialog>
-            <Heading>The Heading</Heading>
-            <Header>The Header</Header>
-            <Divider />
-            <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
-            <ButtonGroup>
-              <Button variant="secondary" onPress={chain(close, action('cancel'))}>Cancel</Button>
-            </ButtonGroup>
-          </Dialog>
-        )}
+        <Dialog>
+          <Heading>The Heading</Heading>
+          <Header>The Header</Header>
+          <Divider />
+          <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
+        </Dialog>
       </DialogTrigger>
     </div>
   );

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -314,12 +314,17 @@ function renderPopover({width = 'auto', ...props}) {
     <div style={{display: 'flex', width, margin: '100px 0'}}>
       <DialogTrigger {...props} onOpenChange={action('open change')}>
         <ActionButton>Trigger</ActionButton>
-        <Dialog>
-          <Heading>The Heading</Heading>
-          <Header>The Header</Header>
-          <Divider />
-          <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
-        </Dialog>
+        {(close) => (
+          <Dialog>
+            <Heading>The Heading</Heading>
+            <Header>The Header</Header>
+            <Divider />
+            <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
+            <ButtonGroup>
+              <Button variant="secondary" onPress={chain(close, action('cancel'))}>Cancel</Button>
+            </ButtonGroup>
+          </Dialog>
+        )}
       </DialogTrigger>
     </div>
   );

--- a/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
@@ -12,6 +12,7 @@
 
 import {act, fireEvent, render, waitFor, within} from '@testing-library/react';
 import {ActionButton, Button} from '@react-spectrum/button';
+import {ButtonGroup} from '@react-spectrum/buttongroup';
 import {Dialog, DialogTrigger} from '../';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import {Provider} from '@react-spectrum/provider';
@@ -122,6 +123,46 @@ describe('DialogTrigger', function () {
     let popover = getByTestId('popover');
     expect(popover).toBeVisible();
     expect(popover).toHaveAttribute('style');
+  });
+
+  it('popovers should be closeable', function () {
+    let {getByRole, getByText, queryByRole} = render(
+      <Provider theme={theme}>
+        <DialogTrigger type="popover">
+          <ActionButton>Trigger</ActionButton>
+          {(close) => (
+            <Dialog>
+              contents
+              <ButtonGroup>
+                <Button variant="secondary" onPress={close}>
+                  Cancel
+                </Button>
+              </ButtonGroup>
+            </Dialog>
+          )}
+        </DialogTrigger>
+      </Provider>
+    );
+
+    let triggerButton = getByRole('button');
+    triggerPress(triggerButton);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    let dialog = getByRole('dialog');
+    expect(dialog).toBeVisible();
+
+    let cancelButton = getByText('Cancel');
+    triggerPress(cancelButton);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    dialog = queryByRole('dialog');
+    expect(dialog).toBeNull();
   });
 
   it('should trigger a modal instead of a popover on mobile', function () {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/985

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [N/A?] Updated documentation (if it already exists for this component).
- [N/A?] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
Open the Storybook for DialogTrigger popover, verify that contents are visible, try to close it with the cancel button, verify it's closed
<!--- Include instructions to test this pull request -->
