### PR TITLE
Issue 1998: Added originalEvent to usePress and useHover hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,8 +77,7 @@ module.exports = {
     'expect': true,
     'JSX': 'readonly',
     'NodeJS': 'readonly',
-    'AsyncIterable': 'readonly',
-    'globalThis': 'readonly'
+    'AsyncIterable': 'readonly'
   },
   settings: {
     jsdoc: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,8 @@ module.exports = {
     'expect': true,
     'JSX': 'readonly',
     'NodeJS': 'readonly',
-    'AsyncIterable': 'readonly'
+    'AsyncIterable': 'readonly',
+    'globalThis': 'readonly'
   },
   settings: {
     jsdoc: {

--- a/packages/@react-aria/interactions/src/useHover.ts
+++ b/packages/@react-aria/interactions/src/useHover.ts
@@ -102,21 +102,25 @@ export function useHover(props: HoverProps): HoverResult {
   useEffect(setupGlobalTouchEvents, []);
 
   let {hoverProps, triggerHoverEnd} = useMemo(() => {
-    let triggerHoverStart = (event, pointerType) => {
+    let triggerHoverStart = (originalEvent, pointerType) => {
       state.pointerType = pointerType;
-      if (isDisabled || pointerType === 'touch' || state.isHovered || !event.currentTarget.contains(event.target)) {
+      if (
+        isDisabled || pointerType === 'touch' || state.isHovered ||
+        !originalEvent.currentTarget.contains(originalEvent.target)
+      ) {
         return;
       }
 
       state.isHovered = true;
-      let target = event.target;
+      let target = originalEvent.target;
       state.target = target;
 
       if (onHoverStart) {
         onHoverStart({
           type: 'hoverstart',
           target,
-          pointerType
+          pointerType,
+          originalEvent
         });
       }
 
@@ -127,7 +131,7 @@ export function useHover(props: HoverProps): HoverResult {
       setHovered(true);
     };
 
-    let triggerHoverEnd = (event, pointerType) => {
+    let triggerHoverEnd = (originalEvent, pointerType) => {
       state.pointerType = '';
       state.target = null;
 
@@ -136,12 +140,13 @@ export function useHover(props: HoverProps): HoverResult {
       }
 
       state.isHovered = false;
-      let target = event.target;
+      let target = originalEvent.target;
       if (onHoverEnd) {
         onHoverEnd({
           type: 'hoverend',
           target,
-          pointerType
+          pointerType,
+          originalEvent
         });
       }
 

--- a/packages/@react-aria/interactions/test/useHover.test.js
+++ b/packages/@react-aria/interactions/test/useHover.test.js
@@ -76,7 +76,7 @@ describe('useHover', function () {
       fireEvent(el, pointerEvent('pointerover', {pointerType: 'mouse'}));
       fireEvent(el, pointerEvent('pointerout', {pointerType: 'mouse'}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverstart',
           target: el,
@@ -162,7 +162,7 @@ describe('useHover', function () {
       fireEvent(el, pointerEvent('pointerover', {pointerType: 'mouse'}));
       fireEvent(el, pointerEvent('pointerout', {pointerType: 'mouse'}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverstart',
           target: el,
@@ -223,7 +223,7 @@ describe('useHover', function () {
 
       fireEvent(el, pointerEvent('pointerover', {pointerType: 'mouse'}));
       expect(el.textContent).toBe('test-hovered');
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverstart',
           target: el,
@@ -246,7 +246,7 @@ describe('useHover', function () {
       );
       el = res.getByText('test');
       expect(el.textContent).toBe('test');
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverend',
           target: el,
@@ -276,7 +276,7 @@ describe('useHover', function () {
       fireEvent.mouseEnter(el);
       fireEvent.mouseLeave(el);
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverstart',
           target: el,
@@ -358,7 +358,7 @@ describe('useHover', function () {
       fireEvent.mouseEnter(el);
       fireEvent.mouseLeave(el);
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverstart',
           target: el,
@@ -393,7 +393,7 @@ describe('useHover', function () {
 
       fireEvent.mouseEnter(el);
       expect(el.textContent).toBe('test-hovered');
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverstart',
           target: el,
@@ -416,7 +416,7 @@ describe('useHover', function () {
       );
       el = res.getByText('test');
       expect(el.textContent).toBe('test');
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'hoverend',
           target: el,

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -77,7 +77,7 @@ describe('usePress', function () {
 
       // How else to get the DOM node it renders the hook to?
       // let el = events[0].target;
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -139,7 +139,7 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 100, clientY: 100}));
       fireEvent(el, pointerEvent('pointermove', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -172,7 +172,7 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointermove', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -256,7 +256,7 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
       fireEvent(el, pointerEvent('pointercancel', {pointerId: 1, pointerType: 'mouse'}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -300,7 +300,7 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
       fireEvent(el, new MouseEvent('dragstart', {bubbles: true, cancelable: true, composed: true}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -346,7 +346,7 @@ describe('usePress', function () {
 
       // How else to get the DOM node it renders the hook to?
       // let el = events[0].target;
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -473,7 +473,7 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0}));
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -560,7 +560,7 @@ describe('usePress', function () {
       fireEvent.mouseUp(el, {detail: 1});
       fireEvent.click(el, {detail: 1});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -622,7 +622,7 @@ describe('usePress', function () {
       fireEvent.mouseUp(document.body, {detail: 1, clientX: 100, clientY: 100});
       fireEvent.mouseEnter(el);
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -656,7 +656,7 @@ describe('usePress', function () {
       fireEvent.mouseUp(el, {detail: 1});
       fireEvent.click(el, {detail: 1});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -741,7 +741,7 @@ describe('usePress', function () {
       fireEvent.mouseUp(el, {detail: 1, shiftKey: true});
       fireEvent.click(el, {detail: 1});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -869,7 +869,7 @@ describe('usePress', function () {
       fireEvent.mouseDown(el, {detail: 1});
       fireEvent(el, new MouseEvent('dragstart', {bubbles: true, cancelable: true, composed: true}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -915,7 +915,7 @@ describe('usePress', function () {
       fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -976,7 +976,7 @@ describe('usePress', function () {
       fireEvent.touchMove(el, {changedTouches: [{identifier: 1, clientX: 100, clientY: 100}]});
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 100, clientY: 100}]});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1009,7 +1009,7 @@ describe('usePress', function () {
       fireEvent.touchMove(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1100,7 +1100,7 @@ describe('usePress', function () {
       fireEvent.mouseUp(el);
       fireEvent.click(el);
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1185,7 +1185,7 @@ describe('usePress', function () {
       fireEvent.touchCancel(el);
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1230,7 +1230,7 @@ describe('usePress', function () {
       fireEvent.scroll(document.body);
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1281,7 +1281,7 @@ describe('usePress', function () {
 
       fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1341,7 +1341,7 @@ describe('usePress', function () {
       fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
       fireEvent(el, new MouseEvent('dragstart', {bubbles: true, cancelable: true, composed: true}));
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1423,7 +1423,7 @@ describe('usePress', function () {
       fireEvent.keyDown(el, {key: ' '});
       fireEvent.keyUp(el, {key: ' '});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1498,7 +1498,7 @@ describe('usePress', function () {
       fireEvent.click(el);
 
       // Click event, which is called when Enter key on a link is handled natively, should trigger a click.
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'click'
         },
@@ -1570,7 +1570,7 @@ describe('usePress', function () {
       fireEvent.keyUp(el, {key: 'Enter'});
 
       // Enter key should trigger press events on element with role="link"
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1645,7 +1645,7 @@ describe('usePress', function () {
       fireEvent.keyDown(el, {key: ' '});
       fireEvent.keyUp(el, {key: ' '});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1708,7 +1708,7 @@ describe('usePress', function () {
       fireEvent.keyDown(el, {key: ' ', shiftKey: true});
       fireEvent.keyUp(el, {key: ' ', ctrlKey: true});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,
@@ -1771,7 +1771,7 @@ describe('usePress', function () {
       fireEvent.keyDown(el, {key: ' '});
       fireEvent.keyUp(el, {key: ' '});
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         // First sequence. Ensure the key up on the body causes a press end.
         {
           type: 'pressstart',
@@ -1878,7 +1878,7 @@ describe('usePress', function () {
       let el = getByText('test');
       fireEvent.click(el);
 
-      expect(events).toEqual([
+      expect(events).toMatchObject([
         {
           type: 'pressstart',
           target: el,

--- a/packages/@react-types/shared/src/events.d.ts
+++ b/packages/@react-types/shared/src/events.d.ts
@@ -16,8 +16,6 @@ import {
   SyntheticEvent
 } from 'react';
 
-type DOMKeyboardEvent = globalThis.KeyboardEvent
-
 // Event bubbling can be problematic in real-world applications, so the default for React Spectrum components
 // is not to propagate. This can be overridden by calling continuePropagation() on the event.
 export type BaseEvent<T extends SyntheticEvent> = T & {
@@ -29,8 +27,6 @@ export type BaseEvent<T extends SyntheticEvent> = T & {
 export type KeyboardEvent = BaseEvent<ReactKeyboardEvent<any>>;
 
 export type PointerType = 'mouse' | 'pen' | 'touch' | 'keyboard' | 'virtual';
-
-export type OriginalPressEvent = DOMKeyboardEvent | MouseEvent | PointerEvent | DragEvent | TouchEvent
 
 export interface PressEvent {
   /** The type of press event being fired. */
@@ -46,10 +42,8 @@ export interface PressEvent {
   /** Whether the meta keyboard modifier was held during the press event. */
   metaKey: boolean,
   /** The original DOM event that triggered the press event. */
-  originalEvent: OriginalPressEvent
+  originalEvent: any
 }
-
-export type OriginalHoverEvent = MouseEvent | PointerEvent | TouchEvent
 
 export interface HoverEvent {
   /** The type of hover event being fired. */
@@ -59,7 +53,7 @@ export interface HoverEvent {
   /** The target element of the hover event. */
   target: HTMLElement,
   /** The original DOM event that triggered the hover event. */
-  originalEvent: OriginalHoverEvent
+  originalEvent: any
 }
 
 export interface KeyboardEvents {

--- a/packages/@react-types/shared/src/events.d.ts
+++ b/packages/@react-types/shared/src/events.d.ts
@@ -16,6 +16,8 @@ import {
   SyntheticEvent
 } from 'react';
 
+type DOMKeyboardEvent = globalThis.KeyboardEvent
+
 // Event bubbling can be problematic in real-world applications, so the default for React Spectrum components
 // is not to propagate. This can be overridden by calling continuePropagation() on the event.
 export type BaseEvent<T extends SyntheticEvent> = T & {
@@ -27,6 +29,8 @@ export type BaseEvent<T extends SyntheticEvent> = T & {
 export type KeyboardEvent = BaseEvent<ReactKeyboardEvent<any>>;
 
 export type PointerType = 'mouse' | 'pen' | 'touch' | 'keyboard' | 'virtual';
+
+export type OriginalPressEvent = DOMKeyboardEvent | MouseEvent | PointerEvent | DragEvent | TouchEvent
 
 export interface PressEvent {
   /** The type of press event being fired. */
@@ -40,8 +44,12 @@ export interface PressEvent {
   /** Whether the ctrl keyboard modifier was held during the press event. */
   ctrlKey: boolean,
   /** Whether the meta keyboard modifier was held during the press event. */
-  metaKey: boolean
+  metaKey: boolean,
+  /** The original DOM event that triggered the press event. */
+  originalEvent: OriginalPressEvent
 }
+
+export type OriginalHoverEvent = MouseEvent | PointerEvent | TouchEvent
 
 export interface HoverEvent {
   /** The type of hover event being fired. */
@@ -49,7 +57,9 @@ export interface HoverEvent {
   /** The pointer type that triggered the hover event. */
   pointerType: 'mouse' | 'pen',
   /** The target element of the hover event. */
-  target: HTMLElement
+  target: HTMLElement,
+  /** The original DOM event that triggered the hover event. */
+  originalEvent: OriginalHoverEvent
 }
 
 export interface KeyboardEvents {


### PR DESCRIPTION
Closes #1998

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Now, you should see `originalEvent` field in `usePress` and `useHover` events

<!--- Include instructions to test this pull request -->
