### PR TITLE
fix(#1029): NumberField: fix accessibility role and aria-value* props

### DIFF
--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -220,8 +220,12 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState,
     {
       onWheel,
       // override the spinbutton role, we can't focus a spin button with VO
-      role: 'textfield',
-      'aria-roledescription': formatMessage('Spin button number field')
+      role: null,
+      'aria-roledescription': formatMessage('Spin button number field'),
+      'aria-valuemax': null,
+      'aria-valuemin': null,
+      'aria-valuenow': null,
+      'aria-valuetext': null
     }
   );
   return {

--- a/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
@@ -12,12 +12,12 @@
 
 import {action} from '@storybook/addon-actions';
 import {chain} from '@react-aria/utils';
+import {Flex} from '@react-spectrum/layout';
 import {Form} from '@react-spectrum/form';
 import {Item, Picker} from '@react-spectrum/picker';
 import {NumberField} from '../src';
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
-import {Flex} from "@react-spectrum/layout";
 
 storiesOf('NumberField', module)
   .addParameters({providerSwitcher: {status: 'notice'}})

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -1405,14 +1405,14 @@ describe('NumberField', function () {
       formatOptions: {style: 'currency', currency: 'EUR'}
     });
 
-    expect(textField).toHaveAttribute('aria-valuenow', '100');
-    expect(textField).toHaveAttribute('aria-valuetext', '€100.00');
-    expect(textField).toHaveAttribute('aria-valuemin', '0');
-    expect(textField).toHaveAttribute('aria-valuemax', '100');
+    expect(textField).not.toHaveAttribute('aria-valuenow', '100');
+    expect(textField).not.toHaveAttribute('aria-valuetext', '€100.00');
+    expect(textField).not.toHaveAttribute('aria-valuemin', '0');
+    expect(textField).not.toHaveAttribute('aria-valuemax', '100');
     expect(textField).toHaveAttribute('aria-readonly', 'true');
     expect(textField).toHaveAttribute('aria-required', 'true');
     expect(textField).toHaveAttribute('aria-disabled', 'true');
-    expect(textField).toHaveAttribute('role', 'textfield');
+    expect(textField).not.toHaveAttribute('role');
 
     // TODO: check aria-controls
     expect(incrementButton).toHaveAttribute('aria-label', 'Increment');
@@ -1502,7 +1502,7 @@ describe('NumberField', function () {
     ${'NumberField'} | ${{label: 'this is the stepper that never ends'}}
   `('$Name supports labels', ({props}) => {
     let {getByLabelText, getByRole} = render(<Provider theme={theme} locale="en-US"><NumberField {...props} /></Provider>);
-    let spinButton = getByRole('textfield');
+    let spinButton = getByRole('textbox');
     expect(getByLabelText(props.label)).toBe(spinButton);
     expect(spinButton).toHaveAttribute('aria-roledescription', 'Spin button number field');
   });


### PR DESCRIPTION
While NumberField uses useSpinButton, we need to override the spinbutton role, otherwise we can't focus the control button with VoiceOver on iOS.

* Use role="textbox" rather than role="textfield" for input.
* With role="textbox" instead of role="spinbutton", aria-valuemin, aria-valuemax, aria-valuenow, and aria-valuetext are no longer valid attributes for the input.

Closes 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/pull/1029).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. http://localhost:9003/?path=/story/numberfield--default
2. For each of the NumberField story, verify that there are "No accessibility violations found." in the Accessibility Add-on panel.

## 🧢 Your Project:

Adobe/Accessibility
