### PR TITLE
Making disabled NumberField button styles more specific than active styles 

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/stepper/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/stepper/skin.css
@@ -67,13 +67,6 @@ governing permissions and limitations under the License.
     }
   }
 
-  .spectrum-Stepper-button {
-    &:disabled,
-    &.is-disabled {
-      border-color: var(--spectrum-textfield-border-color-disabled);
-    }
-  }
-
   &:focus,
   &:active {
     .spectrum-Stepper-button {
@@ -83,6 +76,13 @@ governing permissions and limitations under the License.
     &:invalid,
     &.is-invalid {
       border-color: var(--spectrum-textfield-border-color-error);
+    }
+  }
+
+  .spectrum-Stepper-button {
+    &:disabled,
+    &.is-disabled {
+      border-color: var(--spectrum-textfield-border-color-disabled);
     }
   }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
