### PR TITLE
Fix incorrect positioning of useOverlayPosition

### DIFF
--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -210,14 +210,6 @@ function computePosition(
   // add the crossOffset from props
   position[crossAxis] += crossOffset;
 
-  // this is button center position - the overlay size + half of the button to align bottom of overlay with button center
-  let minViablePosition = childOffset[crossAxis] + (childOffset[crossSize] / 2) - overlaySize[crossSize];
-  // this is button position of center, aligns top of overlay with button center
-  let maxViablePosition = childOffset[crossAxis] + (childOffset[crossSize] / 2);
-
-  // clamp it into the range of the min/max positions
-  position[crossAxis] = Math.min(Math.max(minViablePosition, position[crossAxis]), maxViablePosition);
-
   // Floor these so the position isn't placed on a partial pixel, only whole pixels. Shouldn't matter if it was floored or ceiled, so chose one.
   if (placement === axis) {
     // If the container is positioned (non-static), then we use the container's actual

--- a/packages/@react-aria/overlays/stories/UseOverlayPosition.stories.tsx
+++ b/packages/@react-aria/overlays/stories/UseOverlayPosition.stories.tsx
@@ -45,10 +45,10 @@ function Trigger(props: {
           margin: 0,
           listStyleType: 'none'
         }}>
-        <li>Hello Hello Hello Hello Hello</li>
-        <li>Hello Hello Hello</li>
+        <li>Hello Hello</li>
+        <li>Hello Hello</li>
         <li>Hello</li>
-        <li>Hello Hello Hello</li>
+        <li>Hello Hello</li>
         <li>Hello</li>
       </ul>
     </div>
@@ -69,8 +69,8 @@ storiesOf('UseOverlayPosition', module)
   .add('document.body container bottom', () => <Trigger withPortal placement="bottom" />)
   .add('document.body container bottom left', () => <Trigger withPortal placement="bottom left" />)
   .add('document.body container bottom right', () => <Trigger withPortal placement="bottom right" />)
-  .add('document.body small trigger bottom left', () => <Trigger buttonWidth={100} withPortal placement="bottom left" />)
-  .add('document.body small trigger bottom right', () => <Trigger buttonWidth={100} withPortal placement="bottom right" />)
+  .add('document.body small trigger bottom left', () => <Trigger buttonWidth={80} withPortal placement="bottom left" />)
+  .add('document.body small trigger bottom right', () => <Trigger buttonWidth={80} withPortal placement="bottom right" />)
   .add('document.body container top', () => <Trigger withPortal placement="top" />)
   .add('positioned container bottom', () => <Trigger withPortal={false} placement="bottom" />)
   .add('positioned container bottom left', () => <Trigger withPortal={false} placement="bottom left" />)

--- a/packages/@react-aria/overlays/stories/UseOverlayPosition.stories.tsx
+++ b/packages/@react-aria/overlays/stories/UseOverlayPosition.stories.tsx
@@ -8,9 +8,10 @@ import {useOverlayTriggerState} from '@react-stately/overlays';
 
 function Trigger(props: {
   withPortal: boolean,
-  placement: Placement
+  placement: Placement,
+  buttonWidth?: number
 }) {
-  const {withPortal, placement} = props;
+  const {withPortal, placement, buttonWidth = 300} = props;
   const targetRef = React.useRef<HTMLButtonElement>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const state = useOverlayTriggerState({
@@ -29,9 +30,9 @@ function Trigger(props: {
   });
 
   let overlay = (
-    <div 
-      ref={overlayRef} 
-      {...mergeProps(overlayProps, overlayPositionProps)} 
+    <div
+      ref={overlayRef}
+      {...mergeProps(overlayProps, overlayPositionProps)}
       style={{
         ...overlayPositionProps.style,
         boxShadow: '0 0 4px 0 rgba(0,0,0,0.25)',
@@ -44,10 +45,10 @@ function Trigger(props: {
           margin: 0,
           listStyleType: 'none'
         }}>
+        <li>Hello Hello Hello Hello Hello</li>
+        <li>Hello Hello Hello</li>
         <li>Hello</li>
-        <li>Hello</li>
-        <li>Hello</li>
-        <li>Hello</li>
+        <li>Hello Hello Hello</li>
         <li>Hello</li>
       </ul>
     </div>
@@ -57,8 +58,8 @@ function Trigger(props: {
     overlay = ReactDOM.createPortal(overlay, document.body);
   }
   return (
-    <div style={{position: 'relative', margin: 'auto'}}>
-      <button ref={targetRef} {...triggerProps} onClick={() => state.toggle()}>Trigger (open: {`${state.isOpen}`})</button>
+    <div style={{position: 'relative', margin: 'auto', padding: 12}}>
+      <button ref={targetRef} {...triggerProps} style={{width: buttonWidth}} onClick={() => state.toggle()}>Trigger<br />(open: {`${state.isOpen}`})</button>
       {state.isOpen && overlay}
     </div>
   );
@@ -66,6 +67,12 @@ function Trigger(props: {
 
 storiesOf('UseOverlayPosition', module)
   .add('document.body container bottom', () => <Trigger withPortal placement="bottom" />)
+  .add('document.body container bottom left', () => <Trigger withPortal placement="bottom left" />)
+  .add('document.body container bottom right', () => <Trigger withPortal placement="bottom right" />)
+  .add('document.body small trigger bottom left', () => <Trigger buttonWidth={100} withPortal placement="bottom left" />)
+  .add('document.body small trigger bottom right', () => <Trigger buttonWidth={100} withPortal placement="bottom right" />)
   .add('document.body container top', () => <Trigger withPortal placement="top" />)
   .add('positioned container bottom', () => <Trigger withPortal={false} placement="bottom" />)
+  .add('positioned container bottom left', () => <Trigger withPortal={false} placement="bottom left" />)
+  .add('positioned container bottom right', () => <Trigger withPortal={false} placement="bottom right" />)
   .add('positioned container top', () => <Trigger withPortal={false} placement="top" />);


### PR DESCRIPTION
The positioning of `useOverlayPosition` is incorrect.
When placement is given as `'bottom left'`, the overlay is placed to the incorrect position as the following screenshot:

<img width="378" alt="image" src="https://user-images.githubusercontent.com/3102175/99701816-50183b80-2ad8-11eb-9949-49a5664210ea.png">

while it should be positioned to the correct position as:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/3102175/99702126-c74dcf80-2ad8-11eb-857e-a6e6d925926c.png">


This fixes the behavior by removing the min/max logic in `calculatePosition`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

I added some storybook test cases. Without the fix, the overlays will be positioned in a wrong position.
