### PR TITLE
Fix keyboard navigation behavior of ActionGroup

### DIFF
--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -350,8 +350,9 @@ interface ActionGroupMenuProps<T> extends AriaLabelingProps {
 }
 
 function ActionGroupMenu<T>({state, isDisabled, isEmphasized, staticColor, items, onAction, summaryIcon, hideButtonText, isOnlyItem, orientation, ...otherProps}: ActionGroupMenuProps<T>) {
-  // Random key that won't conflict with any real items in the collection.
-  let key = useId();
+  // Use the key of the first item within the menu as the key of the button.
+  // The key must actually exist in the collection for focus to work correctly.
+  let key = items[0].key;
   let {buttonProps} = useActionGroupItem({key}, state);
 
   // The menu button shouldn't act like an actual action group item.

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -718,6 +718,34 @@ describe('ActionGroup', function () {
       expect(onAction).toHaveBeenCalledWith('three');
     });
 
+    it('handles keyboard focus management properly', function () {
+      let onAction = jest.fn();
+      let tree = render(
+        <Provider theme={theme}>
+          <ActionGroup overflowMode="collapse" onAction={onAction}>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
+            <Item key="four">Four</Item>
+          </ActionGroup>
+        </Provider>
+      );
+
+      let actiongroup = tree.getByRole('toolbar');
+      let buttons = within(actiongroup).getAllByRole('button');
+      expect(buttons.length).toBe(2);
+      expect(buttons[0]).toHaveAttribute('tabIndex', '0');
+      expect(buttons[1]).toHaveAttribute('tabIndex', '0');
+
+      act(() => buttons[0].focus());
+      expect(buttons[0]).toHaveAttribute('tabIndex', '0');
+      expect(buttons[1]).toHaveAttribute('tabIndex', '-1');
+
+      pressArrowRight(buttons[0]);
+      expect(buttons[0]).toHaveAttribute('tabIndex', '-1');
+      expect(buttons[1]).toHaveAttribute('tabIndex', '0');
+    });
+
     it('passes aria labeling props through to menu button if it is the only child', function () {
       jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function () {
         if (this instanceof HTMLButtonElement) {


### PR DESCRIPTION
Fixes an issue where all of the items got `tabIndex=0` when focusing the menu trigger of a collapsed ActionGroup. This is because the key we were using didn't actually exist in the collection, and useListState set the focused key to null. Now I'm using the key of the first item within the menu for the key of the button, which is kinda hacky but solves the problem for now.