### PR TITLE
Add anatomy diagrams to React Aria docs

### DIFF
--- a/packages/@react-aria/breadcrumbs/docs/anatomy.svg
+++ b/packages/@react-aria/breadcrumbs/docs/anatomy.svg
@@ -1,4 +1,4 @@
-<svg style="max-height: 115px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 402.401 115">
+<svg style="max-height: 115px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 402.401 115">
   <title>Breadcrumbs anatomy diagram</title>
   <desc>Shows a breadcrumbs component with labels pointing to its parts, including the navigation container, breadcrumb items, separators, and current page elements.</desc>
   <defs>
@@ -8,36 +8,36 @@
   </defs>
   <g transform="translate(-126.542 -64)">
     <g transform="translate(-425 -559)">
-      <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(738.881 695.995) rotate(-90)" fill="#6a8dd4" />
-      <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(651.881 695.995) rotate(-90)" fill="#6a8dd4" />
-      <rect width="6" height="9" transform="translate(651.5 687)" fill="none" /><text transform="translate(669.5 673.5)" fill="#6a8dd4" font-size="24" font-family="Adobe-Clean">
+      <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(738.881 695.995) rotate(-90)" fill="var(--anatomy-gray-600)" />
+      <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(651.881 695.995) rotate(-90)" fill="var(--anatomy-gray-600)" />
+      <rect width="6" height="9" transform="translate(651.5 687)" fill="none" /><text transform="translate(669.5 673.5)" fill="var(--anatomy-gray-600)" font-size="24" font-family="Adobe-Clean">
         <tspan x="0" y="24">Trend</tspan>
-      </text><text transform="translate(552.5 673.5)" fill="#6a8dd4" font-size="24" font-family="Adobe-Clean">
+      </text><text transform="translate(552.5 673.5)" fill="var(--anatomy-gray-600)" font-size="24" font-family="Adobe-Clean">
         <tspan x="0" y="24">Sub Item</tspan>
-      </text><text transform="translate(756.5 673.5)" fill="#3f6dc8" font-size="24" font-family="Adobe-Clean" style="font-weight: 500">
+      </text><text transform="translate(756.5 673.5)" fill="var(--anatomy-gray-700)" font-size="24" font-family="Adobe-Clean" style="font-weight: 500">
         <tspan x="0" y="24">January 2019 Assets</tspan>
       </text>
       <g transform="translate(593 640.5)" clip-path="url(#a)">
-        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(0 25.5)" fill="#9eb6e5" />
-        <line y1="28" transform="translate(2.5)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(0 25.5)" fill="var(--anatomy-gray-500)" />
+        <line y1="28" transform="translate(2.5)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" />
       </g>
       <g transform="translate(388 279)">
-        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(351 401)" fill="#9eb6e5" />
-        <line y1="42" transform="translate(353.5 361.5)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(351 401)" fill="var(--anatomy-gray-500)" />
+        <line y1="42" transform="translate(353.5 361.5)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" />
       </g>
       <g transform="translate(857 640.5)" clip-path="url(#a)">
-        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(0 25.5)" fill="#9eb6e5" />
-        <line y1="28" transform="translate(2.5)" fill="none" stroke="#9eb6e5" stroke-width="1" />
-      </g><text transform="translate(596 636)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(0 25.5)" fill="var(--anatomy-gray-500)" />
+        <line y1="28" transform="translate(2.5)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" />
+      </g><text transform="translate(596 636)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-43.882" y="0">Breadcrumb item</tspan>
-      </text><text transform="translate(742 636)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      </text><text transform="translate(742 636)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-24.694" y="0">Separator</tspan>
-      </text><text transform="translate(860 636)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      </text><text transform="translate(860 636)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-32.669" y="0">Current page</tspan>
-      </text><text transform="translate(745 734)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      </text><text transform="translate(745 734)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-27.917" y="0">Navigation</tspan>
       </text>
-      <path d="M-8551.769,3890.234v8.53h401.4v-8.53" transform="translate(9103.811 -3182.375)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+      <path d="M-8551.769,3890.234v8.53h401.4v-8.53" transform="translate(9103.811 -3182.375)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/breadcrumbs/docs/anatomy.svg
+++ b/packages/@react-aria/breadcrumbs/docs/anatomy.svg
@@ -8,7 +8,6 @@
   </defs>
   <g transform="translate(-126.542 -64)">
     <g transform="translate(-425 -559)">
-      <rect width="9" height="6" transform="translate(738.5 696) rotate(-90)" fill="#f0f" opacity="0" />
       <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(738.881 695.995) rotate(-90)" fill="#6a8dd4" />
       <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(651.881 695.995) rotate(-90)" fill="#6a8dd4" />
       <rect width="6" height="9" transform="translate(651.5 687)" fill="none" /><text transform="translate(669.5 673.5)" fill="#6a8dd4" font-size="24" font-family="Adobe-Clean">

--- a/packages/@react-aria/breadcrumbs/docs/anatomy.svg
+++ b/packages/@react-aria/breadcrumbs/docs/anatomy.svg
@@ -1,0 +1,44 @@
+<svg style="max-height: 115px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 402.401 115">
+  <title>Breadcrumbs anatomy diagram</title>
+  <desc>Shows a breadcrumbs component with labels pointing to its parts, including the navigation container, breadcrumb items, separators, and current page elements.</desc>
+  <defs>
+    <clipPath id="a">
+      <rect width="5" height="30.5" fill="none" />
+    </clipPath>
+  </defs>
+  <g transform="translate(-126.542 -64)">
+    <g transform="translate(-425 -559)">
+      <rect width="9" height="6" transform="translate(738.5 696) rotate(-90)" fill="#f0f" opacity="0" />
+      <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(738.881 695.995) rotate(-90)" fill="#6a8dd4" />
+      <path d="M8.988.752A.75.75,0,0,0,7.707.22L4.5,3.433,1.283.22A.751.751,0,1,0,.22,1.282L3.963,5.023a.75.75,0,0,0,1.06,0L8.766,1.282A.75.75,0,0,0,8.988.752Z" transform="translate(651.881 695.995) rotate(-90)" fill="#6a8dd4" />
+      <rect width="6" height="9" transform="translate(651.5 687)" fill="none" /><text transform="translate(669.5 673.5)" fill="#6a8dd4" font-size="24" font-family="Adobe-Clean">
+        <tspan x="0" y="24">Trend</tspan>
+      </text><text transform="translate(552.5 673.5)" fill="#6a8dd4" font-size="24" font-family="Adobe-Clean">
+        <tspan x="0" y="24">Sub Item</tspan>
+      </text><text transform="translate(756.5 673.5)" fill="#3f6dc8" font-size="24" font-family="Adobe-Clean" style="font-weight: 500">
+        <tspan x="0" y="24">January 2019 Assets</tspan>
+      </text>
+      <g transform="translate(593 640.5)" clip-path="url(#a)">
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(0 25.5)" fill="#9eb6e5" />
+        <line y1="28" transform="translate(2.5)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+      </g>
+      <g transform="translate(388 279)">
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(351 401)" fill="#9eb6e5" />
+        <line y1="42" transform="translate(353.5 361.5)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+      </g>
+      <g transform="translate(857 640.5)" clip-path="url(#a)">
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(0 25.5)" fill="#9eb6e5" />
+        <line y1="28" transform="translate(2.5)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+      </g><text transform="translate(596 636)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-43.882" y="0">Breadcrumb item</tspan>
+      </text><text transform="translate(742 636)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-24.694" y="0">Separator</tspan>
+      </text><text transform="translate(860 636)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-32.669" y="0">Current page</tspan>
+      </text><text transform="translate(745 734)" fill="#3f6dc8" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-27.917" y="0">Navigation</tspan>
+      </text>
+      <path d="M-8551.769,3890.234v8.53h401.4v-8.53" transform="translate(9103.811 -3182.375)" fill="none" stroke="#9eb6e5" stroke-width="1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/breadcrumbs/docs/useBreadcrumbs.mdx
+++ b/packages/@react-aria/breadcrumbs/docs/useBreadcrumbs.mdx
@@ -13,6 +13,7 @@ export default Layout;
 import docs from 'docs:@react-aria/breadcrumbs';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType} from '@react-spectrum/docs';
 import packageData from '@react-aria/breadcrumbs/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useBreadcrumbs, useBreadcrumbItem} from '@react-aria/breadcrumbs';
@@ -52,8 +53,10 @@ Breadcrumbs provide a list of links to parent pages of the current page in heira
 
 ## Anatomy
 
-Breadcrumbs consist of a navigation landmark element and a list of links. The last link
-represents the current page in the hierarchy, with the previous links representing the
+<Anatomy />
+
+Breadcrumbs consist of a navigation landmark element and a list of links, typically with a visual separator
+icon between each item. The last link represents the current page in the hierarchy, with the previous links representing the
 parent pages of the current page. Each of these parent links can be clicked, tapped, or
 triggered via the <kbd>Enter</kbd> key to navigate to that page. Optionally, breadcrumbs can be used
 in place of a page title, in which case the last breadcrumb acts as a heading.

--- a/packages/@react-aria/checkbox/docs/checkbox-anatomy.svg
+++ b/packages/@react-aria/checkbox/docs/checkbox-anatomy.svg
@@ -3,12 +3,11 @@
   <desc>Shows a checkbox component with labels pointing to its parts, including the input, and label elements.</desc>
   <g transform="translate(-72 -88)">
     <g transform="translate(127 88)">
-      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Subscribe</tspan>
       </text>
       <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="#718dcf" />
       <g transform="translate(3 16.5)">
-        <rect width="15" height="15" fill="#f0f" opacity="0" />
         <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="#fafafa" />
       </g>
     </g>
@@ -18,7 +17,7 @@
       <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-57 80)">
-      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
       <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />

--- a/packages/@react-aria/checkbox/docs/checkbox-anatomy.svg
+++ b/packages/@react-aria/checkbox/docs/checkbox-anatomy.svg
@@ -1,0 +1,27 @@
+<svg style="max-height: 48px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 249 48">
+  <title>Checkbox anatomy diagram</title>
+  <desc>Shows a checkbox component with labels pointing to its parts, including the input, and label elements.</desc>
+  <g transform="translate(-72 -88)">
+    <g transform="translate(127 88)">
+      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Subscribe</tspan>
+      </text>
+      <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="#718dcf" />
+      <g transform="translate(3 16.5)">
+        <rect width="15" height="15" fill="#f0f" opacity="0" />
+        <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="#fafafa" />
+      </g>
+    </g>
+    <g transform="translate(-76 433.5)"><text transform="translate(383 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.826" y="0">Label</tspan>
+      </text>
+      <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-57 80)">
+      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-26.299" y="0">Input</tspan>
+      </text>
+      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/checkbox/docs/checkbox-anatomy.svg
+++ b/packages/@react-aria/checkbox/docs/checkbox-anatomy.svg
@@ -1,26 +1,26 @@
-<svg style="max-height: 48px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 249 48">
+<svg style="max-height: 48px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 249 48">
   <title>Checkbox anatomy diagram</title>
   <desc>Shows a checkbox component with labels pointing to its parts, including the input, and label elements.</desc>
   <g transform="translate(-72 -88)">
     <g transform="translate(127 88)">
-      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Subscribe</tspan>
       </text>
-      <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="#718dcf" />
+      <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="var(--anatomy-gray-600)" />
       <g transform="translate(3 16.5)">
-        <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="#fafafa" />
+        <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="var(--anatomy-gray-50)" />
       </g>
     </g>
-    <g transform="translate(-76 433.5)"><text transform="translate(383 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(-76 433.5)"><text transform="translate(383 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
-      <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="#a2b6e1" />
+      <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-57 80)">
-      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
-      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
+      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/checkbox/docs/checkboxgroup-anatomy.svg
+++ b/packages/@react-aria/checkbox/docs/checkboxgroup-anatomy.svg
@@ -1,0 +1,62 @@
+<svg style="max-height: 246px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 260.139 246">
+  <title>Checkbox group anatomy diagram</title>
+  <desc>Shows a checkbox group component with labels pointing to its parts, including the checkbox group label, and group element containing three checkboxes with input and label elements.</desc>
+  <g transform="translate(-138 -76)">
+    <g transform="translate(192 249)">
+      <rect width="95" height="48" fill="red" opacity="0" />
+      <g transform="translate(0 13.5)" fill="#fdfdfe">
+        <path d="M 18 19.5 L 3 19.5 C 2.172899961471558 19.5 1.5 18.82710075378418 1.5 18 L 1.5 3 C 1.5 2.172899961471558 2.172899961471558 1.5 3 1.5 L 18 1.5 C 18.82710075378418 1.5 19.5 2.172899961471558 19.5 3 L 19.5 18 C 19.5 18.82710075378418 18.82710075378418 19.5 18 19.5 Z" stroke="none" />
+        <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="#718dcf" />
+      </g><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Shopping</tspan>
+      </text>
+    </g>
+    <g transform="translate(192 201)">
+      <rect width="95" height="48" fill="red" opacity="0" />
+      <g transform="translate(0 13.5)" fill="#fdfdfe">
+        <path d="M 18 19.5 L 3 19.5 C 2.172899961471558 19.5 1.5 18.82710075378418 1.5 18 L 1.5 3 C 1.5 2.172899961471558 2.172899961471558 1.5 3 1.5 L 18 1.5 C 18.82710075378418 1.5 19.5 2.172899961471558 19.5 3 L 19.5 18 C 19.5 18.82710075378418 18.82710075378418 19.5 18 19.5 Z" stroke="none" />
+        <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="#718dcf" />
+      </g><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Music</tspan>
+      </text>
+    </g>
+    <g transform="translate(192 153)">
+      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Travel</tspan>
+      </text>
+      <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="#718dcf" />
+      <g transform="translate(3 16.5)">
+        <rect width="15" height="15" fill="#f0f" opacity="0" />
+        <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="#fafafa" />
+      </g>
+    </g>
+    <g transform="translate(9 145)">
+      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-26.299" y="0">Input</tspan>
+      </text>
+      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
+    </g><text transform="translate(195 135)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Interests</tspan>
+    </text>
+    <g transform="translate(-200 439)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-54.763" y="0">Checkbox group label</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g><text transform="translate(361.139 230.413)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <tspan x="0" y="0">Group</tspan>
+    </text>
+    <rect width="8" height="1" transform="translate(344.14 226.419)" fill="#a2b6e1" />
+    <g transform="translate(335.14 156)">
+      <rect width="8" height="1" fill="#a2b6e1" />
+      <rect width="1" height="141" transform="translate(8)" fill="#a2b6e1" />
+      <rect width="8" height="1" transform="translate(0 140)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-123 635.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-38.246" y="0">Checkbox label</tspan>
+      </text>
+      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/checkbox/docs/checkboxgroup-anatomy.svg
+++ b/packages/@react-aria/checkbox/docs/checkboxgroup-anatomy.svg
@@ -1,59 +1,59 @@
-<svg style="max-height: 246px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 260.139 246">
+<svg style="max-height: 246px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 260.139 246">
   <title>Checkbox group anatomy diagram</title>
   <desc>Shows a checkbox group component with labels pointing to its parts, including the checkbox group label, and group element containing three checkboxes with input and label elements.</desc>
   <g transform="translate(-138 -76)">
     <g transform="translate(192 249)">
-      <g transform="translate(0 13.5)" fill="#fdfdfe">
+      <g transform="translate(0 13.5)" fill="var(--anatomy-gray-75)">
         <path d="M 18 19.5 L 3 19.5 C 2.172899961471558 19.5 1.5 18.82710075378418 1.5 18 L 1.5 3 C 1.5 2.172899961471558 2.172899961471558 1.5 3 1.5 L 18 1.5 C 18.82710075378418 1.5 19.5 2.172899961471558 19.5 3 L 19.5 18 C 19.5 18.82710075378418 18.82710075378418 19.5 18 19.5 Z" stroke="none" />
-        <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="#718dcf" />
-      </g><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="var(--anatomy-gray-600)" />
+      </g><text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Shopping</tspan>
       </text>
     </g>
     <g transform="translate(192 201)">
-      <g transform="translate(0 13.5)" fill="#fdfdfe">
+      <g transform="translate(0 13.5)" fill="var(--anatomy-gray-75)">
         <path d="M 18 19.5 L 3 19.5 C 2.172899961471558 19.5 1.5 18.82710075378418 1.5 18 L 1.5 3 C 1.5 2.172899961471558 2.172899961471558 1.5 3 1.5 L 18 1.5 C 18.82710075378418 1.5 19.5 2.172899961471558 19.5 3 L 19.5 18 C 19.5 18.82710075378418 18.82710075378418 19.5 18 19.5 Z" stroke="none" />
-        <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="#718dcf" />
-      </g><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="var(--anatomy-gray-600)" />
+      </g><text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Music</tspan>
       </text>
     </g>
     <g transform="translate(192 153)">
-      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Travel</tspan>
       </text>
-      <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="#718dcf" />
+      <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="var(--anatomy-gray-600)" />
       <g transform="translate(3 16.5)">
-        <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="#fafafa" />
+        <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="var(--anatomy-gray-50)" />
       </g>
     </g>
     <g transform="translate(9 145)">
-      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
-      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
-    </g><text transform="translate(195 135)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(195 135)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
       <tspan x="0" y="0">Interests</tspan>
     </text>
     <g transform="translate(-200 439)">
-      <text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -350)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-54.763" y="0">Checkbox group label</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-    </g><text transform="translate(361.139 230.413)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(361.139 230.413)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
       <tspan x="0" y="0">Group</tspan>
     </text>
-    <rect width="8" height="1" transform="translate(344.14 226.419)" fill="#a2b6e1" />
+    <rect width="8" height="1" transform="translate(344.14 226.419)" fill="var(--anatomy-gray-500)" />
     <g transform="translate(335.14 156)">
-      <rect width="8" height="1" fill="#a2b6e1" />
-      <rect width="1" height="141" transform="translate(8)" fill="#a2b6e1" />
-      <rect width="8" height="1" transform="translate(0 140)" fill="#a2b6e1" />
+      <rect width="8" height="1" fill="var(--anatomy-gray-500)" />
+      <rect width="1" height="141" transform="translate(8)" fill="var(--anatomy-gray-500)" />
+      <rect width="8" height="1" transform="translate(0 140)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-123 635.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-38.246" y="0">Checkbox label</tspan>
       </text>
