### PR TITLE
Limit props to the interface when calling useTabPanel

### DIFF
--- a/packages/@react-aria/tabs/src/useTabPanel.ts
+++ b/packages/@react-aria/tabs/src/useTabPanel.ts
@@ -54,12 +54,10 @@ export function useTabPanel<T>(props: AriaTabPanelProps, state: TabListState<T>,
   }, [ref]);
 
   const id = generateId(state, state?.selectedKey, 'tabpanel');
-  const tabPanelProps = useLabels({...props, id});
+  const tabPanelProps = useLabels({...props, id, 'aria-labelledby': generateId(state, state?.selectedKey, 'tab')});
 
   return {
     tabPanelProps: mergeProps(tabPanelProps, {
-      id,
-      'aria-labelledby': generateId(state, state?.selectedKey, 'tab'),
       tabIndex,
       role: 'tabpanel',
       'aria-describedby': props['aria-describedby'],

--- a/packages/@react-aria/tabs/src/useTabPanel.ts
+++ b/packages/@react-aria/tabs/src/useTabPanel.ts
@@ -14,7 +14,7 @@ import {AriaTabPanelProps} from '@react-types/tabs';
 import {generateId} from './utils';
 import {getFocusableTreeWalker} from '@react-aria/focus';
 import {HTMLAttributes, RefObject, useLayoutEffect, useState} from 'react';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useLabels} from '@react-aria/utils';
 import {TabListState} from '@react-stately/tabs';
 
 interface TabPanelAria {
@@ -53,20 +53,17 @@ export function useTabPanel<T>(props: AriaTabPanelProps, state: TabListState<T>,
     }
   }, [ref]);
 
-  props = {
-    id: props.id,
-    'aria-describedby': props['aria-describedby'],
-    'aria-details': props['aria-details'],
-    'aria-label': props['aria-label'],
-    'aria-labelledby': props['aria-labelledby']
-  };
+  const id = generateId(state, state?.selectedKey, 'tabpanel');
+  const tabPanelProps = useLabels({...props, id});
 
   return {
-    tabPanelProps: mergeProps(props, {
-      id: generateId(state, state?.selectedKey, 'tabpanel'),
+    tabPanelProps: mergeProps(tabPanelProps, {
+      id,
       'aria-labelledby': generateId(state, state?.selectedKey, 'tab'),
       tabIndex,
-      role: 'tabpanel'
+      role: 'tabpanel',
+      'aria-describedby': props['aria-describedby'],
+      'aria-details': props['aria-details']
     })
   };
 }

--- a/packages/@react-aria/tabs/src/useTabPanel.ts
+++ b/packages/@react-aria/tabs/src/useTabPanel.ts
@@ -53,6 +53,14 @@ export function useTabPanel<T>(props: AriaTabPanelProps, state: TabListState<T>,
     }
   }, [ref]);
 
+  props = {
+    id: props.id,
+    'aria-describedby': props['aria-describedby'],
+    'aria-details': props['aria-details'],
+    'aria-label': props['aria-label'],
+    'aria-labelledby': props['aria-labelledby']
+  };
+
   return {
     tabPanelProps: mergeProps(props, {
       id: generateId(state, state?.selectedKey, 'tabpanel'),


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1886

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Open the Storybook in the `Tabs.stories.tsx`, verify the stories 'tabs at the bottom'. The `div` should not contain the HTML attribute `height` with the value "size-1000",

## 🧢 Your Project:

Outside adobe.
