### PR TITLE
fix(#1271): tabpanel should be labelled by the Picker button element when Tabs are collapsed

### DIFF
--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -14,7 +14,7 @@ import {classNames, SlotProvider, unwrapDOMRef, useStyleProps, useValueEffect} f
 import {DOMProps, Node, Orientation} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import {Item, Picker} from '@react-spectrum/picker';
-import {mergeProps, useLayoutEffect} from '@react-aria/utils';
+import {mergeProps, useId, useLayoutEffect} from '@react-aria/utils';
 import React, {HTMLAttributes, Key, MutableRefObject, useCallback, useEffect, useRef, useState} from 'react';
 import {SingleSelectListState, useSingleSelectListState} from '@react-stately/list';
 import {SpectrumPickerProps} from '@react-types/select';
@@ -105,6 +105,12 @@ export function Tabs<T extends object>(props: SpectrumTabsProps<T>) {
 
   useResizeObserver({ref: wrapperRef, onResize: checkShouldCollapse});
 
+  // When the tabs are collapsed, the tabPanel should be labelled by the Picker button element.
+  let collapsibleTabListId = useId();
+  if (collapse) {
+    tabPanelProps['aria-labelledby'] = collapsibleTabListId;
+  }
+
   let tablist = (
     <TabList
       {...tabListProps}
@@ -130,6 +136,7 @@ export function Tabs<T extends object>(props: SpectrumTabsProps<T>) {
       {orientation !== 'vertical' &&
         <CollapsibleTabList
           {...props}
+          id={collapsibleTabListId}
           tabListclassName={classNames(
             styles,
             'spectrum-TabsPanel-tabs'
@@ -349,7 +356,8 @@ function TabPicker<T>(props: TabPickerProps<T>) {
     'aria-labelledby': ariaLabeledBy,
     'aria-label': ariaLabel,
     density,
-    className
+    className,
+    id
   } = props;
 
   let ref = useRef();
@@ -393,6 +401,7 @@ function TabPicker<T>(props: TabPickerProps<T>) {
         }}>
         <Picker
           {...pickerProps}
+          id={id}
           items={items}
           ref={ref}
           isQuiet

--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -107,7 +107,7 @@ export function Tabs<T extends object>(props: SpectrumTabsProps<T>) {
 
   // When the tabs are collapsed, the tabPanel should be labelled by the Picker button element.
   let collapsibleTabListId = useId();
-  if (collapse) {
+  if (collapse && orientation !== 'vertical') {
     tabPanelProps['aria-labelledby'] = collapsibleTabListId;
   }
 

--- a/packages/@react-spectrum/tabs/test/Tabs.test.js
+++ b/packages/@react-spectrum/tabs/test/Tabs.test.js
@@ -318,6 +318,7 @@ describe('Tabs', function () {
 
     tabpanel = getByRole('tabpanel');
     expect(tabpanel).toHaveTextContent(items[2].children);
+    expect(tabpanel).toHaveAttribute('aria-labelledby', `${picker.id}`);
   });
 
   it('doesn\'t collapse when it can render all the tabs horizontally', function () {
@@ -407,6 +408,7 @@ describe('Tabs', function () {
 
     let picker = getByRole('button');
     expect(picker).toBeTruthy();
+    expect(tabpanel).toHaveAttribute('aria-labelledby', `${picker.id}`);
 
     spy.mockImplementationOnce(function () {
       if (this instanceof HTMLDivElement) {
@@ -439,6 +441,7 @@ describe('Tabs', function () {
     tabpanel = getByRole('tabpanel');
     expect(tabpanel).toBeTruthy();
     expect(tabpanel).toHaveTextContent(items[1].children);
+    expect(tabpanel).toHaveAttribute('aria-labelledby', items[1].id);
 
     tablist = getByRole('tablist');
     expect(tablist).toBeTruthy();

--- a/packages/@react-spectrum/tabs/test/Tabs.test.js
+++ b/packages/@react-spectrum/tabs/test/Tabs.test.js
@@ -410,6 +410,27 @@ describe('Tabs', function () {
     expect(picker).toBeTruthy();
     expect(tabpanel).toHaveAttribute('aria-labelledby', `${picker.id}`);
 
+    rerender(
+      <Provider theme={theme}>
+        <Tabs aria-label="Test Tabs" items={newItems} orientation="vertical">
+          {item => (
+            <Item key={item.name} title={item.name}>
+              {item.children}
+            </Item>
+          )}
+        </Tabs>
+      </Provider>
+    );
+
+    tablist = getByRole('tablist');
+    expect(tablist).toBeTruthy();
+    expect(() => getByRole('button')).toThrow();
+
+    tabpanel = getByRole('tabpanel');
+    expect(tabpanel).toBeTruthy();
+    expect(tabpanel).toHaveTextContent(items[0].children);
+    expect(tabpanel).toHaveAttribute('aria-labelledby', items[0].id);
+
     spy.mockImplementationOnce(function () {
       if (this instanceof HTMLDivElement) {
         return {


### PR DESCRIPTION
The aria-labelledby attribute on the tabpanel should be updated to refer to the Picker rather than the current tab, which is no longer in the DOM.


Closes #1271 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue #1271](https://github.com/adobe/react-spectrum/issues/1271).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open http://localhost:9003/?path=/story/tabs--collapse-behavior
2. Inspect the element with `role="tabpanel"` in the Web Inspector
4. resize the webpage viewport width to test.
3. Verify that when the Tabs are collapsed the tabpanel element's `aria-labelledby` attribute points to the Picker button element.
4. Verify that when the Tabs are not collapsed the tabpanel element's `aria-labelledby` attribute points to the selected Tab.

## 🧢 Your Project:

Adobe/Accessibility
