### PR TITLE
fix - useOverlayPosition mount flicker

### DIFF
--- a/packages/@react-aria/focus/src/useFocusable.tsx
+++ b/packages/@react-aria/focus/src/useFocusable.tsx
@@ -11,7 +11,7 @@
  */
 
 import {FocusableDOMProps, FocusableProps} from '@react-types/shared';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useSyncRef} from '@react-aria/utils';
 import React, {HTMLAttributes, MutableRefObject, ReactNode, RefObject, useContext, useEffect} from 'react';
 import {useFocus, useKeyboard} from '@react-aria/interactions';
 
@@ -33,15 +33,7 @@ let FocusableContext = React.createContext<FocusableContextValue>(null);
 
 function useFocusableContext(ref: RefObject<HTMLElement>): FocusableContextValue {
   let context = useContext(FocusableContext) || {};
-
-  useEffect(() => {
-    if (context && context.ref) {
-      context.ref.current = ref.current;
-      return () => {
-        context.ref.current = null;
-      };
-    }
-  }, [context, ref]);
+  useSyncRef(context, ref);
 
   return context;
 }

--- a/packages/@react-aria/interactions/src/DOMPropsContext.ts
+++ b/packages/@react-aria/interactions/src/DOMPropsContext.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {mergeProps} from '@react-aria/utils';
-import React, {HTMLAttributes, MutableRefObject, RefObject, useContext, useEffect} from 'react';
+import {mergeProps, useSyncRef} from '@react-aria/utils';
+import React, {HTMLAttributes, MutableRefObject, RefObject, useContext} from 'react';
 
 interface DOMPropsResponderProps extends HTMLAttributes<HTMLElement> {
   ref?: RefObject<HTMLElement>
@@ -32,16 +32,7 @@ export function useDOMPropsResponderContext(props: DOMPropsResponderProps): DOMP
     props = mergeProps(contextProps, props);
     register();
   }
-
-  // Sync ref from <DOMPropsResponder> with ref passed to the useHover hook.
-  useEffect(() => {
-    if (context && context.ref) {
-      context.ref.current = props.ref.current;
-      return () => {
-        context.ref.current = null;
-      };
-    }
-  }, [context, props.ref]);
+  useSyncRef(context, props.ref);
 
   return props;
 }

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -22,6 +22,7 @@ import {isVirtualClick} from './utils';
 import {PointerType, PressEvents} from '@react-types/shared';
 import {PressResponderContext} from './context';
 import {useGlobalListeners} from '@react-aria/utils';
