### PR TITLE
Support for dropping files and directories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,7 +75,8 @@ module.exports = {
     'jest': true,
     'expect': true,
     'JSX': 'readonly',
-    'NodeJS': 'readonly'
+    'NodeJS': 'readonly',
+    'AsyncIterable': 'readonly'
   },
   settings: {
     jsdoc: {

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -12,7 +12,7 @@
 
 import {announce} from '@react-aria/live-announcer';
 import {ariaHideOutside} from '@react-aria/overlays';
-import {DragEndEvent, DragItem, DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropOperation, DropTarget as DroppableCollectionTarget} from '@react-types/shared';
+import {DragEndEvent, DragItem, DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropItem, DropOperation, DropTarget as DroppableCollectionTarget} from '@react-types/shared';
 import {getDragModality, getTypes} from './utils';
 import {useEffect, useState} from 'react';
 
@@ -477,9 +477,10 @@ class DragSession {
     }
 
     if (typeof this.currentDropTarget.onDrop === 'function') {
-      let items = this.dragTarget.items.map(item => ({
-        types: new Set(item.types),
-        getData: (type: string) => Promise.resolve(item.getData(type))
+      let items: DropItem[] = this.dragTarget.items.map(item => ({
+        kind: 'text',
+        types: new Set(Object.keys(item)),
+        getText: (type: string) => Promise.resolve(item[type])
       }));
 
       let rect = this.currentDropTarget.element.getBoundingClientRect();

--- a/packages/@react-aria/dnd/src/constants.ts
+++ b/packages/@react-aria/dnd/src/constants.ts
@@ -51,3 +51,4 @@ function invert(object) {
 
 export const NATIVE_DRAG_TYPES = new Set(['text/plain', 'text/uri-list', 'text/html']);
 export const CUSTOM_DRAG_TYPE = 'application/vnd.react-aria.items+json';
+export const GENERIC_TYPE = 'application/octet-stream';

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -12,15 +12,15 @@
 
 import {DragEvent, HTMLAttributes, RefObject, useLayoutEffect, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
+import {DragTypes, readFromDataTransfer} from './utils';
 import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, DROP_OPERATION_ALLOWED, DROP_OPERATION_TO_DROP_EFFECT} from './constants';
-import {DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropMoveEvent, DropOperation} from '@react-types/shared';
-import {readFromDataTransfer} from './utils';
+import {DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropMoveEvent, DropOperation, DragTypes as IDragTypes} from '@react-types/shared';
 import {useVirtualDrop} from './useVirtualDrop';
 
 interface DropOptions {
   ref: RefObject<HTMLElement>,
-  getDropOperation?: (types: Set<string>, allowedOperations: DropOperation[]) => DropOperation,
-  getDropOperationForPoint?: (types: Set<string>, allowedOperations: DropOperation[], x: number, y: number) => DropOperation,
+  getDropOperation?: (types: IDragTypes, allowedOperations: DropOperation[]) => DropOperation,
+  getDropOperationForPoint?: (types: IDragTypes, allowedOperations: DropOperation[], x: number, y: number) => DropOperation,
   onDropEnter?: (e: DropEnterEvent) => void,
   onDropMove?: (e: DropMoveEvent) => void,
   // When the user hovers over the drop target for a period of time.
@@ -60,7 +60,7 @@ export function useDrop(options: DropOptions): DropResult {
 
     if (typeof options.getDropOperationForPoint === 'function') {
       let allowedOperations = effectAllowedToOperations(e.dataTransfer.effectAllowed);
-      let types = new Set(e.dataTransfer.types);
+      let types = new DragTypes(e.dataTransfer);
       let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
       let dropOperation = options.getDropOperationForPoint(types, allowedOperations, state.x - rect.x, state.y - rect.y);
       state.dropEffect = DROP_OPERATION_TO_DROP_EFFECT[dropOperation] || 'none';
@@ -101,7 +101,7 @@ export function useDrop(options: DropOptions): DropResult {
     let dropOperation = allowedOperations[0];
 
     if (typeof options.getDropOperation === 'function') {
-      let types = new Set(e.dataTransfer.types);
+      let types = new DragTypes(e.dataTransfer);
       dropOperation = options.getDropOperation(types, allowedOperations);
     }
 
@@ -110,7 +110,7 @@ export function useDrop(options: DropOptions): DropResult {
     }
 
     if (typeof options.getDropOperationForPoint === 'function') {
-      let types = new Set(e.dataTransfer.types);
+      let types = new DragTypes(e.dataTransfer);
       let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
       dropOperation = options.getDropOperationForPoint(types, allowedOperations, e.clientX - rect.x, e.clientY - rect.y);
     }

--- a/packages/@react-aria/dnd/stories/DraggableCollection.tsx
+++ b/packages/@react-aria/dnd/stories/DraggableCollection.tsx
@@ -88,10 +88,8 @@ function DraggableCollection(props) {
 
         return {
           // @ts-ignore
-          types: ['text/plain', item.value.type],
-          getData() {
-            return item.textValue;
-          }
+          [item.value.type]: item.textValue,
+          'text/plain': item.textValue
         };
       });
     },

--- a/packages/@react-aria/dnd/stories/DroppableGrid.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableGrid.tsx
@@ -28,9 +28,15 @@ import {useListData} from '@react-stately/data';
 import {useListState} from '@react-stately/list';
 import {useVisuallyHidden} from '@react-aria/visually-hidden';
 
+interface ListItem {
+  id: string,
+  type: string,
+  text: string
+}
+
 export function DroppableGridExample(props) {
   let id = React.useRef(props.items?.length || 3);
-  let list = useListData({
+  let list = useListData<ListItem>({
     initialItems: props.items || [
       {id: '1', type: 'folder', text: 'One'},
       {id: '2', type: 'item', text: 'Two'},
@@ -44,26 +50,42 @@ export function DroppableGridExample(props) {
     }
 
     if (e.target.type === 'root' || e.target.dropPosition !== 'on') {
-      let items = [];
+      let items: ListItem[] = [];
       for (let item of e.items) {
         let type: string;
-        if (item.types.has('folder')) {
-          type = 'folder';
-        } else if (item.types.has('item')) {
-          type = 'item';
-        } else if (item.types.has('text/plain')) {
-          type = 'text/plain';
-        }
+        if (item.kind === 'text') {
+          if (item.types.has('folder')) {
+            type = 'folder';
+          } else if (item.types.has('item')) {
+            type = 'item';
+          } else if (item.types.has('text/plain')) {
+            type = 'text/plain';
+          }
 
-        if (!type) {
-          continue;
-        }
+          if (!type) {
+            continue;
+          }
 
-        items.push({
-          id: String(++id.current),
-          type,
-          text: await item.getData(type)
-        });
+          items.push({
+            id: String(++id.current),
+            type,
+            text: await item.getText(type)
+          });
+        } else if (item.kind === 'file') {
+          items.push({
+            id: String(++id.current),
+            type: 'file',
+            text: item.name
+          });
+        } else if (item.kind === 'directory') {
+          for await (let entry of item.getEntries()) {
+            items.push({
+              id: String(++id.current),
+              type: entry.kind === 'directory' ? 'folder' : 'file',
+              text: entry.name
+            });
+          }
+        }
       }
 
       if (e.target.type === 'root') {
@@ -113,7 +135,7 @@ function DroppableGrid(props) {
     })
   });
 
-  let defaultGetDropOperation = (target, types, allowedOperations) => {
+  let defaultGetDropOperation = (target, items, allowedOperations) => {
     if (target.type === 'root') {
       return 'move';
     }

--- a/packages/@react-aria/dnd/stories/DroppableListBox.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableListBox.tsx
@@ -44,21 +44,23 @@ export function DroppableListBoxExample(props) {
       let items = [];
       for (let item of e.items) {
         let type: string;
-        if (item.types.has('folder')) {
-          type = 'folder';
-        } else if (item.types.has('item')) {
-          type = 'item';
-        }
+        if (item.kind === 'text') {
+          if (item.types.has('folder')) {
+            type = 'folder';
+          } else if (item.types.has('item')) {
+            type = 'item';
+          }
 
-        if (!type) {
-          continue;
-        }
+          if (!type) {
+            continue;
+          }
 
-        items.push({
-          id: String(++id.current),
-          type,
-          text: await item.getData(type)
-        });
+          items.push({
+            id: String(++id.current),
+            type,
+            text: await item.getText(type)
+          });
+        }
       }
 
       if (e.target.type === 'root') {

--- a/packages/@react-aria/dnd/stories/Reorderable.tsx
+++ b/packages/@react-aria/dnd/stories/Reorderable.tsx
@@ -50,19 +50,21 @@ export function ReorderableGridExample(props) {
     if (e.target.type !== 'root' && e.target.dropPosition !== 'on') {
       let items = [];
       for (let item of e.items) {
-        let type: string;
-        if (item.types.has('folder')) {
-          type = 'folder';
-        } else if (item.types.has('item')) {
-          type = 'item';
-        }
+        if (item.kind === 'text') {
+          let type: string;
+          if (item.types.has('folder')) {
+            type = 'folder';
+          } else if (item.types.has('item')) {
+            type = 'item';
+          }
 
-        if (!type) {
-          continue;
-        }
+          if (!type) {
+            continue;
+          }
 
-        let data = JSON.parse(await item.getData(type));
-        items.push(data.id);
+          let data = JSON.parse(await item.getText(type));
+          items.push(data.id);
+        }
       }
 
       if (e.target.dropPosition === 'before') {
@@ -121,14 +123,8 @@ function ReorderableGrid(props) {
 
         return {
           // @ts-ignore
-          types: ['text/plain', item.value.type],
-          getData(type) {
-            if (type === 'text/plain') {
-              return item.textValue;
-            }
-
-            return JSON.stringify(item.value);
-          }
+          [item.value.type]: JSON.stringify(item.value),
+          'text/plain': item.textValue
         };
       });
     },

--- a/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
+++ b/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
@@ -46,26 +46,28 @@ export function VirtualizedListBoxExample(props) {
     if (e.target.type === 'root' || e.target.dropPosition !== 'on') {
       let items = [];
       for (let item of e.items) {
-        let type: string;
-        if (props.accept) {
-          if (item.types.has(props.accept)) {
-            type = props.accept;
+        if (item.kind === 'text') {
+          let type: string;
+          if (props.accept) {
+            if (item.types.has(props.accept)) {
+              type = props.accept;
+            }
+          } else if (item.types.has('folder')) {
+            type = 'folder';
+          } else if (item.types.has('item')) {
+            type = 'item';
           }
-        } else if (item.types.has('folder')) {
-          type = 'folder';
-        } else if (item.types.has('item')) {
-          type = 'item';
-        }
 
-        if (!type) {
-          continue;
-        }
+          if (!type) {
+            continue;
+          }
 
-        items.push({
-          id: String(++id.current),
-          type,
-          text: await item.getData(type)
-        });
+          items.push({
+            id: String(++id.current),
+            type,
+            text: await item.getText(type)
+          });
+        }
       }
 
       if (e.target.type === 'root') {

--- a/packages/@react-aria/dnd/stories/dnd.stories.tsx
+++ b/packages/@react-aria/dnd/stories/dnd.stories.tsx
@@ -187,8 +187,7 @@ function Draggable() {
   let {dragProps, dragButtonProps, isDragging} = useDrag({
     getItems() {
       return [{
-        types: ['text/plain'],
-        getData: () => 'hello world'
+        'text/plain': 'hello world'
       }];
     },
     getAllowedDropOperations() {
@@ -202,8 +201,7 @@ function Draggable() {
   let {clipboardProps} = useClipboard({
     getItems() {
       return [{
-        types: ['text/plain'],
-        getData: () => 'hello world'
+        'text/plain': 'hello world'
       }];
     }
   });
@@ -336,10 +334,8 @@ function DraggableCollection(props) {
 
         return {
           // @ts-ignore
-          types: ['text/plain', item.value.type],
-          getData() {
-            return item.textValue;
-          }
+          [item.value.type]: item.textValue,
+          'text/plain': item.textValue
         };
       });
     },

--- a/packages/@react-aria/dnd/test/examples.js
+++ b/packages/@react-aria/dnd/test/examples.js
@@ -19,8 +19,7 @@ export function Draggable(props) {
   let {dragProps, dragButtonProps, isDragging} = useDrag({
     getItems() {
       return [{
-        types: ['text/plain'],
-        getData: () => 'hello world'
+        'text/plain': 'hello world'
       }];
     },
     ...props

--- a/packages/@react-aria/dnd/test/mocks.js
+++ b/packages/@react-aria/dnd/test/mocks.js
@@ -18,7 +18,59 @@ export class DataTransferItem {
   }
 
   getAsString(callback) {
-    callback(this._data);
+    if (this.kind === 'string') {
+      callback(this._data);
+    }
+  }
+
+  getAsFile() {
+    if (this.kind === 'file' && this._data instanceof FileSystemFileEntry) {
+      return this._data._file;
+    }
+  }
+
+  webkitGetAsEntry() {
+    if (this.kind === 'file') {
+      return this._data;
+    }
+  }
+}
+
+export class FileSystemFileEntry {
+  constructor(file) {
+    this.isFile = true;
+    this.isDirectory = false;
+    this.name = file.name;
+    this._file = file;
+  }
+
+  file(cb) {
+    cb(this._file);
+  }
+}
+
+export class FileSystemDirectoryEntry {
+  constructor(name, entries) {
+    this.isFile = false;
+    this.isDirectory = true;
+    this.name = name;
+    this._entries = entries;
+  }
+
+  createReader() {
+    return new FileSystemDirectoryReader(this._entries);
+  }
+}
+
+class FileSystemDirectoryReader {
+  constructor(entries) {
+    this._entries = entries;
+  }
+
+  readEntries(cb) {
+    let entries = this._entries;
+    this._entries = [];
+    cb(entries);
   }
 }
 
@@ -28,7 +80,14 @@ export class DataTransferItemList {
   }
 
   add(data, type) {
-    this._items.push(new DataTransferItem(type, data));
+    if (data instanceof File) {
+      this._items.push(new DataTransferItem(data.type, new FileSystemFileEntry(data), 'file'));
+    } else if (data instanceof FileSystemDirectoryEntry) {
+      // Not supported in the real API but used for mocking...
+      this._items.push(new DataTransferItem('', data, 'file'));
+    } else {
+      this._items.push(new DataTransferItem(type, data));
+    }
   }
 
   *[Symbol.iterator]() {
@@ -48,11 +107,23 @@ export class DataTransfer {
   }
 
   get types() {
-    return this.items._items.map(item => item.type);
+    let types = new Set();
+    for (let item of this.items) {
+      if (item.kind === 'file') {
+        types.add('Files');
+      } else {
+        types.add(item.type);
+      }
+    }
+    return [...types];
+  }
+
+  get files() {
+    return this.items._items.filter(item => item.kind === 'file').map(item => item.getAsFile());
   }
 
   getData(type) {
-    return this.items._items.find(item => item.type === type)?._data;
+    return this.items._items.find(item => item.kind === 'string' && item.type === type)?._data;
   }
 }
 

--- a/packages/@react-aria/dnd/test/useClipboard.test.js
+++ b/packages/@react-aria/dnd/test/useClipboard.test.js
@@ -20,8 +20,7 @@ function Copyable(props) {
   let {clipboardProps} = useClipboard({
     getItems: () => [
       {
-        types: ['text/plain'],
-        getData: () => 'hello world'
+        'text/plain': 'hello world'
       }
     ],
     ...props
@@ -165,12 +164,13 @@ describe('useClipboard', () => {
     expect(onPaste).toHaveBeenCalledTimes(1);
     expect(onPaste).toHaveBeenCalledWith([
       {
+        kind: 'text',
         types: new Set(['text/plain']),
-        getData: expect.any(Function)
+        getText: expect.any(Function)
       }
     ]);
 
-    expect(await onPaste.mock.calls[0][0][0].getData('text/plain')).toBe('hello world');
+    expect(await onPaste.mock.calls[0][0][0].getText('text/plain')).toBe('hello world');
   });
 
   it('should only enable pasting when focused', () => {
@@ -201,8 +201,7 @@ describe('useClipboard', () => {
   describe('data', () => {
     it('should work with custom data types', async () => {
       let getItems = () => [{
-        types: ['test'],
-        getData: () => 'test data'
+        test: 'test data'
       }];
 
       let onPaste = jest.fn();
@@ -220,21 +219,20 @@ describe('useClipboard', () => {
       expect(onPaste).toHaveBeenCalledTimes(1);
       expect(onPaste).toHaveBeenCalledWith([
         {
+          kind: 'text',
           types: new Set(['test']),
-          getData: expect.any(Function)
+          getText: expect.any(Function)
         }
       ]);
 
-      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('test data');
+      expect(await onPaste.mock.calls[0][0][0].getText('test')).toBe('test data');
     });
 
     it('should work with multiple items of the same custom type', async () => {
       let getItems = () => [{
-        types: ['test'],
-        getData: () => 'item 1'
+        test: 'item 1'
       }, {
-        types: ['test'],
-        getData: () => 'item 2'
+        test: 'item 2'
       }];
 
       let onPaste = jest.fn();
@@ -258,23 +256,25 @@ describe('useClipboard', () => {
       expect(onPaste).toHaveBeenCalledTimes(1);
       expect(onPaste).toHaveBeenCalledWith([
         {
+          kind: 'text',
           types: new Set(['test']),
-          getData: expect.any(Function)
+          getText: expect.any(Function)
         },
         {
+          kind: 'text',
           types: new Set(['test']),
-          getData: expect.any(Function)
+          getText: expect.any(Function)
         }
       ]);
 
-      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('item 1');
-      expect(await onPaste.mock.calls[0][0][1].getData('test')).toBe('item 2');
+      expect(await onPaste.mock.calls[0][0][0].getText('test')).toBe('item 1');
+      expect(await onPaste.mock.calls[0][0][1].getText('test')).toBe('item 2');
     });
 
     it('should work with items of multiple types', async () => {
       let getItems = () => [{
-        types: ['test', 'text/plain'],
-        getData: () => 'test data'
+        test: 'test data',
+        'text/plain': 'test data'
       }];
 
       let onPaste = jest.fn();
@@ -299,22 +299,23 @@ describe('useClipboard', () => {
       expect(onPaste).toHaveBeenCalledTimes(1);
       expect(onPaste).toHaveBeenCalledWith([
         {
+          kind: 'text',
           types: new Set(['test', 'text/plain']),
-          getData: expect.any(Function)
+          getText: expect.any(Function)
         }
       ]);
 
-      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('test data');
-      expect(await onPaste.mock.calls[0][0][0].getData('text/plain')).toBe('test data');
+      expect(await onPaste.mock.calls[0][0][0].getText('test')).toBe('test data');
+      expect(await onPaste.mock.calls[0][0][0].getText('text/plain')).toBe('test data');
     });
 
     it('should work with multiple items of multiple types', async () => {
       let getItems = () => [{
-        types: ['test', 'text/plain'],
-        getData: () => 'item 1'
+        test: 'item 1',
+        'text/plain': 'item 1'
       }, {
-        types: ['test', 'text/plain'],
-        getData: () => 'item 2'
+        test: 'item 2',
+        'text/plain': 'item 2'
       }];
 
       let onPaste = jest.fn();
@@ -342,19 +343,21 @@ describe('useClipboard', () => {
       expect(onPaste).toHaveBeenCalledTimes(1);
       expect(onPaste).toHaveBeenCalledWith([
         {
+          kind: 'text',
           types: new Set(['test', 'text/plain']),
-          getData: expect.any(Function)
+          getText: expect.any(Function)
         },
         {
+          kind: 'text',
           types: new Set(['test', 'text/plain']),
-          getData: expect.any(Function)
+          getText: expect.any(Function)
         }
       ]);
 
-      expect(await onPaste.mock.calls[0][0][0].getData('test')).toBe('item 1');
-      expect(await onPaste.mock.calls[0][0][0].getData('text/plain')).toBe('item 1');
-      expect(await onPaste.mock.calls[0][0][1].getData('test')).toBe('item 2');
-      expect(await onPaste.mock.calls[0][0][1].getData('text/plain')).toBe('item 2');
+      expect(await onPaste.mock.calls[0][0][0].getText('test')).toBe('item 1');
+      expect(await onPaste.mock.calls[0][0][0].getText('text/plain')).toBe('item 1');
+      expect(await onPaste.mock.calls[0][0][1].getText('test')).toBe('item 2');
+      expect(await onPaste.mock.calls[0][0][1].getText('text/plain')).toBe('item 2');
     });
   });
 });

--- a/packages/@react-aria/dnd/test/useDraggableCollection.test.js
+++ b/packages/@react-aria/dnd/test/useDraggableCollection.test.js
@@ -73,9 +73,9 @@ describe('useDraggableCollection', () => {
       });
 
       expect([...dataTransfer.items]).toEqual([
-        new DataTransferItem('text/plain', 'Bar'),
         new DataTransferItem('folder', 'Bar'),
-        new DataTransferItem('application/vnd.react-aria.items+json', JSON.stringify([{'text/plain': 'Bar', folder: 'Bar'}]))
+        new DataTransferItem('text/plain', 'Bar'),
+        new DataTransferItem('application/vnd.react-aria.items+json', JSON.stringify([{folder: 'Bar', 'text/plain': 'Bar'}]))
       ]);
       expect(dataTransfer._dragImage.node.textContent).toBe('Bar');
       expect(dataTransfer._dragImage.node.querySelector('.badge')).toBeNull();
@@ -101,14 +101,15 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Bar');
 
       fireEvent(cells[1], new DragEvent('dragend', {dataTransfer, clientX: 2, clientY: 2}));
       expect(onDragEnd).toHaveBeenCalledTimes(1);
@@ -164,11 +165,11 @@ describe('useDraggableCollection', () => {
       });
 
       expect([...dataTransfer.items]).toEqual([
-        new DataTransferItem('text/plain', 'Foo\nBar'),
         new DataTransferItem('folder', 'Foo'),
+        new DataTransferItem('text/plain', 'Foo\nBar'),
         new DataTransferItem('application/vnd.react-aria.items+json', JSON.stringify([
-          {'text/plain': 'Foo', folder: 'Foo'},
-          {'text/plain': 'Bar', folder: 'Bar'}
+          {folder: 'Foo', 'text/plain': 'Foo'},
+          {folder: 'Bar', 'text/plain': 'Bar'}
         ]))
       ]);
       expect(dataTransfer._dragImage.node.querySelector('span').textContent).toBe('Bar');
@@ -186,21 +187,23 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           },
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Foo');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Foo');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Foo');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Foo');
 
-      expect(await onDrop.mock.calls[0][0].items[1].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[1].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[1].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[1].getText('folder')).toBe('Bar');
 
       fireEvent(cells[1], new DragEvent('dragend', {dataTransfer, clientX: 2, clientY: 2}));
       expect(onDragEnd).toHaveBeenCalledTimes(1);
@@ -254,10 +257,10 @@ describe('useDraggableCollection', () => {
       });
 
       expect([...dataTransfer.items]).toEqual([
-        new DataTransferItem('text/plain', 'Bar'),
         new DataTransferItem('folder', 'Bar'),
+        new DataTransferItem('text/plain', 'Bar'),
         new DataTransferItem('application/vnd.react-aria.items+json', JSON.stringify([
-          {'text/plain': 'Bar', folder: 'Bar'}
+          {folder: 'Bar', 'text/plain': 'Bar'}
         ]))
       ]);
       expect(dataTransfer._dragImage.node.querySelector('span').textContent).toBe('Bar');
@@ -275,14 +278,15 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Bar');
 
       fireEvent(cells[1], new DragEvent('dragend', {dataTransfer, clientX: 2, clientY: 2}));
       expect(onDragEnd).toHaveBeenCalledTimes(1);
@@ -363,14 +367,15 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Bar');
 
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledWith({
@@ -452,21 +457,23 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           },
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Foo');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Foo');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Foo');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Foo');
 
-      expect(await onDrop.mock.calls[0][0].items[1].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[1].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[1].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[1].getText('folder')).toBe('Bar');
 
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledWith({
@@ -544,14 +551,15 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Bar');
 
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledWith({
@@ -626,14 +634,15 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Bar');
 
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledWith({
@@ -703,21 +712,23 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           },
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Foo');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Foo');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Foo');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Foo');
 
-      expect(await onDrop.mock.calls[0][0].items[1].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[1].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[1].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[1].getText('folder')).toBe('Bar');
 
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledWith({
@@ -785,14 +796,15 @@ describe('useDraggableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain', 'folder']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('Bar');
-      expect(await onDrop.mock.calls[0][0].items[0].getData('folder')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('Bar');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('folder')).toBe('Bar');
 
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledWith({

--- a/packages/@react-aria/dnd/test/useDroppableCollection.test.js
+++ b/packages/@react-aria/dnd/test/useDroppableCollection.test.js
@@ -205,8 +205,9 @@ describe('useDroppableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
@@ -215,7 +216,7 @@ describe('useDroppableCollection', () => {
       cells = within(grid).getAllByRole('gridcell');
       expect(cells.map(cell => cell.textContent)).toEqual(['One', 'Two', 'hello world', 'Three']);
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('hello world');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('hello world');
     });
 
     it('should auto scroll when near the bottom', () => {
@@ -326,8 +327,9 @@ describe('useDroppableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
@@ -336,7 +338,7 @@ describe('useDroppableCollection', () => {
       cells = within(grid).getAllByRole('gridcell');
       expect(cells.map(cell => cell.textContent)).toEqual(['One', 'hello world', 'Two', 'Three']);
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('hello world');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('hello world');
     });
 
     it('should support arrow key navigation', () => {
@@ -814,8 +816,9 @@ describe('useDroppableCollection', () => {
         dropOperation: 'move',
         items: [
           {
+            kind: 'text',
             types: new Set(['text/plain']),
-            getData: expect.any(Function)
+            getText: expect.any(Function)
           }
         ]
       });
@@ -824,7 +827,7 @@ describe('useDroppableCollection', () => {
       cells = within(grid).getAllByRole('gridcell');
       expect(cells.map(cell => cell.textContent)).toEqual(['One', 'hello world', 'Two', 'Three']);
 
-      expect(await onDrop.mock.calls[0][0].items[0].getData('text/plain')).toBe('hello world');
+      expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('hello world');
     });
 
     it('should add descriptions to each item', () => {

--- a/packages/@react-stately/dnd/src/useDroppableCollectionState.ts
+++ b/packages/@react-stately/dnd/src/useDroppableCollectionState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, DropOperation, DroppableCollectionProps, DropTarget, ItemDropTarget, Node} from '@react-types/shared';
+import {Collection, DragTypes, DropOperation, DroppableCollectionProps, DropTarget, ItemDropTarget, Node} from '@react-types/shared';
 import {useState} from 'react';
 
 interface DroppableCollectionStateOptions extends DroppableCollectionProps {
@@ -22,7 +22,7 @@ export interface DroppableCollectionState {
   target: DropTarget,
   setTarget(target: DropTarget): void,
   isDropTarget(target: DropTarget): boolean,
-  getDropOperation(target: DropTarget, types: Set<string>, allowedOperations: DropOperation[]): DropOperation
+  getDropOperation(target: DropTarget, types: DragTypes, allowedOperations: DropOperation[]): DropOperation
 }
 
 export function useDroppableCollectionState(props: DroppableCollectionStateOptions): DroppableCollectionState  {

--- a/packages/@react-types/shared/src/dnd.d.ts
+++ b/packages/@react-types/shared/src/dnd.d.ts
@@ -21,8 +21,7 @@ export interface DragDropEvent {
 export type DropOperation = 'copy' | 'link' | 'move' | 'cancel';
 
 export interface DragItem {
-  types: Iterable<string>,
-  getData(type: string): string
+  [type: string]: string
 }
 
 export interface DragStartEvent extends DragDropEvent {
@@ -54,10 +53,27 @@ export interface DropExitEvent extends DragDropEvent {
   type: 'dropexit'
 }
 
-export interface DropItem {
+export interface TextItem {
+  kind: 'text',
   types: Set<string>,
-  getData(type: string): Promise<string>
+  getText(type: string): Promise<string>
 }
+
+export interface FileItem {
+  kind: 'file',
+  type: string,
+  name: string,
+  getFile(): Promise<File>,
+  getText(): Promise<string>
+}
+
+export interface DirectoryItem {
+  kind: 'directory',
+  name: string,
+  getEntries(): AsyncIterable<FileItem | DirectoryItem>
+}
+
+export type DropItem = TextItem | FileItem | DirectoryItem;
 
 export interface DropEvent extends DragDropEvent {
   type: 'drop',
@@ -98,8 +114,12 @@ interface DroppableCollectionDropEvent extends DropEvent {
   target: DropTarget
 }
 
+export interface DragTypes {
+  has(type: string): boolean
+}
+
 export interface DroppableCollectionProps {
-  getDropOperation?: (target: DropTarget, types: Set<string>, allowedOperations: DropOperation[]) => DropOperation,
+  getDropOperation?: (target: DropTarget, types: DragTypes, allowedOperations: DropOperation[]) => DropOperation,
   onDropEnter?: (e: DroppableCollectionEnterEvent) => void,
   onDropMove?: (e: DroppableCollectionMoveEvent) => void,
   onDropActivate?: (e: DroppableCollectionActivateEvent) => void,


### PR DESCRIPTION
Depends on #1701.

This adds support for dropping files from a user's filesystem (e.g. Finder), as well as directories of files. The API for drop items has changed accordingly to support these items in addition to the existing `text` items. In addition, the API for dragging changed slightly to simplify it a bit. Currently only dropping files is supported, dragging files is not because no browser currently supports this well. 

Pasting files is also "supported", but only Safari currently works. Other browsers don't allow pasting files at all. Unfortunately, this means copy/paste as a keyboard friendly alternative to dragging and dropping files won't really work for a majority of users, and we'll need to encourage applications to provide alternative ways of uploading files other than drag and drop/copy paste (e.g. an upload file button).

There are many, many browser bugs in these APIs so we have a lot of different workarounds. I will be opening many issues to report what I found, but please see the comments in the code for now. I tried to provide a nice API wrapper around most of them so that we can hide as many of the differences as possible, and also be able to switch to better browser APIs if/when they become available.