### PR TITLE
Fix documentation on return type of useMenuSection

### DIFF
--- a/packages/@react-aria/menu/src/useMenuSection.ts
+++ b/packages/@react-aria/menu/src/useMenuSection.ts
@@ -27,7 +27,7 @@ interface MenuSectionAria {
   /** Props for the heading element, if any. */
   headingProps: HTMLAttributes<HTMLElement>,
 
-  /** Props for the heading element, if any. */
+  /** Props for the group element. */
   groupProps: HTMLAttributes<HTMLElement>
 }
 


### PR DESCRIPTION
We had a copy paste issue


Closes https://github.com/adobe/react-spectrum/issues/1266

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
