### PR TITLE
support disallowEmptySelection with useSelect()

### DIFF
--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -39,9 +39,9 @@ export function useSingleSelectListState<T extends object>(props: SingleSelectLi
   let [selectedKey, setSelectedKey] = useControlledState(props.selectedKey, props.defaultSelectedKey ?? null, props.onSelectionChange);
   let selectedKeys = useMemo(() => selectedKey != null ? [selectedKey] : [], [selectedKey]);
   let {collection, disabledKeys, selectionManager} = useListState({
+    disallowEmptySelection: true,
     ...props,
     selectionMode: 'single',
-    disallowEmptySelection: true,
     selectedKeys,
     onSelectionChange: (keys: Set<Key>) => {
       let key = keys.values().next().value;


### PR DESCRIPTION
If the value a `Select/Picker` component represents is optional, the end user should be able to select it again to toggle it off.

The way `useSingleSelectListState` is currently setup, one cannot actually configure the `disallowEmptySelection` prop. This PR just moves the `disallowEmptySelection` higher up in the spread so that it acts as a default but still can be set to false when desired.

## ✅ Pull Request Checklist:

Not sure any of the below are relevant to this rather small adjustment.

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)