### PR TITLE
Slider: Work around TalkBack not announcing the output element's text content

### DIFF
--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -166,6 +166,8 @@ export function useSlider(
     };
   }
 
+  const outputId = `${fieldProps.id}-output`;
+
   return {
     labelProps,
     // The root element of the Slider will have role="group" to group together
@@ -182,7 +184,8 @@ export function useSlider(
     }, moveProps),
     outputProps: {
       htmlFor: state.values.map((_, index) => getSliderThumbId(state, index)).join(' '),
-      'aria-labelledby': labelProps.id,
+      id: outputId,
+      'aria-labelledby': `${labelProps.id} ${outputId}`,
       'aria-live': 'off'
     }
   };

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -185,7 +185,7 @@ export function useSlider(
     outputProps: {
       htmlFor: state.values.map((_, index) => getSliderThumbId(state, index)).join(' '),
       id: outputId,
-      'aria-labelledby': `${labelProps.id} ${outputId}`,
+      'aria-labelledby': `${labelProps.id || fieldProps.id} ${outputId}`,
       'aria-live': 'off'
     }
   };

--- a/packages/@react-aria/slider/src/useSlider.ts
+++ b/packages/@react-aria/slider/src/useSlider.ts
@@ -166,8 +166,6 @@ export function useSlider(
     };
   }
 
-  const outputId = `${fieldProps.id}-output`;
-
   return {
     labelProps,
     // The root element of the Slider will have role="group" to group together
@@ -184,8 +182,6 @@ export function useSlider(
     }, moveProps),
     outputProps: {
       htmlFor: state.values.map((_, index) => getSliderThumbId(state, index)).join(' '),
-      id: outputId,
-      'aria-labelledby': `${labelProps.id || fieldProps.id} ${outputId}`,
       'aria-live': 'off'
     }
   };

--- a/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
+++ b/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
@@ -51,7 +51,7 @@ describe('RangeSlider', function () {
     let output = getByRole('status');
     expect(output).toHaveTextContent('0 – 100');
     expect(output).toHaveAttribute('for', getAllByRole('slider').map(s => s.id).join(' '));
-    expect(output).toHaveAttribute('aria-labelledby', `${label.id} ${output.id}`);
+    expect(output).not.toHaveAttribute('aria-labelledby');
     expect(output).toHaveAttribute('aria-live', 'off');
   });
 

--- a/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
+++ b/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
@@ -51,7 +51,7 @@ describe('RangeSlider', function () {
     let output = getByRole('status');
     expect(output).toHaveTextContent('0 – 100');
     expect(output).toHaveAttribute('for', getAllByRole('slider').map(s => s.id).join(' '));
-    expect(output).toHaveAttribute('aria-labelledby', label.id);
+    expect(output).toHaveAttribute('aria-labelledby', `${label.id} ${output.id}`);
     expect(output).toHaveAttribute('aria-live', 'off');
   });
 

--- a/packages/@react-spectrum/slider/test/Slider.test.tsx
+++ b/packages/@react-spectrum/slider/test/Slider.test.tsx
@@ -52,7 +52,7 @@ describe('Slider', function () {
     let output = getByRole('status');
     expect(output).toHaveTextContent('0');
     expect(output).toHaveAttribute('for', getByRole('slider').id);
-    expect(output).toHaveAttribute('aria-labelledby', label.id);
+    expect(output).toHaveAttribute('aria-labelledby', `${label.id} ${output.id}`);
     expect(output).toHaveAttribute('aria-live', 'off');
   });
 

--- a/packages/@react-spectrum/slider/test/Slider.test.tsx
+++ b/packages/@react-spectrum/slider/test/Slider.test.tsx
@@ -52,7 +52,7 @@ describe('Slider', function () {
     let output = getByRole('status');
     expect(output).toHaveTextContent('0');
     expect(output).toHaveAttribute('for', getByRole('slider').id);
-    expect(output).toHaveAttribute('aria-labelledby', `${label.id} ${output.id}`);
+    expect(output).not.toHaveAttribute('aria-labelledby');
     expect(output).toHaveAttribute('aria-live', 'off');
   });
 


### PR DESCRIPTION
Closes #1400 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 1400](https://github.com/adobe/react-spectrum/issue/1400).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open http://localhost:9003/iframe.html?id=slider--formatoptions-centimeter on Android device with TalkBack screen reader turned on.
2. Navigate to output element showing the current value of the Slider.
3. Output should announce as "Label 0 centimeters status"

## 🧢 Your Project:

Adobe/accessibility