-      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
+      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/checkbox/docs/checkboxgroup-anatomy.svg
+++ b/packages/@react-aria/checkbox/docs/checkboxgroup-anatomy.svg
@@ -3,7 +3,6 @@
   <desc>Shows a checkbox group component with labels pointing to its parts, including the checkbox group label, and group element containing three checkboxes with input and label elements.</desc>
   <g transform="translate(-138 -76)">
     <g transform="translate(192 249)">
-      <rect width="95" height="48" fill="red" opacity="0" />
       <g transform="translate(0 13.5)" fill="#fdfdfe">
         <path d="M 18 19.5 L 3 19.5 C 2.172899961471558 19.5 1.5 18.82710075378418 1.5 18 L 1.5 3 C 1.5 2.172899961471558 2.172899961471558 1.5 3 1.5 L 18 1.5 C 18.82710075378418 1.5 19.5 2.172899961471558 19.5 3 L 19.5 18 C 19.5 18.82710075378418 18.82710075378418 19.5 18 19.5 Z" stroke="none" />
         <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="#718dcf" />
@@ -12,7 +11,6 @@
       </text>
     </g>
     <g transform="translate(192 201)">
-      <rect width="95" height="48" fill="red" opacity="0" />
       <g transform="translate(0 13.5)" fill="#fdfdfe">
         <path d="M 18 19.5 L 3 19.5 C 2.172899961471558 19.5 1.5 18.82710075378418 1.5 18 L 1.5 3 C 1.5 2.172899961471558 2.172899961471558 1.5 3 1.5 L 18 1.5 C 18.82710075378418 1.5 19.5 2.172899961471558 19.5 3 L 19.5 18 C 19.5 18.82710075378418 18.82710075378418 19.5 18 19.5 Z" stroke="none" />
         <path d="M 3 3 L 3.000007629394531 3 C 3.000005722045898 3.000001907348633 3.000001907348633 3.000005722045898 3 3 L 3 18 L 18 18 L 18 3 L 3 3 M 3 0 L 18 0 C 19.65685081481934 0 21 1.343149185180664 21 3 L 21 18 C 21 19.65685081481934 19.65685081481934 21 18 21 L 3 21 C 1.343149185180664 21 0 19.65685081481934 0 18 L 0 3 C 0 1.343149185180664 1.343149185180664 0 3 0 Z" stroke="none" fill="#718dcf" />
@@ -21,17 +19,16 @@
       </text>
     </g>
     <g transform="translate(192 153)">
-      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Travel</tspan>
       </text>
       <path d="M3,0H18a3,3,0,0,1,3,3V18a3,3,0,0,1-3,3H3a3,3,0,0,1-3-3V3A3,3,0,0,1,3,0Z" transform="translate(0 13.5)" fill="#718dcf" />
       <g transform="translate(3 16.5)">
-        <rect width="15" height="15" fill="#f0f" opacity="0" />
         <path d="M5.617,14a1.53,1.53,0,0,1-1.224-.625L.839,8.505A1.681,1.681,0,0,1,.59,6.876,1.567,1.567,0,0,1,1.835,5.861a1.525,1.525,0,0,1,1.452.648l2.33,3.232,6.1-8.1A1.525,1.525,0,0,1,13.165.991,1.567,1.567,0,0,1,14.41,2.006a1.681,1.681,0,0,1-.249,1.63L6.841,13.375A1.53,1.53,0,0,1,5.617,14Z" transform="translate(0 0)" fill="#fafafa" />
       </g>
     </g>
     <g transform="translate(9 145)">
-      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
       <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
@@ -39,7 +36,7 @@
       <tspan x="0" y="0">Interests</tspan>
     </text>
     <g transform="translate(-200 439)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-54.763" y="0">Checkbox group label</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
@@ -53,7 +50,7 @@
       <rect width="8" height="1" transform="translate(0 140)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-123 635.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-38.246" y="0">Checkbox label</tspan>
       </text>
       <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />

--- a/packages/@react-aria/checkbox/docs/useCheckbox.mdx
+++ b/packages/@react-aria/checkbox/docs/useCheckbox.mdx
@@ -16,6 +16,7 @@ import focusDocs from 'docs:@react-aria/focus';
 import statelyDocs from 'docs:@react-stately/toggle';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/checkbox/package.json';
+import Anatomy from './checkbox-anatomy.svg';
 
 ```jsx import
 import {useCheckbox} from '@react-aria/checkbox';
@@ -55,6 +56,8 @@ that can be styled as needed.
 * Indeterminate state support
 
 ## Anatomy
+
+<Anatomy />
 
 A checkbox consists of a visual selection indicator and a label. Checkboxes support three
 selection states: checked, unchecked, and indeterminate. Users may click or touch a checkbox

--- a/packages/@react-aria/checkbox/docs/useCheckboxGroup.mdx
+++ b/packages/@react-aria/checkbox/docs/useCheckboxGroup.mdx
@@ -16,6 +16,7 @@ import focusDocs from 'docs:@react-aria/focus';
 import statelyDocs from 'docs:@react-stately/checkbox';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/checkbox/package.json';
+import Anatomy from './checkboxgroup-anatomy.svg';
 
 ```jsx import
 import {useCheckboxGroup, useCheckboxGroupItem} from '@react-aria/checkbox';
@@ -59,6 +60,8 @@ checkbox groups that can be styled as needed.
 * Group and checkbox labeling support for assistive technology
 
 ## Anatomy
+
+<Anatomy />
 
 A checkbox group consists of a set of checkboxes, and a label. Each checkbox
 includes a label and a visual selection indicator. Zero or more checkboxes

--- a/packages/@react-aria/dialog/docs/anatomy.svg
+++ b/packages/@react-aria/dialog/docs/anatomy.svg
@@ -25,13 +25,13 @@
       </text>
     </g>
     <g transform="translate(-318 401)">
-      <rect width="20" height="83" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-10.699" y="0">Title</tspan>
       </text>
       <path d="M-682-298.5a2.5,2.5,0,0,1,2-2.449V-381h1v80.05a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-682-298.5Z" transform="translate(1081.5 38)" fill="#718dcf" />
     </g>
     <g transform="translate(-230 401)">
-      <rect width="20" height="55" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-16.874" y="0">Dialog</tspan>
       </text>
       <path d="M-770-326.5a2.5,2.5,0,0,1,2-2.45V-381h1v52.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-770-326.5Z" transform="translate(1169.5 38)" fill="#718dcf" />

--- a/packages/@react-aria/dialog/docs/anatomy.svg
+++ b/packages/@react-aria/dialog/docs/anatomy.svg
@@ -1,0 +1,40 @@
+<svg style="max-height: 308px; background: #B6C5E7; padding: 32px 32px 48px 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 398 308">
+  <title>Dialog anatomy diagram</title>
+  <desc>Shows a dialog component with labels pointing to its parts, including the title, and dialog container elements.</desc>
+  <g transform="translate(-28 -40)">
+    <g transform="translate(0 68)">
+      <rect width="398" height="250" rx="4" transform="translate(28 30)" fill="#fff" />
+      <g transform="translate(226.457 208)">
+        <g transform="translate(-0.457)" fill="rgba(255,0,0,0)" stroke="#718dcf" stroke-width="2">
+          <rect width="72" height="32" rx="16" stroke="none" />
+          <rect x="1" y="1" width="70" height="30" rx="15" fill="none" />
+        </g><text transform="translate(16.5 20)" fill="#718dcf" font-size="14" font-family="Adobe-Clean" style="font-weight: 700">
+          <tspan x="0" y="0">Cancel</tspan>
+        </text>
+        <g transform="translate(88)">
+          <rect width="72" height="32" rx="16" transform="translate(-0.457)" fill="#4a6fc3" /><text transform="translate(35.543 20)" fill="#fff" font-size="14" font-family="Adobe-Clean" style="font-weight: 700">
+            <tspan x="-20.174" y="0">Enable</tspan>
+          </text>
+        </g>
+      </g><text transform="translate(68 87.964)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean" style="font-weight: 700">
+        <tspan x="0" y="0">Enable smart filters?</tspan>
+      </text>
+      <rect width="318" height="2" rx="1" transform="translate(68 104)" fill="#e5ebf7" /><text transform="translate(68 136)" fill="#4a6fc3" font-size="14" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Smart filters are nondestructive and will preserve your </tspan>
+        <tspan x="0" y="21">original images.</tspan>
+      </text>
+    </g>
+    <g transform="translate(-318 401)">
+      <rect width="20" height="83" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-10.699" y="0">Title</tspan>
+      </text>
+      <path d="M-682-298.5a2.5,2.5,0,0,1,2-2.449V-381h1v80.05a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-682-298.5Z" transform="translate(1081.5 38)" fill="#718dcf" />
+    </g>
+    <g transform="translate(-230 401)">
+      <rect width="20" height="55" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-16.874" y="0">Dialog</tspan>
+      </text>
+      <path d="M-770-326.5a2.5,2.5,0,0,1,2-2.45V-381h1v52.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-770-326.5Z" transform="translate(1169.5 38)" fill="#718dcf" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/dialog/docs/anatomy.svg
+++ b/packages/@react-aria/dialog/docs/anatomy.svg
@@ -1,40 +1,40 @@
-<svg style="max-height: 308px; background: #B6C5E7; padding: 32px 32px 48px 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 398 308">
+<svg style="max-height: 308px; background: var(--anatomy-gray-400); padding: 32px 32px 48px 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 398 308">
   <title>Dialog anatomy diagram</title>
   <desc>Shows a dialog component with labels pointing to its parts, including the title, and dialog container elements.</desc>
   <g transform="translate(-28 -40)">
     <g transform="translate(0 68)">
-      <rect width="398" height="250" rx="4" transform="translate(28 30)" fill="#fff" />
+      <rect width="398" height="250" rx="4" transform="translate(28 30)" fill="var(--anatomy-gray-50)" />
       <g transform="translate(226.457 208)">
-        <g transform="translate(-0.457)" fill="rgba(255,0,0,0)" stroke="#718dcf" stroke-width="2">
+        <g transform="translate(-0.457)" fill="rgba(255,0,0,0)" stroke="var(--anatomy-gray-600)" stroke-width="2">
           <rect width="72" height="32" rx="16" stroke="none" />
           <rect x="1" y="1" width="70" height="30" rx="15" fill="none" />
-        </g><text transform="translate(16.5 20)" fill="#718dcf" font-size="14" font-family="Adobe-Clean" style="font-weight: 700">
+        </g><text transform="translate(16.5 20)" fill="var(--anatomy-gray-600)" font-size="14" font-family="Adobe-Clean" style="font-weight: 700">
           <tspan x="0" y="0">Cancel</tspan>
         </text>
         <g transform="translate(88)">
-          <rect width="72" height="32" rx="16" transform="translate(-0.457)" fill="#4a6fc3" /><text transform="translate(35.543 20)" fill="#fff" font-size="14" font-family="Adobe-Clean" style="font-weight: 700">
+          <rect width="72" height="32" rx="16" transform="translate(-0.457)" fill="var(--anatomy-gray-700)" /><text transform="translate(35.543 20)" fill="var(--anatomy-gray-50)" font-size="14" font-family="Adobe-Clean" style="font-weight: 700">
             <tspan x="-20.174" y="0">Enable</tspan>
           </text>
         </g>
-      </g><text transform="translate(68 87.964)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean" style="font-weight: 700">
+      </g><text transform="translate(68 87.964)" fill="var(--anatomy-gray-700)" font-size="18" font-family="Adobe-Clean" style="font-weight: 700">
         <tspan x="0" y="0">Enable smart filters?</tspan>
       </text>
-      <rect width="318" height="2" rx="1" transform="translate(68 104)" fill="#e5ebf7" /><text transform="translate(68 136)" fill="#4a6fc3" font-size="14" font-family="Adobe-Clean">
+      <rect width="318" height="2" rx="1" transform="translate(68 104)" fill="var(--anatomy-gray-200)" /><text transform="translate(68 136)" fill="var(--anatomy-gray-700)" font-size="14" font-family="Adobe-Clean">
         <tspan x="0" y="0">Smart filters are nondestructive and will preserve your </tspan>
         <tspan x="0" y="21">original images.</tspan>
       </text>
     </g>
     <g transform="translate(-318 401)">
-      <text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-10.699" y="0">Title</tspan>
       </text>
-      <path d="M-682-298.5a2.5,2.5,0,0,1,2-2.449V-381h1v80.05a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-682-298.5Z" transform="translate(1081.5 38)" fill="#718dcf" />
+      <path d="M-682-298.5a2.5,2.5,0,0,1,2-2.449V-381h1v80.05a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-682-298.5Z" transform="translate(1081.5 38)" fill="var(--anatomy-gray-600)" />
     </g>
     <g transform="translate(-230 401)">
-      <text transform="translate(402 -348)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-16.874" y="0">Dialog</tspan>
       </text>
-      <path d="M-770-326.5a2.5,2.5,0,0,1,2-2.45V-381h1v52.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-770-326.5Z" transform="translate(1169.5 38)" fill="#718dcf" />
+      <path d="M-770-326.5a2.5,2.5,0,0,1,2-2.45V-381h1v52.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-770-326.5Z" transform="translate(1169.5 38)" fill="var(--anatomy-gray-600)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/dialog/docs/useDialog.mdx
+++ b/packages/@react-aria/dialog/docs/useDialog.mdx
@@ -15,6 +15,7 @@ import overlaysDocs from 'docs:@react-aria/overlays';
 import focusDocs from 'docs:@react-aria/focus';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/dialog/package.json';
+import Anatomy from './anatomy.svg';
 
 ---
 category: Overlays
@@ -53,6 +54,8 @@ helps achieve accessible dialogs that can be styled as needed.
 * Handles closing the dialog when interacting outside and pressing the <kbd>Escape</kbd> key, when combined with <TypeLink links={overlaysDocs.links} type={overlaysDocs.exports.useOverlay} />
 
 ## Anatomy
+
+<Anatomy />
 
 A dialog consists of a container element and an optional title. `useDialog` handles
 exposing this to assistive technology using ARIA. It can be combined

--- a/packages/@react-aria/listbox/docs/anatomy.svg
+++ b/packages/@react-aria/listbox/docs/anatomy.svg
@@ -1,76 +1,76 @@
-<svg style="max-height: 304px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 402 304">
+<svg style="max-height: 304px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 402 304">
   <title>Listbox anatomy diagram</title>
   <desc>Shows a listbox with labels pointing to its parts, including the label, listbox, group, section heading, option, option label, and option description elements.</desc>
   <g transform="translate(-376 -35)">
-    <g transform="translate(504 100)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+    <g transform="translate(504 100)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
       <rect width="214" height="239" rx="6" stroke="none" />
       <rect x="0.75" y="0.75" width="212.5" height="237.5" rx="5.25" fill="none" />
     </g>
-    <text transform="translate(504 93)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+    <text transform="translate(504 93)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
       <tspan x="0" y="0">Label</tspan>
     </text>
-    <g transform="translate(505 131)" fill="#486ec2" opacity="0.04">
+    <g transform="translate(505 131)" fill="var(--anatomy-gray-900)" opacity="0.04">
       <path d="M0,0H212V64H0Z" stroke="none" />
       <path d="M 1 1 L 1 63 L 211 63 L 211 1 L 1 1 M 0 0 L 212 0 L 212 64 L 0 64 L 0 0 Z" stroke="none" fill="rgba(0,0,0,0)" />
-    </g><text transform="translate(522 158)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </g><text transform="translate(522 158)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Option 1</tspan>
-    </text><text transform="translate(522 227)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </text><text transform="translate(522 227)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Option 2</tspan>
     </text>
-    <g transform="translate(397 492.5)"><text transform="translate(346 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(397 492.5)"><text transform="translate(346 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="0" y="0">Option</tspan>
       </text>
-      <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
+      <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(685 142.981)">
-      <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="#6a87cd" />
+      <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="var(--anatomy-gray-600)" />
     </g>
     <g transform="translate(110 396)">
-      <text transform="translate(416 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(416 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-27.651" y="0">Label</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
     </g>
-    <g transform="translate(104 500.755)"><text transform="translate(334 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(104 500.755)"><text transform="translate(334 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-31.298" y="0">Option label</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g><text transform="translate(522 183)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
       <tspan x="0" y="0">Description</tspan>
     </text><text transform="translate(522 252)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
       <tspan x="0" y="0">Description</tspan>
-    </text><text transform="translate(522 295)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </text><text transform="translate(522 295)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Option 3</tspan>
     </text><text transform="translate(522 320)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
       <tspan x="0" y="0">Description</tspan>
     </text>
-    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-93.132" y="0">Option description</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(295 421)">
-      <text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -349)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-17.972" y="0">Listbox</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-    </g><text transform="translate(522 122)" fill="#496ec2" font-size="14" font-family="Adobe-Clean" style="font-weight: 700; letter-spacing: 0.06em">
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(522 122)" fill="var(--anatomy-gray-800)" font-size="14" font-family="Adobe-Clean" style="font-weight: 700; letter-spacing: 0.06em">
       <tspan x="0" y="0">SECTION TITLE</tspan>
     </text>
     <g transform="translate(104 464.755)">
