### PR TITLE
fix(#1885) Making ListLayout updateItemSize early return if layoutInfo is undefined

### DIFF
--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -22,8 +22,10 @@ import {Heading} from '@react-spectrum/text';
 import {HidingColumns} from './HidingColumns';
 import {IllustratedMessage} from '@react-spectrum/illustratedmessage';
 import {Link} from '@react-spectrum/link';
-import React from 'react';
+import {Radio, RadioGroup} from '@react-spectrum/radio';
+import React, {Key, useState} from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
+import {SelectionMode} from '@react-types/shared';
 import {storiesOf} from '@storybook/react';
 import {Switch} from '@react-spectrum/switch';
 import {useAsyncList} from '@react-stately/data';
@@ -238,6 +240,13 @@ storiesOf('TableView', module)
           }
         </TableBody>
       </TableView>
+    )
+  )
+  .add(
+    // For testing https://github.com/adobe/react-spectrum/issues/1885
+    'controlled selection mode',
+    () => (
+      <ControlledSelectionMode />
     )
   )
   .add(
@@ -1004,5 +1013,31 @@ function AsyncServerFilterTable(props) {
         </TableBody>
       </TableView>
     </div>
+  );
+}
+
+function ControlledSelectionMode() {
+  let [selectionMode, setSelectionMode] = useState('none' as SelectionMode);
+  let [selectedKeys, setSelectedKeys] = React.useState(new Set([]) as 'all' | Iterable<Key>);
+
+  return (
+    <Flex direction="column" flexGrow={1} maxWidth="size-6000">
+      <RadioGroup defaultValue="none" onChange={(value: SelectionMode) => setSelectionMode(value)} label="Show / Hide">
+        <Radio value="multiple">Multiple</Radio>
+        <Radio value="none">None</Radio>
+      </RadioGroup>
+      <TableView overflowMode="wrap" selectionMode={selectionMode} selectedKeys={selectedKeys} aria-label="TableView with controlled selection" width="100%" height="100%" onSelectionChange={setSelectedKeys}>
+        <TableHeader columns={columns}>
+          {column => <Column>{column.name}</Column>}
+        </TableHeader>
+        <TableBody items={items}>
+          {item =>
+            (<Row key={item.foo}>
+              {key => <Cell>{item[key]}</Cell>}
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    </Flex>
   );
 }

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -244,9 +244,9 @@ storiesOf('TableView', module)
   )
   .add(
     // For testing https://github.com/adobe/react-spectrum/issues/1885
-    'controlled selection mode',
+    'swap selection mode',
     () => (
-      <ControlledSelectionMode />
+      <ChangableSelectionMode />
     )
   )
   .add(
@@ -1016,7 +1016,7 @@ function AsyncServerFilterTable(props) {
   );
 }
 
-function ControlledSelectionMode() {
+function ChangableSelectionMode() {
   let [selectionMode, setSelectionMode] = useState('none' as SelectionMode);
   let [selectedKeys, setSelectedKeys] = React.useState(new Set([]) as 'all' | Iterable<Key>);
 

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3333,6 +3333,7 @@ describe('TableView', function () {
         userEvent.click(within(row).getByRole('checkbox'));
         expect(row).toHaveAttribute('aria-selected', 'true');
 
+        // Without ListLayout fix, throws here with "TypeError: Cannot set property 'estimatedSize' of undefined"
         rerender(tree, <ControlledSelection selectionMode="none" />);
         act(() => jest.runAllTimers());
         expect(() => tree.getByRole('checkbox')).toThrow();

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -311,6 +311,11 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
 
   updateItemSize(key: Key, size: Size) {
     let layoutInfo = this.layoutInfos.get(key);
+    // If no layoutInfo, item has been deleted/removed.
+    if (!layoutInfo) {
+      return false;
+    }
+
     layoutInfo.estimatedSize = false;
     if (layoutInfo.rect.height !== size.height) {
       // Copy layout info rather than mutating so that later caches are invalidated.


### PR DESCRIPTION
Closes #1885

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test steps:
1. Go to http://localhost:9003/?path=/story/tableview--controlled-selection-mode
2. change selection mode to multiple
3. Select any table row
4. Change selection mode to none. Note the table shouldn't throw
## 🧢 Your Project:

<!--- Company/project for pull request -->
