### PR TITLE
Moving Focus after disabling an input

### DIFF
--- a/packages/@react-aria/focus/docs/FocusRing.mdx
+++ b/packages/@react-aria/focus/docs/FocusRing.mdx
@@ -16,6 +16,7 @@ import packageData from '@react-aria/focus/package.json';
 
 ```tsx import
 import {FocusRing} from '@react-aria/focus';
+import {useFocusWithin} from '@react-aria/interactions';
 ```
 
 ---
@@ -59,10 +60,16 @@ This example shows how to use `<FocusRing>` to apply a CSS class when keyboard f
   font-size: 14px;
   padding: 4px 8px;
 }
-
+.button:disabled {
+background: #6f6f6f;
+}
 .button.focus-ring {
   outline: 2px solid dodgerblue;
   outline-offset: 2px;
+}
+
+.button + .button {
+  margin-inline-start: 6px;
 }
 ```
 
@@ -70,4 +77,34 @@ This example shows how to use `<FocusRing>` to apply a CSS class when keyboard f
 <FocusRing focusRingClass="focus-ring">
   <button className="button">Test</button>
 </FocusRing>
+```
+
+### Disabled
+When an interactive element is disabled, it should not show the focus ring and focus should be moved elsewhere.
+
+```tsx example
+function FocusSwitcher() {
+    let [disableToggle, setDisableToggle] = React.useState(false);
+    let [isFocusWithin, setFocusWithin] = React.useState(false);
+    let {focusWithinProps} = useFocusWithin({
+      onFocusWithinChange: isFocusWithin => setFocusWithin(isFocusWithin)
+    })
+    let btn1 = React.useRef();
+    let btn2 = React.useRef();
+    React.useEffect(() => {
+      if (isFocusWithin) {
+        disableToggle ? btn2.current.focus() : btn1.current.focus();
+      }
+    }, [disableToggle, isFocusWithin, btn1, btn2]);
+    return (
+      <div {...focusWithinProps}>
+        <FocusRing isDisabled={disableToggle} focusRingClass="focus-ring">
+          <button disabled={disableToggle} onClick={() => setDisableToggle(true)} ref={btn1} className="button">Test1</button>
+        </FocusRing>
+        <FocusRing isDisabled={!disableToggle} focusRingClass="focus-ring">
+          <button disabled={!disableToggle} onClick={() => setDisableToggle(false)} ref={btn2} className="button">Test2</button>
+        </FocusRing>
+      </div>
+    );
+}
 ```

--- a/packages/@react-aria/focus/src/FocusRing.tsx
+++ b/packages/@react-aria/focus/src/FocusRing.tsx
@@ -32,7 +32,9 @@ interface FocusRingProps {
   /** Whether the element is a text input. */
   isTextInput?: boolean,
   /** Whether the element will be auto focused. */
-  autoFocus?: boolean
+  autoFocus?: boolean,
+  /** Whether the element we're applying focus ring to is disabled. */
+  isDisabled?: boolean
 }
 
 /**
@@ -41,15 +43,15 @@ interface FocusRingProps {
  * not with a mouse, touch, or other input methods.
  */
 export function FocusRing(props: FocusRingProps) {
-  let {children, focusClass, focusRingClass} = props;
+  let {children, focusClass, focusRingClass, isDisabled} = props;
   let {isFocused, isFocusVisible, focusProps} = useFocusRing(props);
   let child = React.Children.only(children);
 
   return React.cloneElement(child, mergeProps(child.props, {
     ...focusProps,
     className: clsx({
-      [focusClass || '']: isFocused,
-      [focusRingClass || '']: isFocusVisible
+      [focusClass || '']: isFocused && !isDisabled,
+      [focusRingClass || '']: isFocusVisible && !isDisabled
     })
   }));
 }

--- a/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryMultiSlider.tsx
@@ -81,7 +81,7 @@ export function StoryThumb(props: StoryThumbProps) {
   }, state);
 
   return (
-    <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+    <FocusRing within isDisabled={isDisabled} focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
       <div
         {...thumbProps}
         className={classNames(styles, 'thumb', 'thumbHandle', {thumbDisabled: isDisabled})}

--- a/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
+++ b/packages/@react-aria/slider/stories/StoryRangeSlider.tsx
@@ -68,7 +68,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
               width: `${(state.getThumbPercent(1) - state.getThumbPercent(0)) * 100}%`
             }} />
         </div>
