### PR TITLE
Don't text select after dismissing a dialog in FF

### DIFF
--- a/packages/@react-aria/dialog/docs/useDialog.mdx
+++ b/packages/@react-aria/dialog/docs/useDialog.mdx
@@ -135,19 +135,11 @@ function ModalDialog(props) {
         left: 0,
         bottom: 0,
         right: 0,
+        background: 'rgba(0, 0, 0, 0.5)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center'
       }}>
-      <div
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          right: 0,
-          background: 'rgba(0, 0, 0, 0.5)'
-        }} />
       <FocusScope contain restoreFocus autoFocus>
         <div
           {...overlayProps}

--- a/packages/@react-aria/dialog/docs/useDialog.mdx
+++ b/packages/@react-aria/dialog/docs/useDialog.mdx
@@ -135,11 +135,19 @@ function ModalDialog(props) {
         left: 0,
         bottom: 0,
         right: 0,
-        background: 'rgba(0, 0, 0, 0.5)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center'
       }}>
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          background: 'rgba(0, 0, 0, 0.5)'
+        }} />
       <FocusScope contain restoreFocus autoFocus>
         <div
           {...overlayProps}
@@ -147,6 +155,7 @@ function ModalDialog(props) {
           {...modalProps}
           ref={ref}
           style={{
+            position: 'relative',
             background: 'white',
             color: 'black',
             padding: 30

--- a/packages/@react-aria/dialog/docs/useDialog.mdx
+++ b/packages/@react-aria/dialog/docs/useDialog.mdx
@@ -147,7 +147,6 @@ function ModalDialog(props) {
           {...modalProps}
           ref={ref}
           style={{
-            position: 'relative',
             background: 'white',
             color: 'black',
             padding: 30

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -38,6 +38,10 @@ export function useInteractOutside(props: InteractOutsideProps) {
     let onPointerDown = (e) => {
       if (isValidEvent(e, ref)) {
         state.isPointerDown = true;
+        // for the same reason as usePress
+        if (e.button === 0) {
+          e.preventDefault();
+        }
       }
     };
 
@@ -47,6 +51,9 @@ export function useInteractOutside(props: InteractOutsideProps) {
         if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
           state.isPointerDown = false;
           onInteractOutside(e);
+          if (e.button === 0) {
+            e.preventDefault();
+          }
         }
       };
 
@@ -65,6 +72,9 @@ export function useInteractOutside(props: InteractOutsideProps) {
         } else if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
           state.isPointerDown = false;
           onInteractOutside(e);
+          if (e.button === 0) {
+            e.preventDefault();
+          }
         }
       };
 
@@ -73,6 +83,9 @@ export function useInteractOutside(props: InteractOutsideProps) {
         if (onInteractOutside && state.isPointerDown && isValidEvent(e, ref)) {
           state.isPointerDown = false;
           onInteractOutside(e);
+          if (e.button === 0) {
+            e.preventDefault();
+          }
         }
       };
 

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -38,7 +38,8 @@ export function useInteractOutside(props: InteractOutsideProps) {
     let onPointerDown = (e) => {
       if (isValidEvent(e, ref)) {
         state.isPointerDown = true;
-        // for the same reason as usePress
+        // Due to browser inconsistencies, we prevent
+        // default on pointer down. FF will otherwise try to start text selection.
         if (e.button === 0) {
           e.preventDefault();
         }


### PR DESCRIPTION
Follow logic of usePress and preventDefault on clicks handled by useInteractOutside, which is can be thought of as usePressOutside

Closes https://github.com/adobe/react-spectrum/issues/919

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
