### PR TITLE
prevent shrinking of custom width below defined

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/slider/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/slider/index.css
@@ -59,7 +59,7 @@ governing permissions and limitations under the License.
 
   width: var(--spectrum-global-dimension-size-2400);
   min-inline-size: var(--spectrum-slider-min-width);
-
+  flex-shrink: 0;
 
   &.spectrum-Slider--positionTop {
     display: inline-flex;


### PR DESCRIPTION
fixes slider shrinking to containing parent width.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

goto side custom width story, width is like 350 to 400px
in chrome dev tools change the width to 300
see that the slider stays full custom width and doesn't shrink to width

## 🧢 Your Project:
RSP