### PR TITLE
fix: call `useTreeData().move()` more time

### DIFF
--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -309,7 +309,7 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
         }
 
         items = updateTree(items, key, () => null);
-        return updateTree(items, toParentKey, parentNode => ({
+        const finalItems = updateTree(items, toParentKey, parentNode => ({
           key: parentNode.key,
           parentKey: parentNode.parentKey,
           value: parentNode.value,
@@ -319,6 +319,14 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
             ...parentNode.children.slice(index)
           ]
         }));
+
+        const collectNodesForMap = (items: TreeNode<T>['children']) => items.forEach(i => {
+          map.set(i.key, i);
+          collectNodesForMap(i.children);
+        });
+        collectNodesForMap(finalItems);
+
+        return finalItems;
       });
     },
     update(oldKey: Key, newValue: T) {

--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -540,4 +540,24 @@ describe('useTreeData', function () {
     expect(result.current.items[0].children[1].children[0]).toBe(initialResult.items[0].children[1].children[0]);
     expect(result.current.items[0].children[2]).toBe(initialResult.items[0].children[2]);
   });
+
+  it('should move an item to a same parent more time', function () {
+    let {result} = renderHook(() => useTreeData({initialItems: initial, getChildren, getKey}));
+
+    act(() => {
+      result.current.move('Sam', 'David', 0);
+    });
+
+    expect(result.current.items[0].children[0].key).toBe('Sam');
+    expect(result.current.items[0].children[1].key).toBe('John');
+    expect(result.current.items[0].children[2].key).toBe('Jane');
+
+    act(() => {
+      result.current.move('Sam', 'David', 1);
+    });
+
+    expect(result.current.items[0].children[0].key).toBe('John');
+    expect(result.current.items[0].children[1].key).toBe('Sam');
+    expect(result.current.items[0].children[2].key).toBe('Jane');
+  });
 });


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Tree data will lock or lose node when call `move()` more time.

## 🧢 Your Project:

<!--- Company/project for pull request -->
