### PR TITLE
[menu docs fix] broken spectrum links

### DIFF
--- a/packages/@react-spectrum/menu/docs/Menu.mdx
+++ b/packages/@react-spectrum/menu/docs/Menu.mdx
@@ -36,7 +36,7 @@ keywords: [menu trigger, dropdown, action menu]
   packageData={packageData}
   componentNames={['Menu', 'MenuTrigger']}
   sourceData={[
-    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/popovers/'}
+    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/popover/'}
   ]} />
 
 ## Example

--- a/packages/@react-spectrum/menu/docs/MenuTrigger.mdx
+++ b/packages/@react-spectrum/menu/docs/MenuTrigger.mdx
@@ -34,7 +34,7 @@ keywords: [menu, dropdown, action menu]
   packageData={packageData}
   componentNames={['MenuTrigger', 'Menu']}
   sourceData={[
-    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/popovers/'}
+    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/popover/'}
   ]} />
 
 ## Example
@@ -92,7 +92,7 @@ function Example() {
 
 ### Align and direction
 
-[View guidelines](https://spectrum.adobe.com/page/popovers/#Placement)
+[View guidelines](https://spectrum.adobe.com/page/popover/#Placement)
 
 The `align` prop aligns the Menu relative to the trigger and the `direction` prop controls the direction the Menu will render.
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Spectrum links to Popovers should no longer be broken

## 🧢 Your Project:

RSP
