### PR TITLE
Tooltip API review and fixes

### DIFF
--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -14,7 +14,7 @@ import {FocusEvents} from '@react-types/shared';
 import {HoverProps, isFocusVisible, PressProps, usePress} from '@react-aria/interactions';
 import {HTMLAttributes, RefObject, useEffect, useRef} from 'react';
 import {mergeProps, useId} from '@react-aria/utils';
-import {TooltipTriggerAriaProps} from '@react-types/tooltip';
+import {TooltipTriggerProps} from '@react-types/tooltip';
 import {TooltipTriggerState} from '@react-stately/tooltip';
 import {useFocusable} from '@react-aria/focus';
 import {useHover} from '@react-aria/interactions';
@@ -24,7 +24,7 @@ interface TooltipTriggerAria {
   tooltipProps: HTMLAttributes<HTMLElement>
 }
 
-export function useTooltipTrigger(props: TooltipTriggerAriaProps, state: TooltipTriggerState, ref: RefObject<HTMLElement>) : TooltipTriggerAria {
+export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTriggerState, ref: RefObject<HTMLElement>) : TooltipTriggerAria {
   let {
     isDisabled
   } = props;

--- a/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
+++ b/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
@@ -25,6 +25,7 @@ import React from 'react';
 import SettingsIcon from '@spectrum-icons/workflow/Settings';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
+import {Tooltip, TooltipTrigger} from '@react-spectrum/tooltip';
 import ViewCardIcon from '@spectrum-icons/workflow/ViewCard';
 import ViewGridIcon from '@spectrum-icons/workflow/ViewGrid';
 import ViewListIcon from '@spectrum-icons/workflow/ViewList';
@@ -203,6 +204,10 @@ storiesOf('ActionGroup', module)
         {item => <Item key={item.name} textValue={item.name}>{item.children}</Item>}
       </ActionGroup>
     )
+  )
+  .add(
+    'with tooltips',
+    () => renderTooltips({})
   );
 
 
@@ -256,6 +261,26 @@ function renderIcons(props, items: any = docItems) {
             <Item key={itemProps.name} textValue={itemProps.name} aria-label={itemProps.children}>
               <IconElement />
             </Item>
+          );
+        })
+      }
+    </ActionGroup>
+  );
+}
+
+function renderTooltips(props, items: any = docItems) {
+  return (
+    <ActionGroup selectionMode="single" onSelectionChange={s => onSelectionChange([...s])} {...props}>
+      {
+        items.map((itemProps) => {
+          let IconElement = iconMap[itemProps.children];
+          return (
+            <TooltipTrigger>
+              <Item key={itemProps.name} textValue={itemProps.children} aria-label={itemProps.children}>
+                <IconElement />
+              </Item>
+              <Tooltip>{itemProps.children}</Tooltip>
+            </TooltipTrigger>
           );
         })
       }

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -18,6 +18,7 @@ import {Item} from '@react-stately/collections';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import {theme} from '@react-spectrum/theme-default';
+import {Tooltip, TooltipTrigger} from '@react-spectrum/tooltip';
 import {triggerPress} from '@react-spectrum/test-utils';
 import userEvent from '@testing-library/user-event';
 import V2Button from '@react/react-spectrum/Button';
@@ -603,5 +604,29 @@ describe('ActionGroup', function () {
 
     let dialog = tree.getByRole('dialog');
     expect(dialog).toBeVisible();
+  });
+
+  it('supports TooltipTrigger as a wrapper around items', function () {
+    let tree = render(
+      <Provider theme={theme}>
+        <ActionGroup>
+          <TooltipTrigger>
+            <Item>Hi</Item>
+            <Tooltip>
+              I'm a tooltip
+            </Tooltip>
+          </TooltipTrigger>
+        </ActionGroup>
+      </Provider>
+    );
+
+    let button = tree.getByRole('button');
+    fireEvent.keyDown(document.body, {key: 'Tab'});
+    fireEvent.keyUp(document.body, {key: 'Tab'});
+    act(() => button.focus());
+
+    let tooltip = tree.getByRole('tooltip');
+    expect(tooltip).toBeVisible();
+    expect(button).toHaveAttribute('aria-describedby', tooltip.id);
   });
 });

