### PR TITLE
Allow OverlayContainer to render into a custom portalContainer

### DIFF
--- a/packages/@react-aria/overlays/src/useModal.tsx
+++ b/packages/@react-aria/overlays/src/useModal.tsx
@@ -17,6 +17,11 @@ interface ModalProviderProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode
 }
 
+interface OverlayContainerProps extends ModalProviderProps {
+  /** @default document.body */
+  portalContainer?: HTMLElement
+}
+
 interface ModalContext {
   parent: ModalContext | null,
   modalCount: number,
@@ -113,9 +118,9 @@ export function OverlayProvider(props: ModalProviderProps) {
  * nested modal is opened. Only the top-most modal or overlay should
  * be accessible at once.
  */
-export function OverlayContainer(props: ModalProviderProps): React.ReactPortal {
+export function OverlayContainer({portalContainer = document.body, ...props}: OverlayContainerProps): React.ReactPortal {
   let contents = <OverlayProvider {...props} />;
-  return ReactDOM.createPortal(contents, document.body);
+  return ReactDOM.createPortal(contents, portalContainer);
 }
 
 interface ModalAriaProps extends HTMLAttributes<HTMLElement> {

--- a/packages/@react-aria/overlays/test/useModal.test.js
+++ b/packages/@react-aria/overlays/test/useModal.test.js
@@ -21,7 +21,7 @@ function ModalDOM(props) {
 
 function Modal(props) {
   return (
-    <OverlayContainer data-testid={props.providerId || 'modal-provider'}>
+    <OverlayContainer data-testid={props.providerId || 'modal-provider'} portalContainer={props.portalContainer}>
       <ModalDOM modalId={props.modalId}>{props.children}</ModalDOM>
     </OverlayContainer>
   );
@@ -87,5 +87,26 @@ describe('useModal', function () {
 
     res.rerender(<Example />);
     expect(rootProvider).not.toHaveAttribute('aria-hidden');
+  });
+});
+
+describe('OverlayContainer', () => {
+  it('should be able to render in a custom portalContainer', () => {
+    function Test(props) {
+      return (
+        <OverlayProvider data-testid="root-provider">
+          This is the root provider.
+          {props.showModal &&
+            <Modal portalContainer={document.querySelector('[data-testid="portal-container"]')}>{props.children}</Modal>
+          }
+          <div data-testid="portal-container" />
+        </OverlayProvider>
+      );
+    }
+
+    let {getByTestId, rerender} = render(<Test />);
+    rerender(<Test showModal>This is in portal container.</Test>);
+
+    expect(getByTestId('portal-container').textContent).toBe('This is in portal container.');
   });
 });


### PR DESCRIPTION
It's sometimes useful to render overlays within some inner absolute container that is not `document.body`. You kinda acknowledge such use cases by allowing to configure `watchModals` with a custom `selector`:
https://github.com/adobe/react-spectrum/blob/cca9be14e491fb3050f394be0c48830d9f4dd77f/packages/%40react-aria/aria-modal-polyfill/src/index.ts#L18
So it made sense to me that a similar thing should be supported here as well.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

`yarn test`
