### PR TITLE
Tabs design updates

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tabs/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tabs/index.css
@@ -40,7 +40,7 @@ governing permissions and limitations under the License.
   z-index: 0;
 
   margin: 0;
-  padding: 0 var(--spectrum-tabs-focus-ring-padding-x);
+  padding: 0;
 
   /* Friends should align to the top of the tabs */
   vertical-align: top;
@@ -259,16 +259,22 @@ governing permissions and limitations under the License.
 
 .spectrum-TabsPanel-collapseWrapper {
   display: flex;
-  overflow: hidden;
   position: relative;
 }
 
 .spectrum-TabsPanel-tabs {
-  flex-grow: 1;
+  flex-grow: 0;
   flex-shrink: 0;
   flex-basis: 0%;
 }
 
 .spectrum-TabsPanel-tabpanel {
   flex-grow: 1;
+  border: var(--spectrum-tabs-focus-ring-size) solid transparent;
+}
+
+.spectrum-TabsPanel--vertical {
+  .spectrum-Tabs {
+    padding-right: var(--spectrum-global-dimension-size-160);
+  }
 }

--- a/packages/@adobe/spectrum-css-temp/components/tabs/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/tabs/skin.css
@@ -95,3 +95,13 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+.spectrum-TabsPanel-tabpanel {
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-ring {
+    border-color: var(--spectrum-tabs-focus-ring-color);
+  }
+}

--- a/packages/@react-aria/tabs/package.json
+++ b/packages/@react-aria/tabs/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@react-aria/focus": "^3.2.4",
     "@react-aria/i18n": "^3.3.0",
     "@react-aria/interactions": "^3.3.3",
     "@react-aria/selection": "^3.3.2",

--- a/packages/@react-spectrum/tabs/chromatic/Tabs.chromatic.tsx
+++ b/packages/@react-spectrum/tabs/chromatic/Tabs.chromatic.tsx
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import {Content} from '@react-spectrum/view';
 import {Heading, Text} from '@react-spectrum/text';
 import {Item, TabList, TabPanels, Tabs} from '../';
 import {Meta, Story} from '@storybook/react';

--- a/packages/@react-spectrum/tabs/chromatic/Tabs.chromatic.tsx
+++ b/packages/@react-spectrum/tabs/chromatic/Tabs.chromatic.tsx
@@ -12,7 +12,7 @@
 
 import {Content} from '@react-spectrum/view';
 import {Heading, Text} from '@react-spectrum/text';
-import {Item, Tabs} from '../';
+import {Item, TabList, TabPanels, Tabs} from '../';
 import {Meta, Story} from '@storybook/react';
 import React from 'react';
 import {SpectrumTabsProps} from '@react-types/tabs';
@@ -32,47 +32,57 @@ export default meta;
 
 
 const Template = <T extends object>(): Story<SpectrumTabsProps<T>> => (args) => (
+
   <Tabs {...args} aria-label="Tab example" maxWidth={500}>
-    <Item title="Tab 1" key="val1">
-      <Content margin="size-160">
-        <Heading>Tab Body 1</Heading>
-        <Text>
-          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-        </Text>
-      </Content>
-    </Item>
-    <Item title="Tab 2" key="val2">
-      <Content margin="size-160">
-        <Heading>Tab Body 2</Heading>
-        <Text>
-          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-        </Text>
-      </Content>
-    </Item>
-    <Item title="Tab 3" key="val3">
-      <Content margin="size-160">
-        <Heading>Tab Body 3</Heading>
-        <Text>
-          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-        </Text>
-      </Content>
-    </Item>
-    <Item title="Tab 4" key="val4">
-      <Content margin="size-160">
-        <Heading>Tab Body 4</Heading>
-        <Text>
-          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-        </Text>
-      </Content>
-    </Item>
-    <Item title="Tab 5" key="val5">
-      <Content margin="size-160">
-        <Heading>Tab Body 5</Heading>
-        <Text>
-          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-        </Text>
-      </Content>
-    </Item>
+    <TabList>
+      <Item key="val1">Tab 1</Item>
+      <Item key="val2">Tab 2</Item>
+      <Item key="val3">Tab 3</Item>
+      <Item key="val4">Tab 4</Item>
+      <Item key="val5">Tab 5</Item>
+    </TabList>
+    <TabPanels>
+      <Item title="Tab 1" key="val1">
+        <Content margin="size-160">
+          <Heading>Tab Body 1</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+          </Text>
+        </Content>
+      </Item>
+      <Item title="Tab 2" key="val2">
+        <Content margin="size-160">
+          <Heading>Tab Body 2</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+          </Text>
+        </Content>
+      </Item>
+      <Item title="Tab 3" key="val3">
+        <Content margin="size-160">
+          <Heading>Tab Body 3</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+          </Text>
+        </Content>
+      </Item>
+      <Item title="Tab 4" key="val4">
+        <Content margin="size-160">
+          <Heading>Tab Body 4</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+          </Text>
+        </Content>
+      </Item>
+      <Item title="Tab 5" key="val5">
+        <Content margin="size-160">
+          <Heading>Tab Body 5</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+          </Text>
+        </Content>
+      </Item>
+    </TabPanels>
   </Tabs>
 );
 

