### PR TITLE
[useButton & useToggleButton]: Add dynamic ref type depending on elementType props

### DIFF
--- a/packages/@react-aria/button/docs/useToggleButton.mdx
+++ b/packages/@react-aria/button/docs/useToggleButton.mdx
@@ -62,7 +62,7 @@ the state using the <kbd>Space</kbd> or <kbd>Enter</kbd> keys.
 whether the user is currently pressing the button:
 
 <TypeContext.Provider value={docs.links}>
-  <InterfaceType properties={docs.links[docs.exports.useToggleButton.return.id].properties} />
+  <InterfaceType properties={docs.links[docs.exports.useToggleButton.return.base.id].properties} />
 </TypeContext.Provider>
 
 Selection state is managed by the <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useToggleState} />

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -33,19 +33,19 @@ export interface ButtonAria<T> {
 }
 
 /* eslint-disable no-redeclare */
+export function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
+export function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
+export function useButton(props: AriaButtonProps<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
+export function useButton(props: AriaButtonProps<'input'>, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
+export function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
+export function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
 /**
  * Provides the behavior and accessibility implementation for a button component. Handles mouse, keyboard, and touch interactions,
  * focus behavior, and ARIA props for both native button elements and custom element types.
  * @param props - Props to be applied to the button.
  * @param ref - A ref to a DOM element for the button.
  */
-function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-function useButton(props: AriaButtonProps<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-function useButton(props: AriaButtonProps<'input'>, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
-function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
+export function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
 /* eslint-enable no-redeclare */
   let {
     elementType = 'button',
@@ -107,5 +107,3 @@ function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): Bu
     })
   };
 }
-
-export {useButton};

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -10,17 +10,24 @@
  * governing permissions and limitations under the License.
  */
 
+import {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ElementType,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  RefObject
+} from 'react';
 import {AriaButtonProps} from '@react-types/button';
-import {ButtonHTMLAttributes, RefObject} from 'react';
 import {filterDOMProps} from '@react-aria/utils';
 import {mergeProps} from '@react-aria/utils';
 import {useFocusable} from '@react-aria/focus';
 import {usePress} from '@react-aria/interactions';
 
 