--- a/packages/@react-spectrum/tooltip/src/Tooltip.tsx
+++ b/packages/@react-spectrum/tooltip/src/Tooltip.tsx
@@ -11,39 +11,40 @@
  */
 
 import AlertSmall from '@spectrum-icons/ui/AlertSmall';
-import {classNames, useStyleProps} from '@react-spectrum/utils';
+import {classNames, createDOMRef, useStyleProps} from '@react-spectrum/utils';
+import {DOMRef} from '@react-types/shared';
 import InfoSmall from '@spectrum-icons/ui/InfoSmall';
 import {mergeProps} from '@react-aria/utils';
-import React, {RefObject, useRef} from 'react';
+import React, {useContext, useImperativeHandle, useRef} from 'react';
 import {SpectrumTooltipProps} from '@react-types/tooltip';
 import styles from '@adobe/spectrum-css-temp/components/tooltip/vars.css';
 import SuccessSmall from '@spectrum-icons/ui/SuccessSmall';
+import {TooltipContext} from './context';
 import {useTooltip} from '@react-aria/tooltip';
-import {useTooltipProvider} from './TooltipTrigger';
 
 let iconMap = {
-  neutral: '',
   info: InfoSmall,
   positive: SuccessSmall,
   negative: AlertSmall
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function Tooltip(props: SpectrumTooltipProps, ref: RefObject<HTMLDivElement>) {
+function Tooltip(props: SpectrumTooltipProps, ref: DOMRef) {
+  let {ref: overlayRef, arrowProps, ...tooltipProviderProps} = useContext(TooltipContext);
   let defaultRef = useRef();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ref = ref || defaultRef; // need to figure out how to merge?
-  let {ref: overlayRef, ...tooltipProviderProps} = useTooltipProvider();
+  overlayRef = overlayRef || defaultRef;
   props = mergeProps(props, tooltipProviderProps);
   let {
     variant = 'neutral',
-    placement = 'right',
+    placement = 'top',
     isOpen,
     showIcon,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
   let {tooltipProps} = useTooltip(props);
+
+  // Sync ref with overlayRef from context.
+  useImperativeHandle(ref, () => createDOMRef(overlayRef));
 
   let Icon = iconMap[variant];
 
@@ -68,11 +69,10 @@ function Tooltip(props: SpectrumTooltipProps, ref: RefObject<HTMLDivElement>) {
           {props.children}
         </span>
       )}
-      <span className={classNames(styles, 'spectrum-Tooltip-tip')} />
+      <span {...arrowProps} className={classNames(styles, 'spectrum-Tooltip-tip')} />
     </div>
   );
 }
-
 
 /**
  * Display container for Tooltip content. Has a directional arrow dependent on its placement.

--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -10,30 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import {DOMRef, StyleProps} from '@react-types/shared';
 import {FocusableProvider} from '@react-aria/focus';
 import {Overlay} from '@react-spectrum/overlays';
-import {PlacementAxis} from '@react-types/overlays';
-import React, {RefObject, useContext, useRef} from 'react';
-import {TooltipTriggerProps} from '@react-types/tooltip';
-import {useDOMRef} from '@react-spectrum/utils';
+import React, {ReactElement, useRef} from 'react';
+import {SpectrumTooltipTriggerProps} from '@react-types/tooltip';
+import {TooltipContext} from './context';
 import {useOverlayPosition} from '@react-aria/overlays';
 import {useTooltipTrigger} from '@react-aria/tooltip';
 import {useTooltipTriggerState} from '@react-stately/tooltip';
 
-interface TooltipContextProps extends StyleProps {
-  ref?: RefObject<HTMLDivElement>,
-  placement?: PlacementAxis,
-  isOpen?: boolean
-}
-
-const TooltipContext = React.createContext<TooltipContextProps>({});
-
-export function useTooltipProvider(): TooltipContextProps {
-  return useContext(TooltipContext) || {};
-}
-
-function TooltipTrigger(props: TooltipTriggerProps, ref: DOMRef<HTMLElement>) {
+function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
   let {
     children,
     isDisabled
@@ -43,17 +29,15 @@ function TooltipTrigger(props: TooltipTriggerProps, ref: DOMRef<HTMLElement>) {
 
   let state = useTooltipTriggerState(props);
 
-  let domRef = useDOMRef(ref);
-  let triggerRef = useRef<HTMLElement>();
-  let tooltipTriggerRef = domRef || triggerRef;
+  let tooltipTriggerRef = useRef<HTMLElement>();
   let overlayRef = useRef<HTMLDivElement>();
 
   let {triggerProps, tooltipProps} = useTooltipTrigger({
     isDisabled
   }, state, tooltipTriggerRef);
 
-  let {overlayProps, placement} = useOverlayPosition({
-    placement: props.placement || 'right',
+  let {overlayProps, arrowProps, placement} = useOverlayPosition({
+    placement: props.placement || 'top',
     targetRef: tooltipTriggerRef,
     overlayRef,
     isOpen: state.isOpen
@@ -69,6 +53,7 @@ function TooltipTrigger(props: TooltipTriggerProps, ref: DOMRef<HTMLElement>) {
           placement,
           ref: overlayRef,
           UNSAFE_style: overlayProps.style,
+          arrowProps,
           ...tooltipProps
         }}>
         <Overlay isOpen={state.isOpen}>
@@ -79,8 +64,25 @@ function TooltipTrigger(props: TooltipTriggerProps, ref: DOMRef<HTMLElement>) {
   );
 }
 
+// Support TooltipTrigger inside components using CollectionBuilder.
+TooltipTrigger.getCollectionNode = function* (props: SpectrumTooltipTriggerProps) {
+  let [trigger, tooltip] = React.Children.toArray(props.children) as [ReactElement, ReactElement];
+  yield {
+    element: trigger,
+    wrapper: (element) => (
+      <TooltipTrigger key={element.key} {...props}>
+        {element}
+        {tooltip}
+      </TooltipTrigger>
+    )
+  };
+};
+
 /**
- * Display container for Tooltip content. Has a directional arrow dependent on its placement.
+ * TooltipTrigger wraps around a trigger element and a Tooltip. It handles opening and closing
+ * the Tooltip when the user hovers over or focuses the trigger, and positioning the Tooltip
+ * relative to the trigger.
  */
-let _TooltipTrigger = React.forwardRef(TooltipTrigger);
+// We don't want getCollectionNode to show up in the type definition
+let _TooltipTrigger = TooltipTrigger as (props: SpectrumTooltipTriggerProps) => JSX.Element;
 export {_TooltipTrigger as TooltipTrigger};

--- a/packages/@react-spectrum/tooltip/src/context.ts
+++ b/packages/@react-spectrum/tooltip/src/context.ts
@@ -10,20 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaTooltipProps} from '@react-types/tooltip';
-import {filterDOMProps, mergeProps} from '@react-aria/utils';
-import {HTMLAttributes} from 'react';
+import {PlacementAxis} from '@react-types/overlays';
+import React, {HTMLAttributes, RefObject} from 'react';
+import {StyleProps} from '@react-types/shared';
 
