### PR TITLE
Support custom key in getCollectionNode

### DIFF
--- a/packages/@react-stately/collections/src/CollectionBuilder.ts
+++ b/packages/@react-stately/collections/src/CollectionBuilder.ts
@@ -120,9 +120,15 @@ export class CollectionBuilder<T extends object> {
         let childNode = result.value;
 
         partialNode.index = index;
+
+        let nodeKey = childNode.key;
+        if (!nodeKey) {
+          nodeKey = childNode.element ? null : this.getKey(element as CollectionElement<T>, partialNode, state, parentKey);
+        }
+
         let nodes = this.getFullNode({
           ...childNode,
-          key: childNode.element ? null : this.getKey(element as CollectionElement<T>, partialNode, state, parentKey),
+          key: nodeKey,
           index,
           wrapper: compose(partialNode.wrapper, childNode.wrapper)
         }, this.getChildState(state, childNode), parentKey ? `${parentKey}${element.key}` : element.key, parentNode);


### PR DESCRIPTION
This change makes it possible to use a prop other than `key` in components that implement the `getCollectionNode` method.

The context here is that we're attempting to use `@react-stately/collections` to help us build a new `Select` component (similar to `Picker` in `@react-spectrum` world). However our component interface does not use `key` prop - instead we use a `value` prop like below:

```tsx
<Select label="color">
  <SelectOption value="red" />
  <SelectOption value="orange" />
  <SelectOption value="yellow" />
  <SelectOption value="green" />
  <SelectOption value="blue" />
  <SelectOption value="purple" />
</Select>
```

The flexibility that `getCollectionNode` provides already is **almost** enough, except that it's impossible to customize the value used for the key. https://github.com/adobe/react-spectrum/blob/main/packages/%40react-stately/collections/src/CollectionBuilder.ts#L116 seems to indicate that `getCollectionNode` should return a `PartialNode`, which indicates support for a `key` prop: https://github.com/adobe/react-spectrum/blob/main/packages/%40react-stately/collections/src/types.ts#L18. However, supplying a key prop like below does not work:

```ts
SelectOption.getCollectionNode = function* getCollectionNode(props): Generator<PartialNode<object>> {
  let { value, children } = props;

  let textValue = (typeof children === 'string' ? children : '') || props['aria-label'] || value || '';

  yield {
    type: 'item',
    props,

    // would like the key to equal the value passed into the props
    key: props.value,
    rendered: children || value,
    textValue,
    'aria-label': props['aria-label'],
    hasChildNodes: false,
  };
};
```

The solution (I think, admittedly I'm not terribly familiar with the react-spectrum codebase so I might be missing context here) was to adjust the `getFullNode` logic to prefer the key returned from `getCollectionNode` if not falsey.

With this change we're seeing correct behavior (note the `data-key` prop on the options, etc):

<img width="916" alt="Screen Shot 2021-02-11 at 9 56 57 PM" src="https://user-images.githubusercontent.com/847542/107728680-528fc900-6cb4-11eb-9623-97155a283c57.png">

Versus behavior prior to the change in this PR:

<img width="884" alt="Screen Shot 2021-02-11 at 9 57 28 PM" src="https://user-images.githubusercontent.com/847542/107728698-5cb1c780-6cb4-11eb-8ac4-768a33eb701c.png">

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).

No issue for this that I could find.

- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.

No tests for this area of the code that I could find.

- [ ] Updated documentation (if it already exists for this component).

No documentation for this area of the code that I could find.

- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

NA