--- a/packages/@react-spectrum/tabs/chromatic/Tabs.chromatic.tsx
+++ b/packages/@react-spectrum/tabs/chromatic/Tabs.chromatic.tsx
@@ -42,45 +42,35 @@ const Template = <T extends object>(): Story<SpectrumTabsProps<T>> => (args) => 
       <Item key="val5">Tab 5</Item>
     </TabList>
     <TabPanels>
-      <Item title="Tab 1" key="val1">
-        <Content margin="size-160">
-          <Heading>Tab Body 1</Heading>
-          <Text>
-            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-          </Text>
-        </Content>
+      <Item key="val1">
+        <Heading>Tab Body 1</Heading>
+        <Text>
+          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+        </Text>
       </Item>
-      <Item title="Tab 2" key="val2">
-        <Content margin="size-160">
-          <Heading>Tab Body 2</Heading>
-          <Text>
-            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-          </Text>
-        </Content>
+      <Item key="val2">
+        <Heading>Tab Body 2</Heading>
+        <Text>
+          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+        </Text>
       </Item>
-      <Item title="Tab 3" key="val3">
-        <Content margin="size-160">
-          <Heading>Tab Body 3</Heading>
-          <Text>
-            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-          </Text>
-        </Content>
+      <Item key="val3">
+        <Heading>Tab Body 3</Heading>
+        <Text>
+          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+        </Text>
       </Item>
-      <Item title="Tab 4" key="val4">
-        <Content margin="size-160">
-          <Heading>Tab Body 4</Heading>
-          <Text>
-            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-          </Text>
-        </Content>
+      <Item key="val4">
+        <Heading>Tab Body 4</Heading>
+        <Text>
+          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+        </Text>
       </Item>
-      <Item title="Tab 5" key="val5">
-        <Content margin="size-160">
-          <Heading>Tab Body 5</Heading>
-          <Text>
-            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-          </Text>
-        </Content>
+      <Item key="val5">
+        <Heading>Tab Body 5</Heading>
+        <Text>
+          Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+        </Text>
       </Item>
     </TabPanels>
   </Tabs>

--- a/packages/@react-spectrum/tabs/stories/Tabs.stories.js
+++ b/packages/@react-spectrum/tabs/stories/Tabs.stories.js
@@ -11,7 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionGroup, Content, Flex, Heading, Text} from '@adobe/react-spectrum';
+import {ActionGroup, Flex, Heading, Text} from '@adobe/react-spectrum';
 import Bookmark from '@spectrum-icons/workflow/Bookmark';
 import {Button} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
@@ -20,6 +20,7 @@ import Dashboard from '@spectrum-icons/workflow/Dashboard';
 import {Item, TabList, TabPanels, Tabs} from '..';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
