### PR TITLE
Add missing import to docs

### DIFF
--- a/packages/@react-aria/menu/docs/useMenuTrigger.mdx
+++ b/packages/@react-aria/menu/docs/useMenuTrigger.mdx
@@ -93,7 +93,7 @@ In addition, see [useMenu](useMenu.html) for examples of menu item groups, and m
 ```tsx example
 import {useMenuTriggerState} from '@react-stately/menu';
 import {useButton} from '@react-aria/button';
-import {useMenu, useMenuItem} from '@react-aria/menu';
+import {useMenu, useMenuItem, useMenuTrigger} from '@react-aria/menu';
 import {useTreeState} from '@react-stately/tree';
 import {Item} from '@react-stately/collections';
 import {mergeProps} from '@react-aria/utils';


### PR DESCRIPTION
HI team,

I was going through the `useMenuTrigger`  documentation to use in my own project and noticed that there was an import missing in the example for `useMenuTrigger`. I've added it in this PR 👍🏼 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
