### PR TITLE
Implement staticColor prop for ActionButton and ToggleButton

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -270,6 +270,23 @@ a.spectrum-ActionButton {
   font-weight: var(--spectrum-actionbutton-quiet-text-font-weight);
 }
 
+.spectrum-ActionButton--emphasized,
+.spectrum-ActionButton--staticColor {
+  @inherit: %spectrum-ButtonWithFocusRing;
+
+  &:after {
+    /* Override border-radius set in %spectrum-ButtonWithFocusRing since this is not a pill button */
+    border-radius: calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-alias-focus-ring-gap));
+  }
+
+  &:focus-ring {
+    &:after {
+      /* action buttons only have a 1px border, not 2px */
+      margin: calc(calc(var(--spectrum-alias-focus-ring-gap) * -1) - var(--spectrum-actionbutton-quiet-border-size));
+    }
+  }
+}
+
 .spectrum-LogicButton {
   @inherit: %spectrum-BaseButton;
   @inherit: %spectrum-ButtonWithFocusRing;

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -676,8 +676,11 @@ governing permissions and limitations under the License.
 
 .spectrum-ActionButton--staticWhite {
   mix-blend-mode: screen;
+  --spectrum-actionbutton-static-background-color-hover: rgba(255, 255, 255, 0.1);
+  --spectrum-actionbutton-static-background-color-focus: rgba(255, 255, 255, 0.1);
+  --spectrum-actionbutton-static-background-color-active: rgba(255, 255, 255, 0.2);
   --spectrum-actionbutton-static-border-color: rgba(255, 255, 255, 0.3);
-  --spectrum-actionbutton-static-border-color-hover: white; /* ?? */
+  --spectrum-actionbutton-static-border-color-hover: white;
   --spectrum-actionbutton-static-border-color-active: white;
   --spectrum-actionbutton-static-border-color-focus: white;
   --spectrum-actionbutton-static-border-disabled: rgba(255, 255, 255, 0.15);
@@ -687,9 +690,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ActionButton--staticWhite.spectrum-ActionButton--quiet {
-  --spectrum-actionbutton-static-background-color-hover: rgba(255, 255, 255, 0.1);
-  --spectrum-actionbutton-static-background-color-focus: rgba(255, 255, 255, 0.1);
-  --spectrum-actionbutton-static-background-color-active: rgba(255, 255, 255, 0.2);
   --spectrum-actionbutton-static-border-color: transparent;
   --spectrum-actionbutton-static-border-color-hover: transparent;
   --spectrum-actionbutton-static-border-color-active: transparent;
@@ -697,8 +697,11 @@ governing permissions and limitations under the License.
 
 .spectrum-ActionButton--staticBlack {
   mix-blend-mode: multiply;
+  --spectrum-actionbutton-static-background-color-hover: rgba(0, 0, 0, 0.1);
+  --spectrum-actionbutton-static-background-color-focus: rgba(0, 0, 0, 0.1);
+  --spectrum-actionbutton-static-background-color-active: rgba(0, 0, 0, 0.2);
   --spectrum-actionbutton-static-border-color: rgba(0, 0, 0, 0.3);
-  --spectrum-actionbutton-static-border-color-hover: black; /* ?? */
+  --spectrum-actionbutton-static-border-color-hover: black;
   --spectrum-actionbutton-static-border-color-active: black;
   --spectrum-actionbutton-static-border-color-focus: black;
   --spectrum-actionbutton-static-border-disabled: rgba(0, 0, 0, 0.15);
@@ -708,9 +711,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ActionButton--staticBlack.spectrum-ActionButton--quiet {
-  --spectrum-actionbutton-static-background-color-hover: rgba(0, 0, 0, 0.1);
-  --spectrum-actionbutton-static-background-color-focus: rgba(0, 0, 0, 0.1);
-  --spectrum-actionbutton-static-background-color-active: rgba(0, 0, 0, 0.2);
   --spectrum-actionbutton-static-border-color: transparent;
   --spectrum-actionbutton-static-border-color-hover: transparent;
   --spectrum-actionbutton-static-border-color-active: transparent;

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -669,6 +669,175 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-ActionButton--staticWhite {
+  mix-blend-mode: screen;
+  --spectrum-actionbutton-static-border-color: rgba(255, 255, 255, 0.3);
+  --spectrum-actionbutton-static-border-color-hover: white; /* ?? */
+  --spectrum-actionbutton-static-border-color-active: white;
+  --spectrum-actionbutton-static-border-color-focus: white;
+  --spectrum-actionbutton-static-border-disabled: rgba(255, 255, 255, 0.15);
+  --spectrum-actionbutton-static-color: white;
+  --spectrum-actionbutton-static-color-selected: black; /* becomes the background of the parent element due to mix-blend-mode */
+  --spectrum-actionbutton-static-color-disabled: rgba(255, 255, 255, 0.15);
+}
+
+.spectrum-ActionButton--staticWhite.spectrum-ActionButton--quiet {
+  --spectrum-actionbutton-static-background-color-hover: rgba(255, 255, 255, 0.1);
+  --spectrum-actionbutton-static-background-color-focus: rgba(255, 255, 255, 0.1);
+  --spectrum-actionbutton-static-background-color-active: rgba(255, 255, 255, 0.2);
+  --spectrum-actionbutton-static-border-color: transparent;
+  --spectrum-actionbutton-static-border-color-hover: transparent;
+  --spectrum-actionbutton-static-border-color-active: transparent;
+}
+
+.spectrum-ActionButton--staticBlack {
+  mix-blend-mode: multiply;
+  --spectrum-actionbutton-static-border-color: rgba(0, 0, 0, 0.3);
+  --spectrum-actionbutton-static-border-color-hover: black; /* ?? */
+  --spectrum-actionbutton-static-border-color-active: black;
+  --spectrum-actionbutton-static-border-color-focus: black;
+  --spectrum-actionbutton-static-border-disabled: rgba(0, 0, 0, 0.15);
+  --spectrum-actionbutton-static-color: black;
+  --spectrum-actionbutton-static-color-selected: white; /* becomes the background of the parent element due to mix-blend-mode */
+  --spectrum-actionbutton-static-color-disabled: rgba(0, 0, 0, 0.15);
+}
+
+.spectrum-ActionButton--staticBlack.spectrum-ActionButton--quiet {
+  --spectrum-actionbutton-static-background-color-hover: rgba(0, 0, 0, 0.1);
+  --spectrum-actionbutton-static-background-color-focus: rgba(0, 0, 0, 0.1);
+  --spectrum-actionbutton-static-background-color-active: rgba(0, 0, 0, 0.2);
+  --spectrum-actionbutton-static-border-color: transparent;
+  --spectrum-actionbutton-static-border-color-hover: transparent;
+  --spectrum-actionbutton-static-border-color-active: transparent;
+}
+
+.spectrum-ActionButton--staticColor {
+  background-color: transparent;
+  border-color: var(--spectrum-actionbutton-static-border-color);
+  color: var(--spectrum-actionbutton-static-color);
+
+  .spectrum-Icon {
+    fill: var(--spectrum-actionbutton-static-color);
+  }
+
+  &:hover {
+    background-color: var(--spectrum-actionbutton-static-background-color-hover);
+    border-color: var(--spectrum-actionbutton-static-border-color-hover);
+    color: var(--spectrum-actionbutton-static-color);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-actionbutton-static-color);
+    }
+
+    .spectrum-ActionButton-hold {
+      fill: var(--spectrum-actionbutton-static-color);
+    }
+  }
+
+  &:focus-ring {
+    background-color: var(--spectrum-actionbutton-static-background-color-focus);
+    border-color: var(--spectrum-actionbutton-static-border-color-focus);
+    box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-border-color-focus);
+    color: var(--spectrum-actionbutton-static-color);
+
+    &.is-active {
+      border-color: var(--spectrum-actionbutton-static-color);
+    }
+
+    .spectrum-Icon {
+      fill: var(--spectrum-actionbutton-static-color);
+    }
+
+    .spectrum-ActionButton-hold {
+      fill: var(--spectrum-actionbutton-static-color);
+    }
+  }
+
+  &.is-active {
+    background-color: var(--spectrum-actionbutton-static-background-color-active);
+    border-color: var(--spectrum-actionbutton-static-border-color-active);
+    color: var(--spectrum-actionbutton-static-color);
+
+    .spectrum-ActionButton-hold {
+      fill: var(--spectrum-actionbutton-static-color);
+    }
+  }
+
+  &:disabled,
+  &.is-disabled {
+    background-color: transparent;
+    border-color: var(--spectrum-actionbutton-static-border-disabled);
+    color: var(--spectrum-actionbutton-static-color-disabled);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-actionbutton-static-color-disabled);
+    }
+
+    .spectrum-ActionButton-hold {
+      fill: var(--spectrum-actionbutton-static-color-disabled);
+    }
+  }
+
+  &.spectrum-ActionButton--quiet.is-selected,
+  &.is-selected {
+    background-color: var(--spectrum-actionbutton-static-color);
+    border-color: var(--spectrum-actionbutton-static-color);
+    color: var(--spectrum-actionbutton-static-color-selected);
+
+    .spectrum-Icon {
+      fill: var(--spectrum-actionbutton-static-color-selected);
+    }
+
+    &:focus-ring {
+      background-color: var(--spectrum-actionbutton-static-color);
+      border-color: var(--spectrum-actionbutton-static-color);
+      color: var(--spectrum-actionbutton-static-color-selected);
+      box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-color);
+
+      &:hover {
+        /* change 1px of focus ring blue to match the rest of the hover state */
+        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-color);
+      }
+
+      &.is-active {
+        /* change 1px of focus ring blue to match the rest of the active state */
+        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-color);
+        border-color: var(--spectrum-actionbutton-static-color);
+      }
+
+      .spectrum-Icon {
+        fill: var(--spectrum-actionbutton-static-color-selected);
+      }
+    }
+
+    &:hover,
+    &.is-active {
+      background-color: var(--spectrum-actionbutton-static-color);
+      border-color: var(--spectrum-actionbutton-static-color);
+      color: var(--spectrum-actionbutton-static-color-selected);
+
+      .spectrum-Icon {
+        fill: var(--spectrum-actionbutton-static-color-selected);
+      }
+    }
+
+    &:disabled,
+    &.is-disabled {
+      background-color: transparent;
+      border-color: var(--spectrum-actionbutton-static-border-disabled);
+      color: var(--spectrum-actionbutton-static-color-disabled);
+
+      .spectrum-Icon {
+        fill: var(--spectrum-actionbutton-static-color-disabled);
+      }
+
+      .spectrum-ActionButton-hold {
+        fill: var(--spectrum-actionbutton-static-color-disabled);
+      }
+    }
+  }
+}
+
 .spectrum-Button--warning.spectrum-Button--quiet {
   background-color: var(--spectrum-button-quiet-warning-background-color);
   border-color: var(--spectrum-button-quiet-warning-border-color);

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -16,7 +16,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-LogicButton,
-.spectrum-Button {
+.spectrum-Button,
+.spectrum-ActionButton--emphasized {
   &:focus-ring,
   &.is-focused {
     &:after {
@@ -503,9 +504,13 @@ governing permissions and limitations under the License.
 
   &:focus-ring {
     background-color: var(--spectrum-actionbutton-emphasized-background-color-key-focus);
-    border-color: var(--spectrum-actionbutton-emphasized-border-color-key-focus);
-    box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-border-color-key-focus);
+    border-color: var(--spectrum-actionbutton-emphasized-border-color);
+    box-shadow: none;
     color: var(--spectrum-actionbutton-emphasized-text-color-key-focus);
+
+    &.is-active {
+      border-color: var(--spectrum-actionbutton-emphasized-border-color-down);
+    }
 
     .spectrum-Icon {
       fill: var(--spectrum-actionbutton-emphasized-icon-color-key-focus);
@@ -541,6 +546,13 @@ governing permissions and limitations under the License.
     }
   }
 
+  &.spectrum-ActionButton--quiet {
+    &:focus-ring {
+      border-color: var(--spectrum-actionbutton-quiet-border-color);
+      box-shadow: none;
+    }
+  }
+
   &.spectrum-ActionButton--quiet.is-selected,
   &.is-selected {
     background-color: var(--spectrum-actionbutton-emphasized-background-color-selected);
@@ -553,18 +565,11 @@ governing permissions and limitations under the License.
 
     &:focus-ring {
       background-color: var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-key-focus);
-      box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-emphasized-border-color-selected-key-focus);
+      border-color: var(--spectrum-actionbutton-emphasized-border-color-selected);
+      box-shadow: none;
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus);
 
-      &:hover {
-        /* change 1px of focus ring blue to match the rest of the hover state */
-        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-emphasized-border-color-selected-hover);
-      }
-
       &.is-active {
-        /* change 1px of focus ring blue to match the rest of the active state */
-        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-emphasized-border-color-selected-down);
         border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-down);
       }
 