+import {TextField} from '@react-spectrum/textfield';
 
 storiesOf('Tabs', module)
   .add(
@@ -119,20 +120,12 @@ storiesOf('Tabs', module)
       <Flex minHeight={400} minWidth={400} UNSAFE_style={{borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--spectrum-global-color-gray-800)', padding: '10px'}}>
         <Tabs>
           <TabList>
-            <Item title="Tab 1" />
-            <Item title="Tab 2" />
+            <Item>Tab 1</Item>
+            <Item>Tab 2</Item>
           </TabList>
           <TabPanels>
-            <Item title="Tab 1">
-              <Content>
-                <Text>Hello World</Text>
-              </Content>
-            </Item>
-            <Item title="Tab 2">
-              <Content>
-                <Text>Goodbye World</Text>
-              </Content>
-            </Item>
+            <Item>Hello World</Item>
+            <Item>Goodbye World</Item>
           </TabPanels>
         </Tabs>
       </Flex>
@@ -152,16 +145,8 @@ storiesOf('Tabs', module)
             </Item>
           </TabList>
           <TabPanels>
-            <Item>
-              <Content margin="size-160">
-                <Text>Text</Text>
-              </Content>
-            </Item>
-            <Item>
-              <Content margin="size-160">
-                <Text>Text 2</Text>
-              </Content>
-            </Item>
+            <Item>Text</Item>
+            <Item>Text 2</Item>
           </TabPanels>
         </Tabs>
       )
@@ -170,68 +155,111 @@ storiesOf('Tabs', module)
   .add(
     'Tab with flex container in between',
     () => <DynamicTabsWithDecoration />
+  )
+  .add(
+    'tabs at the bottom',
+    () => (
+      (
+        <Tabs maxWidth={500}>
+          <TabPanels height="size-1000">
+            <Item>Text 1</Item>
+            <Item>Text 2</Item>
+          </TabPanels>
+          <TabList>
+            <Item>Tab 1</Item>
+            <Item>Tab 2</Item>
+          </TabList>
+        </Tabs>
+      )
+    )
+  )
+  .add(
+    'tabs on the right',
+    () => (
+      (
+        <Tabs maxWidth={500} orientation="vertical">
+          <TabPanels>
+            <Item>Text 1</Item>
+            <Item>Text 2</Item>
+          </TabPanels>
+          <TabList>
+            <Item>Tab 1</Item>
+            <Item>Tab 2</Item>
+          </TabList>
+        </Tabs>
+      )
+    )
+  )
+  .add(
+    'focusable element in tab panel',
+    () => (
+      <Tabs maxWidth={500}>
+        <TabList>
+          <Item>Tab 1</Item>
+          <Item>Tab 2</Item>
+        </TabList>
+        <TabPanels>
+          <Item>
+            <TextField label="Tab 1" />
+          </Item>
+          <Item>
+            <TextField label="Tab 2" isDisabled />
+          </Item>
+        </TabPanels>
+      </Tabs>
+    )
   );
 
 function render(props = {}) {
   return (
     <Tabs {...props} aria-label="Tab example" maxWidth={500} onSelectionChange={action('onSelectionChange')}>
       <TabList>
-        <Item title="Tab 1" key="val1" />
-        <Item title="Tab 2" key="val2" />
-        <Item title="Tab 3" key="val3" />
-        <Item title="Tab 4" key="val4" />
-        <Item title="Tab 5" key="val5" />
+        <Item key="val1">Tab 1</Item>
+        <Item key="val2">Tab 2</Item>
+        <Item key="val3">Tab 3</Item>
+        <Item key="val4">Tab 4</Item>
+        <Item key="val5">Tab 5</Item>
       </TabList>
       <TabPanels>
-        <Item title="Tab 1" key="val1">
-          <Content margin="size-160">
-            <Heading>Tab Body 1</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val1">
+          <Heading>Tab Body 1</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 2" key="val2">
-          <Content margin="size-160">
-            <Heading>Tab Body 2</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val2">
+          <Heading>Tab Body 2</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 3" key="val3">
-          <Content margin="size-160">
-            <Heading>Tab Body 3</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val3">
+          <Heading>Tab Body 3</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 4" key="val4">
-          <Content margin="size-160">
-            <Heading>Tab Body 4</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val4">
+          <Heading>Tab Body 4</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 5" key="val5">
-          <Content margin="size-160">
-            <Heading>Tab Body 5</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val5">
+          <Heading>Tab Body 5</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
       </TabPanels>
     </Tabs>
@@ -242,49 +270,43 @@ function renderWithIcons(props = {}) {
   return (
     <Tabs {...props} aria-label="Tab example" maxWidth={500} onSelectionChange={action('onSelectionChange')}>
       <TabList>
-        <Item key="dashboard" textValue="Dashboard">
+        <Item key="dashboard">
           <Dashboard />
           <Text>Dashboard</Text>
         </Item>
-        <Item key="calendar" textValue="Calendar">
+        <Item key="calendar">
           <Calendar />
           <Text>Calendar</Text>
         </Item>
-        <Item key="bookmark" textValue="Bookmark">
+        <Item key="bookmark">
           <Bookmark />
           <Text>Bookmark</Text>
         </Item>
       </TabList>
       <TabPanels>
         <Item key="dashboard">
-          <Content margin="size-160">
-            <Heading>Dashboard</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+          <Heading>Dashboard</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item key="calendar" textValue="Calendar">
-          <Content margin="size-160">
-            <Heading>Calendar</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="calendar">
+          <Heading>Calendar</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
         <Item key="bookmark">
-          <Content margin="size-160">
-            <Heading>Bookmark</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+          <Heading>Bookmark</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
       </TabPanels>
     </Tabs>
@@ -295,62 +317,52 @@ function renderWithFalsyKey(props = {}) {
   return (
     <Tabs {...props} aria-label="Tab example" maxWidth={500} onSelectionChange={action('onSelectionChange')}>
       <TabList>
-        <Item title="Tab 1" key="" />
-        <Item title="Tab 2" key="val2" />
-        <Item title="Tab 3" key="val3" />
-        <Item title="Tab 4" key="val4" />
-        <Item title="Tab 5" key="val5" />
+        <Item key="">Tab 1</Item>
+        <Item key="val2">Tab 2</Item>
+        <Item key="val3">Tab 3</Item>
+        <Item key="val4">Tab 4</Item>
+        <Item key="val5">Tab 5</Item>
       </TabList>
       <TabPanels>
-        <Item title="Tab 1" key="">
-          <Content margin="size-160">
-            <Heading>Tab Body 1</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="">
+          <Heading>Tab Body 1</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 2" key="val2">
-          <Content margin="size-160">
-            <Heading>Tab Body 2</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val2">
+          <Heading>Tab Body 2</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 3" key="val3">
-          <Content margin="size-160">
-            <Heading>Tab Body 3</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val3">
+          <Heading>Tab Body 3</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 4" key="val4">
-          <Content margin="size-160">
-            <Heading>Tab Body 4</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val4">
+          <Heading>Tab Body 4</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
-        <Item title="Tab 5" key="val5">
-          <Content margin="size-160">
-            <Heading>Tab Body 5</Heading>
-            <Text>
-              Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-              Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-              Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-            </Text>
-          </Content>
+        <Item key="val5">
+          <Heading>Tab Body 5</Heading>
+          <Text>
+            Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+            Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+            Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+          </Text>
         </Item>
       </TabPanels>
     </Tabs>
@@ -390,7 +402,7 @@ let DynamicTabs = (props = {}) => {
       <Tabs {...props} aria-label="Tab example" items={tabs} onSelectionChange={action('onSelectionChange')}>
         <TabList>
           {item => (
-            <Item key={item.name} textValue={item.name}>
+            <Item key={item.name}>
               {item.icon}
               <Text>{item.name}</Text>
             </Item>
@@ -399,14 +411,12 @@ let DynamicTabs = (props = {}) => {
         <TabPanels>
           {item => (
             <Item key={item.name}>
-              <Content margin="size-160">
-                <Heading>{item.children}</Heading>
-                <Text>
-                  Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-                  Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-                  Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-                </Text>
-              </Content>
+              <Heading>{item.children}</Heading>
+              <Text>
+                Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+                Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+                Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+              </Text>
             </Item>
           )}
         </TabPanels>
@@ -431,7 +441,7 @@ let OrientationFlip = (props = {}) => {
       <Tabs {...props} aria-label="Tab example" items={items} onSelectionChange={action('onSelectionChange')} orientation={flipOrientation ? 'horizontal' : 'vertical'}>
         <TabList>
           {item => (
-            <Item key={item.name} textValue={item.name}>
+            <Item key={item.name}>
               {item.icon}
               <Text>{item.name}</Text>
             </Item>
@@ -440,14 +450,12 @@ let OrientationFlip = (props = {}) => {
         <TabPanels>
           {item => (
             <Item key={item.name}>
-              <Content margin="size-160">
-                <Heading>{item.children}</Heading>
-                <Text>
-                  Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-                  Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-                  Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-                </Text>
-              </Content>
+              <Heading>{item.children}</Heading>
+              <Text>
+                Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+                Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+                Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+              </Text>
             </Item>
           )}
         </TabPanels>
@@ -484,42 +492,38 @@ let DynamicTabsWithDecoration = (props = {}) => {
   return (
     <div style={{width: '80%'}}>
       <Tabs {...props} aria-label="Tab example" items={tabs} onSelectionChange={action('onSelectionChange')}>
-        <Flex direction="column">
-          <Flex direction="row" alignItems="center">
-            <TabList>
-              {item => (
-                <Item key={item.name} textValue={item.name}>
-                  {item.icon}
-                  <Text>{item.name}</Text>
-                </Item>
-              )}
-            </TabList>
-            <Flex alignItems="center" justifyContent="end" flexGrow={1} alignSelf="stretch" UNSAFE_style={{borderBottom: 'var(--spectrum-alias-border-size-thick) solid var(--spectrum-global-color-gray-200)'}}>
-              <ActionGroup marginEnd="30px" disabledKeys={tabs.length === 1 ? ['remove'] : undefined} onAction={val => val === 'add' ? addTab() : removeTab()}>
-                <Item key="add">
-                  <Text>Add Tab</Text>
-                </Item>
-                <Item key="remove">
-                  <Text>Remove Tab</Text>
-                </Item>
-              </ActionGroup>
-            </Flex>
-          </Flex>
-          <TabPanels>
+        <Flex direction="row" alignItems="center">
+          <TabList>
             {item => (
               <Item key={item.name}>
-                <Content margin="size-160">
-                  <Heading>{item.children}</Heading>
-                  <Text>
-                    Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
-                    Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
-                    Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
-                  </Text>
-                </Content>
+                {item.icon}
+                <Text>{item.name}</Text>
               </Item>
             )}
-          </TabPanels>
+          </TabList>
+          <Flex alignItems="center" justifyContent="end" flexGrow={1} alignSelf="stretch" UNSAFE_style={{borderBottom: 'var(--spectrum-alias-border-size-thick) solid var(--spectrum-global-color-gray-200)'}}>
+            <ActionGroup marginEnd="30px" disabledKeys={tabs.length === 1 ? ['remove'] : undefined} onAction={val => val === 'add' ? addTab() : removeTab()}>
+              <Item key="add">
+                <Text>Add Tab</Text>
+              </Item>
+              <Item key="remove">
+                <Text>Remove Tab</Text>
+              </Item>
+            </ActionGroup>
+          </Flex>
         </Flex>
+        <TabPanels>
+          {item => (
+            <Item key={item.name}>
+              <Heading>{item.children}</Heading>
+              <Text>
+                Dolore ex esse laboris elit magna esse sunt. Pariatur in veniam Lorem est occaecat do magna nisi mollit ipsum sit adipisicing fugiat ex. Pariatur ullamco exercitation ea qui adipisicing.
+                Id cupidatat aute id ut excepteur exercitation magna pariatur. Mollit irure irure reprehenderit pariatur eiusmod proident Lorem deserunt duis cillum mollit. Do reprehenderit sit cupidatat quis laborum in do culpa nisi ipsum. Velit aliquip commodo ea ipsum incididunt culpa nostrud deserunt incididunt exercitation. In quis proident sit ad dolore tempor. Eiusmod pariatur quis commodo labore cupidatat cillum enim eiusmod voluptate laborum culpa. Laborum cupidatat incididunt velit voluptate incididunt occaecat quis do.
+                Consequat adipisicing irure Lorem commodo officia sint id. Velit sit magna aliquip eiusmod non id deserunt. Magna veniam ad consequat dolor cupidatat esse enim Lorem ullamco. Anim excepteur consectetur id in. Mollit laboris duis labore enim duis esse reprehenderit.
+              </Text>
+            </Item>
+          )}
+        </TabPanels>
       </Tabs>
     </div>
   );

--- a/packages/@react-spectrum/tabs/test/Tabs.test.js
+++ b/packages/@react-spectrum/tabs/test/Tabs.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, render, within} from '@testing-library/react';
+import {act, fireEvent, render, waitFor, within} from '@testing-library/react';
 import {Item, TabList, TabPanels, Tabs} from '../src';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -569,5 +569,37 @@ describe('Tabs', function () {
     expect(onSelectionChange).toHaveBeenCalledWith('');
     tabpanel = getByRole('tabpanel');
     expect(tabpanel).toHaveTextContent(items[1].children);
+  });
+
+  it('tabpanel should have tabIndex=0 only when there are no focusable elements', async function () {
+    let {getByRole, getAllByRole} = render(
+      <Provider theme={theme}>
+        <Tabs maxWidth={500}>
+          <TabList>
+            <Item>Tab 1</Item>
+            <Item>Tab 2</Item>
+          </TabList>
+          <TabPanels>
+            <Item>
+              <input />
+            </Item>
+            <Item>
+              <input disabled />
+            </Item>
+          </TabPanels>
+        </Tabs>
+      </Provider>
+    );
+
+    let tabpanel = getByRole('tabpanel');
+    await waitFor(() => expect(tabpanel).not.toHaveAttribute('tabindex'));
+
+    let tabs = getAllByRole('tab');
+    triggerPress(tabs[1]);
+
+    await waitFor(() => expect(tabpanel).toHaveAttribute('tabindex', '0'));
+
+    triggerPress(tabs[0]);
+    await waitFor(() => expect(tabpanel).not.toHaveAttribute('tabindex'));
   });
 });

--- a/packages/@react-stately/collections/src/Item.ts
+++ b/packages/@react-stately/collections/src/Item.ts
@@ -18,12 +18,12 @@ function Item<T>(props: ItemProps<T>): ReactElement { // eslint-disable-line @ty
   return null;
 }
 
-Item.getCollectionNode = function* getCollectionNode<T>(props: ItemProps<T>): Generator<PartialNode<T>> {
+Item.getCollectionNode = function* getCollectionNode<T>(props: ItemProps<T>, context: any): Generator<PartialNode<T>> {
   let {childItems, title, children} = props;
 
   let rendered = props.title || props.children;
   let textValue = props.textValue || (typeof rendered === 'string' ? rendered : '') || props['aria-label'] || '';
-  if (!textValue) {
+  if (!textValue && !context?.suppressTextValueWarning) {
     console.warn('<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.');
   }
 

--- a/packages/@react-stately/list/src/useListState.ts
+++ b/packages/@react-stately/list/src/useListState.ts
@@ -18,8 +18,11 @@ import {useCollection} from '@react-stately/collections';
 
 export interface ListProps<T> extends CollectionBase<T>, MultipleSelection {
   /** Filter function to generate a filtered list of nodes. */
-  filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>
+  filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>,
+  /** @private */
+  suppressTextValueWarning?: boolean
 }
+
 export interface ListState<T> {
   /** A collection of items in the list. */
   collection: Collection<Node<T>>,
@@ -46,8 +49,9 @@ export function useListState<T extends object>(props: ListProps<T>): ListState<T
   , [props.disabledKeys]);
 
   let factory = nodes => filter ? new ListCollection(filter(nodes)) : new ListCollection(nodes as Iterable<Node<T>>);
+  let context = useMemo(() => ({suppressTextValueWarning: props.suppressTextValueWarning}), [props.suppressTextValueWarning]);
 
-  let collection = useCollection(props, factory, null, [filter]);
+  let collection = useCollection(props, factory, context, [filter]);
 
   // Reset focused key if that item is deleted from the collection.
   useEffect(() => {

--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -18,8 +18,11 @@ import {useControlledState} from '@react-stately/utils';
 
 export interface SingleSelectListProps<T> extends CollectionBase<T>, SingleSelection {
   /** Filter function to generate a filtered list of nodes. */
-  filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>
+  filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>,
+  /** @private */
+  suppressTextValueWarning?: boolean
 }
+
 export interface SingleSelectListState<T> extends ListState<T> {
   /** The key for the currently selected item. */
   readonly selectedKey: Key,

--- a/packages/@react-stately/tabs/src/useTabsState.ts
+++ b/packages/@react-stately/tabs/src/useTabsState.ts
@@ -17,7 +17,10 @@ import {useEffect} from 'react';
 export interface TabListState<T> extends SingleSelectListState<T> {}
 
 export function useTabListState<T extends object>(props: TabListProps<T>): TabListState<T> {
-  let state = useSingleSelectListState<T>(props);
+  let state = useSingleSelectListState<T>({
+    ...props,
+    suppressTextValueWarning: true
+  });
 
   useEffect(() => {
     // Ensure a tab is always selected (in case no selected key was specified or if selected item was deleted from collection)


### PR DESCRIPTION
Fixes #1755 #1737

* Fixes spectrum design feedback.
* Implements focus ring design for tabpanel
* Changes tabpanel to only have tabIndex=0 when there are no tabbable elements within it
* Adds support for style props to `<TabList>` and `<TabPanels>`
* Suppresses warning about `textValue` prop on `<Item>` elements in tabs since we don't support typeahead there anyway.
* Simplifies stories and adds a few new ones.