### PR TITLE
Implement copy/paste support

### DIFF
--- a/packages/@react-aria/dnd/src/index.ts
+++ b/packages/@react-aria/dnd/src/index.ts
@@ -16,3 +16,4 @@ export * from './useDroppableCollection';
 export * from './useDroppableItem';
 export * from './useDropIndicator';
 export * from './useDraggableItem';
+export * from './useClipboard';

--- a/packages/@react-aria/dnd/src/useClipboard.ts
+++ b/packages/@react-aria/dnd/src/useClipboard.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {chain} from '@react-aria/utils';
+import {DragItem, DropItem} from '@react-types/shared';
+import {HTMLAttributes, useEffect, useRef} from 'react';
+import {readFromDataTransfer, writeToDataTransfer} from './utils';
+import {useFocus} from '@react-aria/interactions';
+
+interface ClipboardProps {
+  getItems?: () => DragItem[],
+  onCopy?: () => void,
+  onCut?: () => void,
+  onPaste?: (items: DropItem[]) => void
+}
+
+interface ClipboardResult {
+  clipboardProps: HTMLAttributes<HTMLElement>
+}
+
+const globalEvents = new Map();
+function addGlobalEventListener(event, fn) {
+  let eventData = globalEvents.get(event);
+  if (!eventData) {
+    let handlers = new Set<(e: Event) => void>();
+    let listener = (e) => {
+      for (let handler of handlers) {
+        handler(e);
+      }
+    };
+
+    eventData = {listener, handlers};
+    globalEvents.set(event, eventData);
+
+    document.addEventListener(event, listener);
+  }
+
+  eventData.handlers.add(fn);
+  return () => {
+    eventData.handlers.delete(fn);
+    if (eventData.handlers.size === 0) {
+      document.removeEventListener(event, eventData.listener);
+      globalEvents.delete(event);
+    }
+  };
+}
+
+export function useClipboard(options: ClipboardProps): ClipboardResult {
+  let ref = useRef(options);
+  ref.current = options;
+
+  let isFocusedRef = useRef(false);
+  let {focusProps} = useFocus({
+    onFocusChange: (isFocused) => {
+      isFocusedRef.current = isFocused;
+    }
+  });
+
+  useEffect(() => {
+    let onBeforeCopy = (e: ClipboardEvent) => {
+      // Enable the "Copy" menu item in Safari if this element is focused and copying is supported.
+      let options = ref.current;
+      if (isFocusedRef.current && options.getItems) {
+        e.preventDefault();
+      }
+    };
+
+    let onCopy = (e: ClipboardEvent) => {
+      let options = ref.current;
+      if (!isFocusedRef.current || !options.getItems) {
+        return;
+      }
+
+      e.preventDefault();
+      writeToDataTransfer(e.clipboardData, options.getItems());
+      options.onCopy?.();
+    };
+
+    let onBeforeCut = (e: ClipboardEvent) => {
+      let options = ref.current;
+      if (isFocusedRef.current && options.onCut && options.getItems) {
+        e.preventDefault();
+      }
+    };
+
+    let onCut = (e: ClipboardEvent) => {
+      let options = ref.current;
+      if (!isFocusedRef.current || !options.onCut || !options.getItems) {
+        return;
+      }
+
+      e.preventDefault();
+      writeToDataTransfer(e.clipboardData, options.getItems());
+      options.onCut();
+    };
+
+    let onBeforePaste = (e: ClipboardEvent) => {
+      let options = ref.current;
+      // Unfortunately, e.clipboardData.types is not available in this event so we always
+      // have to enable the Paste menu item even if the type of data is unsupported.
+      if (isFocusedRef.current && options.onPaste) {
+        e.preventDefault();
+      }
+    };
+
+    let onPaste = (e: ClipboardEvent) => {
+      let options = ref.current;
+      if (!isFocusedRef.current || !options.onPaste) {
+        return;
+      }
+
+      e.preventDefault();
+      let items = readFromDataTransfer(e.clipboardData);
+      options.onPaste(items);
+    };
+
+    return chain(
+      addGlobalEventListener('beforecopy', onBeforeCopy),
+      addGlobalEventListener('copy', onCopy),
+      addGlobalEventListener('beforecut', onBeforeCut),
+      addGlobalEventListener('cut', onCut),
+      addGlobalEventListener('beforepaste', onBeforePaste),
+      addGlobalEventListener('paste', onPaste)
+    );
+  }, []);
+
+  return {
+    clipboardProps: focusProps
+  };
+}