-      <text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(366 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-80.977" y="0">Section heading</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g>
-    <rect width="8" height="1" transform="translate(732.14 223.776)" fill="#a2b6e1" />
+    <rect width="8" height="1" transform="translate(732.14 223.776)" fill="var(--anatomy-gray-500)" />
     <g transform="translate(723.117 108)">
-      <rect width="8.023" height="1" fill="#a2b6e1" />
-      <rect width="1" height="226.234" transform="translate(8.023)" fill="#a2b6e1" />
-      <rect width="8.023" height="1" transform="translate(0 225.234)" fill="#a2b6e1" />
-    </g><text transform="translate(745 229)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <rect width="8.023" height="1" fill="var(--anatomy-gray-500)" />
+      <rect width="1" height="226.234" transform="translate(8.023)" fill="var(--anatomy-gray-500)" />
+      <rect width="8.023" height="1" transform="translate(0 225.234)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(745 229)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
       <tspan x="0" y="0">Group</tspan>
     </text>
   </g>

--- a/packages/@react-aria/listbox/docs/anatomy.svg
+++ b/packages/@react-aria/listbox/docs/anatomy.svg
@@ -1,0 +1,78 @@
+<svg style="max-height: 304px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 402 304">
+  <title>Listbox anatomy diagram</title>
+  <desc>Shows a listbox with labels pointing to its parts, including the label, listbox, group, section heading, option, option label, and option description elements.</desc>
+  <g transform="translate(-376 -35)">
+    <g transform="translate(504 100)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+      <rect width="214" height="239" rx="6" stroke="none" />
+      <rect x="0.75" y="0.75" width="212.5" height="237.5" rx="5.25" fill="none" />
+    </g>
+    <text transform="translate(504 93)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Label</tspan>
+    </text>
+    <g transform="translate(505 131)" fill="#486ec2" opacity="0.04">
+      <path d="M0,0H212V64H0Z" stroke="none" />
+      <path d="M 1 1 L 1 63 L 211 63 L 211 1 L 1 1 M 0 0 L 212 0 L 212 64 L 0 64 L 0 0 Z" stroke="none" fill="rgba(0,0,0,0)" />
+    </g><text transform="translate(522 158)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Option 1</tspan>
+    </text><text transform="translate(522 227)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Option 2</tspan>
+    </text>
+    <g transform="translate(397 492.5)"><text transform="translate(346 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="0" y="0">Option</tspan>
+      </text>
+      <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(685 142.981)">
+      <rect width="18" height="18" transform="translate(0 0.019)" fill="#f0f" opacity="0" />
+      <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="#6a87cd" />
+    </g>
+    <g transform="translate(110 396)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(416 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-27.651" y="0">Label</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(104 500.755)"><text transform="translate(334 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-31.298" y="0">Option label</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g><text transform="translate(522 183)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Description</tspan>
+    </text><text transform="translate(522 252)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Description</tspan>
+    </text><text transform="translate(522 295)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Option 3</tspan>
+    </text><text transform="translate(522 320)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Description</tspan>
+    </text>
+    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-93.132" y="0">Option description</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(295 421)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-17.972" y="0">Listbox</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g><text transform="translate(522 122)" fill="#496ec2" font-size="14" font-family="Adobe-Clean" style="font-weight: 700; letter-spacing: 0.06em">
+      <tspan x="0" y="0">SECTION TITLE</tspan>
+    </text>
+    <g transform="translate(104 464.755)">
+      <text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-80.977" y="0">Section heading</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g>
+    <rect width="8" height="1" transform="translate(732.14 223.776)" fill="#a2b6e1" />
+    <g transform="translate(723.117 108)">
+      <rect width="8.023" height="1" fill="#a2b6e1" />
+      <rect width="1" height="226.234" transform="translate(8.023)" fill="#a2b6e1" />
+      <rect width="8.023" height="1" transform="translate(0 225.234)" fill="#a2b6e1" />
+    </g><text transform="translate(745 229)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <tspan x="0" y="0">Group</tspan>
+    </text>
+  </g>
+</svg>

--- a/packages/@react-aria/listbox/docs/anatomy.svg
+++ b/packages/@react-aria/listbox/docs/anatomy.svg
@@ -23,11 +23,10 @@
       <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
     </g>
     <g transform="translate(685 142.981)">
-      <rect width="18" height="18" transform="translate(0 0.019)" fill="#f0f" opacity="0" />
       <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="#6a87cd" />
     </g>
     <g transform="translate(110 396)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(416 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(416 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-27.651" y="0">Label</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
@@ -52,7 +51,7 @@
       <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
     </g>
     <g transform="translate(295 421)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-17.972" y="0">Listbox</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />

--- a/packages/@react-aria/listbox/docs/useListBox.mdx
+++ b/packages/@react-aria/listbox/docs/useListBox.mdx
@@ -16,6 +16,7 @@ import selectionDocs from 'docs:@react-stately/selection';
 import statelyDocs from 'docs:@react-stately/list';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/listbox/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useListBox, useListBoxSection, useOption} from '@react-aria/listbox';
@@ -65,6 +66,8 @@ Note: `useListBox` only handles the list itself. For a dropdown similar to a `<s
 * Virtualized scrolling support for performance with long lists
 
 ## Anatomy
+
+<Anatomy />
 
 A listbox consists of a container element, with a list of options or groups inside.
 `useListBox`, `useOption`, and `useListBoxSection` handle exposing this to assistive

--- a/packages/@react-aria/menu/docs/menu-anatomy.svg
+++ b/packages/@react-aria/menu/docs/menu-anatomy.svg
@@ -1,0 +1,76 @@
+<svg style="max-height: 284px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 20 537 284">
+  <title>Menu anatomy diagram</title>
+  <desc>Shows a menu with labels pointing to its parts, including the label, menu, group, section heading, menu item, menu item label, menu item description, and menu item keyboard shortcut elements.</desc>
+  <g transform="translate(-356 -35)">
+    <g transform="translate(504 100)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+      <rect width="214" height="239" rx="6" stroke="none" />
+      <rect x="0.75" y="0.75" width="212.5" height="237.5" rx="5.25" fill="none" />
+    </g>
+    <g transform="translate(505 131)" fill="#486ec2" opacity="0.04">
+      <path d="M0,0H212V64H0Z" stroke="none" />
+      <path d="M 1 1 L 1 63 L 211 63 L 211 1 L 1 1 M 0 0 L 212 0 L 212 64 L 0 64 L 0 0 Z" stroke="none" fill="rgba(0,0,0,0)" />
+    </g><text transform="translate(522 158)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Option 1</tspan>
+    </text><text transform="translate(522 227)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Option 2</tspan>
+    </text>
+    <g transform="translate(397 498.5)"><text transform="translate(346 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="0" y="0">Menu item</tspan>
+      </text>
+      <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(397 472.5)"><text transform="translate(346 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="0" y="0">Menu item keyboard shortcut</tspan>
+      </text>
+      <path d="M-1244-611.5v-32.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v32.05Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(104 500.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-82.589" y="0">Menu item label</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g><text transform="translate(522 183)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Description</tspan>
+    </text><text transform="translate(522 252)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Description</tspan>
+    </text><text transform="translate(522 295)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Option 3</tspan>
+    </text><text transform="translate(522 320)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Description</tspan>
+    </text>
+    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-113.126" y="0">Menu item description</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(295 421)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-14.612" y="0">Menu</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g><text transform="translate(522 122)" fill="#496ec2" font-size="14" font-family="Adobe-Clean" style="font-weight: 700; letter-spacing: 0.06em">
+      <tspan x="0" y="0">SECTION TITLE</tspan>
+    </text>
+    <g transform="translate(104 464.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-80.977" y="0">Section heading</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g>
+    <rect width="8" height="1" transform="translate(732.14 223.776)" fill="#a2b6e1" />
+    <g transform="translate(723.117 108)">
+      <rect width="8.023" height="1" fill="#a2b6e1" />
+      <rect width="1" height="226.234" transform="translate(8.023)" fill="#a2b6e1" />
+      <rect width="8.023" height="1" transform="translate(0 225.234)" fill="#a2b6e1" />
+    </g><text transform="translate(745 229)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <tspan x="0" y="0">Group</tspan>
+    </text><text transform="translate(669 158)" fill="rgba(73,110,194,0.75)" font-size="20" font-family="LucidaGrande, Lucida Grande">
+      <tspan x="0" y="0">⌘</tspan>
+      <tspan y="0" font-family="Adobe-Clean">K</tspan>
+    </text>
+    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-113.126" y="0">Menu item description</tspan>
+      </text>
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/menu/docs/menu-anatomy.svg
+++ b/packages/@react-aria/menu/docs/menu-anatomy.svg
@@ -1,76 +1,76 @@
-<svg style="max-height: 284px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 20 537 284">
+<svg style="max-height: 284px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 20 537 284">
   <title>Menu anatomy diagram</title>
   <desc>Shows a menu with labels pointing to its parts, including the label, menu, group, section heading, menu item, menu item label, menu item description, and menu item keyboard shortcut elements.</desc>
   <g transform="translate(-356 -35)">
-    <g transform="translate(504 100)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+    <g transform="translate(504 100)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
       <rect width="214" height="239" rx="6" stroke="none" />
       <rect x="0.75" y="0.75" width="212.5" height="237.5" rx="5.25" fill="none" />
     </g>
-    <g transform="translate(505 131)" fill="#486ec2" opacity="0.04">
+    <g transform="translate(505 131)" fill="var(--anatomy-gray-900)" opacity="0.04">
       <path d="M0,0H212V64H0Z" stroke="none" />
       <path d="M 1 1 L 1 63 L 211 63 L 211 1 L 1 1 M 0 0 L 212 0 L 212 64 L 0 64 L 0 0 Z" stroke="none" fill="rgba(0,0,0,0)" />
-    </g><text transform="translate(522 158)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </g><text transform="translate(522 158)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Option 1</tspan>
-    </text><text transform="translate(522 227)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </text><text transform="translate(522 227)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Option 2</tspan>
     </text>
-    <g transform="translate(397 498.5)"><text transform="translate(346 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(397 498.5)"><text transform="translate(346 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="0" y="0">Menu item</tspan>
       </text>
-      <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
+      <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(953 -1564.5) rotate(-90)" fill="var(--anatomy-gray-500)" />
     </g>
-    <g transform="translate(397 472.5)"><text transform="translate(346 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(397 472.5)"><text transform="translate(346 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="0" y="0">Menu item keyboard shortcut</tspan>
       </text>
-      <path d="M-1244-611.5v-32.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v32.05Z" transform="translate(953 -1564.5) rotate(-90)" fill="#a2b6e1" />
+      <path d="M-1244-611.5v-32.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v32.05Z" transform="translate(953 -1564.5) rotate(-90)" fill="var(--anatomy-gray-500)" />
     </g>
-    <g transform="translate(104 500.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(104 500.755)"><text transform="translate(366 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-82.589" y="0">Menu item label</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g><text transform="translate(522 183)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
       <tspan x="0" y="0">Description</tspan>
     </text><text transform="translate(522 252)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
       <tspan x="0" y="0">Description</tspan>
-    </text><text transform="translate(522 295)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </text><text transform="translate(522 295)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Option 3</tspan>
     </text><text transform="translate(522 320)" fill="rgba(73,110,194,0.75)" font-size="16" font-family="Adobe-Clean">
       <tspan x="0" y="0">Description</tspan>
     </text>
-    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-113.126" y="0">Menu item description</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(295 421)">
-      <text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -349)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.612" y="0">Menu</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-    </g><text transform="translate(522 122)" fill="#496ec2" font-size="14" font-family="Adobe-Clean" style="font-weight: 700; letter-spacing: 0.06em">
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(522 122)" fill="var(--anatomy-gray-800)" font-size="14" font-family="Adobe-Clean" style="font-weight: 700; letter-spacing: 0.06em">
       <tspan x="0" y="0">SECTION TITLE</tspan>
     </text>
-    <g transform="translate(104 464.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(104 464.755)"><text transform="translate(366 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-80.977" y="0">Section heading</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g>
-    <rect width="8" height="1" transform="translate(732.14 223.776)" fill="#a2b6e1" />
+    <rect width="8" height="1" transform="translate(732.14 223.776)" fill="var(--anatomy-gray-500)" />
     <g transform="translate(723.117 108)">
-      <rect width="8.023" height="1" fill="#a2b6e1" />
-      <rect width="1" height="226.234" transform="translate(8.023)" fill="#a2b6e1" />
-      <rect width="8.023" height="1" transform="translate(0 225.234)" fill="#a2b6e1" />
-    </g><text transform="translate(745 229)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <rect width="8.023" height="1" fill="var(--anatomy-gray-500)" />
+      <rect width="1" height="226.234" transform="translate(8.023)" fill="var(--anatomy-gray-500)" />
+      <rect width="8.023" height="1" transform="translate(0 225.234)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(745 229)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
       <tspan x="0" y="0">Group</tspan>
     </text><text transform="translate(669 158)" fill="rgba(73,110,194,0.75)" font-size="20" font-family="LucidaGrande, Lucida Grande">
       <tspan x="0" y="0">⌘</tspan>
       <tspan y="0" font-family="Adobe-Clean">K</tspan>
     </text>
-    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(104 526.755)"><text transform="translate(366 -344.755)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-113.126" y="0">Menu item description</tspan>
       </text>
-      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
+      <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/menu/docs/menu-anatomy.svg
+++ b/packages/@react-aria/menu/docs/menu-anatomy.svg
@@ -43,7 +43,7 @@
       <path d="M2,42V4.95a2.5,2.5,0,1,1,1,0V42Z" transform="translate(413.5 -351.754) rotate(90)" fill="#a2b6e1" />
     </g>
     <g transform="translate(295 421)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -349)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.612" y="0">Menu</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />

--- a/packages/@react-aria/menu/docs/menu-trigger-anatomy.svg
+++ b/packages/@react-aria/menu/docs/menu-trigger-anatomy.svg
@@ -13,27 +13,19 @@
       <tspan x="0" y="0">Rename</tspan>
     </text>
     <g transform="translate(906 815)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.612" y="0">Menu</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
     </g>
     <g transform="translate(1099 443.801)">
-      <g transform="translate(0 0.199)" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
-        <rect width="165" height="44" stroke="none" />
-        <rect x="0.5" y="0.5" width="164" height="43" fill="none" />
-      </g>
       <g transform="translate(0 0.199)" fill="#e5ebf7" stroke="rgba(0,0,0,0)" stroke-width="1">
         <rect width="165" height="44" rx="4" stroke="none" />
         <rect x="0.5" y="0.5" width="164" height="43" rx="3.5" fill="none" />
       </g>
       <path d="M5.525,0h154.7a5.525,5.525,0,0,1,5.525,5.525V38.674a5.525,5.525,0,0,1-5.525,5.525H5.525A5.525,5.525,0,0,1,0,38.674V5.525A5.525,5.525,0,0,1,5.525,0Zm0,1.381A4.144,4.144,0,0,0,1.381,5.525V38.674a4.144,4.144,0,0,0,4.144,4.144h154.7a4.144,4.144,0,0,0,4.144-4.144V5.525a4.144,4.144,0,0,0-4.144-4.144Z" fill="#a2b6e1" />
       <g transform="translate(9.248 9.52)">
-        <g transform="translate(-0.248 -0.321)" fill="#486ec2" stroke="#486ec2" stroke-width="1" opacity="0">
-          <rect width="26" height="26" stroke="none" />
-          <rect x="0.5" y="0.5" width="25" height="25" fill="none" />
-        </g>
         <g transform="translate(10.366 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
           <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
           <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
@@ -51,7 +43,7 @@
       </text>
     </g>
     <g transform="translate(715 765)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-33.755" y="0">Menu Trigger</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />

--- a/packages/@react-aria/menu/docs/menu-trigger-anatomy.svg
+++ b/packages/@react-aria/menu/docs/menu-trigger-anatomy.svg
@@ -1,0 +1,61 @@
+<svg style="max-height: 246px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 254 246">
+  <title>Menu trigger anatomy diagram</title>
+  <desc>Shows a menu trigger component with labels pointing to its parts, including the trigger, and menu elements.</desc>
+  <g transform="translate(-1083 -404)">
+    <g transform="translate(1099 494)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+      <rect width="238" height="156" rx="6" stroke="none" />
+      <rect x="0.75" y="0.75" width="236.5" height="154.5" rx="5.25" fill="none" />
+    </g><text transform="translate(1117 529)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Open</tspan>
+    </text><text transform="translate(1117 577)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Edit</tspan>
+    </text><text transform="translate(1117 625)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Rename</tspan>
+    </text>
+    <g transform="translate(906 815)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-14.612" y="0">Menu</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(1099 443.801)">
+      <g transform="translate(0 0.199)" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+        <rect width="165" height="44" stroke="none" />
+        <rect x="0.5" y="0.5" width="164" height="43" fill="none" />
+      </g>
+      <g transform="translate(0 0.199)" fill="#e5ebf7" stroke="rgba(0,0,0,0)" stroke-width="1">
+        <rect width="165" height="44" rx="4" stroke="none" />
+        <rect x="0.5" y="0.5" width="164" height="43" rx="3.5" fill="none" />
+      </g>
+      <path d="M5.525,0h154.7a5.525,5.525,0,0,1,5.525,5.525V38.674a5.525,5.525,0,0,1-5.525,5.525H5.525A5.525,5.525,0,0,1,0,38.674V5.525A5.525,5.525,0,0,1,5.525,0Zm0,1.381A4.144,4.144,0,0,0,1.381,5.525V38.674a4.144,4.144,0,0,0,4.144,4.144h154.7a4.144,4.144,0,0,0,4.144-4.144V5.525a4.144,4.144,0,0,0-4.144-4.144Z" fill="#a2b6e1" />
+      <g transform="translate(9.248 9.52)">
+        <g transform="translate(-0.248 -0.321)" fill="#486ec2" stroke="#486ec2" stroke-width="1" opacity="0">
+          <rect width="26" height="26" stroke="none" />
+          <rect x="0.5" y="0.5" width="25" height="25" fill="none" />
+        </g>
+        <g transform="translate(10.366 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
+          <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
+          <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
+        </g>
+        <g transform="translate(18.446 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
+          <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
+          <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
+        </g>
+        <g transform="translate(2.285 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
+          <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
+          <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
+        </g>
+      </g><text transform="translate(44 26.199)" fill="#486ec2" font-size="18" font-family="Adobe-Clean">
+        <tspan x="0" y="0">More Actions</tspan>
+      </text>
+    </g>
+    <g transform="translate(715 765)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-33.755" y="0">Menu Trigger</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/menu/docs/menu-trigger-anatomy.svg
+++ b/packages/@react-aria/menu/docs/menu-trigger-anatomy.svg
@@ -1,53 +1,53 @@
-<svg style="max-height: 246px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 254 246">
+<svg style="max-height: 246px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 254 246">
   <title>Menu trigger anatomy diagram</title>
   <desc>Shows a menu trigger component with labels pointing to its parts, including the trigger, and menu elements.</desc>
   <g transform="translate(-1083 -404)">
-    <g transform="translate(1099 494)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+    <g transform="translate(1099 494)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
       <rect width="238" height="156" rx="6" stroke="none" />
       <rect x="0.75" y="0.75" width="236.5" height="154.5" rx="5.25" fill="none" />
-    </g><text transform="translate(1117 529)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </g><text transform="translate(1117 529)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Open</tspan>
-    </text><text transform="translate(1117 577)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </text><text transform="translate(1117 577)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Edit</tspan>
-    </text><text transform="translate(1117 625)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+    </text><text transform="translate(1117 625)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
       <tspan x="0" y="0">Rename</tspan>
     </text>
     <g transform="translate(906 815)">
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.612" y="0">Menu</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(1099 443.801)">
-      <g transform="translate(0 0.199)" fill="#e5ebf7" stroke="rgba(0,0,0,0)" stroke-width="1">
+      <g transform="translate(0 0.199)" fill="var(--anatomy-gray-200)" stroke="rgba(0,0,0,0)" stroke-width="1">
         <rect width="165" height="44" rx="4" stroke="none" />
         <rect x="0.5" y="0.5" width="164" height="43" rx="3.5" fill="none" />
       </g>
-      <path d="M5.525,0h154.7a5.525,5.525,0,0,1,5.525,5.525V38.674a5.525,5.525,0,0,1-5.525,5.525H5.525A5.525,5.525,0,0,1,0,38.674V5.525A5.525,5.525,0,0,1,5.525,0Zm0,1.381A4.144,4.144,0,0,0,1.381,5.525V38.674a4.144,4.144,0,0,0,4.144,4.144h154.7a4.144,4.144,0,0,0,4.144-4.144V5.525a4.144,4.144,0,0,0-4.144-4.144Z" fill="#a2b6e1" />
+      <path d="M5.525,0h154.7a5.525,5.525,0,0,1,5.525,5.525V38.674a5.525,5.525,0,0,1-5.525,5.525H5.525A5.525,5.525,0,0,1,0,38.674V5.525A5.525,5.525,0,0,1,5.525,0Zm0,1.381A4.144,4.144,0,0,0,1.381,5.525V38.674a4.144,4.144,0,0,0,4.144,4.144h154.7a4.144,4.144,0,0,0,4.144-4.144V5.525a4.144,4.144,0,0,0-4.144-4.144Z" fill="var(--anatomy-gray-500)" />
       <g transform="translate(9.248 9.52)">
-        <g transform="translate(10.366 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
+        <g transform="translate(10.366 10.37)" fill="var(--anatomy-gray-900)" stroke="var(--anatomy-gray-900)" stroke-width="1">
           <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
           <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
         </g>
-        <g transform="translate(18.446 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
+        <g transform="translate(18.446 10.37)" fill="var(--anatomy-gray-900)" stroke="var(--anatomy-gray-900)" stroke-width="1">
           <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
           <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
         </g>
-        <g transform="translate(2.285 10.37)" fill="#486ec2" stroke="#486ec2" stroke-width="1">
+        <g transform="translate(2.285 10.37)" fill="var(--anatomy-gray-900)" stroke="var(--anatomy-gray-900)" stroke-width="1">
           <circle cx="2.348" cy="2.348" r="2.348" stroke="none" />
           <circle cx="2.348" cy="2.348" r="1.848" fill="none" />
         </g>
-      </g><text transform="translate(44 26.199)" fill="#486ec2" font-size="18" font-family="Adobe-Clean">
+      </g><text transform="translate(44 26.199)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">More Actions</tspan>
       </text>
     </g>
     <g transform="translate(715 765)">
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-33.755" y="0">Menu Trigger</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/menu/docs/useMenu.mdx
+++ b/packages/@react-aria/menu/docs/useMenu.mdx
@@ -16,6 +16,7 @@ import selectionDocs from 'docs:@react-stately/selection';
 import treeDocs from 'docs:@react-stately/tree';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/menu/package.json';
+import Anatomy from './menu-anatomy.svg';
 
 ```jsx import
 import {useMenu, useMenuSection, useMenuItem} from '@react-aria/menu';
@@ -63,6 +64,8 @@ Note: `useMenu` only handles the menu itself. For a dropdown menu, combine with 
 * Virtualized scrolling support for performance with long lists
 
 ## Anatomy
+
+<Anatomy />
 
 A menu consists of a container element, with a list of menu items or groups inside.
 `useMenu`, `useMenuItem`, and `useMenuSection` handle exposing this to assistive

--- a/packages/@react-aria/menu/docs/useMenuTrigger.mdx
+++ b/packages/@react-aria/menu/docs/useMenuTrigger.mdx
@@ -18,6 +18,7 @@ import buttonDocs from 'docs:@react-aria/button';
 import statelyDocs from 'docs:@react-stately/menu';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/menu/package.json';
+import Anatomy from './menu-trigger-anatomy.svg';
 
 ```jsx import
 import {useMenuTrigger} from '@react-aria/menu';
@@ -54,6 +55,8 @@ combined with [useMenu](useMenu.html) helps achieve accessible menu components t
   the first or last item accordingly
 
 ## Anatomy
+
+<Anatomy />
 
 A menu trigger consists of a button or other trigger element combined with a popup menu.
 It should be combined with [useButton](useButton.html) and [useMenu](useMenu.html), which handle

--- a/packages/@react-aria/meter/docs/anatomy.svg
+++ b/packages/@react-aria/meter/docs/anatomy.svg
@@ -1,0 +1,48 @@
+<svg style="max-height: 119px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 242 119">
+  <title>Meter anatomy diagram</title>
+  <desc>Shows a meter with labels pointing to its parts, including the label, fill, track, and value label elements.</desc>
+  <defs>
+    <clipPath id="a">
+      <rect width="192" height="9" fill="red" />
+    </clipPath>
+  </defs>
+  <g transform="translate(-51 -40)">
+    <g transform="translate(-133 401)">
+      <rect width="20" height="19" transform="translate(401 -343)" fill="red" opacity="0" /><text transform="translate(411 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-14.157" y="0">Value</tspan>
+      </text>
+      <path d="M-6211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.051a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6211-360.5Z" transform="translate(6619.5 36)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-336 401)">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.826" y="0">Label</tspan>
+      </text>
+      <path d="M-6008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6008-360.5Z" transform="translate(6407.5 36)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(12 24)">
+      <rect width="240" height="51" transform="translate(40 45)" fill="none" /><text transform="translate(40 69)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Tasks completed</tspan>
+      </text><text transform="translate(280 69)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+        <tspan x="-39.996" y="0">4 of 5</tspan>
+      </text>
+      <g transform="translate(8 -70)">
+        <rect width="240" height="9" rx="4.5" transform="translate(32 157)" fill="#dae2f4" />
+        <g transform="translate(32 157)" clip-path="url(#a)">
+          <rect width="240" height="9" rx="4.5" fill="#4a6fc3" />
+        </g>
+      </g>
+    </g>
+    <g transform="translate(-100 472.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.435" y="0">Track</tspan>
+      </text>
+      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-274 472.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-7.501" y="0">Fill</tspan>
+      </text>
+      <path d="M-6068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(6431.5 96)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/meter/docs/anatomy.svg
+++ b/packages/@react-aria/meter/docs/anatomy.svg
@@ -1,4 +1,4 @@
-<svg style="max-height: 119px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 242 119">
+<svg style="max-height: 119px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 242 119">
   <title>Meter anatomy diagram</title>
   <desc>Shows a meter with labels pointing to its parts, including the label, fill, track, and value label elements.</desc>
   <defs>
@@ -8,41 +8,41 @@
   </defs>
   <g transform="translate(-51 -40)">
     <g transform="translate(-133 401)">
-      <text transform="translate(411 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(411 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.157" y="0">Value</tspan>
       </text>
-      <path d="M-6211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.051a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6211-360.5Z" transform="translate(6619.5 36)" fill="#a2b6e1" />
+      <path d="M-6211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.051a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6211-360.5Z" transform="translate(6619.5 36)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-336 401)">
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
-      <path d="M-6008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6008-360.5Z" transform="translate(6407.5 36)" fill="#a2b6e1" />
+      <path d="M-6008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6008-360.5Z" transform="translate(6407.5 36)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(12 24)">
-      <rect width="240" height="51" transform="translate(40 45)" fill="none" /><text transform="translate(40 69)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <rect width="240" height="51" transform="translate(40 45)" fill="none" /><text transform="translate(40 69)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">Tasks completed</tspan>
-      </text><text transform="translate(280 69)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+      </text><text transform="translate(280 69)" fill="var(--anatomy-gray-700)" font-size="18" font-family="Adobe-Clean">
         <tspan x="-39.996" y="0">4 of 5</tspan>
       </text>
       <g transform="translate(8 -70)">
-        <rect width="240" height="9" rx="4.5" transform="translate(32 157)" fill="#dae2f4" />
+        <rect width="240" height="9" rx="4.5" transform="translate(32 157)" fill="var(--anatomy-gray-300)" />
         <g transform="translate(32 157)" clip-path="url(#a)">
-          <rect width="240" height="9" rx="4.5" fill="#4a6fc3" />
+          <rect width="240" height="9" rx="4.5" fill="var(--anatomy-gray-700)" />
         </g>
       </g>
     </g>
     <g transform="translate(-100 472.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.435" y="0">Track</tspan>
       </text>
-      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
+      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-274 472.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-7.501" y="0">Fill</tspan>
       </text>
-      <path d="M-6068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(6431.5 96)" fill="#a2b6e1" />
+      <path d="M-6068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(6431.5 96)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/meter/docs/anatomy.svg
+++ b/packages/@react-aria/meter/docs/anatomy.svg
@@ -8,13 +8,13 @@
   </defs>
   <g transform="translate(-51 -40)">
     <g transform="translate(-133 401)">
-      <rect width="20" height="19" transform="translate(401 -343)" fill="red" opacity="0" /><text transform="translate(411 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(411 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.157" y="0">Value</tspan>
       </text>
       <path d="M-6211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.051a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6211-360.5Z" transform="translate(6619.5 36)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-336 401)">
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
       <path d="M-6008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6008-360.5Z" transform="translate(6407.5 36)" fill="#a2b6e1" />
@@ -33,13 +33,13 @@
       </g>
     </g>
     <g transform="translate(-100 472.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.435" y="0">Track</tspan>
       </text>
       <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-274 472.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-7.501" y="0">Fill</tspan>
       </text>
       <path d="M-6068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(6431.5 96)" fill="#a2b6e1" />

--- a/packages/@react-aria/meter/docs/useMeter.mdx
+++ b/packages/@react-aria/meter/docs/useMeter.mdx
@@ -13,6 +13,7 @@ export default Layout;
 import docs from 'docs:@react-aria/meter';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType} from '@react-spectrum/docs';
 import packageData from '@react-aria/meter/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useMeter} from '@react-aria/meter';
@@ -54,8 +55,10 @@ See the [useProgressBar](useProgressBar.html) hook for more details about progre
 
 ## Anatomy
 
+<Anatomy />
+
 Meters consist of a track element showing the full value in a range,
-a bar element showing the current value, and a label. The track and bar elements
+a fill element showing the current value, a label, and an optional value label. The track and bar elements
 represent the value visually, while a wrapper element represents the meter to
 assistive technology using the [meter](https://www.w3.org/TR/wai-aria-1.2/#meter)
 ARIA role.

--- a/packages/@react-aria/progress/docs/anatomy.svg
+++ b/packages/@react-aria/progress/docs/anatomy.svg
@@ -1,4 +1,4 @@
-<svg style="max-height: 119px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 241 119">
+<svg style="max-height: 119px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 241 119">
   <title>Progress bar anatomy diagram</title>
   <desc>Shows a progress bar with labels pointing to its parts, including the label, fill, track, and value label elements.</desc>
   <defs>
@@ -7,41 +7,41 @@
     </clipPath>
   </defs>
   <g transform="translate(-52 -40)">
-    <g transform="translate(-133 401)"><text transform="translate(411 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    <g transform="translate(-133 401)"><text transform="translate(411 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-14.157" y="0">Value</tspan>
       </text>
-      <path d="M-5211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5211-360.5Z" transform="translate(5619.5 36)" fill="#a2b6e1" />
+      <path d="M-5211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5211-360.5Z" transform="translate(5619.5 36)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-336 401)">
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
-      <path d="M-5008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5008-360.5Z" transform="translate(5407.5 36)" fill="#a2b6e1" />
+      <path d="M-5008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5008-360.5Z" transform="translate(5407.5 36)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(12 24)">
-      <rect width="240" height="51" transform="translate(40 45)" fill="none" /><text transform="translate(40 69)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <rect width="240" height="51" transform="translate(40 45)" fill="none" /><text transform="translate(40 69)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">Loading data…</tspan>
-      </text><text transform="translate(280 69)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+      </text><text transform="translate(280 69)" fill="var(--anatomy-gray-700)" font-size="18" font-family="Adobe-Clean">
         <tspan x="-32.49" y="0">26%</tspan>
       </text>
       <g transform="translate(8 -70)">
-        <rect width="240" height="9" rx="4.5" transform="translate(32 157)" fill="#dae2f4" />
+        <rect width="240" height="9" rx="4.5" transform="translate(32 157)" fill="var(--anatomy-gray-300)" />
         <g transform="translate(32 157)" clip-path="url(#a)">
-          <rect width="240" height="9" rx="4.5" fill="#718dcf" />
+          <rect width="240" height="9" rx="4.5" fill="var(--anatomy-gray-600)" />
         </g>
       </g>
     </g>
     <g transform="translate(-143 472.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.435" y="0">Track</tspan>
       </text>
-      <path d="M-5199-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(5562.5 96)" fill="#a2b6e1" />
+      <path d="M-5199-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(5562.5 96)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-274 472.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-7.501" y="0">Fill</tspan>
       </text>
-      <path d="M-5068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(5431.5 96)" fill="#a2b6e1" />
+      <path d="M-5068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(5431.5 96)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/progress/docs/anatomy.svg
+++ b/packages/@react-aria/progress/docs/anatomy.svg
@@ -13,7 +13,7 @@
       <path d="M-5211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5211-360.5Z" transform="translate(5619.5 36)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-336 401)">
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
       <path d="M-5008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5008-360.5Z" transform="translate(5407.5 36)" fill="#a2b6e1" />
@@ -32,13 +32,13 @@
       </g>
     </g>
     <g transform="translate(-143 472.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.435" y="0">Track</tspan>
       </text>
       <path d="M-5199-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(5562.5 96)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-274 472.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-7.501" y="0">Fill</tspan>
       </text>
       <path d="M-5068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(5431.5 96)" fill="#a2b6e1" />

--- a/packages/@react-aria/progress/docs/anatomy.svg
+++ b/packages/@react-aria/progress/docs/anatomy.svg
@@ -1,0 +1,47 @@
+<svg style="max-height: 119px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 241 119">
+  <title>Progress bar anatomy diagram</title>
+  <desc>Shows a progress bar with labels pointing to its parts, including the label, fill, track, and value label elements.</desc>
+  <defs>
+    <clipPath id="a">
+      <rect width="63" height="9" fill="red" />
+    </clipPath>
+  </defs>
+  <g transform="translate(-52 -40)">
+    <g transform="translate(-133 401)"><text transform="translate(411 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-14.157" y="0">Value</tspan>
+      </text>
+      <path d="M-5211-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5211-360.5Z" transform="translate(5619.5 36)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-336 401)">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.826" y="0">Label</tspan>
+      </text>
+      <path d="M-5008-360.5a2.5,2.5,0,0,1,2-2.45V-379h1v16.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-5008-360.5Z" transform="translate(5407.5 36)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(12 24)">
+      <rect width="240" height="51" transform="translate(40 45)" fill="none" /><text transform="translate(40 69)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Loading data…</tspan>
+      </text><text transform="translate(280 69)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+        <tspan x="-32.49" y="0">26%</tspan>
+      </text>
+      <g transform="translate(8 -70)">
+        <rect width="240" height="9" rx="4.5" transform="translate(32 157)" fill="#dae2f4" />
+        <g transform="translate(32 157)" clip-path="url(#a)">
+          <rect width="240" height="9" rx="4.5" fill="#718dcf" />
+        </g>
+      </g>
+    </g>
+    <g transform="translate(-143 472.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.435" y="0">Track</tspan>
+      </text>
+      <path d="M-5199-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(5562.5 96)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-274 472.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-7.501" y="0">Fill</tspan>
+      </text>
+      <path d="M-5068-425.5v-20.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v20.05Z" transform="translate(5431.5 96)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/progress/docs/useProgressBar.mdx
+++ b/packages/@react-aria/progress/docs/useProgressBar.mdx
@@ -13,6 +13,7 @@ export default Layout;
 import docs from 'docs:@react-aria/progress';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType} from '@react-spectrum/docs';
 import packageData from '@react-aria/progress/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useProgressBar} from '@react-aria/progress';
@@ -52,8 +53,10 @@ progress bars and spinners that can be styled as needed.
 
 ## Anatomy
 
+<Anatomy />
+
 Progress bars consist of a track element showing the full progress of an operation,
-a bar element showing the current progress, and a label. The track and bar elements
+a fill element showing the current progress, a label, and an optional value label. The track and bar elements
 represent the progress visually, while a wrapper element represents the progress to
 assistive technology using the [progressbar](https://www.w3.org/TR/wai-aria-1.2/#progressbar)
 ARIA role.

--- a/packages/@react-aria/radio/docs/anatomy.svg
+++ b/packages/@react-aria/radio/docs/anatomy.svg
@@ -1,0 +1,61 @@
+<svg style="max-height: 246px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 295.139 246">
+  <title>Radio group anatomy diagram</title>
+  <desc>Shows a radio group component with labels pointing to its parts, including the radio group label, and radio group element containing three radios with input and label elements.</desc>
+  <g transform="translate(-138 -76)">
+    <g transform="translate(192 153)">
+      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Cat</tspan>
+      </text>
+      <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="7.5">
+        <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
+        <circle cx="10.5" cy="10.5" r="6.75" fill="none" />
+      </g>
+    </g>
+    <g transform="translate(192 201)">
+      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Dog</tspan>
+      </text>
+      <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
+        <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
+        <circle cx="10.5" cy="10.5" r="9" fill="none" />
+      </g>
+    </g>
+    <g transform="translate(9 145)">
+      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-26.299" y="0">Input</tspan>
+      </text>
+      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
+    </g><text transform="translate(195 135)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Favorite Pet</tspan>
+    </text>
+    <g transform="translate(-200 439)">
+      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-45.006" y="0">Radio group label</tspan>
+      </text>
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(192 249)">
+      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Dragon</tspan>
+      </text>
+      <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
+        <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
+        <circle cx="10.5" cy="10.5" r="9" fill="none" />
+      </g>
+    </g><text transform="translate(361.139 230.413)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <tspan x="0" y="0">Radio group</tspan>
+    </text>
+    <rect width="8" height="1" transform="translate(344.14 226.419)" fill="#a2b6e1" />
+    <g transform="translate(335.14 156)">
+      <rect width="8" height="1" fill="#a2b6e1" />
+      <rect width="1" height="141" transform="translate(8)" fill="#a2b6e1" />
+      <rect width="8" height="1" transform="translate(0 140)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-123 635.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-28.49" y="0">Radio label</tspan>
+      </text>
+      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/radio/docs/anatomy.svg
+++ b/packages/@react-aria/radio/docs/anatomy.svg
@@ -1,61 +1,61 @@
-<svg style="max-height: 246px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 295.139 246">
+<svg style="max-height: 246px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 295.139 246">
   <title>Radio group anatomy diagram</title>
   <desc>Shows a radio group component with labels pointing to its parts, including the radio group label, and radio group element containing three radios with input and label elements.</desc>
   <g transform="translate(-138 -76)">
     <g transform="translate(192 153)">
-      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Cat</tspan>
       </text>
-      <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="7.5">
+      <g transform="translate(0 13.5)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-600)" stroke-width="7.5">
         <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
         <circle cx="10.5" cy="10.5" r="6.75" fill="none" />
       </g>
     </g>
     <g transform="translate(192 201)">
-      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Dog</tspan>
       </text>
-      <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
+      <g transform="translate(0 13.5)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-600)" stroke-width="3">
         <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
         <circle cx="10.5" cy="10.5" r="9" fill="none" />
       </g>
     </g>
     <g transform="translate(9 145)">
-      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
-      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
-    </g><text transform="translate(195 135)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(195 135)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
       <tspan x="0" y="0">Favorite Pet</tspan>
     </text>
     <g transform="translate(-200 439)">
-      <text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -350)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-45.006" y="0">Radio group label</tspan>
       </text>
-      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(192 249)">
-      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Dragon</tspan>
       </text>
-      <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
+      <g transform="translate(0 13.5)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-600)" stroke-width="3">
         <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
         <circle cx="10.5" cy="10.5" r="9" fill="none" />
       </g>
-    </g><text transform="translate(361.139 230.413)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+    </g><text transform="translate(361.139 230.413)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
       <tspan x="0" y="0">Radio group</tspan>
     </text>
-    <rect width="8" height="1" transform="translate(344.14 226.419)" fill="#a2b6e1" />
+    <rect width="8" height="1" transform="translate(344.14 226.419)" fill="var(--anatomy-gray-500)" />
     <g transform="translate(335.14 156)">
-      <rect width="8" height="1" fill="#a2b6e1" />
-      <rect width="1" height="141" transform="translate(8)" fill="#a2b6e1" />
-      <rect width="8" height="1" transform="translate(0 140)" fill="#a2b6e1" />
+      <rect width="8" height="1" fill="var(--anatomy-gray-500)" />
+      <rect width="1" height="141" transform="translate(8)" fill="var(--anatomy-gray-500)" />
+      <rect width="8" height="1" transform="translate(0 140)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-123 635.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-28.49" y="0">Radio label</tspan>
       </text>
-      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />
+      <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/radio/docs/anatomy.svg
+++ b/packages/@react-aria/radio/docs/anatomy.svg
@@ -3,7 +3,7 @@
   <desc>Shows a radio group component with labels pointing to its parts, including the radio group label, and radio group element containing three radios with input and label elements.</desc>
   <g transform="translate(-138 -76)">
     <g transform="translate(192 153)">
-      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Cat</tspan>
       </text>
       <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="7.5">
@@ -12,7 +12,7 @@
       </g>
     </g>
     <g transform="translate(192 201)">
-      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Dog</tspan>
       </text>
       <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
@@ -21,7 +21,7 @@
       </g>
     </g>
     <g transform="translate(9 145)">
-      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
       <path d="M-2458.95-69H-2479v-1h20.05a2.5,2.5,0,0,1,2.45-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-2458.95-69Z" transform="translate(2639 101.5)" fill="#a2b6e1" />
@@ -29,13 +29,13 @@
       <tspan x="0" y="0">Favorite Pet</tspan>
     </text>
     <g transform="translate(-200 439)">
-      <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -350)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-45.006" y="0">Radio group label</tspan>
       </text>
       <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
     </g>
     <g transform="translate(192 249)">
-      <rect width="95" height="48" fill="red" opacity="0" /><text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <text transform="translate(36 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Dragon</tspan>
       </text>
       <g transform="translate(0 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
@@ -52,7 +52,7 @@
       <rect width="8" height="1" transform="translate(0 140)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-123 635.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-28.49" y="0">Radio label</tspan>
       </text>
       <path d="M-6242-425.5v-20.05a2.5,2.5,0,0,1-2-2.451,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.451v20.05Z" transform="translate(6605.5 96)" fill="#a2b6e1" />

--- a/packages/@react-aria/radio/docs/useRadioGroup.mdx
+++ b/packages/@react-aria/radio/docs/useRadioGroup.mdx
@@ -16,6 +16,7 @@ import focusDocs from 'docs:@react-aria/focus';
 import statelyDocs from 'docs:@react-stately/radio';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/radio/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useRadioGroup, useRadio} from '@react-aria/radio';
@@ -58,6 +59,8 @@ radio groups that can be styled as needed.
 * Group and radio labeling support for assistive technology
 
 ## Anatomy
+
+<Anatomy />
 
 A radio group consists of a set of radio buttons, and a label. Each radio
 includes a label and a visual selection indicator. A single radio button

--- a/packages/@react-aria/searchfield/docs/anatomy.svg
+++ b/packages/@react-aria/searchfield/docs/anatomy.svg
@@ -4,7 +4,6 @@
   <g transform="translate(-341 -234)">
     <g transform="translate(0 195)">
       <g transform="translate(309 38)">
-        <rect width="264" height="84" transform="translate(40 30)" fill="red" opacity="0" />
         <g transform="translate(40 66)" fill="#fff" stroke="#beccea" stroke-width="1.5">
           <rect width="264" height="48" rx="6" stroke="none" />
           <rect x="0.75" y="0.75" width="262.5" height="46.5" rx="5.25" fill="none" />
@@ -15,21 +14,21 @@
         </text>
       </g>
       <g transform="translate(111 433)">
-        <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-13.149" y="0">Input</tspan>
         </text>
         <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
         <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
       </g>
       <g transform="translate(-41 400)">
-        <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-27.651" y="0">Label</tspan>
         </text>
         <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="#a2b6e1" />
         <rect width="1" height="17" transform="translate(401.5 -343)" fill="#a2b6e1" />
       </g>
       <g transform="translate(193 433)">
-        <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-31.174" y="0">Clear button</tspan>
         </text>
         <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
@@ -37,11 +36,9 @@
       </g>
     </g>
     <g transform="translate(360 310)">
-      <rect width="25" height="25" fill="#ff13dc" opacity="0" />
       <path d="M22.489,20.446l-5.365-5.364a8.853,8.853,0,1,0-2.041,2.041l5.365,5.365a1.45,1.45,0,0,0,2.042-2.042ZM3.733,9.945a6.212,6.212,0,1,1,6.212,6.212A6.212,6.212,0,0,1,3.733,9.945Z" transform="translate(0.409 0.409)" fill="#4a6fc3" />
     </g>
     <g transform="translate(588 316)">
-      <rect width="14" height="14" fill="red" opacity="0" />
       <line x1="9.786" y2="9.786" transform="translate(2.266 2.266)" stroke="#496ec2" stroke-linecap="round" stroke-width="1.68" />
       <line x1="9.79" y1="9.786" transform="translate(2.266 2.266)" stroke="#496ec2" stroke-linecap="round" stroke-width="1.68" />
     </g>

--- a/packages/@react-aria/searchfield/docs/anatomy.svg
+++ b/packages/@react-aria/searchfield/docs/anatomy.svg
@@ -1,46 +1,46 @@
-<svg style="max-height: 113px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 286 113">
+<svg style="max-height: 113px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 286 113">
   <title>Search field anatomy diagram</title>
   <desc>Shows a search field component with labels pointing to its parts, including the label, input, and clear button elements.</desc>
   <g transform="translate(-341 -234)">
     <g transform="translate(0 195)">
       <g transform="translate(309 38)">
-        <g transform="translate(40 66)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+        <g transform="translate(40 66)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
           <rect width="264" height="48" rx="6" stroke="none" />
           <rect x="0.75" y="0.75" width="262.5" height="46.5" rx="5.25" fill="none" />
-        </g><text transform="translate(85 97)" fill="#496ec2" font-size="21" font-family="Adobe-Clean">
+        </g><text transform="translate(85 97)" fill="var(--anatomy-gray-800)" font-size="21" font-family="Adobe-Clean">
           <tspan x="0" y="0">Value</tspan>
-        </text><text transform="translate(40 54)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+        </text><text transform="translate(40 54)" fill="var(--anatomy-gray-700)" font-size="18" font-family="Adobe-Clean">
           <tspan x="0" y="0">Label</tspan>
         </text>
       </g>
       <g transform="translate(111 433)">
-        <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-13.149" y="0">Input</tspan>
         </text>
-        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
-        <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="var(--anatomy-gray-500)" />
+        <rect width="1" height="27" transform="translate(401.5 -343)" fill="var(--anatomy-gray-500)" />
       </g>
       <g transform="translate(-41 400)">
-        <text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(410 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-27.651" y="0">Label</tspan>
         </text>
-        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="#a2b6e1" />
-        <rect width="1" height="17" transform="translate(401.5 -343)" fill="#a2b6e1" />
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="var(--anatomy-gray-500)" />
+        <rect width="1" height="17" transform="translate(401.5 -343)" fill="var(--anatomy-gray-500)" />
       </g>
       <g transform="translate(193 433)">
-        <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-31.174" y="0">Clear button</tspan>
         </text>
-        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
-        <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="var(--anatomy-gray-500)" />
+        <rect width="1" height="27" transform="translate(401.5 -343)" fill="var(--anatomy-gray-500)" />
       </g>
     </g>
     <g transform="translate(360 310)">
-      <path d="M22.489,20.446l-5.365-5.364a8.853,8.853,0,1,0-2.041,2.041l5.365,5.365a1.45,1.45,0,0,0,2.042-2.042ZM3.733,9.945a6.212,6.212,0,1,1,6.212,6.212A6.212,6.212,0,0,1,3.733,9.945Z" transform="translate(0.409 0.409)" fill="#4a6fc3" />
+      <path d="M22.489,20.446l-5.365-5.364a8.853,8.853,0,1,0-2.041,2.041l5.365,5.365a1.45,1.45,0,0,0,2.042-2.042ZM3.733,9.945a6.212,6.212,0,1,1,6.212,6.212A6.212,6.212,0,0,1,3.733,9.945Z" transform="translate(0.409 0.409)" fill="var(--anatomy-gray-700)" />
     </g>
     <g transform="translate(588 316)">
-      <line x1="9.786" y2="9.786" transform="translate(2.266 2.266)" stroke="#496ec2" stroke-linecap="round" stroke-width="1.68" />
-      <line x1="9.79" y1="9.786" transform="translate(2.266 2.266)" stroke="#496ec2" stroke-linecap="round" stroke-width="1.68" />
+      <line x1="9.786" y2="9.786" transform="translate(2.266 2.266)" stroke="var(--anatomy-gray-800)" stroke-linecap="round" stroke-width="1.68" />
+      <line x1="9.79" y1="9.786" transform="translate(2.266 2.266)" stroke="var(--anatomy-gray-800)" stroke-linecap="round" stroke-width="1.68" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/searchfield/docs/anatomy.svg
+++ b/packages/@react-aria/searchfield/docs/anatomy.svg
@@ -1,0 +1,49 @@
+<svg style="max-height: 113px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 286 113">
+  <title>Search field anatomy diagram</title>
+  <desc>Shows a search field component with labels pointing to its parts, including the label, input, and clear button elements.</desc>
+  <g transform="translate(-341 -234)">
+    <g transform="translate(0 195)">
+      <g transform="translate(309 38)">
+        <rect width="264" height="84" transform="translate(40 30)" fill="red" opacity="0" />
+        <g transform="translate(40 66)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+          <rect width="264" height="48" rx="6" stroke="none" />
+          <rect x="0.75" y="0.75" width="262.5" height="46.5" rx="5.25" fill="none" />
+        </g><text transform="translate(85 97)" fill="#496ec2" font-size="21" font-family="Adobe-Clean">
+          <tspan x="0" y="0">Value</tspan>
+        </text><text transform="translate(40 54)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+          <tspan x="0" y="0">Label</tspan>
+        </text>
+      </g>
+      <g transform="translate(111 433)">
+        <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-13.149" y="0">Input</tspan>
+        </text>
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
+        <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
+      </g>
+      <g transform="translate(-41 400)">
+        <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-27.651" y="0">Label</tspan>
+        </text>
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="#a2b6e1" />
+        <rect width="1" height="17" transform="translate(401.5 -343)" fill="#a2b6e1" />
+      </g>
+      <g transform="translate(193 433)">
+        <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-31.174" y="0">Clear button</tspan>
+        </text>
+        <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
+        <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
+      </g>
+    </g>
+    <g transform="translate(360 310)">
+      <rect width="25" height="25" fill="#ff13dc" opacity="0" />
+      <path d="M22.489,20.446l-5.365-5.364a8.853,8.853,0,1,0-2.041,2.041l5.365,5.365a1.45,1.45,0,0,0,2.042-2.042ZM3.733,9.945a6.212,6.212,0,1,1,6.212,6.212A6.212,6.212,0,0,1,3.733,9.945Z" transform="translate(0.409 0.409)" fill="#4a6fc3" />
+    </g>
+    <g transform="translate(588 316)">
+      <rect width="14" height="14" fill="red" opacity="0" />
+      <line x1="9.786" y2="9.786" transform="translate(2.266 2.266)" stroke="#496ec2" stroke-linecap="round" stroke-width="1.68" />
+      <line x1="9.79" y1="9.786" transform="translate(2.266 2.266)" stroke="#496ec2" stroke-linecap="round" stroke-width="1.68" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/searchfield/docs/useSearchField.mdx
+++ b/packages/@react-aria/searchfield/docs/useSearchField.mdx
@@ -15,6 +15,7 @@ import statelyDocs from 'docs:@react-stately/searchfield';
 import buttonDocs from 'docs:@react-aria/button';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/searchfield/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useSearchField} from '@react-aria/searchfield';
@@ -54,10 +55,12 @@ search fields that can be styled as needed.
 
 ## Anatomy
 
+<Anatomy />
+
 Search fields consist of an input element, a label, and an optional clear button.
 `useSearchField` automatically manages the labeling and relationships between the elements,
-and handles keyboard events. Users can press the <kbd>Escape</kbd> key to clear the search field, or the
-<kbd>Enter</kbd> key to trigger the `onSubmit` event.
+and handles keyboard events. Users can press the <kbd>Escape</kbd> key to clear the search field, or
+the <kbd>Enter</kbd> key to trigger the `onSubmit` event.
 
 `useSearchField` returns two sets of props that you should spread onto the appropriate element:
 

--- a/packages/@react-aria/select/docs/anatomy.svg
+++ b/packages/@react-aria/select/docs/anatomy.svg
@@ -1,69 +1,69 @@
-<svg style="max-height: 319px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 484 319">
+<svg style="max-height: 319px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 484 319">
   <title>Select anatomy diagram</title>
   <desc>Shows two select elements, one open and one closed, with labels pointing to their parts including the label, trigger, value, and menu.</desc>
   <g transform="translate(-246 -33)">
     <g transform="translate(13 -7)">
-      <g transform="translate(246 109)" fill="#e5ebf7" stroke="#a2b6e1" stroke-width="1.5">
+      <g transform="translate(246 109)" fill="var(--anatomy-gray-200)" stroke="var(--anatomy-gray-500)" stroke-width="1.5">
         <rect width="214" height="48" rx="6" stroke="none" />
         <rect x="0.75" y="0.75" width="212.5" height="46.5" rx="5.25" fill="none" />
       </g>
-      <g transform="translate(503 109)" fill="#e5ebf7" stroke="#a2b6e1" stroke-width="1.5">
+      <g transform="translate(503 109)" fill="var(--anatomy-gray-200)" stroke="var(--anatomy-gray-500)" stroke-width="1.5">
         <rect width="214" height="48" rx="6" stroke="none" />
         <rect x="0.75" y="0.75" width="212.5" height="46.5" rx="5.25" fill="none" />
-      </g><text transform="translate(264 139)" fill="#718dcf" font-size="20" font-family="Adobe-Clean">
+      </g><text transform="translate(264 139)" fill="var(--anatomy-gray-600)" font-size="20" font-family="Adobe-Clean">
         <tspan x="0" y="0">Option 1</tspan>
-      </text><text transform="translate(521 139)" fill="#718dcf" font-size="20" font-family="Adobe-Clean">
+      </text><text transform="translate(521 139)" fill="var(--anatomy-gray-600)" font-size="20" font-family="Adobe-Clean">
         <tspan x="0" y="0">Option 1</tspan>
       </text>
       <g transform="translate(427 128.5)">
-        <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="#718dcf" />
+        <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="var(--anatomy-gray-600)" />
       </g>
       <g transform="translate(684 128.5)">
-        <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="#718dcf" />
-      </g><text transform="translate(246 97)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+        <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="var(--anatomy-gray-600)" />
+      </g><text transform="translate(246 97)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">Label</tspan>
-      </text><text transform="translate(503 97)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      </text><text transform="translate(503 97)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">Label</tspan>
       </text>
-      <g transform="translate(503 166)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+      <g transform="translate(503 166)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
         <rect width="214" height="156" rx="6" stroke="none" />
         <rect x="0.75" y="0.75" width="212.5" height="154.5" rx="5.25" fill="none" />
-      </g><text transform="translate(521 201)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      </g><text transform="translate(521 201)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
         <tspan x="0" y="0">Option 1</tspan>
-      </text><text transform="translate(521 249)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      </text><text transform="translate(521 249)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
         <tspan x="0" y="0">Option 2</tspan>
-      </text><text transform="translate(521 297)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+      </text><text transform="translate(521 297)" fill="var(--anatomy-gray-800)" font-size="20" font-family="Adobe-Clean">
         <tspan x="0" y="0">Option 3</tspan>
       </text>
-      <g transform="translate(-102 542)"><text transform="translate(402 -354)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <g transform="translate(-102 542)"><text transform="translate(402 -354)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-14.157" y="0">Value</tspan>
         </text>
-        <path d="M0,2.5A2.5,2.5,0,0,0,2,4.95V29H3V4.95A2.5,2.5,0,1,0,0,2.5Z" transform="translate(399.5 -398)" fill="#a2b6e1" />
+        <path d="M0,2.5A2.5,2.5,0,0,0,2,4.95V29H3V4.95A2.5,2.5,0,1,0,0,2.5Z" transform="translate(399.5 -398)" fill="var(--anatomy-gray-500)" />
       </g>
       <g transform="translate(-49 437)">
-        <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-17.641" y="0">Trigger</tspan>
         </text>
-        <path d="M-1270-401.5a2.5,2.5,0,0,1,2-2.45V-417h1v13.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1270-401.5Z" transform="translate(1669.5 74)" fill="#a2b6e1" />
+        <path d="M-1270-401.5a2.5,2.5,0,0,1,2-2.45V-417h1v13.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1270-401.5Z" transform="translate(1669.5 74)" fill="var(--anatomy-gray-500)" />
       </g>
       <g transform="translate(-149 401)">
-        <text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(410 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-27.651" y="0">Label</tspan>
         </text>
-        <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" /><text transform="translate(410 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-27.651" y="0">Label</tspan>
         </text>
-        <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+        <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="var(--anatomy-gray-500)" />
       </g>
       <g transform="translate(338 672.5)">
-        <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-14.612" y="0">Menu</tspan>
         </text>
-        <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(1607.5 282)" fill="#a2b6e1" />
+        <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(1607.5 282)" fill="var(--anatomy-gray-500)" />
       </g>
     </g>
     <g transform="translate(697 178.981)">
-      <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="#6a87cd" />
+      <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="var(--anatomy-gray-600)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/select/docs/anatomy.svg
+++ b/packages/@react-aria/select/docs/anatomy.svg
@@ -1,0 +1,72 @@
+<svg style="max-height: 319px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 484 319">
+  <title>Select anatomy diagram</title>
+  <desc>Shows two select elements, one open and one closed, with labels pointing to their parts including the label, trigger, value, and menu.</desc>
+  <g transform="translate(-246 -33)">
+    <g transform="translate(13 -7)">
+      <g transform="translate(246 109)" fill="#e5ebf7" stroke="#a2b6e1" stroke-width="1.5">
+        <rect width="214" height="48" rx="6" stroke="none" />
+        <rect x="0.75" y="0.75" width="212.5" height="46.5" rx="5.25" fill="none" />
+      </g>
+      <g transform="translate(503 109)" fill="#e5ebf7" stroke="#a2b6e1" stroke-width="1.5">
+        <rect width="214" height="48" rx="6" stroke="none" />
+        <rect x="0.75" y="0.75" width="212.5" height="46.5" rx="5.25" fill="none" />
+      </g><text transform="translate(264 139)" fill="#718dcf" font-size="20" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Option 1</tspan>
+      </text><text transform="translate(521 139)" fill="#718dcf" font-size="20" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Option 1</tspan>
+      </text>
+      <g transform="translate(427 128.5)">
+        <rect width="15" height="9" transform="translate(0.006 0)" fill="#f0f" opacity="0" />
+        <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="#718dcf" />
+      </g>
+      <g transform="translate(684 128.5)">
+        <rect width="15" height="9" transform="translate(0.006 0)" fill="#f0f" opacity="0" />
+        <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="#718dcf" />
+      </g><text transform="translate(246 97)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Label</tspan>
+      </text><text transform="translate(503 97)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Label</tspan>
+      </text>
+      <g transform="translate(503 166)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+        <rect width="214" height="156" rx="6" stroke="none" />
+        <rect x="0.75" y="0.75" width="212.5" height="154.5" rx="5.25" fill="none" />
+      </g><text transform="translate(521 201)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Option 1</tspan>
+      </text><text transform="translate(521 249)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Option 2</tspan>
+      </text><text transform="translate(521 297)" fill="#496ec2" font-size="20" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Option 3</tspan>
+      </text>
+      <g transform="translate(-102 542)"><text transform="translate(402 -354)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-14.157" y="0">Value</tspan>
+        </text>
+        <path d="M0,2.5A2.5,2.5,0,0,0,2,4.95V29H3V4.95A2.5,2.5,0,1,0,0,2.5Z" transform="translate(399.5 -398)" fill="#a2b6e1" />
+      </g>
+      <g transform="translate(-49 437)">
+        <rect width="20" height="16" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-17.641" y="0">Trigger</tspan>
+        </text>
+        <path d="M-1270-401.5a2.5,2.5,0,0,1,2-2.45V-417h1v13.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1270-401.5Z" transform="translate(1669.5 74)" fill="#a2b6e1" />
+      </g>
+      <g transform="translate(-149 401)">
+        <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-27.651" y="0">Label</tspan>
+        </text>
+        <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-27.651" y="0">Label</tspan>
+        </text>
+        <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
+      </g>
+      <g transform="translate(338 672.5)">
+        <rect width="20" height="31" transform="translate(354 -360.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-14.612" y="0">Menu</tspan>
+        </text>
+        <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(1607.5 282)" fill="#a2b6e1" />
+      </g>
+    </g>
+    <g transform="translate(697 178.981)">
+      <rect width="18" height="18" transform="translate(0 0.019)" fill="#f0f" opacity="0" />
+      <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="#6a87cd" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/select/docs/anatomy.svg
+++ b/packages/@react-aria/select/docs/anatomy.svg
@@ -16,11 +16,9 @@
         <tspan x="0" y="0">Option 1</tspan>
       </text>
       <g transform="translate(427 128.5)">
-        <rect width="15" height="9" transform="translate(0.006 0)" fill="#f0f" opacity="0" />
         <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="#718dcf" />
       </g>
       <g transform="translate(684 128.5)">
-        <rect width="15" height="9" transform="translate(0.006 0)" fill="#f0f" opacity="0" />
         <path d="M15,1.5A1.5,1.5,0,0,0,12.437.437L7.5,5.382,2.567.437A1.505,1.505,0,1,0,.437,2.565l6,5.993a1.5,1.5,0,0,0,2.115,0l6-5.993A1.5,1.5,0,0,0,15,1.5Z" transform="translate(0.004 0.006)" fill="#718dcf" />
       </g><text transform="translate(246 97)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">Label</tspan>
@@ -43,13 +41,13 @@
         <path d="M0,2.5A2.5,2.5,0,0,0,2,4.95V29H3V4.95A2.5,2.5,0,1,0,0,2.5Z" transform="translate(399.5 -398)" fill="#a2b6e1" />
       </g>
       <g transform="translate(-49 437)">
-        <rect width="20" height="16" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-17.641" y="0">Trigger</tspan>
         </text>
         <path d="M-1270-401.5a2.5,2.5,0,0,1,2-2.45V-417h1v13.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1270-401.5Z" transform="translate(1669.5 74)" fill="#a2b6e1" />
       </g>
       <g transform="translate(-149 401)">
-        <rect width="20" height="23" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-27.651" y="0">Label</tspan>
         </text>
         <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
@@ -58,14 +56,13 @@
         <path d="M-1170-358.5a2.5,2.5,0,0,1,2-2.45V-381h1v20.05a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-1170-358.5Z" transform="translate(1569.5 38)" fill="#a2b6e1" />
       </g>
       <g transform="translate(338 672.5)">
-        <rect width="20" height="31" transform="translate(354 -360.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-14.612" y="0">Menu</tspan>
         </text>
         <path d="M-1244-611.5V-639.55a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-611.5Z" transform="translate(1607.5 282)" fill="#a2b6e1" />
       </g>
     </g>
     <g transform="translate(697 178.981)">
-      <rect width="18" height="18" transform="translate(0 0.019)" fill="#f0f" opacity="0" />
       <path d="M5.672,13.022A1.366,1.366,0,0,1,4.6,12.509l-3.321-4A1.336,1.336,0,0,1,3.388,6.858l2.284,2.66,6.29-8a1.335,1.335,0,1,1,2.1,1.642L6.709,12.508A1.3,1.3,0,0,1,5.672,13.022Z" transform="translate(0.335 -0.673)" fill="#6a87cd" />
     </g>
   </g>

--- a/packages/@react-aria/select/docs/useSelect.mdx
+++ b/packages/@react-aria/select/docs/useSelect.mdx
@@ -19,6 +19,7 @@ import focusDocs from 'docs:@react-aria/focus';
 import listboxDocs from 'docs:@react-aria/listbox';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/select/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useSelect} from '@react-aria/select';
@@ -66,6 +67,8 @@ select components that can be styled as needed without compromising on high qual
 * Mobile screen reader listbox dismissal support
 
 ## Anatomy
+
+<Anatomy />
 
 A select consists of a label, a button which displays a selected value, and a listbox, displayed in a
 popup. Users can click, touch, or use the keyboard on the button to open the listbox popup. `useSelect`

--- a/packages/@react-aria/slider/docs/anatomy.svg
+++ b/packages/@react-aria/slider/docs/anatomy.svg
@@ -1,53 +1,53 @@
-<svg style="max-height: 115px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 275 115">
+<svg style="max-height: 115px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 275 115">
   <title>Slider anatomy diagram</title>
   <desc>Shows a slider with labels pointing to its parts including the label, group, track, thumb, and output elements.</desc>
   <g transform="translate(-36 -40)">
     <g transform="translate(-130 401)">
-      <text transform="translate(423 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(423 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-17.544" y="0">Output</tspan>
       </text>
-      <path d="M-6714-361.5a2.5,2.5,0,0,1,2-2.45V-380h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6714-361.5Z" transform="translate(7134.5 37)" fill="#a2b6e1" />
+      <path d="M-6714-361.5a2.5,2.5,0,0,1,2-2.45V-380h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6714-361.5Z" transform="translate(7134.5 37)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-348 401)">
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
-      <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="#a2b6e1" />
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="var(--anatomy-gray-500)" />
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
-    </g><text transform="translate(40 93)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+    </g><text transform="translate(40 93)" fill="var(--anatomy-gray-600)" font-size="18" font-family="Adobe-Clean">
       <tspan x="0" y="0">Label</tspan>
-    </text><text transform="translate(304 93)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+    </text><text transform="translate(304 93)" fill="var(--anatomy-gray-700)" font-size="18" font-family="Adobe-Clean">
       <tspan x="-17.298" y="0">24</tspan>
     </text>
-    <path d="M0,0H88.5A1.5,1.5,0,0,1,90,1.5v0A1.5,1.5,0,0,1,88.5,3H0A0,0,0,0,1,0,3V0A0,0,0,0,1,0,0Z" transform="translate(214 113)" fill="#4a6fc3" />
-    <path d="M1.5,0H138a0,0,0,0,1,0,0V3a0,0,0,0,1,0,0H1.5A1.5,1.5,0,0,1,0,1.5v0A1.5,1.5,0,0,1,1.5,0Z" transform="translate(40 113)" fill="#4a6fc3" />
+    <path d="M0,0H88.5A1.5,1.5,0,0,1,90,1.5v0A1.5,1.5,0,0,1,88.5,3H0A0,0,0,0,1,0,3V0A0,0,0,0,1,0,0Z" transform="translate(214 113)" fill="var(--anatomy-gray-700)" />
+    <path d="M1.5,0H138a0,0,0,0,1,0,0V3a0,0,0,0,1,0,0H1.5A1.5,1.5,0,0,1,0,1.5v0A1.5,1.5,0,0,1,1.5,0Z" transform="translate(40 113)" fill="var(--anatomy-gray-700)" />
     <g transform="translate(184 102)" fill="none">
       <path d="M12,0A12,12,0,1,1,0,12,12,12,0,0,1,12,0Z" stroke="none" />
-      <path d="M 12 3 C 7.037380218505859 3 3 7.037380218505859 3 12 C 3 16.96261978149414 7.037380218505859 21 12 21 C 16.96261978149414 21 21 16.96261978149414 21 12 C 21 7.037380218505859 16.96261978149414 3 12 3 M 12 0 C 18.62742042541504 0 24 5.372579574584961 24 12 C 24 18.62742042541504 18.62742042541504 24 12 24 C 5.372579574584961 24 0 18.62742042541504 0 12 C 0 5.372579574584961 5.372579574584961 0 12 0 Z" stroke="none" fill="#4a6fc3" />
+      <path d="M 12 3 C 7.037380218505859 3 3 7.037380218505859 3 12 C 3 16.96261978149414 7.037380218505859 21 12 21 C 16.96261978149414 21 21 16.96261978149414 21 12 C 21 7.037380218505859 16.96261978149414 3 12 3 M 12 0 C 18.62742042541504 0 24 5.372579574584961 24 12 C 24 18.62742042541504 18.62742042541504 24 12 24 C 5.372579574584961 24 0 18.62742042541504 0 12 C 0 5.372579574584961 5.372579574584961 0 12 0 Z" stroke="none" fill="var(--anatomy-gray-700)" />
     </g>
     <g transform="translate(-284 468.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.435" y="0">Track</tspan>
       </text>
-      <path d="M-6750-422.5v-20.051a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-422.5Z" transform="translate(7113.5 93)" fill="#a2b6e1" />
+      <path d="M-6750-422.5v-20.051a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-422.5Z" transform="translate(7113.5 93)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-168 468.5)">
-      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-18.128" y="0">Thumb</tspan>
       </text>
-      <path d="M-6674-424.5v-18.049a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v18.05Z" transform="translate(7037.5 95)" fill="#a2b6e1" />
+      <path d="M-6674-424.5v-18.049a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v18.05Z" transform="translate(7037.5 95)" fill="var(--anatomy-gray-500)" />
     </g>
-    <g transform="translate(36 99)" fill="none" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="2">
+    <g transform="translate(36 99)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="2">
       <rect width="272" height="30" rx="4" stroke="none" />
       <rect x="0.5" y="0.5" width="271" height="29" rx="3.5" fill="none" />
     </g>
     <g transform="translate(-228 424)">
-      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-15.854" y="0">Group</tspan>
       </text>
-      <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="#a2b6e1" />
+      <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/slider/docs/anatomy.svg
+++ b/packages/@react-aria/slider/docs/anatomy.svg
@@ -3,17 +3,17 @@
   <desc>Shows a slider with labels pointing to its parts including the label, group, track, thumb, and output elements.</desc>
   <g transform="translate(-36 -40)">
     <g transform="translate(-130 401)">
-      <rect width="20" height="19" transform="translate(413 -343)" fill="red" opacity="0" /><text transform="translate(423 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(423 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-17.544" y="0">Output</tspan>
       </text>
       <path d="M-6714-361.5a2.5,2.5,0,0,1,2-2.45V-380h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6714-361.5Z" transform="translate(7134.5 37)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-348 401)">
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
       <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="#a2b6e1" />
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.826" y="0">Label</tspan>
       </text>
     </g><text transform="translate(40 93)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
@@ -28,13 +28,13 @@
       <path d="M 12 3 C 7.037380218505859 3 3 7.037380218505859 3 12 C 3 16.96261978149414 7.037380218505859 21 12 21 C 16.96261978149414 21 21 16.96261978149414 21 12 C 21 7.037380218505859 16.96261978149414 3 12 3 M 12 0 C 18.62742042541504 0 24 5.372579574584961 24 12 C 24 18.62742042541504 18.62742042541504 24 12 24 C 5.372579574584961 24 0 18.62742042541504 0 12 C 0 5.372579574584961 5.372579574584961 0 12 0 Z" stroke="none" fill="#4a6fc3" />
     </g>
     <g transform="translate(-284 468.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.435" y="0">Track</tspan>
       </text>
       <path d="M-6750-422.5v-20.051a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-422.5Z" transform="translate(7113.5 93)" fill="#a2b6e1" />
     </g>
     <g transform="translate(-168 468.5)">
-      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-18.128" y="0">Thumb</tspan>
       </text>
       <path d="M-6674-424.5v-18.049a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v18.05Z" transform="translate(7037.5 95)" fill="#a2b6e1" />
@@ -44,7 +44,7 @@
       <rect x="0.5" y="0.5" width="271" height="29" rx="3.5" fill="none" />
     </g>
     <g transform="translate(-228 424)">
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-15.854" y="0">Group</tspan>
       </text>
       <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="#a2b6e1" />

--- a/packages/@react-aria/slider/docs/anatomy.svg
+++ b/packages/@react-aria/slider/docs/anatomy.svg
@@ -1,0 +1,53 @@
+<svg style="max-height: 115px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 275 115">
+  <title>Slider anatomy diagram</title>
+  <desc>Shows a slider with labels pointing to its parts including the label, group, track, thumb, and output elements.</desc>
+  <g transform="translate(-36 -40)">
+    <g transform="translate(-130 401)">
+      <rect width="20" height="19" transform="translate(413 -343)" fill="red" opacity="0" /><text transform="translate(423 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-17.544" y="0">Output</tspan>
+      </text>
+      <path d="M-6714-361.5a2.5,2.5,0,0,1,2-2.45V-380h1v16.049a2.5,2.5,0,0,1,2,2.45,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6714-361.5Z" transform="translate(7134.5 37)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-348 401)">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.826" y="0">Label</tspan>
+      </text>
+      <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="#a2b6e1" />
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.826" y="0">Label</tspan>
+      </text>
+    </g><text transform="translate(40 93)" fill="#718dcf" font-size="18" font-family="Adobe-Clean">
+      <tspan x="0" y="0">Label</tspan>
+    </text><text transform="translate(304 93)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+      <tspan x="-17.298" y="0">24</tspan>
+    </text>
+    <path d="M0,0H88.5A1.5,1.5,0,0,1,90,1.5v0A1.5,1.5,0,0,1,88.5,3H0A0,0,0,0,1,0,3V0A0,0,0,0,1,0,0Z" transform="translate(214 113)" fill="#4a6fc3" />
+    <path d="M1.5,0H138a0,0,0,0,1,0,0V3a0,0,0,0,1,0,0H1.5A1.5,1.5,0,0,1,0,1.5v0A1.5,1.5,0,0,1,1.5,0Z" transform="translate(40 113)" fill="#4a6fc3" />
+    <g transform="translate(184 102)" fill="none">
+      <path d="M12,0A12,12,0,1,1,0,12,12,12,0,0,1,12,0Z" stroke="none" />
+      <path d="M 12 3 C 7.037380218505859 3 3 7.037380218505859 3 12 C 3 16.96261978149414 7.037380218505859 21 12 21 C 16.96261978149414 21 21 16.96261978149414 21 12 C 21 7.037380218505859 16.96261978149414 3 12 3 M 12 0 C 18.62742042541504 0 24 5.372579574584961 24 12 C 24 18.62742042541504 18.62742042541504 24 12 24 C 5.372579574584961 24 0 18.62742042541504 0 12 C 0 5.372579574584961 5.372579574584961 0 12 0 Z" stroke="none" fill="#4a6fc3" />
+    </g>
+    <g transform="translate(-284 468.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.435" y="0">Track</tspan>
+      </text>
+      <path d="M-6750-422.5v-20.051a2.5,2.5,0,0,1-2-2.449,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.449V-422.5Z" transform="translate(7113.5 93)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-168 468.5)">
+      <rect width="20" height="23" transform="translate(354 -352.5)" fill="red" opacity="0" /><text transform="translate(364 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-18.128" y="0">Thumb</tspan>
+      </text>
+      <path d="M-6674-424.5v-18.049a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v18.05Z" transform="translate(7037.5 95)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(36 99)" fill="none" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="2">
+      <rect width="272" height="30" rx="4" stroke="none" />
+      <rect x="0.5" y="0.5" width="271" height="29" rx="3.5" fill="none" />
+    </g>
+    <g transform="translate(-228 424)">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-15.854" y="0">Group</tspan>
+      </text>
+      <path d="M-6496-361.5a2.5,2.5,0,0,1,2-2.449V-380h1v16.051a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-6496-361.5Z" transform="translate(6895.5 37)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/slider/docs/useSlider.mdx
+++ b/packages/@react-aria/slider/docs/useSlider.mdx
@@ -15,6 +15,7 @@ import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@re
 import packageData from '@react-aria/slider/package.json';
 import statelyDocs from 'docs:@react-stately/slider';
 import i18nDocs from 'docs:@react-aria/i18n';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useSlider, useSliderThumb} from '@react-aria/slider';
@@ -66,6 +67,8 @@ sliders that can be styled as needed.
 * Support for mirroring in RTL locales
 
 ## Anatomy
+
+<Anatomy />
 
 Sliders consist of a track element showing the range of available values,
 one or more thumbs showing the current values, an

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -12,10 +12,10 @@ interface SliderThumbAria {
   /** Props for the root thumb element; handles the dragging motion. */
   thumbProps: HTMLAttributes<HTMLElement>,
 
-  /** Props for the range input. */
+  /** Props for the visually hidden range input element. */
   inputProps: InputHTMLAttributes<HTMLInputElement>,
 
-  /** Props for the label element for this thumb. */
+  /** Props for the label element for this thumb (optional). */
   labelProps: LabelHTMLAttributes<HTMLLabelElement>
 }
 

--- a/packages/@react-aria/switch/docs/anatomy.svg
+++ b/packages/@react-aria/switch/docs/anatomy.svg
@@ -1,0 +1,28 @@
+<svg style="max-height: 48px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 334 48">
+  <title>Switch anatomy diagram</title>
+  <desc>Shows a switch component with labels pointing to its parts, including the input, and label elements.</desc>
+  <g transform="translate(-99 -107.5)">
+    <g transform="translate(153 107.5)">
+      <path d="M0,0H113V48H0Z" fill="red" opacity="0" />
+      <rect width="39" height="21" rx="10.5" transform="translate(0 13.5)" fill="#718dcf" /><text transform="translate(54 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Low power mode</tspan>
+      </text>
+      <g transform="translate(18 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
+        <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
+        <circle cx="10.5" cy="10.5" r="9" fill="none" />
+      </g>
+    </g>
+    <g transform="translate(-30 99.5)">
+      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-26.299" y="0">Input</tspan>
+      </text>
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="#a2b6e1" />
+      <rect width="21" height="1" transform="translate(160 31.5)" fill="#a2b6e1" />
+      <g transform="translate(66 354)"><text transform="translate(383 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+          <tspan x="-13.826" y="0">Label</tspan>
+        </text>
+        <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="#a2b6e1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/switch/docs/anatomy.svg
+++ b/packages/@react-aria/switch/docs/anatomy.svg
@@ -1,27 +1,27 @@
-<svg style="max-height: 48px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 334 48">
+<svg style="max-height: 48px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 334 48">
   <title>Switch anatomy diagram</title>
   <desc>Shows a switch component with labels pointing to its parts, including the input, and label elements.</desc>
   <g transform="translate(-99 -107.5)">
     <g transform="translate(153 107.5)">
       <path d="M0,0H113V48H0Z" fill="red" opacity="0" />
-      <rect width="39" height="21" rx="10.5" transform="translate(0 13.5)" fill="#718dcf" /><text transform="translate(54 30)" fill="#4a6fc3" font-size="21" font-family="Adobe-Clean">
+      <rect width="39" height="21" rx="10.5" transform="translate(0 13.5)" fill="var(--anatomy-gray-600)" /><text transform="translate(54 30)" fill="var(--anatomy-gray-700)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Low power mode</tspan>
       </text>
-      <g transform="translate(18 13.5)" fill="#fff" stroke="#718dcf" stroke-width="3">
+      <g transform="translate(18 13.5)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-600)" stroke-width="3">
         <circle cx="10.5" cy="10.5" r="10.5" stroke="none" />
         <circle cx="10.5" cy="10.5" r="9" fill="none" />
       </g>
     </g>
     <g transform="translate(-30 99.5)">
-      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <rect width="23" height="20" transform="translate(160 22)" fill="red" opacity="0" /><text transform="translate(156 35)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-26.299" y="0">Input</tspan>
       </text>
-      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="#a2b6e1" />
-      <rect width="21" height="1" transform="translate(160 31.5)" fill="#a2b6e1" />
-      <g transform="translate(66 354)"><text transform="translate(383 -316.5)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="var(--anatomy-gray-500)" />
+      <rect width="21" height="1" transform="translate(160 31.5)" fill="var(--anatomy-gray-500)" />
+      <g transform="translate(66 354)"><text transform="translate(383 -316.5)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
           <tspan x="-13.826" y="0">Label</tspan>
         </text>
-        <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="#a2b6e1" />
+        <path d="M-7607-395.5v-39.05a2.5,2.5,0,0,1-2-2.45,2.5,2.5,0,0,1,2.5-2.5,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2,2.45v39.05Z" transform="translate(760.5 -7928.5) rotate(-90)" fill="var(--anatomy-gray-500)" />
       </g>
     </g>
   </g>

--- a/packages/@react-aria/switch/docs/useSwitch.mdx
+++ b/packages/@react-aria/switch/docs/useSwitch.mdx
@@ -16,6 +16,7 @@ import focusDocs from 'docs:@react-aria/focus';
 import statelyDocs from 'docs:@react-stately/toggle';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/switch/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useSwitch} from '@react-aria/switch';
@@ -55,6 +56,8 @@ as a switch. `useSwitch` helps achieve accessible switches that can be styled as
 * Exposed as a switch to assistive technology via ARIA
 
 ## Anatomy
+
+<Anatomy />
 
 A switch consists of a visual selection indicator and a label. Users may click or touch a switch
 to toggle the selection state, or use the <kbd>Tab</kbd> key to navigate to it and the <kbd>Space</kbd> key to toggle it.

--- a/packages/@react-aria/textfield/docs/anatomy.svg
+++ b/packages/@react-aria/textfield/docs/anatomy.svg
@@ -1,0 +1,31 @@
+<svg style="max-height: 113px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 272 113">
+  <title>Text field anatomy diagram</title>
+  <desc>Shows a text field component with labels pointing to its parts, including the input, and label elements.</desc>
+  <g transform="translate(-341 -39)">
+    <g transform="translate(309 38)">
+      <rect width="264" height="84" transform="translate(40 30)" fill="red" opacity="0" />
+      <g transform="translate(40 66)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+        <rect width="264" height="48" rx="6" stroke="none" />
+        <rect x="0.75" y="0.75" width="262.5" height="46.5" rx="5.25" fill="none" />
+      </g><text transform="translate(58 96)" fill="#496ec2" font-size="21" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Value</tspan>
+      </text><text transform="translate(40 54)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+        <tspan x="0" y="0">Label</tspan>
+      </text>
+    </g>
+    <g transform="translate(156 435)">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-13.149" y="0">Input</tspan>
+      </text>
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
+      <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(-41 400)">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-27.651" y="0">Label</tspan>
+      </text>
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="#a2b6e1" />
+      <rect width="1" height="17" transform="translate(401.5 -343)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/textfield/docs/anatomy.svg
+++ b/packages/@react-aria/textfield/docs/anatomy.svg
@@ -1,31 +1,31 @@
-<svg style="max-height: 113px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 272 113">
+<svg style="max-height: 113px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 272 113">
   <title>Text field anatomy diagram</title>
   <desc>Shows a text field component with labels pointing to its parts, including the input, and label elements.</desc>
   <g transform="translate(-341 -39)">
     <g transform="translate(309 38)">
       <rect width="264" height="84" transform="translate(40 30)" fill="red" opacity="0" />
-      <g transform="translate(40 66)" fill="#fff" stroke="#beccea" stroke-width="1.5">
+      <g transform="translate(40 66)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
         <rect width="264" height="48" rx="6" stroke="none" />
         <rect x="0.75" y="0.75" width="262.5" height="46.5" rx="5.25" fill="none" />
-      </g><text transform="translate(58 96)" fill="#496ec2" font-size="21" font-family="Adobe-Clean">
+      </g><text transform="translate(58 96)" fill="var(--anatomy-gray-800)" font-size="21" font-family="Adobe-Clean">
         <tspan x="0" y="0">Value</tspan>
-      </text><text transform="translate(40 54)" fill="#4a6fc3" font-size="18" font-family="Adobe-Clean">
+      </text><text transform="translate(40 54)" fill="var(--anatomy-gray-700)" font-size="18" font-family="Adobe-Clean">
         <tspan x="0" y="0">Label</tspan>
       </text>
     </g>
     <g transform="translate(156 435)">
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(402 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-13.149" y="0">Input</tspan>
       </text>
-      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="#a2b6e1" />
-      <rect width="1" height="27" transform="translate(401.5 -343)" fill="#a2b6e1" />
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -317)" fill="var(--anatomy-gray-500)" />
+      <rect width="1" height="27" transform="translate(401.5 -343)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(-41 400)">
-      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <rect width="20" height="19" transform="translate(392 -343)" fill="red" opacity="0" /><text transform="translate(410 -348)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-27.651" y="0">Label</tspan>
       </text>
-      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="#a2b6e1" />
-      <rect width="1" height="17" transform="translate(401.5 -343)" fill="#a2b6e1" />
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(399.5 -327)" fill="var(--anatomy-gray-500)" />
+      <rect width="1" height="17" transform="translate(401.5 -343)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/textfield/docs/useTextField.mdx
+++ b/packages/@react-aria/textfield/docs/useTextField.mdx
@@ -13,6 +13,7 @@ export default Layout;
 import docs from 'docs:@react-aria/textfield';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType} from '@react-spectrum/docs';
 import packageData from '@react-aria/textfield/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useTextField} from '@react-aria/textfield';
@@ -41,7 +42,7 @@ keywords: [textfield, textbox, input, label, aria]
 ## Features
 
 Text fields can be built with [&lt;input&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
-or [&lt;textarea&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 
+or [&lt;textarea&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
 and [&lt;label&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) elements,
 but you must manually ensure that they are semantically connected via ids for accessibility.
 `useTextField` helps automate this, and handle other accessibility features while
@@ -53,6 +54,8 @@ allowing for custom styling.
 * Required and invalid states exposed to assistive technology via ARIA
 
 ## Anatomy
+
+<Anatomy />
 
 Text fields consist of an input element and a label. `useTextField` automatically manages
 the relationship between the two elements using the `for` attribute on the `<label>` element

--- a/packages/@react-aria/tooltip/docs/anatomy.svg
+++ b/packages/@react-aria/tooltip/docs/anatomy.svg
@@ -1,73 +1,73 @@
-<svg style="max-height: 97px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 172 97">
+<svg style="max-height: 97px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 172 97">
   <title>Tooltip trigger anatomy diagram</title>
   <desc>Shows a tooltip trigger component with labels pointing to its parts, including the tooltip, and trigger elements.</desc>
   <g transform="translate(-83 -24)">
-    <g transform="translate(149 73)" fill="#fff" stroke="#a2b6e1" stroke-width="1.5">
+    <g transform="translate(149 73)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-500)" stroke-width="1.5">
       <rect width="48" height="48" rx="6" stroke="none" />
       <rect x="0.75" y="0.75" width="46.5" height="46.5" rx="5.25" fill="none" />
     </g>
     <g transform="translate(41 -154)">
-      <path d="M-4012,154h12l-6,6Zm-25,0a4,4,0,0,1-4-4V122a4,4,0,0,1,4-4h62a4,4,0,0,1,4,4v28a4,4,0,0,1-4,4Z" transform="translate(4137 62)" fill="#4a6fc3" /><text transform="translate(131 204)" fill="#fff" font-size="18" font-family="Adobe-Clean">
+      <path d="M-4012,154h12l-6,6Zm-25,0a4,4,0,0,1-4-4V122a4,4,0,0,1,4-4h62a4,4,0,0,1,4,4v28a4,4,0,0,1-4,4Z" transform="translate(4137 62)" fill="var(--anatomy-gray-700)" /><text transform="translate(131 204)" fill="var(--anatomy-gray-50)" font-size="18" font-family="Adobe-Clean">
         <tspan x="-13.23" y="0">Flip</tspan>
       </text>
     </g>
     <g transform="translate(-38 2)">
-      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-34.333" y="0">Tooltip</tspan>
       </text>
-      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="#a2b6e1" />
-      <rect width="21" height="1" transform="translate(160 31.5)" fill="#a2b6e1" />
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="var(--anatomy-gray-500)" />
+      <rect width="21" height="1" transform="translate(160 31.5)" fill="var(--anatomy-gray-500)" />
     </g>
     <g transform="translate(149 73)">
       <g transform="translate(11.381 11.381)">
-        <g transform="translate(22.007 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(22.007 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(19.026 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(19.026 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(16.045 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(16.045 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(13.064 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(13.064 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(10.083 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(10.083 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(7.102 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(7.102 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(4.121 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(4.121 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <g transform="translate(1.14 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+        <g transform="translate(1.14 11.276)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-700)" stroke-width="1">
           <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
           <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
         </g>
-        <path d="M4.8,20.9H19.811a.6.6,0,0,0,.421-1.018l-7.5-7.5a.6.6,0,0,0-.844,0l-7.5,7.5A.6.6,0,0,0,4.8,20.9Z" transform="translate(0.161 1.7)" fill="#4a6fc3" stroke="rgba(0,0,0,0)" stroke-width="1" />
-        <path d="M12.729,10.522l7.5-7.5a.584.584,0,0,0,.176-.417.6.6,0,0,0-.6-.6H4.8a.6.6,0,0,0-.6.6.584.584,0,0,0,.176.417l7.5,7.5A.6.6,0,0,0,12.729,10.522ZM7.514,3.788H17.1L12.307,8.581Z" transform="translate(0.161 -0.263)" fill="#4a6fc3" stroke="rgba(0,0,0,0)" stroke-width="1" />
+        <path d="M4.8,20.9H19.811a.6.6,0,0,0,.421-1.018l-7.5-7.5a.6.6,0,0,0-.844,0l-7.5,7.5A.6.6,0,0,0,4.8,20.9Z" transform="translate(0.161 1.7)" fill="var(--anatomy-gray-700)" stroke="rgba(0,0,0,0)" stroke-width="1" />
+        <path d="M12.729,10.522l7.5-7.5a.584.584,0,0,0,.176-.417.6.6,0,0,0-.6-.6H4.8a.6.6,0,0,0-.6.6.584.584,0,0,0,.176.417l7.5,7.5A.6.6,0,0,0,12.729,10.522ZM7.514,3.788H17.1L12.307,8.581Z" transform="translate(0.161 -0.263)" fill="var(--anatomy-gray-700)" stroke="rgba(0,0,0,0)" stroke-width="1" />
       </g>
     </g>
     <g transform="translate(-38 2)">
-      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <text transform="translate(156 35)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
         <tspan x="-34.333" y="0">Tooltip</tspan>
       </text>
-      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="#a2b6e1" />
-      <rect width="21" height="1" transform="translate(160 31.5)" fill="#a2b6e1" />
-    </g><text transform="translate(254 101)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="var(--anatomy-gray-500)" />
+      <rect width="21" height="1" transform="translate(160 31.5)" fill="var(--anatomy-gray-500)" />
+    </g><text transform="translate(254 101)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
       <tspan x="-35.282" y="0">Trigger</tspan>
     </text>
     <g transform="translate(0 -18)">
-      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(189 112.5)" fill="#a2b6e1" />
-      <rect width="21" height="1" transform="translate(194 114.5)" fill="#a2b6e1" />
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(189 112.5)" fill="var(--anatomy-gray-500)" />
+      <rect width="21" height="1" transform="translate(194 114.5)" fill="var(--anatomy-gray-500)" />
     </g>
   </g>
 </svg>

--- a/packages/@react-aria/tooltip/docs/anatomy.svg
+++ b/packages/@react-aria/tooltip/docs/anatomy.svg
@@ -1,0 +1,73 @@
+<svg style="max-height: 97px; background: #f4f6fc; padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 172 97">
+  <title>Tooltip trigger anatomy diagram</title>
+  <desc>Shows a tooltip trigger component with labels pointing to its parts, including the tooltip, and trigger elements.</desc>
+  <g transform="translate(-83 -24)">
+    <g transform="translate(149 73)" fill="#fff" stroke="#a2b6e1" stroke-width="1.5">
+      <rect width="48" height="48" rx="6" stroke="none" />
+      <rect x="0.75" y="0.75" width="46.5" height="46.5" rx="5.25" fill="none" />
+    </g>
+    <g transform="translate(41 -154)">
+      <path d="M-4012,154h12l-6,6Zm-25,0a4,4,0,0,1-4-4V122a4,4,0,0,1,4-4h62a4,4,0,0,1,4,4v28a4,4,0,0,1-4,4Z" transform="translate(4137 62)" fill="#4a6fc3" /><text transform="translate(131 204)" fill="#fff" font-size="18" font-family="Adobe-Clean">
+        <tspan x="-13.23" y="0">Flip</tspan>
+      </text>
+    </g>
+    <g transform="translate(-38 2)">
+      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-34.333" y="0">Tooltip</tspan>
+      </text>
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="#a2b6e1" />
+      <rect width="21" height="1" transform="translate(160 31.5)" fill="#a2b6e1" />
+    </g>
+    <g transform="translate(149 73)">
+      <g transform="translate(11.381 11.381)">
+        <g transform="translate(22.007 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(19.026 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(16.045 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(13.064 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(10.083 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(7.102 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(4.121 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <g transform="translate(1.14 11.276)" fill="#4a6fc3" stroke="#4a6fc3" stroke-width="1">
+          <rect width="1.789" height="1.789" rx="0.25" stroke="none" />
+          <rect x="0.5" y="0.5" width="0.789" height="0.789" rx="0.25" fill="none" />
+        </g>
+        <path d="M4.8,20.9H19.811a.6.6,0,0,0,.421-1.018l-7.5-7.5a.6.6,0,0,0-.844,0l-7.5,7.5A.6.6,0,0,0,4.8,20.9Z" transform="translate(0.161 1.7)" fill="#4a6fc3" stroke="rgba(0,0,0,0)" stroke-width="1" />
+        <path d="M12.729,10.522l7.5-7.5a.584.584,0,0,0,.176-.417.6.6,0,0,0-.6-.6H4.8a.6.6,0,0,0-.6.6.584.584,0,0,0,.176.417l7.5,7.5A.6.6,0,0,0,12.729,10.522ZM7.514,3.788H17.1L12.307,8.581Z" transform="translate(0.161 -0.263)" fill="#4a6fc3" stroke="rgba(0,0,0,0)" stroke-width="1" />
+      </g>
+    </g>
+    <g transform="translate(-38 2)">
+      <text transform="translate(156 35)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+        <tspan x="-34.333" y="0">Tooltip</tspan>
+      </text>
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(180 29.5)" fill="#a2b6e1" />
+      <rect width="21" height="1" transform="translate(160 31.5)" fill="#a2b6e1" />
+    </g><text transform="translate(254 101)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic">
+      <tspan x="-35.282" y="0">Trigger</tspan>
+    </text>
+    <g transform="translate(0 -18)">
+      <circle cx="2.5" cy="2.5" r="2.5" transform="translate(189 112.5)" fill="#a2b6e1" />
+      <rect width="21" height="1" transform="translate(194 114.5)" fill="#a2b6e1" />
+    </g>
+  </g>
+</svg>

--- a/packages/@react-aria/tooltip/docs/useTooltipTrigger.mdx
+++ b/packages/@react-aria/tooltip/docs/useTooltipTrigger.mdx
@@ -14,6 +14,7 @@ import docs from 'docs:@react-aria/tooltip';
 import statelyDocs from 'docs:@react-stately/tooltip';
 import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-aria/tooltip/package.json';
+import Anatomy from './anatomy.svg';
 
 ```jsx import
 import {useTooltipTrigger} from '@react-aria/tooltip';
@@ -55,7 +56,9 @@ fully accessible tooltips that can be styled as needed.
 
 ## Anatomy
 
-A tooltip consists of two parts, the trigger element and the tooltip itself.
+<Anatomy />
+
+A tooltip consists of two parts: the trigger element and the tooltip itself.
 Users may reveal the tooltip by hovering or focusing the trigger.
 
 `useTooltipTrigger` returns props to be spread onto its target trigger and the tooltip:

--- a/packages/@react-spectrum/dialog/docs/images/DialogAnatomy.svg
+++ b/packages/@react-spectrum/dialog/docs/images/DialogAnatomy.svg
@@ -9,7 +9,7 @@
       <rect width="400" height="168" stroke="none"/>
       <rect x="0.5" y="0.5" width="399" height="167" fill="none"/>
     </g>
-    <text id="Body_area" data-name="Body area" transform="translate(596 229)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="-25.818" y="0">Body area</tspan></text>
+    <text id="Body_area" data-name="Body area" transform="translate(596 229)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-25.818" y="0">Body area</tspan></text>
     <g id="Rectangle_138302" data-name="Rectangle 138302" transform="translate(608 348)" fill="rgba(74,111,195,0.05)" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="4 2">
       <rect width="188" height="32" stroke="none"/>
       <rect x="0.5" y="0.5" width="187" height="31" fill="none"/>
@@ -26,13 +26,13 @@
       <rect width="188" height="32" stroke="none"/>
       <rect x="0.5" y="0.5" width="187" height="31" fill="none"/>
     </g>
-    <text id="Title_area" data-name="Title area" transform="translate(471 103)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="-23.608" y="0">Title area</tspan></text>
-    <text id="Footer_content_area_optional_" data-name="Footer content area (optional)" transform="translate(490 368)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="-75.985" y="0">Footer content area (optional)</tspan></text>
-    <text id="Header_content_area_optional_" data-name="Header content area (optional)" transform="translate(688 103)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="-78.11" y="0">Header content area (optional)</tspan></text>
-    <text id="Button_group_area" data-name="Button group area" transform="translate(702 368)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="-46.169" y="0">Button group area</tspan></text>
-    <text id="Header" transform="translate(870.999 103)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">Header</tspan></text>
-    <text id="Footer" transform="translate(869.999 368)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">Footer</tspan></text>
-    <text id="Body" transform="translate(869.999 228)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">Body</tspan></text>
+    <text id="Title_area" data-name="Title area" transform="translate(471 103)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-23.608" y="0">Title area</tspan></text>
+    <text id="Footer_content_area_optional_" data-name="Footer content area (optional)" transform="translate(490 368)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-75.985" y="0">Footer content area (optional)</tspan></text>
+    <text id="Header_content_area_optional_" data-name="Header content area (optional)" transform="translate(688 103)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-78.11" y="0">Header content area (optional)</tspan></text>
+    <text id="Button_group_area" data-name="Button group area" transform="translate(702 368)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-46.169" y="0">Button group area</tspan></text>
+    <text id="Header" transform="translate(870.999 103)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Header</tspan></text>
+    <text id="Footer" transform="translate(869.999 368)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Footer</tspan></text>
+    <text id="Body" transform="translate(869.999 228)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Body</tspan></text>
     <rect id="Rectangle_138454" data-name="Rectangle 138454" width="8" height="1" transform="translate(853 99)" fill="#4a6fc3"/>
     <rect id="Rectangle_138456" data-name="Rectangle 138456" width="8" height="1" transform="translate(853 364)" fill="#4a6fc3"/>
     <rect id="Rectangle_138455" data-name="Rectangle 138455" width="8" height="1" transform="translate(853 224)" fill="#4a6fc3"/>
@@ -51,7 +51,7 @@
       <rect id="Rectangle_138453-3" data-name="Rectangle 138453" width="1" height="168" transform="translate(852 582)" fill="#4a6fc3"/>
       <rect id="Rectangle_138452-3" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 749)" fill="#4a6fc3"/>
     </g>
