### PR TITLE
Update Flex.mdx

### DIFF
--- a/packages/@react-spectrum/layout/docs/Flex.mdx
+++ b/packages/@react-spectrum/layout/docs/Flex.mdx
@@ -136,7 +136,7 @@ an `alignItems` value to account for this.
 ### Justification
 
 The `justifyContent` prop can be used to align items along the main axis. When `direction` is `"column"`, this refers
-to horizontal alignment, and when `direction` is `"row"` it refers to vertical alignment.
+to vertical alignment, and when `direction` is `"row"` it refers to horizontal alignment.
 
 This example vertically centers the stack of items within the available space defined by a container.
 

--- a/packages/@react-spectrum/layout/docs/Flex.mdx
+++ b/packages/@react-spectrum/layout/docs/Flex.mdx
@@ -136,7 +136,7 @@ an `alignItems` value to account for this.
 ### Justification
 
 The `justifyContent` prop can be used to align items along the main axis. When `direction` is `"column"`, this refers
-to vertical alignment, and when `direction` is `"column"` it refers to horizontal alignment.
+to horizontal alignment, and when `direction` is `"row"` it refers to vertical alignment.
 
 This example vertically centers the stack of items within the available space defined by a container.
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Both cases said `"column"`. Fixed to specify the correct behavior for "row" and match the order of the previous section.
