### PR TITLE
Fix text selection starting on drag in RangeSlider

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/slider/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/slider/index.css
@@ -184,10 +184,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Slider--range {
-  .spectrum-Slider-value {
-    user-select: text;
-  }
-
   .spectrum-Slider-track {
     &:first-of-type {
       padding-block: 0;


### PR DESCRIPTION
Not sure why it was different in css than regular slider...