### PR TITLE
Fixing MenuTrigger docs examples

### DIFF
--- a/packages/@react-spectrum/menu/docs/MenuTrigger.mdx
+++ b/packages/@react-spectrum/menu/docs/MenuTrigger.mdx
@@ -155,24 +155,24 @@ By default, the Menu flips direction automatically upon opening when space is li
 ```tsx example
 <Flex gap="size-100">
   <MenuTrigger shouldFlip>
-    <ActionButton aria-label="More options">
-      <More />
+    <ActionButton>
+      View
+    </ActionButton>
+    <Menu>
+      <Item key="side">Side bar</Item>
+      <Item key="options">Page options</Item>
+      <Item key="edit">Edit Panel</Item>
+    </Menu>
+  </MenuTrigger>
+  <MenuTrigger shouldFlip={false}>
+    <ActionButton>
+      Edit
     </ActionButton>
     <Menu>
       <Item key="cut">Cut</Item>
       <Item key="copy">Copy</Item>
       <Item key="paste">Paste</Item>
     </Menu>
-    </MenuTrigger>
-    <MenuTrigger shouldFlip={false}>
-      <ActionButton>
-        Edit
-      </ActionButton>
-      <Menu>
-        <Item key="cut">Cut</Item>
-        <Item key="copy">Copy</Item>
-        <Item key="paste">Paste</Item>
-      </Menu>
   </MenuTrigger>
 </Flex>
 ```


### PR DESCRIPTION
Small fix, just noticed that this was broken when looking at flip behavior

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
