### PR TITLE
Adding Picker story for falsy/none/null key

### DIFF
--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -284,6 +284,17 @@ storiesOf('Picker', module)
     )
   )
   .add(
+    'falsy item key',
+    () => (
+      <Picker label="Test" onSelectionChange={action('selectionChange')}>
+        <Item key="">None</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
+      </Picker>
+    )
+  )
+  .add(
     'no visible label',
     () => (
       <Picker aria-label="Test" onSelectionChange={action('selectionChange')}>


### PR DESCRIPTION
Followup to #1015

Adding a story for testing picker none example.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Confirm that picker works with the new falsy story.

## 🧢 Your Project:
RSP