### PR TITLE
[react-stately][useControlledState] Allow undefined params

### DIFF
--- a/packages/@react-stately/utils/src/useControlledState.ts
+++ b/packages/@react-stately/utils/src/useControlledState.ts
@@ -13,9 +13,9 @@
 import {useCallback, useRef, useState} from 'react';
 
 export function useControlledState<T>(
-  value: T,
-  defaultValue: T,
-  onChange: (value: T, ...args: any[]) => void
+  value: T | undefined,
+  defaultValue: T | undefined,
+  onChange: ((value: T, ...args: any[]) => void) | undefined
 ): [T, (value: T | ((prevState: T) => T), ...args: any[]) => void]  {
   let [stateValue, setStateValue] = useState(value || defaultValue);
   let ref = useRef(value !== undefined);


### PR DESCRIPTION
Closes #1859 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] ~~Added/updated unit tests and storybook for this change (for new code or code which already has tests).~~ (No existing way of checking types found, so I couldn't test this.)
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
Try doing `useControlledState(undefined, undefined, undefined)` in typescript with `strictNullChecks` compiler option turned on. There should not be any TypeScript errors.

## 🧢 Your Project:
https://github.com/ChocolateLoverRaj/color-picker
<!--- Company/project for pull request -->