-    <text id="Divider" transform="translate(334 126)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="-36.14" y="0">Divider</tspan></text>
+    <text id="Divider" transform="translate(334 126)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-36.14" y="0">Divider</tspan></text>
     <path id="Union_58" data-name="Union 58" d="M-9114.949-372H-9168v-1h53.05a2.5,2.5,0,0,1,2.451-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9114.949-372Z" transform="translate(9508 495.501)" fill="#718dcf"/>
   </g>
 </svg>

--- a/packages/@react-spectrum/dialog/docs/images/DialogAnatomy.svg
+++ b/packages/@react-spectrum/dialog/docs/images/DialogAnatomy.svg
@@ -1,57 +1,57 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="611.999" height="372" viewBox="0 0 611.999 372">
   <g id="Group_72711" data-name="Group 72711" transform="translate(-297 -48)">
-    <rect id="Background" width="480" height="372" rx="4" transform="translate(356 48)" fill="#f4f6fc"/>
+    <rect id="Background" width="480" height="372" rx="4" transform="translate(356 48)" fill="var(--anatomy-gray-100)"/>
     <g id="Rule" transform="translate(396 122)">
       <rect id="Placement_Area" data-name="Placement Area" width="400" height="2" fill="red" opacity="0"/>
-      <rect id="Bar" width="400" height="2" rx="1" fill="#dae2f4"/>
+      <rect id="Bar" width="400" height="2" rx="1" fill="var(--anatomy-gray-300)"/>
     </g>
