### PR TITLE
fix(#1149) useTooltipTrigger should not add aria-describedby when Tooltip it references is not in DOM

### DIFF
--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -132,7 +132,7 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
 
   return {
     triggerProps: {
-      'aria-describedby': state.open ? tooltipId : undefined,
+      'aria-describedby': state.isOpen ? tooltipId : undefined,
       ...mergeProps(focusableProps, hoverProps, pressProps)
     },
     tooltipProps: {

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -831,11 +831,13 @@ describe('TooltipTrigger', function () {
       );
       fireEvent.mouseMove(document.body);
       let button = getByLabelText('trigger');
+      expect(button).not.toHaveAttribute('aria-describedBy');
       fireEvent.mouseEnter(button);
       fireEvent.mouseMove(button);
       let tooltip = getByRole('tooltip');
       expect(button).toHaveAttribute('aria-describedBy', tooltip.id);
       fireEvent.mouseLeave(button);
+      expect(button).not.toHaveAttribute('aria-describedBy');
     });
   });
 });


### PR DESCRIPTION
`useTooltipTrigger` always adds `aria-describedby` regardless of whether the `state.isOpen` or not.

At:
https://github.com/adobe/react-spectrum/blob/975957a3c3fb4a9f3be358428e0980a4d4e51c1a/packages/%40react-aria/tooltip/src/useTooltipTrigger.ts#L135
`state.open` is a `function`, so it's always `true`, whereas `state.isOpen` is a `boolean`, this line should be:
```jsx
      'aria-describedby': state.isOpen ? tooltipId : undefined,
```

Closes #1149

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 1149](https://github.com/adobe/react-spectrum/issues/1149).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Inspect and TooltipTrigger examples in Storybook
2. The trigger element should not have `aria-describedby` when the Tooltip is hidden, and should only have it when the Tooltip opens on hover or focus.

## 🧢 Your Project:

Adobe/Accessibility
