### PR TITLE
Alternative workaround for Chrome label self-reference bug

### DIFF
--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -55,11 +55,7 @@ export function useSliderThumb(
   const {labelProps, fieldProps} = useLabel({
     ...opts,
     id,
-    // Override due to a Chrome bug where aria-labelledby cannot be a self-reference.
-    // Instead, we put the label on the thumb element and point to it with aria-labelledby.
-    // See https://bugs.chromium.org/p/chromium/issues/detail?id=1159567
-    'aria-label': undefined,
-    'aria-labelledby': `${labelId} ${opts['aria-labelledby'] ?? ''} ${ariaLabel ? thumbId : ''}`.trim()
+    'aria-labelledby': `${labelId} ${opts['aria-labelledby'] ?? ''}`.trim()
   });
 
   const value = state.values[index];
@@ -172,8 +168,6 @@ export function useSliderThumb(
     thumbProps: !isDisabled ? mergeProps(
       moveProps,
       {
-        id: thumbId,
-        'aria-label': ariaLabel,
         onMouseDown: () => {onDown(null);},
         onPointerDown: (e: React.PointerEvent) => {onDown(e.pointerId);},
         onTouchStart: (e: React.TouchEvent) => {onDown(e.changedTouches[0].identifier);}

--- a/packages/@react-aria/utils/src/useHiddenText.ts
+++ b/packages/@react-aria/utils/src/useHiddenText.ts
@@ -1,0 +1,55 @@
+/*
+* Copyright 2020 Adobe. All rights reserved.
+* This file is licensed to you under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed under
+* the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+* OF ANY KIND, either express or implied. See the License for the specific language
+* governing permissions and limitations under the License.
+*/
+
+import {useLayoutEffect} from './useLayoutEffect';
+import {useState} from 'react';
+
+let elementId = 0;
+const nodes = new Map<string, {refCount: number, element: HTMLElement}>();
+
+// This function generates a hidden span element containing with an id that can be
+// pointed to by aria-labelledby or aria-describedby.
+export function useHiddenText(label: string): string {
+  let [id, setId] = useState(null);
+
+  useLayoutEffect(() => {
+    if (!label) {
+      return;
+    }
+
+    let node = nodes.get(label);
+    if (!node) {
+      let id = `react-aria-description-${elementId++}`;
+      setId(id);
+
+      let span = document.createElement('span');
+      span.id = id;
+      span.style.display = 'none';
+      span.textContent = label;
+      document.body.appendChild(span);
+      node = {refCount: 0, element: span};
+      nodes.set(label, node);
+    } else {
+      setId(node.element.id);
+    }
+
+    node.refCount++;
+    return () => {
+      if (--node.refCount === 0) {
+        node.element.remove();
+        nodes.delete(label);
+      }
+    };
+  }, [label]);
+
+  return label ? id : undefined;
+}

--- a/packages/@react-aria/utils/src/useLabels.ts
+++ b/packages/@react-aria/utils/src/useLabels.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, DOMProps} from '@react-types/shared';
-import {useId} from './useId';
+import {useHiddenText} from './useHiddenText';
 
 /**
  * Merges aria-label and aria-labelledby into aria-labelledby when both exist.
@@ -20,17 +20,19 @@ import {useId} from './useId';
  */
 export function useLabels(props: DOMProps & AriaLabelingProps, defaultLabel?: string): DOMProps & AriaLabelingProps {
   let {
-    id,
     'aria-label': label,
     'aria-labelledby': labelledBy
   } = props;
 
-  // If there is both an aria-label and aria-labelledby,
-  // combine them by pointing to the element itself.
-  id = useId(id);
+  // If there is both an aria-label and aria-labelledby, create a hidden span element
+  // that holds the label and reference that in aria-labelledby. Normally we'd use a
+  // self reference to the element itself, but this is currently broken in Chrome.
+  // See https://bugs.chromium.org/p/chromium/issues/detail?id=1159567
+  let hiddenLabelId = useHiddenText(labelledBy && label ? label : undefined);
   if (labelledBy && label) {
-    let ids = new Set([...labelledBy.trim().split(/\s+/), id]);
+    let ids = new Set([...labelledBy.trim().split(/\s+/), hiddenLabelId]);
     labelledBy = [...ids].join(' ');
+    label = undefined;
   } else if (labelledBy) {
     labelledBy = labelledBy.trim().split(/\s+/).join(' ');
   }
@@ -41,7 +43,6 @@ export function useLabels(props: DOMProps & AriaLabelingProps, defaultLabel?: st
   }
 
   return {
-    id,
     'aria-label': label,
     'aria-labelledby': labelledBy
   };


### PR DESCRIPTION
Alternative workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1159567. Tests not updated yet. Not sure we'll go with it.