-    <g id="Rectangle_138301" data-name="Rectangle 138301" transform="translate(396 140)" fill="rgba(74,111,195,0.05)" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="4 2">
+    <g id="Rectangle_138301" data-name="Rectangle 138301" transform="translate(396 140)" fill="rgba(74,111,195,0.05)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="4 2">
       <rect width="400" height="168" stroke="none"/>
       <rect x="0.5" y="0.5" width="399" height="167" fill="none"/>
     </g>
-    <text id="Body_area" data-name="Body area" transform="translate(596 229)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-25.818" y="0">Body area</tspan></text>
-    <g id="Rectangle_138302" data-name="Rectangle 138302" transform="translate(608 348)" fill="rgba(74,111,195,0.05)" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="4 2">
+    <text id="Body_area" data-name="Body area" transform="translate(596 229)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-25.818" y="0">Body area</tspan></text>
+    <g id="Rectangle_138302" data-name="Rectangle 138302" transform="translate(608 348)" fill="rgba(74,111,195,0.05)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="4 2">
       <rect width="188" height="32" stroke="none"/>
       <rect x="0.5" y="0.5" width="187" height="31" fill="none"/>
     </g>
-    <g id="Rectangle_138303" data-name="Rectangle 138303" transform="translate(570 88)" fill="none" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="4 2">
+    <g id="Rectangle_138303" data-name="Rectangle 138303" transform="translate(570 88)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="4 2">
       <rect width="226" height="22" stroke="none"/>
       <rect x="0.5" y="0.5" width="225" height="21" fill="none"/>
     </g>
