### PR TITLE
Observe Combobox trigger for resize

### DIFF
--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -14,7 +14,6 @@ import {AriaButtonProps} from '@react-types/button';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
 import {
   classNames,
-  unwrapDOMRef,
   useFocusableRef,
   useIsMobileDevice,
   useResizeObserver,

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -114,11 +114,7 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
     onResize: onResize
   });
 
-  useLayoutEffect(() => {
-    let buttonWidth = unwrappedButtonRef.current.offsetWidth;
-    let inputWidth = inputRef.current.offsetWidth;
-    setMenuWidth(buttonWidth + inputWidth);
-  }, [scale, unwrappedButtonRef, inputRef]);
+  useLayoutEffect(onResize, [scale, onResize]);
 
   let style = {
     ...overlayProps.style,

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -12,7 +12,7 @@
 
 import {AriaButtonProps} from '@react-types/button';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
-import {classNames, unwrapDOMRef, useFocusableRef, useIsMobileDevice} from '@react-spectrum/utils';
+import {classNames, unwrapDOMRef, useFocusableRef, useIsMobileDevice, useResizeObserver} from '@react-spectrum/utils';
 import {DismissButton, useOverlayPosition} from '@react-aria/overlays';
 import {DOMRefValue, FocusableRef, FocusableRefValue} from '@react-types/shared';
 import {Field} from '@react-spectrum/label';
@@ -23,15 +23,14 @@ import {MobileComboBox} from './MobileComboBox';
 import {Placement} from '@react-types/overlays';
 import {Popover} from '@react-spectrum/overlays';
 import {PressResponder, useHover} from '@react-aria/interactions';
-import React, {InputHTMLAttributes, ReactElement, RefObject, useRef, useState} from 'react';
+import React, {InputHTMLAttributes, ReactElement, RefObject, useCallback, useRef, useState} from 'react';
 import {SpectrumComboBoxProps} from '@react-types/combobox';
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
 import {TextFieldBase} from '@react-spectrum/textfield';
 import {useComboBox} from '@react-aria/combobox';
 import {useComboBoxState} from '@react-stately/combobox';
 import {useFilter} from '@react-aria/i18n';
-import {useLayoutEffect} from '@react-aria/utils';
-import {useProvider, useProviderProps} from '@react-spectrum/provider';
+import {useProviderProps} from '@react-spectrum/provider';
 
 function ComboBox<T extends object>(props: SpectrumComboBoxProps<T>, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);
@@ -86,13 +85,17 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
 
   // Measure the width of the inputfield and the button to inform the width of the menu (below).
   let [menuWidth, setMenuWidth] = useState(null);
-  let {scale} = useProvider();
 
-  useLayoutEffect(() => {
+  let onResize = useCallback(() => {
     let buttonWidth = buttonRef.current.UNSAFE_getDOMNode().offsetWidth;
     let inputWidth = inputRef.current.offsetWidth;
     setMenuWidth(buttonWidth + inputWidth);
-  }, [scale, buttonRef, inputRef]);
+  }, [buttonRef, inputRef, setMenuWidth]);
+
+  useResizeObserver({
+    ref: domRef,
+    onResize: onResize
+  });
 
   let style = {
     ...overlayProps.style,

--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -11,10 +11,10 @@
  */
 
 import {action} from '@storybook/addon-actions';
+import {ActionButton, Button} from '@react-spectrum/button';
 import Add from '@spectrum-icons/workflow/Add';
 import Alert from '@spectrum-icons/workflow/Alert';
 import Bell from '@spectrum-icons/workflow/Bell';
-import {ActionButton, Button} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
 import {ComboBox, Item, Section} from '../';
 import Copy from '@spectrum-icons/workflow/Copy';

--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -14,13 +14,13 @@ import {action} from '@storybook/addon-actions';
 import Add from '@spectrum-icons/workflow/Add';
 import Alert from '@spectrum-icons/workflow/Alert';
 import Bell from '@spectrum-icons/workflow/Bell';
-import {Button} from '@react-spectrum/button';
+import {ActionButton, Button} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
 import {ComboBox, Item, Section} from '../';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Draw from '@spectrum-icons/workflow/Draw';
 import {Flex} from '@react-spectrum/layout';
-import React from 'react';
+import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
 import {TextField} from '@react-spectrum/textfield';
@@ -344,6 +344,10 @@ storiesOf('ComboBox', module)
     )
   )
   .add(
+    'resize',
+    () => <ResizeCombobox />
+  )
+  .add(
     'in small div',
     () => (
       <Flex width="size-500">
@@ -656,6 +660,26 @@ function AllControlledOpenComboBox(props) {
         )}
       </ComboBox>
     </div>
+  );
+}
+
+function ResizeCombobox() {
+  let [size, setSize] = useState(true);
+
+  return (
+    <Flex direction="column" gap="size-200" alignItems="start">
+      <div style={{width: size ? '200px' : '300px'}}>
+        <ComboBox label="Combobox" {...actions} width="100%">
+          <Item key="one">Item One</Item>
+          <Item key="two" textValue="Item Two">
+            <Copy size="S" />
+            <Text>Item Two</Text>
+          </Item>
+          <Item key="three">Item Three</Item>
+        </ComboBox>
+      </div>
+      <ActionButton onPress={() => setSize(prev => !prev)}>Toggle size</ActionButton>
+    </Flex>
   );
 }
 

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -143,19 +143,14 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       let width = unwrappedTriggerRef.current.offsetWidth;
       setButtonWidth(width);
     }
