### PR TITLE
picker adding text color for disabled active selected value

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
@@ -45,6 +45,9 @@ governing permissions and limitations under the License.
         color: var(--spectrum-dropdown-icon-color-disabled);
       }
     }
+    &:active .spectrum-Dropdown-label {
+      color: var(--spectrum-dropdown-text-color-disabled);
+    }
     .spectrum-Dropdown-label {
       &.is-placeholder {
         color: var(--spectrum-dropdown-placeholder-text-color-disabled);

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -108,6 +108,16 @@ storiesOf('Picker', module)
     )
   )
   .add(
+    'isDisabled, selectedKey',
+    () => (
+      <Picker label="Test" isDisabled selectedKey="One" onSelectionChange={action('selectionChange')}>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
+      </Picker>
+    )
+  )
+  .add(
     'labelAlign: end',
     () => (
       <Picker direction="top" label="Test" labelAlign="end" onSelectionChange={action('selectionChange')}>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1079

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Added a new storybook for this case.
Goto the 'isDisabled, selectedKey` story.
Click on "One" and the text color won't change.

## 🧢 Your Project:
RSP