### PR TITLE
fix(#1727) Controlled combobox value reset and menu open behavior

### DIFF
--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -429,13 +429,13 @@ storiesOf('ComboBox', module)
   .add(
     'inputValue and isOpen (controlled)',
     () => (
-      <ControlledValueOpenCombobox />
+      <ControlledValueOpenCombobox allowsCustomValue />
     )
   )
   .add(
     'selectedKey and isOpen (controlled)',
     () => (
-      <ControlledKeyOpenCombobox />
+      <ControlledKeyOpenCombobox allowsCustomValue />
     )
   )
   .add(
@@ -921,31 +921,65 @@ let ControlledOpenCombobox = (props) => {
 let ControlledValueOpenCombobox = (props) => {
   let [fieldState, setFieldState] = React.useState({
     isOpen: false,
-    inputValue: ''
+    inputValue: '',
+    isFocused: false
   });
 
   let onInputChange = (value: string) => {
-    setFieldState({
+    setFieldState(prevState => ({
       isOpen: true,
-      inputValue: value
-    });
+      inputValue: value,
+      isFocused: prevState.isFocused
+    }));
   };
 
   let onOpenChange = (isOpen: boolean) => {
+    console.log('on open change')
     setFieldState(prevState => ({
       isOpen: isOpen,
-      inputValue: prevState.inputValue
+      inputValue: prevState.inputValue,
+      isFocused: prevState.isFocused
     }));
   };
 
   let onSelectionChange = (key) => {
-    setFieldState({
-      isOpen: false,
-      inputValue: items.find(item => item.id === key)?.name ?? ''
+    let newInputValue = items.find(item => item.id === key)?.name;
+    setFieldState(prevState => {
+      console.log('prevstate', prevState);
+      return {
+        isOpen: prevState.isOpen,
+        // If key is null (aka selected key is being cleared), preserve previous open state
+        // e.g. if user clears input field, previous open state will be open then this onSelectionChange will fire for the selected key removal. We'll want to keep that open state
+        // isOpen: key == null && prevState.isFocused ? prevState.isOpen : false,
+        inputValue: newInputValue ?? (props.allowsCustomValue ? prevState.inputValue : ''),
+        isFocused: prevState.isFocused
+      }
     });
   };
 
+  // TODO: A bit annoying but can't figure out an alternative here. Without tracking focus state manually,
+  // onSelectionChange doesn't have enough information to set the proper open state.
+  // The two cases that are seen as the same from inside onSelectionChange but want to have two different final open states:
+  // 1. User has a selected key and then deletes all input text. This causes onInputChange to fire -> isOpen = true and inputValue = "" -> onSelectionChange fires to remove selectedKey -> prevInputValue = "" prevIsOpen = true -> desired end state is to keep isOpen as true
+  // 2. User doesn't have a selected key but has the menu open and blurs. This causes onSelectionChange to fire with null  -> prevInputValue = "" prevIsOpen = true -> desired end state is to keep isOpen as false
+  let onFocus = () => {
+    setFieldState(prevState => ({
+      isOpen: prevState.isOpen,
+      inputValue: prevState.inputValue,
+      isFocused: true
+    }));
+  };
+
+  let onBlur = () => {
+    setFieldState(prevState => ({
+      isOpen: prevState.isOpen,
+      inputValue: prevState.inputValue,
+      isFocused: false
+    }));
+  };
+
   return (
+    // <ComboBox label="Combobox" {...mergeProps(props, actions)} defaultItems={items} isOpen={fieldState.isOpen} onOpenChange={onOpenChange} inputValue={fieldState.inputValue} onInputChange={onInputChange} onSelectionChange={onSelectionChange} onBlur={onBlur} onFocus={onFocus}>
     <ComboBox label="Combobox" {...mergeProps(props, actions)} defaultItems={items} isOpen={fieldState.isOpen} onOpenChange={onOpenChange} inputValue={fieldState.inputValue} onInputChange={onInputChange} onSelectionChange={onSelectionChange}>
       {(item: any) => <Item>{item.name}</Item>}
     </ComboBox>
@@ -972,8 +1006,18 @@ let ControlledKeyOpenCombobox = (props) => {
     }));
   };
 
+  // Handle removing selected key if input text is deleted
+  let onInputChange = (value: string) => {
+    setFieldState(prevState => {
+      return {
+        isOpen: prevState.isOpen,
+        selectedKey: value === '' ? null : prevState.selectedKey
+      }
+    })
+  };
+
   return (
-    <ComboBox label="Combobox" {...mergeProps(props, actions)} isOpen={fieldState.isOpen} onOpenChange={onOpenChange} selectedKey={fieldState.selectedKey} onSelectionChange={onSelectionChange}>
+    <ComboBox label="Combobox" {...mergeProps(props, actions)} isOpen={fieldState.isOpen} onOpenChange={onOpenChange} selectedKey={fieldState.selectedKey} onSelectionChange={onSelectionChange} onInputChange={onInputChange}>
       <Item key="one">Item One</Item>
       <Item key="two" textValue="Item Two">
         <Copy size="S" />

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -71,11 +71,18 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateProps<T>)
       props.onSelectionChange(key);
     }
 
-    // If open state or selectedKey is uncontrolled and key is the same, reset the inputValue and close the menu
+    // If key is the same as the selectedKey, reset the inputValue and close the menu.
     // (scenario: user clicks on already selected option)
-    if (props.isOpen === undefined || props.selectedKey === undefined) {
-      if (key === selectedKey) {
+    // Defer to user if input Value/open state is controlled alongside other props
+    if (key === selectedKey) {
+      if (props.inputValue === undefined || !multipleControlledProps) {
         resetInputValue();
+      }
+
+      if (props.isOpen === undefined || !multipleControlledProps) {
+        // Stop menu from reopening from useEffect and trigger close menu
+        let itemText = collection.getItem(selectedKey)?.textValue ?? '';
+        lastValue.current = itemText;
         triggerState.close();
       }
     }

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -55,6 +55,9 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateProps<T>)
     shouldCloseOnBlur = true
   } = props;
 
+  let multipleControlledProps = (props.selectedKey !== undefined && props.inputValue !== undefined) ||
+  (props.inputValue !== undefined && props.isOpen !== undefined) ||
+  (props.selectedKey !== undefined && props.isOpen !== undefined);
   let [showAllItems, setShowAllItems] = useState(false);
   let [isFocused, setFocusedState] = useState(false);
   let [inputValue, setInputValue] = useControlledState(
@@ -190,9 +193,10 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateProps<T>)
       selectionManager.setFocusedKey(null);
       setShowAllItems(false);
 
-      // Set selectedKey to null when the user clears the input.
-      // If controlled, this is the application developer's responsibility.
-      if (inputValue === '' && (props.inputValue === undefined || props.selectedKey === undefined)) {
+      // Set selectedKey to null when the user clears the input. Only do this if selectedKey is undefined or if there is a single controlled prop.
+      // If controlled, this is the application developer's responsibility. Users who control open state and selected key MUST also have a onInputChange handler
+      // so they can control if the key gets cleared upon clearing the input field
+      if (inputValue === '' && (props.selectedKey === undefined || !multipleControlledProps)) {
         setSelectedKey(null);
       }
     }
@@ -262,11 +266,7 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateProps<T>)
   let commitSelection = () => {
     // If multiple things are controlled, call onSelectionChange
     // Note that users who control open state and input value MUST also have a onSelectionChange handler to properly close the menu and reset input value
-    if (
-      (props.selectedKey !== undefined && props.inputValue !== undefined) ||
-      (props.inputValue !== undefined && props.isOpen !== undefined) ||
-      (props.selectedKey !== undefined && props.isOpen !== undefined)
-    ) {
+    if (multipleControlledProps) {
       props.onSelectionChange(selectedKey);
 
       // If multiple things are controlled but inputValue isn't, reset the input value for the user


### PR DESCRIPTION
Closes #1727 

Specifically fixes these two flows:
1. Clearing input value should open the menu (controlled value/key + controlled open ComboBox)
2. Clicking on a selected option should reset the input value and close the menu (controlled key + controlled open ComboBox)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
