### PR TITLE
SSR docs and bugfix

### DIFF
--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@react-aria/i18n": "^3.1.0",
+    "@react-aria/ssr": "3.0.0-alpha.1",
     "@react-aria/visually-hidden": "^3.2.0",
     "@react-spectrum/actiongroup": "^3.1.0",
     "@react-spectrum/breadcrumbs": "^3.1.1",

--- a/packages/@adobe/react-spectrum/src/index.ts
+++ b/packages/@adobe/react-spectrum/src/index.ts
@@ -43,3 +43,4 @@ export {Item, Section} from '@react-stately/collections';
 export {useAsyncList, useListData, useTreeData} from '@react-stately/data';
 export {VisuallyHidden} from '@react-aria/visually-hidden';
 export {useCollator, useDateFormatter, useMessageFormatter, useNumberFormatter} from '@react-aria/i18n';
+export {SSRProvider} from '@react-aria/ssr';

--- a/packages/@react-aria/i18n/docs/internationalization.mdx
+++ b/packages/@react-aria/i18n/docs/internationalization.mdx
@@ -101,6 +101,9 @@ import {I18nProvider} from '@react-aria/i18n';
 </I18nProvider>
 ```
 
+**Note:** if you are using server side rendering, you should always specify a locale rather than relying on browser defaults
+to ensure that the server and client match. See the [SSR docs](ssr.html#locale-selection) for more information.
+
 ## Supported locales
 
 React Aria currently supports over 30 locales. They are listed below.

--- a/packages/@react-aria/ssr/docs/SSRProvider.mdx
+++ b/packages/@react-aria/ssr/docs/SSRProvider.mdx
@@ -1,0 +1,53 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-aria/ssr';
+import {HeaderInfo, PropTable} from '@react-spectrum/docs';
+import packageData from '@react-aria/ssr/package.json';
+
+```tsx import
+import {useCollator} from '@react-aria/ssr';
+```
+
+---
+category: Server Side Rendering
+keywords: [ssr, server side rendering, aria, next.js, gatsby]
+---
+
+# SSRProvider
+
+<p>{docs.exports.SSRProvider.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['SSRProvider']} />
+
+## Introduction
+
+`SSRProvider` should be used as a wrapper for the entire application during server side rendering.
+It works together with the [useId](useId.html) hook to ensure that auto generated ids are consistent
+between the client and server by resetting the id internal counter on each request.
+See the [server side rendering](ssr.html) docs for more information.
+
+## Props
+
+<PropTable component={docs.exports.SSRProvider} links={docs.links} />
+
+## Example
+
+```tsx
+import {SSRProvider} from '@react-aria/ssr';
+
+<SSRProvider>
+  <YourApp />
+</SSRProvider>
+```

--- a/packages/@react-aria/ssr/docs/useIsSSR.mdx
+++ b/packages/@react-aria/ssr/docs/useIsSSR.mdx
@@ -1,0 +1,54 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-aria/ssr';
+import {HeaderInfo, FunctionAPI} from '@react-spectrum/docs';
+import packageData from '@react-aria/ssr/package.json';
+
+---
+category: Server Side Rendering
+keywords: [ssr, server side rendering, aria, next.js, gatsby]
+---
+
+# useIsSSR
+
+<p>{docs.exports.useIsSSR.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useIsSSR']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useIsSSR} links={docs.links} />
+
+## Introduction
+
+`useIsSSR` returns `true` during server rendering and hydration, and updates to `false`
+immediately after hydration. This can be used to ensure that the server rendered HTML
+and initially hydrated DOM match, but trigger an additional render after hydration to
+run browser-specific code. For example, it could be used to run media queries or feature
+detection for browser-specific APIs that affect rendering but cannot be run server side.
+
+This hook must be used in combination with the [SSRProvider](SSRProvider.html) component
+wrapping your application. See the [server side rendering](ssr.html) docs for more information.
+
+## Example
+
+```tsx
+import {useIsSSR} from '@react-aria/ssr';
+
+function MyComponent() {
+  let isSSR = useIsSSR();
+  return <span>{isSSR ? 'Server' : 'Client'}</span>;
+}
+```

--- a/packages/@react-aria/ssr/src/SSRProvider.tsx
+++ b/packages/@react-aria/ssr/src/SSRProvider.tsx
@@ -36,21 +36,21 @@ const defaultContext: SSRContextValue = {
 const SSRContext = React.createContext<SSRContextValue>(defaultContext);
 
 interface SSRProviderProps {
+  /** Your application here. */
   children: ReactNode
 }
 
 /**
  * When using SSR with React Aria, applications must be wrapped in an SSRProvider.
- * This ensures that auto generated ids are consistent between the client and server
- * by resetting the incremented value on each request.
+ * This ensures that auto generated ids are consistent between the client and server.
  */
 export function SSRProvider(props: SSRProviderProps): JSX.Element {
   let cur = useContext(SSRContext);
-  let value: SSRContextValue = {
+  let value: SSRContextValue = useMemo(() => ({
     // If this is the first SSRProvider, set to zero, otherwise increment.
-    prefix: cur === defaultContext ? 0 : cur.prefix + 1,
+    prefix: cur === defaultContext ? 0 : ++cur.prefix,
     current: 0
-  };
+  }), [cur]);
 
   return (
     <SSRContext.Provider value={value}>
@@ -78,7 +78,11 @@ export function useSSRSafeId(defaultId?: string): string {
   return useMemo(() => defaultId || `react-aria-${ctx.prefix}-${++ctx.current}`, [defaultId]);
 }
 
-/** @private */
+/**
+ * Returns whether the component is currently being server side rendered or
+ * hydrated on the client. Can be used to delay browser-specific rendering
+ * until after hydration.
+ */
 export function useIsSSR(): boolean {
   let cur = useContext(SSRContext);
   let isInSSRContext = cur !== defaultContext;

--- a/packages/@react-aria/ssr/test/SSRProvider.test.js
+++ b/packages/@react-aria/ssr/test/SSRProvider.test.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import {render} from '@testing-library/react';
+import {SSRProvider} from '../';
+import {useId} from '@react-aria/utils';
+
+function Test() {
+  return <div data-testid="test" id={useId()} />;
+}
+
+describe('SSRProvider', function () {
+  it('it should generate consistent unique ids', function () {
+    let tree = render(
+      <SSRProvider>
+        <Test />
+        <Test />
+      </SSRProvider>
+    );
+
+    let divs = tree.getAllByTestId('test');
+    expect(divs[0].id).toBe('react-aria-0-1');
+    expect(divs[1].id).toBe('react-aria-0-2');
+  });
+
+  it('it should generate consistent unique ids with nested SSR providers', function () {
+    let tree = render(
+      <SSRProvider>
+        <SSRProvider>
+          <Test />
+        </SSRProvider>
+        <SSRProvider>
+          <Test />
+        </SSRProvider>
+      </SSRProvider>
+    );
+
+    let divs = tree.getAllByTestId('test');
+    expect(divs[0].id).toBe('react-aria-1-1');
+    expect(divs[1].id).toBe('react-aria-2-1');
+  });
+});

--- a/packages/dev/docs/pages/react-aria/ssr.mdx
+++ b/packages/dev/docs/pages/react-aria/ssr.mdx
@@ -1,0 +1,87 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+---
+category: Concepts
+keywords: [ssr, server side rendering, aria, next.js, gatsby]
+---
+
+# Server Side Rendering
+
+This page describes how to use React Aria with server side rendering, including frameworks like Next.js and Gatsby.
+
+## Introduction
+
+**Server side rendering**, or SSR, is the process of rendering components to HTML on the server, rather than rendering them only on the client. **Static rendering** is a similar approach, but pre-renders pages to HTML at build time rather than on each request. These techniques can help improve perceived loading performance and SEO. React Aria supports both of these approaches, either through a custom implementation or via frameworks like [Next.js](https://nextjs.org) and [Gatsby](https://www.gatsbyjs.com).
+
+## SSR Provider
+
+In React, SSR works by rendering the component to HTML on the server, and then **hydrating** the DOM tree with events and state on the client. This enables applications to both render complete HTML in advance for performance and SEO, but also support rich interactions on the client.
+
+In order to make components using React Aria work with SSR, you will need to wrap your application in an [SSRProvider](SSRProvider.html). This signals to all nested React Aria hooks that they are being rendered in an SSR context.
+
+```tsx
+import {SSRProvider} from '@react-aria/ssr';
+
+<SSRProvider>
+  <App />
+</SSRProvider>
+```
+
+Wrapping your application in an `SSRProvider` helps ensure that the HTML generated on the server matches the DOM structure hydrated on the client. Specifically, it affects React Aria’s automatic id generation, and you can also use this information to influence rendering in your own components.
+
+## Automatic ID Generation
+
+When using SSR, only a single copy of React Aria can be on the page at a time. This is in contrast to client-side rendering, where multiple copies from different parts of an app can coexist. Internally, many components rely on auto-generated ids to link related elements via ARIA attributes. These ids typically use a randomly generated seed plus an incrementing counter to ensure uniqueness even when multiple instances of React Aria are on the page. With SSR, we need to ensure that these ids are consistent between the server and client.  This means the counter resets on every request, and we use a consistent seed. Due to this, multiple copies of React Aria cannot be supported because the auto-generated ids would conflict.
+
+If you use React Aria’s [useId](useId.html) hook in your own components, `SSRProvider` will ensure the ids are consistent when server rendered. No additional changes in each component are required to enable
+SSR support.
+
+## SSR specific rendering
+
+You can also use the [useIsSSR](useIsSSR.html) hook in your own components to determine whether they are running in an SSR context. This hook returns `true` both during server rendering and hydration, but updates immediately to `false` after hydration. You can use this to delay browser-specific code like media queries and feature detection until after the client has hydrated.
+
+```tsx
+import {useIsSSR} from '@react-aria/ssr';
+
+function MyComponent() {
+  let isSSR = useIsSSR();
+  return <span>{isSSR ? 'Server' : 'Client'}</span>
+}
+```
+
+## Locale selection
+
+When using server side rendering, the application should be wrapped in an [I18nProvider](I18nProvider.html) with an explicit `locale` prop, rather than relying on automatic locale selection. This ensures that the locale of the content rendered on the server matches the locale expected by the browser. The `Accept-Language` HTTP header, which the browser sends to the server with the user’s desired language, could be used to implement this. You could also use an in-application setting for this if available, or locale specific URLs, for example. In addition to passing the `locale` prop to the `I18nProvider`, you should also ensure the `lang` and `dir` attributes are set on the `<html>` element for your page.
+
+```tsx
+import {SSRProvider} from '@react-aria/ssr';
+import {I18nProvider, useLocale} from '@react-aria/i18n';
+
+function App() {
+  let {locale, direction} = useLocale();
+
+  return (
+    <html lang={locale} dir={direction}>
+      {/* your app here */}
+    </html>
+  );
+}
+
+<SSRProvider>
+  <I18nProvider locale={locale}>
+    <App />
+  </I18nProvider>
+</SSRProvider>
+```
+
+See the [internationalization docs](internationalization.html) for more information about i18n in React Aria.

--- a/packages/dev/docs/pages/react-spectrum/ssr.mdx
+++ b/packages/dev/docs/pages/react-spectrum/ssr.mdx
@@ -1,0 +1,81 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+---
+category: Concepts
+keywords: [ssr, server side rendering, spectrum, next.js, gatsby]
+order: 4
+---
+
+# Server Side Rendering
+
+This page describes how to use React Spectrum with server side rendering, including frameworks like Next.js and Gatsby.
+
+## Introduction
+
+**Server side rendering**, or SSR, is the process of rendering components to HTML on the server, rather than rendering them only on the client. **Static rendering** is a similar approach, but pre-renders pages to HTML at build time rather than on each request. These techniques can help improve perceived loading performance and SEO. React Spectrum supports both of these approaches, either through a custom implementation or via frameworks like [Next.js](https://nextjs.org) and [Gatsby](https://www.gatsbyjs.com).
+
+## SSR Provider
+
+In React, SSR works by rendering the component to HTML on the server, and then **hydrating** the DOM tree with events and state on the client. This enables applications to both render complete HTML in advance for performance and SEO, but also support rich interactions on the client.
+
+In order to make React Spectrum components work with SSR, you will need to wrap your application in an [SSRProvider](../react-aria/SSRProvider.html) component. This signals to all nested React Spectrum components that they are being rendered in an SSR context.
+
+```tsx
+import {SSRProvider, Provider, defaultTheme} from '@adobe/react-spectrum';
+
+<SSRProvider>
+  <Provider theme={defaultTheme} locale={locale}>
+    <App />
+  </Provider>
+</SSRProvider>
+```
+
+Wrapping your application in an `SSRProvider` ensures that the HTML generated on the server matches the DOM structure hydrated on the client. Specifically, it affects four things: id generation for accessibility, media queries, feature detection, and automatic locale selection.
+
+When using SSR, only a single copy of React Spectrum can be on the page at a time. This is in contrast to client-side rendering, where multiple copies from different parts of an app can coexist. Internally, many components rely on auto-generated ids to link related elements via ARIA attributes. When server side rendering, these ids need to be consistent so they match between the server and client, and this would not be possible with multiple copies of React Spectrum.
+
+Media queries and DOM feature detection cannot be performed on the server because they depend on specific browser parameters that aren’t sent as part of the request. In cases where these affect the rendering of a particular component, this check is delayed until just after hydration is completed. This ensures that the rendering is consistent between the server and hydrated DOM, but updated immediately after the page becomes interactive.
+
+Finally, when using server side rendering, the `locale` prop should be set explicitly on the `Provider` rather than relying on automatic locale selection. This could be done by using the `Accept-Language` HTTP header, which the browser sends to the server with the user’s desired language. You could also use an in-application setting for this if available, or separate locale-specific URLs, for example.
+
+## Next.js
+
+[Next.js](https://nextjs.org) is a framework for building websites and web applications with React. It supports both server side rendering as well as static rendering. In addition to using an `SSRProvider`, a small amount of configuration is required to get React Spectrum’s CSS working with Next.js.
+
+First, you’ll need to install a couple Next.js plugins:
+
+```
+yarn add next-compose-plugins @zeit/next-css next-transpile-modules
+```
+
+With these installed, add the following to your `next.config.js` file. This will ensure that React Spectrum’s CSS is loaded properly by Next.js.
+
+```tsx
+const withPlugins = require('next-compose-plugins');
+const withCSS = require('@zeit/next-css');
+const withTM = require('next-transpile-modules')([
+  '@adobe/react-spectrum',
+  '@spectrum-icons/.*',
+  '@react-spectrum/.*'
+]);
+
+module.exports = withPlugins([withCSS, withTM], {
+  // Your Next.js configuration
+});
+```
+
+For an example of a working Next.js app using React Spectrum, see [this repo](https://github.com/devongovett/rsp-next).
+
+## Gatsby
+
+[Gatsby](https://www.gatsbyjs.com) is a static site generator built with React. Gatsby works out of the box with React Spectrum without any additional configuration. For an example of a working Gatsby site using React Spectrum, see [this repo](https://github.com/devongovett/rsp-gatsby).

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -225,6 +225,7 @@ const CATEGORY_ORDER = [
   '...',
   'Content',
   'Internationalization',
+  'Server Side Rendering',
   'Utilities'
 ];
 
@@ -353,7 +354,7 @@ function Nav({currentPageName, pages}) {
             <li className={sideNavStyles['spectrum-SideNav-item']}>
               <h3 className={sideNavStyles['spectrum-SideNav-heading']} id={headingId}>{key}</h3>
               <ul className={sideNavStyles['spectrum-SideNav']} aria-labelledby={headingId}>
-                {pageMap[key].sort((a, b) => a.title < b.title ? -1 : 1).map(p => <SideNavItem {...p} />)}
+                {pageMap[key].sort((a, b) => (a.order || 0) < (b.order || 0) || a.title < b.title ? -1 : 1).map(p => <SideNavItem {...p} />)}
               </ul>
             </li>
           );

--- a/packages/dev/docs/src/syntax-highlight.css
+++ b/packages/dev/docs/src/syntax-highlight.css
@@ -145,12 +145,14 @@
 }
 
 :global(.storage.type),
+:global(.storage.modifier),
 :global(.constant.color),
 :global(.support.property-value.css) {
   color: var(--hljs-keyword-color);
 }
 
-:global(.entity.function) {
+:global(.entity.function),
+:global(.support.function) {
   color: var(--hljs-function-color);
 }
 

--- a/packages/dev/parcel-optimizer-ssg/SSGOptimizer.js
+++ b/packages/dev/parcel-optimizer-ssg/SSGOptimizer.js
@@ -41,7 +41,8 @@ module.exports = new Optimizer({
           keywords: meta.keywords,
           date: meta.date,
           author: meta.author,
-          image: getImageURL(meta.image, bundleGraph, b)
+          image: getImageURL(meta.image, bundleGraph, b),
+          order: meta.order
         });
       }
     });
@@ -66,7 +67,8 @@ module.exports = new Optimizer({
           keywords: mainAsset.meta.keywords,
           date: mainAsset.meta.date,
           author: mainAsset.meta.author,
-          image: getImageURL(mainAsset.meta.image, bundleGraph, bundle)
+          image: getImageURL(mainAsset.meta.image, bundleGraph, bundle),
+          order: mainAsset.meta.order
         },
         toc: mainAsset.meta.toc,
         publicUrl: bundle.target.publicUrl

--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -125,6 +125,7 @@ module.exports = new Transformer({
     let date = '';
     let author = '';
     let image = '';
+    let order;
     const extractToc = (options) => {
       const settings = options || {};
       const depth = settings.maxDepth || 6;
@@ -177,6 +178,7 @@ module.exports = new Transformer({
           description = yamlData.description || '';
           date = yamlData.date || '';
           author = yamlData.author || '';
+          order = yamlData.order;
           if (yamlData.image) {
             image = asset.addDependency({
               moduleSpecifier: yamlData.image,
@@ -245,6 +247,7 @@ module.exports = new Transformer({
     asset.meta.date = date;
     asset.meta.author = author;
     asset.meta.image = image;
+    asset.meta.order = order;
     asset.meta.isMDX = true;
     asset.isSplittable = false;
 


### PR DESCRIPTION
Adds docs for SSR including how to use react-aria and react-spectrum with Next.js and Gatsby. Also fixes a bug I found in SSRProvider, and exports SSRProvider from the monopackage.

DO NOT MERGE until the release.