### PR TITLE
Move children from LinkProps to SpectrumLinkProps and remove LinkProps

### DIFF
--- a/packages/@react-types/link/src/index.d.ts
+++ b/packages/@react-types/link/src/index.d.ts
@@ -13,14 +13,11 @@
 import {AriaLabelingProps, PressEvents, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
-export interface LinkProps extends PressEvents {
-  /** The content to display in the link. */
-  children: ReactNode
-}
-
-export interface AriaLinkProps extends LinkProps, AriaLabelingProps {}
+export interface AriaLinkProps extends PressEvents, AriaLabelingProps { }
 
 export interface SpectrumLinkProps extends AriaLinkProps, StyleProps {
+  /** The content to display in the link. */
+  children: ReactNode,
   /**
    * The [visual style](https://spectrum.adobe.com/page/link/#Options) of the link.
    * @default 'primary'


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1762

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

No regressions with `useLink`

children no longer a typescript required prop for `useLink`

## 🧢 Your Project:

<!--- Company/project for pull request -->