+import {useLayoutEffect} from '@react-aria/utils';
 
 export interface PressProps extends PressEvents {
   /** Whether the target is in a controlled press state (e.g. an overlay it triggers is open). */
@@ -72,7 +73,7 @@ function usePressResponderContext(props: PressHookProps): PressHookProps {
   }
 
   // Sync ref from <PressResponder> with ref passed to usePress.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (context && context.ref) {
       context.ref.current = props.ref.current;
       return () => {

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -21,8 +21,7 @@ import {HTMLAttributes, RefObject, useContext, useEffect, useMemo, useRef, useSt
 import {isVirtualClick} from './utils';
 import {PointerType, PressEvents} from '@react-types/shared';
 import {PressResponderContext} from './context';
-import {useGlobalListeners} from '@react-aria/utils';
-import {useLayoutEffect} from '@react-aria/utils';
+import {useGlobalListeners, useLayoutEffect} from '@react-aria/utils';
 
 export interface PressProps extends PressEvents {
   /** Whether the target is in a controlled press state (e.g. an overlay it triggers is open). */

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -16,12 +16,11 @@
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
 import {disableTextSelection, restoreTextSelection} from './textSelection';
-import {focusWithoutScrolling, mergeProps} from '@react-aria/utils';
+import {focusWithoutScrolling, mergeProps, useGlobalListeners, useSyncRef} from '@react-aria/utils';
 import {HTMLAttributes, RefObject, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {isVirtualClick} from './utils';
 import {PointerType, PressEvents} from '@react-types/shared';
 import {PressResponderContext} from './context';
-import {useGlobalListeners, useLayoutEffect} from '@react-aria/utils';
 
 export interface PressProps extends PressEvents {
   /** Whether the target is in a controlled press state (e.g. an overlay it triggers is open). */
@@ -70,16 +69,7 @@ function usePressResponderContext(props: PressHookProps): PressHookProps {
     props = mergeProps(contextProps, props) as PressHookProps;
     register();
   }
-
-  // Sync ref from <PressResponder> with ref passed to usePress.
-  useLayoutEffect(() => {
-    if (context && context.ref) {
-      context.ref.current = props.ref.current;
-      return () => {
-        context.ref.current = null;
-      };
-    }
-  }, [context, props.ref]);
+  useSyncRef(context, props.ref);
 
   return props;
 }

--- a/packages/@react-aria/overlays/src/useOverlayPosition.ts
+++ b/packages/@react-aria/overlays/src/useOverlayPosition.ts
@@ -11,7 +11,7 @@
  */
 
 import {calculatePosition, PositionResult} from './calculatePosition';
-import {HTMLAttributes, RefObject, useCallback, useEffect, useRef, useState} from 'react';
+import {HTMLAttributes, RefObject, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import {Placement, PlacementAxis, PositionProps} from '@react-types/overlays';
 import {useCloseOnScroll} from './useCloseOnScroll';
 import {useLocale} from '@react-aria/i18n';
@@ -122,7 +122,7 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
   }, deps);
 
   // Update position when anything changes
-  useEffect(updatePosition, deps);
+  useLayoutEffect(updatePosition, deps);
 
   // Update position on window resize
   useResize(updatePosition);
@@ -130,7 +130,7 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
   // Reposition the overlay and do not close on scroll while the visual viewport is resizing.
   // This will ensure that overlays adjust their positioning when the iOS virtual keyboard appears.
   let isResizing = useRef(false);
-  useEffect(() => {
+  useLayoutEffect(() => {
     let timeout: NodeJS.Timeout;
     let onResize = () => {
       isResizing.current = true;
@@ -185,7 +185,7 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
 }
 
 function useResize(onResize) {
-  useEffect(() => {
+  useLayoutEffect(() => {
     window.addEventListener('resize', onResize, false);
     return () => {
       window.removeEventListener('resize', onResize, false);

--- a/packages/@react-aria/overlays/src/useOverlayPosition.ts
+++ b/packages/@react-aria/overlays/src/useOverlayPosition.ts
@@ -11,9 +11,10 @@
  */
 
 import {calculatePosition, PositionResult} from './calculatePosition';
-import {HTMLAttributes, RefObject, useCallback, useLayoutEffect, useRef, useState} from 'react';
+import {HTMLAttributes, RefObject, useCallback, useRef, useState} from 'react';
 import {Placement, PlacementAxis, PositionProps} from '@react-types/overlays';
 import {useCloseOnScroll} from './useCloseOnScroll';
+import {useLayoutEffect} from '@react-aria/utils';
 import {useLocale} from '@react-aria/i18n';
 
 interface AriaPositionProps extends PositionProps {

--- a/packages/@react-aria/utils/src/useSyncRef.ts
+++ b/packages/@react-aria/utils/src/useSyncRef.ts
@@ -10,22 +10,21 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './useId';
-export * from './chain';
-export * from './mergeProps';
-export * from './filterDOMProps';
-export * from './focusWithoutScrolling';
-export * from './getOffset';
-export * from './number';
-export * from './runAfterTransition';
-export * from './useDrag1D';
-export * from './useGlobalListeners';
-export * from './useLabels';
-export * from './useUpdateEffect';
-export * from './useLayoutEffect';
-export * from './useResizeObserver';
-export * from './useSyncRef';
-export * from './getScrollParent';
-export * from './useViewportSize';
-export * from './useDescription';
-export * from './platform';
+import {MutableRefObject, RefObject} from 'react';
+import {useLayoutEffect} from './';
+
+interface ContextValue<T> {
+  ref?: MutableRefObject<T>
+}
+
+// Syncs ref from context with ref passed to hook
+export function useSyncRef<T>(context: ContextValue<T>, ref: RefObject<T>) {
+  useLayoutEffect(() => {
+    if (context && context.ref) {
+      context.ref.current = ref.current;
+      return () => {
+        context.ref.current = null;
+      };
+    }
+  }, [context, ref]);
+}

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -16,9 +16,10 @@ import {MenuContext} from './context';
 import {MenuItem} from './MenuItem';
 import {MenuSection} from './MenuSection';
 import {mergeProps} from '@react-aria/utils';
-import React, {ReactElement, useContext, useEffect} from 'react';
+import React, {ReactElement, useContext} from 'react';
 import {SpectrumMenuProps} from '@react-types/menu';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
+import {useLayoutEffect} from '@react-aria/utils';
 import {useMenu} from '@react-aria/menu';
 import {useTreeState} from '@react-stately/tree';
 
@@ -34,7 +35,7 @@ function Menu<T extends object>(props: SpectrumMenuProps<T>, ref: DOMRef<HTMLULi
   let {styleProps} = useStyleProps(completeProps);
 
   // Sync ref from <MenuTrigger> context with DOM ref.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (contextProps && contextProps.ref) {
       contextProps.ref.current = domRef.current;
       return () => {

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -15,11 +15,10 @@ import {DOMRef} from '@react-types/shared';
 import {MenuContext} from './context';
 import {MenuItem} from './MenuItem';
 import {MenuSection} from './MenuSection';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useSyncRef} from '@react-aria/utils';
 import React, {ReactElement, useContext} from 'react';
 import {SpectrumMenuProps} from '@react-types/menu';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
-import {useLayoutEffect} from '@react-aria/utils';
 import {useMenu} from '@react-aria/menu';
 import {useTreeState} from '@react-stately/tree';
 
@@ -33,16 +32,7 @@ function Menu<T extends object>(props: SpectrumMenuProps<T>, ref: DOMRef<HTMLULi
   let state = useTreeState(completeProps);
   let {menuProps} = useMenu(completeProps, state, domRef);
   let {styleProps} = useStyleProps(completeProps);
-
-  // Sync ref from <MenuTrigger> context with DOM ref.
-  useLayoutEffect(() => {
-    if (contextProps && contextProps.ref) {
-      contextProps.ref.current = domRef.current;
-      return () => {
-        contextProps.ref.current = null;
-      };
-    }
-  }, [contextProps, domRef]);
+  useSyncRef(contextProps, domRef);
 
   return (
     <ul


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1694

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/1694).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
One can check this [storybook example](http://localhost:9003/?path=/story/useoverlayposition--positioned-container-bottom). 
Sometimes after reload clicking on trigger leads to flicker. Note - Only happens on first mount as new position gets stored and it's used in re-renders.
<!--- Include instructions to test this pull request -->

## 🧢 Your Project:
GeekyAnts
<!--- Company/project for pull request -->
