### PR TITLE
Fix link to architecture documentation in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Lastly, please follow the pull request template when submitting a pull request!
 All third-party contributions to this project must be accompanied by a signed contributor license agreement. This gives Adobe permission to redistribute your contributions as part of the project. [Sign our CLA](https://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
 
 ## Where to start
-There are many places to dive into react-spectrum to help out. Before you take on a feature or issue, make sure you become familiar with [our architecture](architecture.html).
+There are many places to dive into react-spectrum to help out. Before you take on a feature or issue, make sure you become familiar with [our architecture](https://react-spectrum.adobe.com/architecture.html).
 
 If you are looking for place to start, consider the following options:
 - Look for issues tagged with help wanted and/or good first issue.


### PR DESCRIPTION
While reading the contributing guidelines, I noticed that the link to the documentation of the architecture was broken. This PR fixes that link so it points to [the page](https://react-spectrum.adobe.com/architecture.html) that is referred to elsewhere.