### PR TITLE
Preventing form submission on Enter if combobox menu is open

### DIFF
--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -102,6 +102,11 @@ export function useComboBox<T>(props: AriaComboBoxProps<T>, state: ComboBoxState
     switch (e.key) {
       case 'Enter':
       case 'Tab':
+        // Prevent form submission if menu is open since we may be selecting a option
+        if (state.isOpen && e.key === 'Enter') {
+          e.preventDefault();
+        }
+
         state.commit();
         break;
       case 'Escape':


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1646

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
