### PR TITLE
Improve aria labelling of NumberField increment and decrement buttons

### DIFF
--- a/packages/@react-aria/numberfield/intl/ar-AE.json
+++ b/packages/@react-aria/numberfield/intl/ar-AE.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "نقصان",
-  "Increment": "زيادة",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/bg-BG.json
+++ b/packages/@react-aria/numberfield/intl/bg-BG.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Стъпка на намаление",
-  "Increment": "Стъпка на увеличение",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/cs-CZ.json
+++ b/packages/@react-aria/numberfield/intl/cs-CZ.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Snížení",
-  "Increment": "Zvýšení",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/da-DK.json
+++ b/packages/@react-aria/numberfield/intl/da-DK.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Reduktion",
-  "Increment": "Forøgelse",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/de-DE.json
+++ b/packages/@react-aria/numberfield/intl/de-DE.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Verringern",
-  "Increment": "Erhöhen",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/el-GR.json
+++ b/packages/@react-aria/numberfield/intl/el-GR.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Μείωση",
-  "Increment": "Προσαύξηση",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/en-US.json
+++ b/packages/@react-aria/numberfield/intl/en-US.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Decrement",
-  "Increment": "Increment",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/es-ES.json
+++ b/packages/@react-aria/numberfield/intl/es-ES.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Decrecimiento",
-  "Increment": "Incremento",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/et-EE.json
+++ b/packages/@react-aria/numberfield/intl/et-EE.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Vähendamine",
-  "Increment": "Suurendamine",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/fi-FI.json
+++ b/packages/@react-aria/numberfield/intl/fi-FI.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Vähennys",
-  "Increment": "Lisäys",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/fr-FR.json
+++ b/packages/@react-aria/numberfield/intl/fr-FR.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Décrémenter",
-  "Increment": "Incrémenter",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/he-IL.json
+++ b/packages/@react-aria/numberfield/intl/he-IL.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "הפחתה",
-  "Increment": "תוספת",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/hr-HR.json
+++ b/packages/@react-aria/numberfield/intl/hr-HR.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Smanjenje",
-  "Increment": "Povećanje",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/hu-HU.json
+++ b/packages/@react-aria/numberfield/intl/hu-HU.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Csökkentés",
-  "Increment": "Növelés",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/it-IT.json
+++ b/packages/@react-aria/numberfield/intl/it-IT.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Decrementa",
-  "Increment": "Incrementa",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ja-JP.json
+++ b/packages/@react-aria/numberfield/intl/ja-JP.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "減らす",
-  "Increment": "増やす",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ko-KR.json
+++ b/packages/@react-aria/numberfield/intl/ko-KR.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "감소",
-  "Increment": "증가",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/lt-LT.json
+++ b/packages/@react-aria/numberfield/intl/lt-LT.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Sumažėjimas",
-  "Increment": "Padidėjimas",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/lv-LV.json
+++ b/packages/@react-aria/numberfield/intl/lv-LV.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Samazinājums",
-  "Increment": "Palielinājums",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/nb-NO.json
+++ b/packages/@react-aria/numberfield/intl/nb-NO.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Reduser",
-  "Increment": "Øk",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/nl-NL.json
+++ b/packages/@react-aria/numberfield/intl/nl-NL.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Afname",
-  "Increment": "Toename",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/pl-PL.json
+++ b/packages/@react-aria/numberfield/intl/pl-PL.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Dekrementuj",
-  "Increment": "Inkrementuj",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/pt-BR.json
+++ b/packages/@react-aria/numberfield/intl/pt-BR.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Decrementar",
-  "Increment": "Incrementar",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ro-RO.json
+++ b/packages/@react-aria/numberfield/intl/ro-RO.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Amortizare",
-  "Increment": "Creştere",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/ru-RU.json
+++ b/packages/@react-aria/numberfield/intl/ru-RU.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Уменьшить",
-  "Increment": "Увеличить",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sk-SK.json
+++ b/packages/@react-aria/numberfield/intl/sk-SK.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Zníženie",
-  "Increment": "Prírastok",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sl-SI.json
+++ b/packages/@react-aria/numberfield/intl/sl-SI.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Zmanjšanje",
-  "Increment": "Povečanje",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sr-SP.json
+++ b/packages/@react-aria/numberfield/intl/sr-SP.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Smanjenje",
-  "Increment": "Povećanje",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/sv-SE.json
+++ b/packages/@react-aria/numberfield/intl/sv-SE.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Minska",
-  "Increment": "Öka",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/tr-TR.json
+++ b/packages/@react-aria/numberfield/intl/tr-TR.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Azalış",
-  "Increment": "Artış",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/uk-UA.json
+++ b/packages/@react-aria/numberfield/intl/uk-UA.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "Зменшення",
-  "Increment": "Збільшення",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/zh-CN.json
+++ b/packages/@react-aria/numberfield/intl/zh-CN.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "递减",
-  "Increment": "递增",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/intl/zh-TW.json
+++ b/packages/@react-aria/numberfield/intl/zh-TW.json
@@ -1,5 +1,5 @@
 {
-  "Decrement": "減值",
-  "Increment": "增值",
+  "decrease": "Decrease {fieldLabel}",
+  "increase": "Increase {fieldLabel}",
   "Number field": "Number field"
 }

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -58,6 +58,7 @@ function supportsNativeBeforeInputEvent() {
 
 export function useNumberField(props: NumberFieldProps, state: NumberFieldState): NumberFieldAria {
   let {
+    id,
     decrementAriaLabel,
     incrementAriaLabel,
     isDisabled,
@@ -83,7 +84,7 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState)
 
   const formatMessage = useMessageFormatter(intlMessages);
 
-  const inputId = useId();
+  const inputId = useId(id);
 
   let {focusProps} = useFocus({
     onBlur: () => {
@@ -111,44 +112,6 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState)
       textValue: state.inputValue
     }
   );
-
-  let onButtonPressStart = (e) => {
-    // If focus is already on the input, keep it there so we don't hide the
-    // software keyboard when tapping the increment/decrement buttons.
-    if (document.activeElement === inputRef.current) {
-      return;
-    }
-
-    // Otherwise, when using a mouse, move focus to the input.
-    // On touch, or with a screen reader, focus the button so that the software
-    // keyboard does not appear and the screen reader cursor is not moved off the button.
-    if (e.pointerType === 'mouse') {
-      inputRef.current.focus();
-    } else {
-      e.target.focus();
-    }
-  };
-
-  incrementAriaLabel = incrementAriaLabel || formatMessage('Increment');
-  decrementAriaLabel = decrementAriaLabel || formatMessage('Decrement');
-
-  const incrementButtonProps: AriaButtonProps = mergeProps(incButtonProps, {
-    'aria-label': incrementAriaLabel,
-    'aria-controls': inputId,
-    excludeFromTabOrder: true,
-    preventFocusOnPress: true,
-    isDisabled: !state.canIncrement,
-    onPressStart: onButtonPressStart
-  });
-
-  const decrementButtonProps: AriaButtonProps = mergeProps(decButtonProps, {
-    'aria-label': decrementAriaLabel,
-    'aria-controls': inputId,
-    excludeFromTabOrder: true,
-    preventFocusOnPress: true,
-    isDisabled: !state.canDecrement,
-    onPressStart: onButtonPressStart
-  });
 
   let onWheel = useCallback((e) => {
     // If the input isn't supposed to receive input, do nothing.
@@ -347,6 +310,65 @@ export function useNumberField(props: NumberFieldProps, state: NumberFieldState)
       spellCheck: 'false'
     }
   );
+
+  let onButtonPressStart = (e) => {
+    // If focus is already on the input, keep it there so we don't hide the
+    // software keyboard when tapping the increment/decrement buttons.
+    if (document.activeElement === inputRef.current) {
+      return;
+    }
+
+    // Otherwise, when using a mouse, move focus to the input.
+    // On touch, or with a screen reader, focus the button so that the software
+    // keyboard does not appear and the screen reader cursor is not moved off the button.
+    if (e.pointerType === 'mouse') {
+      inputRef.current.focus();
+    } else {
+      e.target.focus();
+    }
+  };
+
+  // Determine the label for the increment and decrement buttons. There are 4 cases:
+  //
+  // 1. With a visible label that is a string: aria-label: `Increase ${props.label}`
+  // 2. With a visible label that is JSX: aria-label: 'Increase', aria-labelledby: '${incrementId} ${labelId}'
+  // 3. With an aria-label: aria-label: `Increase ${props['aria-label']}`
+  // 4. With an aria-labelledby: aria-label: 'Increase', aria-labelledby: `${incrementId} ${props['aria-labelledby']}`
+  //
+  // (1) and (2) could possibly be combined and both use aria-labelledby. However, placing the label in
+  // the aria-label string rather than using aria-labelledby gives more flexibility to translators to change
+  // the order or add additional words around the label if needed.
+  let fieldLabel = props['aria-label'] || (typeof props.label === 'string' ? props.label : '');
+  let ariaLabelledby: string;
+  if (!fieldLabel) {
+    ariaLabelledby = props.label != null ? labelProps.id : props['aria-labelledby'];
+  }
+
+  let incrementId = useId();
+  let decrementId = useId();
+
+  const incrementButtonProps: AriaButtonProps = mergeProps(incButtonProps, {
+    'aria-label': incrementAriaLabel || formatMessage('increase', {fieldLabel}).trim(),
+    id: ariaLabelledby && !incrementAriaLabel ? incrementId : null,
+    'aria-labelledby': ariaLabelledby && !incrementAriaLabel ? `${incrementId} ${ariaLabelledby}` : null,
+    'aria-controls': inputId,
+    excludeFromTabOrder: true,
+    preventFocusOnPress: true,
+    isDisabled: !state.canIncrement,
+    onPressStart: onButtonPressStart
+  });
+
+  const decrementButtonProps: AriaButtonProps = mergeProps(decButtonProps, {
+    'aria-label': decrementAriaLabel || formatMessage('decrease', {fieldLabel}).trim(),
+    id: ariaLabelledby && !decrementAriaLabel ? decrementId : null,
+    'aria-labelledby': ariaLabelledby && !decrementAriaLabel ? `${decrementId} ${ariaLabelledby}` : null,
+    'aria-controls': inputId,
+    excludeFromTabOrder: true,
+    preventFocusOnPress: true,
+    isDisabled: !state.canDecrement,
+    onPressStart: onButtonPressStart
+  });
+
   return {
     numberFieldProps: {
       role: 'group',

--- a/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
@@ -42,19 +42,19 @@ storiesOf('NumberField', module)
   )
   .add(
     'currency',
-    () => render({formatOptions: {style: 'currency', currency: 'EUR'}})
+    () => render({formatOptions: {style: 'currency', currency: 'EUR'}, label: 'Price'})
   )
   .add(
     'percent',
-    () => render({formatOptions: {style: 'percent'}})
+    () => render({formatOptions: {style: 'percent'}, label: 'Tax'})
   )
   .add(
     'percent min = 2 max = 2 fraction digits',
-    () => render({formatOptions: {style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2}})
+    () => render({formatOptions: {style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2}, label: 'Tax'})
   )
   .add(
     'percent min = 2 max = 3 fraction digits',
-    () => render({formatOptions: {style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 3}})
+    () => render({formatOptions: {style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 3}, label: 'Tax'})
   )
   .add(
     'minValue = 0, 0 fraction digits',
@@ -62,7 +62,7 @@ storiesOf('NumberField', module)
   )
   .add(
     'percent using sign',
-    () => render({formatOptions: {style: 'percent', signDisplay: 'always'}})
+    () => render({formatOptions: {style: 'percent', signDisplay: 'always'}, label: 'Tax'})
   )
   .add(
     'disabled',
@@ -154,7 +154,16 @@ storiesOf('NumberField', module)
   )
   .add(
     'no visible label',
-    () => renderNoLabel({isRequired: true, 'aria-label': 'Enter numbers'})
+    () => renderNoLabel({isRequired: true, 'aria-label': 'Width'})
+  )
+  .add(
+    'aria-labelledby',
+    () => (
+      <>
+        <label htmlFor="numberfield" id="label">Width</label>
+        {renderNoLabel({isRequired: true, id: 'numberfield', 'aria-labelledby': 'label'})}
+      </>
+    )
   )
   .add(
     'custom width',
@@ -162,7 +171,7 @@ storiesOf('NumberField', module)
   )
   .add(
     'custom width no visible label',
-    () => renderNoLabel({width: 'size-3000', isRequired: true, 'aria-label': 'Enter numbers'})
+    () => renderNoLabel({width: 'size-3000', isRequired: true, 'aria-label': 'Width'})
   )
   .add(
     'controlled',
@@ -179,7 +188,7 @@ storiesOf('NumberField', module)
 
 function render(props: any = {}) {
   return (
-    <NumberField {...props} onChange={action('onChange')} UNSAFE_className="custom_classname" label="Enter numbers" />
+    <NumberField onChange={action('onChange')} UNSAFE_className="custom_classname" label="Width" {...props} />
   );
 }
 
@@ -202,7 +211,7 @@ function renderSet() {
 
 function NumberFieldControlled(props) {
   let [value, setValue] = useState(10);
-  return <NumberField {...props} formatOptions={{style: 'currency', currency: 'EUR'}} value={value} onChange={chain(setValue, action('onChange'))} label="Enter numbers" />;
+  return <NumberField {...props} formatOptions={{style: 'currency', currency: 'EUR'}} value={value} onChange={chain(setValue, action('onChange'))} label="Price" />;
 }
 
 function NumberFieldWithCurrencySelect(props) {
@@ -212,7 +221,7 @@ function NumberFieldWithCurrencySelect(props) {
   let [currencyDisplay, setCurrencyDisplay] = useState('symbol');
   return (
     <Form>
-      <NumberField label="Monies" {...props} formatOptions={{style: 'currency', currency, currencySign, currencyDisplay}} value={value} onChange={chain(setValue, action('onChange'))} />
+      <NumberField label="Price" {...props} formatOptions={{style: 'currency', currency, currencySign, currencyDisplay}} value={value} onChange={chain(setValue, action('onChange'))} />
       <Picker
         onSelectionChange={item => setCurrency(String(item))}
         label="Choose Currency"

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -1459,10 +1459,123 @@ describe('NumberField', function () {
     expect(textField).toHaveAttribute('aria-required', 'true');
     expect(textField).toHaveAttribute('aria-disabled', 'true');
     expect(textField).not.toHaveAttribute('role');
+    expect(textField).toHaveAttribute('id', 'test-numberfield-id');
 
-    // TODO: check aria-controls
-    expect(incrementButton).toHaveAttribute('aria-label', 'Increment');
-    expect(decrementButton).toHaveAttribute('aria-label', 'Decrement');
+    expect(incrementButton).toHaveAttribute('aria-controls', textField.id);
+    expect(decrementButton).toHaveAttribute('aria-controls', textField.id);
+  });
+
+  describe('labeling', () => {
+    it('string label', () => {
+      let {textField, incrementButton, decrementButton} = renderNumberField({
+        label: 'Width',
+        'aria-label': null
+      });
+
+      expect(textField).toHaveAttribute('aria-labelledby');
+      expect(textField).toHaveAttribute('id');
+
+      let labelId = textField.getAttribute('aria-labelledby');
+      let label = document.getElementById(labelId);
+      expect(label).toHaveTextContent('Width');
+      expect(label).toHaveAttribute('for', textField.id);
+
+      expect(incrementButton).toHaveAttribute('aria-label', 'Increase Width');
+      expect(incrementButton).not.toHaveAttribute('id');
+      expect(incrementButton).not.toHaveAttribute('aria-labelledby');
+      expect(decrementButton).toHaveAttribute('aria-label', 'Decrease Width');
+      expect(decrementButton).not.toHaveAttribute('id');
+      expect(decrementButton).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('aria-label', () => {
+      let {textField, incrementButton, decrementButton} = renderNumberField({
+        'aria-label': 'Width'
+      });
+
+      expect(textField).not.toHaveAttribute('aria-labelledby');
+      expect(textField).toHaveAttribute('aria-label', 'Width');
+
+      expect(incrementButton).toHaveAttribute('aria-label', 'Increase Width');
+      expect(incrementButton).not.toHaveAttribute('id');
+      expect(incrementButton).not.toHaveAttribute('aria-labelledby');
+      expect(decrementButton).toHaveAttribute('aria-label', 'Decrease Width');
+      expect(decrementButton).not.toHaveAttribute('id');
+      expect(decrementButton).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('JSX label', () => {
+      let {textField, incrementButton, decrementButton} = renderNumberField({
+        label: <span>Width</span>,
+        'aria-label': null
+      });
+
+      expect(textField).toHaveAttribute('aria-labelledby');
+      expect(textField).toHaveAttribute('id');
+
+      let labelId = textField.getAttribute('aria-labelledby');
+      let label = document.getElementById(labelId);
+      expect(label).toHaveTextContent('Width');
+      expect(label).toHaveAttribute('for', textField.id);
+
+      expect(incrementButton).toHaveAttribute('aria-label', 'Increase');
+      expect(incrementButton).toHaveAttribute('id');
+      expect(incrementButton).toHaveAttribute('aria-labelledby', `${incrementButton.id} ${labelId}`);
+      expect(decrementButton).toHaveAttribute('aria-label', 'Decrease');
+      expect(decrementButton).toHaveAttribute('id');
+      expect(decrementButton).toHaveAttribute('aria-labelledby', `${decrementButton.id} ${labelId}`);
+    });
+
+    it('aria-labelledby', () => {
+      let {textField, incrementButton, decrementButton} = renderNumberField({
+        'aria-labelledby': 'label-id',
+        'aria-label': null
+      });
+
+      expect(textField).toHaveAttribute('aria-labelledby', 'label-id');
+      expect(textField).toHaveAttribute('id');
+
+      expect(incrementButton).toHaveAttribute('aria-label', 'Increase');
+      expect(incrementButton).toHaveAttribute('id');
+      expect(incrementButton).toHaveAttribute('aria-labelledby', `${incrementButton.id} label-id`);
+      expect(decrementButton).toHaveAttribute('aria-label', 'Decrease');
+      expect(decrementButton).toHaveAttribute('id');
+      expect(decrementButton).toHaveAttribute('aria-labelledby', `${decrementButton.id} label-id`);
+    });
+
+    it('custom incrementAriaLabel', () => {
+      let {textField, incrementButton, decrementButton} = renderNumberField({
+        'aria-label': 'Width',
+        incrementAriaLabel: 'Increment'
+      });
+
+      expect(textField).not.toHaveAttribute('aria-labelledby');
+      expect(textField).toHaveAttribute('aria-label', 'Width');
+
+      expect(incrementButton).toHaveAttribute('aria-label', 'Increment');
+      expect(incrementButton).not.toHaveAttribute('id');
+      expect(incrementButton).not.toHaveAttribute('aria-labelledby');
+      expect(decrementButton).toHaveAttribute('aria-label', 'Decrease Width');
+      expect(decrementButton).not.toHaveAttribute('id');
+      expect(decrementButton).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('custom decrementAriaLabel', () => {
+      let {textField, incrementButton, decrementButton} = renderNumberField({
+        'aria-label': 'Width',
+        decrementAriaLabel: 'Decrement'
+      });
+
+      expect(textField).not.toHaveAttribute('aria-labelledby');
+      expect(textField).toHaveAttribute('aria-label', 'Width');
+
+      expect(incrementButton).toHaveAttribute('aria-label', 'Increase Width');
+      expect(incrementButton).not.toHaveAttribute('id');
+      expect(incrementButton).not.toHaveAttribute('aria-labelledby');
+      expect(decrementButton).toHaveAttribute('aria-label', 'Decrement');
+      expect(decrementButton).not.toHaveAttribute('id');
+      expect(decrementButton).not.toHaveAttribute('aria-labelledby');
+    });
   });
 
   it.each`


### PR DESCRIPTION
Changes the labels to more user friendly terms: increase and decrease, instead of increment and decrement. In addition, adds the field label into the aria-label so that it reads e.g. "Increase width" instead of just "Increase". There are a bunch of possible cases for this to cover all of the possible ways the component could be labelled. See the tests and stories for details.