### PR TITLE
fix(#1152): add order style prop

### DIFF
--- a/packages/@react-spectrum/layout/chromatic/Flex.chromatic.tsx
+++ b/packages/@react-spectrum/layout/chromatic/Flex.chromatic.tsx
@@ -151,4 +151,14 @@ storiesOf('Flex', module)
         <View backgroundColor="magenta-600" width="size-800" height="size-800" />
       </Flex>
     )
+  )
+  .add(
+    'ordered',
+    () => (
+      <Flex direction="row" gap="size-100" justifyContent="space-evenly" width="80%">
+        <View backgroundColor="celery-600" order={2} width="size-800" height="size-800" />
+        <View backgroundColor="blue-600" width="size-800" height="size-800" />
+        <View backgroundColor="magenta-600" order={1} width="size-800" height="size-800" />
+      </Flex>
+    )
   );

--- a/packages/@react-spectrum/layout/stories/Flex.stories.tsx
+++ b/packages/@react-spectrum/layout/stories/Flex.stories.tsx
@@ -149,4 +149,14 @@ storiesOf('Flex', module)
         <View backgroundColor="magenta-600" width="size-800" height="size-800" />
       </Flex>
     )
+  )
+  .add(
+    'ordered',
+    () => (
+      <Flex direction="row" gap="size-100" justifyContent="space-evenly" width="80%">
+        <View backgroundColor="celery-600" order={2} width="size-800" height="size-800" />
+        <View backgroundColor="blue-600" width="size-800" height="size-800" />
+        <View backgroundColor="magenta-600" order={1} width="size-800" height="size-800" />
+      </Flex>
+    )
   );

--- a/packages/@react-spectrum/utils/src/styleProps.ts
+++ b/packages/@react-spectrum/utils/src/styleProps.ts
@@ -47,6 +47,7 @@ export const baseStyleProps: StyleHandlers = {
   end: [rtl('right', 'left'), dimensionValue],
   left: ['left', dimensionValue],
   right: ['right', dimensionValue],
+  order: ['order', anyValue],
   flex: ['flex', flexValue],
   flexGrow: ['flexGrow', passthroughStyle],
   flexShrink: ['flexShrink', passthroughStyle],


### PR DESCRIPTION
Closes #1152 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
When using order prop, make sure that the elements follow the order specified on the prop.

## 🧢 Your Project:
