### PR TITLE
docs: Add selected/disabled states to useCheckboxGroupItem example

### DIFF
--- a/packages/@react-aria/checkbox/docs/useCheckboxGroup.mdx
+++ b/packages/@react-aria/checkbox/docs/useCheckboxGroup.mdx
@@ -129,7 +129,7 @@ function Checkbox(props) {
     <label
       style={{
         display: 'block',
-        color: (isDisabled && 'slategray') || (isSelected && 'royalblue'),
+        color: (isDisabled && 'var(--gray)') || (isSelected && 'var(--blue)'),
       }}>
       <input {...inputProps} ref={ref} />
       {children}

--- a/packages/@react-aria/checkbox/docs/useCheckboxGroup.mdx
+++ b/packages/@react-aria/checkbox/docs/useCheckboxGroup.mdx
@@ -122,16 +122,23 @@ function Checkbox(props) {
   let ref = React.useRef();
   let {inputProps} = useCheckboxGroupItem(props, state, ref);
 
+  let isDisabled = state.isDisabled || props.isDisabled;
+  let isSelected = state.isSelected(props.value);
+
   return (
-    <label style={{display: 'block'}}>
-      <input {...inputProps} />
+    <label
+      style={{
+        display: 'block',
+        color: (isDisabled && 'slategray') || (isSelected && 'royalblue'),
+      }}>
+      <input {...inputProps} ref={ref} />
       {children}
     </label>
   );
 }
 
 <CheckboxGroup label="Favorite sports">
-  <Checkbox value="soccer">Soccer</Checkbox>
+  <Checkbox value="soccer" isDisabled>Soccer</Checkbox>
   <Checkbox value="baseball">Baseball</Checkbox>
   <Checkbox value="basketball">Basketball</Checkbox>
 </CheckboxGroup>


### PR DESCRIPTION
Closes #1302

Shows getting `selected` and `disabled` states for checkboxgroup item (which is different from standalone checkbox) in docs example. Also adds missing `ref`.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
