### PR TITLE
Fix numberfield css specificity collision

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/inputgroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/inputgroup/index.css
@@ -15,7 +15,6 @@ governing permissions and limitations under the License.
 :root {
   /* Todo: move to DNA */
   --spectrum-combobox-quiet-fieldbutton-border-radius: 0;
-  --spectrum-combobox-field-border-width-right: 0;
   --spectrum-combobox-quiet-fieldbutton-padding-right: 0;
   --spectrum-combobox-quiet-fieldbutton-padding-left: var(--spectrum-global-dimension-size-130);
   --spectrum-combobox-validation-icon-right: var(--spectrum-global-dimension-size-100);
@@ -71,7 +70,7 @@ governing permissions and limitations under the License.
 .spectrum-InputGroup-input {
   border-start-end-radius: var(--spectrum-combobox-textfield-border-top-right-radius);
   border-end-end-radius: var(--spectrum-combobox-textfield-border-bottom-right-radius);
-  border-inline-end: var(--spectrum-combobox-field-border-width-right);
+  border-inline-end-style: none;
 }
 
 .spectrum-InputGroup--quiet {

--- a/packages/@adobe/spectrum-css-temp/components/stepper/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/stepper/index.css
@@ -25,7 +25,8 @@ governing permissions and limitations under the License.
   --spectrum-stepper-default-width-mobile: calc(var(--spectrum-component-single-line-height) * 5);
 }
 
-.spectrum-Stepper {
+/* increase specificity to not collide with InputGroup */
+.spectrum-Stepper.spectrum-Stepper {
   display: inline-grid;
   grid-template-rows: auto auto;
   grid-template-columns: 1fr auto;
@@ -38,7 +39,9 @@ governing permissions and limitations under the License.
   line-height: 0;
   border-radius: var(--spectrum-border-radius);
   transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out, box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
+}
 
+.spectrum-Stepper {
   &:not(.spectrum-Stepper--quiet):not(.spectrum-Stepper--showStepper) {
     .spectrum-Stepper-input {
       border-inline-end-width: var(--spectrum-stepper-border-size-default);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
