### PR TITLE
Fixing fieldlabel css so only textareas expand to fill available height

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -73,6 +73,9 @@ governing permissions and limitations under the License.
     .spectrum-Field-field {
       /* If the user overrides the width of the field, propagate to the inner component */
       width: 100%;
+    }
+
+    .spectrum-Field-field--multiline {
       flex: 1 1 auto;
     }
   }
@@ -84,9 +87,11 @@ governing permissions and limitations under the License.
     align-items: flex-start;
 
     .spectrum-Field-field {
-      /* If the user overrides the height of the field, propagate to the inner component */
-      height: 100%;
       flex: 1;
+    }
+
+    .spectrum-Field-field--multiline {
+      height: 100%;
     }
   }
 }

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -203,7 +203,6 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
     triggerRef,
     autoFocus,
     style,
-    UNSAFE_className,
     className,
     loadingState,
     isOpen
@@ -247,7 +246,6 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
               'spectrum-InputGroup--invalid': validationState === 'invalid',
               'is-hovered': isHovered
             },
-            UNSAFE_className,
             className
           )
         }>

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -187,7 +187,8 @@ interface ComboBoxInputProps extends SpectrumComboBoxProps<unknown> {
   inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>,
   triggerProps: AriaButtonProps,
   triggerRef: RefObject<FocusableRefValue<HTMLElement>>,
-  style?: React.CSSProperties
+  style?: React.CSSProperties,
+  className?: string
 }
 
 const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInputProps, ref: RefObject<HTMLElement>) {
@@ -203,6 +204,7 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
     autoFocus,
     style,
     UNSAFE_className,
+    className,
     loadingState,
     isOpen
   } = props;
@@ -245,7 +247,8 @@ const ComboBoxInput = React.forwardRef(function ComboBoxInput(props: ComboBoxInp
               'spectrum-InputGroup--invalid': validationState === 'invalid',
               'is-hovered': isHovered
             },
-            UNSAFE_className
+            UNSAFE_className,
+            className
           )
         }>
         <TextFieldBase

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -161,7 +161,13 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
     );
 
     textField = React.cloneElement(textField, mergeProps(textField.props, {
-      className: classNames(labelStyles, 'spectrum-Field-field')
+      className: classNames(
+        labelStyles,
+        'spectrum-Field-field',
+        {
+          'spectrum-Field-field--multiline': multiLine
+        }
+      )
     }));
 
     return (


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
