### PR TITLE
Add support for a custom document in `watchModals`

### DIFF
--- a/packages/@react-aria/aria-modal-polyfill/src/index.ts
+++ b/packages/@react-aria/aria-modal-polyfill/src/index.ts
@@ -14,10 +14,12 @@ import {hideOthers} from 'aria-hidden';
 
 type Revert = () => void;
 
+const currentDocument = typeof document !== 'undefined' ? document : undefined;
+
 /**
  * Acts as a polyfill for `aria-modal` by watching for added modals and hiding any surrounding DOM elements with `aria-hidden`.
  */
-export function watchModals(selector:string = 'body'): Revert {
+export function watchModals(selector:string = 'body', {document = currentDocument} = {}): Revert {
   /**
    * Listen for additions to the child list of the selected element (defaults to body). This is where providers render modal portals.
    * When one is added, see if there is a modal inside it, if there is, then hide everything else from screen readers.


### PR DESCRIPTION
When rendering into iframes, for example when using [react-frame-component](https://github.com/ryanseddon/react-frame-component/), the usual intention is to listen for events from that iframe's document/window and not from the ones in the frame in which the script is executed (those can be two different global environments).

This is a somewhat test PR - we wonder if you would be open to accepting similar ones for more places in the code. I believe that a `useGlobals` hook (or similar) could be introduced and those globals could be provided using React context so all hooks could receive that information from the context, without manual prop drilling using options etc.