### PR TITLE
chore: fix typo on Contribute docs page

### DIFF
--- a/packages/dev/docs/pages/contribute.mdx
+++ b/packages/dev/docs/pages/contribute.mdx
@@ -18,7 +18,7 @@ keywords: [react spectrum contributions, bug reports, feature requests]
 
 # Contribute
 
-Thanks for choosing to contribute! We look forward to improving web applications together. Here you will find information on how propose bug fixes, suggest improvements, and develop locally.
+Thanks for choosing to contribute! We look forward to improving web applications together. Here you will find information on how to propose bug fixes, suggest improvements, and develop locally.
 
 ## Better together
 We believe that the best way to build a better web is together as a community. The React Spectrum project aims to make it easier to build design systems and component libraries with high quality interactions and accessibility for all. The core team and all external contributors follow the same process in order maintain a high quality codebase.


### PR DESCRIPTION
quick fix for typo on https://react-spectrum.adobe.com/contribute.html

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
