### PR TITLE
Revert to node 12.22 to fix nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ orbs:
 executors:
   rsp:
     docker:
-      - image: cimg/node:14.16
+      - image: cimg/node:12.22
     environment:
       CACHE_VERSION: v1
     working_directory: ~/react-spectrum
 
   rsp-large:
     docker:
-      - image: cimg/node:14.16
+      - image: cimg/node:12.22
     resource_class: large
     environment:
       CACHE_VERSION: v1
@@ -21,7 +21,7 @@ executors:
 
   rsp-xlarge:
     docker:
-      - image: cimg/node:14.16
+      - image: cimg/node:12.22
     resource_class: xlarge
     environment:
       CACHE_VERSION: v1


### PR DESCRIPTION
Node 14 fails to build the nightly release, reverting back to node 12 where it is successful and keeping a different branch open to debug 14


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