-export interface ButtonAria {
+export interface ButtonAria<T> {
   /** Props for the button element. */
-  buttonProps: ButtonHTMLAttributes<HTMLButtonElement>,
+  buttonProps: T,
   /** Whether the button is currently pressed. */
   isPressed: boolean
 }
@@ -31,7 +38,71 @@ export interface ButtonAria {
  * @param props - Props to be applied to the button.
  * @param ref - A ref to a DOM element for the button.
  */
-export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): ButtonAria {
+
+/* eslint-disable no-redeclare */
+function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
+function useButton(props: AriaButtonProps<'area'>, ref: RefObject<HTMLAreaElement>): ButtonAria<HTMLAttributes<HTMLAreaElement>>;
+function useButton(props: AriaButtonProps<'audio'>, ref: RefObject<HTMLAudioElement>): ButtonAria<HTMLAttributes<HTMLAudioElement>>;
+function useButton(props: AriaButtonProps<'base'>, ref: RefObject<HTMLBaseElement>): ButtonAria<HTMLAttributes<HTMLBaseElement>>;
+function useButton(props: AriaButtonProps<'br'>, ref: RefObject<HTMLBRElement>): ButtonAria<HTMLAttributes<HTMLBRElement>>;
+function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
+function useButton(props: AriaButtonProps<'canvas'>, ref: RefObject<HTMLCanvasElement>): ButtonAria<HTMLAttributes<HTMLCanvasElement>>;
+function useButton(props: AriaButtonProps<'data'>, ref: RefObject<HTMLDataElement>): ButtonAria<HTMLAttributes<HTMLDataElement>>;
+function useButton(props: AriaButtonProps<'details'>, ref: RefObject<HTMLDetailsElement>): ButtonAria<HTMLAttributes<HTMLDetailsElement>>;
+function useButton(props: AriaButtonProps<'dialog'>, ref: RefObject<HTMLDialogElement>): ButtonAria<HTMLAttributes<HTMLDialogElement>>;
+function useButton(props: AriaButtonProps<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
+function useButton(props: AriaButtonProps<'embed'>, ref: RefObject<HTMLEmbedElement>): ButtonAria<HTMLAttributes<HTMLEmbedElement>>;
+function useButton(props: AriaButtonProps<'fieldset'>, ref: RefObject<HTMLFieldSetElement>): ButtonAria<HTMLAttributes<HTMLFieldSetElement>>;
+function useButton(props: AriaButtonProps<'form'>, ref: RefObject<HTMLFormElement>): ButtonAria<HTMLAttributes<HTMLFormElement>>;
+function useButton(props: AriaButtonProps<'h1'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useButton(props: AriaButtonProps<'h2'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useButton(props: AriaButtonProps<'h3'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useButton(props: AriaButtonProps<'h4'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useButton(props: AriaButtonProps<'h5'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useButton(props: AriaButtonProps<'h6'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useButton(props: AriaButtonProps<'hr'>, ref: RefObject<HTMLHRElement>): ButtonAria<HTMLAttributes<HTMLHRElement>>;
+function useButton(props: AriaButtonProps<'iframe'>, ref: RefObject<HTMLIFrameElement>): ButtonAria<HTMLAttributes<HTMLIFrameElement>>;
+function useButton(props: AriaButtonProps<'img'>, ref: RefObject<HTMLImageElement>): ButtonAria<HTMLAttributes<HTMLImageElement>>;
+function useButton(props: AriaButtonProps<'input'>, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
+function useButton(props: AriaButtonProps<'label'>, ref: RefObject<HTMLLabelElement>): ButtonAria<HTMLAttributes<HTMLLabelElement>>;
+function useButton(props: AriaButtonProps<'legend'>, ref: RefObject<HTMLLegendElement>): ButtonAria<HTMLAttributes<HTMLLegendElement>>;
+function useButton(props: AriaButtonProps<'li'>, ref: RefObject<HTMLLIElement>): ButtonAria<HTMLAttributes<HTMLLIElement>>;
+function useButton(props: AriaButtonProps<'link'>, ref: RefObject<HTMLLinkElement>): ButtonAria<HTMLAttributes<HTMLLinkElement>>;
+function useButton(props: AriaButtonProps<'map'>, ref: RefObject<HTMLMapElement>): ButtonAria<HTMLAttributes<HTMLMapElement>>;
+function useButton(props: AriaButtonProps<'menu'>, ref: RefObject<HTMLMenuElement>): ButtonAria<HTMLAttributes<HTMLMenuElement>>;
+function useButton(props: AriaButtonProps<'meta'>, ref: RefObject<HTMLMetaElement>): ButtonAria<HTMLAttributes<HTMLMetaElement>>;
+function useButton(props: AriaButtonProps<'meter'>, ref: RefObject<HTMLMeterElement>): ButtonAria<HTMLAttributes<HTMLMeterElement>>;
+function useButton(props: AriaButtonProps<'object'>, ref: RefObject<HTMLObjectElement>): ButtonAria<HTMLAttributes<HTMLObjectElement>>;
+function useButton(props: AriaButtonProps<'ol'>, ref: RefObject<HTMLOListElement>): ButtonAria<HTMLAttributes<HTMLOListElement>>;
+function useButton(props: AriaButtonProps<'optgroup'>, ref: RefObject<HTMLOptGroupElement>): ButtonAria<HTMLAttributes<HTMLOptGroupElement>>;
+function useButton(props: AriaButtonProps<'option'>, ref: RefObject<HTMLOptionElement>): ButtonAria<HTMLAttributes<HTMLOptionElement>>;
+function useButton(props: AriaButtonProps<'output'>, ref: RefObject<HTMLOutputElement>): ButtonAria<HTMLAttributes<HTMLOutputElement>>;
+function useButton(props: AriaButtonProps<'p'>, ref: RefObject<HTMLParagraphElement>): ButtonAria<HTMLAttributes<HTMLParagraphElement>>;
+function useButton(props: AriaButtonProps<'param'>, ref: RefObject<HTMLParamElement>): ButtonAria<HTMLAttributes<HTMLParamElement>>;
+function useButton(props: AriaButtonProps<'picture'>, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
+function useButton(props: AriaButtonProps<'pre'>, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
+function useButton(props: AriaButtonProps<'progress'>, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
+function useButton(props: AriaButtonProps<'script'>, ref: RefObject<HTMLScriptElement>): ButtonAria<HTMLAttributes<HTMLScriptElement>>;
+function useButton(props: AriaButtonProps<'select'>, ref: RefObject<HTMLSelectElement>): ButtonAria<HTMLAttributes<HTMLSelectElement>>;
+function useButton(props: AriaButtonProps<'slot'>, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
+function useButton(props: AriaButtonProps<'source'>, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;
+function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
+function useButton(props: AriaButtonProps<'style'>, ref: RefObject<HTMLStyleElement>): ButtonAria<HTMLAttributes<HTMLStyleElement>>;
+function useButton(props: AriaButtonProps<'svg'>, ref: RefObject<SVGElement>): ButtonAria<HTMLAttributes<SVGElement>>;
+function useButton(props: AriaButtonProps<'table'>, ref: RefObject<HTMLTableElement>): ButtonAria<HTMLAttributes<HTMLTableElement>>;
+function useButton(props: AriaButtonProps<'td'>, ref: RefObject<HTMLTableDataCellElement>): ButtonAria<HTMLAttributes<HTMLTableDataCellElement>>;
+function useButton(props: AriaButtonProps<'template'>, ref: RefObject<HTMLTemplateElement>): ButtonAria<HTMLAttributes<HTMLTemplateElement>>;
+function useButton(props: AriaButtonProps<'textarea'>, ref: RefObject<HTMLTextAreaElement>): ButtonAria<HTMLAttributes<HTMLTextAreaElement>>;
+function useButton(props: AriaButtonProps<'tfoot'>, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
+function useButton(props: AriaButtonProps<'th'>, ref: RefObject<HTMLTableHeaderCellElement>): ButtonAria<HTMLAttributes<HTMLTableHeaderCellElement>>;
+function useButton(props: AriaButtonProps<'thead'>, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
+function useButton(props: AriaButtonProps<'time'>, ref: RefObject<HTMLTimeElement>): ButtonAria<HTMLAttributes<HTMLTimeElement>>;
+function useButton(props: AriaButtonProps<'title'>, ref: RefObject<HTMLTitleElement>): ButtonAria<HTMLAttributes<HTMLTitleElement>>;
+function useButton(props: AriaButtonProps<'track'>, ref: RefObject<HTMLTrackElement>): ButtonAria<HTMLAttributes<HTMLTrackElement>>;
+function useButton(props: AriaButtonProps<'ul'>, ref: RefObject<HTMLUListElement>): ButtonAria<HTMLAttributes<HTMLUListElement>>;
+function useButton(props: AriaButtonProps<'video'>, ref: RefObject<HTMLVideoElement>): ButtonAria<HTMLAttributes<HTMLVideoElement>>;
+function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLElement>;
+function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<any> {
   let {
     elementType = 'button',
     isDisabled,
@@ -92,3 +163,5 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
     })
   };
 }
+
+export {useButton};

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -41,59 +41,12 @@ export interface ButtonAria<T> {
 
 /* eslint-disable no-redeclare */
 function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-function useButton(props: AriaButtonProps<'area'>, ref: RefObject<HTMLAreaElement>): ButtonAria<HTMLAttributes<HTMLAreaElement>>;
-function useButton(props: AriaButtonProps<'base'>, ref: RefObject<HTMLBaseElement>): ButtonAria<HTMLAttributes<HTMLBaseElement>>;
 function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-function useButton(props: AriaButtonProps<'canvas'>, ref: RefObject<HTMLCanvasElement>): ButtonAria<HTMLAttributes<HTMLCanvasElement>>;
-function useButton(props: AriaButtonProps<'data'>, ref: RefObject<HTMLDataElement>): ButtonAria<HTMLAttributes<HTMLDataElement>>;
-function useButton(props: AriaButtonProps<'details'>, ref: RefObject<HTMLDetailsElement>): ButtonAria<HTMLAttributes<HTMLDetailsElement>>;
-function useButton(props: AriaButtonProps<'dialog'>, ref: RefObject<HTMLDialogElement>): ButtonAria<HTMLAttributes<HTMLDialogElement>>;
 function useButton(props: AriaButtonProps<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-function useButton(props: AriaButtonProps<'embed'>, ref: RefObject<HTMLEmbedElement>): ButtonAria<HTMLAttributes<HTMLEmbedElement>>;
-function useButton(props: AriaButtonProps<'fieldset'>, ref: RefObject<HTMLFieldSetElement>): ButtonAria<HTMLAttributes<HTMLFieldSetElement>>;
-function useButton(props: AriaButtonProps<'form'>, ref: RefObject<HTMLFormElement>): ButtonAria<HTMLAttributes<HTMLFormElement>>;
-function useButton(props: AriaButtonProps<'h1'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useButton(props: AriaButtonProps<'h2'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useButton(props: AriaButtonProps<'h3'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useButton(props: AriaButtonProps<'h4'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useButton(props: AriaButtonProps<'h5'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useButton(props: AriaButtonProps<'h6'>, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useButton(props: AriaButtonProps<'hr'>, ref: RefObject<HTMLHRElement>): ButtonAria<HTMLAttributes<HTMLHRElement>>;
-function useButton(props: AriaButtonProps<'iframe'>, ref: RefObject<HTMLIFrameElement>): ButtonAria<HTMLAttributes<HTMLIFrameElement>>;
-function useButton(props: AriaButtonProps<'img'>, ref: RefObject<HTMLImageElement>): ButtonAria<HTMLAttributes<HTMLImageElement>>;
 function useButton(props: AriaButtonProps<'input'>, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-function useButton(props: AriaButtonProps<'label'>, ref: RefObject<HTMLLabelElement>): ButtonAria<HTMLAttributes<HTMLLabelElement>>;
-function useButton(props: AriaButtonProps<'legend'>, ref: RefObject<HTMLLegendElement>): ButtonAria<HTMLAttributes<HTMLLegendElement>>;
-function useButton(props: AriaButtonProps<'li'>, ref: RefObject<HTMLLIElement>): ButtonAria<HTMLAttributes<HTMLLIElement>>;
-function useButton(props: AriaButtonProps<'link'>, ref: RefObject<HTMLLinkElement>): ButtonAria<HTMLAttributes<HTMLLinkElement>>;
-function useButton(props: AriaButtonProps<'map'>, ref: RefObject<HTMLMapElement>): ButtonAria<HTMLAttributes<HTMLMapElement>>;
-function useButton(props: AriaButtonProps<'menu'>, ref: RefObject<HTMLMenuElement>): ButtonAria<HTMLAttributes<HTMLMenuElement>>;
-function useButton(props: AriaButtonProps<'meter'>, ref: RefObject<HTMLMeterElement>): ButtonAria<HTMLAttributes<HTMLMeterElement>>;
-function useButton(props: AriaButtonProps<'ol'>, ref: RefObject<HTMLOListElement>): ButtonAria<HTMLAttributes<HTMLOListElement>>;
-function useButton(props: AriaButtonProps<'optgroup'>, ref: RefObject<HTMLOptGroupElement>): ButtonAria<HTMLAttributes<HTMLOptGroupElement>>;
-function useButton(props: AriaButtonProps<'option'>, ref: RefObject<HTMLOptionElement>): ButtonAria<HTMLAttributes<HTMLOptionElement>>;
-function useButton(props: AriaButtonProps<'output'>, ref: RefObject<HTMLOutputElement>): ButtonAria<HTMLAttributes<HTMLOutputElement>>;
-function useButton(props: AriaButtonProps<'p'>, ref: RefObject<HTMLParagraphElement>): ButtonAria<HTMLAttributes<HTMLParagraphElement>>;
-function useButton(props: AriaButtonProps<'picture'>, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
-function useButton(props: AriaButtonProps<'pre'>, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
-function useButton(props: AriaButtonProps<'progress'>, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
-function useButton(props: AriaButtonProps<'select'>, ref: RefObject<HTMLSelectElement>): ButtonAria<HTMLAttributes<HTMLSelectElement>>;
-function useButton(props: AriaButtonProps<'slot'>, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
-function useButton(props: AriaButtonProps<'source'>, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;
 function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-function useButton(props: AriaButtonProps<'svg'>, ref: RefObject<SVGElement>): ButtonAria<HTMLAttributes<SVGElement>>;
-function useButton(props: AriaButtonProps<'table'>, ref: RefObject<HTMLTableElement>): ButtonAria<HTMLAttributes<HTMLTableElement>>;
-function useButton(props: AriaButtonProps<'td'>, ref: RefObject<HTMLTableDataCellElement>): ButtonAria<HTMLAttributes<HTMLTableDataCellElement>>;
-function useButton(props: AriaButtonProps<'template'>, ref: RefObject<HTMLTemplateElement>): ButtonAria<HTMLAttributes<HTMLTemplateElement>>;
-function useButton(props: AriaButtonProps<'textarea'>, ref: RefObject<HTMLTextAreaElement>): ButtonAria<HTMLAttributes<HTMLTextAreaElement>>;
-function useButton(props: AriaButtonProps<'tfoot'>, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
-function useButton(props: AriaButtonProps<'th'>, ref: RefObject<HTMLTableHeaderCellElement>): ButtonAria<HTMLAttributes<HTMLTableHeaderCellElement>>;
-function useButton(props: AriaButtonProps<'thead'>, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
-function useButton(props: AriaButtonProps<'time'>, ref: RefObject<HTMLTimeElement>): ButtonAria<HTMLAttributes<HTMLTimeElement>>;
-function useButton(props: AriaButtonProps<'title'>, ref: RefObject<HTMLTitleElement>): ButtonAria<HTMLAttributes<HTMLTitleElement>>;
-function useButton(props: AriaButtonProps<'ul'>, ref: RefObject<HTMLUListElement>): ButtonAria<HTMLAttributes<HTMLUListElement>>;
-function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLElement>;
-function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<any> {
+function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
+function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
   let {
     elementType = 'button',
     isDisabled,

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -82,7 +82,6 @@ function useButton(props: AriaButtonProps<'param'>, ref: RefObject<HTMLParamElem
 function useButton(props: AriaButtonProps<'picture'>, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
 function useButton(props: AriaButtonProps<'pre'>, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
 function useButton(props: AriaButtonProps<'progress'>, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
-function useButton(props: AriaButtonProps<'script'>, ref: RefObject<HTMLScriptElement>): ButtonAria<HTMLAttributes<HTMLScriptElement>>;
 function useButton(props: AriaButtonProps<'select'>, ref: RefObject<HTMLSelectElement>): ButtonAria<HTMLAttributes<HTMLSelectElement>>;
 function useButton(props: AriaButtonProps<'slot'>, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
 function useButton(props: AriaButtonProps<'source'>, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -32,14 +32,13 @@ export interface ButtonAria<T> {
   isPressed: boolean
 }
 
+/* eslint-disable no-redeclare */
 /**
  * Provides the behavior and accessibility implementation for a button component. Handles mouse, keyboard, and touch interactions,
  * focus behavior, and ARIA props for both native button elements and custom element types.
  * @param props - Props to be applied to the button.
  * @param ref - A ref to a DOM element for the button.
  */
-
-/* eslint-disable no-redeclare */
 function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
 function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
 function useButton(props: AriaButtonProps<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
@@ -47,6 +46,7 @@ function useButton(props: AriaButtonProps<'input'>, ref: RefObject<HTMLInputElem
 function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
 function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
 function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
+/* eslint-enable no-redeclare */
   let {
     elementType = 'button',
     isDisabled,

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -42,9 +42,7 @@ export interface ButtonAria<T> {
 /* eslint-disable no-redeclare */
 function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
 function useButton(props: AriaButtonProps<'area'>, ref: RefObject<HTMLAreaElement>): ButtonAria<HTMLAttributes<HTMLAreaElement>>;
-function useButton(props: AriaButtonProps<'audio'>, ref: RefObject<HTMLAudioElement>): ButtonAria<HTMLAttributes<HTMLAudioElement>>;
 function useButton(props: AriaButtonProps<'base'>, ref: RefObject<HTMLBaseElement>): ButtonAria<HTMLAttributes<HTMLBaseElement>>;
-function useButton(props: AriaButtonProps<'br'>, ref: RefObject<HTMLBRElement>): ButtonAria<HTMLAttributes<HTMLBRElement>>;
 function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
 function useButton(props: AriaButtonProps<'canvas'>, ref: RefObject<HTMLCanvasElement>): ButtonAria<HTMLAttributes<HTMLCanvasElement>>;
 function useButton(props: AriaButtonProps<'data'>, ref: RefObject<HTMLDataElement>): ButtonAria<HTMLAttributes<HTMLDataElement>>;
@@ -70,15 +68,12 @@ function useButton(props: AriaButtonProps<'li'>, ref: RefObject<HTMLLIElement>):
 function useButton(props: AriaButtonProps<'link'>, ref: RefObject<HTMLLinkElement>): ButtonAria<HTMLAttributes<HTMLLinkElement>>;
 function useButton(props: AriaButtonProps<'map'>, ref: RefObject<HTMLMapElement>): ButtonAria<HTMLAttributes<HTMLMapElement>>;
 function useButton(props: AriaButtonProps<'menu'>, ref: RefObject<HTMLMenuElement>): ButtonAria<HTMLAttributes<HTMLMenuElement>>;
-function useButton(props: AriaButtonProps<'meta'>, ref: RefObject<HTMLMetaElement>): ButtonAria<HTMLAttributes<HTMLMetaElement>>;
 function useButton(props: AriaButtonProps<'meter'>, ref: RefObject<HTMLMeterElement>): ButtonAria<HTMLAttributes<HTMLMeterElement>>;
-function useButton(props: AriaButtonProps<'object'>, ref: RefObject<HTMLObjectElement>): ButtonAria<HTMLAttributes<HTMLObjectElement>>;
 function useButton(props: AriaButtonProps<'ol'>, ref: RefObject<HTMLOListElement>): ButtonAria<HTMLAttributes<HTMLOListElement>>;
 function useButton(props: AriaButtonProps<'optgroup'>, ref: RefObject<HTMLOptGroupElement>): ButtonAria<HTMLAttributes<HTMLOptGroupElement>>;
 function useButton(props: AriaButtonProps<'option'>, ref: RefObject<HTMLOptionElement>): ButtonAria<HTMLAttributes<HTMLOptionElement>>;
 function useButton(props: AriaButtonProps<'output'>, ref: RefObject<HTMLOutputElement>): ButtonAria<HTMLAttributes<HTMLOutputElement>>;
 function useButton(props: AriaButtonProps<'p'>, ref: RefObject<HTMLParagraphElement>): ButtonAria<HTMLAttributes<HTMLParagraphElement>>;
-function useButton(props: AriaButtonProps<'param'>, ref: RefObject<HTMLParamElement>): ButtonAria<HTMLAttributes<HTMLParamElement>>;
 function useButton(props: AriaButtonProps<'picture'>, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
 function useButton(props: AriaButtonProps<'pre'>, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
 function useButton(props: AriaButtonProps<'progress'>, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
@@ -86,7 +81,6 @@ function useButton(props: AriaButtonProps<'select'>, ref: RefObject<HTMLSelectEl
 function useButton(props: AriaButtonProps<'slot'>, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
 function useButton(props: AriaButtonProps<'source'>, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;
 function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-function useButton(props: AriaButtonProps<'style'>, ref: RefObject<HTMLStyleElement>): ButtonAria<HTMLAttributes<HTMLStyleElement>>;
 function useButton(props: AriaButtonProps<'svg'>, ref: RefObject<SVGElement>): ButtonAria<HTMLAttributes<SVGElement>>;
 function useButton(props: AriaButtonProps<'table'>, ref: RefObject<HTMLTableElement>): ButtonAria<HTMLAttributes<HTMLTableElement>>;
 function useButton(props: AriaButtonProps<'td'>, ref: RefObject<HTMLTableDataCellElement>): ButtonAria<HTMLAttributes<HTMLTableDataCellElement>>;
@@ -97,9 +91,7 @@ function useButton(props: AriaButtonProps<'th'>, ref: RefObject<HTMLTableHeaderC
 function useButton(props: AriaButtonProps<'thead'>, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
 function useButton(props: AriaButtonProps<'time'>, ref: RefObject<HTMLTimeElement>): ButtonAria<HTMLAttributes<HTMLTimeElement>>;
 function useButton(props: AriaButtonProps<'title'>, ref: RefObject<HTMLTitleElement>): ButtonAria<HTMLAttributes<HTMLTitleElement>>;
-function useButton(props: AriaButtonProps<'track'>, ref: RefObject<HTMLTrackElement>): ButtonAria<HTMLAttributes<HTMLTrackElement>>;
 function useButton(props: AriaButtonProps<'ul'>, ref: RefObject<HTMLUListElement>): ButtonAria<HTMLAttributes<HTMLUListElement>>;
-function useButton(props: AriaButtonProps<'video'>, ref: RefObject<HTMLVideoElement>): ButtonAria<HTMLAttributes<HTMLVideoElement>>;
 function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<HTMLElement>): ButtonAria<HTMLElement>;
 function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<any> {
   let {

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -72,7 +72,6 @@ function useToggleButton(props: AriaToggleButtonProps<'param'>, state: ToggleSta
 function useToggleButton(props: AriaToggleButtonProps<'picture'>, state: ToggleState, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'pre'>, state: ToggleState, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'progress'>, state: ToggleState, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'script'>, state: ToggleState, ref: RefObject<HTMLScriptElement>): ButtonAria<HTMLAttributes<HTMLScriptElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'select'>, state: ToggleState, ref: RefObject<HTMLSelectElement>): ButtonAria<HTMLAttributes<HTMLSelectElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'slot'>, state: ToggleState, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'source'>, state: ToggleState, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -24,12 +24,11 @@ import {chain} from '@react-aria/utils';
 import {mergeProps} from '@react-aria/utils';
 import {ToggleState} from '@react-stately/toggle';
 
+/* eslint-disable no-redeclare */
 /**
  * Provides the behavior and accessibility implementation for a toggle button component.
  * ToggleButtons allow users to toggle a selection on or off, for example switching between two states or modes.
  */
-
- /* eslint-disable no-redeclare */
 function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
@@ -37,6 +36,7 @@ function useToggleButton(props: AriaToggleButtonProps<'input'>, state: ToggleSta
 function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
 function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
 function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
+/* eslint-enable no-redeclare */
   const {isSelected} = state;
   const {isPressed, buttonProps} = useButton({
     ...props,

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -32,9 +32,7 @@ import {ToggleState} from '@react-stately/toggle';
  /* eslint-disable no-redeclare */
 function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'area'>, state: ToggleState, ref: RefObject<HTMLAreaElement>): ButtonAria<HTMLAttributes<HTMLAreaElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'audio'>, state: ToggleState, ref: RefObject<HTMLAudioElement>): ButtonAria<HTMLAttributes<HTMLAudioElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'base'>, state: ToggleState, ref: RefObject<HTMLBaseElement>): ButtonAria<HTMLAttributes<HTMLBaseElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'br'>, state: ToggleState, ref: RefObject<HTMLBRElement>): ButtonAria<HTMLAttributes<HTMLBRElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'canvas'>, state: ToggleState, ref: RefObject<HTMLCanvasElement>): ButtonAria<HTMLAttributes<HTMLCanvasElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'data'>, state: ToggleState, ref: RefObject<HTMLDataElement>): ButtonAria<HTMLAttributes<HTMLDataElement>>;
@@ -60,15 +58,12 @@ function useToggleButton(props: AriaToggleButtonProps<'li'>, state: ToggleState,
 function useToggleButton(props: AriaToggleButtonProps<'link'>, state: ToggleState, ref: RefObject<HTMLLinkElement>): ButtonAria<HTMLAttributes<HTMLLinkElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'map'>, state: ToggleState, ref: RefObject<HTMLMapElement>): ButtonAria<HTMLAttributes<HTMLMapElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'menu'>, state: ToggleState, ref: RefObject<HTMLMenuElement>): ButtonAria<HTMLAttributes<HTMLMenuElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'meta'>, state: ToggleState, ref: RefObject<HTMLMetaElement>): ButtonAria<HTMLAttributes<HTMLMetaElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'meter'>, state: ToggleState, ref: RefObject<HTMLMeterElement>): ButtonAria<HTMLAttributes<HTMLMeterElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'object'>, state: ToggleState, ref: RefObject<HTMLObjectElement>): ButtonAria<HTMLAttributes<HTMLObjectElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'ol'>, state: ToggleState, ref: RefObject<HTMLOListElement>): ButtonAria<HTMLAttributes<HTMLOListElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'optgroup'>, state: ToggleState, ref: RefObject<HTMLOptGroupElement>): ButtonAria<HTMLAttributes<HTMLOptGroupElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'option'>, state: ToggleState, ref: RefObject<HTMLOptionElement>): ButtonAria<HTMLAttributes<HTMLOptionElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'output'>, state: ToggleState, ref: RefObject<HTMLOutputElement>): ButtonAria<HTMLAttributes<HTMLOutputElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'p'>, state: ToggleState, ref: RefObject<HTMLParagraphElement>): ButtonAria<HTMLAttributes<HTMLParagraphElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'param'>, state: ToggleState, ref: RefObject<HTMLParamElement>): ButtonAria<HTMLAttributes<HTMLParamElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'picture'>, state: ToggleState, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'pre'>, state: ToggleState, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'progress'>, state: ToggleState, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
@@ -76,7 +71,6 @@ function useToggleButton(props: AriaToggleButtonProps<'select'>, state: ToggleSt
 function useToggleButton(props: AriaToggleButtonProps<'slot'>, state: ToggleState, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'source'>, state: ToggleState, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'style'>, state: ToggleState, ref: RefObject<HTMLStyleElement>): ButtonAria<HTMLAttributes<HTMLStyleElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'svg'>, state: ToggleState, ref: RefObject<SVGElement>): ButtonAria<HTMLAttributes<SVGElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'table'>, state: ToggleState, ref: RefObject<HTMLTableElement>): ButtonAria<HTMLAttributes<HTMLTableElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'td'>, state: ToggleState, ref: RefObject<HTMLTableDataCellElement>): ButtonAria<HTMLAttributes<HTMLTableDataCellElement>>;
@@ -87,9 +81,7 @@ function useToggleButton(props: AriaToggleButtonProps<'th'>, state: ToggleState,
 function useToggleButton(props: AriaToggleButtonProps<'thead'>, state: ToggleState, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'time'>, state: ToggleState, ref: RefObject<HTMLTimeElement>): ButtonAria<HTMLAttributes<HTMLTimeElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'title'>, state: ToggleState, ref: RefObject<HTMLTitleElement>): ButtonAria<HTMLAttributes<HTMLTitleElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'track'>, state: ToggleState, ref: RefObject<HTMLTrackElement>): ButtonAria<HTMLAttributes<HTMLTrackElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'ul'>, state: ToggleState, ref: RefObject<HTMLUListElement>): ButtonAria<HTMLAttributes<HTMLUListElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'video'>, state: ToggleState, ref: RefObject<HTMLVideoElement>): ButtonAria<HTMLAttributes<HTMLVideoElement>>;
 function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLElement>;
 function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<any> {
   const {isSelected} = state;

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -10,18 +10,89 @@
  * governing permissions and limitations under the License.
  */
 
+import {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ElementType,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  RefObject
+} from 'react';
 import {AriaToggleButtonProps} from '@react-types/button';
 import {ButtonAria, useButton} from './useButton';
 import {chain} from '@react-aria/utils';
 import {mergeProps} from '@react-aria/utils';
-import {RefObject} from 'react';
 import {ToggleState} from '@react-stately/toggle';
 
 /**
  * Provides the behavior and accessibility implementation for a toggle button component.
  * ToggleButtons allow users to toggle a selection on or off, for example switching between two states or modes.
  */
-export function useToggleButton(props: AriaToggleButtonProps, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria {
+
+ /* eslint-disable no-redeclare */
+function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'area'>, state: ToggleState, ref: RefObject<HTMLAreaElement>): ButtonAria<HTMLAttributes<HTMLAreaElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'audio'>, state: ToggleState, ref: RefObject<HTMLAudioElement>): ButtonAria<HTMLAttributes<HTMLAudioElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'base'>, state: ToggleState, ref: RefObject<HTMLBaseElement>): ButtonAria<HTMLAttributes<HTMLBaseElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'br'>, state: ToggleState, ref: RefObject<HTMLBRElement>): ButtonAria<HTMLAttributes<HTMLBRElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'canvas'>, state: ToggleState, ref: RefObject<HTMLCanvasElement>): ButtonAria<HTMLAttributes<HTMLCanvasElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'data'>, state: ToggleState, ref: RefObject<HTMLDataElement>): ButtonAria<HTMLAttributes<HTMLDataElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'details'>, state: ToggleState, ref: RefObject<HTMLDetailsElement>): ButtonAria<HTMLAttributes<HTMLDetailsElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'dialog'>, state: ToggleState, ref: RefObject<HTMLDialogElement>): ButtonAria<HTMLAttributes<HTMLDialogElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'embed'>, state: ToggleState, ref: RefObject<HTMLEmbedElement>): ButtonAria<HTMLAttributes<HTMLEmbedElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'fieldset'>, state: ToggleState, ref: RefObject<HTMLFieldSetElement>): ButtonAria<HTMLAttributes<HTMLFieldSetElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'form'>, state: ToggleState, ref: RefObject<HTMLFormElement>): ButtonAria<HTMLAttributes<HTMLFormElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'h1'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'h2'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'h3'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'h4'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'h5'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'h6'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'hr'>, state: ToggleState, ref: RefObject<HTMLHRElement>): ButtonAria<HTMLAttributes<HTMLHRElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'iframe'>, state: ToggleState, ref: RefObject<HTMLIFrameElement>): ButtonAria<HTMLAttributes<HTMLIFrameElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'img'>, state: ToggleState, ref: RefObject<HTMLImageElement>): ButtonAria<HTMLAttributes<HTMLImageElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'label'>, state: ToggleState, ref: RefObject<HTMLLabelElement>): ButtonAria<HTMLAttributes<HTMLLabelElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'legend'>, state: ToggleState, ref: RefObject<HTMLLegendElement>): ButtonAria<HTMLAttributes<HTMLLegendElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'li'>, state: ToggleState, ref: RefObject<HTMLLIElement>): ButtonAria<HTMLAttributes<HTMLLIElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'link'>, state: ToggleState, ref: RefObject<HTMLLinkElement>): ButtonAria<HTMLAttributes<HTMLLinkElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'map'>, state: ToggleState, ref: RefObject<HTMLMapElement>): ButtonAria<HTMLAttributes<HTMLMapElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'menu'>, state: ToggleState, ref: RefObject<HTMLMenuElement>): ButtonAria<HTMLAttributes<HTMLMenuElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'meta'>, state: ToggleState, ref: RefObject<HTMLMetaElement>): ButtonAria<HTMLAttributes<HTMLMetaElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'meter'>, state: ToggleState, ref: RefObject<HTMLMeterElement>): ButtonAria<HTMLAttributes<HTMLMeterElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'object'>, state: ToggleState, ref: RefObject<HTMLObjectElement>): ButtonAria<HTMLAttributes<HTMLObjectElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'ol'>, state: ToggleState, ref: RefObject<HTMLOListElement>): ButtonAria<HTMLAttributes<HTMLOListElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'optgroup'>, state: ToggleState, ref: RefObject<HTMLOptGroupElement>): ButtonAria<HTMLAttributes<HTMLOptGroupElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'option'>, state: ToggleState, ref: RefObject<HTMLOptionElement>): ButtonAria<HTMLAttributes<HTMLOptionElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'output'>, state: ToggleState, ref: RefObject<HTMLOutputElement>): ButtonAria<HTMLAttributes<HTMLOutputElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'p'>, state: ToggleState, ref: RefObject<HTMLParagraphElement>): ButtonAria<HTMLAttributes<HTMLParagraphElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'param'>, state: ToggleState, ref: RefObject<HTMLParamElement>): ButtonAria<HTMLAttributes<HTMLParamElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'picture'>, state: ToggleState, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'pre'>, state: ToggleState, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'progress'>, state: ToggleState, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'script'>, state: ToggleState, ref: RefObject<HTMLScriptElement>): ButtonAria<HTMLAttributes<HTMLScriptElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'select'>, state: ToggleState, ref: RefObject<HTMLSelectElement>): ButtonAria<HTMLAttributes<HTMLSelectElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'slot'>, state: ToggleState, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'source'>, state: ToggleState, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'style'>, state: ToggleState, ref: RefObject<HTMLStyleElement>): ButtonAria<HTMLAttributes<HTMLStyleElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'svg'>, state: ToggleState, ref: RefObject<SVGElement>): ButtonAria<HTMLAttributes<SVGElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'table'>, state: ToggleState, ref: RefObject<HTMLTableElement>): ButtonAria<HTMLAttributes<HTMLTableElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'td'>, state: ToggleState, ref: RefObject<HTMLTableDataCellElement>): ButtonAria<HTMLAttributes<HTMLTableDataCellElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'template'>, state: ToggleState, ref: RefObject<HTMLTemplateElement>): ButtonAria<HTMLAttributes<HTMLTemplateElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'textarea'>, state: ToggleState, ref: RefObject<HTMLTextAreaElement>): ButtonAria<HTMLAttributes<HTMLTextAreaElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'tfoot'>, state: ToggleState, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'th'>, state: ToggleState, ref: RefObject<HTMLTableHeaderCellElement>): ButtonAria<HTMLAttributes<HTMLTableHeaderCellElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'thead'>, state: ToggleState, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'time'>, state: ToggleState, ref: RefObject<HTMLTimeElement>): ButtonAria<HTMLAttributes<HTMLTimeElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'title'>, state: ToggleState, ref: RefObject<HTMLTitleElement>): ButtonAria<HTMLAttributes<HTMLTitleElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'track'>, state: ToggleState, ref: RefObject<HTMLTrackElement>): ButtonAria<HTMLAttributes<HTMLTrackElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'ul'>, state: ToggleState, ref: RefObject<HTMLUListElement>): ButtonAria<HTMLAttributes<HTMLUListElement>>;
+function useToggleButton(props: AriaToggleButtonProps<'video'>, state: ToggleState, ref: RefObject<HTMLVideoElement>): ButtonAria<HTMLAttributes<HTMLVideoElement>>;
+function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLElement>;
+function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<any> {
   const {isSelected} = state;
   const {isPressed, buttonProps} = useButton({
     ...props,
@@ -35,3 +106,5 @@ export function useToggleButton(props: AriaToggleButtonProps, state: ToggleState
     })
   };
 }
