### PR TITLE
Fix ios is over target

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -118,7 +118,7 @@ export function usePress(props: PressHookProps): PressResult {
     target: null,
     isOverTarget: false,
     pointerType: null,
-    targetRect: null,
+    targetRect: null
   });
 
   let {addGlobalListener, removeAllGlobalListeners} = useGlobalListeners();
@@ -188,11 +188,8 @@ export function usePress(props: PressHookProps): PressResult {
       }
     };
 
-    let triggerPressUp = (
-      originalEvent: EventBase,
-      pointerType: PointerType
-    ) => {
-      let { onPressUp, isDisabled } = propsRef.current;
+    let triggerPressUp = (originalEvent: EventBase, pointerType: PointerType) => {
+      let {onPressUp, isDisabled} = propsRef.current;
       if (isDisabled) {
         return;
       }
@@ -229,11 +226,13 @@ export function usePress(props: PressHookProps): PressResult {
           e.preventDefault();
           e.stopPropagation();
 
+
           // If the event is repeating, it may have started on a different element
           // after which focus moved to the current element. Ignore these events and
           // only handle the first key down event.
           if (!state.isPressed && !e.repeat) {
             state.target = e.currentTarget as HTMLElement;
+            state.targetRect = e.currentTarget.getBoundingClientRect();
             state.isPressed = true;
             triggerPressStart(e, 'keyboard');
 
@@ -306,18 +305,15 @@ export function usePress(props: PressHookProps): PressResult {
 
         // iOS safari fires pointer events from VoiceOver (but only when outside an iframe...)
         // https://bugs.webkit.org/show_bug.cgi?id=222627
-        state.pointerType = isVirtualPointerEvent(e.nativeEvent)
-          ? "virtual"
-          : e.pointerType;
+        state.pointerType = isVirtualPointerEvent(e.nativeEvent) ? 'virtual' : e.pointerType;
 
         e.stopPropagation();
         if (!state.isPressed) {
           state.isPressed = true;
           state.isOverTarget = true;
           state.activePointerId = e.pointerId;
-          const targetRect = e.currentTarget.getBoundingClientRect();
           state.target = e.currentTarget;
-          state.targetRect = targetRect;
+          state.targetRect = e.currentTarget.getBoundingClientRect();
 
           if (!isDisabled && !preventFocusOnPress) {
             focusWithoutScrolling(e.currentTarget);
@@ -326,9 +322,9 @@ export function usePress(props: PressHookProps): PressResult {
           disableTextSelection();
           triggerPressStart(e, state.pointerType);
 
-          addGlobalListener(document, "pointermove", onPointerMove, false);
-          addGlobalListener(document, "pointerup", onPointerUp, false);
-          addGlobalListener(document, "pointercancel", onPointerCancel, false);
+          addGlobalListener(document, 'pointermove', onPointerMove, false);
+          addGlobalListener(document, 'pointerup', onPointerUp, false);
+          addGlobalListener(document, 'pointercancel', onPointerCancel, false);
         }
       };
 
@@ -369,29 +365,16 @@ export function usePress(props: PressHookProps): PressResult {
           }
         } else if (state.isOverTarget) {
           state.isOverTarget = false;
-          triggerPressEnd(
-            createEvent(state.target, e),
-            state.pointerType,
-            false
-          );
+          triggerPressEnd(createEvent(state.target, e), state.pointerType, false);
         }
       };
 
       let onPointerUp = (e: PointerEvent) => {
-        if (
-          e.pointerId === state.activePointerId &&
-          state.isPressed &&
-          e.button === 0
-        ) {
-
+        if (e.pointerId === state.activePointerId && state.isPressed && e.button === 0) {
           if (isOverTarget(e, state.targetRect)) {
             triggerPressEnd(createEvent(state.target, e), state.pointerType);
           } else if (state.isOverTarget) {
-            triggerPressEnd(
-              createEvent(state.target, e),
-              state.pointerType,
-              false
-            );
+            triggerPressEnd(createEvent(state.target, e), state.pointerType, false);
           }
 
           state.isPressed = false;
@@ -432,6 +415,7 @@ export function usePress(props: PressHookProps): PressResult {
         state.isPressed = true;
         state.isOverTarget = true;
         state.target = e.currentTarget;
+        state.targetRect = e.currentTarget.getBoundingClientRect();
         state.pointerType = isVirtualClick(e.nativeEvent) ? 'virtual' : 'mouse';
 
         if (!isDisabled && !preventFocusOnPress) {
@@ -499,6 +483,7 @@ export function usePress(props: PressHookProps): PressResult {
         state.isOverTarget = true;
         state.isPressed = true;
         state.target = e.currentTarget;
+        state.targetRect = e.currentTarget.getBoundingClientRect();
         state.pointerType = 'touch';
 
         // Due to browser inconsistencies, especially on mobile browsers, we prevent default
@@ -652,12 +637,10 @@ interface EventPoint {
 }
 
 function isOverTarget(point: EventPoint, rect: DOMRect) {
-  const result =
-    (point.clientX || 0) >= (rect.left || 0) &&
+  return (point.clientX || 0) >= (rect.left || 0) &&
     (point.clientX || 0) <= (rect.right || 0) &&
     (point.clientY || 0) >= (rect.top || 0) &&
     (point.clientY || 0) <= (rect.bottom || 0);
-  return result;
 }
 
 function shouldPreventDefault(target: Element) {

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -124,7 +124,6 @@ export function usePress(props: PressHookProps): PressResult {
   let {addGlobalListener, removeAllGlobalListeners} = useGlobalListeners();
 
   let pressProps = useMemo(() => {
-    console.log("update state");
     let state = ref.current;
     let triggerPressStart = (originalEvent: EventBase, pointerType: PointerType) => {
       let {onPressStart, onPressChange, isDisabled} = propsRef.current;
@@ -234,13 +233,6 @@ export function usePress(props: PressHookProps): PressResult {
           // after which focus moved to the current element. Ignore these events and
           // only handle the first key down event.
           if (!state.isPressed && !e.repeat) {
-            const {
-              top,
-              left,
-              bottom,
-              right,
-            } = e.currentTarget.getBoundingClientRect();
-            console.log('onKeyDown target', { top, left, bottom, right });
             state.target = e.currentTarget as HTMLElement;
             state.isPressed = true;
             triggerPressStart(e, 'keyboard');
@@ -301,7 +293,6 @@ export function usePress(props: PressHookProps): PressResult {
 
     if (typeof PointerEvent !== 'undefined') {
       pressProps.onPointerDown = (e) => {
-        console.log("onPointerDown");
         // Only handle left clicks
         if (e.button !== 0) {
           return;
@@ -325,12 +316,8 @@ export function usePress(props: PressHookProps): PressResult {
           state.isOverTarget = true;
           state.activePointerId = e.pointerId;
           const targetRect = e.currentTarget.getBoundingClientRect();
-          const { top, left, bottom, right } = targetRect;
-          console.log("onPointerDown target", { top, left, bottom, right });
           state.target = e.currentTarget;
           state.targetRect = targetRect;
-
-          console.log("onPointerDown target", state.target);
 
           if (!isDisabled && !preventFocusOnPress) {
             focusWithoutScrolling(e.currentTarget);
@@ -363,7 +350,6 @@ export function usePress(props: PressHookProps): PressResult {
         // Safari on iOS sometimes fires pointerup events, even
         // when the touch isn't over the target, so double check.
         if (e.button === 0 && isOverTarget(e, state.targetRect)) {
-          console.log("---onPointerUp---");
           triggerPressUp(e, state.pointerType);
         }
       };
@@ -397,18 +383,6 @@ export function usePress(props: PressHookProps): PressResult {
           state.isPressed &&
           e.button === 0
         ) {
-          const { clientY, clientX } = e;
-          const {
-            top,
-            left,
-            bottom,
-            right,
-          } = state.target.getBoundingClientRect();
-          console.log(
-            "onPointerUp",
-            { clientY, clientX },
-            { top, left, bottom, right }
-          );
 
           if (isOverTarget(e, state.targetRect)) {
             triggerPressEnd(createEvent(state.target, e), state.pointerType);
@@ -457,13 +431,6 @@ export function usePress(props: PressHookProps): PressResult {
 
         state.isPressed = true;
         state.isOverTarget = true;
-        const {
-          top,
-          left,
-          bottom,
-          right,
-        } = e.currentTarget.getBoundingClientRect();
-        console.log('onMouseDown target', { top, left, bottom, right });
         state.target = e.currentTarget;
         state.pointerType = isVirtualClick(e.nativeEvent) ? 'virtual' : 'mouse';
 
@@ -531,13 +498,6 @@ export function usePress(props: PressHookProps): PressResult {
         state.ignoreEmulatedMouseEvents = true;
         state.isOverTarget = true;
         state.isPressed = true;
-        const {
-          top,
-          left,
-          bottom,
-          right,
-        } = e.currentTarget.getBoundingClientRect();
-        console.log('onTouchStart target', { top, left, bottom, right });
         state.target = e.currentTarget;
         state.pointerType = 'touch';
 
@@ -692,14 +652,11 @@ interface EventPoint {
 }
 
 function isOverTarget(point: EventPoint, rect: DOMRect) {
-  const { clientY, clientX } = point;
-  const { top, left, bottom, right } = rect;
   const result =
     (point.clientX || 0) >= (rect.left || 0) &&
     (point.clientX || 0) <= (rect.right || 0) &&
     (point.clientY || 0) >= (rect.top || 0) &&
     (point.clientY || 0) <= (rect.bottom || 0);
-  console.log({ clientY, clientX }, { top, left, bottom, right }, result);
   return result;
 }
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1807

It seems like we can't reuse `state.target` in `isOverTarget` in different handlers since `target.getBoundingClientRect()` can return different values. So I save the original  `target.getBoundingClientRect()` to `state.targetRect` instead.

Here is how I understand what happens:
- `onPointerDown`
  - save `e.currentTarget` to `state.target`
  - add `onPointerUp` as global listener
- pressProps.onPointerUp
  - "Safari on iOS sometimes fires pointerup events, even when the touch isn't over the target, so double check.
     _No sure that changes we need to use `state.targetRect` here_
- `onPointerUp`
  - checking `isOverTarget`
  _the main problem is here: the coordinates of the `state.target` might be changed. That is why we are I using `state.targetRect` here_
  - call `triggerPressEnd` with 3rd arg (wasPressed) depends on `isOverTarget` result
  - `triggerPressEnd`
    - calls `onPress` if `wasPressed` is `true`

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

I was testing this using storybook. Add the following component to e.g. `Button.stories.tsx`.

```
function ButtonAlongsideWithInputAndAdditionalContent(props: any = {}) {
  return <Flex direction="column">
    <Flex height="size-2000">
      <Text>Content</Text>
    </Flex>
    <TextField name="field" label="Field" placeholder="placeholder" />
    <Button onPress={() => alert('pressed')}>
        Button
      </Button>
  </Flex>
}
```

Also, I've left `console.log` if the first commit so it might be used for debugging.

## 🧢 Your Project:

n/a
