### PR TITLE
@adobe/react-spectrum needs to include '*.css' in its sideEffects

### DIFF
--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -10,7 +10,9 @@
   "files": [
     "dist"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "scripts": {
     "prepublishOnly": "mkdir -p dist; cp src/index.ts dist/types.d.ts; cp src/index.ts dist/module.js; babel --root-mode upward src/index.ts -o dist/main.js"
   },

--- a/scripts/lint-packages.js
+++ b/scripts/lint-packages.js
@@ -59,7 +59,7 @@ for (let pkg of packages) {
     softAssert(json.source, `${pkg} did not have "source"`);
     softAssert.equal(json.source, 'src/index.ts', `${pkg} did not match "src/index.ts"`);
     softAssert.deepEqual(json.files, ['dist', 'src'], `${pkg} did not match "files"`);
-    if (pkg.includes('@react-spectrum') || pkg.includes('@react-aria/visually-hidden')) {
+    if (pkg.includes('@react-spectrum') || pkg.includes('@react-aria/visually-hidden') || pkg.includes('@adobe/react-spectrum')) {
       softAssert.deepEqual(json.sideEffects, ['*.css'], `${pkg} is missing sideEffects: [ '*.css' ]`);
     } else {
       softAssert.equal(json.sideEffects, false, `${pkg} is missing sideEffects: false`);


### PR DESCRIPTION
Adding a missing side effect configuration.

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues). **- NA**
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests). **- NA**
- [X] Filled out test instructions. **- NA**
- [X] Updated documentation (if it already exists for this component).**- NA**
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/) **- NA**

## 📝 Test Instructions:

Stolen from https://github.com/adobe/react-spectrum/pull/707

Build an app with a minimal webpack config:
```js
const path = require("path");

module.exports = {
	entry: "./index.js",
	output: {
		filename: "index.js",
		path: path.resolve(__dirname, "public"),
	},
	mode: "production",
	module: {
		rules: [
			{
				test: /\.m?js$/,
				exclude: /(node_modules|bower_components)/,
				use: {
					loader: "babel-loader",
					options: {
						presets: ["@babel/preset-react"],
					},
				},
			},
			{
				test: /\.css$/i,
				use: ["style-loader", "css-loader"],
				// this was previously necessary:
				// sideEffects: true
			},
		],
	},
};
```
## 🧢 Your Project:

Intended to be used in Workfront, in the future.