-    <g id="Rectangle_138450" data-name="Rectangle 138450" transform="translate(396 88)" fill="rgba(74,111,195,0.05)" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="4 2">
+    <g id="Rectangle_138450" data-name="Rectangle 138450" transform="translate(396 88)" fill="rgba(74,111,195,0.05)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="4 2">
       <rect width="150" height="22" stroke="none"/>
       <rect x="0.5" y="0.5" width="149" height="21" fill="none"/>
     </g>
-    <g id="Rectangle_138449" data-name="Rectangle 138449" transform="translate(396 348)" fill="none" stroke="#a2b6e1" stroke-width="1" stroke-dasharray="4 2">
+    <g id="Rectangle_138449" data-name="Rectangle 138449" transform="translate(396 348)" fill="none" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="4 2">
       <rect width="188" height="32" stroke="none"/>
       <rect x="0.5" y="0.5" width="187" height="31" fill="none"/>
     </g>
-    <text id="Title_area" data-name="Title area" transform="translate(471 103)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-23.608" y="0">Title area</tspan></text>
-    <text id="Footer_content_area_optional_" data-name="Footer content area (optional)" transform="translate(490 368)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-75.985" y="0">Footer content area (optional)</tspan></text>
-    <text id="Header_content_area_optional_" data-name="Header content area (optional)" transform="translate(688 103)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-78.11" y="0">Header content area (optional)</tspan></text>
-    <text id="Button_group_area" data-name="Button group area" transform="translate(702 368)" fill="#496ec2" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-46.169" y="0">Button group area</tspan></text>
-    <text id="Header" transform="translate(870.999 103)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Header</tspan></text>
-    <text id="Footer" transform="translate(869.999 368)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Footer</tspan></text>
-    <text id="Body" transform="translate(869.999 228)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Body</tspan></text>
-    <rect id="Rectangle_138454" data-name="Rectangle 138454" width="8" height="1" transform="translate(853 99)" fill="#4a6fc3"/>
-    <rect id="Rectangle_138456" data-name="Rectangle 138456" width="8" height="1" transform="translate(853 364)" fill="#4a6fc3"/>
-    <rect id="Rectangle_138455" data-name="Rectangle 138455" width="8" height="1" transform="translate(853 224)" fill="#4a6fc3"/>
+    <text id="Title_area" data-name="Title area" transform="translate(471 103)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-23.608" y="0">Title area</tspan></text>
+    <text id="Footer_content_area_optional_" data-name="Footer content area (optional)" transform="translate(490 368)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-75.985" y="0">Footer content area (optional)</tspan></text>
+    <text id="Header_content_area_optional_" data-name="Header content area (optional)" transform="translate(688 103)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-78.11" y="0">Header content area (optional)</tspan></text>
+    <text id="Button_group_area" data-name="Button group area" transform="translate(702 368)" fill="var(--anatomy-gray-800)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-46.169" y="0">Button group area</tspan></text>
+    <text id="Header" transform="translate(870.999 103)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Header</tspan></text>
+    <text id="Footer" transform="translate(869.999 368)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Footer</tspan></text>
+    <text id="Body" transform="translate(869.999 228)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="0" y="0">Body</tspan></text>
+    <rect id="Rectangle_138454" data-name="Rectangle 138454" width="8" height="1" transform="translate(853 99)" fill="var(--anatomy-gray-700)"/>
+    <rect id="Rectangle_138456" data-name="Rectangle 138456" width="8" height="1" transform="translate(853 364)" fill="var(--anatomy-gray-700)"/>
+    <rect id="Rectangle_138455" data-name="Rectangle 138455" width="8" height="1" transform="translate(853 224)" fill="var(--anatomy-gray-700)"/>
     <g id="Group_72702" data-name="Group 72702" transform="translate(0 -494)">
