### PR TITLE
RSP-1253: Update NoSearchResults svg formatting

### DIFF
--- a/packages/@spectrum-icons/illustrations/src/NoSearchResults.tsx
+++ b/packages/@spectrum-icons/illustrations/src/NoSearchResults.tsx
@@ -3,29 +3,11 @@ import React from "react";
 
 export default function NoSearchResults(props: IllustrationProps) {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="99.039"
-      height="94.342"
-      {...getIllustrationProps(props)}
-    >
-      <g
-        fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path
-          d="M93.113 88.415a5.38 5.38 0 0 1-7.61 0L58.862 61.773a1.018 1.018 0 0 1 0-1.44l6.17-6.169a1.018 1.018 0 0 1 1.439 0l26.643 26.643a5.38 5.38 0 0 1 0 7.608z"
-          stroke-width="2.99955"
-        ></path>
-        <path
-          stroke-width="2"
-          d="M59.969 59.838l-3.246-3.246M61.381 51.934l3.246 3.246M64.609 61.619l13.327 13.327"
-        ></path>
-        <path
-          d="M13.311 47.447A28.87 28.87 0 1 0 36.589 1.5c-10.318 0-20.141 5.083-24.7 13.46M2.121 38.734l15.536-15.536M17.657 38.734L2.121 23.198"
-          stroke-width="3"
-        ></path>
+    <svg xmlns="http://www.w3.org/2000/svg" width="99.039" height="94.342" {...getIllustrationProps(props)}>
+      <g fill="none" strokeLinecap="round" strokeLinejoin="round" >
+        <path d="M93.113 88.415a5.38 5.38 0 0 1-7.61 0L58.862 61.773a1.018 1.018 0 0 1 0-1.44l6.17-6.169a1.018 1.018 0 0 1 1.439 0l26.643 26.643a5.38 5.38 0 0 1 0 7.608z" strokeWidth="2.99955"/>
+        <path strokeWidth="2" d="M59.969 59.838l-3.246-3.246M61.381 51.934l3.246 3.246M64.609 61.619l13.327 13.327" />
+        <path strokeWidth="3" d="M13.311 47.447A28.87 28.87 0 1 0 36.589 1.5c-10.318 0-20.141 5.083-24.7 13.46M2.121 38.734l15.536-15.536M17.657 38.734L2.121 23.198" />
       </g>
     </svg>
   );


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1253

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Nothing should have changed, IllustratedMessages test still test this component. Checked the built docs and storybook and the illustration still renders as expected 👍 


## 🗒 Side Note: 

Changes were 
`stroke-linecap` --> `strokeLinecap`
`stroke-linejoin` --> `strokeLinejoin`
`stroke-width` --> `strokeWidth`

Also compressed the component to have it follow the same style as all the other `Illustrations`
 

## 🧢 Your Project:

Adobe