### PR TITLE
Prevent allowCustomValue ComboBox from removing selected key on blur if inputValue wasn't changed

### DIFF
--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -1463,6 +1463,35 @@ describe('ComboBox', function () {
       expect(() => getByRole('listbox')).toThrow();
     });
 
+    it('retains selected key on blur if input value matches', function () {
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <ComboBox label="Test" allowsCustomValue selectedKey="2" onOpenChange={onOpenChange} onSelectionChange={onSelectionChange}>
+            <Item key="1">Bulbasaur</Item>
+            <Item key="2">Squirtle</Item>
+            <Item key="3">Charmander</Item>
+          </ComboBox>
+        </Provider>
+      );
+
+      let combobox = getByRole('combobox');
+      expect(onSelectionChange).not.toHaveBeenCalled();
+
+      act(() => {
+        userEvent.click(combobox);
+        jest.runAllTimers();
+      });
+
+      expect(document.activeElement).toBe(combobox);
+
+      act(() => {
+        combobox.blur();
+        jest.runAllTimers();
+      });
+
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+
     it('clears the input field if value doesn\'t match a combobox option and no item is focused (menuTrigger=manual case)', function () {
       let {getByRole, getAllByRole} = render(
         <Provider theme={theme}>

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -218,7 +218,10 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateProps<T>)
       }
     } else if (shouldCloseOnBlur) {
       if (allowsCustomValue) {
-        commitCustomValue();
+        let itemText = collection.getItem(selectedKey)?.textValue ?? '';
+        if (inputValue !== itemText) {
+          commitCustomValue();
+        }
       } else {
         resetInputValue();
         // Close menu if blurring away from the combobox

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -217,11 +217,9 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateProps<T>)
         open();
       }
     } else if (shouldCloseOnBlur) {
-      if (allowsCustomValue) {
-        let itemText = collection.getItem(selectedKey)?.textValue ?? '';
-        if (inputValue !== itemText) {
-          commitCustomValue();
-        }
+      let itemText = collection.getItem(selectedKey)?.textValue ?? '';
+      if (allowsCustomValue && inputValue !== itemText) {
+        commitCustomValue();
       } else {
         resetInputValue();
         // Close menu if blurring away from the combobox


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
