### PR TITLE
Revert function signature breaking change useStyleProps

### DIFF
--- a/packages/@react-spectrum/layout/src/Flex.tsx
+++ b/packages/@react-spectrum/layout/src/Flex.tsx
@@ -34,7 +34,7 @@ function Flex(props: FlexProps, ref: DOMRef<HTMLDivElement>) {
   let breakpointProvider = useBreakpoint();
   let matchedBreakpoints = breakpointProvider?.matchedBreakpoints || ['base'];
   let {styleProps} = useStyleProps(otherProps);
-  let {styleProps: flexStyle} = useStyleProps(otherProps, {handlers: flexStyleProps});
+  let {styleProps: flexStyle} = useStyleProps(otherProps, flexStyleProps);
   let domRef = useDOMRef(ref);
   let isSSR = useIsSSR();
 

--- a/packages/@react-spectrum/layout/src/Grid.tsx
+++ b/packages/@react-spectrum/layout/src/Grid.tsx
@@ -45,7 +45,7 @@ function Grid(props: GridProps, ref: DOMRef<HTMLDivElement>) {
     children,
     ...otherProps
   } = props;
-  let {styleProps} = useStyleProps(otherProps, {handlers: gridStyleProps});
+  let {styleProps} = useStyleProps(otherProps, gridStyleProps);
   styleProps.style.display = 'grid'; // inline-grid?
   let domRef = useDOMRef(ref);
 

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -91,7 +91,7 @@ function Provider(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
   // Only wrap in a DOM node if the theme, colorScheme, or scale changed
   let contents = children;
   let domProps = filterDOMProps(otherProps);
-  let {styleProps} = useStyleProps(otherProps, {matchedBreakpoints});
+  let {styleProps} = useStyleProps(otherProps, undefined, {matchedBreakpoints});
   if (!prevContext || props.locale || theme !== prevContext.theme || colorScheme !== prevContext.colorScheme || scale !== prevContext.scale || Object.keys(domProps).length > 0 || otherProps.UNSAFE_className || Object.keys(styleProps.style).length > 0) {
     contents = (
       <ProviderWrapper {...props} UNSAFE_style={{isolation: !prevContext ? 'isolate' : undefined, ...styleProps.style}} ref={ref}>

--- a/packages/@react-spectrum/utils/src/styleProps.ts
+++ b/packages/@react-spectrum/utils/src/styleProps.ts
@@ -219,19 +219,20 @@ export function convertStyleProps(props: ViewStyleProps, handlers: StyleHandlers
   return style;
 }
 
-export function useStyleProps<T extends StyleProps>(props: T, options: {
-  handlers?: StyleHandlers,
+type StylePropsOptions = {
   matchedBreakpoints?: Breakpoint[]
-} = {
-  handlers: baseStyleProps
-}) {
+};
+
+export function useStyleProps<T extends StyleProps>(
+  props: T,
+  handlers: StyleHandlers = baseStyleProps,
+  options: StylePropsOptions = {}) {
   let {
     UNSAFE_className,
     UNSAFE_style,
     ...otherProps
   } = props;
   let {
-    handlers = baseStyleProps,
     matchedBreakpoints = ['base']
   } = options;
   let breakpointProvider = useBreakpoint();

--- a/packages/@react-spectrum/utils/src/styleProps.ts
+++ b/packages/@react-spectrum/utils/src/styleProps.ts
@@ -226,7 +226,8 @@ type StylePropsOptions = {
 export function useStyleProps<T extends StyleProps>(
   props: T,
   handlers: StyleHandlers = baseStyleProps,
-  options: StylePropsOptions = {}) {
+  options: StylePropsOptions = {}
+) {
   let {
     UNSAFE_className,
     UNSAFE_style,

--- a/packages/@react-spectrum/view/src/View.tsx
+++ b/packages/@react-spectrum/view/src/View.tsx
@@ -23,7 +23,7 @@ function View(props: ViewProps, ref: DOMRef) {
     children,
     ...otherProps
   } = props;
-  let {styleProps} = useStyleProps(props, {handlers: viewStyleProps});
+  let {styleProps} = useStyleProps(props, viewStyleProps);
   let domRef = useDOMRef(ref);
 
   return (


### PR DESCRIPTION
Closes <!-- Github issue # here -->
While not documented, this function is technically exported, better to be safe and keep the existing function signature unbroken
introduced in https://github.com/adobe/react-spectrum/pull/1684

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