@@ -737,11 +742,15 @@ governing permissions and limitations under the License.
   &:focus-ring {
     background-color: var(--spectrum-actionbutton-static-background-color-focus);
     border-color: var(--spectrum-actionbutton-static-border-color-focus);
-    box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-border-color-focus);
+    box-shadow: none;
     color: var(--spectrum-actionbutton-static-color);
 
+    &:hover {
+      border-color: var(--spectrum-actionbutton-static-border-color-focus);
+    }
+
     &.is-active {
-      border-color: var(--spectrum-actionbutton-static-color);
+      border-color: var(--spectrum-actionbutton-static-color-focus);
     }
 
     .spectrum-Icon {
@@ -750,6 +759,10 @@ governing permissions and limitations under the License.
 
     .spectrum-ActionButton-hold {
       fill: var(--spectrum-actionbutton-static-color);
+    }
+
+    &:after {
+      box-shadow: 0 0 0 var(--spectrum-button-primary-focus-ring-size-key-focus) var(--spectrum-actionbutton-static-border-color-focus);
     }
   }
 
@@ -792,16 +805,11 @@ governing permissions and limitations under the License.
       background-color: var(--spectrum-actionbutton-static-color);
       border-color: var(--spectrum-actionbutton-static-color);
       color: var(--spectrum-actionbutton-static-color-selected);
