### PR TITLE
Plop improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:storybook-17": "yarn add -W react@17.0.0-rc.1 react-dom@17.0.0-rc.1 && NODE_ENV=production build-storybook -c .storybook -o dist/$(git rev-parse HEAD)/storybook-17",
     "start:chromatic": "NODE_ENV=storybook start-storybook -p 9004 --ci -c '.chromatic'",
     "build:chromatic": "build-storybook -c .chromatic -o dist/$(git rev-parse HEAD)/chromatic",
-    "start:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=dev parcel 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx' --no-cache",
+    "start:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=dev parcel 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx'",
     "build:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=staging parcel build 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx' --no-scope-hoist",
     "test": "yarn jest",
     "test:ssr": "yarn jest --config jest.ssr.config.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:storybook-17": "yarn add -W react@17.0.0-rc.1 react-dom@17.0.0-rc.1 && NODE_ENV=production build-storybook -c .storybook -o dist/$(git rev-parse HEAD)/storybook-17",
     "start:chromatic": "NODE_ENV=storybook start-storybook -p 9004 --ci -c '.chromatic'",
     "build:chromatic": "build-storybook -c .chromatic -o dist/$(git rev-parse HEAD)/chromatic",
-    "start:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=dev parcel 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx'",
+    "start:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=dev parcel 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx' --no-cache",
     "build:docs": "PARCEL_WORKER_BACKEND=process DOCS_ENV=staging parcel build 'packages/@react-{spectrum,aria,stately}/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx' --no-scope-hoist",
     "test": "yarn jest",
     "test:ssr": "yarn jest --config jest.ssr.config.js",

--- a/plop-templates/@react-aria/docs/useComponent.mdx.hbs
+++ b/plop-templates/@react-aria/docs/useComponent.mdx.hbs
@@ -15,7 +15,7 @@ import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType} from '@react-spectr
 import packageData from '@react-aria/{{packageName}}/package.json';
 
 ```jsx import
-import {use {{~componentName~}} } from '@react-aria/{{packageName}}';
+import {use{{componentName~}}} from '@react-aria/{{packageName}}';
 ```
 
 ---
@@ -36,7 +36,7 @@ keywords: []
 
 ## API
 
-<FunctionAPI function={docs.exports.use{{~componentName~}}} links={docs.links} />
+<FunctionAPI function={docs.exports.use{{componentName~}}} links={docs.links} />
 
 ## Features
 
@@ -48,7 +48,7 @@ keywords: []
 *For hooks that are meant for more general use, include a Usage section detailing the props/params the hook accepts and returns.*
 
 <TypeContext.Provider value={docs.links}>
-  <InterfaceType properties={docs.links[docs.exports.use{{~componentName~}}.return.id].properties} />
+  <InterfaceType properties={docs.links[docs.exports.use{{componentName}}.return.id].properties} />
 </TypeContext.Provider>
 
 
@@ -56,7 +56,7 @@ keywords: []
 
 *List the props/params that the hook uses and list the props that the hook returns. *
 <TypeContext.Provider value={docs.links}>
-  <InterfaceType properties={docs.links[docs.exports.use{{~componentName~}}.return.id].properties} />
+  <InterfaceType properties={docs.links[docs.exports.use{{componentName}}.return.id].properties} />
 </TypeContext.Provider>
 
 

--- a/plop-templates/@react-aria/docs/useComponent.mdx.hbs
+++ b/plop-templates/@react-aria/docs/useComponent.mdx.hbs
@@ -36,7 +36,7 @@ keywords: []
 
 ## API
 
