### PR TITLE
Removing broken Item Spectrum link from Menu docs

### DIFF
--- a/packages/@react-spectrum/menu/docs/Menu.mdx
+++ b/packages/@react-spectrum/menu/docs/Menu.mdx
@@ -254,8 +254,6 @@ Sections without a `title` must provide an `aria-label` for accessibility.
 
 Items within Menu also allow for additional content used to better communicate options. Icons and descriptions can be added to the `children` of `Item` as shown in the example below. If a description is added, the prop `slot="description"` must be used to distinguish the different `<Text>` elements.
 
-[View guidelines](https://spectrum.adobe.com/page/popovers/#Content-types)
-
 ```tsx example
 import {Keyboard, Text} from '@react-spectrum/text';
 <MenuTrigger>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1555
Docs for Items will be handled separately

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
