### PR TITLE
Fix tab icon animation in Safari

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tabs/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tabs/index.css
@@ -79,7 +79,9 @@ governing permissions and limitations under the License.
   .spectrum-Icon {
     /* Vertical centering */
     block-size: var(--spectrum-tabs-item-height);
-    transition: color var(--spectrum-global-animation-duration-100) ease-out;
+    transition: fill var(--spectrum-global-animation-duration-100) ease-out;
+    /* Prevents a wiggle in Safari when switching tabs. */
+    transform: translate3d(0, 0, 0);
 
     & + .spectrum-Tabs-itemLabel {
       margin-inline-start: var(--spectrum-tabs-icon-gap);

--- a/packages/@adobe/spectrum-css-temp/components/tabs/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/tabs/skin.css
@@ -37,14 +37,14 @@ governing permissions and limitations under the License.
   color: var(--spectrum-tabs-text-color);
 
   .spectrum-Icon {
-    color: var(--spectrum-tabs-icon-color)
+    fill: var(--spectrum-tabs-icon-color)
   }
 
   &:hover {
     color: var(--spectrum-tabs-text-color-hover);
 
     .spectrum-Icon {
-      color: var(--spectrum-tabs-icon-color-hover)
+      fill: var(--spectrum-tabs-icon-color-hover)
     }
   }
 
@@ -52,7 +52,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-tabs-text-color-selected);
 
     .spectrum-Icon {
-      color: var(--spectrum-tabs-icon-color-selected)
+      fill: var(--spectrum-tabs-icon-color-selected)
     }
   }
 
@@ -64,7 +64,7 @@ governing permissions and limitations under the License.
     }
 
     .spectrum-Icon {
-      color: var(--spectrum-tabs-icon-color-key-focus)
+      fill: var(--spectrum-tabs-icon-color-key-focus)
     }
   }
 
@@ -72,7 +72,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-tabs-text-color-disabled);
 
     .spectrum-Icon {
-      color: var(--spectrum-tabs-icon-color-disabled)
+      fill: var(--spectrum-tabs-icon-color-disabled)
     }
   }
 }


### PR DESCRIPTION
Safari doesn't support transitioning `currentColor` in SVGs apparently.