-<FunctionAPI function={docs.exports.use{{~componentName~}} links={docs.links} />
+<FunctionAPI function={docs.exports.use{{~componentName~}}} links={docs.links} />
 
 ## Features
 

--- a/plop-templates/@react-aria/package.json.hbs
+++ b/plop-templates/@react-aria/package.json.hbs
@@ -18,7 +18,8 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2"
+    "@babel/runtime": "^7.6.2",
+    "@react-types/{{packageName}}": "3.0.0-alpha.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/plop-templates/@react-aria/package.json.hbs
+++ b/plop-templates/@react-aria/package.json.hbs
@@ -18,8 +18,12 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    {{#if (includes scopes "@react-types")}}
     "@babel/runtime": "^7.6.2",
     "@react-types/{{packageName}}": "3.0.0-alpha.1"
+    {{else}}
+    "@babel/runtime": "^7.6.2"
+    {{/if}}
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/plop-templates/@react-aria/src/useComponent.ts.hbs
+++ b/plop-templates/@react-aria/src/useComponent.ts.hbs
@@ -11,13 +11,13 @@
  */
 
 {{#if (includes scopes "@react-types")}}
-import {Aria{{~componentName}}Props} from '@react-types/{{packageName}}';
+import {Aria{{componentName}}Props} from '@react-types/{{packageName}}';
 {{else}}
 export interface Aria{{componentName}}Props {
 }
 {{/if}}
 
-interface Aria{{componentName}}Options extends Aria{{~componentName}}Props {
+interface Aria{{componentName}}Options extends Aria{{componentName}}Props {
 }
 
 interface {{componentName}}Aria {

--- a/plop-templates/@react-aria/src/useComponent.ts.hbs
+++ b/plop-templates/@react-aria/src/useComponent.ts.hbs
@@ -10,7 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+{{#if (includes scopes "@react-types")}}
 import {Aria{{~componentName}}Props} from '@react-types/{{packageName}}';
+{{else}}
+export interface Aria{{componentName}}Props {
+}
+{{/if}}
 
 interface Aria{{componentName}}Options extends Aria{{~componentName}}Props {
 }
@@ -23,6 +28,6 @@ interface {{componentName}}Aria {
  * @param props - Props for the {{componentName}}.
  * @param state - State for the {{componentName}}.
  */
-export function use{{componentName}}(props: Aria{{componentName}}Options, state /*: type me */): {{componentName}}Aria {
+export function use{{componentName}}(props: Aria{{componentName}}Options, state /* type me */): {{componentName}}Aria {
   return {};
 }

--- a/plop-templates/@react-aria/src/useComponent.ts.hbs
+++ b/plop-templates/@react-aria/src/useComponent.ts.hbs
@@ -3,19 +3,26 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 
-interface {{componentName}}Props {
+import {Aria{{~componentName}}Props} from '@react-types/{{packageName}}';
+
+interface Aria{{componentName}}Options extends Aria{{~componentName}}Props {
 }
 
 interface {{componentName}}Aria {
 }
 
-export function use{{componentName}}(props: {{componentName}}Props, state): {{componentName}}Aria {
+/**
+ * TODO: Description here
+ * @param props - Props for the {{componentName}}.
+ * @param state - State for the {{componentName}}.
+ */
+export function use{{componentName}}(props: Aria{{componentName}}Options, state /*: type me */): {{componentName}}Aria {
   return {};
 }

--- a/plop-templates/@react-aria/src/useComponent.ts.hbs
+++ b/plop-templates/@react-aria/src/useComponent.ts.hbs
@@ -19,7 +19,7 @@ interface {{componentName}}Aria {
 }
 
 /**
- * TODO: Description here
+ * TODO: Add description of aria hook here.
  * @param props - Props for the {{componentName}}.
  * @param state - State for the {{componentName}}.
  */

--- a/plop-templates/@react-aria/test/useComponent.test.js.hbs
+++ b/plop-templates/@react-aria/test/useComponent.test.js.hbs
@@ -13,7 +13,7 @@
 import {render} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
 import React, {useRef} from 'react';
-import {use {{~componentName~}} } from '../';
+import {use{{componentName~}}} from '../';
 
 describe('use{{componentName}}', function () {
   it('fill me in', function () {

--- a/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
+++ b/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
@@ -23,7 +23,6 @@ storiesOf('{{componentName}}', module)
 
 function render(props: Spectrum{{componentName}}Props = {}) {
   return (
-    <{{componentName}} {...props}>
-    </{{componentName}}>
+    <{{componentName}} {...props} />
   );
 }

--- a/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
+++ b/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
@@ -12,8 +12,16 @@
 
 import { {{~componentName~}} } from '../';
 import React from 'react';
+{{#if (includes scopes "@react-types")}}
 import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+{{/if}}
 import {storiesOf} from '@storybook/react';
+
+{{#unless (includes scopes "@react-types")}}
+interface Spectrum{{componentName}}Props {
+
+}
+{{/unless}}
 
 storiesOf('{{componentName}}', module)
   .add(

--- a/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
+++ b/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
@@ -10,8 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { {{~componentName~}} , {{componentName~}} Props} from '../';
+import { {{~componentName~}} } from '../';
 import React from 'react';
+import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
 import {storiesOf} from '@storybook/react';
 
 storiesOf('{{componentName}}', module)
@@ -20,7 +21,7 @@ storiesOf('{{componentName}}', module)
     () => render({})
   );
 
-function render(props:{{componentName}}Props = {}) {
+function render(props: Spectrum{{componentName}}Props = {}) {
   return (
     <{{componentName}} {...props}>
     </{{componentName}}>

--- a/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
+++ b/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
@@ -13,7 +13,7 @@
 import { {{~componentName~}} } from '../';
 import React from 'react';
 {{#if (includes scopes "@react-types")}}
-import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+import {Spectrum{{componentName}}Props} from '@react-types/{{packageName}}';
 {{/if}}
 import {storiesOf} from '@storybook/react';
 

--- a/plop-templates/@react-spectrum/docs/Component.mdx.hbs
+++ b/plop-templates/@react-spectrum/docs/Component.mdx.hbs
@@ -62,7 +62,7 @@ keywords: []
 
 ## Props
 
-<PropTable component={docs.exports.{{~componentName~}}} links={docs.links} />
+<PropTable component={docs.exports.{{componentName~}}} links={docs.links} />
 
 ## Visual options
 

--- a/plop-templates/@react-spectrum/package.json.hbs
+++ b/plop-templates/@react-spectrum/package.json.hbs
@@ -26,10 +26,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@react-aria/{{packageName}}": "^3.0.0-alpha.1",
-    "@react-aria/utils": "^3.0.0-alpha.1",
-    "@react-spectrum/utils": "^3.0.0-alpha.1",
-    "@react-stately/{{packageName}}": "^3.0.0-alpha.1"
+    "@react-aria/{{packageName}}": "3.0.0-alpha.1",
+    "@react-aria/utils": "^3.0.0",
+    "@react-spectrum/utils": "^3.0.0",
+    "@react-stately/{{packageName}}": "3.0.0-alpha.1",
+    "@react-types/shared": "^3.0.0",
+    "@react-types/{{packageName}}": "3.0.0-alpha.1"
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1"

--- a/plop-templates/@react-spectrum/package.json.hbs
+++ b/plop-templates/@react-spectrum/package.json.hbs
@@ -26,12 +26,18 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    {{#if (includes scopes "@react-aria")}}
     "@react-aria/{{packageName}}": "3.0.0-alpha.1",
+    {{/if}}
     "@react-aria/utils": "^3.0.0",
     "@react-spectrum/utils": "^3.0.0",
+    {{#if (includes scopes "@react-stately")}}
     "@react-stately/{{packageName}}": "3.0.0-alpha.1",
-    "@react-types/shared": "^3.0.0",
-    "@react-types/{{packageName}}": "3.0.0-alpha.1"
+    {{/if}}
+    {{#if (includes scopes "@react-types")}}
+    "@react-types/{{packageName}}": "3.0.0-alpha.1",
+    {{/if}}
+    "@react-types/shared": "^3.0.0"
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1"

--- a/plop-templates/@react-spectrum/src/Component.tsx.hbs
+++ b/plop-templates/@react-spectrum/src/Component.tsx.hbs
@@ -10,16 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, DOMRef, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
-import {mergeProps} from '@react-aria/utils';
-import { {{~componentName}}Props} from '@react-types/${{packageName}}';
+import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
+import {DOMRef} from '@react-types/shared';
+import {filterDOMProps, mergeProps} from '@react-aria/utils';
+import { Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
 import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/{{componentCSS}}/vars.css';
 import {use {{~componentName~}} } from '@react-aria/{{packageName}}';
 import {use {{~componentName~}} State} from '@react-stately/{{packageName}}';
 import {useProviderProps} from '@react-spectrum/provider';
 
-function {{componentName}}(props: {{componentName}}Props, ref: DOMRef) {
+function {{componentName}}(props: Spectrum{{componentName}}Props, ref: DOMRef) {
   props = useProviderProps(props);
   let {styleProps} = useStyleProps(props);
   let state = use{{componentName}}State(props);
@@ -38,5 +39,8 @@ function {{componentName}}(props: {{componentName}}Props, ref: DOMRef) {
   );
 }
 
+/**
+ * TODO: Description here
+ */
 const _{{componentName}} = React.forwardRef({{componentName}});
 export {_{{componentName}} as {{componentName~}} };

--- a/plop-templates/@react-spectrum/src/Component.tsx.hbs
+++ b/plop-templates/@react-spectrum/src/Component.tsx.hbs
@@ -19,16 +19,16 @@ import {DOMProps, DOMRef, StyleProps} from '@react-types/shared';
 import {filterDOMProps} from '@react-aria/utils';
 import React from 'react';
 {{#if (includes scopes "@react-types")}}
-import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+import {Spectrum{{componentName}}Props} from '@react-types/{{packageName}}';
 {{/if}}
 {{#if componentCSS}}
 import styles from '@adobe/spectrum-css-temp/components/{{componentCSS}}/vars.css';
 {{/if}}
 {{#if (includes scopes "@react-aria")}}
-import {use {{~componentName~}} } from '@react-aria/{{packageName}}';
+import {use{{componentName~}}} from '@react-aria/{{packageName}}';
 {{/if}}
 {{#if (includes scopes "@react-stately")}}
-import {use {{~componentName~}} State} from '@react-stately/{{packageName}}';
+import {use{{componentName}}State} from '@react-stately/{{packageName}}';
 {{/if}}
 import {useProviderProps} from '@react-spectrum/provider';
 
@@ -71,4 +71,4 @@ function {{componentName}}(props: Spectrum{{componentName}}Props, ref: DOMRef<HT
  * TODO: Add description of component here.
  */
 const _{{componentName}} = React.forwardRef({{componentName}});
-export {_{{componentName}} as {{componentName~}} };
+export {_{{componentName}} as {{componentName~}}};

--- a/plop-templates/@react-spectrum/src/Component.tsx.hbs
+++ b/plop-templates/@react-spectrum/src/Component.tsx.hbs
@@ -14,27 +14,44 @@ import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import {filterDOMProps} from '@react-aria/utils';
 import React from 'react';
+{{#if (includes scopes "@react-types")}}
 import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+{{/if}}
 {{#if componentCSS}}
 import styles from '@adobe/spectrum-css-temp/components/{{componentCSS}}/vars.css';
 {{/if}}
+{{#if (includes scopes "@react-aria")}}
 import {use {{~componentName~}} } from '@react-aria/{{packageName}}';
+{{/if}}
+{{#if (includes scopes "@react-stately")}}
 import {use {{~componentName~}} State} from '@react-stately/{{packageName}}';
+{{/if}}
 import {useProviderProps} from '@react-spectrum/provider';
+
+{{#unless (includes scopes "@react-types")}}
+export interface Spectrum{{componentName}}Props {
+}
+{{/unless}}
 
 function {{componentName}}(props: Spectrum{{componentName}}Props, ref: DOMRef<HTMLDivElement>) {
   // Grabs specific props from the closest Provider (see https://react-spectrum.adobe.com/react-spectrum/Provider.html#property-groups). Remove if your component doesn't support any of the listed props.
   props = useProviderProps(props);
   // Handles RSP specific style options, UNSAFE_style, and UNSAFE_className props (see https://react-spectrum.adobe.com/react-spectrum/styling.html#style-props)
   let {styleProps} = useStyleProps(props);
+  {{#if (includes scopes "@react-stately")}}
   let state = use{{componentName}}State(props);
+  {{/if}}
+  {{#if (includes scopes "@react-aria")}}
   let ariaProps = use{{componentName}}(props, state);
+  {{/if}}
   let domRef = useDOMRef(ref);
 
   return (
     <div
       {...filterDOMProps(props)}
+      {{#if (includes scopes "@react-aria")}}
       {...ariaProps}
+      {{/if}}
       {...styleProps}
       ref={domRef}
       {{#if componentCSS}}

--- a/plop-templates/@react-spectrum/src/Component.tsx.hbs
+++ b/plop-templates/@react-spectrum/src/Component.tsx.hbs
@@ -12,16 +12,20 @@
 
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
-import {filterDOMProps, mergeProps} from '@react-aria/utils';
-import { Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+import {filterDOMProps} from '@react-aria/utils';
 import React from 'react';
+import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+{{#if componentCSS}}
 import styles from '@adobe/spectrum-css-temp/components/{{componentCSS}}/vars.css';
+{{/if}}
 import {use {{~componentName~}} } from '@react-aria/{{packageName}}';
 import {use {{~componentName~}} State} from '@react-stately/{{packageName}}';
 import {useProviderProps} from '@react-spectrum/provider';
 
-function {{componentName}}(props: Spectrum{{componentName}}Props, ref: DOMRef) {
+function {{componentName}}(props: Spectrum{{componentName}}Props, ref: DOMRef<HTMLDivElement>) {
+  // Grabs specific props from the closest Provider (see https://react-spectrum.adobe.com/react-spectrum/Provider.html#property-groups). Remove if your component doesn't support any of the listed props.
   props = useProviderProps(props);
+  // Handles RSP specific style options, UNSAFE_style, and UNSAFE_className props (see https://react-spectrum.adobe.com/react-spectrum/styling.html#style-props)
   let {styleProps} = useStyleProps(props);
   let state = use{{componentName}}State(props);
   let ariaProps = use{{componentName}}(props, state);
@@ -33,14 +37,16 @@ function {{componentName}}(props: Spectrum{{componentName}}Props, ref: DOMRef) {
       {...ariaProps}
       {...styleProps}
       ref={domRef}
-      className={classNames(styles, '', styleProps.className)}>
-
-    </div>
+      {{#if componentCSS}}
+      className={classNames(styles, '', styleProps.className)} />
+      {{else}}
+      className={styleProps.className} />
+      {{/if}}
   );
 }
 
 /**
- * TODO: Description here
+ * TODO: Add description of component here.
  */
 const _{{componentName}} = React.forwardRef({{componentName}});
 export {_{{componentName}} as {{componentName~}} };

--- a/plop-templates/@react-spectrum/src/Component.tsx.hbs
+++ b/plop-templates/@react-spectrum/src/Component.tsx.hbs
@@ -11,7 +11,11 @@
  */
 
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
+{{#if (includes scopes "@react-types")}}
 import {DOMRef} from '@react-types/shared';
+{{else}}
+import {DOMProps, DOMRef, StyleProps} from '@react-types/shared';
+{{/if}}
 import {filterDOMProps} from '@react-aria/utils';
 import React from 'react';
 {{#if (includes scopes "@react-types")}}
@@ -29,7 +33,8 @@ import {use {{~componentName~}} State} from '@react-stately/{{packageName}}';
 import {useProviderProps} from '@react-spectrum/provider';
 
 {{#unless (includes scopes "@react-types")}}
-export interface Spectrum{{componentName}}Props {
+export interface Spectrum{{componentName}}Props extends DOMProps, StyleProps {
+  onChange?: any
 }
 {{/unless}}
 

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -22,9 +22,8 @@ storiesOf('{{componentName}}', module)
     () => render({})
   );
 
-function render(props:{{componentName}}Props = {}) {
+function render(props: {{componentName}}Props) {
   return (
-    <{{componentName}} {...props} onClick={action('onClick')}>
-    </{{componentName}}>
+    <{{componentName}} {...props} onChange={action('onChange')} />
   );
 }

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -12,10 +12,10 @@
 
 import {action} from '@storybook/addon-actions';
 {{#if (includes scopes "@react-types")}}
-import { {{~componentName~}}} from '../';
-import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+import { {{~componentName~}} } from '../';
+import {Spectrum{{componentName}}Props} from '@react-types/{{packageName}}';
 {{else}}
-import { {{~componentName~}}, Spectrum{{~componentName}}Props} from '../';
+import { {{~componentName}}, Spectrum{{componentName}}Props} from '../';
 {{/if}}
 import React from 'react';
 import {storiesOf} from '@storybook/react';

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -12,10 +12,10 @@
 
 import {action} from '@storybook/addon-actions';
 {{#if (includes scopes "@react-types")}}
-import { {{~componentName~}}} from '../';
-import { Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+import {{{~componentName~}}} from '../';
+import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
 {{else}}
-import { {{~componentName~}}, Spectrum{{~componentName}}Props} from '../';
+import {{{~componentName~}}, Spectrum{{~componentName}}Props} from '../';
 {{/if}}
 import React from 'react';
 import {storiesOf} from '@storybook/react';

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -3,7 +3,7 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
@@ -11,7 +11,8 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import { {{~componentName~}} , {{componentName~}} Props} from '../';
+import { {{~componentName~}}} from '../';
+import { {{~componentName}}Props} from '@react-types/{{packageName}}';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
@@ -23,7 +24,7 @@ storiesOf('{{componentName}}', module)
 
 function render(props:{{componentName}}Props = {}) {
   return (
-    <{{componentName}} {...props}>
+    <{{componentName}} {...props} onClick={action('onClick')}>
     </{{componentName}}>
   );
 }

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -12,10 +12,10 @@
 
 import {action} from '@storybook/addon-actions';
 {{#if (includes scopes "@react-types")}}
-import {{{~componentName~}}} from '../';
+import { {{~componentName~}}} from '../';
 import {Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
 {{else}}
-import {{{~componentName~}}, Spectrum{{~componentName}}Props} from '../';
+import { {{~componentName~}}, Spectrum{{~componentName}}Props} from '../';
 {{/if}}
 import React from 'react';
 import {storiesOf} from '@storybook/react';

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -11,8 +11,12 @@
  */
 
 import {action} from '@storybook/addon-actions';
+{{#if (includes scopes "@react-types")}}
 import { {{~componentName~}}} from '../';
-import { {{~componentName}}Props} from '@react-types/{{packageName}}';
+import { Spectrum{{~componentName}}Props} from '@react-types/{{packageName}}';
+{{else}}
+import { {{~componentName~}}, Spectrum{{~componentName}}Props} from '../';
+{{/if}}
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
@@ -22,7 +26,7 @@ storiesOf('{{componentName}}', module)
     () => render({})
   );
 
-function render(props: {{componentName}}Props) {
+function render(props: Spectrum{{componentName}}Props) {
   return (
     <{{componentName}} {...props} onChange={action('onChange')} />
   );

--- a/plop-templates/@react-spectrum/test/Component.test.js.hbs
+++ b/plop-templates/@react-spectrum/test/Component.test.js.hbs
@@ -17,7 +17,7 @@ import React from 'react';
 describe('{{componentName}}', function () {
   it.each`
     Name | Component      | props
-    ${'{{componentName}}'} | ${ {{~componentName~}} }| $\{{}}
+    ${'{{componentName}}'} | ${ {{~componentName~}} } | $\{{}}
   `('$Name handles defaults', function ({Component, props}) {
     let tree = render(<Component {...props} />);
 

--- a/plop-templates/@react-spectrum/test/Component.test.js.hbs
+++ b/plop-templates/@react-spectrum/test/Component.test.js.hbs
@@ -13,16 +13,14 @@
 import { {{~componentName~}} } from '../';
 import {render} from '@testing-library/react';
 import React from 'react';
-import V2{{componentName}} from '@react/react-spectrum/{{componentName}}';
 
 describe('{{componentName}}', function () {
   it.each`
     Name | Component      | props
     ${'{{componentName}}'} | ${ {{~componentName~}} }| $\{{}}
-    ${'V2{{componentName}}'}      | ${V2 {{~componentName~}} }      | $\{{}}
   `('$Name handles defaults', function ({Component, props}) {
     let tree = render(<Component {...props} />);
 
-    expect(true).toBeTruthy();
+    expect(tree).toBeTruthy();
   });
 });

--- a/plop-templates/@react-spectrum/test/Component.test.js.hbs
+++ b/plop-templates/@react-spectrum/test/Component.test.js.hbs
@@ -15,14 +15,13 @@ import {render} from '@testing-library/react';
 import React from 'react';
 import V2{{componentName}} from '@react/react-spectrum/{{componentName}}';
 
-
 describe('{{componentName}}', function () {
   it.each`
     Name | Component      | props
     ${'{{componentName}}'} | ${ {{~componentName~}} }| $\{{}}
     ${'V2{{componentName}}'}      | ${V2 {{~componentName~}} }      | $\{{}}
   `('$Name handles defaults', function ({Component, props}) {
-    let {getByRole, getByText} = render(<Component {...props}></Component>);
+    let tree = render(<Component {...props} />);
 
     expect(true).toBeTruthy();
   });

--- a/plop-templates/@react-spectrum/test/Component.test.js.hbs
+++ b/plop-templates/@react-spectrum/test/Component.test.js.hbs
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {{{componentName}}} from '../';
+import { {{~componentName~}} } from '../';
 import {render} from '@testing-library/react';
 import React from 'react';
 import V2{{componentName}} from '@react/react-spectrum/{{componentName}}';

--- a/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
+++ b/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
@@ -29,7 +29,7 @@ keywords: []
 
 ## API
 
-<FunctionAPI function={docs.exports.use{{~componentName~}}State} links={docs.links} />
+<FunctionAPI function={docs.exports.use{{componentName}}State} links={docs.links} />
 
 ## Introduction
 
@@ -41,7 +41,7 @@ keywords: []
 
 ## Interface
 
-<ClassAPI links={docs.links} class={docs.links[docs.exports.use{{~componentName~}}State.return.id]} />
+<ClassAPI links={docs.links} class={docs.links[docs.exports.use{{componentName}}State.return.id]} />
 
 ## Example
 

--- a/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
+++ b/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
@@ -37,7 +37,7 @@ keywords: []
 
 ## Options
 
-<ClassAPI links={docs.links} class={docs.links[docs.exports.use{{~componentName~}}State.parameters[0].value.base.id]} />
+// <ClassAPI links={docs.links} class={docs.links[docs.exports.use{{~componentName~}}State.parameters[0].value.base.id]} />
 
 ## Interface
 

--- a/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
+++ b/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
@@ -37,11 +37,11 @@ keywords: []
 
 ## Options
 
-// <ClassAPI links={docs.links} class={docs.links[docs.exports.use{{~componentName~}}State.parameters[0].value.base.id]} />
+*Include ClassAPI if this stately hook takes options (see useAsyncList for an example)*
 
 ## Interface
 
-<ClassAPI links={docs.links} class={docs.links[docs.exports.use{{~componentName~}}State.return.base.id]} />
+<ClassAPI links={docs.links} class={docs.links[docs.exports.use{{~componentName~}}State.return.id]} />
 
 ## Example
 

--- a/plop-templates/@react-stately/package.json.hbs
+++ b/plop-templates/@react-stately/package.json.hbs
@@ -15,9 +15,14 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    {{#if (includes scopes "@react-types")}}
     "@babel/runtime": "^7.6.2",
     "@react-stately/utils": "^3.0.0",
     "@react-types/{{packageName}}": "3.0.0-alpha.1"
+    {{else}}
+    "@babel/runtime": "^7.6.2",
+    "@react-stately/utils": "^3.0.0"
+    {{/if}}
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/plop-templates/@react-stately/package.json.hbs
+++ b/plop-templates/@react-stately/package.json.hbs
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@react-stately/utils": "^3.0.0-alpha.1"
+    "@react-stately/utils": "^3.0.0",
+    "@react-types/{{packageName}}": "3.0.0-alpha.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/plop-templates/@react-stately/src/useComponentState.ts.hbs
+++ b/plop-templates/@react-stately/src/useComponentState.ts.hbs
@@ -3,16 +3,24 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 
+import { {{~componentName}}Props} from '@react-types/{{packageName}}';
 import {useControlledState} from '@react-stately/utils';
 
-export function use{{componentName}}State(props/*: type me */)/*: type me */  {
+export interface {{componentName}}State {
+
+}
+
+/**
+ * TODO: Description of state hook
+ */
+export function use{{componentName}}State(props: {{componentName}}Props): {{componentName}}State  {
   let [state, setState] = useControlledState(props.value, props.defaultValue, props.onChange);
 
   return [state, setState];

--- a/plop-templates/@react-stately/src/useComponentState.ts.hbs
+++ b/plop-templates/@react-stately/src/useComponentState.ts.hbs
@@ -10,8 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import { {{~componentName}}Props} from '@react-types/{{packageName}}';
 import {useControlledState} from '@react-stately/utils';
+{{#if (includes scopes "@react-types")}}
+import { {{~componentName}}Props} from '@react-types/{{packageName}}';
+{{else}}
+export interface {{componentName}}Props {
+  value?: any,
+  defaultValue?: any,
+  onChange?: any
+}
+{{/if}}
 
 export interface {{componentName}}State {
 

--- a/plop-templates/@react-stately/src/useComponentState.ts.hbs
+++ b/plop-templates/@react-stately/src/useComponentState.ts.hbs
@@ -18,7 +18,7 @@ export interface {{componentName}}State {
 }
 
 /**
- * TODO: Description of state hook
+ * TODO: Add description of state hook here.
  */
 export function use{{componentName}}State(props: {{componentName}}Props): {{componentName}}State  {
   let [state, setState] = useControlledState(props.value, props.defaultValue, props.onChange);

--- a/plop-templates/@react-types/package.json.hbs
+++ b/plop-templates/@react-types/package.json.hbs
@@ -10,7 +10,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
-    "@react-types/shared": "^3.1.0"
+    "@react-types/shared": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/plop-templates/@react-types/src/index.d.ts.hbs
+++ b/plop-templates/@react-types/src/index.d.ts.hbs
@@ -3,7 +3,7 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
@@ -13,9 +13,15 @@
 import {DOMProps, StyleProps} from '@react-types/shared';
 
 export interface {{componentName}}Props {
-  
+  value?: any,
+  defaultValue?: any,
+  onChange?: any
 }
 
-export interface Spectrum{{componentName}}Props extends {{componentName}}Props, DOMProps, StyleProps {
+export interface Aria{{componentName}}Props extends {{componentName}}Props, DOMProps {
+
+}
+
+export interface Spectrum{{componentName}}Props extends Aria{{componentName}}Props, StyleProps {
 
 }

--- a/plop-templates/@react-types/src/index.d.ts.hbs
+++ b/plop-templates/@react-types/src/index.d.ts.hbs
@@ -18,6 +18,7 @@ export interface {{componentName}}Props {
   onChange?: any
 }
 
+{{#if (includes scopes "@react-aria")}}
 export interface Aria{{componentName}}Props extends {{componentName}}Props, DOMProps {
 
 }
@@ -25,3 +26,8 @@ export interface Aria{{componentName}}Props extends {{componentName}}Props, DOMP
 export interface Spectrum{{componentName}}Props extends Aria{{componentName}}Props, StyleProps {
 
 }
+{{else}}
+export interface Spectrum{{componentName}}Props extends {{componentName}}Props, DOMProps, StyleProps {
+
+}
+{{/if}}

--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -21,6 +21,10 @@ module.exports = function (plop) {
     return string.replace(match, replacement);
   });
 
+  plop.setHelper('includes', function (array, string) {
+    return array.includes(string)
+  });
+
   // controller generator
   plop.setGenerator('component', {
     description: 'add new component',
@@ -64,6 +68,7 @@ module.exports = function (plop) {
     actions: function (data) {
       let {projectType, scopes, scopeName, packageName, componentName, componentCSS} = data;
       let actions = [];
+
       if (projectType === rspProject) {
         if (scopes.includes('@react-aria')) {
           actions.push({
@@ -71,7 +76,7 @@ module.exports = function (plop) {
             templateFiles: '../plop-templates/@react-aria/**',
             base: '../plop-templates/@react-aria/',
             destination: `../packages/@react-aria/${packageName}`,
-            data: {componentName}
+            data: {componentName, scopes}
           });
           actions.push({
             type: 'renameMany',
@@ -86,7 +91,7 @@ module.exports = function (plop) {
             templateFiles: '../plop-templates/@react-spectrum/**',
             base: '../plop-templates/@react-spectrum/',
             destination: `../packages/@react-spectrum/${packageName}`,
-            data: {packageName, componentName, componentCSS}
+            data: {packageName, componentName, componentCSS, scopes}
           });
           actions.push({
             type: 'renameMany',
@@ -101,7 +106,7 @@ module.exports = function (plop) {
             templateFiles: '../plop-templates/@react-stately/**',
             base: '../plop-templates/@react-stately/',
             destination: `../packages/@react-stately/${packageName}`,
-            data: {packageName, componentName}
+            data: {packageName, componentName, scopes}
           });
           actions.push({
             type: 'renameMany',
@@ -116,7 +121,7 @@ module.exports = function (plop) {
             templateFiles: '../plop-templates/@react-types/**',
             base: '../plop-templates/@react-types/',
             destination: `../packages/@react-types/${packageName}`,
-            data: {packageName, componentName}
+            data: {packageName, componentName, scopes}
           });
           actions.push({
             type: 'renameMany',

--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -57,7 +57,8 @@ module.exports = function (plop) {
       type: 'input',
       name: 'componentCSS',
       message: 'component css module name, blank if N/A. If unsure, check @adobe/spectrum-css-temp/components for a module containing the desired css (e.g. textfield)',
-      validate: (answer) => answer.length > 0,
+      validate: (answer) => answer.length >= 0,
+      default: null,
       when: ({projectType, scopes}) => projectType === rspProject && scopes.includes('@react-spectrum')
     }],
     actions: function (data) {

--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -45,18 +45,18 @@ module.exports = function (plop) {
     }, {
       type: 'input',
       name: 'packageName',
-      message: 'package name',
+      message: 'package name, all lowercase (e.g. textfield)',
       validate: (answer) => answer.length > 0
     }, {
       type: 'input',
       name: 'componentName',
-      message: 'component name, please use appropriate uppercase',
+      message: 'component name, please use appropriate uppercase (e.g. TextField)',
       validate: (answer) => answer.length > 0,
       when: ({projectType}) => projectType === rspProject
     }, {
       type: 'input',
       name: 'componentCSS',
-      message: 'component css module name, blank if N/A',
+      message: 'component css module name, blank if N/A. If unsure, check @adobe/spectrum-css-temp/components for a module containing the desired css (e.g. textfield)',
       validate: (answer) => answer.length > 0,
       when: ({projectType, scopes}) => projectType === rspProject && scopes.includes('@react-spectrum')
     }],


### PR DESCRIPTION
garage week dev task

- adds some examples in the cli prompts
- user no longer needs to type a space in the css module prompt if they don't put anything in it
- some additional stuff added to templates (jsdocs, types, comments explaining what some hooks do)
- logic to add package imports and types only if user is plopping a specific combo of scopes
- general fixes

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