-        <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+        <FocusRing within isDisabled={props.isDisabled} focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
           <div
             className={styles.thumb}
             style={{
@@ -83,7 +83,7 @@ export function StoryRangeSlider(props: StoryRangeSliderProps) {
             {props.showTip && <div className={styles.tip}>{state.getThumbValueLabel(0)}</div>}
           </div>
         </FocusRing>
-        <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+        <FocusRing within isDisabled={props.isDisabled} focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
           <div
             className={styles.thumb}
             {...maxThumbProps}

--- a/packages/@react-aria/slider/stories/StorySlider.tsx
+++ b/packages/@react-aria/slider/stories/StorySlider.tsx
@@ -61,7 +61,7 @@ export function StorySlider(props: StorySliderProps) {
             width: `${(state.getValuePercent(Math.max(value, origin)) - state.getValuePercent(Math.min(value, origin))) * 100}%`
           }} />
         <div ref={trackRef} className={styles.track} {...trackProps} />
-        <FocusRing within focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
+        <FocusRing within isDisabled={props.isDisabled} focusRingClass={styles.thumbFocusVisible} focusClass={styles.thumbFocused}>
           <div
             className={styles.thumb}
             style={{

--- a/packages/@react-spectrum/breadcrumbs/src/BreadcrumbItem.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/BreadcrumbItem.tsx
@@ -55,7 +55,7 @@ export function BreadcrumbItem(props: BreadcrumbItemProps) {
 
   return (
     <Fragment>
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+      <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')}>
         {element}
       </FocusRing>
       {isCurrent === false &&

--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -39,7 +39,7 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef<HTMLBu
   let isTextOnly = React.Children.toArray(props.children).every(c => !React.isValidElement(c));
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
       <button
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -50,7 +50,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
   }
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
       <ElementType
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}

--- a/packages/@react-spectrum/button/src/ClearButton.tsx
+++ b/packages/@react-spectrum/button/src/ClearButton.tsx
@@ -41,7 +41,7 @@ function ClearButton(props: ClearButtonProps, ref: FocusableRef<HTMLButtonElemen
   let {styleProps} = useStyleProps(otherProps);
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring', focusClassName)} autoFocus={autoFocus}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring', focusClassName)} autoFocus={autoFocus}>
       <button
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -43,7 +43,7 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
   let {styleProps} = useStyleProps(otherProps);
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
       <button
         {...mergeProps(buttonProps, hoverProps)}
         ref={domRef}

--- a/packages/@react-spectrum/button/src/LogicButton.tsx
+++ b/packages/@react-spectrum/button/src/LogicButton.tsx
@@ -36,7 +36,7 @@ function LogicButton(props: SpectrumLogicButtonProps, ref: FocusableRef<HTMLButt
   let {styleProps} = useStyleProps(otherProps);
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
       <button
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}

--- a/packages/@react-spectrum/button/src/ToggleButton.tsx
+++ b/packages/@react-spectrum/button/src/ToggleButton.tsx
@@ -42,7 +42,7 @@ function ToggleButton(props: SpectrumToggleButtonProps, ref: FocusableRef<HTMLBu
   let isTextOnly = React.Children.toArray(props.children).every(c => !React.isValidElement(c));
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
       <button
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}

--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -90,7 +90,7 @@ function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelEleme
           styleProps.className
         )
       }>
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+      <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
         <input
           {...inputProps}
           ref={inputRef}

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -188,6 +188,7 @@ function ComboBox<T extends object>(props: SpectrumComboBoxProps<T>, ref: RefObj
     <FocusRing
       within
       isTextInput
+      isDisabled={isDisabled}
       focusClass={classNames(styles, 'is-focused')}
       focusRingClass={classNames(styles, 'focus-ring')}
       autoFocus={autoFocus}>

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -64,6 +64,7 @@ export function DatePicker(props: SpectrumDatePickerProps) {
     <FocusRing
       within
       isTextInput
+      isDisabled={isDisabled}
       focusClass={classNames(styles, 'is-focused')}
       focusRingClass={classNames(styles, 'focus-ring')}
       autoFocus={autoFocus}>

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -65,6 +65,7 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
     <FocusRing
       within
       isTextInput
+      isDisabled={isDisabled}
       focusClass={classNames(styles, 'is-focused')}
       focusRingClass={classNames(styles, 'focus-ring')}
       autoFocus={autoFocus}>

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -77,7 +77,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
   let isKeyboardModality = isFocusVisible();
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')}>
       <div
         {...mergeProps(optionProps, shouldFocusOnHover ? hoverProps : {})}
         ref={ref}

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -75,7 +75,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
     : rendered;
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')}>
       <li
         {...mergeProps(menuItemProps, hoverProps)}
         ref={ref}

--- a/packages/@react-spectrum/numberfield/src/NumberField.tsx
+++ b/packages/@react-spectrum/numberfield/src/NumberField.tsx
@@ -66,6 +66,7 @@ export const NumberField = React.forwardRef((props: SpectrumNumberFieldProps, re
   return (
     <FocusRing
       within
+      isDisabled={isDisabled}
       focusClass={classNames(inputgroupStyles, 'is-focused', classNames(stepperStyle, 'is-focused'))}
       focusRingClass={classNames(inputgroupStyles, 'focus-ring', classNames(stepperStyle, 'focus-ring'))}
       autoFocus={autoFocus}>

--- a/packages/@react-spectrum/radio/src/Radio.tsx
+++ b/packages/@react-spectrum/radio/src/Radio.tsx
@@ -67,7 +67,7 @@ function Radio(props: SpectrumRadioProps, ref: FocusableRef<HTMLLabelElement>) {
           styleProps.className
         )
       }>
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+      <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
         <input
           {...inputProps}
           ref={inputRef}

--- a/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
@@ -46,7 +46,7 @@ export function SideNavItem<T>(props: SpectrumSideNavItemProps<T>) {
     <div
       {...listItemProps}
       className={className} >
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+      <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')}>
         <a
           {...mergeProps(listItemLinkProps, hoverProps)}
           ref={ref}

--- a/packages/@react-spectrum/slider/src/RangeSlider.tsx
+++ b/packages/@react-spectrum/slider/src/RangeSlider.tsx
@@ -69,11 +69,11 @@ function RangeSlider(props: SpectrumRangeSliderProps, ref: FocusableRef<HTMLDivE
         return (<>
           {lowerTrack}
           {ticks}
-          <FocusRing within focusRingClass={classNames(styles, 'is-focused')}>
+          <FocusRing within isDisabled={props.isDisabled} focusRingClass={classNames(styles, 'is-focused')}>
             {handles[0]}
           </FocusRing>
           {middleTrack}
-          <FocusRing within focusRingClass={classNames(styles, 'is-focused')}>
+          <FocusRing within isDisabled={props.isDisabled} focusRingClass={classNames(styles, 'is-focused')}>
             {handles[1]}
           </FocusRing>
           {upperTrack}</>);

--- a/packages/@react-spectrum/slider/src/Slider.tsx
+++ b/packages/@react-spectrum/slider/src/Slider.tsx
@@ -101,7 +101,7 @@ function Slider(props: SpectrumSliderProps, ref: FocusableRef<HTMLDivElement>) {
               width: `${Math.abs(width) * 100}%`
             }} />);
         }
-        return  (<>{lowerTrack}{ticks}<FocusRing within focusRingClass={classNames(styles, 'is-focused')}>
+        return  (<>{lowerTrack}{ticks}<FocusRing within isDisabled={props.isDisabled} focusRingClass={classNames(styles, 'is-focused')}>
           {handle}
         </FocusRing>{upperTrack}{filledTrack}</>);
       }}

--- a/packages/@react-spectrum/switch/src/Switch.tsx
+++ b/packages/@react-spectrum/switch/src/Switch.tsx
@@ -56,7 +56,7 @@ function Switch(props: SpectrumSwitchProps, ref: FocusableRef<HTMLLabelElement>)
           styleProps.className
         )
       }>
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
+      <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
         <input
           {...inputProps}
           ref={inputRef}

--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -109,7 +109,7 @@ export function Tab<T>(props: TabProps<T>) {
   }) : undefined;
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')}>
       <div
         {...styleProps}
         {...mergeProps(tabProps, hoverProps)}

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -54,7 +54,7 @@ export const Tag = ((props: SpectrumTagProps) => {
   let icon = props.icon || (isInvalid && <Alert />);
 
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+    <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')}>
       <div
         {...styleProps}
         {...mergeProps(tagProps, hoverProps)}

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -121,7 +121,7 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
           }
         )
       }>
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')} isTextInput autoFocus={autoFocus}>
+      <FocusRing isDisabled={isDisabled} focusRingClass={classNames(styles, 'focus-ring')} isTextInput autoFocus={autoFocus}>
         <ElementType
           {...mergeProps(inputProps, hoverProps)}
           ref={inputRef}


### PR DESCRIPTION
For consideration to fix the Issue listed. From discussion and further digging isDisabled wasn't being passed to useFocus and probably wouldn't be the right place to fix it anyways because disabled elements shouldn't fire any events, even blur.
Instead, isDisabled was added as a prop to FocusRing which prevents the rendering of those classes if the FocusRing is disabled. Wrote a demo that shows how FocusRings should be moved when it gets disabled out from under a user.

Closes https://github.com/adobe/react-spectrum/issues/1164

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
