### PR TITLE
ColorWheel: sync input ChangeEvent and value with state

### DIFF
--- a/packages/@react-aria/color/src/useColorWheel.ts
+++ b/packages/@react-aria/color/src/useColorWheel.ts
@@ -13,7 +13,7 @@
 import {ColorWheelProps} from '@react-types/color';
 import {ColorWheelState} from '@react-stately/color';
 import {focusWithoutScrolling, mergeProps, useGlobalListeners} from '@react-aria/utils';
-import React, {HTMLAttributes, InputHTMLAttributes, RefObject, useCallback, useRef} from 'react';
+import React, {ChangeEvent, HTMLAttributes, InputHTMLAttributes, RefObject, useCallback, useRef} from 'react';
 import {useKeyboard, useMove} from '@react-aria/interactions';
 
 interface ColorWheelAriaProps extends ColorWheelProps {
@@ -209,7 +209,11 @@ export function useColorWheel(props: ColorWheelAriaProps, state: ColorWheelState
       min: '0',
       max: '360',
       step: String(step),
-      disabled: isDisabled
+      disabled: isDisabled,
+      value: `${state.value.getChannelValue('hue')}`,
+      onChange: (e: ChangeEvent<HTMLInputElement>) => {
+        state.setHue(parseFloat(e.target.value));
+      }
     },
     thumbPosition: angleToCartesian(state.value.getChannelValue('hue'), thumbRadius)
   };

--- a/packages/@react-aria/color/test/useColorWheel.test.tsx
+++ b/packages/@react-aria/color/test/useColorWheel.test.tsx
@@ -83,6 +83,7 @@ describe('useColorWheel', () => {
     expect(slider).toHaveAttribute('min', '0');
     expect(slider).toHaveAttribute('max', '360');
     expect(slider).toHaveAttribute('step', '1');
+    expect(slider).toHaveAttribute('value', '0');
   });
 
   it('the slider is focusable', () => {
@@ -132,9 +133,11 @@ describe('useColorWheel', () => {
       fireEvent.keyDown(slider, {key: 'Right'});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 1).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '1');
       fireEvent.keyDown(slider, {key: 'Left'});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 0).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '0');
     });
 
     it('up/down works', () => {
@@ -146,9 +149,11 @@ describe('useColorWheel', () => {
       fireEvent.keyDown(slider, {key: 'Up'});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 1).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '1');
       fireEvent.keyDown(slider, {key: 'Down'});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 0).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '0');
     });
 
     it('doesn\'t work when disabled', () => {
@@ -172,6 +177,7 @@ describe('useColorWheel', () => {
       fireEvent.keyDown(slider, {key: 'Left'});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 359).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '359');
     });
 
     it('respects step', () => {
@@ -183,9 +189,11 @@ describe('useColorWheel', () => {
       fireEvent.keyDown(slider, {key: 'Right'});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 45).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '45');
       fireEvent.keyDown(slider, {key: 'Left'});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 0).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '0');
     });
 
     it('can always get back to 0 even with step', () => {
@@ -197,9 +205,11 @@ describe('useColorWheel', () => {
       fireEvent.keyDown(slider, {key: 'Right'});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 0).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '0');
       fireEvent.keyDown(slider, {key: 'Left'});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 330).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '330');
     });
 
     it('steps with page up/down', () => {
@@ -211,9 +221,11 @@ describe('useColorWheel', () => {
       fireEvent.keyDown(slider, {key: 'PageUp'});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 6).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '6');
       fireEvent.keyDown(slider, {key: 'PageDown'});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 0).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '0');
     });
   });
 
@@ -254,6 +266,7 @@ describe('useColorWheel', () => {
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 90).toString('hsla'));
       expect(document.activeElement).toBe(slider);
+      expect(slider).toHaveAttribute('value', '90');
 
       end(thumb, {pageX: CENTER, pageY: CENTER + THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
@@ -284,8 +297,9 @@ describe('useColorWheel', () => {
 
     it('dragging the thumb respects the step', () => {
       let defaultColor = parseColor('hsl(0, 100%, 50%)');
-      let {getByTestId} = render(<ColorWheel defaultValue={defaultColor} onChange={onChangeSpy} step={120} />);
+      let {getByRole, getByTestId} = render(<ColorWheel defaultValue={defaultColor} onChange={onChangeSpy} step={120} />);
       let thumb = getByTestId('thumb');
+      let slider = getByRole('slider');
       let container = getByTestId('container');
       container.getBoundingClientRect = getBoundingClientRect;
 
@@ -294,6 +308,7 @@ describe('useColorWheel', () => {
       move(thumb, {pageX: CENTER, pageY: CENTER + THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 120).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '120');
       end(thumb, {pageX: CENTER, pageY: CENTER + THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
     });
@@ -310,11 +325,13 @@ describe('useColorWheel', () => {
       start(container, {pageX: CENTER, pageY: CENTER + THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 90).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '90');
       expect(document.activeElement).toBe(slider);
 
       move(thumb, {pageX: CENTER - THUMB_RADIUS, pageY: CENTER});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 180).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '180');
       expect(document.activeElement).toBe(slider);
 
       end(thumb, {pageX: CENTER - THUMB_RADIUS, pageY: CENTER});
@@ -345,17 +362,20 @@ describe('useColorWheel', () => {
 
     it('clicking and dragging on the track respects the step', () => {
       let defaultColor = parseColor('hsl(0, 100%, 50%)');
-      let {getByTestId} = render(<ColorWheel defaultValue={defaultColor} onChange={onChangeSpy} step={120} />);
+      let {getByRole, getByTestId} = render(<ColorWheel defaultValue={defaultColor} onChange={onChangeSpy} step={120} />);
       let thumb = getByTestId('thumb');
+      let slider = getByRole('slider');
       let container = getByTestId('container');
       container.getBoundingClientRect = getBoundingClientRect;
 
       start(container, {pageX: CENTER, pageY: CENTER + THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 120).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '120');
       move(thumb, {pageX: CENTER, pageY: CENTER - THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hsla')).toBe(defaultColor.withChannelValue('hue', 240).toString('hsla'));
+      expect(slider).toHaveAttribute('value', '240');
       end(thumb, {pageX: CENTER, pageY: CENTER - THUMB_RADIUS});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
     });

--- a/packages/@react-spectrum/slider/stories/Slider.stories.tsx
+++ b/packages/@react-spectrum/slider/stories/Slider.stories.tsx
@@ -94,7 +94,7 @@ storiesOf('Slider', module)
   )
   .add(
     'step',
-    () => render({label: 'Label', minValue: 0, maxValue: 100, step: 10})
+    () => render({label: 'Label', minValue: 0, maxValue: 100, step: 5})
   )
   .add(
     'isFilled: true',


### PR DESCRIPTION
So that a screen reader user can change the value with focus on the ColorWheel input we need to keep the input value in sync with the ColorWheel value and handle change events from the input.

Per release testing.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open http://localhost:9003/?path=/story/colorwheel--default
2. Open VoiceOver screen reader on macOS or iOS device.
3. Navigate VoiceOver cursor to set focus to the ColorWheel input.
4. The input value should match the hue value of the ColorWheel.
5. Use increment/decrement gesture on iOS or arrow keys to change the value of the input on macOS.
6. Verify that the value change for the input is announced by VoiceOver and that the ColorWheel thumb updates and repositions to display the new hue value.

## 🧢 Your Project:

Adobe/Accessibility