### PR TITLE
Revert docs breadcrumb focus

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css
@@ -104,20 +104,18 @@ governing permissions and limitations under the License.
 
   &[href],
   &[tabindex="0"] {
-    &:not([aria-current]) {
-      cursor: pointer;
+    cursor: pointer;
 
-      &:hover,
-      &:focus-ring {
-        text-decoration: underline;
-      }
+    &:hover,
+    &:focus-ring {
+      text-decoration: underline;
     }
   }
 }
 
 
 .spectrum-Breadcrumbs-item.is-dragged .spectrum-Breadcrumbs-itemLink:before,
-.spectrum-Breadcrumbs-itemLink:not([aria-current]):focus-ring:before {
+.spectrum-Breadcrumbs-itemLink:focus-ring:before {
   position: absolute;
   top: 0;
   inset-inline-start: 0;
@@ -135,12 +133,16 @@ governing permissions and limitations under the License.
   pointer-events: none;
 }
 
-.spectrum-Breadcrumbs--small .spectrum-Breadcrumbs-item {
-  font-size: var(--spectrum-breadcrumb-multiline-item-text-size);
+.spectrum-Breadcrumbs--small {
+  .spectrum-Breadcrumbs-item {
+    font-size: var(--spectrum-breadcrumb-multiline-item-text-size);
+  }
 }
 
-.spectrum-Breadcrumbs--medium .spectrum-Breadcrumbs-item {
-  font-size: var(--spectrum-breadcrumb-compact-item-text-size);
+.spectrum-Breadcrumbs--medium {
+  .spectrum-Breadcrumbs-item {
+    font-size: var(--spectrum-breadcrumb-compact-item-text-size);
+  }
 }
 
 .spectrum-Breadcrumbs--multiline {

--- a/packages/@adobe/spectrum-css-temp/components/breadcrumb/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/breadcrumb/skin.css
@@ -3,6 +3,7 @@ Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
@@ -27,7 +28,7 @@ governing permissions and limitations under the License.
     color: var(--spectrum-breadcrumb-ui-icon-color);
   }
 
-  .spectrum-Breadcrumbs-itemLink:not([aria-current]) {
+  .spectrum-Breadcrumbs-itemLink {
     color: inherit;
 
     &:hover {
@@ -57,12 +58,17 @@ governing permissions and limitations under the License.
     color: var(--spectrum-breadcrumb-text-color-down);
   }
 
-  &.is-selected ~ .spectrum-Breadcrumb:last-of-type {
-    color: var(--spectrum-breadcrumb-text-color);
-  }
-
-  &.is-selected  .spectrum-Breadcrumbs-itemLink:not([aria-current]):focus-ring {
-    color: var(--spectrum-breadcrumb-text-color-down);
-    border-bottom: 0;
+  &.is-selected {
+    ~ .spectrum-Breadcrumb {
+      &:last-of-type {
+        color: var(--spectrum-breadcrumb-text-color);
+      }
+    }
+    .spectrum-Breadcrumbs-itemLink {
+      &:focus-ring {
+        color: var(--spectrum-breadcrumb-text-color-down);
+        border-bottom: 0;
+      }
+    }
   }
 }

--- a/packages/dev/docs/package.json
+++ b/packages/dev/docs/package.json
@@ -8,7 +8,6 @@
     "@mdx-js/react": "^1.5.5",
     "@react-aria/aria-modal-polyfill": "^3.1.0",
     "@react-aria/interactions": "^3.1.0",
-    "@react-aria/utils": "^3.1.0",
     "@react-aria/visually-hidden": "^3.1.0",
     "@react-spectrum/breadcrumbs": "^3.1.0",
     "@react-spectrum/button": "^3.1.0",

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -351,7 +351,6 @@ footer li:last-child:after {
   cursor: pointer;
   &:hover {
     text-decoration: underline;
-    cursor: pointer;
   }
   &:focus:not(:active) {
     text-decoration: underline;

--- a/packages/dev/docs/src/docs.js
+++ b/packages/dev/docs/src/docs.js
@@ -16,10 +16,9 @@ import {Content, View} from '@react-spectrum/view';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Divider} from '@react-spectrum/divider';
 import docsStyle from './docs.css';
-import {focusWithoutScrolling} from '@react-aria/utils';
 import highlightCss from './syntax-highlight.css';
 import {Pressable} from '@react-aria/interactions';
-import React, {useCallback, useLayoutEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
 import {ThemeProvider} from './ThemeSwitcher';
 
@@ -37,63 +36,29 @@ for (let link of links) {
         <Pressable>
           {/* eslint-disable jsx-a11y/click-events-have-key-events */}
           {/* eslint-disable jsx-a11y/anchor-is-valid */}
-          <a role="button" tabIndex={0} aria-haspopup="dialog" data-link={link.dataset.link} className={link.className} onClick={e => e.preventDefault()}>{link.textContent}</a>
+          <a role="link" tabIndex={0} data-link={link.dataset.link} className={link.className} onClick={e => e.preventDefault()}>{link.textContent}</a>
         </Pressable>
         <LinkPopover id={link.dataset.link} />
       </DialogTrigger>
     </ThemeProvider>
   , container);
 
-  link.parentNode.replaceChild(container.firstElementChild, link);
+  link.parentNode.replaceChild(container, link);
 }
 
 function LinkPopover({id}) {
   let ref = useRef();
   let [breadcrumbs, setBreadcrumbs] = useState([document.getElementById(id)]);
 
-  const onBlurCurrentBreadcrumb = useCallback((event) => {
-    event.target.removeEventListener('blur', onBlurCurrentBreadcrumb);
-    event.target.tabIndex = -1;
-  },
-  []);
-
-  const timeoutRef = useRef();
-  useLayoutEffect(() => {
+  useEffect(() => {
     let links = ref.current.querySelectorAll('[data-link]');
     for (let link of links) {
-      // Links with [data-link] will open within the LinkPopover, so [aria-haspopup] is not appropriate.
-      link.removeAttribute('aria-haspopup');
-      // Add click event handler so that the link updates the content of the popover.
       link.addEventListener('click', (e) => {
         e.preventDefault();
         setBreadcrumbs([...breadcrumbs, document.getElementById(link.dataset.link)]);
       });
     }
-
-    
-    if (timeoutRef.current) {
-      cancelAnimationFrame(timeoutRef.current);
-      timeoutRef.current = undefined;
-    }
-
-    // Wait a frame, then focus the current breadcrumb for the popover, 
-    // which ensures that focus is not lost to the document.body when the LinkPopover content changes.
-    timeoutRef.current = requestAnimationFrame(() => {
-      const currentBreadcrumb = ref.current.closest(`.${docsStyle.popover}`).querySelector('[aria-current]');
-      if (currentBreadcrumb) {
-        currentBreadcrumb.tabIndex = 0;
-        currentBreadcrumb.addEventListener('blur', onBlurCurrentBreadcrumb);
-        focusWithoutScrolling(currentBreadcrumb); 
-      }
-    });
-
-    return () => {
-      if (timeoutRef.current) {
-        cancelAnimationFrame(timeoutRef.current);
-        timeoutRef.current = undefined;
-      }
-    };
-  }, [breadcrumbs, onBlurCurrentBreadcrumb, timeoutRef]);
+  }, [breadcrumbs]);
 
   return (
     <Dialog UNSAFE_className={`${highlightCss.spectrum} ${docsStyle.popover}`} size="L">


### PR DESCRIPTION
Reasoning being that we need to manage focus in the docs, not by changing our component if at all possible.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
