### PR TITLE
Implement table headerless column

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -161,7 +161,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Table-cell--hideHeader {
-  padding: 0 2px;
+   padding: 0;
+  justify-content: center;
 }
 
 .spectrum-Table--wrap .spectrum-Table-cellContents {

--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -160,6 +160,15 @@ governing permissions and limitations under the License.
   margin: 0 -4px;
 }
 
+.react-spectrum-Table-cell--hideHeader {
+  padding: 0;
+}
+
+.react-spectrum-Table-cellContents--hideHeader {
+  margin: 0;
+  padding: 0;
+}
+
 .spectrum-Table--wrap .spectrum-Table-cellContents {
   white-space: normal;
 }

--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -160,11 +160,11 @@ governing permissions and limitations under the License.
   margin: 0 -4px;
 }
 
-.react-spectrum-Table-cell--hideHeader {
+.spectrum-Table-cell--hideHeader {
   padding: 0;
 }
 
-.react-spectrum-Table-cellContents--hideHeader {
+.spectrum-Table-cellContents--hideHeader {
   margin: 0;
   padding: 0;
 }

--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -156,17 +156,12 @@ governing permissions and limitations under the License.
   text-overflow: ellipsis;
 
   /* allow focus ring of child to extend outside the bounds */
-  padding: 0 4px;
-  margin: 0 -4px;
+  padding: 4px;
+  margin: -4px;
 }
 
 .spectrum-Table-cell--hideHeader {
-  padding: 0;
-}
-
-.spectrum-Table-cellContents--hideHeader {
-  margin: 0;
-  padding: 0;
+  padding: 0 2px;
 }
 
 .spectrum-Table--wrap .spectrum-Table-cellContents {

--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -161,7 +161,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Table-cell--hideHeader {
-   padding: 0;
+  padding: 0;
   justify-content: center;
 }
 

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -15,9 +15,10 @@ import {HTMLAttributes, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {Node} from '@react-types/shared';
 import {TableState} from '@react-stately/table';
+import {useFocusable} from '@react-aria/focus';
 import {usePress} from '@react-aria/interactions';
 import {useTableCell} from './useTableCell';
-import { useFocusable } from '@react-aria/focus';
+
 
 interface ColumnHeaderProps {
   node: Node<unknown>,
@@ -41,7 +42,7 @@ export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableSt
     }
   });
 
-  let { focusableProps } = useFocusable({}, ref);
+  let {focusableProps} = useFocusable({}, ref);
   let ariaSort: HTMLAttributes<HTMLElement>['aria-sort'] = null;
   if (node.props.allowsSorting) {
     ariaSort = state.sortDescriptor?.column === node.key ? state.sortDescriptor.direction : 'none';

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -42,6 +42,7 @@ export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableSt
     }
   });
 
