### PR TITLE
adding custom width support to meter and progressbar

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -26,7 +26,8 @@ governing permissions and limitations under the License.
 .spectrum-BarLoader-track {
   /* Visually apply border radius to child elements */
   overflow: hidden;
-  width: var(--spectrum-barloader-large-width);
+  min-width: var(--spectrum-barloader-large-width);
+  inline-size: 100%;
   height: var(--spectrum-barloader-large-height);
   border-radius: var(--spectrum-barloader-large-border-radius);
   z-index: 1; /* to fix a weird webkit bug with rounded corners and masking */

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -18,7 +18,8 @@ governing permissions and limitations under the License.
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
-  width: var(--spectrum-barloader-large-width);
+  min-width: var(--spectrum-barloader-large-width);
+  inline-size: var(--spectrum-barloader-large-width);
   vertical-align: top;
   isolation: isolate;
 }

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -64,6 +64,7 @@ governing permissions and limitations under the License.
   flex-flow: row;
   justify-content: space-between;
   inline-size: auto;
+  min-width: fit-content;
 
   .spectrum-BarLoader-label {
     margin-inline-end: var(--spectrum-barloader-large-label-gap-x);

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -66,6 +66,10 @@ governing permissions and limitations under the License.
   inline-size: auto;
   min-width: fit-content;
 
+  .spectrum-BarLoader-track {
+    width: auto;
+  }
+
   .spectrum-BarLoader-label {
     margin-inline-end: var(--spectrum-barloader-large-label-gap-x);
     margin-bottom: 0;

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
-  min-inline-size: 48px;
+  min-inline-size: var(--spectrum-global-dimension-static-size-600);
   inline-size: var(--spectrum-barloader-large-width);
   vertical-align: top;
   isolation: isolate;
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
 .spectrum-BarLoader-track {
   /* Visually apply border radius to child elements */
   overflow: hidden;
-  min-inline-size: 48px;
+  min-inline-size: var(--spectrum-global-dimension-static-size-600);
   inline-size: 100%;
   height: var(--spectrum-barloader-large-height);
   border-radius: var(--spectrum-barloader-large-border-radius);
@@ -92,7 +92,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-BarLoader--small {
-  min-inline-size: 48px;
+  min-inline-size: var(--spectrum-global-dimension-static-size-600);
 
   .spectrum-BarLoader-fill {
     height: var(--spectrum-barloader-small-height);

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
-  min-inline-size: var(--spectrum-barloader-large-width);
+  min-inline-size: 48px;
   inline-size: var(--spectrum-barloader-large-width);
   vertical-align: top;
   isolation: isolate;
@@ -26,12 +26,18 @@ governing permissions and limitations under the License.
   &.spectrum-BarLoader--indeterminate {
     max-inline-size: var(--spectrum-barloader-large-width);
   }
+
+  &.spectrum-BarLoader--indeterminate.spectrum-BarLoader--sideLabel {
+    .spectrum-BarLoader-track {
+      max-inline-size: var(--spectrum-barloader-large-width);
+    }
+  }
 }
 
 .spectrum-BarLoader-track {
   /* Visually apply border radius to child elements */
   overflow: hidden;
-  min-inline-size: var(--spectrum-barloader-large-width);
+  min-inline-size: 48px;
   inline-size: 100%;
   height: var(--spectrum-barloader-large-height);
   border-radius: var(--spectrum-barloader-large-border-radius);
@@ -70,7 +76,7 @@ governing permissions and limitations under the License.
   min-inline-size: fit-content;
 
   .spectrum-BarLoader-track {
-    inline-size: auto;
+    inline-size: inherit;
   }
 
   .spectrum-BarLoader-label {
@@ -86,7 +92,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-BarLoader--small {
-  min-inline-size: var(--spectrum-barloader-small-width);
+  min-inline-size: 48px;
 
   .spectrum-BarLoader-fill {
     height: var(--spectrum-barloader-small-height);

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -22,6 +22,10 @@ governing permissions and limitations under the License.
   inline-size: var(--spectrum-barloader-large-width);
   vertical-align: top;
   isolation: isolate;
+
+  &.spectrum-BarLoader--indeterminate {
+    max-width: var(--spectrum-barloader-large-width);
+  }
 }
 
 .spectrum-BarLoader-track {

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -18,20 +18,20 @@ governing permissions and limitations under the License.
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
-  min-width: var(--spectrum-barloader-large-width);
+  min-inline-size: var(--spectrum-barloader-large-width);
   inline-size: var(--spectrum-barloader-large-width);
   vertical-align: top;
   isolation: isolate;
 
   &.spectrum-BarLoader--indeterminate {
-    max-width: var(--spectrum-barloader-large-width);
+    max-inline-size: var(--spectrum-barloader-large-width);
   }
 }
 
 .spectrum-BarLoader-track {
   /* Visually apply border radius to child elements */
   overflow: hidden;
-  min-width: var(--spectrum-barloader-large-width);
+  min-inline-size: var(--spectrum-barloader-large-width);
   inline-size: 100%;
   height: var(--spectrum-barloader-large-height);
   border-radius: var(--spectrum-barloader-large-border-radius);
@@ -67,11 +67,10 @@ governing permissions and limitations under the License.
   display: inline-flex;
   flex-flow: row;
   justify-content: space-between;
-  inline-size: auto;
-  min-width: fit-content;
+  min-inline-size: fit-content;
 
   .spectrum-BarLoader-track {
-    width: auto;
+    inline-size: auto;
   }
 
   .spectrum-BarLoader-label {
@@ -87,7 +86,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-BarLoader--small {
-  min-width: var(--spectrum-barloader-small-width);
+  min-inline-size: var(--spectrum-barloader-small-width);
 
   .spectrum-BarLoader-fill {
     height: var(--spectrum-barloader-small-height);
@@ -99,7 +98,7 @@ governing permissions and limitations under the License.
   }
 }
 .spectrum-BarLoader--indeterminate .spectrum-BarLoader-fill {
-  width: var(--spectrum-barloader-large-indeterminate-fill-width);
+  inline-size: var(--spectrum-barloader-large-indeterminate-fill-width);
   position: relative;
   animation-timing-function: var(--spectrum-barloader-large-indeterminate-animation-ease);
   will-change: transform;

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -30,6 +30,7 @@ governing permissions and limitations under the License.
   &.spectrum-BarLoader--indeterminate.spectrum-BarLoader--sideLabel {
     .spectrum-BarLoader-track {
       max-inline-size: var(--spectrum-barloader-large-width);
+      inline-size: 100%;
     }
   }
 }

--- a/packages/@react-spectrum/meter/stories/Meter.stories.tsx
+++ b/packages/@react-spectrum/meter/stories/Meter.stories.tsx
@@ -117,6 +117,22 @@ storiesOf('Meter', module)
     }
   )
   .add(
+    'parent width 100%',
+    () => (
+      <span style={{width: '100%'}}>
+        {render({value: 32})}
+      </span>
+    )
+  )
+  .add(
+    'width: 300px',
+    () => render({value: 32, width: '300px'})
+  )
+  .add(
+    'width: 300px, labelPosition: side',
+    () => render({value: 32, width: '300px', labelPosition: 'side'})
+  )
+  .add(
     'Using raw values for minValue, maxValue, and value',
     () => render({
       showValueLabel: true,

--- a/packages/@react-spectrum/meter/stories/Meter.stories.tsx
+++ b/packages/@react-spectrum/meter/stories/Meter.stories.tsx
@@ -125,12 +125,28 @@ storiesOf('Meter', module)
     )
   )
   .add(
+    'parent width 100px',
+    () => (
+      <span style={{width: '100px'}}>
+        {render({value: 32})}
+      </span>
+    )
+  )
+  .add(
     'width: 300px',
     () => render({value: 32, width: '300px'})
   )
   .add(
     'width: 300px, labelPosition: side',
     () => render({value: 32, width: '300px', labelPosition: 'side'})
+  )
+  .add(
+    'width: 30px',
+    () => render({value: 32, width: '30px'})
+  )
+  .add(
+    'width: 30px, labelPosition: side',
+    () => render({value: 32, width: '30px', labelPosition: 'side'})
   )
   .add(
     'Using raw values for minValue, maxValue, and value',

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -139,12 +139,28 @@ storiesOf('Progress/ProgressBar', module)
     )
   )
   .add(
+    'parent width 100px',
+    () => (
+      <span style={{width: '100px'}}>
+        {render()}
+      </span>
+    )
+  )
+  .add(
     'width: 300px',
     () => render({width: '300px'})
   )
   .add(
     'width: 300px, labelPosition: side, isIndeterminate: true',
     () => render({width: '300px', labelPosition: 'side', isIndeterminate: true})
+  )
+  .add(
+    'width: 30px',
+    () => render({width: '30px'})
+  )
+  .add(
+    'width: 30px, labelPosition: side, isIndeterminate: true',
+    () => render({width: '30px', labelPosition: 'side', isIndeterminate: true})
   )
   .add(
     'Using raw values for minValue, maxValue, and value',

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -131,6 +131,22 @@ storiesOf('Progress/ProgressBar', module)
     }
   )
   .add(
+    'parent width 100%',
+    () => (
+      <span style={{width: '100%'}}>
+        {render()}
+      </span>
+    )
+  )
+  .add(
+    'width: 300px',
+    () => render({width: '300px'})
+  )
+  .add(
+    'width: 300px, labelPosition: side, isIndeterminate: true',
+    () => render({width: '300px', labelPosition: 'side', isIndeterminate: true})
+  )
+  .add(
     'Using raw values for minValue, maxValue, and value',
     () => render({
       showValueLabel: true,

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -165,6 +165,10 @@ storiesOf('Progress/ProgressBar', module)
     () => render({width: '300px', value: 100})
   )
   .add(
+    'width: 300px, isIndeterminate: true',
+    () => render({width: '300px', isIndeterminate: true})
+  )
+  .add(
     'width: 300px, labelPosition: side',
     () => render({width: '300px', labelPosition: 'side'})
   )

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -109,6 +109,20 @@ storiesOf('Progress/ProgressBar', module)
     }
   )
   .add(
+    'long label',
+    () => {
+      const value = number('Value', 32, sliderOptions);
+      return render({value, label: 'Super long progress bar label. Sample label copy. Loading...'});
+    }
+  )
+  .add(
+    'long label, labelPosition: side',
+    () => {
+      const value = number('Value', 32, sliderOptions);
+      return render({value, labelPosition: 'side', label: 'Super long progress bar label. Sample label copy. Loading...'});
+    }
+  )
+  .add(
     'isIndeterminate: true',
     () => {
       const value = number('Value', 32, sliderOptions);
@@ -148,7 +162,11 @@ storiesOf('Progress/ProgressBar', module)
   )
   .add(
     'width: 300px',
-    () => render({width: '300px'})
+    () => render({width: '300px', value: 100})
+  )
+  .add(
+    'width: 300px, labelPosition: side',
+    () => render({width: '300px', labelPosition: 'side'})
   )
   .add(
     'width: 300px, labelPosition: side, isIndeterminate: true',
@@ -159,8 +177,16 @@ storiesOf('Progress/ProgressBar', module)
     () => render({width: '30px'})
   )
   .add(
-    'width: 30px, labelPosition: side, isIndeterminate: true',
-    () => render({width: '30px', labelPosition: 'side', isIndeterminate: true})
+    'width: 30px, labelPosition: side, long label',
+    () => render({width: '30px', labelPosition: 'side', label: 'Super long progress bar label. Sample label copy. Loading...'})
+  )
+  .add(
+    'width: 30px, labelPosition: side, isIndeterminate: true, long label, button on left',
+    () =>
+    <>
+      {render({width: '30px', labelPosition: 'side', isIndeterminate: true, label: 'Super long progress bar label. Sample label copy. Loading...'})}
+      <button>Confirm</button>
+    </>
   )
   .add(
     'Using raw values for minValue, maxValue, and value',
@@ -183,7 +209,5 @@ storiesOf('Progress/ProgressBar', module)
   );
 
 function render(props: any = {}) {
-  return (
-    <ProgressBar label="Loading…" {...props} />
-  );
+  return (<ProgressBar label="Loading…" {...props} />);
 }

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -189,7 +189,7 @@ storiesOf('Progress/ProgressBar', module)
     () => render({width: '30px', labelPosition: 'side', label: 'Super long progress bar label. Sample label copy. Loading...'})
   )
   .add(
-    'width: 30px, labelPosition: side, isIndeterminate: true, long label, button on left',
+    'width: 30px, labelPosition: side, isIndeterminate: true, long label, button on right',
     () => (
       <>
         {render({width: '30px', labelPosition: 'side', isIndeterminate: true, label: 'Super long progress bar label. Sample label copy. Loading...'})}

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -186,11 +186,12 @@ storiesOf('Progress/ProgressBar', module)
   )
   .add(
     'width: 30px, labelPosition: side, isIndeterminate: true, long label, button on left',
-    () =>
-    <>
-      {render({width: '30px', labelPosition: 'side', isIndeterminate: true, label: 'Super long progress bar label. Sample label copy. Loading...'})}
-      <button>Confirm</button>
-    </>
+    () => (
+      <>
+        {render({width: '30px', labelPosition: 'side', isIndeterminate: true, label: 'Super long progress bar label. Sample label copy. Loading...'})}
+        <button>Confirm</button>
+      </>
+    )
   )
   .add(
     'Using raw values for minValue, maxValue, and value',

--- a/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/progress/stories/ProgressBar.stories.tsx
@@ -181,6 +181,10 @@ storiesOf('Progress/ProgressBar', module)
     () => render({width: '30px'})
   )
   .add(
+    'width: 30px, size: S',
+    () => render({width: '30px', size: 'S'})
+  )
+  .add(
     'width: 30px, labelPosition: side, long label',
     () => render({width: '30px', labelPosition: 'side', label: 'Super long progress bar label. Sample label copy. Loading...'})
   )


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1192

Changed the width to min-width and added inline size.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Goto the meter and/or progress bar stories
Check out the new width stories
Also check the other stories like side labels without width because that was a problem case when making the change.

## 🧢 Your Project:
RSP