### PR TITLE
fix icon size issue with inherited box sizing

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -104,6 +104,7 @@ governing permissions and limitations under the License.
 
     transition: background var(--spectrum-global-animation-duration-100) ease-out,
                 fill var(--spectrum-global-animation-duration-100) ease-out;
+    box-sizing: initial;
   }
 
 }


### PR DESCRIPTION
Closes #1042 

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/1042).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Render an Action Button with an icon on a page with this style rule applied. Verify the icon is sized correctly
```css
* {
  box-sizing: inherit;
}
```

Since this is an edge case style-only code change, what type of test would y'all like?

## 🧢 Your Project:

Adobe - Magento