+
+export {useToggleButton};

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -31,59 +31,12 @@ import {ToggleState} from '@react-stately/toggle';
 
  /* eslint-disable no-redeclare */
 function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'area'>, state: ToggleState, ref: RefObject<HTMLAreaElement>): ButtonAria<HTMLAttributes<HTMLAreaElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'base'>, state: ToggleState, ref: RefObject<HTMLBaseElement>): ButtonAria<HTMLAttributes<HTMLBaseElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'canvas'>, state: ToggleState, ref: RefObject<HTMLCanvasElement>): ButtonAria<HTMLAttributes<HTMLCanvasElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'data'>, state: ToggleState, ref: RefObject<HTMLDataElement>): ButtonAria<HTMLAttributes<HTMLDataElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'details'>, state: ToggleState, ref: RefObject<HTMLDetailsElement>): ButtonAria<HTMLAttributes<HTMLDetailsElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'dialog'>, state: ToggleState, ref: RefObject<HTMLDialogElement>): ButtonAria<HTMLAttributes<HTMLDialogElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'embed'>, state: ToggleState, ref: RefObject<HTMLEmbedElement>): ButtonAria<HTMLAttributes<HTMLEmbedElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'fieldset'>, state: ToggleState, ref: RefObject<HTMLFieldSetElement>): ButtonAria<HTMLAttributes<HTMLFieldSetElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'form'>, state: ToggleState, ref: RefObject<HTMLFormElement>): ButtonAria<HTMLAttributes<HTMLFormElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'h1'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'h2'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'h3'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'h4'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'h5'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'h6'>, state: ToggleState, ref: RefObject<HTMLHeadingElement>): ButtonAria<HTMLAttributes<HTMLHeadingElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'hr'>, state: ToggleState, ref: RefObject<HTMLHRElement>): ButtonAria<HTMLAttributes<HTMLHRElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'iframe'>, state: ToggleState, ref: RefObject<HTMLIFrameElement>): ButtonAria<HTMLAttributes<HTMLIFrameElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'img'>, state: ToggleState, ref: RefObject<HTMLImageElement>): ButtonAria<HTMLAttributes<HTMLImageElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'label'>, state: ToggleState, ref: RefObject<HTMLLabelElement>): ButtonAria<HTMLAttributes<HTMLLabelElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'legend'>, state: ToggleState, ref: RefObject<HTMLLegendElement>): ButtonAria<HTMLAttributes<HTMLLegendElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'li'>, state: ToggleState, ref: RefObject<HTMLLIElement>): ButtonAria<HTMLAttributes<HTMLLIElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'link'>, state: ToggleState, ref: RefObject<HTMLLinkElement>): ButtonAria<HTMLAttributes<HTMLLinkElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'map'>, state: ToggleState, ref: RefObject<HTMLMapElement>): ButtonAria<HTMLAttributes<HTMLMapElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'menu'>, state: ToggleState, ref: RefObject<HTMLMenuElement>): ButtonAria<HTMLAttributes<HTMLMenuElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'meter'>, state: ToggleState, ref: RefObject<HTMLMeterElement>): ButtonAria<HTMLAttributes<HTMLMeterElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'ol'>, state: ToggleState, ref: RefObject<HTMLOListElement>): ButtonAria<HTMLAttributes<HTMLOListElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'optgroup'>, state: ToggleState, ref: RefObject<HTMLOptGroupElement>): ButtonAria<HTMLAttributes<HTMLOptGroupElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'option'>, state: ToggleState, ref: RefObject<HTMLOptionElement>): ButtonAria<HTMLAttributes<HTMLOptionElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'output'>, state: ToggleState, ref: RefObject<HTMLOutputElement>): ButtonAria<HTMLAttributes<HTMLOutputElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'p'>, state: ToggleState, ref: RefObject<HTMLParagraphElement>): ButtonAria<HTMLAttributes<HTMLParagraphElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'picture'>, state: ToggleState, ref: RefObject<HTMLPictureElement>): ButtonAria<HTMLAttributes<HTMLPictureElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'pre'>, state: ToggleState, ref: RefObject<HTMLPreElement>): ButtonAria<HTMLAttributes<HTMLPreElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'progress'>, state: ToggleState, ref: RefObject<HTMLProgressElement>): ButtonAria<HTMLAttributes<HTMLProgressElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'select'>, state: ToggleState, ref: RefObject<HTMLSelectElement>): ButtonAria<HTMLAttributes<HTMLSelectElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'slot'>, state: ToggleState, ref: RefObject<HTMLSlotElement>): ButtonAria<HTMLAttributes<HTMLSlotElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'source'>, state: ToggleState, ref: RefObject<HTMLSourceElement>): ButtonAria<HTMLAttributes<HTMLSourceElement>>;
 function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'svg'>, state: ToggleState, ref: RefObject<SVGElement>): ButtonAria<HTMLAttributes<SVGElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'table'>, state: ToggleState, ref: RefObject<HTMLTableElement>): ButtonAria<HTMLAttributes<HTMLTableElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'td'>, state: ToggleState, ref: RefObject<HTMLTableDataCellElement>): ButtonAria<HTMLAttributes<HTMLTableDataCellElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'template'>, state: ToggleState, ref: RefObject<HTMLTemplateElement>): ButtonAria<HTMLAttributes<HTMLTemplateElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'textarea'>, state: ToggleState, ref: RefObject<HTMLTextAreaElement>): ButtonAria<HTMLAttributes<HTMLTextAreaElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'tfoot'>, state: ToggleState, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'th'>, state: ToggleState, ref: RefObject<HTMLTableHeaderCellElement>): ButtonAria<HTMLAttributes<HTMLTableHeaderCellElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'thead'>, state: ToggleState, ref: RefObject<HTMLTableSectionElement>): ButtonAria<HTMLAttributes<HTMLTableSectionElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'time'>, state: ToggleState, ref: RefObject<HTMLTimeElement>): ButtonAria<HTMLAttributes<HTMLTimeElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'title'>, state: ToggleState, ref: RefObject<HTMLTitleElement>): ButtonAria<HTMLAttributes<HTMLTitleElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'ul'>, state: ToggleState, ref: RefObject<HTMLUListElement>): ButtonAria<HTMLAttributes<HTMLUListElement>>;
