### PR TITLE
Removing the storybook 'note' that explained a browser preference issue

### DIFF
--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -83,13 +83,11 @@ storiesOf('Button', module)
   )
   .add(
     'element: a, href: \'//example.com\', target: \'_self\'',
-    () => render({elementType: 'a', href: '//example.com', target: '_self', variant: 'primary'}),
-    {note: 'Known browser behavior where button won\'t get keyboard focus in Safari.'}
+    () => render({elementType: 'a', href: '//example.com', target: '_self', variant: 'primary'})
   )
   .add(
     'element: a, rel: \'noopener noreferrer\'',
-    () => render({elementType: 'a', href: '//example.com', rel: 'noopener noreferrer', variant: 'primary'}),
-    {note: 'Known browser behavior where button won\'t get keyboard focus in Safari.'}
+    () => render({elementType: 'a', href: '//example.com', rel: 'noopener noreferrer', variant: 'primary'})
   );
 
 function render(props: any = {}) {


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Removed "note" from last two button stories.

## 🧢 Your Project:

RSP