### PR TITLE
Fix docs useSelect console warning

### DIFF
--- a/packages/@react-aria/select/docs/useSelect.mdx
+++ b/packages/@react-aria/select/docs/useSelect.mdx
@@ -190,7 +190,8 @@ function ListBoxPopup({state, ...otherProps}) {
   // Get props for the listbox
   let {listBoxProps} = useListBox({
     autoFocus: state.focusStrategy || true,
-    disallowEmptySelection: true
+    disallowEmptySelection: true,
+    ...otherProps
   }, state, ref);
 
   // Handle events that should cause the popup to close,


### PR DESCRIPTION
Pass along props so that the Listbox knows that it has been labelled.

Closes https://github.com/adobe/react-spectrum/issues/1179

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
