### PR TITLE
Fix(#1168): Check document.activeElement in focus containment onBlur so focus in iframes is retained

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -245,8 +245,7 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
     };
 
     let onBlur = (e) => {
-      // Brief timeout for document.activeElement to update (e.g. user clicks inside a iframe in a dialog)
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         // Fall back to document.activeElement if e.relatedTarget is null (e.g. user clicks inside a iframe in a dialog)
         let isInAnyScope = isElementInAnyScope(e.relatedTarget || document.activeElement, scopes);
 
@@ -258,7 +257,7 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
             focusedNode.current.focus();
           });
         }
-      }, 10);
+      });
     };
 
     document.addEventListener('keydown', onKeyDown, false);

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -247,8 +247,8 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
     let onBlur = (e) => {
       // Firefox doesn't shift focus back to the Dialog properly without this
       raf.current = requestAnimationFrame(() => {
-        // Fall back to document.activeElement if e.relatedTarget is null (e.g. user clicks inside a iframe in a dialog)
-        let isInAnyScope = isElementInAnyScope(e.relatedTarget || document.activeElement, scopes);
+        // Use document.activeElement instead of e.relatedTarget so we can tell if user clicked into iframe
+        let isInAnyScope = isElementInAnyScope(document.activeElement, scopes);
 
         if (!isInAnyScope) {
           activeScope = scopeRef;

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -245,16 +245,20 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
     };
 
     let onBlur = (e) => {
-      let isInAnyScope = isElementInAnyScope(e.relatedTarget, scopes);
+      // Brief timeout for document.activeElement to update (e.g. user clicks inside a iframe in a dialog)
+      setTimeout(() => {
+        // Fall back to document.activeElement if e.relatedTarget is null (e.g. user clicks inside a iframe in a dialog)
+        let isInAnyScope = isElementInAnyScope(e.relatedTarget || document.activeElement, scopes);
 
-      if (!isInAnyScope) {
-        activeScope = scopeRef;
-        focusedNode.current = e.target;
-        // Firefox doesn't shift focus back to the Dialog properly without this
-        raf.current = requestAnimationFrame(() => {
-          focusedNode.current.focus();
-        });
-      }
+        if (!isInAnyScope) {
+          activeScope = scopeRef;
+          focusedNode.current = e.target;
+          // Firefox doesn't shift focus back to the Dialog properly without this
+          raf.current = requestAnimationFrame(() => {
+            focusedNode.current.focus();
+          });
+        }
+      }, 10);
     };
 
     document.addEventListener('keydown', onKeyDown, false);

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -294,7 +294,7 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(input2);
     });
 
-    it.only('uses document.activeElement instead of e.relatedTarget on blur to determine if focus is still in scope', function () {
+    it('uses document.activeElement instead of e.relatedTarget on blur to determine if focus is still in scope', function () {
       let {getByTestId} = render(
         <div>
           <FocusScope contain>
@@ -314,8 +314,8 @@ describe('FocusScope', function () {
       act(() => {
         // set document.activeElement to input2
         input2.focus();
-        // if onBlur didn't fallback to document.activeElement, this would reset focus to input1
-        fireEvent.blur(input1, {relatedTarget: null})
+        // if onBlur didn't fallback to checking document.activeElement, this would reset focus to input1
+        fireEvent.blur(input1, {relatedTarget: null});
         jest.advanceTimersByTime(10);
       });
 

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -16,21 +16,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 describe('FocusScope', function () {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   beforeEach(() => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
   });
 
   afterEach(() => {
     window.requestAnimationFrame.mockRestore();
-    jest.runAllTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
   });
 
   describe('focus containment', function () {
@@ -255,7 +246,6 @@ describe('FocusScope', function () {
 
       act(() => {
         input2.blur();
-        jest.advanceTimersByTime(10);
       });
       expect(document.activeElement).toBe(input2);
 
@@ -287,7 +277,6 @@ describe('FocusScope', function () {
 
       act(() => {
         input2.blur();
-        jest.advanceTimersByTime(10);
       });
       expect(document.activeElement).toBe(input2);
       fireEvent.focusOut(input2);
@@ -316,7 +305,6 @@ describe('FocusScope', function () {
         input2.focus();
         // if onBlur didn't fallback to checking document.activeElement, this would reset focus to input1
         fireEvent.blur(input1, {relatedTarget: null});
-        jest.advanceTimersByTime(10);
       });
 
       expect(document.activeElement).toBe(input2);

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -244,9 +244,7 @@ describe('FocusScope', function () {
       fireEvent.focusIn(input2);
       expect(document.activeElement).toBe(input2);
 
-      act(() => {
-        input2.blur();
-      });
+      act(() => {input2.blur();});
       expect(document.activeElement).toBe(input2);
 
       act(() => {outside.focus();});
@@ -275,9 +273,7 @@ describe('FocusScope', function () {
       fireEvent.focusIn(input2);
       expect(document.activeElement).toBe(input2);
 
-      act(() => {
-        input2.blur();
-      });
+      act(() => {input2.blur();});
       expect(document.activeElement).toBe(input2);
       fireEvent.focusOut(input2);
       expect(document.activeElement).toBe(input2);

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -84,6 +84,10 @@ storiesOf('Dialog', module)
   .add(
     'cleared content',
     () => renderWithDividerInContent({})
+  )
+  .add(
+    'with iframe',
+    () => renderIframe({})
   );
 
 storiesOf('Dialog/Alert', module)
@@ -238,6 +242,31 @@ function render({width = 'auto', isDismissable = undefined, ...props}) {
             <Header>The Header</Header>
             <Divider />
             <Content>{singleParagraph()}</Content>
+            {!isDismissable &&
+              <ButtonGroup>
+                <Button variant="secondary" onPress={close}>Cancel</Button>
+                <Button variant="cta" onPress={close}>Confirm</Button>
+              </ButtonGroup>}
+          </Dialog>
+        )}
+      </DialogTrigger>
+    </div>
+  );
+}
+
+function renderIframe({width = 'auto', isDismissable = undefined, ...props}) {
+  return (
+    <div style={{display: 'flex', width, margin: '100px 0'}}>
+      <DialogTrigger isDismissable={isDismissable} defaultOpen>
+        <ActionButton>Trigger</ActionButton>
+        {(close) => (
+          <Dialog {...props}>
+            <Heading>The Heading</Heading>
+            <Header>The Header</Header>
+            <Divider />
+            <Content>
+              <iframe width="100%" title="wikipedia" src="https://wikipedia.org/wiki/Main_Page" />
+            </Content>
             {!isDismissable &&
               <ButtonGroup>
                 <Button variant="secondary" onPress={close}>Cancel</Button>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1168
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
