### PR TITLE
Trigger onPressEnd for pressed elements even if they've become disabled

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -146,10 +146,7 @@ export function usePress(props: PressHookProps): PressResult {
     };
 
     let triggerPressEnd = (originalEvent: EventBase, pointerType: PointerType, wasPressed = true) => {
-      let {onPressEnd, onPressChange, onPress, isDisabled} = propsRef.current;
-      if (isDisabled) {
-        return;
-      }
+      let {onPressEnd, onPressChange, onPress} = propsRef.current;
 
       state.ignoreClickAfterPress = true;
 

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -161,7 +161,7 @@ export function usePress(props: PressHookProps): PressResult {
         });
       }
 
-      if (onPressChange && !isDisabled) {
+      if (onPressChange) {
         onPressChange(false);
       }
 

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -146,7 +146,7 @@ export function usePress(props: PressHookProps): PressResult {
     };
 
     let triggerPressEnd = (originalEvent: EventBase, pointerType: PointerType, wasPressed = true) => {
-      let {onPressEnd, onPressChange, onPress} = propsRef.current;
+      let {onPressEnd, onPressChange, onPress, isDisabled} = propsRef.current;
 
       state.ignoreClickAfterPress = true;
 
@@ -161,13 +161,13 @@ export function usePress(props: PressHookProps): PressResult {
         });
       }
 
-      if (onPressChange) {
+      if (onPressChange && !isDisabled) {
         onPressChange(false);
       }
 
       setPressed(false);
 
-      if (onPress && wasPressed) {
+      if (onPress && wasPressed && !isDisabled) {
         onPress({
           type: 'press',
           pointerType,


### PR DESCRIPTION

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
