### PR TITLE
provide more accurate types for useTextField

### DIFF
--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -27,9 +27,9 @@ import {useMenuTrigger} from '@react-aria/menu';
 import {useMessageFormatter} from '@react-aria/i18n';
 import {useTextField} from '@react-aria/textfield';
 
-interface AriaComboBoxProps<T> extends ComboBoxProps<T> {
+interface AriaComboBoxProps<T, InputElement extends HTMLInputElement | HTMLTextAreaElement> extends ComboBoxProps<T> {
   /** The ref for the input element. */
-  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  inputRef: RefObject<InputElement>,
   /** The ref for the list box popover. */
   popoverRef: RefObject<HTMLDivElement>,
   /** The ref for the list box. */
@@ -51,13 +51,17 @@ interface ComboBoxAria {
   labelProps: HTMLAttributes<HTMLElement>
 }
 
+/* eslint-disable no-redeclare */
+export function useComboBox<T>(props: AriaComboBoxProps<T, HTMLInputElement>, state: ComboBoxState<T>): ComboBoxAria;
+export function useComboBox<T>(props: AriaComboBoxProps<T, HTMLTextAreaElement>, state: ComboBoxState<T>): ComboBoxAria;
 /**
  * Provides the behavior and accessibility implementation for a combo box component.
  * A combo box combines a text input with a listbox, allowing users to filter a list of options to items matching a query.
  * @param props - Props for the combo box.
  * @param state - State for the select, as returned by `useComboBoxState`.
  */
-export function useComboBox<T>(props: AriaComboBoxProps<T>, state: ComboBoxState<T>): ComboBoxAria {
+export function useComboBox<T>(props: AriaComboBoxProps<T, any>, state: ComboBoxState<T>): ComboBoxAria {
+/* eslint-enable no-redeclare */
   let {
     buttonRef,
     popoverRef,

--- a/packages/@react-aria/searchfield/src/useSearchField.ts
+++ b/packages/@react-aria/searchfield/src/useSearchField.ts
@@ -19,15 +19,26 @@ import {SearchFieldState} from '@react-stately/searchfield';
 import {useMessageFormatter} from '@react-aria/i18n';
 import {useTextField} from '@react-aria/textfield';
 
-interface SearchFieldAria {
+interface SearchFieldAria<InputElement extends HTMLInputElement | HTMLTextAreaElement> {
   /** Props for the text field's visible label element (if any). */
   labelProps: LabelHTMLAttributes<HTMLLabelElement>,
   /** Props for the input element. */
-  inputProps: InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>,
+  inputProps: InputHTMLAttributes<InputElement>,
   /** Props for the clear button. */
   clearButtonProps: AriaButtonProps
 }
 
+/* eslint-disable no-redeclare */
+export function useSearchField(
+  props: AriaSearchFieldProps<HTMLInputElement>,
+  state: SearchFieldState,
+  inputRef: RefObject<HTMLInputElement>
+): SearchFieldAria<HTMLInputElement>;
+export function useSearchField(
+  props: AriaSearchFieldProps<HTMLTextAreaElement>,
+  state: SearchFieldState,
+  inputRef: RefObject<HTMLTextAreaElement>
+): SearchFieldAria<HTMLTextAreaElement>
 /**
  * Provides the behavior and accessibility implementation for a search field.
  * @param props - Props for the search field.
@@ -35,10 +46,10 @@ interface SearchFieldAria {
  * @param inputRef - A ref to the input element.
  */
 export function useSearchField(
-  props: AriaSearchFieldProps,
+  props: AriaSearchFieldProps<HTMLInputElement | HTMLTextAreaElement>,
   state: SearchFieldState,
-  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>
-): SearchFieldAria {
+  inputRef: RefObject<any>
+): SearchFieldAria<HTMLInputElement | HTMLTextAreaElement> {
   let formatMessage = useMessageFormatter(intlMessages);
   let {
     isDisabled,

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -42,11 +42,7 @@ interface AriaTextFieldOptions<InputElement extends HTMLInputElement | HTMLTextA
   inputElementType?: ElementType
 }
 
-/**
- * Provides the behavior and accessibility implementation for a text field.
- * @param props - Props for the text field.
- * @param ref - Ref to the HTML input or textarea element.
- */
+/* eslint-disable no-redeclare */
 export function useTextField(
   props: AriaTextFieldOptions<HTMLTextAreaElement>,
   ref: RefObject<HTMLTextAreaElement>
@@ -55,10 +51,16 @@ export function useTextField(
   props: AriaTextFieldOptions<HTMLInputElement>,
   ref: RefObject<HTMLInputElement>
 ): InputFieldAria;
+/**
+ * Provides the behavior and accessibility implementation for a text field.
+ * @param props - Props for the text field.
+ * @param ref - Ref to the HTML input or textarea element.
+ */
 export function useTextField(
   props: AriaTextFieldOptions<HTMLInputElement | HTMLTextAreaElement>,
   ref: RefObject<HTMLInputElement | HTMLTextAreaElement>
 ): TextareaFieldAria | InputFieldAria {
+/* eslint-enable no-redeclare */
   let {
     inputElementType = 'input',
     isDisabled = false,

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -18,13 +18,21 @@ import {useFocusable} from '@react-aria/focus';
 import {useLabel} from '@react-aria/label';
 
 interface TextFieldAria {
-  /** Props for the input element. */
-  inputProps: InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>,
   /** Props for the text field's visible label element (if any). */
   labelProps: LabelHTMLAttributes<HTMLLabelElement>
 }
 
-interface AriaTextFieldOptions extends AriaTextFieldProps {
+interface InputFieldAria extends TextFieldAria {
+  /** Props for the input element. */
+  inputProps: InputHTMLAttributes<HTMLInputElement>
+}
+
+interface TextareaFieldAria extends TextFieldAria {
+  /** Props for the textarea element. */
+  inputProps: TextareaHTMLAttributes<HTMLTextAreaElement>
+}
+
+interface AriaTextFieldOptions<InputElement extends HTMLInputElement | HTMLTextAreaElement> extends AriaTextFieldProps<InputElement> {
   /**
    * The HTML element used to render the input, e.g. 'input', or 'textarea'.
    * It determines whether certain HTML attributes will be included in `inputProps`.
@@ -40,9 +48,17 @@ interface AriaTextFieldOptions extends AriaTextFieldProps {
  * @param ref - Ref to the HTML input or textarea element.
  */
 export function useTextField(
-  props: AriaTextFieldOptions,
+  props: AriaTextFieldOptions<HTMLTextAreaElement>,
+  ref: RefObject<HTMLTextAreaElement>
+): TextareaFieldAria;
+export function useTextField(
+  props: AriaTextFieldOptions<HTMLInputElement>,
+  ref: RefObject<HTMLInputElement>
+): InputFieldAria;
+export function useTextField(
+  props: AriaTextFieldOptions<HTMLInputElement | HTMLTextAreaElement>,
   ref: RefObject<HTMLInputElement | HTMLTextAreaElement>
-): TextFieldAria {
+): TextareaFieldAria | InputFieldAria {
   let {
     inputElementType = 'input',
     isDisabled = false,
@@ -77,7 +93,7 @@ export function useTextField(
         'aria-haspopup': props['aria-haspopup'],
         value: props.value,
         defaultValue: props.value ? undefined : props.defaultValue,
-        onChange: (e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+        onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(e.target.value),
         autoComplete: props.autoComplete,
         maxLength: props.maxLength,
         minLength: props.minLength,

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -81,7 +81,7 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
   let buttonRef = useRef<FocusableRefValue<HTMLElement>>();
   let unwrappedButtonRef = useUnwrapDOMRef(buttonRef);
   let listBoxRef = useRef();
-  let inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>();
+  let inputRef = useRef<HTMLInputElement>();
   let domRef = useFocusableRef(ref, inputRef);
 
   let {contains} = useFilter({sensitivity: 'base'});

--- a/packages/@react-spectrum/searchfield/src/SearchField.tsx
+++ b/packages/@react-spectrum/searchfield/src/SearchField.tsx
@@ -43,7 +43,7 @@ function SearchField(props: SpectrumSearchFieldProps, ref: RefObject<TextFieldRe
   } = props;
 
   let state = useSearchFieldState(props);
-  let inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>();
+  let inputRef = useRef<HTMLInputElement>();
   let {labelProps, inputProps, clearButtonProps} = useSearchField(props, state, inputRef);
 
   let clearButton = (

--- a/packages/@react-spectrum/textfield/src/TextArea.tsx
+++ b/packages/@react-spectrum/textfield/src/TextArea.tsx
@@ -18,7 +18,7 @@ import {useControlledState} from '@react-stately/utils';
 import {useProviderProps} from '@react-spectrum/provider';
 import {useTextField} from '@react-aria/textfield';
 
-function TextArea(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
+function TextArea(props: SpectrumTextFieldProps<HTMLTextAreaElement>, ref: RefObject<TextFieldRef>) {
   props = useProviderProps(props);
   let {
     isDisabled = false,

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -29,7 +29,7 @@ import {useFormProps} from '@react-spectrum/form';
 import {useHover} from '@react-aria/interactions';
 import {useProviderProps} from '@react-spectrum/provider';
 
-interface TextFieldBaseProps extends SpectrumTextFieldProps, PressEvents {
+interface TextFieldBaseProps extends SpectrumTextFieldProps<HTMLInputElement | HTMLTextAreaElement>, PressEvents {
   wrapperChildren?: ReactElement | ReactElement[],
   inputClassName?: string,
   validationIconClassName?: string,

--- a/packages/@react-types/searchfield/src/index.d.ts
+++ b/packages/@react-types/searchfield/src/index.d.ts
@@ -20,5 +20,5 @@ export interface SearchFieldProps extends TextFieldProps {
   onClear?: () => void
 }
 
-export interface AriaSearchFieldProps extends SearchFieldProps, AriaTextFieldProps {}
+export interface AriaSearchFieldProps<InputElement extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends SearchFieldProps, AriaTextFieldProps<InputElement> {}
 export interface SpectrumSearchFieldProps extends AriaSearchFieldProps, SpectrumTextFieldProps {}

--- a/packages/@react-types/shared/src/dom.d.ts
+++ b/packages/@react-types/shared/src/dom.d.ts
@@ -63,7 +63,7 @@ export interface FocusableDOMProps extends DOMProps {
 
 // DOM props that apply to all text inputs
 // Ensure this is synced with useTextField
-export interface TextInputDOMProps extends DOMProps {
+export interface TextInputDOMProps<InputElement extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends DOMProps {
   /**
    * Describes the type of autocomplete functionality the input should provide if any. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefautocomplete).
    */
@@ -108,47 +108,47 @@ export interface TextInputDOMProps extends DOMProps {
   /**
    * Handler that is called when the user copies text. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/oncopy).
    */
-  onCopy?: ClipboardEventHandler<HTMLInputElement>,
+  onCopy?: ClipboardEventHandler<InputElement>,
 
   /**
    * Handler that is called when the user cuts text. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/oncut).
    */
-  onCut?: ClipboardEventHandler<HTMLInputElement>,
+  onCut?: ClipboardEventHandler<InputElement>,
 
   /**
    * Handler that is called when the user pastes text. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/onpaste).
    */
-  onPaste?: ClipboardEventHandler<HTMLInputElement>,
+  onPaste?: ClipboardEventHandler<InputElement>,
 
   // Composition events
   /**
    * Handler that is called when a text composition system starts a new text composition session. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionstart_event).
    */
-  onCompositionStart?: CompositionEventHandler<HTMLInputElement>,
-  
+  onCompositionStart?: CompositionEventHandler<InputElement>,
+
   /**
    * Handler that is called when a text composition system completes or cancels the current text composition session. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event).
    */
-  onCompositionEnd?: CompositionEventHandler<HTMLInputElement>,
+  onCompositionEnd?: CompositionEventHandler<InputElement>,
 
   /**
    * Handler that is called when a new character is received in the current text composition session. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionupdate_event).
    */
-  onCompositionUpdate?: CompositionEventHandler<HTMLInputElement>,
+  onCompositionUpdate?: CompositionEventHandler<InputElement>,
 
   // Selection events
   /**
    * Handler that is called when text in the input is selected. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/select_event).
    */
-  onSelect?: ReactEventHandler<HTMLInputElement>,
+  onSelect?: ReactEventHandler<InputElement>,
 
   // Input events
   /**
    * Handler that is called when the input value is about to be modified. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event).
    */
-  onBeforeInput?: FormEventHandler<HTMLInputElement>,
+  onBeforeInput?: FormEventHandler<InputElement>,
   /**
    * Handler that is called when the input value is modified. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
    */
-  onInput?: FormEventHandler<HTMLInputElement>
+  onInput?: FormEventHandler<InputElement>
 }

--- a/packages/@react-types/textfield/src/index.d.ts
+++ b/packages/@react-types/textfield/src/index.d.ts
@@ -29,7 +29,7 @@ import {ReactElement} from 'react';
 
 export interface TextFieldProps extends InputBase, Validation, FocusableProps, TextInputBase, ValueBase<string>, LabelableProps {}
 
-export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, FocusableDOMProps, TextInputDOMProps, AriaValidationProps {
+export interface AriaTextFieldProps<InputElement extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends TextFieldProps, AriaLabelingProps, FocusableDOMProps, TextInputDOMProps<InputElement>, AriaValidationProps {
   // https://www.w3.org/TR/wai-aria-1.2/#textbox
   /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
   'aria-activedescendant'?: string,
@@ -42,7 +42,7 @@ export interface AriaTextFieldProps extends TextFieldProps, AriaLabelingProps, F
   'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog'
 }
 
-export interface SpectrumTextFieldProps extends AriaTextFieldProps, SpectrumLabelableProps, StyleProps {
+export interface SpectrumTextFieldProps<InputElement extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends AriaTextFieldProps<InputElement>, SpectrumLabelableProps, StyleProps {
   /** An icon to display at the start of the input. */
   icon?: ReactElement,
   /** Whether the input should be displayed with a quiet style. */


### PR DESCRIPTION
Closes #1760

This PR uses [Function Overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to support both Textarea and Input elements in `useTextField`. ~If the approach is approvied there will need to be a tweak to the eslint config to allow for overloads https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-redeclare.md~ (I discovered the precedent of eslint-disable lines in `useButton`)

I also think this might open up support for closing https://github.com/adobe/react-spectrum/issues/1178 since the overload should allow props that only apply to Textarea or Input however I haven't attempted to solve that yet. 

In order to achieve fixing that there will need to be a split of `AriaTextFieldProps` into `AriaTextFieldInputProps` and `AriaTextFieldTextareaProps` such that the overload will allow only Textarea props when the signature matches. 

I'm happy to tweak this as needed

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

No regressions in `useTextField`

Case described here works https://codesandbox.io/s/affectionate-bardeen-rtfmw

## 🧢 Your Project:

<!--- Company/project for pull request -->
