### PR TITLE
Adds support for pointer events to `useDrag1D`

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/splitview/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/splitview/index.css
@@ -43,6 +43,7 @@ governing permissions and limitations under the License.
   width: var(--spectrum-rail-gripper-width);
   height: var(--spectrum-rail-gripper-height);
   border-width: var(--spectrum-rail-gripper-border-width-vertical) var(--spectrum-rail-gripper-border-width-horizontal);
+  touch-action: none;
 }
 
 .spectrum-SplitView-splitter {
@@ -51,6 +52,7 @@ governing permissions and limitations under the License.
 
   /* Prevent text selection while dragging */
   user-select: none;
+  touch-action: none;
 
   width: var(--spectrum-rail-handle-width);
   height: 100%;

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -56,7 +56,7 @@ export function useSlider(
   // It is set onMouseDown; see trackProps below.
   const realTimeTrackDraggingIndex = useRef<number | undefined>(undefined);
   const isTrackDragging = useRef(false);
-  const {onMouseDown, onMouseEnter, onMouseOut} = useDrag1D({
+  const draggableProps = useDrag1D({
     containerRef: trackRef as any,
     reverse: false,
     orientation: 'horizontal',
@@ -82,6 +82,7 @@ export function useSlider(
     }
   });
 
+  let downHandlerName = draggableProps.onMouseDown ? 'onMouseDown' : 'onPointerDown';
   return {
     labelProps,
 
@@ -93,7 +94,7 @@ export function useSlider(
       ...fieldProps
     },
     trackProps: mergeProps({
-      onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
+      [ downHandlerName ]: (e: { clientX: number, clientY: number, preventDefault: () => void }) => {
         // We only trigger track-dragging if the user clicks on the track itself.
         if (trackRef.current && isSliderEditable) {
           // Find the closest thumb
@@ -118,7 +119,7 @@ export function useSlider(
             // is updated while you're still holding the mouse button down.  And we
             // set dragging on now, so that onChangeEnd() won't fire yet when we set
             // the value.  Dragging state will be reset to false in onDrag above, even
-            // if no dragging actually occurs.
+            // if no dragging actually occurs.  
             state.setThumbDragging(realTimeTrackDraggingIndex.current, true);
             state.setThumbValue(index, value);
           } else {
@@ -127,7 +128,7 @@ export function useSlider(
         }
       }
     }, {
-      onMouseDown, onMouseEnter, onMouseOut
+      ...draggableProps
     })
   };
 }

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -113,11 +113,7 @@ export function useSliderThumb(
         state.setThumbValue(index, parseFloat(e.target.value));
       }
     }),
-    thumbProps: isEditable ? mergeProps({
-      onMouseDown: draggableProps.onMouseDown,
-      onMouseEnter: draggableProps.onMouseEnter,
-      onMouseOut: draggableProps.onMouseOut
-    }, {
+    thumbProps: isEditable ? mergeProps(draggableProps, {
       onMouseDown: focusInput
     }) : {},
     labelProps

--- a/packages/@react-aria/slider/stories/story-slider.css
+++ b/packages/@react-aria/slider/stories/story-slider.css
@@ -27,6 +27,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  touch-action: none;
 }
 
 .thumbHandle {

--- a/packages/@react-aria/slider/test/PointerEventFake.js
+++ b/packages/@react-aria/slider/test/PointerEventFake.js
@@ -1,0 +1,17 @@
+/*
+  This exists because  JSDOM's PointerEvent doesn't work right.
+  see: https://github.com/jsdom/jsdom/pull/2666.
+  and https://github.com/testing-library/dom-testing-library/issues/558.
+*/
+
+const pointerEventCtorProps = ['clientX', 'clientY', 'pointerType'];
+export default class PointerEventFake extends Event {
+  constructor(type, props = {}) {
+    super(type, props);
+    pointerEventCtorProps.forEach((prop) => {
+      if (props[prop] != null) {
+        this[prop] = props[prop];
+      }
+    });
+  }
+}

--- a/packages/@react-aria/splitview/src/useSplitView.ts
+++ b/packages/@react-aria/splitview/src/useSplitView.ts
@@ -10,10 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {chain} from '@react-aria/utils';
 import {HTMLAttributes, useEffect, useRef} from 'react';
+import {mergeProps, useDrag1D} from '@react-aria/utils';
 import {SplitViewAriaProps, SplitViewState} from '@react-types/shared';
-import {useDrag1D} from '@react-aria/utils';
 import {useId} from '@react-aria/utils';
 
 interface AriaSplitViewProps {
@@ -80,11 +79,12 @@ export function useSplitView(props: SplitViewAriaProps, state: SplitViewState): 
   let ariaValueMax = 100;
   let ariaValueNow = (handleState.offset - containerState.minPos) / (containerState.maxPos - containerState.minPos) * 100 | 0;
 
-  let onMouseDown = allowsResizing ? chain(draggableProps.onMouseDown, propsOnMouseDown) : undefined;
-  let onMouseEnter = allowsResizing ? draggableProps.onMouseEnter : undefined;
-  let onMouseOut = allowsResizing ? draggableProps.onMouseOut : undefined;
-  let onKeyDown = allowsResizing ? draggableProps.onKeyDown : undefined;
   let tabIndex = allowsResizing ? 0 : undefined;
+  let mergedDraggableProps = {};
+  if (allowsResizing) {
+    const downHandlerName = draggableProps.onMouseDown ? 'onMouseDown' : 'onPointerDown';
+    mergedDraggableProps = mergeProps(draggableProps, {[downHandlerName]: propsOnMouseDown});
+  }
 
   return {
     containerProps: {
@@ -99,10 +99,7 @@ export function useSplitView(props: SplitViewAriaProps, state: SplitViewState): 
       'aria-labelledby': props['aria-labelledby'],
       role: 'separator',
       'aria-controls': id,
-      onMouseDown,
-      onMouseEnter,
-      onMouseOut,
-      onKeyDown
+      ...mergedDraggableProps
     },
     primaryPaneProps: {
       id

--- a/packages/@react-spectrum/splitview/test/SplitView.test.js
+++ b/packages/@react-spectrum/splitview/test/SplitView.test.js
@@ -15,6 +15,20 @@ import React from 'react';
 import {SplitView} from '../';
 import V2SplitView from '@react/react-spectrum/SplitView';
 
+// workaround for: https://github.com/testing-library/react-testing-library/issues/783
+const origPointerEnter = fireEvent.pointerEnter;
+const origPointerLeave = fireEvent.pointerLeave;
+fireEvent.pointerEnter = (...args) => {
+  fireEvent.pointerOver(...args);
+  origPointerEnter(...args);
+};
+
+fireEvent.pointerLeave = (...args) => {
+  fireEvent.pointerOver(...args);
+  origPointerLeave(...args);
+};
+
+
 describe('SplitView tests', function () {
   // Stub offsetWidth/offsetHeight so we can calculate min/max sizes correctly
   let stub1, stub2;
@@ -516,6 +530,534 @@ describe('SplitView tests', function () {
     fireEvent.mouseDown(splitSeparator, {clientX: props.primarySize, clientY: 20, button: 0});
     fireEvent.mouseMove(splitSeparator, {clientX: props.primarySize + 5, clientY: 20});
     fireEvent.mouseUp(splitSeparator, {clientX: props.primarySize + 5, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', `width: ${props.primarySize}px;`);
+    expect(onResizeSpy).toHaveBeenCalledWith(props.primarySize + 5);
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '50');
+  });
+});
+
+describe('SplitView tests using PointerEvents', function () {
+
+  // PointerEvents are not natively supported by JSDOM currently, you have to bring your own Event Implementation.
+  const pointerEventCtorProps = ['clientX', 'clientY', 'pointerType'];
+  class PointerEventFake extends Event {
+    constructor(type, props = {}) {
+      super(type, props);
+      pointerEventCtorProps.forEach((prop) => {
+        if (props[prop] != null) {
+          this[prop] = props[prop];
+        }
+      });
+    }
+  }
+  let origPointerEvent;
+  // Stub offsetWidth/offsetHeight so we can calculate min/max sizes correctly
+  let stub1, stub2;
+  beforeAll(function () {
+    origPointerEvent = window.PointerEvent;
+    window.PointerEvent = PointerEventFake;
+ 
+    stub1 = jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 1000);
+    stub2 = jest.spyOn(window.HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(() => 1000);
+  });
+
+  afterAll(function () {
+    delete window.PointerEvent;
+    if (origPointerEvent) {
+      window.PointerEvent = origPointerEvent;
+    }
+    stub1.mockReset();
+    stub2.mockReset();
+  });
+
+  afterEach(function () {
+    document.body.style.cursor = null;
+  });
+
+  it.each`
+    Name             | Component      | props
+    ${'SplitView'}   | ${SplitView}   | ${{UNSAFE_className: 'splitview'}}
+    ${'V2SplitView'} | ${V2SplitView} | ${{className: 'splitview'}}
+  `('$Name handles defaults', async function ({Component, props}) {
+    let onResizeSpy = jest.fn();
+    let onResizeEndSpy = jest.fn();
+    let {getByRole} = render(
+      <Component {...props} onResize={onResizeSpy} onResizeEnd={onResizeEndSpy} UNSAFE_style={{width: '100%'}}>
+        <div>Left</div>
+        <div>Right</div>
+      </Component>
+    );
+
+    let splitview = document.querySelector('.splitview');
+    splitview.getBoundingClientRect = jest.fn(() => ({left: 0, right: 1000}));
+    let splitSeparator = getByRole('separator');
+    let primaryPane = splitview.childNodes[0];
+    expect(splitview.childNodes[1]).toEqual(splitSeparator);
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    let id = primaryPane.getAttribute('id');
+    expect(splitSeparator).toHaveAttribute('aria-controls', id);
+    expect(splitSeparator).toHaveAttribute('tabindex', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemin', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemax', '100');
+    expect(onResizeSpy).not.toHaveBeenCalled();
+    expect(onResizeEndSpy).not.toHaveBeenCalled();
+
+    let clientY = 20; // arbitrary
+    // move pointer over to 310 and verify that the size changed to 310
+    fireEvent.pointerEnter(splitSeparator, {clientX: 304, clientY});
+    fireEvent.pointerMove(splitSeparator, {clientX: 304, clientY});
+    expect(document.body.style.cursor).toBe('e-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 304, clientY, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 307, clientY}); // extra move so cursor change flushes
+    expect(onResizeSpy).toHaveBeenLastCalledWith(307);
+    fireEvent.pointerMove(splitSeparator, {clientX: 310, clientY});
+    expect(onResizeSpy).toHaveBeenLastCalledWith(310);
+    expect(document.body.style.cursor).toBe('ew-resize');
+    fireEvent.pointerUp(splitSeparator, {clientX: 310, clientY, button: 0});
+    expect(onResizeEndSpy).toHaveBeenLastCalledWith(310);
+    expect(primaryPane).toHaveAttribute('style', 'width: 310px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '1');
+
+    // move pointer to the far end so that it maxes out 1000px - secondaryMin(304px) = 696px
+    // visual state: primary is maxed out, secondary is at minimum, pointer is beyond the container width
+    fireEvent.pointerEnter(splitSeparator, {clientX: 310, clientY});
+    fireEvent.pointerMove(splitSeparator, {clientX: 310, clientY});
+    expect(document.body.style.cursor).toBe('ew-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 310, clientY, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 1001, clientY});
+    expect(onResizeSpy).toHaveBeenLastCalledWith(696);
+    fireEvent.pointerUp(splitSeparator, {clientX: 1001, clientY, button: 0});
+    expect(onResizeEndSpy).toHaveBeenLastCalledWith(696);
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // move pointer so we shrink to the far left for minimum, non-collapisble = 304px;
+    // visual state: primary is at minimum size, secondary is maxed out, pointer is to the left of the split by a lot
+    fireEvent.pointerEnter(splitSeparator, {clientX: 696, clientY});
+    fireEvent.pointerMove(splitSeparator, {clientX: 696, clientY});
+    expect(document.body.style.cursor).toBe('w-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 696, clientY, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 0, clientY});
+    expect(onResizeSpy).toHaveBeenLastCalledWith(304);
+    fireEvent.pointerUp(splitSeparator, {clientX: 0, clientY, button: 0});
+    expect(onResizeEndSpy).toHaveBeenLastCalledWith(304);
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate right 304px + 10px = 314px
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(onResizeSpy).toHaveBeenLastCalledWith(314);
+    expect(onResizeEndSpy).toHaveBeenLastCalledWith(314);
+    expect(primaryPane).toHaveAttribute('style', 'width: 314px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '2');
+
+    // use keyboard to navigate left 314px - 10px = 304px
+    fireEvent.keyDown(splitSeparator, {key: 'Left'});
+    expect(onResizeSpy).toHaveBeenLastCalledWith(304);
+    expect(onResizeEndSpy).toHaveBeenLastCalledWith(304);
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Left'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate left a second time should do nothing
+    let countResizeEndCall = onResizeEndSpy.mock.calls.length;
+    fireEvent.keyDown(splitSeparator, {key: 'Left'});
+    expect(onResizeEndSpy.mock.calls.length).toBe(countResizeEndCall);
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Left'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate up shouldn't move
+    fireEvent.keyDown(splitSeparator, {key: 'Up'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Up'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate down shouldn't move
+    fireEvent.keyDown(splitSeparator, {key: 'Down'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Down'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate End should maximize the primary view -> 696px
+    fireEvent.keyDown(splitSeparator, {key: 'End'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'End'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate right at max size should do nothing
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate Home should minimize the primary view -> 304px
+    fireEvent.keyDown(splitSeparator, {key: 'Home'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Home'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate Enter should do nothing because default does not allow collapsings
+    fireEvent.keyDown(splitSeparator, {key: 'Enter'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Enter'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate right 304px + 10px = 314px and then use Enter, should do nothing
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 314px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    fireEvent.keyDown(splitSeparator, {key: 'Enter'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 314px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Enter'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '2');
+  });
+
+  it.each`
+    Name             | Component      | props
+    ${'SplitView'}   | ${SplitView}   | ${{UNSAFE_className: 'splitview'}}
+    ${'V2SplitView'} | ${V2SplitView} | ${{className: 'splitview'}}
+  `('$Name handles primaryPane being second', function ({Component, props}) {
+    let {getByRole} = render(
+      <Component {...props} primaryPane={1} UNSAFE_style={{width: '100%'}}>
+        <div>Left</div>
+        <div>Right</div>
+      </Component>
+    );
+
+    let splitview = document.querySelector('.splitview');
+    splitview.getBoundingClientRect = jest.fn(() => ({left: 0, right: 1000}));
+    let splitSeparator = getByRole('separator');
+    let primaryPane = splitview.childNodes[2];
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    let id = primaryPane.getAttribute('id');
+    expect(splitSeparator).toHaveAttribute('aria-controls', id);
+    expect(splitSeparator).toHaveAttribute('tabindex', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemin', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemax', '100');
+    expect(document.body.style.cursor).toBe('');
+
+    // primary as second means pointer needs to go to 696px to get the handle
+    // move pointer over to 670 and verify that the size changed to 1000px - 670px = 330px
+    fireEvent.pointerEnter(splitSeparator, {clientX: 696, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 696, clientY: 20});
+    expect(document.body.style.cursor).toBe('w-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 696, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 680, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 670, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 670, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 330px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '6');
+
+    // move pointer to the far end so that it maxes out 1000px - secondaryMin(304px) = 696px
+    fireEvent.pointerEnter(splitSeparator, {clientX: 670, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 670, clientY: 20});
+    expect(document.body.style.cursor).toBe('ew-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 670, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 0, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 0, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate right 696px - 10px = 686px
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 686px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '97');
+
+    // use keyboard to navigate left 686px + 10px = 696px
+    fireEvent.keyDown(splitSeparator, {key: 'Left'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Left'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate Home should minimize the primary view -> 304px
+    fireEvent.keyDown(splitSeparator, {key: 'Home'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Home'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate right at min size should do nothing
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate End should maximize the primary view -> 696px
+    fireEvent.keyDown(splitSeparator, {key: 'End'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'End'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate left at max size should do nothing
+    fireEvent.keyDown(splitSeparator, {key: 'Left'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Left'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+  });
+
+
+  it.each`
+    Name             | Component      | props
+    ${'SplitView'}   | ${SplitView}   | ${{allowsCollapsing: true, UNSAFE_className: 'splitview'}}
+    ${'V2SplitView'} | ${V2SplitView} | ${{collapsible: true, className: 'splitview'}}
+  `('$Name handles allowsCollapsing', function ({Component, props}) {
+    let {getByRole} = render(
+      <Component {...props} UNSAFE_style={{width: '100%'}}>
+        <div>Left</div>
+        <div>Right</div>
+      </Component>
+    );
+
+    let splitview = document.querySelector('.splitview');
+    splitview.getBoundingClientRect = jest.fn(() => ({left: 0, right: 1000}));
+    let splitSeparator = getByRole('separator');
+    let primaryPane = splitview.childNodes[0];
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    let id = primaryPane.getAttribute('id');
+    expect(splitSeparator).toHaveAttribute('aria-controls', id);
+    expect(splitSeparator).toHaveAttribute('tabindex', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemin', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemax', '100');
+    expect(document.body.style.cursor).toBe('');
+
+    // move pointer over to 310 and verify that the size changed
+    fireEvent.pointerEnter(splitSeparator, {clientX: 304, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 304, clientY: 20});
+    expect(document.body.style.cursor).toBe('e-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 304, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 310, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 310, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 310px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '1');
+
+    // move pointer to the far end so that it maxes out 1000px - secondaryMin(304px) = 696px
+    fireEvent.pointerEnter(splitSeparator, {clientX: 310, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 310, clientY: 20});
+    expect(document.body.style.cursor).toBe('ew-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 310, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 1001, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 1001, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // move pointer so we shrink to the collapse point 304px - 50px threshold - 1px = 253px
+    fireEvent.pointerEnter(splitSeparator, {clientX: 696, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 696, clientY: 20});
+    expect(document.body.style.cursor).toBe('w-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 696, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 253, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 253, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 0px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '-77');
+
+    // move pointer so we recover from the collapsing
+    fireEvent.pointerEnter(splitSeparator, {clientX: 0, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 0, clientY: 20});
+    expect(document.body.style.cursor).toBe('e-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 0, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 254, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 254, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate right 304px + 10px = 314px
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 314px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '2');
+
+    // use keyboard to navigate left 314px - 10px = 304px
+    fireEvent.keyDown(splitSeparator, {key: 'Left'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Left'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate left a second time should do nothing
+    fireEvent.keyDown(splitSeparator, {key: 'Left'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Left'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate up shouldn't move
+    fireEvent.keyDown(splitSeparator, {key: 'Up'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Up'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate down shouldn't move
+    fireEvent.keyDown(splitSeparator, {key: 'Down'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Down'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+
+    // use keyboard to navigate End should maximize the primary view -> 696px
+    fireEvent.keyDown(splitSeparator, {key: 'End'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'End'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate right at max should do nothing
+    fireEvent.keyDown(splitSeparator, {key: 'Right'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Right'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // use keyboard to navigate Home should minimize the primary view, b/c of allows collapsing -> 0px
+    fireEvent.keyDown(splitSeparator, {key: 'Home'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 0px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Home'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '-77');
+
+    // reset us to max size -> 696px
+    fireEvent.keyDown(splitSeparator, {key: 'End'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'End'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // collapse us with Enter
+    fireEvent.keyDown(splitSeparator, {key: 'Enter'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 0px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Enter'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '-77');
+
+    // use keyboard to navigate Right should restore it to the last size
+    fireEvent.keyDown(splitSeparator, {key: 'Enter'});
+    expect(primaryPane).toHaveAttribute('style', 'width: 696px;');
+    fireEvent.keyUp(splitSeparator, {key: 'Enter'});
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it.each`
+    Name             | Component      | props
+    ${'SplitView'}   | ${SplitView}   | ${{UNSAFE_className: 'splitview'}}
+    ${'V2SplitView'} | ${V2SplitView} | ${{className: 'splitview'}}
+  `('$Name should render a vertical split view', function ({Component, props}) {
+    let {getByRole} = render(
+      <Component {...props} orientation="vertical">
+        <div>Left</div>
+        <div>Right</div>
+      </Component>
+    );
+
+    let splitview = document.querySelector('.splitview');
+    splitview.getBoundingClientRect = jest.fn(() => ({top: 0, bottom: 1000}));
+    let splitSeparator = getByRole('separator');
+    let primaryPane = splitview.childNodes[0];
+    expect(primaryPane).toHaveAttribute('style', 'height: 304px;');
+    let id = primaryPane.getAttribute('id');
+    expect(splitSeparator).toHaveAttribute('aria-controls', id);
+    expect(splitSeparator).toHaveAttribute('tabindex', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemin', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemax', '100');
+
+    // move pointer over to 310 and verify that the size changed
+    fireEvent.pointerEnter(splitSeparator, {clientX: 20, clientY: 304});
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 304});
+    expect(document.body.style.cursor).toBe('s-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 20, clientY: 304, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 307}); // extra move so cursor change flushes
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 310});
+    expect(document.body.style.cursor).toBe('ns-resize');
+    fireEvent.pointerUp(splitSeparator, {clientX: 20, clientY: 310, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'height: 310px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '1');
+
+    // move pointer to the far end so that it maxes out 1000px - secondaryMin(304px) = 696px
+    fireEvent.pointerEnter(splitSeparator, {clientX: 20, clientY: 310});
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 310});
+    expect(document.body.style.cursor).toBe('ns-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 20, clientY: 310, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 1001});
+    fireEvent.pointerUp(splitSeparator, {clientX: 20, clientY: 1001, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'height: 696px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '100');
+
+    // move pointer so we shrink to the far left for minimum, non-collapisble = 304px;
+    fireEvent.pointerEnter(splitSeparator, {clientX: 20, clientY: 696});
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 696});
+    expect(document.body.style.cursor).toBe('n-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: 20, clientY: 696, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 20, clientY: 0});
+    fireEvent.pointerUp(splitSeparator, {clientX: 20, clientY: 0, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'height: 304px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+  });
+
+
+  it.each`
+    Name             | Component      | props
+    ${'SplitView'}   | ${SplitView}   | ${{allowsResizing: false, UNSAFE_className: 'splitview'}}
+    ${'V2SplitView'} | ${V2SplitView} | ${{resizable: false, className: 'splitview'}}
+  `('$Name can be non-resizable', async function ({Component, props}) {
+    let {getByRole} = render(
+      <Component {...props} UNSAFE_style={{width: '100%'}}>
+        <div>Left</div>
+        <div>Right</div>
+      </Component>
+    );
+
+    let splitview = document.querySelector('.splitview');
+    splitview.getBoundingClientRect = jest.fn(() => ({left: 0, right: 1000}));
+    let splitSeparator = getByRole('separator');
+    let primaryPane = splitview.childNodes[0];
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    let id = primaryPane.getAttribute('id');
+    expect(splitSeparator).toHaveAttribute('aria-controls', id);
+    expect(splitSeparator).not.toHaveAttribute('tabindex');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemin', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemax', '100');
+
+    // move pointer over to 310 and verify that the size changed
+    fireEvent.pointerEnter(splitSeparator, {clientX: 304, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: 304, clientY: 20});
+    expect(document.body.style.cursor).toBe('');
+    fireEvent.pointerDown(splitSeparator, {clientX: 304, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: 307, clientY: 20}); // extra move so cursor change flushes
+    fireEvent.pointerMove(splitSeparator, {clientX: 310, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: 310, clientY: 20, button: 0});
+    expect(primaryPane).toHaveAttribute('style', 'width: 304px;');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  // V2 version doesn't have this capability, firstly limited by onpointerDown `if (this.props.primarySize !== undefined) {`
+  it.each`
+    Name             | Component      | props
+    ${'SplitView'}   | ${SplitView}   | ${{primarySize: 500, UNSAFE_className: 'splitview'}}
+  `('$Name can have its size controlled', async function ({Component, props}) {
+    let onResizeSpy = jest.fn();
+    let {getByRole} = render(
+      <Component {...props} onResize={onResizeSpy} UNSAFE_style={{width: '100%'}}>
+        <div>Left</div>
+        <div>Right</div>
+      </Component>
+    );
+
+    let splitview = document.querySelector('.splitview');
+    splitview.getBoundingClientRect = jest.fn(() => ({left: 0, right: 1000}));
+    let splitSeparator = getByRole('separator');
+    let primaryPane = splitview.childNodes[0];
+    expect(primaryPane).toHaveAttribute('style', `width: ${props.primarySize}px;`);
+    let id = primaryPane.getAttribute('id');
+    expect(splitSeparator).toHaveAttribute('aria-controls', id);
+    expect(splitSeparator).toHaveAttribute('tabindex', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuenow', '50');
+    expect(splitSeparator).toHaveAttribute('aria-valuemin', '0');
+    expect(splitSeparator).toHaveAttribute('aria-valuemax', '100');
+
+    // move pointer over to 505 and verify that the size didn't change
+    fireEvent.pointerEnter(splitSeparator, {clientX: props.primarySize, clientY: 20});
+    fireEvent.pointerMove(splitSeparator, {clientX: props.primarySize, clientY: 20});
+    expect(document.body.style.cursor).toBe('ew-resize');
+    fireEvent.pointerDown(splitSeparator, {clientX: props.primarySize, clientY: 20, button: 0});
+    fireEvent.pointerMove(splitSeparator, {clientX: props.primarySize + 5, clientY: 20});
+    fireEvent.pointerUp(splitSeparator, {clientX: props.primarySize + 5, clientY: 20, button: 0});
     expect(primaryPane).toHaveAttribute('style', `width: ${props.primarySize}px;`);
     expect(onResizeSpy).toHaveBeenCalledWith(props.primarySize + 5);
     expect(splitSeparator).toHaveAttribute('aria-valuenow', '50');


### PR DESCRIPTION
Closes #1063 

This adds support with feature detection for `PointerEvents` to the existing `useDrag1D`, without altering its declared API.
In reality, several places were making use of items passed back in the output of `useDrag1D` in a way that was probably not intended in the API, by limiting the returned properties in order to do things like event chaining.  I fixed all the places that were doing this to be compatible with my changes, and added tests that cover all existing uses of useDrag1D to use pointerEvents as well as mouseEvents.  I also added the `touch-events: none` CSS declaration to draggable elements so that they can be dragged using PointerEvents without triggering things like scrolling.

Worth noting: 
JSDOM doesn't support PointerEvents currently, as it is missing the event type for `PointerEvent` on the window object.  I added my own (rather poor) polyfill in order to support testing of PointerEvents via JSDOM/jest.  It should be removed if/when JSDOM adds support for PointerEvents (see: https://github.com/jsdom/jsdom/pull/2666).

Also, I had to work around a testing-library bug with PointerEvents as well:
The workaround is pretty harmless (see line 18 in SplitView.test.js.  That workaround can be removed when https://github.com/testing-library/react-testing-library/issues/783 is fixed and we've upgraded to that version of testing-library.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Manual testing steps:
Modern desktop browser: 
Visit the storybook for Slider and Split view.
The Slider and Split view should work the same as they did before this change, you are able to drag the draggable elements.

Modern mobile browser:
Visit the storybook for Slider and Split view.  It should be possible to drag the draggable elements, before this change it was not.

Legacy browser that doesn't support PointerEvents (Safari 12 or IE 10):
Visit the storybook for Slider and Split view.  It should work as it did before this change, as it still uses mouse events.

## 🧢 Your Project:

Not for any particular project, just because I was interested.