-interface TooltipAria {
-  tooltipProps: HTMLAttributes<HTMLElement>
+interface TooltipContextProps extends StyleProps {
+  ref?: RefObject<HTMLDivElement>,
+  placement?: PlacementAxis,
+  arrowProps?: HTMLAttributes<HTMLElement>
 }
 
-export function useTooltip(props: AriaTooltipProps): TooltipAria {
-  let domProps = filterDOMProps(props, {labelable: true});
-
-  return {
-    tooltipProps: mergeProps(domProps, {
-      role: 'tooltip'
-    })
-  };
-}
+export const TooltipContext = React.createContext<TooltipContextProps>({});

--- a/packages/@react-spectrum/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/@react-spectrum/tooltip/stories/Tooltip.stories.tsx
@@ -24,6 +24,10 @@ storiesOf('Tooltip', module)
     () => render('This is a tooltip.', {placement: 'left'})
   )
   .add(
+    'placement: right',
+    () => render('This is a tooltip.', {placement: 'right'})
+  )
+  .add(
     'placement: top',
     () => render('This is a tooltip.', {placement: 'top'})
   )

--- a/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
+++ b/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
@@ -27,6 +27,10 @@ storiesOf('TooltipTrigger', module)
     () => render({placement: 'left'})
   )
   .add(
+    'placement: right',
+    () => render({placement: 'right'})
+  )
+  .add(
     'placement: start',
     () => render({placement: 'start'})
   )
