### PR TITLE
Do not close tray on scroll

### DIFF
--- a/packages/@react-aria/combobox/test/useComboBox.test.js
+++ b/packages/@react-aria/combobox/test/useComboBox.test.js
@@ -36,8 +36,9 @@ describe('useComboBox', function () {
   it('should return default props for all the button group elements', function () {
     let props = {
       label: 'test label',
-      buttonRef: {current: true},
-      textFieldRef: {current: true},
+      popoverRef: React.createRef(),
+      triggerRef: React.createRef(),
+      textFieldRef: React.createRef(),
       layout: mockLayout
     };
 

--- a/packages/@react-aria/menu/test/useMenuTrigger.test.js
+++ b/packages/@react-aria/menu/test/useMenuTrigger.test.js
@@ -20,7 +20,7 @@ describe('useMenuTrigger', function () {
   let setFocusStrategy = jest.fn();
 
   let renderMenuTriggerHook = (menuTriggerProps, menuTriggerState, ref) => {
-    let {result} = renderHook(() => useMenuTrigger(menuTriggerProps, menuTriggerState, ref));
+    let {result} = renderHook(() => useMenuTrigger(menuTriggerProps, menuTriggerState, ref || React.createRef()));
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
     return result.current;
   };
@@ -93,7 +93,7 @@ describe('useMenuTrigger', function () {
     let preventDefault = jest.fn();
     let stopPropagation = jest.fn();
 
-    let {menuTriggerProps} = renderMenuTriggerHook(props, state, {current: true});
+    let {menuTriggerProps} = renderMenuTriggerHook(props, state, {current: {}});
     expect(typeof menuTriggerProps.onKeyDown).toBe('function');
 
     // doesn't trigger event if isDefaultPrevented returns true

--- a/packages/@react-aria/overlays/src/useCloseOnScroll.ts
+++ b/packages/@react-aria/overlays/src/useCloseOnScroll.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {RefObject, useEffect} from 'react';
+
+// This behavior moved from useOverlayTrigger to useOverlayPosition.
+// For backward compatibility, where useOverlayTrigger handled hiding the popover on close,
+// it sets a close function here mapped from the trigger element. This way we can avoid
+// forcing users to pass an onClose function to useOverlayPosition which could be considered
+// a breaking change.
+export const onCloseMap: WeakMap<HTMLElement, () => void> = new WeakMap();
+
+interface CloseOnScrollOptions {
+  triggerRef: RefObject<HTMLElement>,
+  isOpen?: boolean,
+  onClose?: () => void
+}
+
+/** @private */
+export function useCloseOnScroll(opts: CloseOnScrollOptions) {
+  let {triggerRef, isOpen, onClose} = opts;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let onScroll = (e: MouseEvent) => {
+      // Ignore if scrolling an scrollable region outside the trigger's tree.
+      let target = e.target as HTMLElement;
+      if (!triggerRef.current || !target.contains(triggerRef.current)) {
+        return;
+      }
+
+      let onCloseHandler = onClose || onCloseMap.get(triggerRef.current);
+      if (onCloseHandler) {
+        onCloseHandler();
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, true);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [isOpen, onClose, triggerRef]);
+}

--- a/packages/@react-aria/overlays/src/useOverlayPosition.ts
+++ b/packages/@react-aria/overlays/src/useOverlayPosition.ts
@@ -13,6 +13,7 @@
 import {calculatePosition, PositionResult} from './calculatePosition';
 import {HTMLAttributes, RefObject, useCallback, useEffect, useState} from 'react';
 import {Placement, PlacementAxis, PositionProps} from '@react-types/overlays';
+import {useCloseOnScroll} from './useCloseOnScroll';
 import {useLocale} from '@react-aria/i18n';
 
 interface AriaPositionProps extends PositionProps {
@@ -38,7 +39,9 @@ interface AriaPositionProps extends PositionProps {
    * Whether the overlay should update its position automatically.
    * @default true
    */
-  shouldUpdatePosition?: boolean
+  shouldUpdatePosition?: boolean,
+  /** Handler that is called when the overlay should close. */
+  onClose?: () => void
 }
 
 interface PositionAria {
@@ -69,7 +72,8 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
     offset = 0,
     crossOffset = 0,
     shouldUpdatePosition = true,
-    isOpen = true
+    isOpen = true,
+    onClose
   } = props;
   let [position, setPosition] = useState<PositionResult>({
     position: {},
@@ -119,6 +123,14 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
 
   // Update position on window resize
   useResize(updatePosition);
+
+  // When scrolling a parent scrollable region of the trigger (other than the body),
+  // we hide the popover. Otherwise, its position would be incorrect.
+  useCloseOnScroll({
+    triggerRef: targetRef,
+    isOpen,
+    onClose
+  });
 
   return {
     overlayProps: {

--- a/packages/@react-aria/overlays/src/useOverlayTrigger.ts
+++ b/packages/@react-aria/overlays/src/useOverlayTrigger.ts
@@ -12,6 +12,7 @@
 
 import {AriaButtonProps} from '@react-types/button';
 import {HTMLAttributes, RefObject, useEffect} from 'react';
+import {onCloseMap} from './useCloseOnScroll';
 import {OverlayTriggerState} from '@react-stately/overlays';
 import {useId} from '@react-aria/utils';
 
@@ -36,28 +37,13 @@ export function useOverlayTrigger(props: OverlayTriggerProps, state: OverlayTrig
   let {type} = props;
   let {isOpen} = state;
 
-  // When scrolling a parent scrollable region of the trigger (other than the body),
-  // we hide the popover. Otherwise, its position would be incorrect.
+  // Backward compatibility. Share state close function with useOverlayPosition so it can close on scroll
+  // without forcing users to pass onClose.
   useEffect(() => {
-    if (!isOpen) {
-      return;
+    if (ref.current) {
+      onCloseMap.set(ref.current, state.close);
     }
-
-    let onScroll = (e: MouseEvent) => {
-      // Ignore if scrolling an scrollable region outside the trigger's tree.
-      let target = e.target as HTMLElement;
-      if (!ref.current || !target.contains(ref.current)) {
-        return;
-      }
-
-      state.close();
-    };
-
-    window.addEventListener('scroll', onScroll, true);
-    return () => {
-      window.removeEventListener('scroll', onScroll, true);
-    };
-  }, [isOpen, ref]);
+  });
 
   // Aria 1.1 supports multiple values for aria-haspopup other than just menus.
   // https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup

--- a/packages/@react-aria/overlays/test/useOverlayPosition.test.js
+++ b/packages/@react-aria/overlays/test/useOverlayPosition.test.js
@@ -109,4 +109,39 @@ describe('useOverlayPosition', function () {
       max-height: 386px;
     `);
   });
+
+  it('should close the overlay when the trigger scrolls', function () {
+    let onClose = jest.fn();
+    let res = render(
+      <div data-testid="scrollable">
+        <Example isOpen onClose={onClose} />
+      </div>
+    );
+
+    let scrollable = res.getByTestId('scrollable');
+    fireEvent.scroll(scrollable);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not close the overlay when an adjacent scrollable region scrolls', function () {
+    let onClose = jest.fn();
+    let res = render(
+      <div>
+        <Example isOpen onClose={onClose} />
+        <div data-testid="scrollable">test</div>
+      </div>
+    );
+
+    let scrollable = res.getByTestId('scrollable');
+    fireEvent.scroll(scrollable);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should close the overlay when the body scrolls', function () {
+    let onClose = jest.fn();
+    render(<Example isOpen onClose={onClose} />);
+
+    fireEvent.scroll(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/@react-aria/overlays/test/useOverlayTrigger.test.js
+++ b/packages/@react-aria/overlays/test/useOverlayTrigger.test.js
@@ -12,18 +12,25 @@
 
 import {fireEvent, render} from '@testing-library/react';
 import React, {useRef} from 'react';
-import {useOverlayTrigger} from '../';
+import {useOverlayPosition, useOverlayTrigger} from '../';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 
 function Example(props) {
   let ref = useRef();
+  let containerRef = useRef();
+  let overlayRef = useRef();
   let state = useOverlayTriggerState(props);
   useOverlayTrigger(props, state, ref);
+  useOverlayPosition({
+    targetRef: ref,
+    containerRef,
+    overlayRef
+  });
   return <div ref={ref} data-testid={props['data-testid'] || 'test'}>{props.children}</div>;
 }
 
 describe('useOverlayTrigger', function () {
-  it('should close the overlay when the trigger scrolls', function () {
+  it('should close the overlay when the trigger scrolls with useOverlayPosition for backward compatibility', function () {
     let onOpenChange = jest.fn();
     let res = render(
       <div data-testid="scrollable">
@@ -37,7 +44,7 @@ describe('useOverlayTrigger', function () {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('should not close the overlay when an adjacent scrollable region scrolls', function () {
+  it('should not close the overlay when an adjacent scrollable region scrolls with useOverlayPosition for backward compatibility', function () {
     let onOpenChange = jest.fn();
     let res = render(
       <div>
@@ -51,7 +58,7 @@ describe('useOverlayTrigger', function () {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it('should close the overlay when the body scrolls', function () {
+  it('should close the overlay when the body scrolls  with useOverlayPosition for backward compatibility', function () {
     let onOpenChange = jest.fn();
     render(<Example isOpen onOpenChange={onOpenChange} />);
 

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -74,16 +74,16 @@ function ComboBox<T extends object>(props: SpectrumComboBoxProps<T>, ref: RefObj
     state
   );
 
+  let isMobile = useMediaQuery('(max-width: 700px)');
   let {overlayProps, placement} = useOverlayPosition({
     targetRef: unwrapDOMRef(triggerRef),
     overlayRef: unwrapDOMRef(popoverRef),
     scrollRef: listboxRef,
     placement: `${direction} end` as Placement,
     shouldFlip: shouldFlip,
-    isOpen: state.isOpen
+    isOpen: state.isOpen && !isMobile,
+    onClose: state.close
   });
-
-  let isMobile = useMediaQuery('(max-width: 700px)');
 
   let comboBoxAutoFocus;
   // Focus first/last item on menu open if focusStategy is set (done by up/down arrows)

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -43,16 +43,17 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
 
   let {menuTriggerProps, menuProps} = useMenuTrigger({}, state, menuTriggerRef);
 
+  let isMobile = useIsMobileDevice();
   let {overlayProps: positionProps, placement} = useOverlayPosition({
     targetRef: menuTriggerRef,
     overlayRef: unwrapDOMRef(menuPopoverRef),
     scrollRef: menuRef,
     placement: `${direction} ${align}` as Placement,
     shouldFlip: shouldFlip,
-    isOpen: state.isOpen
+    isOpen: state.isOpen && !isMobile,
+    onClose: state.close
   });
 
-  let isMobile = useIsMobileDevice();
   let menuContext = {
     ...menuProps,
     ref: menuRef,

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -80,6 +80,7 @@ describe('MenuTrigger', function () {
     offsetWidth = jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 1000);
     offsetHeight = jest.spyOn(window.HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(() => 1000);
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    jest.spyOn(window.screen, 'width', 'get').mockImplementation(() => 1024);
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => setTimeout(cb, 0));
     jest.useFakeTimers();
   });

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -75,13 +75,15 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     keyboardDelegate: layout
   }, state, unwrapDOMRef(triggerRef));
 
+  let isMobile = useIsMobileDevice();
   let {overlayProps, placement, updatePosition} = useOverlayPosition({
     targetRef: unwrapDOMRef(triggerRef),
     overlayRef: unwrapDOMRef(popoverRef),
     scrollRef: listboxRef,
     placement: `${direction} ${align}` as Placement,
     shouldFlip: shouldFlip,
-    isOpen: state.isOpen
+    isOpen: state.isOpen && !isMobile,
+    onClose: state.close
   });
 
   let {hoverProps, isHovered} = useHover({isDisabled});
@@ -101,7 +103,6 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   let isLoadingMore = props.isLoading && state.collection.size > 0;
 
   // On small screen devices, the listbox is rendered in a tray, otherwise a popover.
-  let isMobile = useIsMobileDevice();
   let listbox = (
     <FocusScope restoreFocus>
       <DismissButton onDismiss={() => state.close()} />

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -32,6 +32,7 @@ describe('Picker', function () {
     offsetWidth = jest.spyOn(window.HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => 1000);
     offsetHeight = jest.spyOn(window.HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(() => 1000);
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    jest.spyOn(window.screen, 'width', 'get').mockImplementation(() => 1024);
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => setTimeout(cb, 0));
     jest.useFakeTimers();
   });


### PR DESCRIPTION
Follow up from #1007.

Tapping near the bottom of the screen on an iPhone causes Safari to show its toolbar. When a tray is showing, this causes scrolling of the page to occur which makes the tray close. We want to avoid this so the user can actually tap on the item they meant to.

Unfortunately, this is currently handled in `useOverlayTrigger` rather than `useOverlayPosition`, and we'd need to pass a prop through 3+ layers to get it there. Additionally, we'd probably like it to not be the default. We'd like to move this handling into `useOverlayPosition` given that it only affects positioning, but to do that we'd need an additional `onClose` prop to be passed which would be a breaking change.

To work around this, we do move it, but keep a WeakMap of trigger DOM node to an `onClose` function. This is set in `useOverlayTrigger` and we fall back to that function in `useOverlayPosition` if no prop is passed directly. This keeps backward compatibility without requiring the user to add `onClose`, while still moving the code to `useOverlayPosition` and allowing that to disable closing on scroll by setting `isOpen` to false when in a tray.