### PR TITLE
Link all references to Spectrum dimension values (#1169)

### DIFF
--- a/packages/@react-spectrum/layout/docs/Flex.mdx
+++ b/packages/@react-spectrum/layout/docs/Flex.mdx
@@ -40,7 +40,7 @@ more complex layouts.
 
 In addition to the properties widely supported by CSS, React Spectrum also shims the `gap` property, along
 with `rowGap` and `columnGap`. These properties make it much easier to build layouts
-with consistent space between each item. The gap can be defined with Spectrum [dimension variables](styling.html#dimension-values)
+with consistent space between each item. The gap can be defined with [Spectrum dimension variables](styling.html#dimension-values)
 to ensure consistency across applications, and allow the layout to adapt to different devices automatically.
 In addition, these values can be autocompleted in many IDEs for convenience.
 
@@ -48,7 +48,8 @@ In addition, these values can be autocompleted in many IDEs for convenience.
 
 ### Vertical stack
 
-This example shows a simple vertical stack, with a gap between each item defined using a Spectrum dimension variable.
+This example shows a simple vertical stack, with a gap between each item defined
+using a [Spectrum dimension variable](styling.html#dimension-values).
 
 ```tsx example
 <Flex direction="column" width="size-2000" gap="size-100">

--- a/packages/@react-spectrum/layout/docs/Grid.mdx
+++ b/packages/@react-spectrum/layout/docs/Grid.mdx
@@ -35,7 +35,7 @@ category: Layout
 
 The `Grid` component can be used to layout its children in two dimensions with
 [CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout).
-Any React Spectrum component can be used as a child, and Spectrum [dimension variables](styling.html#dimension-values)
+Any React Spectrum component can be used as a child, and [Spectrum dimension variables](styling.html#dimension-values)
 can be used to define sizing and spacing, which ensures consistency across applications, and allows the layout to adapt
 to different devices automatically. In addition, these values can be autocompleted in many IDEs for convenience.
 
@@ -69,7 +69,8 @@ Each child uses the `gridArea` prop to declare which area it should be placed in
 
 This example creates an implicit grid. It declares the columns using the `repeat` function to automatically generate
 as many columns as fit, and uses the `autoRows` prop to set the size of the implicitly created rows. The items are
-centered horizontally within the container, and have a gap between them defined using a Spectrum dimension variable.
+centered horizontally within the container, and have a gap between them defined
+using a [Spectrum dimension variable](styling.html#dimension-values).
 Resize your browser to see how items reflow.
 
 ```tsx import

--- a/packages/dev/docs/pages/react-spectrum/layout.mdx
+++ b/packages/dev/docs/pages/react-spectrum/layout.mdx
@@ -63,12 +63,13 @@ more complex layouts.
 
 In addition to the properties widely supported by CSS, React Spectrum also shims the `gap` property, along
 with `rowGap` and `columnGap`. These properties make it much easier to build layouts
-with consistent space between each item. The gap can be defined with Spectrum [dimension variables](styling.html#dimension-values)
+with consistent space between each item. The gap can be defined with [Spectrum dimension variables](styling.html#dimension-values)
 to ensure consistency across applications, and allow the layout to adapt to different devices automatically.
 
 ### Example
 
-This example shows a simple vertical stack, with a gap between each item defined using a Spectrum dimension variable.
+This example shows a simple vertical stack, with a gap between each item defined
+using a [Spectrum dimension variable](styling.html#dimension-values).
 
 ```tsx example
 <Flex direction="column" width="size-2000" gap="size-100">
@@ -97,7 +98,8 @@ layouts without extra presentational elements, keeping your code clean and seman
 are automatically mirrored in right-to-left languages.
 
 The [Grid](Grid.html) component can be used as a container to define a grid layout. Any React Spectrum component can be used as
-a child of a `Grid`. The `Grid` component extends the CSS syntax to support defining grids using Spectrum defined dimension values.
+a child of a `Grid`. The `Grid` component extends the CSS syntax to support
+defining grids using [Spectrum-defined dimension values](styling.html#dimension-values).
 This ensures that sizing and spacing is consistent between applications, and allows the layout to adapt to different devices
 automatically.
 
@@ -110,7 +112,7 @@ places them into these named regions.
 
 In addition, you can define the `columns` and `rows`
 props on the `Grid` container to specify the widths and heights of the columns and rows respectively. This can be
-done using Spectrum dimension values to ensure they are adaptive on various devices.
+done using [Spectrum dimension values](styling.html#dimension-values) to ensure they are adaptive on various devices.
 
 The following example shows how you could use `Grid` to declare a common application layout, with a header, sidebar,
 content area, and footer. Notice how there are no nested layout elements — the layout is entirely declared in the


### PR DESCRIPTION
Closes #1169 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

- Clone repo, run `yarn install` then `yarn start:docs`
- Load up the Flex, Grid and Layout documentation pages.
- See sweet sweet linkage to Spectrum dimension values in all places where the term is used.