@@ -61,6 +65,19 @@ storiesOf('TooltipTrigger', module)
   .add(
     'trigger disabled',
     () => renderDisabledTrigger()
+  )
+  .add(
+    'arrow positioning at edge',
+    () => (
+      <div style={{width: '100%'}}>
+        <TooltipTrigger onOpenChange={action('openChange')}>
+          <ActionButton>Trigger Tooltip</ActionButton>
+          <Tooltip>
+            Long tooltip message that just goes on and on.
+          </Tooltip>
+        </TooltipTrigger>
+      </div>
+    )
   );
 
 function render(props = {}) {

--- a/packages/@react-spectrum/tooltip/test/Tooltip.test.js
+++ b/packages/@react-spectrum/tooltip/test/Tooltip.test.js
@@ -13,15 +13,31 @@
 import React from 'react';
 import {render} from '@testing-library/react';
 import {Tooltip} from '../';
-import V2Tooltip from '@react/react-spectrum/Tooltip';
 
 describe('Tooltip', function () {
-  it.each`
-  Name           | Component
-  ${'Tooltip'}   | ${Tooltip}
-  ${'V2Tooltip'} | ${V2Tooltip}
-  `('$Name supports children', ({Component}) => {
-    let {getByText} = render(<Component>This is a tooltip</Component>);
-    expect(getByText('This is a tooltip')).toBeTruthy();
+  it('supports children', () => {
+    let {getByRole} = render(<Tooltip>This is a tooltip</Tooltip>);
+    let tooltip = getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('role', 'tooltip');
+    expect(tooltip).toHaveTextContent('This is a tooltip');
+  });
+
+  it('supports aria-label', () => {
+    let {getByRole} = render(<Tooltip aria-label="Tooltip" />);
+    let tooltip = getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('aria-label', 'Tooltip');
+  });
+
+  it('supports aria-labelledby', () => {
+    let {getByRole} = render(<Tooltip aria-labelledby="test" />);
+    let tooltip = getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('aria-labelledby', 'test');
+  });
+
+  it('supports a ref', () => {
+    let ref = React.createRef();
+    let {getByRole} = render(<Tooltip ref={ref}>This is a tooltip</Tooltip>);
+    let tooltip = getByRole('tooltip');
+    expect(ref.current.UNSAFE_getDOMNode()).toBe(tooltip);
   });
 });

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -16,7 +16,10 @@ import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import {theme} from '@react-spectrum/theme-default';
 import {Tooltip, TooltipTrigger} from '../';
-import {TOOLTIP_COOLDOWN, TOOLTIP_DELAY} from '@react-stately/tooltip';
+
+// Sync with useTooltipTriggerState.ts
+const TOOLTIP_DELAY = 1500;
+const TOOLTIP_COOLDOWN = 500;
 
 let CLOSE_TIME = 350;
 
@@ -567,6 +570,26 @@ describe('TooltipTrigger', function () {
       expect(() => getByText(helpfulText)).toThrow();
       fireEvent.mouseLeave(badButton);
     });
+  });
+
+  it('supports a ref on the Tooltip', () => {
+    let ref = React.createRef();
+    let {getByRole} = render(
+      <Provider theme={theme}>
+        <TooltipTrigger>
+          <ActionButton>Trigger</ActionButton>
+          <Tooltip ref={ref}>Helpful information.</Tooltip>
+        </TooltipTrigger>
+      </Provider>
+    );
+
+    let button = getByRole('button');
+    act(() => {
+      button.focus();
+    });
+
+    let tooltip = getByRole('tooltip');
+    expect(ref.current.UNSAFE_getDOMNode()).toBe(tooltip);
   });
 
   describe('overlay properties', () => {

--- a/packages/@react-stately/tooltip/package.json
+++ b/packages/@react-stately/tooltip/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@react-aria/utils": "^3.2.0",
     "@react-stately/overlays": "^3.1.0",
     "@react-stately/utils": "^3.1.0",
     "@react-types/tooltip": "3.0.0-alpha.0"

--- a/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
+++ b/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
@@ -11,14 +11,11 @@
  */
 
 import {TooltipTriggerProps} from '@react-types/tooltip';
-import {useEffect} from 'react';
-import {useId} from '@react-aria/utils';
+import {useEffect, useMemo} from 'react';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 
-export const TOOLTIP_DELAY = 1500; // this seems to be a 1.5 second delay, check with design
-export const TOOLTIP_COOLDOWN = 500;
-
-interface TooltipTriggerStateProps extends TooltipTriggerProps {}
+const TOOLTIP_DELAY = 1500; // this seems to be a 1.5 second delay, check with design
+const TOOLTIP_COOLDOWN = 500;
 
 export interface TooltipTriggerState {
   isOpen: boolean,
@@ -27,16 +24,15 @@ export interface TooltipTriggerState {
 }
 
 let tooltips = {};
+let tooltipId = 0;
 let globalWarmedUp = false;
 let globalWarmUpTimeout = null;
 let globalCooldownTimeout = null;
 
-
-export function useTooltipTriggerState(props: TooltipTriggerStateProps): TooltipTriggerState {
+export function useTooltipTriggerState(props: TooltipTriggerProps): TooltipTriggerState {
   let {delay = TOOLTIP_DELAY} = props;
   let {isOpen, open, close} = useOverlayTriggerState(props);
-  // this is a unique id for the tooltips in the map, it's not a dom id
-  let id = useId();
+  let id = useMemo(() => `${++tooltipId}`, []);
 
   let ensureTooltipEntry = () => {
     tooltips[id] = hideTooltip;

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -11,20 +11,21 @@
  */
 
 import {AriaLabelingProps, DOMProps, StyleProps} from '@react-types/shared';
-import {HTMLAttributes, ReactElement, ReactNode} from 'react';
-import {PositionProps} from '@react-types/overlays';
+import {OverlayTriggerProps, PositionProps} from '@react-types/overlays';
+import {ReactElement, ReactNode} from 'react';
 
-export interface TooltipTriggerProps extends PositionProps {
-  children: ReactElement[],
+export interface TooltipTriggerProps extends OverlayTriggerProps {
   isDisabled?: boolean,
-  onOpenChange?: (isOpen: boolean) => void,
   delay?: number
 }
 
-export interface TooltipProps extends DOMProps {
+export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, PositionProps {
+  children: [ReactElement, ReactElement]
+}
+
+export interface TooltipProps {
   children: ReactNode,
-  isOpen?: boolean,
-  role?: 'tooltip'
+  isOpen?: boolean
 }
 
 export interface AriaTooltipProps extends TooltipProps, DOMProps, AriaLabelingProps {}
@@ -33,10 +34,4 @@ export interface SpectrumTooltipProps extends AriaTooltipProps, StyleProps {
   variant?: 'neutral' | 'positive' | 'negative' | 'info',
   placement?: 'start' | 'end' | 'right' | 'left' | 'top' | 'bottom',
   showIcon?: boolean
-}
-
-export interface TriggerProps extends DOMProps, HTMLAttributes<HTMLElement> {}
-
-export interface TooltipTriggerAriaProps {
-  isDisabled: boolean
 }


### PR DESCRIPTION
Fixes a few things I found while reviewing the Tooltip API:

* Remove `role` prop from Tooltip since it only allows one value anyway.
* Remove unnecessary `useId` from Tooltip since the id comes from TooltipTrigger.
* Support aria labeling in Tooltip.
* Change default placement to `top` to match Spectrum.
* Support passing a DOMRef `ref` to Tooltip and sync with ref from TooltipTrigger context.
* Remove forward ref from TooltipTrigger to match DialogTrigger. Ref can be added to Tooltip directly.
* Don't export `useTooltipProvider` from package.
* Don't export `TOOLTIP_DELAY` and `TOOLTIP_COOLDOWN` from package.
* Don't depend on aria package in stately.
* Separate spectrum props from aria/stately tooltip trigger props.
* Support for TooltipTriggers wrapping Item in ActionGroup and other collections. Closes #1034.
* Use `arrowProps` from `useOverlayPosition` to fix positioning of tip when near the edge of the window. Closes #1033.