+  // Needed to pick up the focusable context, enabling things like Tooltips for example
   let {focusableProps} = useFocusable({}, ref);
   let ariaSort: HTMLAttributes<HTMLElement>['aria-sort'] = null;
   if (node.props.allowsSorting) {

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -17,6 +17,7 @@ import {Node} from '@react-types/shared';
 import {TableState} from '@react-stately/table';
 import {usePress} from '@react-aria/interactions';
 import {useTableCell} from './useTableCell';
+import { useFocusable } from '@react-aria/focus';
 
 interface ColumnHeaderProps {
   node: Node<unknown>,
@@ -30,7 +31,7 @@ interface ColumnHeaderAria {
 }
 
 export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableState<T>): ColumnHeaderAria {
-  let {node, colspan} = props;
+  let {node, colspan, ref} = props;
   let {gridCellProps} = useTableCell(props, state);
 
   let {pressProps} = usePress({
@@ -40,6 +41,7 @@ export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableSt
     }
   });
 
+  let { focusableProps } = useFocusable({}, ref);
   let ariaSort: HTMLAttributes<HTMLElement>['aria-sort'] = null;
   if (node.props.allowsSorting) {
     ariaSort = state.sortDescriptor?.column === node.key ? state.sortDescriptor.direction : 'none';
@@ -47,7 +49,7 @@ export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableSt
 
   return {
     columnHeaderProps: {
-      ...mergeProps(gridCellProps, pressProps),
+      ...mergeProps(gridCellProps, pressProps, focusableProps),
       role: 'columnheader',
       id: getColumnHeaderId(state, node.key),
       'aria-colspan': colspan && colspan > 1 ? colspan : null,

--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -132,7 +132,7 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
 
   return {
     triggerProps: {
-      'aria-describedby': state.open ? tooltipId : undefined,
+      'aria-describedby': state.isOpen ? tooltipId : undefined,
       ...mergeProps(focusableProps, hoverProps, pressProps)
     },
     tooltipProps: {

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -40,7 +40,7 @@
     "@react-aria/virtualizer": "^3.2.0",
     "@react-spectrum/checkbox": "^3.2.1",
     "@react-spectrum/progress": "^3.1.1",
-    "@react-spectrum/tooltip": "3.0.0",
+    "@react-spectrum/tooltip": "^3.0.0",
     "@react-spectrum/utils": "^3.3.0",
     "@react-stately/collections": "^3.2.1",
     "@react-stately/layout": "^3.1.2",

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -38,6 +38,7 @@
     "@react-aria/table": "3.0.0-alpha.7",
     "@react-aria/utils": "^3.3.0",
     "@react-aria/virtualizer": "^3.2.0",
+    "@react-aria/visually-hidden": "^3.2.1",
     "@react-spectrum/checkbox": "^3.2.1",
     "@react-spectrum/progress": "^3.1.1",
     "@react-spectrum/tooltip": "^3.0.0",

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -40,6 +40,7 @@
     "@react-aria/virtualizer": "^3.2.0",
     "@react-spectrum/checkbox": "^3.2.1",
     "@react-spectrum/progress": "^3.1.1",
+    "@react-spectrum/tooltip": "3.0.0",
     "@react-spectrum/utils": "^3.3.0",
     "@react-stately/collections": "^3.2.1",
     "@react-stately/layout": "^3.1.2",

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -89,8 +89,8 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
     estimatedHeadingHeight: props.overflowMode === 'wrap'
       ? DEFAULT_HEADER_HEIGHT[scale]
       : null,
-    getDefaultWidth: ({width, hideHeader, isSelectionCell}) => {
-      if (isNaN(width) && hideHeader) {
+    getDefaultWidth: ({hideHeader, isSelectionCell}) => {
+      if (hideHeader) {
         return  DEFAULT_HIDE_HEADER_CELL_WIDTH[scale];
       } else if (isSelectionCell) {
         return SELECTION_CELL_DEFAULT_WIDTH;
@@ -409,7 +409,7 @@ function TableColumnHeader({column}) {
             )
           )
         }>
-        {!columnProps?.hideHeader && column.rendered}
+        {!columnProps.hideHeader && column.rendered}
         {columnProps.allowsSorting &&
           <ArrowDownSmall UNSAFE_className={classNames(styles, 'spectrum-Table-sortedIcon')} />
         }

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -396,15 +396,15 @@ function TableColumnHeader({column}) {
               'is-sortable': columnProps.allowsSorting,
               'is-sorted-desc': state.sortDescriptor?.column === column.key && state.sortDescriptor?.direction === 'descending',
               'is-sorted-asc': state.sortDescriptor?.column === column.key && state.sortDescriptor?.direction === 'ascending',
-              'is-hovered': isHovered
+              'is-hovered': isHovered,
+              'spectrum-Table-cell--hideHeader': columnProps.hideHeader
             },
             classNames(
               stylesOverrides,
               'react-spectrum-Table-cell',
               {
                 'react-spectrum-Table-cell--alignCenter': columnProps.align === 'center' || column.colspan > 1,
-                'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end',
-                'react-spectrum-Table-cell--hideHeader': columnProps.hideHeader
+                'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end'
               }
             )
           )
@@ -607,7 +607,7 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
             'spectrum-Table-cell',
             {
               'spectrum-Table-cell--divider': columnProps.showDivider,
-              'react-spectrum-Table-cell--hideHeader': columnProps.hideHeader
+              'spectrum-Table-cell--hideHeader': columnProps.hideHeader
             },
             classNames(
               stylesOverrides,
@@ -625,7 +625,7 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
               styles,
               'spectrum-Table-cellContents',
               {
-                'react-spectrum-Table-cellContents--hideHeader': columnProps.hideHeader
+                'spectrum-Table-cellContents--hideHeader': columnProps.hideHeader
               }
             )
         }>

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -606,15 +606,15 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
             styles,
             'spectrum-Table-cell',
             {
-              'spectrum-Table-cell--divider': columnProps.showDivider
+              'spectrum-Table-cell--divider': columnProps.showDivider,
+              'react-spectrum-Table-cell--hideHeader': columnProps.hideHeader
             },
             classNames(
               stylesOverrides,
               'react-spectrum-Table-cell',
               {
                 'react-spectrum-Table-cell--alignCenter': columnProps.align === 'center',
-                'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end',
-                'react-spectrum-Table-cell--hideHeader': columnProps.hideHeader
+                'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end'
               }
             )
           )
@@ -624,12 +624,9 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
             classNames(
               styles,
               'spectrum-Table-cellContents',
-              classNames(
-                stylesOverrides,
-                {
-                  'react-spectrum-Table-cellContents--hideHeader': columnProps.hideHeader
-                }
-              )
+              {
+                'react-spectrum-Table-cellContents--hideHeader': columnProps.hideHeader
+              }
             )
         }>
           {cell.rendered}

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -58,6 +58,8 @@ const ROW_HEIGHTS = {
   }
 };
 
+const SELECTION_CELL_DEFAULT_WIDTH = 55;
+
 const TableContext = React.createContext<TableState<unknown>>(null);
 function useTableContext() {
   return useContext(TableContext);
@@ -87,7 +89,15 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
     estimatedHeadingHeight: props.overflowMode === 'wrap'
       ? DEFAULT_HEADER_HEIGHT[scale]
       : null,
-    defaultHideHeaderCellWidth: DEFAULT_HIDE_HEADER_CELL_WIDTH[scale] || null
+    getDefaultWidth: ({defaultWidth, width, hideHeader, isSelectionCell}) => {
+      if (!width && hideHeader) {
+        return  DEFAULT_HIDE_HEADER_CELL_WIDTH[scale] || null;
+      }
+      if (isSelectionCell) {
+        return SELECTION_CELL_DEFAULT_WIDTH;
+      }
+      return defaultWidth;
+    }
   }), [props.overflowMode, scale, density]);
   let {direction} = useLocale();
   layout.collection = state.collection;

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -39,8 +39,8 @@ const DEFAULT_HEADER_HEIGHT = {
 };
 
 const DEFAULT_HIDE_HEADER_CELL_WIDTH = {
-  medium: 35,
-  large: 43
+  medium: 38,
+  large: 46
 };
 
 const ROW_HEIGHTS = {
@@ -89,9 +89,10 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
     estimatedHeadingHeight: props.overflowMode === 'wrap'
       ? DEFAULT_HEADER_HEIGHT[scale]
       : null,
-    getDefaultWidth: ({hideHeader, isSelectionCell}) => {
+    getDefaultWidth: ({hideHeader, isSelectionCell, showDivider}) => {
       if (hideHeader) {
-        return  DEFAULT_HIDE_HEADER_CELL_WIDTH[scale];
+        let width = DEFAULT_HIDE_HEADER_CELL_WIDTH[scale];
+        return showDivider ? width + 1 : width;
       } else if (isSelectionCell) {
         return SELECTION_CELL_DEFAULT_WIDTH;
       }
@@ -623,10 +624,7 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
           className={
             classNames(
               styles,
-              'spectrum-Table-cellContents',
-              {
-                'spectrum-Table-cellContents--hideHeader': columnProps.hideHeader
-              }
+              'spectrum-Table-cellContents'
             )
         }>
           {cell.rendered}

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -39,8 +39,8 @@ const DEFAULT_HEADER_HEIGHT = {
 };
 
 const DEFAULT_HIDE_HEADER_CELL_WIDTH = {
-  medium: 34,
-  large: 42
+  medium: 35,
+  large: 43
 };
 
 const ROW_HEIGHTS = {

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -38,9 +38,9 @@ const DEFAULT_HEADER_HEIGHT = {
   large: 40
 };
 
-const DEFAULT_NO_HEADER_CELL_WIDTH = {
-  medium: 39,
-  large: 45
+const DEFAULT_HIDE_HEADER_CELL_WIDTH = {
+  medium: 34,
+  large: 42
 };
 
 const ROW_HEIGHTS = {
@@ -87,7 +87,7 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
     estimatedHeadingHeight: props.overflowMode === 'wrap'
       ? DEFAULT_HEADER_HEIGHT[scale]
       : null,
-    defaultNoheaderCellWidth: DEFAULT_NO_HEADER_CELL_WIDTH[scale] || null
+    defaultHideHeaderCellWidth: DEFAULT_HIDE_HEADER_CELL_WIDTH[scale] || null
   }), [props.overflowMode, scale, density]);
   let {direction} = useLocale();
   layout.collection = state.collection;
@@ -201,9 +201,9 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
           return <TableSelectAllCell column={item} />;
         }
 
-        if (item.props.noHeader) {
+        if (item.props.hideHeader) {
           return (
-            <TooltipTrigger delay={0} placement="top" offset={-15}>
+            <TooltipTrigger placement="top">
               <TableColumnHeader column={item} />
               <Tooltip placement="top">{item.rendered}</Tooltip>
             </TooltipTrigger>
@@ -396,12 +396,12 @@ function TableColumnHeader({column}) {
               {
                 'react-spectrum-Table-cell--alignCenter': columnProps.align === 'center' || column.colspan > 1,
                 'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end',
-                'react-spectrum-Table-cell--noHeader': columnProps.noHeader
+                'react-spectrum-Table-cell--hideHeader': columnProps.hideHeader
               }
             )
           )
         }>
-        {!columnProps?.noHeader && column.rendered}
+        {!columnProps?.hideHeader && column.rendered}
         {columnProps.allowsSorting &&
           <ArrowDownSmall UNSAFE_className={classNames(styles, 'spectrum-Table-sortedIcon')} />
         }
@@ -606,12 +606,12 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
               {
                 'react-spectrum-Table-cell--alignCenter': columnProps.align === 'center',
                 'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end',
-                'react-spectrum-Table-cell--noHeader': columnProps.noHeader
+                'react-spectrum-Table-cell--hideHeader': columnProps.hideHeader
               }
             )
           )
         }>
-        <span className={classNames(styles, 'spectrum-Table-cellContents')}>
+        <span className={classNames(styles, 'spectrum-Table-cellContents', classNames(stylesOverrides, {'react-spectrum-Table-cellContents--hideHeader':columnProps.hideHeader}))}>
           {cell.rendered}
         </span>
       </div>

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -32,6 +32,7 @@ import {useHover} from '@react-aria/interactions';
 import {useLocale, useMessageFormatter} from '@react-aria/i18n';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
 import {useTable, useTableCell, useTableColumnHeader, useTableRow, useTableRowGroup, useTableRowHeader, useTableSelectAllCheckbox, useTableSelectionCheckbox} from '@react-aria/table';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 const DEFAULT_HEADER_HEIGHT = {
   medium: 34,
@@ -410,7 +411,10 @@ function TableColumnHeader({column}) {
             )
           )
         }>