-      box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-color);
-
-      &:hover {
-        /* change 1px of focus ring blue to match the rest of the hover state */
-        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-color);
-      }
+      box-shadow: none;
 
       &.is-active {
         /* change 1px of focus ring blue to match the rest of the active state */
-        box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-static-color);
+        box-shadow: none;
         border-color: var(--spectrum-actionbutton-static-color);
       }
 

--- a/packages/@react-spectrum/button/chromatic/ActionButton.chromatic.tsx
+++ b/packages/@react-spectrum/button/chromatic/ActionButton.chromatic.tsx
@@ -16,6 +16,7 @@ import {Flex} from '@react-spectrum/layout';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
+import {View} from '@react-spectrum/view';
 
 storiesOf('Button/ActionButton', module)
   .add(
@@ -67,5 +68,47 @@ storiesOf('Button/ActionButton', module)
           <Add />
         </ActionButton>
       </Flex>
+    )
+  )
+  .add(
+    'staticColor: white',
+    () => (
+      <View backgroundColor="static-seafoam-600" padding="size-1000">
+        <Flex direction="column" rowGap="size-150">
+          <ActionButton staticColor="white">
+            <Add />
+            <Text>Default</Text>
+          </ActionButton>
+          <ActionButton staticColor="white" isQuiet>
+            <Add />
+            <Text>Quiet</Text>
+          </ActionButton>
+          <ActionButton staticColor="white" isDisabled>
+            <Text>Disabled</Text>
+            <Add />
+          </ActionButton>
+        </Flex>
+      </View>
+    )
+  )
+  .add(
+    'staticColor: black',
+    () => (
+      <View backgroundColor="static-yellow-400" padding="size-1000">
+        <Flex direction="column" rowGap="size-150">
+          <ActionButton staticColor="black">
+            <Add />
+            <Text>Default</Text>
+          </ActionButton>
+          <ActionButton staticColor="black" isQuiet>
+            <Add />
+            <Text>Quiet</Text>
+          </ActionButton>
+          <ActionButton staticColor="black" isDisabled>
+            <Text>Disabled</Text>
+            <Add />
+          </ActionButton>
+        </Flex>
+      </View>
     )
   );

