### PR TITLE
Refine table animations

### DIFF
--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -289,7 +289,7 @@ function TableVirtualizer({layout, collection, focusedKey, renderView, renderWra
       bodyRef.current.scrollTop = rect.y;
       setScrollLeft(bodyRef.current, direction, rect.x);
     },
-    transitionDuration: collection.body.props.isLoading && collection.size > 0 ? 0 : 500
+    transitionDuration: collection.body.props.isLoading ? 160 : 220
   });
 
   let {virtualizerProps} = useVirtualizer({

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -27,6 +27,8 @@ export class TableLayout<T> extends ListLayout<T> {
   columnWidths: Map<Key, number>;
   stickyColumnIndices: number[];
   getDefaultWidth: (props) => string | number;
+  wasLoading = false;
+  isLoading = false;
 
   constructor(options: TableLayoutOptions<T>) {
     super(options);
@@ -44,6 +46,10 @@ export class TableLayout<T> extends ListLayout<T> {
       // Invalidate everything in this layout pass. Will be reset in ListLayout on the next pass.
       this.invalidateEverything = true;
     }
+
+    // Track whether we were previously loading. This is used to adjust the animations of async loading vs inserts.
+    this.wasLoading = this.isLoading;
+    this.isLoading = Boolean(this.collection.body.props.isLoading);
 
     this.buildColumnWidths();
     let header = this.buildHeader();
@@ -405,5 +411,16 @@ export class TableLayout<T> extends ListLayout<T> {
     }
 
     return Math.max(0, Math.min(items.length - 1, low));
+  }
+
+  getInitialLayoutInfo(layoutInfo: LayoutInfo) {
+    let res = super.getInitialLayoutInfo(layoutInfo);
+
+    // If this insert was the result of async loading, remove the zoom effect and just keep the fade in.
+    if (this.wasLoading) {
+      res.transform = null;
+    }
+
+    return res;
   }
 }


### PR DESCRIPTION
Closes #1752

This refines the table animations so that:

* When async loading, there is no zoom effect, only a fade in. No animation at all looked weird, so this seems like a good balance. The fade is also there for loading more as well.
* When inserting/removing a row, the zoom effect is retained. Only fading looked weird because the other rows also move over the top of the added/removed row.
* The duration is much shorter. 160ms for fade in animations, 220ms for zoom.