### PR TITLE
Fix diagonal scrolling in Numberfield

### DIFF
--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -73,6 +73,9 @@ export function useColorField(
   );
 
   let onWheel = useCallback((e) => {
+    if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) {
+      return;
+    }
     if (e.deltaY > 0) {
       increment();
     } else if (e.deltaY < 0) {

--- a/packages/@react-aria/interactions/src/useScrollWheel.ts
+++ b/packages/@react-aria/interactions/src/useScrollWheel.ts
@@ -31,7 +31,6 @@ export function useScrollWheel(props: ScrollWheelProps, ref: RefObject<HTMLEleme
     e.preventDefault();
     e.stopPropagation();
 
-
     if (onScroll) {
       onScroll({deltaX: e.deltaX, deltaY: e.deltaY});
     }
@@ -39,14 +38,13 @@ export function useScrollWheel(props: ScrollWheelProps, ref: RefObject<HTMLEleme
 
   useEffect(() => {
     let elem = ref.current;
-    if (!isDisabled) {
-      elem.addEventListener('wheel', onScrollHandler);
+    if (isDisabled) {
+      return;
     }
+    elem.addEventListener('wheel', onScrollHandler);
 
     return () => {
-      if (!isDisabled) {
-        elem.removeEventListener('wheel', onScrollHandler);
-      }
+      elem.removeEventListener('wheel', onScrollHandler);
     };
   }, [onScrollHandler, ref, isDisabled]);
 }

--- a/packages/@react-aria/interactions/src/useScrollWheel.ts
+++ b/packages/@react-aria/interactions/src/useScrollWheel.ts
@@ -23,7 +23,7 @@ export function useScrollWheel(props: ScrollWheelProps, ref: RefObject<HTMLEleme
   let {onScroll, isDisabled} = props;
   let onScrollHandler = useCallback((e) => {
     // If the ctrlKey is pressed, this is a zoom event, do nothing.
-    if (isDisabled || e.ctrlKey) {
+    if (e.ctrlKey) {
       return;
     }
 
@@ -31,17 +31,22 @@ export function useScrollWheel(props: ScrollWheelProps, ref: RefObject<HTMLEleme
     e.preventDefault();
     e.stopPropagation();
 
+
     if (onScroll) {
       onScroll({deltaX: e.deltaX, deltaY: e.deltaY});
     }
-  }, [onScroll, isDisabled]);
+  }, [onScroll]);
 
   useEffect(() => {
     let elem = ref.current;
-    elem.addEventListener('wheel', onScrollHandler);
+    if (!isDisabled) {
+      elem.addEventListener('wheel', onScrollHandler);
+    }
 
     return () => {
-      elem.removeEventListener('wheel', onScrollHandler);
+      if (!isDisabled) {
+        elem.removeEventListener('wheel', onScrollHandler);
+      }
     };
-  }, [onScrollHandler, ref]);
+  }, [onScrollHandler, ref, isDisabled]);
 }

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -112,6 +112,13 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
   let {focusWithinProps} = useFocusWithin({isDisabled, onFocusWithinChange: setFocusWithin});
 
   let onWheel = useCallback((e) => {
+    // if on a trackpad, users can scroll in both X and Y at once, check the magnitude of the change
+    // if it's mostly in the X direction, then just return, the user probably doesn't mean to inc/dec
+    // this isn't perfect, events come in fast with small deltas and a part of the scroll may give a false indication
+    // especially if the user is scrolling near 45deg
+    if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) {
+      return;
+    }
     if (e.deltaY > 0) {
       increment();
     } else if (e.deltaY < 0) {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1792

also fix performance of useScrollWheel so it's not listened for at all while disabled
things considered while doing this
/**
 * scrollstart/stop by setting a timeout/raf and ending scrolling if no new scroll events
 * have come through in that time period, but if someone is scrolling slowly, this could be a lot of events
 *
 * adding a global document listener, and if the mouse moves declare the scrolling over
 * this could be odd with a mouse though or something where movement is independent of the scrolling
 *
 * listen for how many fingers are down, but that doesn't register on trackpads
 *
 * use wheelDelta but that's deprecated
 *
 * take an absolute value comparison on each event, some flipping may occur if it's a diagonal close to 45 deg
 */

This change is the simplest and behaves correct for everything that is mostly scrolling vertically. I don't think people frequently accidentally scroll close to a 45 deg angle.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
