### PR TITLE
Documentation: Collapsed Tab is cutoff by container in docs

### DIFF
--- a/packages/@react-spectrum/tabs/docs/Tabs.mdx
+++ b/packages/@react-spectrum/tabs/docs/Tabs.mdx
@@ -342,7 +342,7 @@ function Example() {
 
   return (
     <>
-      <div style={{width: collapse ? '100px' : '300px', marginBottom: '50px', height: '150px', maxWidth: '100%'}}>
+      <div style={{width: collapse ? '150px' : '300px', marginBottom: '50px', height: '150px', maxWidth: '100%'}}>
         <Tabs aria-label="Chat log collapse example">
           <Item title="John Doe" key="item1">
             <Content marginTop="size-250" marginStart="size-125">


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1595

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
- This is just a visual issue. 
- Check **Collapse (overflow behavior)** of `react-spectrum/Tabs.html`

![image](https://user-images.githubusercontent.com/46433895/109959011-3cf94680-7d2a-11eb-95fa-2ff0c730c17e.png)


## 🧢 Your Project:

<!--- Company/project for pull request -->
