### PR TITLE
Add codesandbox template to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -36,6 +36,7 @@ Search open/closed issues before submitting since someone might have asked the s
 ## 💻 Code Sample
 
 <!-- Please provide a code repository, gist, code snippet or sample files to reproduce the issue -->
+<!-- You can use this codesandbox template to get started https://codesandbox.io/s/react-spectrum-template-syueo -->
 
 ## 🌍 Your Environment
 


### PR DESCRIPTION
If we offer a link to a codesandbox that people can just start editing, maybe we'll get more reports with a reproduction case


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
