### PR TITLE
fix(#1262): added isDisabled to useInteractOutside

### DIFF
--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -97,7 +97,7 @@ export function useInteractOutside(props: InteractOutsideProps) {
       document.removeEventListener('touchstart', onPointerDown, true);
       document.removeEventListener('touchend', onTouchEnd, true);
     };
-  }, [onInteractOutside, ref, state.ignoreEmulatedMouseEvents, state.isPointerDown]);
+  }, [onInteractOutside, ref, state.ignoreEmulatedMouseEvents, state.isPointerDown, isDisabled]);
 }
 
 function isValidEvent(event, ref) {

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -38,6 +38,9 @@ export function useInteractOutside(props: InteractOutsideProps) {
 
   useEffect(() => {
     let onPointerDown = (e) => {
+      if (isDisabled) {
+        return;
+      }
       if (isValidEvent(e, ref)) {
         state.isPointerDown = true;
       }

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -20,6 +20,8 @@ import {RefObject, SyntheticEvent, useEffect, useRef} from 'react';
 interface InteractOutsideProps {
   ref: RefObject<Element>,
   onInteractOutside?: (e: SyntheticEvent) => void
+  /** Whether the interact outside events should be disabled. */
+  isDisabled?: boolean
 }
 
 /**
@@ -27,7 +29,7 @@ interface InteractOutsideProps {
  * when a user clicks outside them.
  */
 export function useInteractOutside(props: InteractOutsideProps) {
-  let {ref, onInteractOutside} = props;
+  let {ref, onInteractOutside,isDisabled} = props;
   let stateRef = useRef({
     isPointerDown: false,
     ignoreEmulatedMouseEvents: false
@@ -62,6 +64,9 @@ export function useInteractOutside(props: InteractOutsideProps) {
       };
     } else {*/
     let onMouseUp = (e) => {
+      if (isDisabled) {
+        return;
+      }
       if (state.ignoreEmulatedMouseEvents) {
         state.ignoreEmulatedMouseEvents = false;
       } else if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
@@ -71,6 +76,9 @@ export function useInteractOutside(props: InteractOutsideProps) {
     };
 
     let onTouchEnd = (e) => {
+      if (isDisabled) {
+        return;
+      }
       state.ignoreEmulatedMouseEvents = true;
       if (onInteractOutside && state.isPointerDown && isValidEvent(e, ref)) {
         state.isPointerDown = false;

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -19,7 +19,7 @@ import {RefObject, SyntheticEvent, useEffect, useRef} from 'react';
 
 interface InteractOutsideProps {
   ref: RefObject<Element>,
-  onInteractOutside?: (e: SyntheticEvent) => void
+  onInteractOutside?: (e: SyntheticEvent) => void,
   /** Whether the interact outside events should be disabled. */
   isDisabled?: boolean
 }
@@ -29,7 +29,7 @@ interface InteractOutsideProps {
  * when a user clicks outside them.
  */
 export function useInteractOutside(props: InteractOutsideProps) {
-  let {ref, onInteractOutside,isDisabled} = props;
+  let {ref, onInteractOutside, isDisabled} = props;
   let stateRef = useRef({
     isPointerDown: false,
     ignoreEmulatedMouseEvents: false

--- a/packages/@react-aria/interactions/test/useInteractOutside.test.js
+++ b/packages/@react-aria/interactions/test/useInteractOutside.test.js
@@ -172,4 +172,38 @@ describe('useInteractOutside', function () {
       expect(onInteractOutside).not.toHaveBeenCalled();
     });
   });
+  describe('disable interact outside events', function () {
+    it('does not handle pointer events events if disabled', function () {
+      let onInteractOutside = jest.fn();
+      render(
+        <Example isDisabled onInteractOutside={onInteractOutside} />
+      );
+
+      fireEvent(document.body, pointerEvent('mousedown'));
+      fireEvent(document.body, pointerEvent('mouseup'));
+      expect(onInteractOutside).not.toHaveBeenCalled();
+    });
+
+    it('does not handle touch events events if disabled', function () {
+      let onInteractOutside = jest.fn();
+      render(
+        <Example isDisabled onInteractOutside={onInteractOutside} />
+      );
+
+      fireEvent.touchStart(document.body);
+      fireEvent.touchEnd(document.body);
+      expect(onInteractOutside).not.toHaveBeenCalled();
+    });
+
+    it('does not handle mouse events events if disabled', function () {
+      let onInteractOutside = jest.fn();
+      render(
+        <Example isDisabled onInteractOutside={onInteractOutside} />
+      );
+
+      fireEvent.mouseDown(document.body);
+      fireEvent.mouseUp(document.body);
+      expect(onInteractOutside).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/@react-aria/interactions/test/useInteractOutside.test.js
+++ b/packages/@react-aria/interactions/test/useInteractOutside.test.js
@@ -173,7 +173,7 @@ describe('useInteractOutside', function () {
     });
   });
   describe('disable interact outside events', function () {
-    it('does not handle pointer events events if disabled', function () {
+    it('does not handle pointer events if disabled', function () {
       let onInteractOutside = jest.fn();
       render(
         <Example isDisabled onInteractOutside={onInteractOutside} />
@@ -184,7 +184,7 @@ describe('useInteractOutside', function () {
       expect(onInteractOutside).not.toHaveBeenCalled();
     });
 
-    it('does not handle touch events events if disabled', function () {
+    it('does not handle touch events if disabled', function () {
       let onInteractOutside = jest.fn();
       render(
         <Example isDisabled onInteractOutside={onInteractOutside} />
@@ -195,7 +195,7 @@ describe('useInteractOutside', function () {
       expect(onInteractOutside).not.toHaveBeenCalled();
     });
 
-    it('does not handle mouse events events if disabled', function () {
+    it('does not handle mouse events if disabled', function () {
       let onInteractOutside = jest.fn();
       render(
         <Example isDisabled onInteractOutside={onInteractOutside} />


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1262

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

If you use the isDisabled prop, make sure that no events are called.

## 🧢 Your Project:

<!--- Company/project for pull request -->