-        {!columnProps.hideHeader && column.rendered}
+        {columnProps.hideHeader ?
+          <VisuallyHidden>{column.rendered}</VisuallyHidden> :
+          column.rendered
+        }
         {columnProps.allowsSorting &&
           <ArrowDownSmall UNSAFE_className={classNames(styles, 'spectrum-Table-sortedIcon')} />
         }

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -203,7 +203,7 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
 
         if (item.props.noHeader) {
           return (
-            <TooltipTrigger delay={0} placement="top">
+            <TooltipTrigger delay={0} placement="top" offset={-15}>
               <TableColumnHeader column={item} />
               <Tooltip placement="top">{item.rendered}</Tooltip>
             </TooltipTrigger>

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -611,7 +611,19 @@ function TableCellBase({cell, cellRef, ...otherProps}) {
             )
           )
         }>
-        <span className={classNames(styles, 'spectrum-Table-cellContents', classNames(stylesOverrides, {'react-spectrum-Table-cellContents--hideHeader':columnProps.hideHeader}))}>
+        <span
+          className={
+            classNames(
+              styles,
+              'spectrum-Table-cellContents',
+              classNames(
+                stylesOverrides,
+                {
+                  'react-spectrum-Table-cellContents--hideHeader': columnProps.hideHeader
+                }
+              )
+            )
+        }>
           {cell.rendered}
         </span>
       </div>

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -89,14 +89,12 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
     estimatedHeadingHeight: props.overflowMode === 'wrap'
       ? DEFAULT_HEADER_HEIGHT[scale]
       : null,
-    getDefaultWidth: ({defaultWidth, width, hideHeader, isSelectionCell}) => {
-      if (!width && hideHeader) {
-        return  DEFAULT_HIDE_HEADER_CELL_WIDTH[scale] || null;
-      }
-      if (isSelectionCell) {
+    getDefaultWidth: ({width, hideHeader, isSelectionCell}) => {
+      if (isNaN(width) && hideHeader) {
+        return  DEFAULT_HIDE_HEADER_CELL_WIDTH[scale];
+      } else if (isSelectionCell) {
         return SELECTION_CELL_DEFAULT_WIDTH;
       }
-      return defaultWidth;
     }
   }), [props.overflowMode, scale, density]);
   let {direction} = useLocale();

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -15,24 +15,23 @@ import {Checkbox} from '@react-spectrum/checkbox';
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import {FocusRing, useFocusRing} from '@react-aria/focus';
-import {ActionButton} from '@react-spectrum/button';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {layoutInfoToStyle, ScrollView, setScrollLeft, useVirtualizer, VirtualizerItem} from '@react-aria/virtualizer';
 import {mergeProps} from '@react-aria/utils';
 import {ProgressCircle} from '@react-spectrum/progress';