-  }, [unwrappedTriggerRef, setButtonWidth]);
+  }, [unwrappedTriggerRef, setButtonWidth, isMobile]);
 
   useResizeObserver({
     ref: unwrappedTriggerRef,
     onResize: onResize
   });
 
-  useLayoutEffect(() => {
-    if (!isMobile) {
-      let width = unwrappedTriggerRef.current.offsetWidth;
-      setButtonWidth(width);
-    }
-  }, [scale, isMobile, unwrappedTriggerRef, state.selectedKey]);
+  useLayoutEffect(onResize, [scale, state.selectedKey, onResize]);
 
   let overlay;
   if (isMobile) {

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -37,7 +37,7 @@ import {Placement} from '@react-types/overlays';
 import {Popover, Tray} from '@react-spectrum/overlays';
 import {PressResponder, useHover} from '@react-aria/interactions';
 import {ProgressCircle} from '@react-spectrum/progress';
-import React, {ReactElement, useCallback, useMemo, useRef, useState} from 'react';
+import React, {ReactElement, useCallback, useRef, useState} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
 import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
 import {Text} from '@react-spectrum/text';

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -42,7 +42,7 @@ import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
 import {Text} from '@react-spectrum/text';
 import {useFormProps} from '@react-spectrum/form';
 import {useMessageFormatter} from '@react-aria/i18n';
-import {useProviderProps} from '@react-spectrum/provider';
+import {useProvider, useProviderProps} from '@react-spectrum/provider';
 import {useSelectState} from '@react-stately/select';
 
 function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
@@ -136,16 +136,26 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
 
   // Measure the width of the button to inform the width of the menu (below).
   let [buttonWidth, setButtonWidth] = useState(null);
+  let {scale} = useProvider();
 
   let onResize = useCallback(() => {
-    let width = unwrappedTriggerRef.current.offsetWidth;
-    setButtonWidth(width);
+    if (!isMobile) {
+      let width = unwrappedTriggerRef.current.offsetWidth;
+      setButtonWidth(width);
+    }
   }, [unwrappedTriggerRef, setButtonWidth]);
 
   useResizeObserver({
     ref: unwrappedTriggerRef,
     onResize: onResize
   });
+
+  useLayoutEffect(() => {
+    if (!isMobile) {
+      let width = unwrappedTriggerRef.current.offsetWidth;
+      setButtonWidth(width);
+    }
+  }, [scale, isMobile, unwrappedTriggerRef, state.selectedKey]);
 
   let overlay;
   if (isMobile) {

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -16,7 +16,6 @@ import {
   classNames,
   dimensionValue,
   SlotProvider,
-  unwrapDOMRef,
   useDOMRef,
   useIsMobileDevice,
   useStyleProps,
@@ -43,7 +42,7 @@ import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
 import {Text} from '@react-spectrum/text';
 import {useFormProps} from '@react-spectrum/form';
 import {useMessageFormatter} from '@react-aria/i18n';
-import {useProvider, useProviderProps} from '@react-spectrum/provider';
+import {useProviderProps} from '@react-spectrum/provider';
 import {useSelectState} from '@react-stately/select';
 
 function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
@@ -72,7 +71,9 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   let domRef = useDOMRef(ref);
 
   let popoverRef = useRef<DOMRefValue<HTMLDivElement>>();
+  let unwrappedPopoverRef = useUnwrapDOMRef(popoverRef);
   let triggerRef = useRef<FocusableRefValue<HTMLElement>>();
+  let unwrappedTriggerRef = useUnwrapDOMRef(triggerRef);
   let listboxRef = useRef();
 
   // We create the listbox layout in Picker and pass it to ListBoxBase below
@@ -82,12 +83,12 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   let {labelProps, triggerProps, valueProps, menuProps} = useSelect({
     ...props,
     keyboardDelegate: layout
-  }, state, unwrapDOMRef(triggerRef));
+  }, state, unwrappedTriggerRef);
 
   let isMobile = useIsMobileDevice();
   let {overlayProps, placement, updatePosition} = useOverlayPosition({
-    targetRef: unwrapDOMRef(triggerRef),
-    overlayRef: unwrapDOMRef(popoverRef),
+    targetRef: unwrappedTriggerRef,
+    overlayRef: unwrappedPopoverRef,
     scrollRef: listboxRef,
     placement: `${direction} ${align}` as Placement,
     shouldFlip: shouldFlip,
@@ -135,23 +136,14 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
 
   // Measure the width of the button to inform the width of the menu (below).
   let [buttonWidth, setButtonWidth] = useState(null);
-  let {scale} = useProvider();
-  useLayoutEffect(() => {
-    if (!isMobile) {
-      let width = triggerRef.current.UNSAFE_getDOMNode().offsetWidth;
-      setButtonWidth(width);
-    }
-  }, [scale, isMobile, triggerRef, state.selectedKey]);
-
-  let resizeRef = useUnwrapDOMRef(triggerRef);
 
   let onResize = useCallback(() => {
-    let width = resizeRef.current.offsetWidth;
+    let width = unwrappedTriggerRef.current.offsetWidth;
     setButtonWidth(width);
-  }, [resizeRef, setButtonWidth]);
+  }, [unwrappedTriggerRef, setButtonWidth]);
 
   useResizeObserver({
-    ref: resizeRef,
+    ref: unwrappedTriggerRef,
     onResize: onResize
   });
 
@@ -209,7 +201,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       <HiddenSelect
         isDisabled={isDisabled}
         state={state}
-        triggerRef={unwrapDOMRef(triggerRef)}
+        triggerRef={unwrappedTriggerRef}
         label={label}
         name={name} />
       <PressResponder {...mergeProps(hoverProps, triggerProps)}>

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -12,7 +12,16 @@
 
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
-import {classNames, dimensionValue, SlotProvider, unwrapDOMRef, useDOMRef, useIsMobileDevice, useStyleProps} from '@react-spectrum/utils';
+import {
+  classNames,
+  dimensionValue,
+  SlotProvider,
+  unwrapDOMRef,
+  useDOMRef,
+  useIsMobileDevice,
+  useStyleProps,
+  useUnwrapDOMRef
+} from '@react-spectrum/utils';
 import {DismissButton, useOverlayPosition} from '@react-aria/overlays';
 import {DOMRef, DOMRefValue, FocusableRefValue, LabelPosition} from '@react-types/shared';
 import {FieldButton} from '@react-spectrum/button';
@@ -134,9 +143,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     }
   }, [scale, isMobile, triggerRef, state.selectedKey]);
 
-  // Make sure we only unwrap if the trigger changes otherwise we'll retrigger
-  // the observer too often
-  let resizeRef = useMemo(() => unwrapDOMRef(triggerRef), [triggerRef]);
+  let resizeRef = useUnwrapDOMRef(triggerRef);
 
   let onResize = useCallback(() => {
     let width = resizeRef.current.offsetWidth;


### PR DESCRIPTION
combobox menu should remeasure whenever the combobox input/button change size

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
