### PR TITLE
Fix tabbing out of select in react-aria example

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -353,7 +353,11 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
       // next element after the node to restore to instead.
       if ((!nextElement || !isElementInScope(nextElement, scope)) && nodeToRestore) {
         walker.currentNode = nodeToRestore;
-        nextElement = (e.shiftKey ? walker.previousNode() : walker.nextNode()) as HTMLElement;
+
+        // Skip over elements within the scope, in case the scope immediately follows the node to restore.
+        do {
+          nextElement = (e.shiftKey ? walker.previousNode() : walker.nextNode()) as HTMLElement;
+        } while (isElementInScope(nextElement, scope));
 
         e.preventDefault();
         e.stopPropagation();

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -378,6 +378,41 @@ describe('FocusScope', function () {
       fireEvent.keyDown(input1, {key: 'Tab', shiftKey: true});
       expect(document.activeElement).toBe(getByTestId('before'));
     });
+
+    it('should skip over elements within the scope when moving focus to the next element', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <button data-testid="trigger" />
+            {show &&
+              <FocusScope restoreFocus autoFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+            <input data-testid="after" />
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      trigger.focus();
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      let input3 = getByTestId('input3');
+      input3.focus();
+
+      fireEvent.keyDown(input3, {key: 'Tab'});
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
   });
 
   describe('auto focus', function () {

--- a/packages/@react-aria/select/docs/useSelect.mdx
+++ b/packages/@react-aria/select/docs/useSelect.mdx
@@ -189,7 +189,7 @@ function ListBoxPopup({state, ...otherProps}) {
 
   // Get props for the listbox
   let {listBoxProps} = useListBox({
-    autoFocus: state.focusStrategy,
+    autoFocus: state.focusStrategy || true,
     disallowEmptySelection: true
   }, state, ref);
 


### PR DESCRIPTION
Fixes an issue reported by @adamwathan on Twitter: https://twitter.com/adamwathan/status/1301546588020576256.

In the [useSelect example](https://react-spectrum.adobe.com/react-aria/useSelect.html) in the docs, tabbing out of the menu doesn't work as expected and focus stays within it. This does not occur in the React Spectrum picker because it uses a portal to place the menu at the end of the document body. The useSelect example does not do this, so the next thing after the trigger button is the menu itself, so focus is placed back inside on tab. I've fixed this by skipping over elements inside the focus scope when attempting to move to the next element, so now tabbing out of the menu moves to the next element and closes the select as expected.