--- a/packages/@react-aria/dnd/src/useDrag.ts
+++ b/packages/@react-aria/dnd/src/useDrag.ts
@@ -11,16 +11,17 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
-import {CUSTOM_DRAG_TYPE, DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, EFFECT_ALLOWED, NATIVE_DRAG_TYPES} from './constants';
 import {DragEndEvent, DragItem, DragMoveEvent, DragStartEvent, DropOperation, PressEvent} from '@react-types/shared';
 import {DragEvent, HTMLAttributes, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
+import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, EFFECT_ALLOWED} from './constants';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import ReactDOM from 'react-dom';
 import {useDescription} from '@react-aria/utils';
 import {useDragModality} from './utils';
 import {useMessageFormatter} from '@react-aria/i18n';
+import {writeToDataTransfer} from './utils';
 
 interface DragOptions {
   onDragStart?: (e: DragStartEvent) => void,
@@ -63,57 +64,8 @@ export function useDrag(options: DragOptions): DragResult {
   let [isDragging, setDragging] = useState(false);
 
   let onDragStart = (e: DragEvent) => {
-    // The HTML5 drag and drop API doesn't support more than one item of a given type per drag.
-    // In addition, only a small set of types are supported natively for transfer between applications.
-    // We allow for both multiple items, as well as multiple representations of a single item.
-    // In order to make our API work with the native API, we serialize all items to JSON and
-    // store as a single native item. We only need to do this if there is more than one item
-    // of the same type, or if an item has more than one representation. Otherwise the native
-    // API is sufficient.
     let items = options.getItems();
-    let groupedByType = new Map<string, string[]>();
-    let needsCustomData = false;
-    let customData = [];
-    for (let item of items) {
-      let types = [...item.types];
-      if (types.length > 1) {
-        needsCustomData = true;
-      }
-
-      let dataByType = {};
-      for (let type of types) {
-        let typeItems = groupedByType.get(type);
-        if (!typeItems) {
-          typeItems = [];
-          groupedByType.set(type, typeItems);
-        } else {
-          needsCustomData = true;
-        }
-
-        let data = item.getData(type);
-        dataByType[type] = data;
-        typeItems.push(data);
-      }
-
-      customData.push(dataByType);
-    }
-
-    for (let [type, items] of groupedByType) {
-      if (NATIVE_DRAG_TYPES.has(type)) {
-        // Only one item of a given type can be set on a data transfer.
-        // Join all of the items together separated by newlines.
-        let data = items.join('\n');
-        e.dataTransfer.items.add(data, type);
-      } else {
-        // Set data to the first item so we have access to the list of types.
-        e.dataTransfer.items.add(items[0], type);
-      }
-    }
-
-    if (needsCustomData) {
-      let data = JSON.stringify(customData);
-      e.dataTransfer.items.add(data, CUSTOM_DRAG_TYPE);
-    }
+    writeToDataTransfer(e.dataTransfer, items);
 
     if (typeof options.getAllowedDropOperations === 'function') {
       let allowedOperations = options.getAllowedDropOperations();

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -10,10 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import {CUSTOM_DRAG_TYPE, DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, DROP_OPERATION_ALLOWED, DROP_OPERATION_TO_DROP_EFFECT} from './constants';
 import {DragEvent, HTMLAttributes, RefObject, useLayoutEffect, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
-import {DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropItem, DropMoveEvent, DropOperation} from '@react-types/shared';
+import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, DROP_OPERATION_ALLOWED, DROP_OPERATION_TO_DROP_EFFECT} from './constants';
+import {DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropMoveEvent, DropOperation} from '@react-types/shared';
+import {readFromDataTransfer} from './utils';
 import {useVirtualDrop} from './useVirtualDrop';
 
 interface DropOptions {
@@ -154,46 +155,7 @@ export function useDrop(options: DropOptions): DropResult {
 
     if (typeof options.onDrop === 'function') {
       let dropOperation = DROP_EFFECT_TO_DROP_OPERATION[state.dropEffect];
-      let items: DropItem[] = [];
-
-      // If our custom drag type is available, use that. This is a JSON serialized
-      // representation of all items in the drag, set when there are multiple items
-      // of the same type, or an individual item has multiple representations.
-      let hasCustomType = false;
-      if ([...e.dataTransfer.types].includes(CUSTOM_DRAG_TYPE)) {
-        try {
-          let data = e.dataTransfer.getData(CUSTOM_DRAG_TYPE);
-          let parsed = JSON.parse(data);
-          for (let item of parsed) {
-            items.push({
-              types: new Set(Object.keys(item)),
-              getData: (type) => item[type]
-            });
-          }
-
-          hasCustomType = true;
-        } catch (e) {
-          // ignore
-        }
-      }
-
-      // Otherwise, map native drag items to items of a single representation.
-      if (!hasCustomType) {
-        for (let item of e.dataTransfer.items) {
-          if (item.kind === 'string') {
-            items.push({
-              types: new Set([item.type]),
-              getData: () => new Promise(resolve => item.getAsString(resolve))
-            });
-          } else if (item.kind === 'file') {
-            // TODO: file support
-            // items.push({
-            //   types: new Set([item.type]),
-            //   getData: () => Promise.resolve(item.getAsFile()) // ???
-            // });
-          }
-        }
-      }
+      let items = readFromDataTransfer(e.dataTransfer);
 
       let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
       let event: DropEvent = {

--- a/packages/@react-aria/dnd/src/utils.ts
+++ b/packages/@react-aria/dnd/src/utils.ts
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {DragItem} from '@react-types/shared';
+import {CUSTOM_DRAG_TYPE, NATIVE_DRAG_TYPES} from './constants';
+import {DragItem, DropItem} from '@react-types/shared';
 import {DroppableCollectionState} from '@react-stately/dnd';
 import {getInteractionModality, useInteractionModality} from '@react-aria/interactions';
 import {useId} from '@react-aria/utils';
@@ -65,4 +66,102 @@ export function useDragModality() {
 
 export function getDragModality() {
   return mapModality(getInteractionModality());
+}
+
+export function writeToDataTransfer(dataTransfer: DataTransfer, items: DragItem[]) {
+  // The data transfer API doesn't support more than one item of a given type at once.
+  // In addition, only a small set of types are supported natively for transfer between applications.
+  // We allow for both multiple items, as well as multiple representations of a single item.
+  // In order to make our API work with the native API, we serialize all items to JSON and
+  // store as a single native item. We only need to do this if there is more than one item
+  // of the same type, or if an item has more than one representation. Otherwise the native
+  // API is sufficient.
+  let groupedByType = new Map<string, string[]>();
+  let needsCustomData = false;
+  let customData = [];
+  for (let item of items) {
+    let types = [...item.types];
+    if (types.length > 1) {
+      needsCustomData = true;
+    }
+
+    let dataByType = {};
+    for (let type of types) {
+      let typeItems = groupedByType.get(type);
+      if (!typeItems) {
+        typeItems = [];
+        groupedByType.set(type, typeItems);
+      } else {
+        needsCustomData = true;
+      }
+
+      let data = item.getData(type);
+      dataByType[type] = data;
+      typeItems.push(data);
+    }
+
+    customData.push(dataByType);
+  }
+
+  for (let [type, items] of groupedByType) {
+    if (NATIVE_DRAG_TYPES.has(type)) {
+      // Only one item of a given type can be set on a data transfer.
+      // Join all of the items together separated by newlines.
+      let data = items.join('\n');
+      dataTransfer.items.add(data, type);
+    } else {
+      // Set data to the first item so we have access to the list of types.
+      dataTransfer.items.add(items[0], type);
+    }
+  }
+
+  if (needsCustomData) {
+    let data = JSON.stringify(customData);
+    dataTransfer.items.add(data, CUSTOM_DRAG_TYPE);
+  }
+}
+
+export function readFromDataTransfer(dataTransfer: DataTransfer) {
+  let items: DropItem[] = [];
+
+  // If our custom drag type is available, use that. This is a JSON serialized
+  // representation of all items in the drag, set when there are multiple items
+  // of the same type, or an individual item has multiple representations.
+  let hasCustomType = false;
+  if ([...dataTransfer.types].includes(CUSTOM_DRAG_TYPE)) {
+    try {
+      let data = dataTransfer.getData(CUSTOM_DRAG_TYPE);
+      let parsed = JSON.parse(data);
+      for (let item of parsed) {
+        items.push({
+          types: new Set(Object.keys(item)),
+          getData: (type) => item[type]
+        });
+      }
+
+      hasCustomType = true;
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  // Otherwise, map native drag items to items of a single representation.
+  if (!hasCustomType) {
+    for (let item of dataTransfer.items) {
+      if (item.kind === 'string') {
+        items.push({
+          types: new Set([item.type]),
+          getData: () => new Promise(resolve => item.getAsString(resolve))
+        });
+      } else if (item.kind === 'file') {
+        // TODO: file support
+        // items.push({
+        //   types: new Set([item.type]),
+        //   getData: () => Promise.resolve(item.getAsFile()) // ???
+        // });
+      }
+    }
+  }
+
+  return items;
 }

--- a/packages/@react-aria/dnd/stories/DroppableGrid.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableGrid.tsx
@@ -21,7 +21,7 @@ import {Item} from '@react-stately/collections';
 import {ListKeyboardDelegate} from '@react-aria/selection';
 import {mergeProps} from '@react-aria/utils';
 import React from 'react';
-import {useDropIndicator, useDroppableCollection} from '..';
+import {useClipboard, useDropIndicator, useDroppableCollection} from '..';
 import {useDroppableCollectionState} from '@react-stately/dnd';
 import {useGrid, useGridCell, useGridRow} from '@react-aria/grid';
 import {useListData} from '@react-stately/data';
@@ -231,7 +231,8 @@ function DroppableGrid(props) {
             key={item.key}
             item={item}
             state={gridState}
-            dropState={dropState} />
+            dropState={dropState}
+            onPaste={items => props.onDrop({target: {type: 'item', key: item.key, dropPosition: 'before'}, items})} />
           {state.collection.getKeyAfter(item.key) == null &&
             <InsertionIndicator
               key={item.key + '-after'}
@@ -245,7 +246,7 @@ function DroppableGrid(props) {
   );
 }
 
-function CollectionItem({item, state, dropState}) {
+function CollectionItem({item, state, dropState, onPaste}) {
   let rowRef = React.useRef();
   let cellRef = React.useRef();
   let cellNode = [...item.childNodes][0];
@@ -269,11 +270,15 @@ function CollectionItem({item, state, dropState}) {
   }, dropState, dropIndicatorRef);
   let {visuallyHiddenProps} = useVisuallyHidden();
 
+  let {clipboardProps} = useClipboard({
+    onPaste
+  });
+
   return (
     <div {...rowProps} ref={rowRef} style={{outline: 'none'}}>
       <FocusRing focusRingClass={classNames(dndStyles, 'focus-ring')}>
         <div
-          {...gridCellProps}
+          {...mergeProps(gridCellProps, clipboardProps)}
           ref={cellRef}
           className={classNames(dndStyles, 'droppable', {
             'is-drop-target': dropState.isDropTarget({type: 'item', key: item.key, dropPosition: 'on'}),

--- a/packages/@react-aria/dnd/test/mocks.js
+++ b/packages/@react-aria/dnd/test/mocks.js
@@ -62,3 +62,10 @@ export class DragEvent extends MouseEvent {
     this.dataTransfer = init.dataTransfer;
   }
 }
+
+export class ClipboardEvent extends Event {
+  constructor(type, init) {
+    super(type, {...init, bubbles: true, cancelable: true, composed: true});
+    this.clipboardData = init.clipboardData;
+  }
+}

--- a/packages/@react-aria/dnd/test/useClipboard.test.js
+++ b/packages/@react-aria/dnd/test/useClipboard.test.js
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {ClipboardEvent, DataTransfer, DataTransferItem} from './mocks';
+import {fireEvent, render} from '@testing-library/react';
+import React from 'react';
+import {useClipboard} from '../';
+import userEvent from '@testing-library/user-event';
+
+function Copyable(props) {
+  let {clipboardProps} = useClipboard({
+    getItems: () => [
+      {
+        types: ['text/plain'],
+        getData: () => 'hello world'
+      }
+    ],
+    ...props
+  });
+
+  return (
+    <div tabIndex="0" role="button" {...clipboardProps}>Copy</div>
+  );
+}
+
+describe('useClipboard', () => {
+  it('should copy items to the clipboard', () => {
+    let onCopy = jest.fn();
+    let tree = render(<Copyable onCopy={onCopy} />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecopy', {clipboardData}));
+    expect(allowDefault).toBe(false);
+
+    fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+    expect([...clipboardData.items]).toEqual([new DataTransferItem('text/plain', 'hello world')]);
+
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should only enable copying when focused', () => {
+    let onCopy = jest.fn();
+    let tree = render(<Copyable onCopy={onCopy} />);
+    let button = tree.getByRole('button');
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecopy', {clipboardData}));
+    expect(allowDefault).toBe(true);
+
+    fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+    expect([...clipboardData.items].length).toBe(0);
+    expect(onCopy).not.toHaveBeenCalled();
+  });
+
+  it('should not enable copying when there is no getItems option', () => {
+    let onCopy = jest.fn();
+    let tree = render(<Copyable getItems={null} onCopy={onCopy} />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecopy', {clipboardData}));
+    expect(allowDefault).toBe(true);
+
+    fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+    expect([...clipboardData.items].length).toBe(0);
+    expect(onCopy).not.toHaveBeenCalled();
+  });
+
+  it('should cut items to the clipboard', () => {
+    let onCut = jest.fn();
+    let tree = render(<Copyable onCut={onCut} />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecut', {clipboardData}));
+    expect(allowDefault).toBe(false);
+
+    fireEvent(button, new ClipboardEvent('cut', {clipboardData}));
+    expect([...clipboardData.items]).toEqual([new DataTransferItem('text/plain', 'hello world')]);
+
+    expect(onCut).toHaveBeenCalledTimes(1);
+  });
+
+  it('should only enable cutting when focused', () => {
+    let onCut = jest.fn();
+    let tree = render(<Copyable onCut={onCut} />);
+    let button = tree.getByRole('button');
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecut', {clipboardData}));
+    expect(allowDefault).toBe(true);
+
+    fireEvent(button, new ClipboardEvent('cut', {clipboardData}));
+    expect([...clipboardData.items].length).toBe(0);
+    expect(onCut).not.toHaveBeenCalled();
+  });
+
+  it('should not enable cutting when there is no getItems option', () => {
+    let onCut = jest.fn();
+    let tree = render(<Copyable getItems={null} onCut={onCut} />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecut', {clipboardData}));
+    expect(allowDefault).toBe(true);
+
+    fireEvent(button, new ClipboardEvent('cut', {clipboardData}));
+    expect([...clipboardData.items].length).toBe(0);
+    expect(onCut).not.toHaveBeenCalled();
+  });
+
+  it('should not enable cutting when there is no onCut option', () => {
+    let tree = render(<Copyable />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforecut', {clipboardData}));
+    expect(allowDefault).toBe(true);
+
+    fireEvent(button, new ClipboardEvent('cut', {clipboardData}));
+    expect([...clipboardData.items].length).toBe(0);
+  });
+
+  it('should paste items from the clipboard', async () => {
+    let onPaste = jest.fn();
+    let tree = render(<Copyable onPaste={onPaste} />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    clipboardData.items.add('hello world', 'text/plain');
+
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforepaste', {clipboardData}));
+    expect(allowDefault).toBe(false);
+
+    fireEvent(button, new ClipboardEvent('paste', {clipboardData}));
+
+    expect(onPaste).toHaveBeenCalledTimes(1);
+    expect(onPaste).toHaveBeenCalledWith([
+      {
+        types: new Set(['text/plain']),
+        getData: expect.any(Function)
+      }
+    ]);
+
+    expect(await onPaste.mock.calls[0][0][0].getData('text/plain')).toBe('hello world');
+  });
+
+  it('should only enable pasting when focused', () => {
+    let onPaste = jest.fn();
+    let tree = render(<Copyable onPaste={onPaste} />);
+    let button = tree.getByRole('button');
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforepaste', {clipboardData}));
+    expect(allowDefault).toBe(true);
+
+    fireEvent(button, new ClipboardEvent('paste', {clipboardData}));
+    expect(onPaste).not.toHaveBeenCalled();
+  });
+
+  it('should not enable pasting when there is no onPaste option', () => {
+    let tree = render(<Copyable />);
+    let button = tree.getByRole('button');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(button);
+
+    let clipboardData = new DataTransfer();
+    let allowDefault = fireEvent(button, new ClipboardEvent('beforepaste', {clipboardData}));
+    expect(allowDefault).toBe(true);
+  });
+
+  describe('data', () => {
+    it('should work with custom data types', async () => {
+      let getItems = () => [{
+        types: ['test'],
+        getData: () => 'test data'
+      }];
+
+      let onPaste = jest.fn();
+      let tree = render(<Copyable getItems={getItems} onPaste={onPaste} />);
+      let button = tree.getByRole('button');
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(button);
+
+      let clipboardData = new DataTransfer();
+      fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+      expect([...clipboardData.items]).toEqual([new DataTransferItem('test', 'test data')]);
+
+      fireEvent(button, new ClipboardEvent('paste', {clipboardData}));
+      expect(onPaste).toHaveBeenCalledTimes(1);
+      expect(onPaste).toHaveBeenCalledWith([
+        {
+          types: new Set(['test']),
+          getData: expect.any(Function)
+        }
+      ]);
+
+      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('test data');
+    });
+
+    it('should work with multiple items of the same custom type', async () => {
+      let getItems = () => [{
+        types: ['test'],
+        getData: () => 'item 1'
+      }, {
+        types: ['test'],
+        getData: () => 'item 2'
+      }];
+
+      let onPaste = jest.fn();
+      let tree = render(<Copyable getItems={getItems} onPaste={onPaste} />);
+      let button = tree.getByRole('button');
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(button);
+
+      let clipboardData = new DataTransfer();
+      fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+      expect([...clipboardData.items]).toEqual([
+        new DataTransferItem('test', 'item 1'),
+        new DataTransferItem(
+          'application/vnd.react-aria.items+json',
+          JSON.stringify([{test: 'item 1'}, {test: 'item 2'}]
+        ))
+      ]);
+
+      fireEvent(button, new ClipboardEvent('paste', {clipboardData}));
+      expect(onPaste).toHaveBeenCalledTimes(1);
+      expect(onPaste).toHaveBeenCalledWith([
+        {
+          types: new Set(['test']),
+          getData: expect.any(Function)
+        },
+        {
+          types: new Set(['test']),
+          getData: expect.any(Function)
+        }
+      ]);
+
+      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('item 1');
+      expect(await onPaste.mock.calls[0][0][1].getData('test')).toBe('item 2');
+    });
+
+    it('should work with items of multiple types', async () => {
+      let getItems = () => [{
+        types: ['test', 'text/plain'],
+        getData: () => 'test data'
+      }];
+
+      let onPaste = jest.fn();
+      let tree = render(<Copyable getItems={getItems} onPaste={onPaste} />);
+      let button = tree.getByRole('button');
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(button);
+
+      let clipboardData = new DataTransfer();
+      fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+      expect([...clipboardData.items]).toEqual([
+        new DataTransferItem('test', 'test data'),
+        new DataTransferItem('text/plain', 'test data'),
+        new DataTransferItem(
+          'application/vnd.react-aria.items+json',
+          JSON.stringify([{test: 'test data', 'text/plain': 'test data'}]
+        ))
+      ]);
+
+      fireEvent(button, new ClipboardEvent('paste', {clipboardData}));
+      expect(onPaste).toHaveBeenCalledTimes(1);
+      expect(onPaste).toHaveBeenCalledWith([
+        {
+          types: new Set(['test', 'text/plain']),
+          getData: expect.any(Function)
+        }
+      ]);
+
+      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('test data');
+      expect(await onPaste.mock.calls[0][0][0].getData('text/plain')).toBe('test data');
+    });
+
+    it('should work with multiple items of multiple types', async () => {
+      let getItems = () => [{
+        types: ['test', 'text/plain'],
+        getData: () => 'item 1'
+      }, {
+        types: ['test', 'text/plain'],
+        getData: () => 'item 2'
+      }];
+
+      let onPaste = jest.fn();
+      let tree = render(<Copyable getItems={getItems} onPaste={onPaste} />);
+      let button = tree.getByRole('button');
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(button);
+
+      let clipboardData = new DataTransfer();
+      fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+      expect([...clipboardData.items]).toEqual([
+        new DataTransferItem('test', 'item 1'),
+        new DataTransferItem('text/plain', 'item 1\nitem 2'),
+        new DataTransferItem(
+          'application/vnd.react-aria.items+json',
+          JSON.stringify([
+            {test: 'item 1', 'text/plain': 'item 1'},
+            {test: 'item 2', 'text/plain': 'item 2'}
+          ]
+        ))
+      ]);
+
+      fireEvent(button, new ClipboardEvent('paste', {clipboardData}));
+      expect(onPaste).toHaveBeenCalledTimes(1);
+      expect(onPaste).toHaveBeenCalledWith([
+        {
+          types: new Set(['test', 'text/plain']),
+          getData: expect.any(Function)
+        },
+        {
+          types: new Set(['test', 'text/plain']),
+          getData: expect.any(Function)
+        }
+      ]);
+
+      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('item 1');
+      expect(await onPaste.mock.calls[0][0][0].getData('text/plain')).toBe('item 1');
+      expect(await onPaste.mock.calls[0][0][1].getData('test')).toBe('item 2');
+      expect(await onPaste.mock.calls[0][0][1].getData('text/plain')).toBe('item 2');
+    });
+  });
+});

--- a/packages/@react-stately/dnd/src/useDraggableCollectionState.ts
+++ b/packages/@react-stately/dnd/src/useDraggableCollectionState.ts
@@ -23,6 +23,7 @@ export interface DraggableCollectionState {
   collection: Collection<Node<unknown>>,
   selectionManager: MultipleSelectionManager,
   isDragging(key: Key): boolean,
+  getKeysForDrag(key: Key): Set<Key>,
   getItems(key: Key): DragItem[],
   renderPreview(key: Key): JSX.Element,
   startDrag(key: Key, event: DragStartEvent): void,
@@ -52,6 +53,7 @@ export function useDraggableCollectionState(props: DraggableCollectionOptions): 
     isDragging(key) {
       return draggingKeys.has(key);
     },
+    getKeysForDrag: getKeys,
     getItems(key) {
       return props.getItems(getKeys(key));
     },


### PR DESCRIPTION
This adds a `useClipboard` hook which can be used to implement cut/copy/paste support. This is very similar to drag and drop - in fact, they share the same underlying native API (DataTransfer). For this reason, I've added it to the dnd package and examples. I've made copy/paste support use the same API as our dnd API as well, which should make it easy to adopt.

This uses the beforecopy/beforecut/beforepaste events to enable the browser's actions in the Edit menu, but this is only supported in Safari. In other browsers, those options are always enabled. But in Safari this means that only the relevant actions will be enabled when you are focused on an element, which is kinda cool. In addition, cmd/ctrl + c/x/v work as expected and as handled by the browser. You can also trigger these actions with the `document.execCommand` function (after ensuring the element you want it to fire on is focused). Paste can only be triggered in Safari though - in other browsers you'll have to use the browser Edit menu or keyboard shortcuts to paste.

Questions:

1. It's potentially confusing to have copy/paste in the dnd package. Do we want to rename it package to something more generic, e.g. `@react-aria/datatransfer`, or is that also confusing? Another option is to move `useClipboard` to its own package, but then we'd have to export the internal `readFromDataTransfer` and `writeToDataTransfer` functions from the dnd package.
2. Should we rename the `DragItem` and `DropItem` types to something more general as well? Any name suggestions?