--- a/packages/@react-spectrum/button/chromatic/ToggleButton.chromatic.tsx
+++ b/packages/@react-spectrum/button/chromatic/ToggleButton.chromatic.tsx
@@ -52,14 +52,14 @@ storiesOf('Button/ToggleButton', module)
     </Grid>
   ))
   .add('staticColor = white', () => (
-    <View backgroundColor="seafoam-600" padding="size-1000">
+    <View backgroundColor="static-seafoam-600" padding="size-1000">
       <Grid columns={repeat(states.length, '1fr')} autoFlow="row" gap="size-300">
         {combinations.map(c => <ToggleButton {...c} staticColor="white">Button</ToggleButton>)}
       </Grid>
     </View>
   ))
   .add('staticColor = black', () => (
-    <View backgroundColor="yellow-400" padding="size-1000">
+    <View backgroundColor="static-yellow-400" padding="size-1000">
       <Grid columns={repeat(states.length, '1fr')} autoFlow="row" gap="size-300">
         {combinations.map(c => <ToggleButton {...c} staticColor="black">Button</ToggleButton>)}
       </Grid>

--- a/packages/@react-spectrum/button/chromatic/ToggleButton.chromatic.tsx
+++ b/packages/@react-spectrum/button/chromatic/ToggleButton.chromatic.tsx
@@ -11,7 +11,7 @@
  */
 
 import {classNames} from '@react-spectrum/utils';
-import {Grid, repeat} from '@adobe/react-spectrum';
+import {Grid, repeat, View} from '@adobe/react-spectrum';
 import {mergeProps} from '@react-aria/utils';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -50,4 +50,18 @@ storiesOf('Button/ToggleButton', module)
     <Grid columns={repeat(states.length, '1fr')} autoFlow="row" gap="size-300">
       {combinations.map(c => <ToggleButton {...c}>Button</ToggleButton>)}
     </Grid>
+  ))
+  .add('staticColor = white', () => (
+    <View backgroundColor="seafoam-600" padding="size-1000">
+      <Grid columns={repeat(states.length, '1fr')} autoFlow="row" gap="size-300">
+        {combinations.map(c => <ToggleButton {...c} staticColor="white">Button</ToggleButton>)}
+      </Grid>
+    </View>
+  ))
+  .add('staticColor = black', () => (
+    <View backgroundColor="yellow-400" padding="size-1000">
+      <Grid columns={repeat(states.length, '1fr')} autoFlow="row" gap="size-300">
+        {combinations.map(c => <ToggleButton {...c} staticColor="black">Button</ToggleButton>)}
+      </Grid>
+    </View>
   ));

