### PR TITLE
Refactor types around useTooltip, useTooltipTrigger & useTooltipTriggerState

### DIFF
--- a/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
+++ b/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {TooltipTriggerProps} from '@react-types/tooltip';
+import {TooltipTriggerStateProps} from '@react-types/tooltip';
 import {useEffect, useMemo} from 'react';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 
@@ -41,7 +41,7 @@ let globalCooldownTimeout = null;
  * methods to toggle this state. Ensures only one tooltip is open at a time and controls
  * the delay for showing a tooltip.
  */
-export function useTooltipTriggerState(props: TooltipTriggerProps): TooltipTriggerState {
+export function useTooltipTriggerState(props: TooltipTriggerStateProps): TooltipTriggerState {
   let {delay = TOOLTIP_DELAY} = props;
   let {isOpen, open, close} = useOverlayTriggerState(props);
   let id = useMemo(() => `${++tooltipId}`, []);

--- a/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
+++ b/packages/@react-stately/tooltip/src/useTooltipTriggerState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {TooltipTriggerStateProps} from '@react-types/tooltip';
+import {TooltipTriggerProps} from '@react-types/tooltip';
 import {useEffect, useMemo} from 'react';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 
@@ -41,7 +41,7 @@ let globalCooldownTimeout = null;
  * methods to toggle this state. Ensures only one tooltip is open at a time and controls
  * the delay for showing a tooltip.
  */
-export function useTooltipTriggerState(props: TooltipTriggerStateProps): TooltipTriggerState {
+export function useTooltipTriggerState(props: TooltipTriggerProps): TooltipTriggerState {
   let {delay = TOOLTIP_DELAY} = props;
   let {isOpen, open, close} = useOverlayTriggerState(props);
   let id = useMemo(() => `${++tooltipId}`, []);

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -14,30 +14,11 @@ import {AriaLabelingProps, DOMProps, StyleProps} from '@react-types/shared';
 import {OverlayTriggerProps, PositionProps} from '@react-types/overlays';
 import {ReactElement, ReactNode} from 'react';
 
-export interface TooltipTriggerProps extends OverlayTriggerProps {
+export interface TooltipTriggerProps {
   /**
    * Whether the tooltip should be disabled, independent from the trigger.
    */
   isDisabled?: boolean,
-
-  /**
-   * The delay time for the tooltip to show up. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance).
-   */
-  delay?: number,
-
-  /**
-   * The additional offset applied along the main axis between the element and its
-   * anchor element.
-   * @default 7
-   */
-  offset?: number,
-
-  /**
-   * The additional offset applied along the cross axis between the element and its
-   * anchor element.
-   * @default 0
-   */
-  crossOffset?: number,
 
   /**
    * By default, opens for both focus and hover. Can be made to open only for focus.
@@ -45,12 +26,19 @@ export interface TooltipTriggerProps extends OverlayTriggerProps {
   trigger?: 'focus'
 }
 
-export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, PositionProps {
+export interface TooltipTriggerStateProps extends OverlayTriggerProps {
+  /**
+   * The delay time for the tooltip to show up. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance).
+   * @default 1500
+   */
+  delay?: number
+}
+
+export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, TooltipTriggerStateProps, PositionProps {
   children: [ReactElement, ReactElement]
 }
 
 export interface TooltipProps {
-  children: ReactNode,
   isOpen?: boolean
 }
 
@@ -71,5 +59,7 @@ export interface SpectrumTooltipProps extends AriaTooltipProps, StyleProps {
   /**
    * Whether the element is rendered.
    */
-  showIcon?: boolean
+  showIcon?: boolean,
+
+  children: ReactNode
 }

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -33,7 +33,14 @@ export interface TooltipTriggerProps extends OverlayTriggerProps {
 }
 
 export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, PositionProps {
-  children: [ReactElement, ReactElement]
+  children: [ReactElement, ReactElement],
+
+  /**
+   * The additional offset applied along the main axis between the element and its
+   * anchor element.
+   * @default 7
+   */
+  offset?: number
 }
 
 export interface TooltipProps {

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -14,11 +14,17 @@ import {AriaLabelingProps, DOMProps, StyleProps} from '@react-types/shared';
 import {OverlayTriggerProps, PositionProps} from '@react-types/overlays';
 import {ReactElement, ReactNode} from 'react';
 
-export interface TooltipTriggerProps {
+export interface TooltipTriggerProps extends OverlayTriggerProps {
   /**
    * Whether the tooltip should be disabled, independent from the trigger.
    */
   isDisabled?: boolean,
+
+  /**
+   * The delay time for the tooltip to show up. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance).
+   * @default 1500
+   */
+  delay?: number,
 
   /**
    * By default, opens for both focus and hover. Can be made to open only for focus.
@@ -26,15 +32,7 @@ export interface TooltipTriggerProps {
   trigger?: 'focus'
 }
 
-export interface TooltipTriggerStateProps extends OverlayTriggerProps {
-  /**
-   * The delay time for the tooltip to show up. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance).
-   * @default 1500
-   */
-  delay?: number
-}
-
-export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, TooltipTriggerStateProps, PositionProps {
+export interface SpectrumTooltipTriggerProps extends TooltipTriggerProps, PositionProps {
   children: [ReactElement, ReactElement]
 }
 


### PR DESCRIPTION
This reflects reality better - I've refactored those types so particular types only contain types for properties actually utilized by the consuming utility function.

## ✅ Pull Request Checklist:

- [x] Filled out test instructions.

## 📝 Test Instructions:

`yarn check-types`
