### PR TITLE
Patch parcel to workaround docs issue

### DIFF
--- a/patches/@parcel+bundler-default+2.0.0-nightly.359.patch
+++ b/patches/@parcel+bundler-default+2.0.0-nightly.359.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@parcel/bundler-default/lib/DefaultBundler.js b/node_modules/@parcel/bundler-default/lib/DefaultBundler.js
+index 262937e..9262447 100644
+--- a/node_modules/@parcel/bundler-default/lib/DefaultBundler.js
++++ b/node_modules/@parcel/bundler-default/lib/DefaultBundler.js
+@@ -207,6 +207,7 @@ var _default = new _plugin.Bundler({
+     bundleGraph,
+     config
+   }) {
++    return;
+     (0, _assert.default)(config != null); // Step 2: Remove asset graphs that begin with entries to other bundles.
+ 
+     bundleGraph.traverseBundles(bundle => {


### PR DESCRIPTION
Disables the bundle optimization step completely for now. Will result in a single bundle per page duplicating all shared code between pages rather than separate individually cacheable bundles.