--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -27,6 +27,7 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef<HTMLBu
   let {
     isQuiet,
     isDisabled,
+    staticColor,
     children,
     autoFocus,
     ...otherProps
@@ -50,6 +51,9 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef<HTMLBu
             'spectrum-ActionButton',
             {
               'spectrum-ActionButton--quiet': isQuiet,
+              'spectrum-ActionButton--staticColor': !!staticColor,
+              'spectrum-ActionButton--staticWhite': staticColor === 'white',
+              'spectrum-ActionButton--staticBlack': staticColor === 'black',
               'is-active': isPressed,
               'is-disabled': isDisabled,
               'is-hovered': isHovered

--- a/packages/@react-spectrum/button/src/ToggleButton.tsx
+++ b/packages/@react-spectrum/button/src/ToggleButton.tsx
@@ -29,6 +29,7 @@ function ToggleButton(props: SpectrumToggleButtonProps, ref: FocusableRef<HTMLBu
     isQuiet,
     isDisabled,
     isEmphasized,
+    staticColor,
     children,
     autoFocus,
     ...otherProps
@@ -54,6 +55,9 @@ function ToggleButton(props: SpectrumToggleButtonProps, ref: FocusableRef<HTMLBu
             {
               'spectrum-ActionButton--quiet': isQuiet,
               'spectrum-ActionButton--emphasized': isEmphasized,
+              'spectrum-ActionButton--staticColor': !!staticColor,
+              'spectrum-ActionButton--staticWhite': staticColor === 'white',
+              'spectrum-ActionButton--staticBlack': staticColor === 'black',
               'is-active': isPressed,
               'is-disabled': isDisabled,
               'is-hovered': isHovered,

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -27,25 +27,7 @@ storiesOf('Button/ActionButton', module)
   )
   .add(
     'icon',
-    () => (
-      <Flex gap="size-100">
-        <ActionButton
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}>
-          <Add />
-          <Text>Default</Text>
-        </ActionButton>
-        <ActionButton
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled>
-          <Text>Disabled</Text>
-          <Add />
-        </ActionButton>
-      </Flex>
-    )
+    () => renderWithIcon()
   )
   .add(
     'icon only',
@@ -80,8 +62,8 @@ storiesOf('Button/ActionButton', module)
     () => (
       <View backgroundColor="seafoam-600" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
-          {render({staticColor: 'white'})}
-          {render({staticColor: 'white', isQuiet: true})}
+          {renderWithIcon({staticColor: 'white'})}
+          {renderWithIcon({staticColor: 'white', isQuiet: true})}
         </Flex>
       </View>
     )
@@ -91,8 +73,8 @@ storiesOf('Button/ActionButton', module)
     () => (
       <View backgroundColor="yellow-400" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
-          {render({staticColor: 'black'})}
-          {render({staticColor: 'black', isQuiet: true})}
+          {renderWithIcon({staticColor: 'black'})}
+          {renderWithIcon({staticColor: 'black', isQuiet: true})}
         </Flex>
       </View>
     )
@@ -115,6 +97,30 @@ function render(props = {}) {
         isDisabled
         {...props}>
         Disabled
+      </ActionButton>
+    </Flex>
+  );
+}
+
+function renderWithIcon(props = {}) {
+  return (
+    <Flex gap="size-100">
+      <ActionButton
+        onPress={action('press')}
+        onPressStart={action('pressstart')}
+        onPressEnd={action('pressend')}
+        {...props}>
+        <Add />
+        <Text>Default</Text>
+      </ActionButton>
+      <ActionButton
+        onPress={action('press')}
+        onPressStart={action('pressstart')}
+        onPressEnd={action('pressend')}
+        isDisabled
+        {...props}>
+        <Text>Disabled</Text>
+        <Add />
       </ActionButton>
     </Flex>
   );

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -17,6 +17,7 @@ import {Flex} from '@react-spectrum/layout';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
+import {View} from '@react-spectrum/view';
 
 storiesOf('Button/ActionButton', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -73,6 +74,28 @@ storiesOf('Button/ActionButton', module)
   .add(
     'autoFocus',
     () => render({autoFocus: true})
+  )
+  .add(
+    'staticColor: white',
+    () => (
+      <View backgroundColor="seafoam-600" padding="size-1000">
+        <Flex direction="column" rowGap="size-150">
+          {render({staticColor: 'white'})}
+          {render({staticColor: 'white', isQuiet: true})}
+        </Flex>
+      </View>
+    )
+  )
+  .add(
+    'staticColor: black',
+    () => (
+      <View backgroundColor="yellow-400" padding="size-1000">
+        <Flex direction="column" rowGap="size-150">
+          {render({staticColor: 'black'})}
+          {render({staticColor: 'black', isQuiet: true})}
+        </Flex>
+      </View>
+    )
   );
 
 function render(props = {}) {

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -60,7 +60,7 @@ storiesOf('Button/ActionButton', module)
   .add(
     'staticColor: white',
     () => (
-      <View backgroundColor="seafoam-600" padding="size-1000">
+      <View backgroundColor="static-seafoam-600" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
           {renderWithIcon({staticColor: 'white'})}
           {renderWithIcon({staticColor: 'white', isQuiet: true})}
@@ -71,7 +71,7 @@ storiesOf('Button/ActionButton', module)
   .add(
     'staticColor: black',
     () => (
-      <View backgroundColor="yellow-400" padding="size-1000">
+      <View backgroundColor="static-yellow-400" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
           {renderWithIcon({staticColor: 'black'})}
           {renderWithIcon({staticColor: 'black', isQuiet: true})}

--- a/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
@@ -11,11 +11,10 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {Flex} from '@adobe/react-spectrum';
+import {Flex, View} from '@adobe/react-spectrum';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {ToggleButton} from '../';
-
 
 storiesOf('Button/ToggleButton', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -31,6 +30,28 @@ storiesOf('Button/ToggleButton', module)
   ).add(
     'isQuiet & emphasized',
     () => render({isEmphasized: true, isQuiet: true})
+  )
+  .add(
+    'staticColor: white',
+    () => (
+      <View backgroundColor="seafoam-600" padding="size-1000">
+        <Flex direction="column" rowGap="size-150">
+          {render({staticColor: 'white'})}
+          {render({staticColor: 'white', isQuiet: true})}
+        </Flex>
+      </View>
+    )
+  )
+  .add(
+    'staticColor: black',
+    () => (
+      <View backgroundColor="yellow-400" padding="size-1000">
+        <Flex direction="column" rowGap="size-150">
+          {render({staticColor: 'black'})}
+          {render({staticColor: 'black', isQuiet: true})}
+        </Flex>
+      </View>
+    )
   );
 
 function render(props = {}) {
@@ -39,7 +60,10 @@ function render(props = {}) {
       Default
     </ToggleButton>
     <ToggleButton onChange={action('change')} onPress={action('press')} defaultSelected {...props}>
-      Default (uncontrolled)
+      Selected
+    </ToggleButton>
+    <ToggleButton defaultSelected isDisabled {...props}>
+      Disabled + selected
     </ToggleButton>
   </Flex>);
 }

--- a/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
@@ -35,7 +35,7 @@ storiesOf('Button/ToggleButton', module)
   .add(
     'staticColor: white',
     () => (
-      <View backgroundColor="seafoam-600" padding="size-1000">
+      <View backgroundColor="static-seafoam-600" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
           {render({staticColor: 'white'})}
           {render({staticColor: 'white', isQuiet: true})}
@@ -46,7 +46,7 @@ storiesOf('Button/ToggleButton', module)
   .add(
     'staticColor: black',
     () => (
-      <View backgroundColor="yellow-400" padding="size-1000">
+      <View backgroundColor="static-yellow-400" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
           {render({staticColor: 'black'})}
           {render({staticColor: 'black', isQuiet: true})}

--- a/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
@@ -11,7 +11,8 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {Flex, View} from '@adobe/react-spectrum';
+import Add from '@spectrum-icons/workflow/Add';
+import {Flex, Text, View} from '@adobe/react-spectrum';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {ToggleButton} from '../';
@@ -57,13 +58,16 @@ storiesOf('Button/ToggleButton', module)
 function render(props = {}) {
   return (<Flex gap="size-100">
     <ToggleButton onChange={action('change')} onPress={action('press')} {...props}>
-      Default
+      <Add />
+      <Text>Default</Text>
     </ToggleButton>
     <ToggleButton onChange={action('change')} onPress={action('press')} defaultSelected {...props}>
-      Selected
+      <Add />
+      <Text>Selected</Text>
     </ToggleButton>
     <ToggleButton defaultSelected isDisabled {...props}>
-      Disabled + selected
+      <Add />
+      <Text>Disabled + selected</Text>
     </ToggleButton>
   </Flex>);
 }

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -74,7 +74,9 @@ export interface SpectrumButtonProps<T extends ElementType = 'button'> extends A
 
 export interface SpectrumActionButtonProps extends AriaBaseButtonProps, ButtonProps, StyleProps {
   /** Whether the button should be displayed with a [quiet style](https://spectrum.adobe.com/page/action-button/#Quiet). */
-  isQuiet?: boolean
+  isQuiet?: boolean,
+  /** The static color style to apply. Useful when the button appears over a color background. */
+  staticColor?: 'white' | 'black'
 }
 
 export interface SpectrumLogicButtonProps extends AriaBaseButtonProps, ButtonProps, StyleProps {


### PR DESCRIPTION
Implements the new `staticColor` option for ActionButton and ToggleButton, which can be set to `white` or `black`. This is useful when the button is placed over a color background, and will be needed for ActionBar.

The implementation makes use of CSS vars to avoid duplicating all of the classes many times. In addition it uses the mix-blend-mode property to knock out the text in the selected version so that it becomes whatever color is behind the button automatically!

This also implements halo focus rings for emphasized toggle buttons.