-import {TooltipTrigger, Tooltip} from '@react-spectrum/tooltip';
 import React, {ReactElement, useCallback, useContext, useMemo, useRef} from 'react';
 import {Rect, ReusableView, useVirtualizerState} from '@react-stately/virtualizer';
 import {SpectrumColumnProps, SpectrumTableProps, TableNode} from '@react-types/table';
+import styles from '@adobe/spectrum-css-temp/components/table/vars.css';
+import stylesOverrides from './table.css';
 import {TableLayout} from '@react-stately/layout';
 import {TableState, useTableState} from '@react-stately/table';
+import {Tooltip, TooltipTrigger} from '@react-spectrum/tooltip';
 import {useHover} from '@react-aria/interactions';
 import {useLocale, useMessageFormatter} from '@react-aria/i18n';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
 import {useTable, useTableCell, useTableColumnHeader, useTableRow, useTableRowGroup, useTableRowHeader, useTableSelectAllCheckbox, useTableSelectionCheckbox} from '@react-aria/table';
-import styles from '@adobe/spectrum-css-temp/components/table/vars.css';
-import stylesOverrides from './table.css';
 
 const DEFAULT_HEADER_HEIGHT = {
   medium: 34,
@@ -88,7 +87,7 @@ function Table<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLD
     estimatedHeadingHeight: props.overflowMode === 'wrap'
       ? DEFAULT_HEADER_HEIGHT[scale]
       : null,
-    defaultNoheaderCellWidth: DEFAULT_NO_HEADER_CELL_WIDTH[scale] || null,
+    defaultNoheaderCellWidth: DEFAULT_NO_HEADER_CELL_WIDTH[scale] || null
   }), [props.overflowMode, scale, density]);
   let {direction} = useLocale();
   layout.collection = state.collection;
@@ -397,7 +396,7 @@ function TableColumnHeader({column}) {
               {
                 'react-spectrum-Table-cell--alignCenter': columnProps.align === 'center' || column.colspan > 1,
                 'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end',
-                'react-spectrum-Table-cell--noHeader': columnProps.noHeader,
+                'react-spectrum-Table-cell--noHeader': columnProps.noHeader
               }
             )
           )

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -40,8 +40,8 @@ const DEFAULT_HEADER_HEIGHT = {
 };
 
 const DEFAULT_HIDE_HEADER_CELL_WIDTH = {
-  medium: 38,
-  large: 46
+  medium: 36,
+  large: 44
 };
 
 const ROW_HEIGHTS = {

--- a/packages/@react-spectrum/table/src/table.css
+++ b/packages/@react-spectrum/table/src/table.css
@@ -40,7 +40,10 @@
   height: 100%;
 }
 
-.react-spectrum-Table-cell--noHeader {
-  margin: 0;
-  padding: 0 2px;
+.react-spectrum-Table-cell--hideHeader {
+  padding: 0;
+}
+
+.react-spectrum-Table-cellContents--hideHeader {
+  text-overflow: clip;
 }

--- a/packages/@react-spectrum/table/src/table.css
+++ b/packages/@react-spectrum/table/src/table.css
@@ -39,3 +39,8 @@
   width: 100%;
   height: 100%;
 }
+
+.react-spectrum-Table-cell--noHeader {
+  margin: 0;
+  padding: 0 2px;
+}

--- a/packages/@react-spectrum/table/src/table.css
+++ b/packages/@react-spectrum/table/src/table.css
@@ -45,5 +45,6 @@
 }
 
 .react-spectrum-Table-cellContents--hideHeader {
-  text-overflow: clip;
+  margin: 0;
+  padding: 0;
 }

--- a/packages/@react-spectrum/table/src/table.css
+++ b/packages/@react-spectrum/table/src/table.css
@@ -39,12 +39,3 @@
   width: 100%;
   height: 100%;
 }
-
-.react-spectrum-Table-cell--hideHeader {
-  padding: 0;
-}
-
-.react-spectrum-Table-cellContents--hideHeader {
-  margin: 0;
-  padding: 0;
-}

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -12,9 +12,11 @@
 
 import {action} from '@storybook/addon-actions';
 import {ActionButton} from '@react-spectrum/button';
+import Add from '@spectrum-icons/workflow/Add';
 import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {Content} from '@react-spectrum/view';
 import {CRUDExample} from './CRUDExample';
+import Delete from '@spectrum-icons/workflow/Delete';
 import {Flex} from '@react-spectrum/layout';
 import {Heading} from '@react-spectrum/text';
 import {HidingColumns} from './HidingColumns';
@@ -24,8 +26,6 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Switch} from '@react-spectrum/switch';
 import {useAsyncList} from '@react-stately/data';
-import Add from '@spectrum-icons/workflow/Add';
-import Delete from '@spectrum-icons/workflow/Delete';
 
 let columns = [
   {name: 'Foo', key: 'foo'},
@@ -555,8 +555,7 @@ storiesOf('Table', module)
       <Table
         aria-label="Table with static contents"
         width={300}
-        height={200}
-      >
+        height={200}>
         <TableHeader>
           <Column key="foo" allowsSorting>
             Foo
@@ -574,12 +573,12 @@ storiesOf('Table', module)
           <Row>
             <Cell>One</Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Add />
               </ActionButton>
             </Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Delete />
               </ActionButton>
             </Cell>
@@ -589,12 +588,12 @@ storiesOf('Table', module)
           <Row>
             <Cell>One</Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Add />
               </ActionButton>
             </Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Delete />
               </ActionButton>
             </Cell>
@@ -604,12 +603,12 @@ storiesOf('Table', module)
           <Row>
             <Cell>One</Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Add />
               </ActionButton>
             </Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Delete />
               </ActionButton>
             </Cell>
@@ -619,12 +618,12 @@ storiesOf('Table', module)
           <Row>
             <Cell>One</Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Add />
               </ActionButton>
             </Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Delete />
               </ActionButton>
             </Cell>
@@ -634,12 +633,12 @@ storiesOf('Table', module)
           <Row>
             <Cell>One</Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Add />
               </ActionButton>
             </Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Delete />
               </ActionButton>
             </Cell>
@@ -649,12 +648,12 @@ storiesOf('Table', module)
           <Row>
             <Cell>One</Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Add />
               </ActionButton>
             </Cell>
             <Cell>
-              <ActionButton isQuiet={true}>
+              <ActionButton isQuiet>
                 <Delete />
               </ActionButton>
             </Cell>

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -24,6 +24,8 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Switch} from '@react-spectrum/switch';
 import {useAsyncList} from '@react-stately/data';
