### PR TITLE
adding an autofocus story to hexColorField

### DIFF
--- a/packages/@react-spectrum/color/stories/HexColorField.stories.tsx
+++ b/packages/@react-spectrum/color/stories/HexColorField.stories.tsx
@@ -64,6 +64,10 @@ storiesOf('HexColorField', module)
         value="#FF00AA"
         onChange={action('change')} />
     )
+  )
+  .add(
+    'autofocus',
+    () => render({autoFocus: true})
   );
 
 function ControlledHexColorField(props: any = {}) {


### PR DESCRIPTION
No issue from testing session
Adding a story to make sure autofocus works with HexColorField

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

goto storybook
goto hexcolorfield stories
goto the autofocus story
confirm that it is autofocused

## 🧢 Your Project:
RSP