### PR TITLE
Only allow colorfield scrolled stepping when focused

### DIFF
--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -16,7 +16,8 @@ import {
   HTMLAttributes,
   LabelHTMLAttributes,
   RefObject,
-  useCallback, useState
+  useCallback,
+  useState
 } from 'react';
 import {mergeProps, useId} from '@react-aria/utils';
 import {useFocusWithin, useScrollWheel} from '@react-aria/interactions';

--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -16,11 +16,11 @@ import {
   HTMLAttributes,
   LabelHTMLAttributes,
   RefObject,
-  useCallback
+  useCallback, useState
 } from 'react';
 import {mergeProps, useId} from '@react-aria/utils';
 import {useFormattedTextField} from '@react-aria/textfield';
-import {useScrollWheel} from '@react-aria/interactions';
+import {useFocusWithin, useScrollWheel} from '@react-aria/interactions';
 import {useSpinButton} from '@react-aria/spinbutton';
 
 interface ColorFieldAria {
@@ -72,6 +72,9 @@ export function useColorField(
     }
   );
 
+  let [focusWithin, setFocusWithin] = useState(false);
+  let {focusWithinProps} = useFocusWithin({isDisabled, onFocusWithinChange: setFocusWithin});
+
   let onWheel = useCallback((e) => {
     if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) {
       return;
@@ -83,7 +86,7 @@ export function useColorField(
     }
   }, [isReadOnly, isDisabled, decrement, increment]);
   // If the input isn't supposed to receive input, disable scrolling.
-  let scrollingDisabled = isDisabled || isReadOnly;
+  let scrollingDisabled = isDisabled || isReadOnly || !focusWithin;
   useScrollWheel({onScroll: onWheel, isDisabled: scrollingDisabled}, ref);
 
   let onChange = value => {
@@ -101,7 +104,7 @@ export function useColorField(
 
   return {
     labelProps,
-    inputProps: mergeProps(inputProps, spinButtonProps, {
+    inputProps: mergeProps(inputProps, spinButtonProps, focusWithinProps, {
       role: 'textbox',
       'aria-valuemax': null,
       'aria-valuemin': null,

--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -19,8 +19,8 @@ import {
   useCallback, useState
 } from 'react';
 import {mergeProps, useId} from '@react-aria/utils';
-import {useFormattedTextField} from '@react-aria/textfield';
 import {useFocusWithin, useScrollWheel} from '@react-aria/interactions';
+import {useFormattedTextField} from '@react-aria/textfield';
 import {useSpinButton} from '@react-aria/spinbutton';
 
 interface ColorFieldAria {

--- a/packages/@react-spectrum/color/src/ColorField.tsx
+++ b/packages/@react-spectrum/color/src/ColorField.tsx
@@ -10,8 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
+import {classNames} from '@react-spectrum/utils';
 import React, {RefObject, useRef} from 'react';
 import {SpectrumColorFieldProps} from '@react-types/color';
+import styles from './colorfield.css';
 import {TextFieldBase} from '@react-spectrum/textfield';
 import {TextFieldRef} from '@react-types/textfield';
 import {useColorField} from '@react-aria/color';
@@ -40,7 +42,8 @@ function ColorField(props: SpectrumColorFieldProps, ref: RefObject<TextFieldRef>
       ref={ref}
       inputRef={inputRef}
       labelProps={labelProps}
-      inputProps={inputProps} />
+      inputProps={inputProps}
+      inputClassName={classNames(styles, 'react-spectrum-ColorField-input')} />
   );
 }
 

--- a/packages/@react-spectrum/color/src/colorfield.css
+++ b/packages/@react-spectrum/color/src/colorfield.css
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+.react-spectrum-ColorField-input {
+  direction: ltr;
+  text-align: start;
+}


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Also fixes RTL entering of hex values 

From our i18n team:
The characters should flow right to left as you type them, and the entire string should be right-aligned within the text input field. The attached recording illustrates the expected behavior.
https://user-images.githubusercontent.com/698229/115625849-80dfe500-a2b1-11eb-8c88-32b9ff355716.mp4



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
