### PR TITLE
Fix usePreventScroll on iOS with React 17

### DIFF
--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -11,7 +11,7 @@
  */
 
 import {chain, getScrollParent} from '@react-aria/utils';
-import {useEffect} from 'react';
+import {useLayoutEffect} from 'react';
 
 interface PreventScrollOptions {
   /** Whether the scroll lock is disabled. */
@@ -38,7 +38,7 @@ const visualViewport = typeof window !== 'undefined' && window.visualViewport;
 export function usePreventScroll(options: PreventScrollOptions = {}) {
   let {isDisabled} = options;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isDisabled) {
       return;
     }


### PR DESCRIPTION
Apparently React 17 made useEffect cleanup functions async and for some reason that's having an effect on restoring the scroll position on iOS when a dialog closes (it scrolls to the top). Using `useLayoutEffect` instead fixes the issue.