### PR TITLE
Fixes for responsive style props

### DIFF
--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -33,7 +33,7 @@ import {version} from '../package.json';
 const Context = React.createContext<ProviderContext | null>(null);
 Context.displayName = 'ProviderContext';
 
-const DEFAULT_BREAKPOINTS = {S: 380, M: 768, L: 1024};
+const DEFAULT_BREAKPOINTS = {S: 640, M: 768, L: 1024, XL: 1280, XXL: 1536};
 
 function Provider(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
   let prevContext = useProvider();

--- a/packages/@react-spectrum/provider/test/Provider.test.js
+++ b/packages/@react-spectrum/provider/test/Provider.test.js
@@ -33,7 +33,7 @@ let theme = {
 let mediaQueryLight = '(prefers-color-scheme: light)';
 let mediaQueryDark = '(prefers-color-scheme: dark)';
 let mediaQueryMinXSmall = '(min-width: 190px)';
-let mediaQueryMinSmall = '(min-width: 380px)';
+let mediaQueryMinSmall = '(min-width: 640px)';
 let mediaQueryMinMedium = '(min-width: 768px)';
 let mediaQueryMinLarge = '(min-width: 1024px)';
 

--- a/packages/@react-spectrum/utils/src/styleProps.ts
+++ b/packages/@react-spectrum/utils/src/styleProps.ts
@@ -233,12 +233,12 @@ export function useStyleProps<T extends StyleProps>(
     UNSAFE_style,
     ...otherProps
   } = props;
-  let {
-    matchedBreakpoints = ['base']
-  } = options;
   let breakpointProvider = useBreakpoint();
   let {direction} = useLocale();
-  let styles = convertStyleProps(props, handlers, direction, breakpointProvider?.matchedBreakpoints || matchedBreakpoints);
+  let {
+    matchedBreakpoints = breakpointProvider?.matchedBreakpoints || ['base']
+  } = options;
+  let styles = convertStyleProps(props, handlers, direction, matchedBreakpoints);
   let style = {...UNSAFE_style, ...styles};
 
   // @ts-ignore
@@ -264,7 +264,7 @@ export function useStyleProps<T extends StyleProps>(
     className: UNSAFE_className
   };
 
-  if (props.isHidden) {
+  if (getResponsiveProp(props.isHidden, matchedBreakpoints)) {
     styleProps.hidden = true;
   }
 
@@ -281,7 +281,7 @@ export function getResponsiveProp<T>(prop: Responsive<T>, matchedBreakpoints: Br
   if (prop && typeof prop === 'object' && !Array.isArray(prop)) {
     for (let i = 0; i < matchedBreakpoints.length; i++) {
       let breakpoint = matchedBreakpoints[i];
-      if (prop[breakpoint]) {
+      if (prop[breakpoint] != null) {
         return prop[breakpoint];
       }
     }


### PR DESCRIPTION
Fixes a couple issues I found with responsive style props while writing the docs.

1. Default breakpoints. There are now more of them, and the small breakpoint is now 640px instead of 320px. The `base` value should be used for smaller values than that. These values were shamelessly stolen from Tailwind CSS. https://tailwindcss.com/docs/responsive-design
2. Fixed falsy values in responsive style props, as well as the `hidden` DOM attribute for the `isHidden` style prop.