### PR TITLE
Accept tabIndex in the useFocusable hook

### DIFF
--- a/packages/@react-aria/focus/src/useFocusable.tsx
+++ b/packages/@react-aria/focus/src/useFocusable.tsx
@@ -15,6 +15,11 @@ import {mergeProps} from '@react-aria/utils';
 import React, {HTMLAttributes, MutableRefObject, ReactNode, RefObject, useContext, useEffect} from 'react';
 import {useFocus, useKeyboard} from '@react-aria/interactions';
 
+interface FocusableResult {
+  /** Props to spread on the target element. */
+  focusableProps: HTMLAttributes<HTMLElement>
+}
+
 interface FocusableOptions extends FocusableProps, FocusableDOMProps {
   /** Whether focus should be disabled. */
   isDisabled?: boolean
@@ -69,7 +74,7 @@ export {_FocusableProvider as FocusableProvider};
 /**
  * Used to make an element focusable and capable of auto focus.
  */
-export function useFocusable(props: FocusableOptions, domRef: RefObject<HTMLElement>) {
+export function useFocusable(props: FocusableOptions, domRef: RefObject<HTMLElement>): FocusableResult {
   let {focusProps} = useFocus(props);
   let {keyboardProps} = useKeyboard(props);
   let interactions = mergeProps(focusProps, keyboardProps);
@@ -86,7 +91,7 @@ export function useFocusable(props: FocusableOptions, domRef: RefObject<HTMLElem
     focusableProps: mergeProps(
       {
         ...interactions,
-        tabIndex: props.excludeFromTabOrder && !props.isDisabled ? -1 : undefined
+        tabIndex: props.tabIndex ?? (props.excludeFromTabOrder && !props.isDisabled ? -1 : undefined)
       },
       interactionProps
     )

--- a/packages/@react-aria/focus/test/useFocusable.test.tsx
+++ b/packages/@react-aria/focus/test/useFocusable.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import {render} from '@testing-library/react';
+import {useFocusable} from '../';
+
+describe('useFocusable', function () {
+  it('handles defaults', function () {
+    function Test() {
+      const ref = React.useRef(null);
+      const {focusableProps} = useFocusable({}, ref);
+
+      return (
+        <button {...focusableProps}>{'Click me!'}</button>
+      );
+    }
+
+    expect(() => render(<Test />)).not.toThrow();
+  });
+
+  it('provides `tabIndex: -1` when `excludeFromTabOrder` is used', function () {
+    function Test() {
+      const ref = React.useRef(null);
+      const {focusableProps} = useFocusable({excludeFromTabOrder: true}, ref);
+
+      return (
+        <h1 {...focusableProps}>{'Title'}</h1>
+      );
+    }
+
+    const {container} = render(<Test />);
+    expect(container.firstElementChild.getAttribute('tabIndex')).toBe('-1');
+  });
+
+  it('doesn\'t provide `tabIndex` when `excludeFromTabOrder` is used together with `isDisabled`', function () {
+    function Test() {
+      const ref = React.useRef(null);
+      const {focusableProps} = useFocusable({excludeFromTabOrder: true, isDisabled: true}, ref);
+
+      return (
+        <h1 {...focusableProps}>{'Title'}</h1>
+      );
+    }
+
+    const {container} = render(<Test />);
+    expect((container.firstElementChild).getAttribute('tabIndex')).toBe(null);
+  });
+
+  it('accepts `tabIndex`', function () {
+    function Test() {
+      const ref = React.useRef(null);
+      const {focusableProps} = useFocusable({tabIndex: 0}, ref);
+
+      return (
+        <h1 {...focusableProps}>{'Title'}</h1>
+      );
+    }
+
+    const {container} = render(<Test />);
+    expect((container.firstElementChild).getAttribute('tabIndex')).toBe('0');
+  });
+});

--- a/packages/@react-types/shared/src/dom.d.ts
+++ b/packages/@react-types/shared/src/dom.d.ts
@@ -58,7 +58,9 @@ export interface FocusableDOMProps extends DOMProps {
    * be avoided except in rare scenarios where an alternative means of accessing
    * the element or its functionality via the keyboard is available.
    */
-  excludeFromTabOrder?: boolean
+  excludeFromTabOrder?: boolean,
+  /** A tabIndex to return. */
+  tabIndex?: number
 }
 
 // DOM props that apply to all text inputs
@@ -125,7 +127,7 @@ export interface TextInputDOMProps extends DOMProps {
    * Handler that is called when a text composition system starts a new text composition session. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionstart_event).
    */
   onCompositionStart?: CompositionEventHandler<HTMLInputElement>,
-  
+
   /**
    * Handler that is called when a text composition system completes or cancels the current text composition session. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event).
    */


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1384 , cc @ktabors

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

`yarn test`