### PR TITLE
Fix color scheme for scrollbars

### DIFF
--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -142,7 +142,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: Provide
     ...styleProps.style,
     // This ensures that browser native UI like scrollbars are rendered in the right color scheme.
     // See https://web.dev/color-scheme/.
-    colorScheme: props.colorScheme ?? Object.keys(theme).filter(k => k === 'light' || k === 'dark').join(' ')
+    colorScheme: props.colorScheme ?? colorScheme ?? Object.keys(theme).filter(k => k === 'light' || k === 'dark').join(' ')
   };
 
   let hasWarned = useRef(false);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1520

Using this structure in an OS dark theme
```
light
  -> light dark
```
Will result in the inner one using the OS for the color-scheme, and not following the parent light setting.
This is in Chrome and Safari.
See issue for more detailed explanation.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
