### PR TITLE
Prevent autoFocus from being reexecuted during Fast Refresh

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -301,14 +301,16 @@ function focusFirstInScope(scope: HTMLElement[]) {
 }
 
 function useAutoFocus(scopeRef: RefObject<HTMLElement[]>, autoFocus: boolean) {
+  const autoFocusRef = React.useRef(autoFocus);
   useEffect(() => {
-    if (autoFocus) {
+    if (autoFocusRef.current) {
       activeScope = scopeRef;
       if (!isElementInScope(document.activeElement, activeScope.current)) {
         focusFirstInScope(scopeRef.current);
       }
     }
-  }, [scopeRef, autoFocus]);
+    autoFocusRef.current = false;
+  }, []);
 }
 
 function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boolean, contain: boolean) {

--- a/packages/@react-aria/focus/src/useFocusable.tsx
+++ b/packages/@react-aria/focus/src/useFocusable.tsx
@@ -12,7 +12,7 @@
 
 import {FocusableDOMProps, FocusableProps} from '@react-types/shared';
 import {mergeProps, useSyncRef} from '@react-aria/utils';
-import React, {HTMLAttributes, MutableRefObject, ReactNode, RefObject, useContext, useEffect} from 'react';
+import React, {HTMLAttributes, MutableRefObject, ReactNode, RefObject, useContext, useEffect, useRef} from 'react';
 import {useFocus, useKeyboard} from '@react-aria/interactions';
 
 interface FocusableOptions extends FocusableProps, FocusableDOMProps {
@@ -67,12 +67,14 @@ export function useFocusable(props: FocusableOptions, domRef: RefObject<HTMLElem
   let interactions = mergeProps(focusProps, keyboardProps);
   let domProps = useFocusableContext(domRef);
   let interactionProps = props.isDisabled ? {} : domProps;
+  let autoFocusRef = useRef(props.autoFocus);
 
   useEffect(() => {
-    if (props.autoFocus && domRef.current) {
+    if (autoFocusRef.current && domRef.current) {
       domRef.current.focus();
     }
-  }, [props.autoFocus, domRef]);
+    autoFocusRef.current = false;
+  }, []);
 
   return {
     focusableProps: mergeProps(

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {FocusEvent, HTMLAttributes, Key, KeyboardEvent, RefObject, useEffect} from 'react';
+import {FocusEvent, HTMLAttributes, Key, KeyboardEvent, RefObject, useEffect, useRef} from 'react';
 import {focusSafely, getFocusableTreeWalker} from '@react-aria/focus';
 import {FocusStrategy, KeyboardDelegate} from '@react-types/shared';
 import {focusWithoutScrolling, isMac, mergeProps} from '@react-aria/utils';
@@ -284,8 +284,9 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
     }
   };
 
+  const autoFocusRef = useRef(autoFocus);
   useEffect(() => {
-    if (autoFocus) {
+    if (autoFocusRef.current) {
       let focusedKey = null;
 
       // Check focus strategy to determine which item to focus
@@ -309,6 +310,7 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
         focusSafely(ref.current);
       }
     }
+    autoFocusRef.current = false;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
I believe that `autoFocus` prop should behave like the native one - so it should only be handled when the component in question gets mounted to the DOM.

React takes the liberty to refire effects (after cleaning them up) which can already happen today when one performs a Fast Refresh update. I don't think that in such a scenario we should focus the element.

## 📝 Test Instructions:

Assess correct behavior manually - I don't think this deserves unit tests due to rather complex test setup that would be required to cover this.
