### PR TITLE
Intermittent SSR test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=staging parcel build 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx' --no-scope-hoist",
     "test": "yarn jest",
     "test:ssr": "yarn jest --config jest.ssr.config.js",
-    "ci-test": "yarn jest --maxWorkers=2 && yarn test:ssr --maxWorkers=2",
+    "ci-test": "yarn jest --maxWorkers=2 && yarn test:ssr --runInBand",
     "lint": "yarn check-types && eslint packages --ext .js,.ts,.tsx && node scripts/lint-packages.js",
     "jest": "node scripts/jest.js",
     "copyrights": "babel-node --presets @babel/env ./scripts/addHeaders.js",


### PR DESCRIPTION
runInBand means that tests run serially, so we can eliminate the potential for conflict
it may run faster than using the two workers as well due to build machine constraints
faster would be roughly < 17sec

First finding using --runInBand took roughly 31seconds, this is almost double

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
