### PR TITLE
Fix error when buttonRef is not provided to useComboBox

### DIFF
--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -127,7 +127,7 @@ export function useComboBox<T>(props: AriaComboBoxProps<T>, state: ComboBoxState
 
   let onBlur = (e: FocusEvent) => {
     // Ignore blur if focused moved to the button or into the popover.
-    if (e.relatedTarget === buttonRef.current || popoverRef.current?.contains(e.relatedTarget as HTMLElement)) {
+    if (e.relatedTarget === buttonRef?.current || popoverRef.current?.contains(e.relatedTarget as HTMLElement)) {
       return;
     }
 


### PR DESCRIPTION
e.g. in the case of a search autocomplete field that doesn't have an explicit button to open the combobox

Fixes this example on blur: https://codesandbox.io/s/dreamy-burnell-3i2jy?file=/src/ListBox.tsx