### PR TITLE
ColorField docs page and more stories

### DIFF
--- a/packages/@react-spectrum/color/docs/ColorField.mdx
+++ b/packages/@react-spectrum/color/docs/ColorField.mdx
@@ -105,21 +105,21 @@ zero or the current value. A `step` can be set to any positive decimal, defaulti
 
 ## Validation
 
-NumberFields can display a validation state to communicate to the user whether the current value is valid or invalid.
-Implement your own validation logic in your app and pass either `"valid"` or `"invalid"` to the NumberField via the `validationState` prop.
+ColorField can display a validation state to communicate to the user whether the current value is valid or invalid.
+Implement your own validation logic in your app and pass either `"valid"` or `"invalid"` to the ColorField via the `validationState` prop.
 
 The example below illustrates how one would validate if the user has entered a red color.
 ```tsx example
 function Example() {
   let [value, setValue] = React.useState('#e73623');
   let isValid = React.useMemo(() => {
-    if (value.length === 7) {
+    if (value && value.length === 7) {
       let red = parseInt(value.substr(1,2), 16);
       let green = parseInt(value.substr(3,2), 16);
       let blue = parseInt(value.substr(5,2), 16);
       return red > green && red > blue;
     }
-    return value.red && value.red > value.green && value.red > value.blue;
+    return value && value.red && value.red > value.green && value.red > value.blue;
   }, [value]);
 
   return (
@@ -163,9 +163,9 @@ and the contents can still be copied. See [the MDN docs](https://developer.mozil
 ### Label alignment and position
 [View guidelines](https://spectrum.adobe.com/page/text-field/#Label-position)
 
-By default, the label is positioned above the NumberField. The `labelPosition` prop can be used to position the label to the side.
+By default, the label is positioned above the ColorField. The `labelPosition` prop can be used to position the label to the side.
 The `labelAlign` prop can be used to align the label as "start" or "end". For left-to-right (LTR) languages, "start" refers to the
-left most edge of the NumberField and "end" refers to the right most edge. For right-to-left (RTL) languages, this is flipped.
+left most edge of the ColorField and "end" refers to the right most edge. For right-to-left (RTL) languages, this is flipped.
 
 ```tsx example
 <ColorField label="Primary Color" labelPosition="side" labelAlign="end" />

