### PR TITLE
Popover should allow isModal={false} for ComboBox

### DIFF
--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -154,7 +154,8 @@ function ComboBox<T extends object>(props: SpectrumComboBoxProps<T>, ref: RefObj
         placement={placement}
         hideArrow
         shouldCloseOnBlur
-        onClose={state.close}>
+        onClose={state.close}
+        isModal={false}>
         {listbox}
       </Popover>
     );

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -28,7 +28,8 @@ interface PopoverWrapperProps extends HTMLAttributes<HTMLElement> {
   isOpen?: boolean,
   onClose?: () => void,
   shouldCloseOnBlur?: boolean,
-  isKeyboardDismissDisabled?: boolean
+  isKeyboardDismissDisabled?: boolean,
+  isModal?: boolean
 }
 
 /**
@@ -46,7 +47,7 @@ let arrowPlacement = {
 };
 
 function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
-  let {children, placement, arrowProps, onClose, shouldCloseOnBlur, hideArrow, isKeyboardDismissDisabled, ...otherProps} = props;
+  let {children, placement, arrowProps, onClose, shouldCloseOnBlur, hideArrow, isKeyboardDismissDisabled, isModal = true, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let {styleProps} = useStyleProps(props);
 
@@ -60,7 +61,8 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
         onClose={onClose}
         shouldCloseOnBlur={shouldCloseOnBlur}
         isKeyboardDismissDisabled={isKeyboardDismissDisabled}
-        hideArrow={hideArrow}>
+        hideArrow={hideArrow}
+        isModal={isModal}>
         {children}
       </PopoverWrapper>
     </Overlay>
@@ -69,9 +71,9 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
 
 const PopoverWrapper = forwardRef((props: PopoverWrapperProps, ref: RefObject<HTMLDivElement>) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let {children, placement = 'bottom', arrowProps, isOpen, hideArrow, shouldCloseOnBlur, isKeyboardDismissDisabled, ...otherProps} = props;
+  let {children, placement = 'bottom', arrowProps, isOpen, hideArrow, shouldCloseOnBlur, isKeyboardDismissDisabled, isModal = true, ...otherProps} = props;
   let {overlayProps} = useOverlay({...props, isDismissable: true}, ref);
-  let {modalProps} = useModal();
+  let {modalProps} = isModal ? useModal() : {modalProps: {}} ;
 
   return (
     <div

--- a/packages/@react-types/overlays/src/index.d.ts
+++ b/packages/@react-types/overlays/src/index.d.ts
@@ -89,7 +89,8 @@ export interface PopoverProps extends StyleProps, OverlayProps {
   hideArrow?: boolean,
   isOpen?: boolean,
   onClose?: () => void,
-  shouldCloseOnBlur?: boolean
+  shouldCloseOnBlur?: boolean,
+  isModal?: boolean
 }
 
 export interface TrayProps extends StyleProps, OverlayProps {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
