### PR TITLE
Add support for isReadOnly to Picker

### DIFF
--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -46,6 +46,7 @@
     "@react-spectrum/progress": "^3.1.1",
     "@react-spectrum/provider": "^3.1.3",
     "@react-spectrum/text": "^3.1.1",
+    "@react-spectrum/textfield": "^3.1.5",
     "@react-spectrum/utils": "^3.5.1",
     "@react-stately/collections": "^3.3.1",
     "@react-stately/select": "^3.1.1",

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -40,6 +40,7 @@ import React, {ReactElement, useCallback, useRef, useState} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
 import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
 import {Text} from '@react-spectrum/text';
+import {TextFieldBase} from '@react-spectrum/textfield';
 import {useFormProps} from '@react-spectrum/form';
 import {useMessageFormatter} from '@react-aria/i18n';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
@@ -51,6 +52,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   let formatMessage = useMessageFormatter(intlMessages);
   let {
     isDisabled,
+    isReadOnly,
     direction = 'bottom',
     align = 'start',
     shouldFlip = true,
@@ -252,6 +254,16 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       {state.collection.size === 0 ? null : overlay}
     </div>
   );
+
+  if (isReadOnly) {
+    picker = (
+      <TextFieldBase
+        inputProps={{readOnly: isReadOnly, value: state.selectedKey}}
+        isQuiet={isQuiet}
+        isReadOnly={isReadOnly}
+        validationState={validationState} />
+    );
+  }
 
   if (label) {
     let labelWrapperClass = classNames(

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -119,6 +119,16 @@ storiesOf('Picker', module)
         <Item key="Three">Three</Item>
       </Picker>
     )
+)
+  .add(
+    'isReadOnly',
+    () => (
+      <Picker label="Test" isReadOnly onSelectionChange={action('selectionChange')} selectedKey="One">
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
+      </Picker>
+    )
   )
   .add(
     'labelAlign: end',


### PR DESCRIPTION
It will transform Picker into a readonly TextField when isReadOnly prop is used.

PS: I Will fulfill the PR checklist once the maintainers have approved this change.

---

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