-function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLElement>;
-function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<any> {
+function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
+function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
   const {isSelected} = state;
   const {isPressed, buttonProps} = useButton({
     ...props,

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -25,17 +25,17 @@ import {mergeProps} from '@react-aria/utils';
 import {ToggleState} from '@react-stately/toggle';
 
 /* eslint-disable no-redeclare */
+export function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
+export function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
+export function useToggleButton(props: AriaToggleButtonProps<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
+export function useToggleButton(props: AriaToggleButtonProps<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
+export function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
+export function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
 /**
  * Provides the behavior and accessibility implementation for a toggle button component.
  * ToggleButtons allow users to toggle a selection on or off, for example switching between two states or modes.
  */
-function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<HTMLElement>): ButtonAria<HTMLAttributes<HTMLElement>>;
-function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
+export function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
 /* eslint-enable no-redeclare */
   const {isSelected} = state;
   const {isPressed, buttonProps} = useButton({
@@ -50,5 +50,3 @@ function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: Toggl
     })
   };
 }
-
-export {useToggleButton};

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -27,7 +27,7 @@ let VARIANT_MAPPING = {
   negative: 'warning'
 };
 
-function Button(props: SpectrumButtonProps, ref: FocusableRef) {
+function Button(props: SpectrumButtonProps, ref: FocusableRef<HTMLButtonElement>) {
   props = useProviderProps(props);
   props = useSlotProps(props, 'button');
   let {

--- a/packages/@react-spectrum/button/src/ClearButton.tsx
+++ b/packages/@react-spectrum/button/src/ClearButton.tsx
@@ -10,19 +10,18 @@
  * governing permissions and limitations under the License.
  */
 
-import {ButtonProps} from '@react-types/button';
+import {AriaButtonElementTypeProps, ButtonProps} from '@react-types/button';
 import {classNames, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import CrossSmall from '@spectrum-icons/ui/CrossSmall';
 import {DOMProps, FocusableRef, StyleProps} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
-import React, {JSXElementConstructor} from 'react';
+import React, {ElementType} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {useButton} from '@react-aria/button';
 import {useHover} from '@react-aria/interactions';
 
-interface ClearButtonProps extends ButtonProps, DOMProps, StyleProps {
-  elementType?: string | JSXElementConstructor<any>,
+interface ClearButtonProps<T extends ElementType = 'button'> extends ButtonProps, AriaButtonElementTypeProps<T>, DOMProps, StyleProps {
   focusClassName?: string,
   variant?: 'overBackground',
   excludeFromTabOrder?: boolean,
@@ -37,7 +36,7 @@ function ClearButton(props: ClearButtonProps, ref: FocusableRef<HTMLButtonElemen
     autoFocus,
     isDisabled,
     preventFocus,
-    elementType = preventFocus ? 'div' : 'button',
+    elementType = preventFocus ? 'div' : 'button' as ElementType,
     ...otherProps
   } = props;
   let domRef = useFocusableRef(ref);

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, FocusableDOMProps, FocusableProps, PressEvents, StyleProps} from '@react-types/shared';
-import {JSXElementConstructor, ReactNode} from 'react';
+import {ElementType, JSXElementConstructor, ReactNode} from 'react';
 
 interface ButtonProps extends PressEvents, FocusableProps {
   /** Whether the button is disabled. */
@@ -29,12 +29,12 @@ interface ToggleButtonProps extends ButtonProps {
   onChange?: (isSelected: boolean) => void
 }
 
-export interface LinkButtonProps {
+export interface LinkButtonProps<T extends ElementType = 'button'> {
   /**
    * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
    * @default 'button'
    */
-  elementType?: string | JSXElementConstructor<any>,
+  elementType?: T | JSXElementConstructor<any>,
   /** A URL to link to if elementType="a". */
   href?: string,
   /** The target window for the link. */
@@ -59,8 +59,9 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
   type?: 'button' | 'submit' | 'reset'
 }
 
-export interface AriaButtonProps extends ButtonProps, LinkButtonProps, AriaBaseButtonProps {}
-export interface AriaToggleButtonProps extends ToggleButtonProps, AriaBaseButtonProps {}
+export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
+
+export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
 
 export interface SpectrumButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -61,7 +61,7 @@ interface AriaBaseButtonProps<T extends ElementType = 'button'> extends Focusabl
 
 export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps, AriaBaseButtonProps<T> {}
 
-export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, LinkButtonProps, AriaBaseButtonProps<T> {}
+export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, AriaBaseButtonProps<T> {}
 
 export interface SpectrumButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -29,7 +29,15 @@ interface ToggleButtonProps extends ButtonProps {
   onChange?: (isSelected: boolean) => void
 }
 
-export interface LinkButtonProps {
+export interface AriaButtonElementTypeProps<T extends ElementType = 'button'> {
+  /**
+   * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
+   * @default 'button'
+   */
+  elementType?: T | JSXElementConstructor<any>
+}
+
+export interface LinkButtonProps<T extends ElementType = 'button'> extends AriaButtonElementTypeProps<T> {
   /** A URL to link to if elementType="a". */
   href?: string,
   /** The target window for the link. */
@@ -38,7 +46,7 @@ export interface LinkButtonProps {
   rel?: string
 }
 
-interface AriaBaseButtonProps<T extends ElementType = 'button'> extends FocusableDOMProps, AriaLabelingProps {
+interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
   /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
   'aria-expanded'?: boolean,
   /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
@@ -51,17 +59,11 @@ interface AriaBaseButtonProps<T extends ElementType = 'button'> extends Focusabl
    * The behavior of the button when used in an HTML form.
    * @default 'button'
    */
-  type?: 'button' | 'submit' | 'reset',
-  /**
-   * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
-   * @default 'button'
-   */
-  elementType?: T | JSXElementConstructor<any>
+  type?: 'button' | 'submit' | 'reset'
 }
 
-export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps, AriaBaseButtonProps<T> {}
-
-export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, AriaBaseButtonProps<T> {}
+export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
+export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, AriaBaseButtonProps, AriaButtonElementTypeProps<T> {}
 
 export interface SpectrumButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -29,12 +29,7 @@ interface ToggleButtonProps extends ButtonProps {
   onChange?: (isSelected: boolean) => void
 }
 
-export interface LinkButtonProps<T extends ElementType = 'button'> {
-  /**
-   * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
-   * @default 'button'
-   */
-  elementType?: T | JSXElementConstructor<any>,
+export interface LinkButtonProps {
   /** A URL to link to if elementType="a". */
   href?: string,
   /** The target window for the link. */
@@ -43,7 +38,7 @@ export interface LinkButtonProps<T extends ElementType = 'button'> {
   rel?: string
 }
 
-interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
+interface AriaBaseButtonProps<T extends ElementType = 'button'> extends FocusableDOMProps, AriaLabelingProps {
   /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
   'aria-expanded'?: boolean,
   /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
@@ -56,12 +51,17 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
    * The behavior of the button when used in an HTML form.
    * @default 'button'
    */
-  type?: 'button' | 'submit' | 'reset'
+  type?: 'button' | 'submit' | 'reset',
+  /**
+   * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
+   * @default 'button'
+   */
+  elementType?: T | JSXElementConstructor<any>
 }
 
-export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
+export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps, AriaBaseButtonProps<T> {}
 
-export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
+export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, LinkButtonProps, AriaBaseButtonProps<T> {}
 
 export interface SpectrumButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */


### PR DESCRIPTION
Closes #1172

Hello Adobe team 👋 
This is an implementation proposal to the types modification request in response to the following issue: #1172

I modified four files :
- `useButton` and `useToggleButton` hooks on which I added functions overloading (thanks to @devongovett advices) to dynamically modify the generic type passed to the returned `ButtonAria` depending on `elementType` props. I also modified the ref object generic type `HTMLElement` to match with the `elementType` one.
- button types in `@react-types/button`: changed `elementType` type from string to `React.ElementType` which may enforce typing to be sure `buttonProps` ref and `elementType` are corresponding to the HTML DOM element used.
- Button spectrum element for a small generic type update

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).

- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
--> Did not added testable code as my modifications are mainly related to types. Please tell me, otherwise, if it may need some.

- [x] Updated documentation (if it already exists for this component).
--> I assumed the props are automatically generated based on the component's props. If no, could you tell me where to update them on `docs:@react-aria/button` ? Also, I think restriction HTML types who would make sense to be used as a button should be notified on the documentation
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Create a button component :

```typescript
export function Button(props: AriaButtonProps) {
  const ref = React.useRef<HTMLDivElement | null>(null);
  const {buttonProps} = useButton(
    {
      ...props,
      elementType: 'div'
    },
    ref
  );
  return (
    <div {...buttonProps} ref={ref}>
      {props.children}
    </div>
  );
}
```

2. Change `useRef` type, `elementType` and HTML node to whatever you want
3. `buttonProps` type should be good

## 🧢 Your Project:

Personal project -> would like to use react-aria with custom components using Framer Motion which may be have different DOM element.
