### PR TITLE
Return revert function from watchModals

### DIFF
--- a/packages/@react-aria/aria-modal-polyfill/src/index.ts
+++ b/packages/@react-aria/aria-modal-polyfill/src/index.ts
@@ -12,12 +12,14 @@
 
 import {hideOthers} from 'aria-hidden';
 
+type Revert = () => void;
+
 /**
  * Acts as a polyfill for `aria-modal` by watching for added modals and hiding any surrounding DOM elements with `aria-hidden`.
  */
-export function watchModals(selector:string = 'body'): void {
+export function watchModals(selector:string = 'body'): Revert {
   /**
-   * Listen for additions to the child list of body. This is where providers render modal portals.
+   * Listen for additions to the child list of the selected element (defaults to body). This is where providers render modal portals.
    * When one is added, see if there is a modal inside it, if there is, then hide everything else from screen readers.
    * If there was already a modal open and a new one was added, undo everything that the previous modal had hidden and hide based on the new one.
    *
@@ -27,7 +29,7 @@ export function watchModals(selector:string = 'body'): void {
   let target = document.querySelector(selector);
   let config = {childList: true};
   let modalContainers = [];
-  let undo;
+  let undo: Revert | undefined;
 
   let observer = new MutationObserver((mutationRecord) => {
     for (let mutation of mutationRecord) {
@@ -36,9 +38,7 @@ export function watchModals(selector:string = 'body'): void {
         if (addNode) {
           modalContainers.push(addNode);
           let modal = addNode.querySelector('[aria-modal="true"], [data-ismodal]') as HTMLElement;
-          if (undo) {
-            undo();
-          }
+          undo?.();
           undo = hideOthers(modal);
         }
       } else if (mutation.type === 'childList' && mutation.removedNodes.length > 0) {
@@ -58,4 +58,8 @@ export function watchModals(selector:string = 'body'): void {
     }
   });
   observer.observe(target, config);
+  return () => {
+    undo?.();
+    observer.disconnect();
+  };
 }


### PR DESCRIPTION
I need this as I have a modal container that is dynamically rendered.

I'm a little bit confused by this:
1. this kind of feature is not the core functionality of modals/overlays right now. The only thing that happens in relation to `aria-hidden` there is that it is being set on the ModalProvider [here](https://github.com/adobe/react-spectrum/blob/f55249bf75b6fd43fa90b9bece035d1b0af69854/packages/%40react-aria/overlays/src/useModal.tsx#L80). This is somewhat OK as this is usually wrapping the root of the application. However, I think that this is not uncommon to have some non-React elements (there are a lot of popular 3rd party widgets for instance) on the page and from what I understand those require to be aria-hidden. I like that you don't impose extra code on your consumers just to handle some cases that might not apply to them but maybe this should be documented somehow? Currently, you are saying that this helper is mostly useful when one renders their providers in some nested element - but I think there more cases when this is needed and people might not be realizing that.
2. Should the logic in this helper be consolidated with [`ariaHideOutside`](https://github.com/adobe/react-spectrum/blob/f55249bf75b6fd43fa90b9bece035d1b0af69854/packages/%40react-aria/overlays/src/ariaHideOutside.ts#L25)? They both seem to handle very similar logic.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

I've tested it in my private project so far.
