### PR TITLE
WIP fix invalid click event

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -146,6 +146,14 @@ export function usePress(props: PressHookProps): PressResult {
 
       state.didFirePressStart = true;
       setPressed(true);
+      let cancelClick = (e) => {
+        if (originalEvent.currentTarget !== e.target) {
+          e.stopPropagation();
+          e.preventDefault();
+        }
+        document.body.removeEventListener('click', cancelClick, true);
+      };
+      document.body.addEventListener('click', cancelClick, true);
     };
 
     let triggerPressEnd = (originalEvent: EventBase, pointerType: PointerType, wasPressed = true) => {

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -83,6 +83,51 @@ let withSection = [
 ];
 
 storiesOf('MenuTrigger', module)
+  .add('debug',
+    () => (
+      <div style={{ minHeight: "100vh" }}>
+        <MenuTrigger>
+          <ActionButton>Menu</ActionButton>
+          <Menu onAction={(key) => console.log(key)}>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
+            <Item key="four">Four</Item>
+            <Item key="five">Five</Item>
+          </Menu>
+        </MenuTrigger>
+        <button
+          style={{ display: "block", padding: "6px 24px" }}
+          onClick={() => alert("Oh no!")}
+        >
+          Click
+        </button>
+        <button
+          style={{ display: "block", padding: "6px 24px" }}
+          onClick={() => alert("Oh no!")}
+        >
+          Click
+        </button>
+        <button
+          style={{ display: "block", padding: "6px 24px" }}
+          onClick={() => alert("Oh no!")}
+        >
+          Click
+        </button>
+        <button
+          style={{ display: "block", padding: "6px 24px" }}
+          onClick={() => alert("Oh no!")}
+        >
+          Click
+        </button>
+        <button
+          style={{ display: "block", padding: "6px 24px" }}
+          onClick={() => alert("Oh no!")}
+        >
+          Click
+        </button>
+      </div>
+    ))
   .add(
     'default menu (static)',
     () => render(


### PR DESCRIPTION
Starting a PR just to discuss possible workarounds to the issue
https://github.com/adobe/react-spectrum/issues/1513

I'm a little worried that this wouldn't be targeted enough, for instance, a link in a menu might close the menu in onPress, but the user might still expect the default 'onClick' behavior navigation instead of having to handle that themselves.

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
