### PR TITLE
Fix eslint warning about flex support

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Breadcrumbs {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   list-style-type: none;
   flex-wrap: nowrap;
   flex-grow: 1;
@@ -46,7 +46,7 @@ governing permissions and limitations under the License.
 .spectrum-Breadcrumbs-item {
   display: inline-flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
 
   box-sizing: border-box;
   height: var(--spectrum-breadcrumb-list-height);

--- a/packages/@adobe/spectrum-css-temp/components/sidenav/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/sidenav/index.css
@@ -35,7 +35,7 @@ governing permissions and limitations under the License.
   position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   box-sizing: border-box;
 
   inline-size: 100%;


### PR DESCRIPTION
Currently when installing react spectrum in a CRA app eslint may give warnings about mixed support for the `start` value used in the breadcrumbs css.
This was reported in #956, #844 and #768.
I believe the fix is quite simple: change `start` to `flex-start`.

While the eslint warnings only mentioned the breadcrumbs using the `start` value I found that the sidenav component was using this as well.

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
