### PR TITLE
Catch Intl.NumberFormat error for unsupported option

### DIFF
--- a/packages/@react-aria/i18n/src/useNumberFormatter.ts
+++ b/packages/@react-aria/i18n/src/useNumberFormatter.ts
@@ -19,6 +19,7 @@ let supportsSignDisplay = false;
 try {
   // @ts-ignore
   supportsSignDisplay = (new Intl.NumberFormat('de-DE', {signDisplay: 'exceptZero'})).resolvedOptions().signDisplay === 'exceptZero';
+  // eslint-disable-next-line no-empty
 } catch (e) {}
 
 /**

--- a/packages/@react-aria/i18n/src/useNumberFormatter.ts
+++ b/packages/@react-aria/i18n/src/useNumberFormatter.ts
@@ -15,8 +15,11 @@ import {useLocale} from './context';
 
 let formatterCache = new Map<string, Intl.NumberFormat>();
 
-// @ts-ignore
-const supportsSignDisplay = (new Intl.NumberFormat('de-DE', {signDisplay: 'exceptZero'})).resolvedOptions().signDisplay === 'exceptZero';
+let supportsSignDisplay = false;
+try {
+  // @ts-ignore
+  supportsSignDisplay = (new Intl.NumberFormat('de-DE', {signDisplay: 'exceptZero'})).resolvedOptions().signDisplay === 'exceptZero';
+} catch (e) {}
 
 /**
  * Provides localized number formatting for the current locale. Automatically updates when the locale changes,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1248

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
