### PR TITLE
Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,4 +13,4 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 
 [Makefile]
-indent_style = tabs
+indent_style = tab


### PR DESCRIPTION
According to https://editorconfig.org/ the valid options for `indent_style` are "tab" and "space".