### PR TITLE
Textarea should not behave differently inside a flex

### DIFF
--- a/packages/@react-spectrum/textfield/src/TextArea.tsx
+++ b/packages/@react-spectrum/textfield/src/TextArea.tsx
@@ -37,8 +37,11 @@ function TextArea(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
   let onHeightChange = useCallback(() => {
     if (isQuiet) {
       let input = inputRef.current;
+      let prevAlignment = input.style.alignSelf;
+      input.style.alignSelf = 'start';
       input.style.height = 'auto';
       input.style.height = `${input.scrollHeight}px`;
+      input.style.alignSelf = prevAlignment;
     }
   }, [isQuiet, inputRef]);
 

--- a/packages/@react-spectrum/textfield/stories/TextArea.stories.js
+++ b/packages/@react-spectrum/textfield/stories/TextArea.stories.js
@@ -12,12 +12,12 @@
 
 import {action} from '@storybook/addon-actions';
 import {Button} from '@react-spectrum/button';
+import {Flex} from '@react-spectrum/layout';
 import {Form} from '@react-spectrum/form';
 import Info from '@spectrum-icons/workflow/Info';
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {TextArea} from '../';
-import {Flex} from "@react-spectrum/layout";
 
 storiesOf('TextArea', module)
   .addParameters({providerSwitcher: {status: 'positive'}})

--- a/packages/@react-spectrum/textfield/stories/TextArea.stories.js
+++ b/packages/@react-spectrum/textfield/stories/TextArea.stories.js
@@ -17,6 +17,7 @@ import Info from '@spectrum-icons/workflow/Info';
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {TextArea} from '../';
+import {Flex} from "@react-spectrum/layout";
 
 storiesOf('TextArea', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -135,7 +136,8 @@ storiesOf('TextArea', module)
   )
   .add('controlled interactive',
     () => <ControlledTextArea />
-  );
+  )
+  .add('in flex', () => renderInFlexRowAndBlock());
 
 function render(props = {}) {
   return (
@@ -157,5 +159,44 @@ function ControlledTextArea(props) {
       <TextArea label="megatron" value={value} onChange={setValue} {...props} isQuiet />
       <Button variant="primary" onPress={() => setValue('decepticons are evil transformers and should be kicked out of earth')}>Set Text</Button>
     </>
+  );
+}
+
+function renderInFlexRowAndBlock(props = {}) {
+  return (
+    <Flex direction="column" gap="size-300">
+      <Flex gap="size-100">
+        <TextArea
+          label="Default"
+          placeholder="React"
+          {...props} />
+        <TextArea
+          label="Quiet"
+          placeholder="React"
+          isQuiet
+          {...props} />
+        <TextArea
+          label="Quiet"
+          placeholder="React"
+          isQuiet
+          {...props} />
+      </Flex>
+      <div>
+        <TextArea
+          label="Default"
+          placeholder="React"
+          {...props} />
+        <TextArea
+          label="Quiet"
+          placeholder="React"
+          isQuiet
+          {...props} />
+        <TextArea
+          label="Quiet"
+          placeholder="React"
+          isQuiet
+          {...props} />
+      </div>
+    </Flex>
   );
 }

--- a/packages/@react-spectrum/textfield/stories/TextArea.stories.js
+++ b/packages/@react-spectrum/textfield/stories/TextArea.stories.js
@@ -165,6 +165,7 @@ function ControlledTextArea(props) {
 function renderInFlexRowAndBlock(props = {}) {
   return (
     <Flex direction="column" gap="size-300">
+      Align stretch
       <Flex gap="size-100">
         <TextArea
           label="Default"
@@ -181,6 +182,24 @@ function renderInFlexRowAndBlock(props = {}) {
           isQuiet
           {...props} />
       </Flex>
+      Align end
+      <Flex gap="size-100" alignItems="end">
+        <TextArea
+          label="Default"
+          placeholder="React"
+          {...props} />
+        <TextArea
+          label="Quiet"
+          placeholder="React"
+          isQuiet
+          {...props} />
+        <TextArea
+          label="Quiet"
+          placeholder="React"
+          isQuiet
+          {...props} />
+      </Flex>
+      Display block
       <div>
         <TextArea
           label="Default"


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
