### PR TITLE
Prevent extra onChanges from useControlledState

### DIFF
--- a/packages/@react-stately/utils/src/useControlledState.ts
+++ b/packages/@react-stately/utils/src/useControlledState.ts
@@ -32,7 +32,7 @@ export function useControlledState<T>(
   let setValue = useCallback((value, ...args) => {
     let onChangeCaller = (value, ...onChangeArgs) => {
       if (onChange) {
-        if (stateRef.current !== value) {
+        if (!Object.is(stateRef.current, value)) {
           onChange(value, ...onChangeArgs);
         }
       }

--- a/packages/@react-stately/utils/test/useControlledState.test.js
+++ b/packages/@react-stately/utils/test/useControlledState.test.js
@@ -48,6 +48,24 @@ describe('useControlledState tests', function () {
     expect(onChangeSpy).toHaveBeenLastCalledWith('newValue');
   });
 
+  it('using NaN will only trigger onChange once', () => {
+    let onChangeSpy = jest.fn();
+    let {result} = renderHook(() => useControlledState(undefined, undefined, onChangeSpy));
+    let [value, setValue] = result.current;
+    expect(value).not.toBeDefined();
+    expect(onChangeSpy).not.toHaveBeenCalled();
+    act(() => setValue(NaN));
+    [value, setValue] = result.current;
+    expect(value).toBe(NaN);
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenLastCalledWith(NaN);
+
+    act(() => setValue(NaN));
+    [value, setValue] = result.current;
+    expect(value).toBe(NaN);
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('can handle callback setValue behavior', () => {
     let onChangeSpy = jest.fn();
     let {result} = renderHook(() => useControlledState(undefined, 'defaultValue', onChangeSpy));


### PR DESCRIPTION
NaN !== NaN, but we can compare them using Object.is https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
