### PR TITLE
Fix function name typo

### DIFF
--- a/packages/@react-aria/interactions/src/useMove.ts
+++ b/packages/@react-aria/interactions/src/useMove.ts
@@ -172,7 +172,7 @@ export function useMove(props: MoveEvents): MoveResult {
       };
     }
 
-    let triggetKeyboardMove = (deltaX: number, deltaY: number) => {
+    let triggerKeyboardMove = (deltaX: number, deltaY: number) => {
       start();
       move('keyboard', deltaX, deltaY);
       end('keyboard');
@@ -184,25 +184,25 @@ export function useMove(props: MoveEvents): MoveResult {
         case 'ArrowLeft':
           e.preventDefault();
           e.stopPropagation();
-          triggetKeyboardMove(-1, 0);
+          triggerKeyboardMove(-1, 0);
           break;
         case 'Right':
         case 'ArrowRight':
           e.preventDefault();
           e.stopPropagation();
-          triggetKeyboardMove(1, 0);
+          triggerKeyboardMove(1, 0);
           break;
         case 'Up':
         case 'ArrowUp':
           e.preventDefault();
           e.stopPropagation();
-          triggetKeyboardMove(0, -1);
+          triggerKeyboardMove(0, -1);
           break;
         case 'Down':
         case 'ArrowDown':
           e.preventDefault();
           e.stopPropagation();
-          triggetKeyboardMove(0, 1);
+          triggerKeyboardMove(0, 1);
           break;
       }
     };


### PR DESCRIPTION
Fixes a typo [useMove.ts#L175](https://github.com/adobe/react-spectrum/blob/879cbbdd5031a8d6ac4e91272c8e73d7dd38b0c9/packages/%40react-aria/interactions/src/useMove.ts#L175)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
