### PR TITLE
Numberfield fixes: remove aria-roledescription on iOS and replace hyphen with minus sign

### DIFF
--- a/packages/@react-aria/numberfield/intl/ar-AE.json
+++ b/packages/@react-aria/numberfield/intl/ar-AE.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "نقصان",
-  "Enter a number": "أدخل رقماً",
   "Increment": "زيادة",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/bg-BG.json
+++ b/packages/@react-aria/numberfield/intl/bg-BG.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Стъпка на намаление",
-  "Enter a number": "Въведете число",
   "Increment": "Стъпка на увеличение",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/cs-CZ.json
+++ b/packages/@react-aria/numberfield/intl/cs-CZ.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Snížení",
-  "Enter a number": "Zadejte číslo",
   "Increment": "Zvýšení",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/da-DK.json
+++ b/packages/@react-aria/numberfield/intl/da-DK.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Reduktion",
-  "Enter a number": "Skriv et tal",
   "Increment": "Forøgelse",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/de-DE.json
+++ b/packages/@react-aria/numberfield/intl/de-DE.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Verringern",
-  "Enter a number": "Zahl eingeben",
   "Increment": "Erhöhen",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/el-GR.json
+++ b/packages/@react-aria/numberfield/intl/el-GR.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Μείωση",
-  "Enter a number": "Εισαγωγή αριθμού",
   "Increment": "Προσαύξηση",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/en-US.json