--- a/packages/@react-spectrum/color/docs/ColorField.mdx
+++ b/packages/@react-spectrum/color/docs/ColorField.mdx
@@ -1,0 +1,150 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-spectrum/color';
+import {HeaderInfo, PropTable} from '@react-spectrum/docs';
+import packageData from '@react-spectrum/color/package.json';
+
+```jsx import
+import {ColorField} from '@react-spectrum/color';
+import {Flex} from '@react-spectrum/layout';
+```
+
+---
+category: Color
+keywords: [color field, input]
+---
+
+# ColorField
+
+<p>{docs.exports.ColorField.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['ColorField']}
+  sourceData={[]} />
+
+## Example
+
+```tsx example
+<ColorField label="Primary Color" />
+```
+
+## Value
+
+A ColorField's `value` is empty by default, but an initial, uncontrolled, value can be provided using the `defaultValue` prop.
+Alternatively, a controlled value can be provided using the `value` prop. These values must begin with a `#`.
+
+```tsx example
+function Example() {
+  let [value, setValue] = React.useState('#e73623');
+
+  return (
+    <Flex gap="size-150" wrap>
+      <ColorField
+        label="Primary Color (Uncontrolled)"
+        defaultValue="#e73623" />
+
+      <ColorField
+        label="Primary Color (Controlled)"
+        value={value}
+        onChange={setValue} />
+    </Flex>
+  );
+}
+```
+
+Placeholder text, provided using the placeholder prop, describes the expected value or formatting for the ColorField.
+Placeholder text will only appear when the ColorField is empty, and should not be used as a substitute for labeling the
+component with a visible label.
+
+<ColorField placeholder="#e73623" label="Primary Color" />
+
+## Labeling
+
+A visual label should be provided for the ColorField using the `label` prop. If the ColorField is required, the `isRequired` and
+`necessityIndicator` props can be used to show a required state.
+
+```tsx example
+<Flex gap="size-150" wrap>
+  <ColorField label="Primary Color" />
+  <ColorField label="Primary Color" isRequired />
+  <ColorField label="Primary Color" isRequired necessityIndicator="label" />
+  <ColorField label="Primary Color" necessityIndicator="label" />
+</Flex>
+```
+
+### Accessibility
+
+If a visible label isn't specified, an `aria-label` must be provided to the ColorField for
+accessibility. If the field is labeled by a separate element, an `aria-labelledby` prop must be provided using
+the `id` of the labeling element instead.
+
+### Internationalization
+
+In order to internationalize a ColorField, a localized string should be passed to the `label` or `aria-label` prop.
+When the `necessityIndicator` prop is set to `"label"`, a localized string will be provided for `"(required)"` or `"(optional)"` automatically.
+
+## Step values
+
+The `step` prop can be used to snap the value to certain increments, default is one. The steps are calculated starting from
+zero or the current value. A `step` can be any positive decimal.
+
+```tsx example
+<NumberField label="Primary Color" step={16} />
+```
+
+## Props
+
+<PropTable component={docs.exports.ColorField} links={docs.links} />
+
+## Visual options
+
+### Quiet
+
+```tsx example
+<ColorField label="Primary Color" isQuiet />
+```
+
+### Disabled
+
+```tsx example
+<ColorField label="Primary Color" isDisabled defaultValue="#e73623" />
+```
+
+### Read only
+
+The `isReadOnly` boolean prop makes the ColorField's text content immutable. Unlike `isDisabled` the ColorField remains focusable
+and the contents can still be copied. See [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly) for more information.
+
+```tsx example
+<ColorField label="Primary Color" isReadOnly defaultValue="#e73623" />
+```
+
+### Label alignment and position
+[View guidelines](https://spectrum.adobe.com/page/text-field/#Label-position)
+
+By default, the label is positioned above the NumberField. The `labelPosition` prop can be used to position the label to the side.
+The `labelAlign` prop can be used to align the label as "start" or "end". For left-to-right (LTR) languages, "start" refers to the
+left most edge of the NumberField and "end" refers to the right most edge. For right-to-left (RTL) languages, this is flipped.
+
+```tsx example
+<ColorField label="Primary Color" labelPosition="side" labelAlign="end" />
+```
+
+### Custom width
+
+[View guidelines](https://spectrum.adobe.com/page/text-field/#Width)
+
+```tsx example
+<ColorField label="Primary Color" width="size-3600" maxWidth="100%" />
+```

--- a/packages/@react-spectrum/color/docs/ColorField.mdx
+++ b/packages/@react-spectrum/color/docs/ColorField.mdx
@@ -11,8 +11,9 @@ import {Layout} from '@react-spectrum/docs';
 export default Layout;
 
 import docs from 'docs:@react-spectrum/color';
-import {HeaderInfo, PropTable} from '@react-spectrum/docs';
+import {HeaderInfo, PropTable, TypeLink} from '@react-spectrum/docs';
 import packageData from '@react-spectrum/color/package.json';
+import statelyDocs from 'docs:@react-stately/color';
 
 ```jsx import
 import {ColorField} from '@react-spectrum/color';
@@ -43,10 +44,14 @@ keywords: [color field, input]
 
 A ColorField's `value` is empty by default, but an initial, uncontrolled, value can be provided using the `defaultValue` prop.
 Alternatively, a controlled value can be provided using the `value` prop. Valid values are hexadecimal color codes.
+The <TypeLink links={statelyDocs.links} type={statelyDocs.exports.parseColor} /> function is used to parse the initial color
+from a hex value, stored in state.
 
 ```tsx example
+import {parseColor} from '@react-stately/color';
+
 function Example() {
-  let [value, setValue] = React.useState('#e73623');
+  let [value, setValue] = React.useState(parseColor('#e73623'));
 
   return (
     <Flex gap="size-150" wrap>
@@ -108,17 +113,14 @@ zero or the current value. A `step` can be set to any positive decimal, defaulti
 ColorField can display a validation state to communicate to the user whether the current value is valid or invalid.
 Implement your own validation logic in your app and pass either `"valid"` or `"invalid"` to the ColorField via the `validationState` prop.
 
-The example below illustrates how one would validate if the user has entered a red color.
+The example below illustrates how one would validate if the user has entered a red color. In it,
+the <TypeLink links={statelyDocs.links} type={statelyDocs.exports.parseColor} /> function is used to parse the
+initial color from a hexadecimal string so that `value`'s type remains consistent.
+
 ```tsx example
 function Example() {
-  let [value, setValue] = React.useState('#e73623');
+  let [value, setValue] = React.useState(parseColor('#e73623'));
   let isValid = React.useMemo(() => {
-    if (value && value.length === 7) {
-      let red = parseInt(value.substr(1,2), 16);
-      let green = parseInt(value.substr(3,2), 16);
-      let blue = parseInt(value.substr(5,2), 16);
-      return red > green && red > blue;
-    }
     return value && value.red && value.red > value.green && value.red > value.blue;
   }, [value]);
 

--- a/packages/@react-spectrum/color/docs/ColorField.mdx
+++ b/packages/@react-spectrum/color/docs/ColorField.mdx
@@ -68,12 +68,6 @@ function Example() {
 }
 ```
 
-Placeholder text, provided using the `placeholder` prop, describes the expected value or formatting for the ColorField.
-Placeholder text will only appear when the ColorField is empty, and should not be used as a substitute for labeling the
-component with a visible label.
-
-<ColorField placeholder="#e73623" label="Primary Color" />
-
 ## Labeling
 
 A visual label should be provided for the ColorField using the `label` prop. If the ColorField is required, the `isRequired` and
@@ -101,8 +95,9 @@ When the `necessityIndicator` prop is set to `"label"`, a localized string will 
 
 ## Step values
 
-The `step` prop can be used to snap the value to certain increments. The steps are calculated starting from
-zero or the current value. A `step` can be set to any positive decimal, defaulting to `1` if unspecified.
+The `step` prop can be used to increment or decrement the current `value` using up or down arrow keys. These increments
+are calculated from the current `value` or zero if the `value` is empty. A `step` can be set to any positive decimal,
+defaulting to `1` if unspecified.
 
 ```tsx example
 <ColorField label="Primary Color" step={16} />

--- a/packages/@react-spectrum/color/docs/ColorField.mdx
+++ b/packages/@react-spectrum/color/docs/ColorField.mdx
@@ -42,7 +42,7 @@ keywords: [color field, input]
 ## Value
 
 A ColorField's `value` is empty by default, but an initial, uncontrolled, value can be provided using the `defaultValue` prop.
-Alternatively, a controlled value can be provided using the `value` prop. These values must begin with a `#`.
+Alternatively, a controlled value can be provided using the `value` prop. Valid values are hexadecimal color codes.
 
 ```tsx example
 function Example() {
@@ -52,7 +52,7 @@ function Example() {
     <Flex gap="size-150" wrap>
       <ColorField
         label="Primary Color (Uncontrolled)"
-        defaultValue="#e73623" />
+        defaultValue="#e21" />
 
       <ColorField
         label="Primary Color (Controlled)"
@@ -63,7 +63,7 @@ function Example() {
 }
 ```
 
-Placeholder text, provided using the placeholder prop, describes the expected value or formatting for the ColorField.
+Placeholder text, provided using the `placeholder` prop, describes the expected value or formatting for the ColorField.
 Placeholder text will only appear when the ColorField is empty, and should not be used as a substitute for labeling the
 component with a visible label.
 
@@ -96,11 +96,41 @@ When the `necessityIndicator` prop is set to `"label"`, a localized string will 
 
 ## Step values
 
-The `step` prop can be used to snap the value to certain increments, default is one. The steps are calculated starting from
-zero or the current value. A `step` can be any positive decimal.
+The `step` prop can be used to snap the value to certain increments. The steps are calculated starting from
+zero or the current value. A `step` can be set to any positive decimal, defaulting to `1` if unspecified.
 
 ```tsx example
-<NumberField label="Primary Color" step={16} />
+<ColorField label="Primary Color" step={16} />
+```
+
+## Validation
+
+NumberFields can display a validation state to communicate to the user whether the current value is valid or invalid.
+Implement your own validation logic in your app and pass either `"valid"` or `"invalid"` to the NumberField via the `validationState` prop.
+
+The example below illustrates how one would validate if the user has entered a red color.
+```tsx example
+function Example() {
+  let [value, setValue] = React.useState('#e73623');
+  let isValid = React.useMemo(() => {
+    if (value.length === 7) {
+      let red = parseInt(value.substr(1,2), 16);
+      let green = parseInt(value.substr(3,2), 16);
+      let blue = parseInt(value.substr(5,2), 16);
+      return red > green && red > blue;
+    }
+    return value.red && value.red > value.green && value.red > value.blue;
+  }, [value]);
+
+  return (
+    <ColorField
+      validationState={isValid ? 'valid' : 'invalid'}
+      value={value}
+      onChange={setValue}
+      label="Red colors"
+    />
+  );
+}
 ```
 
 ## Props

--- a/packages/@react-spectrum/color/src/ColorField.tsx
+++ b/packages/@react-spectrum/color/src/ColorField.tsx
@@ -44,5 +44,8 @@ function ColorField(props: SpectrumColorFieldProps, ref: RefObject<TextFieldRef>
   );
 }
 
+/**
+ * ColorFields allow users to enter a color in #rrggbb hexadecimal format.
+ */
 const _ColorField = React.forwardRef(ColorField);
 export {_ColorField as ColorField};

--- a/packages/@react-spectrum/color/stories/ColorField.stories.tsx
+++ b/packages/@react-spectrum/color/stories/ColorField.stories.tsx
@@ -50,6 +50,16 @@ storiesOf('ColorField', module)
     () => render({validationState: 'invalid'})
   )
   .add(
+    'required, label, optional',
+    () => (
+      <Flex direction="column" gap="size-100">
+        {render({isRequired: 'true'})}
+        {render({isRequired: 'true', necessityIndicator: 'label'})}
+        {render({necessityIndicator: 'label'})}
+      </Flex>
+    )
+  )
+  .add(
     'with placeholder',
     () => render({placeholder: 'Enter a hex color'})
   )
@@ -68,6 +78,50 @@ storiesOf('ColorField', module)
   .add(
     'autofocus',
     () => render({autoFocus: true})
+  )
+  .add(
+    'placeholder',
+    () => render({placeholder: '#e73623'})
+  )
+  .add(
+    'label side',
+    () => render({labelPosition: 'side'})
+  )
+  .add(
+    'no visible label',
+    () => renderNoLabel({isRequired: true, 'aria-label': 'Primary Color'})
+  )
+  .add(
+    'aria-labelledby',
+    () => (
+      <>
+        <label htmlFor="colorfield" id="label">Primary Color</label>
+        {renderNoLabel({isRequired: true, id: 'colorfield', 'aria-labelledby': 'label'})}
+      </>
+    )
+  )
+  .add(
+    'custom width',
+    () => render({width: 'size-3000'})
+  )
+  .add(
+    'custom width no visible label',
+    () => renderNoLabel({width: 'size-3000', isRequired: true, 'aria-label': 'Primary Color'})
+  )
+  .add(
+    'custom width, labelPosition=side',
+    () => render({width: 'size-3000', labelPosition: 'side'})
+  )
+  .add(
+    'custom width, 10px for min-width',
+    () => (
+      <Flex direction="column" gap="size-100">
+        {render({width: '10px'})}
+        <div style={{width: '10px'}}>
+          {render()}
+        </div>
+      </Flex>
+    )
   );
 
 function ControlledColorField(props: any = {}) {
@@ -102,5 +156,11 @@ function render(props: any = {}) {
       label="Primary Color"
       onChange={action('change')}
       {...props} />
+  );
+}
+
+function renderNoLabel(props: any = {}) {
+  return (
+    <ColorField {...props} onChange={action('onChange')} />
   );
 }

--- a/packages/@react-types/color/src/index.d.ts
+++ b/packages/@react-types/color/src/index.d.ts
@@ -89,6 +89,7 @@ export interface ColorFieldProps extends ValueBase<string | Color>, InputBase, V
 export interface AriaColorFieldProps extends ColorFieldProps, AriaLabelingProps, FocusableDOMProps, Omit<TextInputDOMProps, 'minLength' | 'maxLength' | 'pattern' | 'type' | 'inputMode' | 'autoComplete'>, AriaValidationProps {}
 
 export interface SpectrumColorFieldProps extends AriaColorFieldProps, SpectrumLabelableProps, StyleProps {
+  /** Whether the ColorField should be displayed with a quiet style. */
   isQuiet?: boolean
 }
 

--- a/packages/@react-types/textfield/src/index.d.ts
+++ b/packages/@react-types/textfield/src/index.d.ts
@@ -43,9 +43,9 @@ export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, F
 }
 
 export interface SpectrumTextFieldProps extends AriaTextFieldProps, SpectrumLabelableProps, StyleProps {
-  /** An icon to display at the start of the textfield. */
+  /** An icon to display at the start of the input. */
   icon?: ReactElement,
-  /** Whether the textfield should be displayed with a quiet style. */
+  /** Whether the input should be displayed with a quiet style. */
   isQuiet?: boolean
 }
 


### PR DESCRIPTION
Closes #1606 

Adding a docs page for ColorField within the color package.
Adding some stories to test the full functionality like width, necessity indicator, etc.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test the new stories
Review the new docs page

## 🧢 Your Project:
RSP