### PR TITLE
Revert "Don't text select after dismissing a dialog in FF"

### DIFF
--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -38,11 +38,6 @@ export function useInteractOutside(props: InteractOutsideProps) {
     let onPointerDown = (e) => {
       if (isValidEvent(e, ref)) {
         state.isPointerDown = true;
-        // Due to browser inconsistencies, we prevent
-        // default on pointer down. FF will otherwise try to start text selection.
-        if (e.button === 0) {
-          e.preventDefault();
-        }
       }
     };
 
@@ -52,9 +47,6 @@ export function useInteractOutside(props: InteractOutsideProps) {
         if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
           state.isPointerDown = false;
           onInteractOutside(e);
-          if (e.button === 0) {
-            e.preventDefault();
-          }
         }
       };
 
@@ -73,9 +65,6 @@ export function useInteractOutside(props: InteractOutsideProps) {
         } else if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
           state.isPointerDown = false;
           onInteractOutside(e);
-          if (e.button === 0) {
-            e.preventDefault();
-          }
         }
       };
 
@@ -84,9 +73,6 @@ export function useInteractOutside(props: InteractOutsideProps) {
         if (onInteractOutside && state.isPointerDown && isValidEvent(e, ref)) {
           state.isPointerDown = false;
           onInteractOutside(e);
-          if (e.button === 0) {
-            e.preventDefault();
-          }
         }
       };
 


### PR DESCRIPTION
Reverts adobe/react-spectrum#1187
Closes: https://github.com/adobe/react-spectrum/issues/1220

This caused issues with Combobox and and nested dialogs.
We're currently working on a better fix for the original issue but need to discuss it more