### PR TITLE
Color package dependency fix 

### DIFF
--- a/packages/@react-spectrum/color/package.json
+++ b/packages/@react-spectrum/color/package.json
@@ -41,7 +41,7 @@
     "@react-spectrum/label": "^3.3.3",
     "@react-spectrum/layout": "^3.1.4",
     "@react-spectrum/textfield": "^3.1.6",
-    "@react-spectrum/utils": "^3.5.2",
+    "@react-spectrum/utils": "^3.6.1",
     "@react-stately/color": "3.0.0-beta.2",
     "@react-stately/slider": "^3.0.2",
     "@react-stately/utils": "^3.2.1",


### PR DESCRIPTION
Closes no issue

From a support question where the project wasn't building with only icons, react-spectrum, and color packages. Adding utils with a new version fixed this, so updating the dependency to prevent this issue.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Not sure how to test without deploying and testing via a project like codesandbox or something local.

## 🧢 Your Project:
RSP