-      <rect id="Rectangle_138451" data-name="Rectangle 138451" width="8" height="1" transform="translate(844 582)" fill="#4a6fc3"/>
-      <rect id="Rectangle_138453" data-name="Rectangle 138453" width="1" height="22" transform="translate(852 582)" fill="#4a6fc3"/>
-      <rect id="Rectangle_138452" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 603)" fill="#4a6fc3"/>
+      <rect id="Rectangle_138451" data-name="Rectangle 138451" width="8" height="1" transform="translate(844 582)" fill="var(--anatomy-gray-700)"/>
+      <rect id="Rectangle_138453" data-name="Rectangle 138453" width="1" height="22" transform="translate(852 582)" fill="var(--anatomy-gray-700)"/>
+      <rect id="Rectangle_138452" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 603)" fill="var(--anatomy-gray-700)"/>
     </g>
     <g id="Group_72704" data-name="Group 72704" transform="translate(0 -234)">
-      <rect id="Rectangle_138451-2" data-name="Rectangle 138451" width="8" height="1" transform="translate(844 582)" fill="#4a6fc3"/>
-      <rect id="Rectangle_138453-2" data-name="Rectangle 138453" width="1" height="32" transform="translate(852 582)" fill="#4a6fc3"/>
-      <rect id="Rectangle_138452-2" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 613)" fill="#4a6fc3"/>
+      <rect id="Rectangle_138451-2" data-name="Rectangle 138451" width="8" height="1" transform="translate(844 582)" fill="var(--anatomy-gray-700)"/>
+      <rect id="Rectangle_138453-2" data-name="Rectangle 138453" width="1" height="32" transform="translate(852 582)" fill="var(--anatomy-gray-700)"/>
+      <rect id="Rectangle_138452-2" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 613)" fill="var(--anatomy-gray-700)"/>
     </g>
     <g id="Group_72703" data-name="Group 72703" transform="translate(0 -442)">
