### PR TITLE
Fix type for strictNullChecks

### DIFF
--- a/packages/@react-spectrum/utils/src/BreakpointProvider.tsx
+++ b/packages/@react-spectrum/utils/src/BreakpointProvider.tsx
@@ -5,7 +5,7 @@ interface Breakpoints {
   S?: number,
   M?: number,
   L?: number,
-  [custom: string]: number
+  [custom: string]: number | undefined
 }
 
 interface BreakpointContext {


### PR DESCRIPTION
In react spectrum there was a new type that failing strictNullChecks for a custom string.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
