### PR TITLE
[@react-spectrum/icon] peer dependencies

### DIFF
--- a/packages/@react-spectrum/icon/package.json
+++ b/packages/@react-spectrum/icon/package.json
@@ -41,7 +41,16 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
+    "@adobe/react-spectrum": "^3.0.0-rc.1",
     "@react-spectrum/provider": "^3.0.0-rc.1"
+  },
+  "peerDependenciesMeta": {
+    "@adobe/react-spectrum": {
+      "optional": true
+    },
+    "@react-spectrum/provider": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
* add `@adobe/react-spectrum` as a peer dependency

* mark both `@adobe/react-spectrum` and `@react-spectrum/provider` as optional peer dependencies

Closes #1713

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- (n/a) Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- (n/a) Updated documentation (if it already exists for this component).
- (n/a) Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Use a package manager that is strict about peer dependencies (e.g. PNPM)
2. Create a project that has `@adobe/react-spectrum` as a dependency
3. Add `@react-spectrum/icon` as another dependency
4. Confirm there are no peer dependency errors

## 🧢 Your Project:

Adobe / Adobe Research / internal project