-      <rect id="Rectangle_138451-3" data-name="Rectangle 138451" width="8" height="1" transform="translate(844 582)" fill="#4a6fc3"/>
-      <rect id="Rectangle_138453-3" data-name="Rectangle 138453" width="1" height="168" transform="translate(852 582)" fill="#4a6fc3"/>
-      <rect id="Rectangle_138452-3" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 749)" fill="#4a6fc3"/>
+      <rect id="Rectangle_138451-3" data-name="Rectangle 138451" width="8" height="1" transform="translate(844 582)" fill="var(--anatomy-gray-700)"/>
+      <rect id="Rectangle_138453-3" data-name="Rectangle 138453" width="1" height="168" transform="translate(852 582)" fill="var(--anatomy-gray-700)"/>
+      <rect id="Rectangle_138452-3" data-name="Rectangle 138452" width="8" height="1" transform="translate(844 749)" fill="var(--anatomy-gray-700)"/>
     </g>
-    <text id="Divider" transform="translate(334 126)" fill="#4a6fc3" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-36.14" y="0">Divider</tspan></text>
-    <path id="Union_58" data-name="Union 58" d="M-9114.949-372H-9168v-1h53.05a2.5,2.5,0,0,1,2.451-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9114.949-372Z" transform="translate(9508 495.501)" fill="#718dcf"/>
+    <text id="Divider" transform="translate(334 126)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" style="font-style: italic"><tspan x="-36.14" y="0">Divider</tspan></text>
+    <path id="Union_58" data-name="Union 58" d="M-9114.949-372H-9168v-1h53.05a2.5,2.5,0,0,1,2.451-2,2.5,2.5,0,0,1,2.5,2.5,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9114.949-372Z" transform="translate(9508 495.501)" fill="var(--anatomy-gray-600)"/>
   </g>
 </svg>

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -71,12 +71,35 @@ html, body {
   color-scheme: light dark;
   --blue: #0040ff;
   --gray: #6f6f6f;
+
+  --anatomy-gray-900: #486EC2;
+  --anatomy-gray-800: #496EC2;
+  --anatomy-gray-700: #4a6fc3;
+  --anatomy-gray-600: #718dcf;
+  --anatomy-gray-500: #a2b6e1;
+  --anatomy-gray-400: #beccea;
+  --anatomy-gray-300: #DAE2F4;
+  --anatomy-gray-200: #E5EBF7;
+  --anatomy-gray-100: #f4f6fc;
+  --anatomy-gray-75: #FDFDFE;
+  --anatomy-gray-50: #FFFFFF;
 }
 
 .dark {
   --page-background: var(--spectrum-global-color-gray-75);
   --blue: dodgerblue;
   --gray: #868686;
+  --anatomy-gray-900: #8ca4d9;
+  --anatomy-gray-800: #8ca4d9;
+  --anatomy-gray-700: #8ba3d8;
+  --anatomy-gray-600: #6080ca;
+  --anatomy-gray-500: #3a589b;
+  --anatomy-gray-400: #2e467b;
+  --anatomy-gray-300: #223259;
+  --anatomy-gray-200: #1c2b4b;
+  --anatomy-gray-100: #141e35;
+  --anatomy-gray-75: #0e1525;
+  --anatomy-gray-50: #0c1220;
   .example {
     background-color: var(--spectrum-global-color-gray-100);
   }


### PR DESCRIPTION
This adds anatomy diagrams similar to those found on spectrum.adobe.com to the React Aria docs, under our existing Anatomy section. This provides a more visual way to see all of the parts of a component, which are referred to in the text and API description tables below.

<img width="701" alt="image" src="https://user-images.githubusercontent.com/19409/104072034-52456f00-51d8-11eb-8078-86148fef1206.png">