### PR TITLE
Allow Options with falsey keys to be selected

### DIFF
--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -916,6 +916,72 @@ describe('Picker', function () {
       expect(picker).toHaveTextContent('Three');
     });
 
+    it('can select items with falsy keys', function () {
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <Picker label="Test" onSelectionChange={onSelectionChange}>
+            <Item key="">Empty</Item>
+            <Item key={0}>Zero</Item>
+            <Item key={false}>False</Item>
+          </Picker>
+        </Provider>
+      );
+      
+      let picker = getByRole('button');
+      expect(picker).toHaveTextContent('Select an option…');
+      act(() => triggerPress(picker));
+      act(() => jest.runAllTimers());
+
+      let listbox = getByRole('listbox');
+      let items = within(listbox).getAllByRole('option');
+      expect(items.length).toBe(3);
+      expect(items[0]).toHaveTextContent('Empty');
+      expect(items[1]).toHaveTextContent('Zero');
+      expect(items[2]).toHaveTextContent('False');
+
+      expect(document.activeElement).toBe(listbox);
+
+      act(() => triggerPress(items[0]));
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onSelectionChange).toHaveBeenLastCalledWith('');
+      act(() => jest.runAllTimers());
+      expect(listbox).not.toBeInTheDocument();
+
+      expect(document.activeElement).toBe(picker);
+      expect(picker).toHaveTextContent('Empty');
+
+      act(() => triggerPress(picker));
+      act(() => jest.runAllTimers());
+
+      listbox = getByRole('listbox');
+      let item1 = within(listbox).getByText('Zero');
+
+      act(() => triggerPress(item1));
+      expect(onSelectionChange).toHaveBeenCalledTimes(2);
+      expect(onSelectionChange).toHaveBeenLastCalledWith('0');
+      act(() => jest.runAllTimers());
+      expect(listbox).not.toBeInTheDocument();
+
+      expect(document.activeElement).toBe(picker);
+      expect(picker).toHaveTextContent('Zero');
+
+      act(() => triggerPress(picker));
+      act(() => jest.runAllTimers());
+
+      listbox = getByRole('listbox');
+      let item2 = within(listbox).getByText('False');
+
+      act(() => triggerPress(item2));
+      expect(onSelectionChange).toHaveBeenCalledTimes(3);
+      expect(onSelectionChange).toHaveBeenLastCalledWith('false');
+      act(() => jest.runAllTimers());
+      expect(listbox).not.toBeInTheDocument();
+
+      expect(document.activeElement).toBe(picker);
+      expect(picker).toHaveTextContent('False');
+    });
+
+
     it('can select items with the Space key', function () {
       let {getByRole} = render(
         <Provider theme={theme}>

--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -56,7 +56,7 @@ export function useSingleSelectListState<T extends object>(props: SingleSelectLi
     }
   });
 
-  let selectedItem = selectedKey
+  let selectedItem = selectedKey != null
     ? collection.getItem(selectedKey)
     : null;
 


### PR DESCRIPTION
This PR allows Picker options which have falsey keys (except `null`) to be selected. The use case where a user might encounter this is when a Picker contains an Option with `key=""` as would be the convention in regular HTML when creating a placeholder value for a select input.

Closes #1016

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
1. Construct a Picker with an option containing an empty key
    ```jsx
    <Picker label="Color">
      <Option key="">None</Option>
      <Option key="red">Red</Option>
      <Option key="blue">Blue</Option>
      <Option key="green">Green</Option>
    </Picker>
    ```
2. Select the "None" option
3. Picker should now show "None" in the Picker button

## 🧢 Your Project:

<!--- Company/project for pull request -->