+++ b/packages/@react-aria/numberfield/intl/en-US.json
@@ -1,5 +1,4 @@
 {
-  "Enter a number": "Enter a number",
   "Decrement": "Decrement",
   "Increment": "Increment",
   "Number field": "Number field"

--- a/packages/@react-aria/numberfield/intl/es-ES.json
+++ b/packages/@react-aria/numberfield/intl/es-ES.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Decrecimiento",
-  "Enter a number": "Introduzca un número",
   "Increment": "Incremento",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/et-EE.json
+++ b/packages/@react-aria/numberfield/intl/et-EE.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Vähendamine",
-  "Enter a number": "Sisestage number",
   "Increment": "Suurendamine",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/fi-FI.json
+++ b/packages/@react-aria/numberfield/intl/fi-FI.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Vähennys",
-  "Enter a number": "Anna numero",
   "Increment": "Lisäys",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/fr-FR.json
+++ b/packages/@react-aria/numberfield/intl/fr-FR.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Décrémenter",
-  "Enter a number": "Saisir un nombre",
   "Increment": "Incrémenter",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/he-IL.json
+++ b/packages/@react-aria/numberfield/intl/he-IL.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "הפחתה",
-  "Enter a number": "הזן מספר",
   "Increment": "תוספת",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/hr-HR.json
+++ b/packages/@react-aria/numberfield/intl/hr-HR.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Smanjenje",
-  "Enter a number": "Unesite broj",
   "Increment": "Povećanje",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/hu-HU.json
+++ b/packages/@react-aria/numberfield/intl/hu-HU.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Csökkentés",
-  "Enter a number": "Adjon meg egy számot",
   "Increment": "Növelés",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/it-IT.json
+++ b/packages/@react-aria/numberfield/intl/it-IT.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Decrementa",
-  "Enter a number": "Immetti un numero",
   "Increment": "Incrementa",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ja-JP.json
+++ b/packages/@react-aria/numberfield/intl/ja-JP.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "減らす",
-  "Enter a number": "数字を入力",
   "Increment": "増やす",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ko-KR.json
+++ b/packages/@react-aria/numberfield/intl/ko-KR.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "감소",
-  "Enter a number": "숫자 입력",
   "Increment": "증가",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/lt-LT.json
+++ b/packages/@react-aria/numberfield/intl/lt-LT.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Sumažėjimas",
-  "Enter a number": "Įveskite skaičių",
   "Increment": "Padidėjimas",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/lv-LV.json
+++ b/packages/@react-aria/numberfield/intl/lv-LV.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Samazinājums",
-  "Enter a number": "Ievadiet skaitli",
   "Increment": "Palielinājums",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/nb-NO.json
+++ b/packages/@react-aria/numberfield/intl/nb-NO.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Reduser",
-  "Enter a number": "Oppgi et tall",
   "Increment": "Øk",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/nl-NL.json
+++ b/packages/@react-aria/numberfield/intl/nl-NL.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Afname",
-  "Enter a number": "Getal invoeren",
   "Increment": "Toename",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/pl-PL.json
+++ b/packages/@react-aria/numberfield/intl/pl-PL.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Dekrementuj",
-  "Enter a number": "Wprowadź liczbę",
   "Increment": "Inkrementuj",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/pt-BR.json
+++ b/packages/@react-aria/numberfield/intl/pt-BR.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Decrementar",
-  "Enter a number": "Insira um número",
   "Increment": "Incrementar",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ro-RO.json
+++ b/packages/@react-aria/numberfield/intl/ro-RO.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Amortizare",
-  "Enter a number": "Introduceţi un număr",
   "Increment": "Creştere",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ru-RU.json
+++ b/packages/@react-aria/numberfield/intl/ru-RU.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Уменьшить",
-  "Enter a number": "Введите номер",
   "Increment": "Увеличить",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sk-SK.json
+++ b/packages/@react-aria/numberfield/intl/sk-SK.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Zníženie",
-  "Enter a number": "Zadajte číslo",
   "Increment": "Prírastok",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sl-SI.json
+++ b/packages/@react-aria/numberfield/intl/sl-SI.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Zmanjšanje",
-  "Enter a number": "Vnesite številko",
   "Increment": "Povečanje",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sr-SP.json
+++ b/packages/@react-aria/numberfield/intl/sr-SP.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Smanjenje",
-  "Enter a number": "Unesite broj",
   "Increment": "Povećanje",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sv-SE.json
+++ b/packages/@react-aria/numberfield/intl/sv-SE.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Minska",
-  "Enter a number": "Ange ett tal",
   "Increment": "Öka",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/tr-TR.json
+++ b/packages/@react-aria/numberfield/intl/tr-TR.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Azalış",
-  "Enter a number": "Sayı girin",
   "Increment": "Artış",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/uk-UA.json
+++ b/packages/@react-aria/numberfield/intl/uk-UA.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "Зменшення",
-  "Enter a number": "Уведіть номер",
   "Increment": "Збільшення",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/zh-CN.json
+++ b/packages/@react-aria/numberfield/intl/zh-CN.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "递减",
-  "Enter a number": "输入一个数字",
   "Increment": "递增",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/zh-TW.json
+++ b/packages/@react-aria/numberfield/intl/zh-TW.json
@@ -1,6 +1,5 @@
 {
   "Decrement": "減值",
-  "Enter a number": "輸入數字",
   "Increment": "增值",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -298,7 +298,6 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState)
       'aria-label': props['aria-label'] || null,
       'aria-labelledby': props['aria-labelledby'] || null,
       id: inputId,
-      placeholder: formatMessage('Enter a number'),
       type: 'text', // Can't use type="number" because then we can't have things like $ in the field.
       inputMode,
       onChange,

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -24,7 +24,7 @@ import {
 } from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {isAndroid, isIPhone, mergeProps, useId} from '@react-aria/utils';
+import {isAndroid, isIOS, isIPhone, mergeProps, useId} from '@react-aria/utils';
 import {NumberFieldState} from '@react-stately/numberfield';
 import {SpinButtonProps, useSpinButton} from '@react-aria/spinbutton';
 import {TextInputDOMProps} from '@react-types/shared';
@@ -338,7 +338,8 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState)
     {
       // override the spinbutton role, we can't focus a spin button with VO
       role: null,
-      'aria-roledescription': formatMessage('Number field'),
+      // ignore aria-roledescription on iOS so that required state will announce when it is present
+      'aria-roledescription': (!isIOS() ? formatMessage('Number field') : null),
       'aria-valuemax': null,
       'aria-valuemin': null,
       'aria-valuenow': null,

--- a/packages/@react-aria/spinbutton/src/useSpinButton.ts
+++ b/packages/@react-aria/spinbutton/src/useSpinButton.ts
@@ -123,7 +123,7 @@ export function useSpinButton(
 
   useEffect(() => {
     if (isFocused.current) {
-      announce(textValue === '' ? formatMessage('Empty') : textValue || `${value}`);
+      announce((textValue === '' ? formatMessage('Empty') : textValue || `${value}`).replace('-', '−'), 'assertive');
     }
   }, [textValue, value, formatMessage]);
 
@@ -164,7 +164,7 @@ export function useSpinButton(
       role: 'spinbutton',
       'aria-valuenow': !isNaN(value) ? value : null,
       // by having a message, this prevents iOS VO from reading off '50%' for an empty field
-      'aria-valuetext': textValue === '' || !textValue ? formatMessage('Empty') : textValue,
+      'aria-valuetext': (textValue === '' || !textValue ? formatMessage('Empty') : textValue || `${value}`).replace('-', '−'),
       'aria-valuemin': minValue,
       'aria-valuemax': maxValue,
       'aria-disabled': isDisabled || null,

--- a/packages/@react-aria/spinbutton/test/useSpinButton.test.js
+++ b/packages/@react-aria/spinbutton/test/useSpinButton.test.js
@@ -117,7 +117,7 @@ describe('useSpinButton', function () {
 
     res.rerender(<Example value={3} />);
     expect(announce).toHaveBeenCalledTimes(1);
-    expect(announce).toHaveBeenCalledWith('3');
+    expect(announce).toHaveBeenCalledWith('3', 'assertive');
 
     act(() => {el.blur();});
 
@@ -132,6 +132,20 @@ describe('useSpinButton', function () {
 
     res.rerender(<Example value={3} textValue="3 items" />);
     expect(announce).toHaveBeenCalledTimes(1);
-    expect(announce).toHaveBeenCalledWith('3 items');
+    expect(announce).toHaveBeenCalledWith('3 items', 'assertive');
+  });
+
+  it('should substitute a minus sign for hyphen in the textValue for negative values', function () {
+    let res = render(<Example value={-2} textValue="-2 items" />);
+    let el = res.getByTestId('test');
+    expect(el).toHaveAttribute('aria-valuenow', '-2');
+    expect(el).toHaveAttribute('aria-valuetext', '−2 items');
+    act(() => {el.focus();});
+
+    res.rerender(<Example value={-3} textValue="-3 items" />);
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce).toHaveBeenCalledWith('−3 items', 'assertive');
+    expect(el).toHaveAttribute('aria-valuenow', '-3');
+    expect(el).toHaveAttribute('aria-valuetext', '−3 items');
   });
 });

--- a/packages/@react-types/numberfield/src/index.d.ts
+++ b/packages/@react-types/numberfield/src/index.d.ts
@@ -17,12 +17,11 @@ import {
   InputBase, LabelableProps,
   RangeInputBase, SpectrumLabelableProps,
   StyleProps,
-  TextInputBase,
   Validation,
   ValueBase
 } from '@react-types/shared';
 
-export interface NumberFieldProps extends InputBase, Validation, FocusableProps, TextInputBase, ValueBase<number>, RangeInputBase<number>, LabelableProps {
+export interface NumberFieldProps extends InputBase, Validation, FocusableProps, ValueBase<number>, RangeInputBase<number>, LabelableProps {
   decrementAriaLabel?: string,
   incrementAriaLabel?: string,
   formatOptions?: Intl.NumberFormatOptions

--- a/packages/@react-types/numberfield/src/index.d.ts
+++ b/packages/@react-types/numberfield/src/index.d.ts
@@ -17,11 +17,12 @@ import {
   InputBase, LabelableProps,
   RangeInputBase, SpectrumLabelableProps,
   StyleProps,
+  TextInputBase,
   Validation,
   ValueBase
 } from '@react-types/shared';
 
-export interface NumberFieldProps extends InputBase, Validation, FocusableProps, ValueBase<number>, RangeInputBase<number>, LabelableProps {
+export interface NumberFieldProps extends InputBase, Validation, FocusableProps, TextInputBase, ValueBase<number>, RangeInputBase<number>, LabelableProps {
   decrementAriaLabel?: string,
   incrementAriaLabel?: string,
   formatOptions?: Intl.NumberFormatOptions
@@ -29,7 +30,7 @@ export interface NumberFieldProps extends InputBase, Validation, FocusableProps,
 
 export interface AriaNumberFieldProps extends NumberFieldProps, DOMProps, AriaLabelingProps {}
 
-export interface SpectrumNumberFieldProps extends AriaNumberFieldProps, StyleProps, SpectrumLabelableProps {
+export interface SpectrumNumberFieldProps extends AriaNumberFieldProps, StyleProps, SpectrumLabelableProps, Omit<AriaNumberFieldProps, 'placeholder'> {
   isQuiet?: boolean,
   hideStepper?: boolean,
   formatOptions?: Intl.NumberFormatOptions


### PR DESCRIPTION
Per #1509 and #1486

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 1486](https://github.com/adobe/react-spectrum/issues/1486) and #1509.
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

On an iOS device:

1. Open http://localhost:9003/?path=/story/numberfield--required in Safari.
2. Open VoiceOver
3. Navigate to the NumberField input
4. The input should announce as "Enter numbers, _Enter a number_, text field, required", which corrects a behavior with `aria-roledescription` where the `required` state is not announced.

In Safari on macOS:

1. Open http://localhost:9003/?path=/story/numberfield--currency in Safari.
2. Open VoiceOver
3. Navigate to the NumberField input
4. Press down arrow twice to set the value to -1
5. VoiceOver should announce the value as "minus sign one Euro point zero zero", which corrects a case where the hyphen to indicate negative value in the input was ignored by VoiceOver and negative values were not announced any differently than positive values.

## 🧢 Your Project:

Adobe/Accessibility