### PR TITLE
Always show clear button when mobile combobox has validation state

### DIFF
--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -447,7 +447,7 @@ function ComboBoxTray(props: ComboBoxTrayProps) {
           isLoading={showLoading && loadingState === 'filtering'}
           loadingIndicator={loadingState != null && loadingCircle}
           validationState={validationState}
-          wrapperChildren={(state.inputValue !== '' || loadingState === 'filtering') && !props.isReadOnly && clearButton}
+          wrapperChildren={(state.inputValue !== '' || loadingState === 'filtering' || validationState != null) && !props.isReadOnly && clearButton}
           UNSAFE_className={
             classNames(
               searchStyles,

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -4338,8 +4338,13 @@ describe('ComboBox', function () {
         let allProgressSpinners = within(tray).getAllByRole('progressbar');
         expect(allProgressSpinners.length).toBe(1);
 
-        let validationIcon = within(tray).getByRole('img', {hidden: true});
-        expect(validationIcon).toBeTruthy();
+        let icons = within(tray).getAllByRole('img', {hidden: true});
+        expect(icons.length).toBe(2);
+
+        let clearButton = within(tray).getByLabelText('Clear');
+        expect(clearButton).toBeTruthy();
+
+        expect(within(clearButton).getByRole('img', {hidden: true})).toBe(icons[1]);
 
         let trayInput = within(tray).getByRole('searchbox');
         expect(trayInput).toHaveAttribute('aria-invalid', 'true');


### PR DESCRIPTION
Because the validation icon is visible, show the clear button even when the field is empty so there isn't empty space like we do for loading states.

<img src="https://user-images.githubusercontent.com/19409/120047335-2b41db00-bfc9-11eb-92f4-bc526088f47a.png" width="300">
