### PR TITLE
feat(switch): export prop interface from hook

### DIFF
--- a/packages/@react-aria/switch/src/useSwitch.ts
+++ b/packages/@react-aria/switch/src/useSwitch.ts
@@ -15,6 +15,8 @@ import {InputHTMLAttributes, RefObject} from 'react';
 import {ToggleState} from '@react-stately/toggle';
 import {useToggle} from '@react-aria/toggle';
 
+export {AriaSwitchProps} from '@react-types/switch';
+
 export interface SwitchAria {
   /** Props for the input element. */
   inputProps: InputHTMLAttributes<HTMLInputElement>


### PR DESCRIPTION
Closes N/A

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Not sure if this is something you want to do, but to me it seems practical for `@react-aria/switch` to export the type of its arguments. Might not fit into what you wanna do? Feel free to close this if you don't want it 🙂 

And thank you so much for this project, it's awesome!

## 🧢 Your Project:

<!--- Company/project for pull request -->
