### PR TITLE
Fix prop types for useListBox

### DIFF
--- a/packages/@react-aria/listbox/src/useListBox.ts
+++ b/packages/@react-aria/listbox/src/useListBox.ts
@@ -27,7 +27,7 @@ interface ListBoxAria {
   labelProps: HTMLAttributes<HTMLElement>
 }
 
-interface AriaListBoxOptions<T> extends AriaListBoxProps<T> {
+interface AriaListBoxOptions<T> extends Omit<AriaListBoxProps<T>, 'children'> {
   /** Whether the listbox uses virtual scrolling. */
   isVirtualized?: boolean,
 
@@ -49,7 +49,7 @@ interface AriaListBoxOptions<T> extends AriaListBoxProps<T> {
  * @param props - Props for the listbox.
  * @param state - State for the listbox, as returned by `useListState`.
  */
-export function useListBox<T>(props: Omit<AriaListBoxOptions<T>, 'children'>, state: ListState<T>, ref: RefObject<HTMLElement>): ListBoxAria {
+export function useListBox<T>(props: AriaListBoxOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement>): ListBoxAria {
   let domProps = filterDOMProps(props, {labelable: true});
   let {listProps} = useSelectableList({
     ...props,

--- a/packages/@react-aria/listbox/src/useListBox.ts
+++ b/packages/@react-aria/listbox/src/useListBox.ts
@@ -49,7 +49,7 @@ interface AriaListBoxOptions<T> extends AriaListBoxProps<T> {
  * @param props - Props for the listbox.
  * @param state - State for the listbox, as returned by `useListState`.
  */
-export function useListBox<T>(props: AriaListBoxOptions<T>, state: ListState<T>, ref: RefObject<HTMLElement>): ListBoxAria {
+export function useListBox<T>(props: Omit<AriaListBoxOptions<T>, 'children'>, state: ListState<T>, ref: RefObject<HTMLElement>): ListBoxAria {
   let domProps = filterDOMProps(props, {labelable: true});
   let {listProps} = useSelectableList({
     ...props,
@@ -72,9 +72,10 @@ export function useListBox<T>(props: AriaListBoxOptions<T>, state: ListState<T>,
 
   return {
     labelProps,
-    listBoxProps: mergeProps(domProps, {
+    listBoxProps: mergeProps(domProps, state.selectionManager.selectionMode === 'multiple' ? {
+      'aria-multiselectable': 'true'
+    } : {}, {
       role: 'listbox',
-      'aria-multiselectable': state.selectionManager.selectionMode === 'multiple' ? 'true' : undefined,
       ...mergeProps(fieldProps, listProps)
     })
   };

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -65,7 +65,6 @@ export function useListBoxLayout<T>(state: ListState<T>) {
 /** @private */
 function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElement>) {
   let {layout, state, shouldSelectOnPressUp, focusOnPointerEnter, shouldUseVirtualFocus, domProps = {}, transitionDuration = 0} = props;
-  // @ts-ignore
   let {listBoxProps} = useListBox({
     ...props,
     ...domProps,


### PR DESCRIPTION
Closes #1100

`AriaListBoxOptions -> AriaListBoxProps -> ListBoxProps -> CollectionBase.children`

Any `children` prop passed into `useListBox` was never actually used.