### PR TITLE
SearchField & TextArea stories added - custom width small and min-width

### DIFF
--- a/packages/@react-spectrum/searchfield/stories/SearchField.stories.js
+++ b/packages/@react-spectrum/searchfield/stories/SearchField.stories.js
@@ -11,6 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
+import {Flex} from '@react-spectrum/layout';
 import React from 'react';
 import Refresh from '@spectrum-icons/workflow/Refresh';
 import {SearchField} from '../';
@@ -117,6 +118,15 @@ storiesOf('SearchField', module)
   )
   .add('custom width, labelPosition: side',
     () => render({width: 300, labelPosition: 'side'})
+  )
+  .add('custom width and narrow container',
+    () => (
+      <Flex direction="column" width="30px">
+        {render({defaultValue: 'React', validationState: 'valid'})}
+        {render({defaultValue: 'React', width: 30})}
+        {render({defaultValue: 'React', width: 30, validationState: 'valid'})}
+      </Flex>
+    )
   );
 
 function renderSearchLandmark(child) {

--- a/packages/@react-spectrum/textfield/stories/TextArea.stories.js
+++ b/packages/@react-spectrum/textfield/stories/TextArea.stories.js
@@ -120,6 +120,9 @@ storiesOf('TextArea', module)
   .add('custom width',
     () => render({icon: <Info />, validationState: 'invalid', width: '300px'})
   )
+  .add('custom width small',
+    () => render({icon: <Info />, validationState: 'invalid', width: '30px'})
+  )
   .add('custom width, quiet',
     () => render({icon: <Info />, validationState: 'invalid', width: '300px', isQuiet: true})
   )


### PR DESCRIPTION
Closes - no issue
Added a story to see the min-wdith behavior of searchfield with clear icon and validation indicator.
Added a story to see the min-wdith behavior of textarea with clear icon and validation indicator.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

goto storybook
goto searchfield
goto new story about custom width and narrow parent
current you can't see the value of the input field, this is to demonstrate the fixes needed and improve testing

also goto the textarea custom width small story

## 🧢 Your Project:
RSP
