### PR TITLE
Replace assert.equal with assert.strictEqual and jest.expect

### DIFF
--- a/packages/@react-aria/utils/test/number.test.js
+++ b/packages/@react-aria/utils/test/number.test.js
@@ -4,17 +4,17 @@ import {clamp, snapValueToStep} from '../src/number';
 describe('number utils', () => {
   describe('clamp', () => {
     it('should constrain value between min and max', () => {
-      assert.equal(clamp(5, -1, 1), 1);
-      assert.equal(clamp(-5, -1, 1), -1);
+      assert.strictEqual(clamp(5, -1, 1), 1);
+      assert.strictEqual(clamp(-5, -1, 1), -1);
     });
   });
 
   describe('snapValueToStep', () => {
     it('should snap value to nearest step based on min and max', () => {
-      assert.equal(snapValueToStep(2, -0.5, 100, 3), 2.5);
-      assert.equal(snapValueToStep(-6.2, -2.5, 100, 3), -2.5);
-      assert.equal(snapValueToStep(106.2, -2.5, 100, 3), 99.5);
-      assert.equal(snapValueToStep(-0.009999, -0.5, 0.5, 0.01), -0.01);
+      assert.strictEqual(snapValueToStep(2, -0.5, 100, 3), 2.5);
+      assert.strictEqual(snapValueToStep(-6.2, -2.5, 100, 3), -2.5);
+      assert.strictEqual(snapValueToStep(106.2, -2.5, 100, 3), 99.5);
+      assert.strictEqual(snapValueToStep(-0.009999, -0.5, 0.5, 0.01), -0.01);
     });
   });
 });

--- a/packages/@react-aria/utils/test/number.test.js
+++ b/packages/@react-aria/utils/test/number.test.js
@@ -1,20 +1,19 @@
-import assert from 'assert';
 import {clamp, snapValueToStep} from '../src/number';
 
 describe('number utils', () => {
   describe('clamp', () => {
     it('should constrain value between min and max', () => {
-      assert.strictEqual(clamp(5, -1, 1), 1);
-      assert.strictEqual(clamp(-5, -1, 1), -1);
+      expect(clamp(5, -1, 1).toBe(1));
+      expect(clamp(-5, -1, 1).toBe(1));
     });
   });
 
   describe('snapValueToStep', () => {
     it('should snap value to nearest step based on min and max', () => {
-      assert.strictEqual(snapValueToStep(2, -0.5, 100, 3), 2.5);
-      assert.strictEqual(snapValueToStep(-6.2, -2.5, 100, 3), -2.5);
-      assert.strictEqual(snapValueToStep(106.2, -2.5, 100, 3), 99.5);
-      assert.strictEqual(snapValueToStep(-0.009999, -0.5, 0.5, 0.01), -0.01);
+      expect(snapValueToStep(2, -0.5, 100, 3).toBe(2.5));
+      expect(snapValueToStep(-6.2, -2.5, 100, 3).toBe(-2.5));
+      expect(snapValueToStep(106.2, -2.5, 100, 3).toBe(99.5));
+      expect(snapValueToStep(-0.009999, -0.5, 0.5, 0.01).toBe(-0.01));
     });
   });
 });

--- a/packages/@react-aria/utils/test/number.test.js
+++ b/packages/@react-aria/utils/test/number.test.js
@@ -4,7 +4,7 @@ describe('number utils', () => {
   describe('clamp', () => {
     it('should constrain value between min and max', () => {
       expect(clamp(5, -1, 1)).toBe(1);
-      expect(clamp(-5, -1, 1)).toBe(1);
+      expect(clamp(-5, -1, 1)).toBe(-1);
     });
   });
 

--- a/packages/@react-aria/utils/test/number.test.js
+++ b/packages/@react-aria/utils/test/number.test.js
@@ -3,17 +3,17 @@ import {clamp, snapValueToStep} from '../src/number';
 describe('number utils', () => {
   describe('clamp', () => {
     it('should constrain value between min and max', () => {
-      expect(clamp(5, -1, 1).toBe(1));
-      expect(clamp(-5, -1, 1).toBe(1));
+      expect(clamp(5, -1, 1)).toBe(1);
+      expect(clamp(-5, -1, 1)).toBe(1);
     });
   });
 
   describe('snapValueToStep', () => {
     it('should snap value to nearest step based on min and max', () => {
-      expect(snapValueToStep(2, -0.5, 100, 3).toBe(2.5));
-      expect(snapValueToStep(-6.2, -2.5, 100, 3).toBe(-2.5));
-      expect(snapValueToStep(106.2, -2.5, 100, 3).toBe(99.5));
-      expect(snapValueToStep(-0.009999, -0.5, 0.5, 0.01).toBe(-0.01));
+      expect(snapValueToStep(2, -0.5, 100, 3)).toBe(2.5);
+      expect(snapValueToStep(-6.2, -2.5, 100, 3)).toBe(-2.5);
+      expect(snapValueToStep(106.2, -2.5, 100, 3)).toBe(99.5);
+      expect(snapValueToStep(-0.009999, -0.5, 0.5, 0.01)).toBe(-0.01);
     });
   });
 });

--- a/scripts/lint-packages.js
+++ b/scripts/lint-packages.js
@@ -39,7 +39,7 @@ softAssert.deepEqual = function (val, val2, message) {
 };
 softAssert.equal = function (val, val2, message) {
   try {
-    assert.equal(val, val2, message);
+    assert.strictEqual(val, val2, message);
   } catch {
     console.error(chalk.red(message));
     errors = true;


### PR DESCRIPTION
https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message

> Deprecated: Use assert.strictEqual() instead.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
