### PR TITLE
Fix mismatch of lang and dir attributes of Provider during SSR hydration

### DIFF
--- a/packages/@react-aria/i18n/package.json
+++ b/packages/@react-aria/i18n/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@react-aria/ssr": "3.0.0-alpha.1",
     "@react-types/shared": "^3.1.0",
     "intl-messageformat": "^2.2.0"
   },

--- a/packages/@react-aria/i18n/src/useDefaultLocale.ts
+++ b/packages/@react-aria/i18n/src/useDefaultLocale.ts
@@ -13,6 +13,7 @@
 import {Direction} from '@react-types/shared';
 import {isRTL} from './utils';
 import {useEffect, useState} from 'react';
+import {useIsSSR} from '@react-aria/ssr';
 
 export interface Locale {
   /** The [BCP47](https://www.ietf.org/rfc/bcp/bcp47.txt) language code for the locale. */
@@ -46,7 +47,8 @@ function updateLocale() {
 /**
  * Returns the current browser/system language, and updates when it changes.
  */
-export function useDefaultLocale() {
+export function useDefaultLocale(): Locale {
+  let isSSR = useIsSSR();
   let [defaultLocale, setDefaultLocale] = useState(currentLocale);
 
   useEffect(() => {
@@ -63,6 +65,15 @@ export function useDefaultLocale() {
       }
     };
   }, []);
+
+  // We cannot determine the browser's language on the server, so default to
+  // en-US. This will be updated after hydration on the client to the correct value.
+  if (isSSR) {
+    return {
+      locale: 'en-US',
+      direction: 'ltr'
+    };
+  }
 
   return defaultLocale;
 }

--- a/packages/@react-spectrum/provider/test/Provider.ssr.test.js
+++ b/packages/@react-spectrum/provider/test/Provider.ssr.test.js
@@ -14,6 +14,7 @@ import {testSSR} from '@react-spectrum/test-utils';
 
 describe('Provider SSR', function () {
   it('should render without errors', async function () {
+    jest.spyOn(navigator, 'language', 'get').mockImplementation(() => 'fr');
     await testSSR(__filename, `
       import {Provider} from '../';
       import {theme} from '@react-spectrum/theme-default';


### PR DESCRIPTION
Came across this hydrating error while testing in Next.js