### PR TITLE
Picker within a `<form>` submits the first option by default

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -103,7 +103,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         <label>
           {label}
           <select {...selectProps}>
-            <option hidden disabled />
+            <option />
             {[...state.collection.getKeys()].map(key => {
               let item = state.collection.getItem(key);
               if (item.type === 'item') {

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -103,6 +103,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         <label>
           {label}
           <select {...selectProps}>
+            <option hidden disabled />
             {[...state.collection.getKeys()].map(key => {
               let item = state.collection.getItem(key);
               if (item.type === 'item') {

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1584,7 +1584,7 @@ describe('Picker', function () {
       expect(picker).toHaveTextContent('Select an option…');
       fireEvent.keyDown(picker, {key: 'ArrowLeft'});
       act(() => jest.runAllTimers());
-
+      
       expect(onSelectionChange).toHaveBeenCalledTimes(1);
       expect(picker).toHaveTextContent('One');
 

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -2066,7 +2066,7 @@ describe('Picker', function () {
       fireEvent.submit(getByTestId('form'));
       expect(onSubmit).toHaveBeenCalledTimes(1);
       expect(value).toEqual('');
-    })
+    });
 
     it('Should submit default option', function () {
       let value;
@@ -2092,6 +2092,6 @@ describe('Picker', function () {
       fireEvent.submit(getByTestId('form'));
       expect(onSubmit).toHaveBeenCalledTimes(1);
       expect(value).toEqual('one');
-    })
-  })
+    });
+  });
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1584,7 +1584,7 @@ describe('Picker', function () {
       expect(picker).toHaveTextContent('Select an option…');
       fireEvent.keyDown(picker, {key: 'ArrowLeft'});
       act(() => jest.runAllTimers());
-      
+
       expect(onSelectionChange).toHaveBeenCalledTimes(1);
       expect(picker).toHaveTextContent('One');
 
@@ -1733,10 +1733,11 @@ describe('Picker', function () {
       expect(hiddenSelect).toHaveAttribute('tabIndex', '-1');
 
       let options = within(hiddenSelect).getAllByRole('option', {hidden: true});
-      expect(options.length).toBe(3);
-      expect(options[0]).toHaveTextContent('One');
-      expect(options[1]).toHaveTextContent('Two');
-      expect(options[2]).toHaveTextContent('Three');
+      expect(options.length).toBe(4);
+      expect(options[0]).toHaveTextContent('');
+      expect(options[1]).toHaveTextContent('One');
+      expect(options[2]).toHaveTextContent('Two');
+      expect(options[3]).toHaveTextContent('Three');
 
       fireEvent.change(hiddenSelect, {target: {value: 'two'}});
       expect(onSelectionChange).toHaveBeenCalledTimes(1);
@@ -2039,4 +2040,32 @@ describe('Picker', function () {
       expect(otherButtonFocus).not.toHaveBeenCalled();
     });
   });
+
+  describe('form', function () {
+    it('Should submit empty option by default', function () {
+      let value;
+      let onSubmit = jest.fn(e => {
+        e.preventDefault();
+        let formData = new FormData(e.currentTarget);
+        value = Object.fromEntries(formData).picker;
+      });
+      let {getByTestId} = render(
+        <Provider theme={theme}>
+          <form data-testid="form" onSubmit={onSubmit}>
+            <Picker name="picker" label="Test" autoFocus>
+              <Item key="one">One</Item>
+              <Item key="two">Two</Item>
+              <Item key="three">Three</Item>
+            </Picker>
+            <button type="submit" data-testid="submit">
+              submit
+            </button>
+          </form>
+        </Provider>
+      );
+      fireEvent.submit(getByTestId('form'));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(value).toEqual('');
+    })
+  })
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -2067,5 +2067,31 @@ describe('Picker', function () {
       expect(onSubmit).toHaveBeenCalledTimes(1);
       expect(value).toEqual('');
     })
+
+    it('Should submit default option', function () {
+      let value;
+      let onSubmit = jest.fn(e => {
+        e.preventDefault();
+        let formData = new FormData(e.currentTarget);
+        value = Object.fromEntries(formData).picker;
+      });
+      let {getByTestId} = render(
+        <Provider theme={theme}>
+          <form data-testid="form" onSubmit={onSubmit}>
+            <Picker defaultSelectedKey="one" name="picker" label="Test" autoFocus>
+              <Item key="one">One</Item>
+              <Item key="two">Two</Item>
+              <Item key="three">Three</Item>
+            </Picker>
+            <button type="submit" data-testid="submit">
+              submit
+            </button>
+          </form>
+        </Provider>
+      );
+      fireEvent.submit(getByTestId('form'));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(value).toEqual('one');
+    })
   })
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1634

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
- context: https://github.com/adobe/react-spectrum/discussions/1626
- `yarn test packages/@react-spectrum/picker/test/Picker.test.js`

## 🧢 Your Project:

<!--- Company/project for pull request -->