+import Add from '@spectrum-icons/workflow/Add';
+import Delete from '@spectrum-icons/workflow/Delete';
 
 let columns = [
   {name: 'Foo', key: 'foo'},
@@ -546,6 +548,122 @@ storiesOf('Table', module)
     'async loading',
     () => <AsyncLoadingExample />,
     {chromatic: {disable: true}}
+  )
+  .add(
+    'headerless columns',
+    () => (
+      <Table
+        aria-label="Table with static contents"
+        width={300}
+        height={200}
+      >
+        <TableHeader>
+          <Column key="foo" allowsSorting>
+            Foo
+          </Column>
+          <Column key="addAction" noHeader>
+            Add Item
+          </Column>
+          <Column key="deleteAction" noHeader showDivider>
+            Delete Item
+          </Column>
+          <Column key="bar">Bar</Column>
+          <Column key="baz">Baz</Column>
+        </TableHeader>
+        <TableBody>
+          <Row>
+            <Cell>One</Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Add />
+              </ActionButton>
+            </Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Delete />
+              </ActionButton>
+            </Cell>
+            <Cell>Two</Cell>
+            <Cell>Three</Cell>
+          </Row>
+          <Row>
+            <Cell>One</Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Add />
+              </ActionButton>
+            </Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Delete />
+              </ActionButton>
+            </Cell>
+            <Cell>Two</Cell>
+            <Cell>Three</Cell>
+          </Row>
+          <Row>
+            <Cell>One</Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Add />
+              </ActionButton>
+            </Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Delete />
+              </ActionButton>
+            </Cell>
+            <Cell>Two</Cell>
+            <Cell>Three</Cell>
+          </Row>
+          <Row>
+            <Cell>One</Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Add />
+              </ActionButton>
+            </Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Delete />
+              </ActionButton>
+            </Cell>
+            <Cell>Two</Cell>
+            <Cell>Three</Cell>
+          </Row>
+          <Row>
+            <Cell>One</Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Add />
+              </ActionButton>
+            </Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Delete />
+              </ActionButton>
+            </Cell>
+            <Cell>Two</Cell>
+            <Cell>Three</Cell>
+          </Row>
+          <Row>
+            <Cell>One</Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Add />
+              </ActionButton>
+            </Cell>
+            <Cell>
+              <ActionButton isQuiet={true}>
+                <Delete />
+              </ActionButton>
+            </Cell>
+            <Cell>Two</Cell>
+            <Cell>Three</Cell>
+          </Row>
+        </TableBody>
+      </Table>
+    )
   );
 
 function AsyncLoadingExample() {

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -550,7 +550,7 @@ storiesOf('Table', module)
     {chromatic: {disable: true}}
   )
   .add(
-    'hideHeader multiple columns',
+    'hideHeader',
     () => (
       <Table
         aria-label="Table with static contents"

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -557,7 +557,7 @@ storiesOf('Table', module)
         width={350}
         height={200}>
         <TableHeader>
-          <Column key="foo" allowsSorting>
+          <Column key="foo">
             Foo
           </Column>
           <Column key="addAction" hideHeader>

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -550,20 +550,20 @@ storiesOf('Table', module)
     {chromatic: {disable: true}}
   )
   .add(
-    'headerless columns',
+    'hideHeader multiple columns',
     () => (
       <Table
         aria-label="Table with static contents"
-        width={300}
+        width={350}
         height={200}>
         <TableHeader>
           <Column key="foo" allowsSorting>
             Foo
           </Column>
-          <Column key="addAction" noHeader>
+          <Column key="addAction" hideHeader>
             Add Item
           </Column>
-          <Column key="deleteAction" noHeader showDivider>
+          <Column key="deleteAction" hideHeader showDivider>
             Delete Item
           </Column>
           <Column key="bar">Bar</Column>

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3168,7 +3168,11 @@ describe('Table', function () {
       let className = headers[1].className;
       expect(className.includes('spectrum-Table-cell--hideHeader')).toBeTruthy();
       expect(headers[0]).toHaveTextContent('Foo');
-      expect(headers[1]).toBeEmptyDOMElement();
+      // visually hidden syle
+      expect(headers[1].childNodes[0].style.clipPath).toBe('inset(50%)');
+      expect(headers[1].childNodes[0].style.width).toBe('1px');
+      expect(headers[1].childNodes[0].style.height).toBe('1px');
+      expect(headers[1]).not.toBeEmptyDOMElement();
 
 
       let rows = within(rowgroups[1]).getAllByRole('row');

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3126,12 +3126,12 @@ describe('Table', function () {
 
   describe('headerless columns', function () {
 
-    let renderTable = (props, scale) => render(
+    let renderTable = (props, scale, showDivider = false) => render(
       <Table aria-label="Table" data-testid="test" {...props}>
         <TableHeader>
           <Column key="foo">Foo</Column>
-          <Column key="addAction" hideHeader>
-              Add Item
+          <Column key="addAction" hideHeader showDivider={showDivider}>
+            Add Item
           </Column>
         </TableHeader>
         <TableBody>
@@ -3174,7 +3174,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('35px');
+      expect(rows[0].childNodes[1].style.width).toBe('38px');
       let rowheader = within(rows[0]).getByRole('rowheader');
       expect(rowheader).toHaveTextContent('Foo 1');
       let actionCell = within(rows[0]).getAllByRole('gridcell');
@@ -3195,7 +3195,19 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('43px');
+      expect(rows[0].childNodes[1].style.width).toBe('46px');
+    });
+
+    it('renders table with headerless column and divider', function () {
+      let {getByRole} = renderTable({}, undefined, true);
+      let grid = getByRole('grid');
+      expect(grid).toBeVisible();
+      let rowgroups = within(grid).getAllByRole('rowgroup');
+      expect(rowgroups).toHaveLength(2);
+      let rows = within(rowgroups[1]).getAllByRole('row');
+      expect(rows).toHaveLength(1);
+      // The width of headerless column with divider
+      expect(rows[0].childNodes[1].style.width).toBe('39px');
     });
 
     it('renders table with headerless column with tooltip', function () {
@@ -3211,7 +3223,6 @@ describe('Table', function () {
       });
       let tooltip = getByRole('tooltip');
       expect(tooltip).toBeVisible();
-
     });
 
   });

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3166,7 +3166,7 @@ describe('Table', function () {
       let headers = within(grid).getAllByRole('columnheader');
       expect(headers).toHaveLength(2);
       let className = headers[1].className;
-      expect(className.includes('react-spectrum-Table-cell--hideHeader')).toBeTruthy();
+      expect(className.includes('spectrum-Table-cell--hideHeader')).toBeTruthy();
       expect(headers[0]).toHaveTextContent('Foo');
       expect(headers[1]).toBeEmptyDOMElement();
 
@@ -3182,7 +3182,7 @@ describe('Table', function () {
       let buttons = within(actionCell[0]).getAllByRole('button');
       expect(buttons).toHaveLength(1);
       className = actionCell[0].className;
-      expect(className.includes('react-spectrum-Table-cell--hideHeader')).toBeTruthy();
+      expect(className.includes('spectrum-Table-cell--hideHeader')).toBeTruthy();
     });
 
     it('renders table with headerless column with large scale', function () {

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3178,7 +3178,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('38px');
+      expect(rows[0].childNodes[1].style.width).toBe('36px');
       let rowheader = within(rows[0]).getByRole('rowheader');
       expect(rowheader).toHaveTextContent('Foo 1');
       let actionCell = within(rows[0]).getAllByRole('gridcell');
@@ -3199,7 +3199,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('46px');
+      expect(rows[0].childNodes[1].style.width).toBe('44px');
     });
 
     it('renders table with headerless column and divider', function () {
@@ -3211,7 +3211,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column with divider
-      expect(rows[0].childNodes[1].style.width).toBe('39px');
+      expect(rows[0].childNodes[1].style.width).toBe('37px');
     });
 
     it('renders table with headerless column with tooltip', function () {

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3130,7 +3130,7 @@ describe('Table', function () {
       <Table aria-label="Table" data-testid="test" {...props}>
         <TableHeader>
           <Column key="foo">Foo</Column>
-          <Column key="addAction" noHeader>
+          <Column key="addAction" hideHeader>
               Add Item
           </Column>
         </TableHeader>
@@ -3166,7 +3166,7 @@ describe('Table', function () {
       let headers = within(grid).getAllByRole('columnheader');
       expect(headers).toHaveLength(2);
       let className = headers[1].className;
-      expect(className.includes('react-spectrum-Table-cell--noHeader')).toBeTruthy();
+      expect(className.includes('react-spectrum-Table-cell--hideHeader')).toBeTruthy();
       expect(headers[0]).toHaveTextContent('Foo');
       expect(headers[1]).toBeEmptyDOMElement();
 
@@ -3182,7 +3182,7 @@ describe('Table', function () {
       let buttons = within(actionCell[0]).getAllByRole('button');
       expect(buttons).toHaveLength(1);
       className = actionCell[0].className;
-      expect(className.includes('react-spectrum-Table-cell--noHeader')).toBeTruthy();
+      expect(className.includes('react-spectrum-Table-cell--hideHeader')).toBeTruthy();
     });
 
     it('renders table with headerless column with large scale', function () {

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3174,7 +3174,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('34px');
+      expect(rows[0].childNodes[1].style.width).toBe('35px');
       let rowheader = within(rows[0]).getByRole('rowheader');
       expect(rowheader).toHaveTextContent('Foo 1');
       let actionCell = within(rows[0]).getAllByRole('gridcell');
@@ -3195,7 +3195,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('42px');
+      expect(rows[0].childNodes[1].style.width).toBe('43px');
     });
 
     it('renders table with headerless column with tooltip', function () {

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3174,7 +3174,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('39px');
+      expect(rows[0].childNodes[1].style.width).toBe('34px');
       let rowheader = within(rows[0]).getByRole('rowheader');
       expect(rowheader).toHaveTextContent('Foo 1');
       let actionCell = within(rows[0]).getAllByRole('gridcell');
@@ -3195,7 +3195,7 @@ describe('Table', function () {
       let rows = within(rowgroups[1]).getAllByRole('row');
       expect(rows).toHaveLength(1);
       // The width of headerless column
-      expect(rows[0].childNodes[1].style.width).toBe('45px');
+      expect(rows[0].childNodes[1].style.width).toBe('42px');
     });
 
     it('renders table with headerless column with tooltip', function () {

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -11,6 +11,8 @@
  */
 
 import {act, fireEvent, render as renderComponent, within} from '@testing-library/react';
+import {ActionButton} from '@react-spectrum/button';
+import Add from '@spectrum-icons/workflow/Add';
 import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {CRUDExample} from '../stories/CRUDExample';
 import {getFocusableTreeWalker} from '@react-aria/focus';
@@ -3120,5 +3122,97 @@ describe('Table', function () {
         expect(within(row).getAllByRole('gridcell')).toHaveLength(5);
       }
     });
+  });
+
+  describe('headerless columns', function () {
+
+    let renderTable = (props, scale) => render(
+      <Table aria-label="Table" data-testid="test" {...props}>
+        <TableHeader>
+          <Column key="foo">Foo</Column>
+          <Column key="addAction" noHeader>
+              Add Item
+          </Column>
+        </TableHeader>
+        <TableBody>
+          <Row>
+            <Cell>Foo 1</Cell>
+            <Cell>
+              <ActionButton isQuiet>
+                <Add />
+              </ActionButton>
+            </Cell>
+          </Row>
+        </TableBody>
+      </Table>
+      , scale);
+
+    it('renders  table with headerless column with default scale', function () {
+      let {getByRole} = renderTable();
+      let grid = getByRole('grid');
+      expect(grid).toBeVisible();
+      expect(grid).toHaveAttribute('aria-label', 'Table');
+      expect(grid).toHaveAttribute('data-testid', 'test');
+
+      expect(grid).toHaveAttribute('aria-rowcount', '2');
+      expect(grid).toHaveAttribute('aria-colcount', '2');
+      let rowgroups = within(grid).getAllByRole('rowgroup');
+      expect(rowgroups).toHaveLength(2);
+
+      let headerRows = within(rowgroups[0]).getAllByRole('row');
+      expect(headerRows).toHaveLength(1);
+      expect(headerRows[0]).toHaveAttribute('aria-rowindex', '1');
+
+      let headers = within(grid).getAllByRole('columnheader');
+      expect(headers).toHaveLength(2);
+      let className = headers[1].className;
+      expect(className.includes('react-spectrum-Table-cell--noHeader')).toBeTruthy();
+      expect(headers[0]).toHaveTextContent('Foo');
+      expect(headers[1]).toBeEmptyDOMElement();
+
+
+      let rows = within(rowgroups[1]).getAllByRole('row');
+      expect(rows).toHaveLength(1);
+      // The width of headerless column
+      expect(rows[0].childNodes[1].style.width).toBe('39px');
+      let rowheader = within(rows[0]).getByRole('rowheader');
+      expect(rowheader).toHaveTextContent('Foo 1');
+      let actionCell = within(rows[0]).getAllByRole('gridcell');
+      expect(actionCell).toHaveLength(1);
+      let buttons = within(actionCell[0]).getAllByRole('button');
+      expect(buttons).toHaveLength(1);
+      className = actionCell[0].className;
+      expect(className.includes('react-spectrum-Table-cell--noHeader')).toBeTruthy();
+    });
+
+    it('renders table with headerless column with large scale', function () {
+      let {getByRole} = renderTable({}, 'large');
+      let grid = getByRole('grid');
+      expect(grid).toBeVisible();
+      expect(grid).toHaveAttribute('aria-label', 'Table');
+      expect(grid).toHaveAttribute('data-testid', 'test');
+      let rowgroups = within(grid).getAllByRole('rowgroup');
+      let rows = within(rowgroups[1]).getAllByRole('row');
+      expect(rows).toHaveLength(1);
+      // The width of headerless column
+      expect(rows[0].childNodes[1].style.width).toBe('45px');
+    });
+
+    it('renders table with headerless column with tooltip', function () {
+      let {getByRole} = renderTable({}, 'large');
+      let grid = getByRole('grid');
+      expect(grid).toBeVisible();
+      expect(grid).toHaveAttribute('aria-label', 'Table');
+      expect(grid).toHaveAttribute('data-testid', 'test');
+      let headers = within(grid).getAllByRole('columnheader');
+      let headerlessColumn = headers[1];
+      act(() => {
+        headerlessColumn.focus();
+      });
+      let tooltip = getByRole('tooltip');
+      expect(tooltip).toBeVisible();
+
+    });
+
   });
 });

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -15,7 +15,7 @@ import {InvalidationContext, Layout, LayoutInfo, Rect, Size} from '@react-statel
 import {Key} from 'react';
 // import { DragTarget, DropTarget, DropPosition } from '@react-types/shared';
 
-type ListLayoutOptions<T> = {
+export type ListLayoutOptions<T> = {
   /** The height of a row in px. */
   rowHeight?: number,
   estimatedRowHeight?: number,
@@ -23,8 +23,7 @@ type ListLayoutOptions<T> = {
   estimatedHeadingHeight?: number,
   padding?: number,
   indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number,
-  collator?: Intl.Collator,
-  defaultHideHeaderCellWidth?: number
+  collator?: Intl.Collator
 };
 
 // A wrapper around LayoutInfo that supports heirarchy
@@ -53,7 +52,6 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   protected headingHeight: number;
   protected estimatedHeadingHeight: number;
   protected padding: number;
-  protected defaultHideHeaderCellWidth: number;
   protected indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number;
   protected layoutInfos: Map<Key, LayoutInfo>;
   protected layoutNodes: Map<Key, LayoutNode>;
@@ -85,7 +83,6 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     this.rootNodes = [];
     this.lastWidth = 0;
     this.lastCollection = null;
-    this.defaultHideHeaderCellWidth = options.defaultHideHeaderCellWidth;
   }
 
   getLayoutInfo(key: Key) {

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -23,7 +23,8 @@ type ListLayoutOptions<T> = {
   estimatedHeadingHeight?: number,
   padding?: number,
   indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number,
-  collator?: Intl.Collator
+  collator?: Intl.Collator,
+  defaultNoheaderCellWidth?: number
 };
 
 // A wrapper around LayoutInfo that supports heirarchy
@@ -52,6 +53,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   protected headingHeight: number;
   protected estimatedHeadingHeight: number;
   protected padding: number;
+  protected defaultNoheaderCellWidth: number;
   protected indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number;
   protected layoutInfos: Map<Key, LayoutInfo>;
   protected layoutNodes: Map<Key, LayoutNode>;
@@ -83,6 +85,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     this.rootNodes = [];
     this.lastWidth = 0;
     this.lastCollection = null;
+    this.defaultNoheaderCellWidth = options.defaultNoheaderCellWidth;
   }
 
   getLayoutInfo(key: Key) {

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -24,7 +24,7 @@ type ListLayoutOptions<T> = {
   padding?: number,
   indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number,
   collator?: Intl.Collator,
-  defaultNoheaderCellWidth?: number
+  defaultHideHeaderCellWidth?: number
 };
 
 // A wrapper around LayoutInfo that supports heirarchy
@@ -53,7 +53,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   protected headingHeight: number;
   protected estimatedHeadingHeight: number;
   protected padding: number;
-  protected defaultNoheaderCellWidth: number;
+  protected defaultHideHeaderCellWidth: number;
   protected indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number;
   protected layoutInfos: Map<Key, LayoutInfo>;
   protected layoutNodes: Map<Key, LayoutNode>;
@@ -85,7 +85,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     this.rootNodes = [];
     this.lastWidth = 0;
     this.lastCollection = null;
-    this.defaultNoheaderCellWidth = options.defaultNoheaderCellWidth;
+    this.defaultHideHeaderCellWidth = options.defaultHideHeaderCellWidth;
   }
 
   getLayoutInfo(key: Key) {

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -13,13 +13,25 @@
 import {ColumnProps, TableCollection, TableNode} from '@react-types/table';
 import {Key} from 'react';
 import {LayoutInfo, Point, Rect, Size} from '@react-stately/virtualizer';
-import {LayoutNode, ListLayout} from './ListLayout';
+import {LayoutNode, ListLayout, ListLayoutOptions} from './ListLayout';
+
+
+type TableLayoutOptions<T> = ListLayoutOptions<T> & {
+  getDefaultWidth: (props) => string | number
+}
 
 export class TableLayout<T> extends ListLayout<T> {
   collection: TableCollection<T>;
   lastCollection: TableCollection<T>;
   columnWidths: Map<Key, number>;
   stickyColumnIndices: number[];
+  getDefaultWidth: (props) => string | number;
+
+  constructor(options: TableLayoutOptions<T>) {
+    super(options);
+    this.getDefaultWidth = options.getDefaultWidth;
+  }
+
 
   buildCollection(): LayoutNode[] {
     // If columns changed, clear layout cache.
@@ -52,10 +64,7 @@ export class TableLayout<T> extends ListLayout<T> {
     let remainingSpace = this.virtualizer.visibleRect.width;
     for (let column of this.collection.columns) {
       let props = column.props as ColumnProps<T>;
-      let width = props.width ?? props.defaultWidth;
-      if (!props.width && props.hideHeader) {
-        width = this.defaultHideHeaderCellWidth;
-      }
+      let width = props.width ?? this.getDefaultWidth(props);
       if (width != null) {
         let w = this.parseWidth(width);
         this.columnWidths.set(column.key, w);

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -64,7 +64,7 @@ export class TableLayout<T> extends ListLayout<T> {
     let remainingSpace = this.virtualizer.visibleRect.width;
     for (let column of this.collection.columns) {
       let props = column.props as ColumnProps<T>;
-      let width = props.width ?? this.getDefaultWidth(props);
+      let width = props.width ?? props.defaultWidth ?? this.getDefaultWidth(props);
       if (width != null) {
         let w = this.parseWidth(width);
         this.columnWidths.set(column.key, w);

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -53,8 +53,8 @@ export class TableLayout<T> extends ListLayout<T> {
     for (let column of this.collection.columns) {
       let props = column.props as ColumnProps<T>;
       let width = props.width ?? props.defaultWidth;
-      if (!props.width && props.noHeader) {
-        width = this.defaultNoheaderCellWidth;
+      if (!props.width && props.hideHeader) {
+        width = this.defaultHideHeaderCellWidth;
       }
       if (width != null) {
         let w = this.parseWidth(width);

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -53,6 +53,9 @@ export class TableLayout<T> extends ListLayout<T> {
     for (let column of this.collection.columns) {
       let props = column.props as ColumnProps<T>;
       let width = props.width ?? props.defaultWidth;
+      if (!props.width && props.noHeader) {
+        width = this.defaultNoheaderCellWidth;
+      }
       if (width != null) {
         let w = this.parseWidth(width);
         this.columnWidths.set(column.key, w);

--- a/packages/@react-stately/table/src/TableCollection.ts
+++ b/packages/@react-stately/table/src/TableCollection.ts
@@ -43,8 +43,7 @@ export class TableCollection<T> implements ITableCollection<T> {
         rendered: null,
         childNodes: [],
         props: {
-          isSelectionCell: true,
-          width: 55 // TODO: spectrum??
+          isSelectionCell: true
         }
       };
 

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -41,7 +41,7 @@ export interface ColumnProps<T> {
   minWidth?: number | string,
   maxWidth?: number | string,
   defaultWidth?: number | string,
-  noHeader?: boolean;
+  noHeader?: boolean
 }
 
 // TODO: how to support these in CollectionBuilder...

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -41,7 +41,7 @@ export interface ColumnProps<T> {
   minWidth?: number | string,
   maxWidth?: number | string,
   defaultWidth?: number | string,
-  noHeader?: boolean
+  hideHeader?: boolean
 }
 
 // TODO: how to support these in CollectionBuilder...

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -40,8 +40,7 @@ export interface ColumnProps<T> {
   width?: number | string,
   minWidth?: number | string,
   maxWidth?: number | string,
-  defaultWidth?: number | string,
-  hideHeader?: boolean
+  defaultWidth?: number | string
 }
 
 // TODO: how to support these in CollectionBuilder...
@@ -52,7 +51,8 @@ export interface SpectrumColumnProps<T> extends ColumnProps<T> {
   allowsSorting?: boolean,
   isSticky?: boolean, // shouldStick??
   isRowHeader?: boolean,
-  showDivider?: boolean
+  showDivider?: boolean,
+  hideHeader?: boolean
 }
 
 export interface TableBodyProps<T> extends AsyncLoadable {

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -40,7 +40,8 @@ export interface ColumnProps<T> {
   width?: number | string,
   minWidth?: number | string,
   maxWidth?: number | string,
-  defaultWidth?: number | string
+  defaultWidth?: number | string,
+  noHeader?: boolean;
 }
 
 // TODO: how to support these in CollectionBuilder...


### PR DESCRIPTION
Closes 
https://github.com/adobe/react-spectrum/issues/912

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
Add a `hideHeader` prop to the column. This will
1) Not add a textual header to the column
2) Tooltip will be added instead of the text
3) The column will have a default fixed width depending on the scale

<img width="862" alt="Screen Shot 2020-10-06 at 4 44 31 PM" src="https://user-images.githubusercontent.com/30304082/95271713-6ea9c800-07f3-11eb-98d1-befa3023c89b.png">

<img width="788" alt="Screen Shot 2020-10-06 at 4 44 38 PM" src="https://user-images.githubusercontent.com/30304082/95271722-723d4f00-07f3-11eb-9967-7173abe0578f.png">

<img width="589" alt="Screen Shot 2020-10-06 at 4 45 27 PM" src="https://user-images.githubusercontent.com/30304082/95271728-75383f80-07f3-11eb-908a-d46ea7ef96ae.png">


## 🧢 Your Project: