### PR TITLE
Making TableView columns announce sort info and sort order changes 

### DIFF
--- a/packages/@react-aria/table/intl/en-US.json
+++ b/packages/@react-aria/table/intl/en-US.json
@@ -1,0 +1,5 @@
+{
+  "sortable": "sortable column",
+  "ascending": "ascending",
+  "descending": "descending"
+}

--- a/packages/@react-aria/table/intl/en-US.json
+++ b/packages/@react-aria/table/intl/en-US.json
@@ -1,5 +1,7 @@
 {
   "sortable": "sortable column",
   "ascending": "ascending",
-  "descending": "descending"
+  "descending": "descending",
+  "ascendingSort": "sorted by column {columnIndex} in ascending order",
+  "descendingSort": "sorted by column {columnIndex} in descending order"
 }

--- a/packages/@react-aria/table/intl/en-US.json
+++ b/packages/@react-aria/table/intl/en-US.json
@@ -2,6 +2,6 @@
   "sortable": "sortable column",
   "ascending": "ascending",
   "descending": "descending",
-  "ascendingSort": "sorted by column {columnIndex} in ascending order",
-  "descendingSort": "sorted by column {columnIndex} in descending order"
+  "ascendingSort": "sorted by column {columnName} in ascending order",
+  "descendingSort": "sorted by column {columnName} in descending order"
 }

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -22,6 +22,7 @@
     "@react-aria/grid": "3.0.0-beta.1",
     "@react-aria/i18n": "^3.3.1",
     "@react-aria/interactions": "^3.5.0",
+    "@react-aria/live-announcer": "^3.0.0",
     "@react-aria/selection": "^3.5.0",
     "@react-aria/utils": "^3.8.1",
     "@react-stately/table": "3.0.0-beta.1",

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -102,8 +102,8 @@ export function useTable<T>(props: TableProps<T>, state: TableState<T>, ref: Ref
   let {column, direction: sortDirection} = state.sortDescriptor || {};
   let formatMessage = useMessageFormatter(intlMessages);
   let sortDescription = useMemo(() => {
-    let columnIndex = state.collection.columns.findIndex(c => c.key === column);
-    return sortDirection && column ? formatMessage(`${sortDirection}Sort`, {columnIndex: columnIndex + 1}) : undefined;
+    let columnName = state.collection.columns.find(c => c.key === column)?.textValue;
+    return sortDirection && column ? formatMessage(`${sortDirection}Sort`, {columnName}) : undefined;
   }, [sortDirection, column, state.collection.columns]);
 
   let descriptionProps = useDescription(sortDescription);

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -10,15 +10,19 @@
  * governing permissions and limitations under the License.
  */
 
+import {announce} from '@react-aria/live-announcer';
 import {GridAria, GridProps, useGrid} from '@react-aria/grid';
 import {gridIds} from './utils';
+// @ts-ignore
+import intlMessages from '../intl/*.json';
 import {Layout} from '@react-stately/virtualizer';
+import {mergeProps, useDescription, useId, useUpdateEffect} from '@react-aria/utils';
 import {Node} from '@react-types/shared';
 import {RefObject, useMemo} from 'react';
 import {TableKeyboardDelegate} from './TableKeyboardDelegate';
 import {TableState} from '@react-stately/table';
 import {useCollator, useLocale} from '@react-aria/i18n';
-import {useId} from '@react-aria/utils';
+import {useMessageFormatter} from '@react-aria/i18n';
 
 interface TableProps<T> extends GridProps {
   /** The layout object for the table. Computes what content is visible and how to position and style them. */
@@ -95,7 +99,21 @@ export function useTable<T>(props: TableProps<T>, state: TableState<T>, ref: Ref
     gridProps['aria-rowcount'] = state.collection.size + state.collection.headerRows.length;
   }
 
+  let {column, direction: sortDirection} = state.sortDescriptor || {};
+  let formatMessage = useMessageFormatter(intlMessages);
+  let sortDescription = useMemo(() => {
+    let columnIndex = state.collection.columns.findIndex(c => c.key === column);
+    return sortDirection && column ? formatMessage(`${sortDirection}Sort`, {columnIndex: columnIndex + 1}) : undefined;
+  }, [sortDirection, column, state.collection.columns]);
+
+  let descriptionProps = useDescription(sortDescription);
+
+  // Only announce after initial render, tabbing to the table will tell you the initial sort info already
+  useUpdateEffect(() => {
+    announce(sortDescription, 'assertive', 500);
+  }, [sortDescription]);
+
   return {
-    gridProps
+    gridProps: mergeProps(gridProps, descriptionProps)
   };
 }

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -10,13 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import {announce} from '@react-aria/live-announcer';
 import {getColumnHeaderId} from './utils';
 import {GridNode} from '@react-types/grid';
-import {HTMLAttributes, RefObject, useRef} from 'react';
+import {HTMLAttributes, RefObject} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {mergeProps, useDescription, useUpdateEffect} from '@react-aria/utils';
+import {mergeProps, useDescription} from '@react-aria/utils';
 import {TableState} from '@react-stately/table';
 import {useFocusable} from '@react-aria/focus';
 import {useGridCell} from '@react-aria/grid';
@@ -61,22 +60,12 @@ export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableSt
   let sortDescription;
   let isSortedColumn = state.sortDescriptor?.column === node.key;
   let sortDirection = state.sortDescriptor?.direction;
-  let lastSortDirection = useRef(isSortedColumn ? sortDirection : 'none');
   if (allowsSorting) {
-    // TODO should it announce "sortable none" when a column is sortable but doesn't have sort order applied or is "sortable" enough?
     sortDescription = `${formatMessage('sortable')}`;
     if (isSortedColumn && sortDirection) {
       sortDescription = `${sortDescription}, ${formatMessage(sortDirection)}`;
     }
   }
-
-  useUpdateEffect(() => {
-    if (allowsSorting && isSortedColumn && sortDirection !== lastSortDirection.current) {
-      // TODO is it enough to simply announce "ascending"/"descending" or should I include the node.textValue? If the latter, then will need to require the user to pass in textValue
-      announce(`${node.textValue} ${formatMessage(sortDirection)}`, 'assertive', 500);
-      lastSortDirection.current = sortDirection;
-    }
-  }, [allowsSorting, isSortedColumn, sortDirection, node.textValue]);
 
   let descriptionProps = useDescription(sortDescription);
 

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -59,7 +59,8 @@ export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableSt
   let ariaSort: HTMLAttributes<HTMLElement>['aria-sort'] = null;
   let isSortedColumn = state.sortDescriptor?.column === node.key;
   let sortDirection = state.sortDescriptor?.direction;
-  if (node.props.allowsSorting) {
+  // aria-sort not supported in Android Talkback
+  if (node.props.allowsSorting && !isAndroid()) {
     ariaSort = isSortedColumn ? sortDirection : 'none';
   }
 

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -2273,13 +2273,13 @@ describe('TableView', function () {
         expect(columnheaders).toHaveLength(3);
 
         triggerPress(columnheaders[1]);
-        expect(announce).toHaveBeenLastCalledWith('sorted by column 2 in descending order', 'assertive', 500);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column Bar in descending order', 'assertive', 500);
         triggerPress(columnheaders[1]);
-        expect(announce).toHaveBeenLastCalledWith('sorted by column 2 in ascending order', 'assertive', 500);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column Bar in ascending order', 'assertive', 500);
         triggerPress(columnheaders[0]);
-        expect(announce).toHaveBeenLastCalledWith('sorted by column 1 in ascending order', 'assertive', 500);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column Foo in ascending order', 'assertive', 500);
         triggerPress(columnheaders[0]);
-        expect(announce).toHaveBeenLastCalledWith('sorted by column 1 in descending order', 'assertive', 500);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column Foo in descending order', 'assertive', 500);
       });
     });
   });

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -2242,6 +2242,44 @@ describe('TableView', function () {
         triggerPress(row);
         expect(announce).toHaveBeenLastCalledWith('Sam Smith not selected.');
       });
+
+      it('should announce changes in sort order', function () {
+        function ExampleSortTable() {
+          let [sortDescriptor, setSortDescriptor] = React.useState({column: 'bar', direction: 'ascending'});
+
+          return (
+            <TableView aria-label="Table" sortDescriptor={sortDescriptor} onSortChange={setSortDescriptor}>
+              <TableHeader>
+                <Column key="foo" allowsSorting>Foo</Column>
+                <Column key="bar" allowsSorting>Bar</Column>
+                <Column key="baz">Baz</Column>
+              </TableHeader>
+              <TableBody>
+                <Row>
+                  <Cell>Foo 1</Cell>
+                  <Cell>Bar 1</Cell>
+                  <Cell>Baz 1</Cell>
+                </Row>
+              </TableBody>
+            </TableView>
+          )
+        }
+
+
+        let tree = render(<ExampleSortTable />);
+        let table = tree.getByRole('grid');
+        let columnheaders = within(table).getAllByRole('columnheader');
+        expect(columnheaders).toHaveLength(3);
+
+        triggerPress(columnheaders[1]);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column 2 in descending order', 'assertive', 500);
+        triggerPress(columnheaders[1]);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column 2 in ascending order', 'assertive', 500);
+        triggerPress(columnheaders[0]);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column 1 in ascending order', 'assertive', 500);
+        triggerPress(columnheaders[0]);
+        expect(announce).toHaveBeenLastCalledWith('sorted by column 1 in descending order', 'assertive', 500);
+      })
     });
   });
 

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -151,7 +151,7 @@ describe('TableView', function () {
     expect(headers[2]).toHaveAttribute('aria-colindex', '3');
 
     for (let header of headers) {
-      expect(header).not.toHaveAttribute('aria-sort');
+      expect(header).not.toHaveAttribute('aria-describedby');
     }
 
     expect(headers[0]).toHaveTextContent('Foo');
@@ -232,7 +232,7 @@ describe('TableView', function () {
     expect(headers[3]).toHaveAttribute('aria-colindex', '4');
 
     for (let header of headers) {
-      expect(header).not.toHaveAttribute('aria-sort');
+      expect(header).not.toHaveAttribute('aria-describedby');
     }
 
     let checkbox = within(headers[0]).getByRole('checkbox');
@@ -3089,7 +3089,7 @@ describe('TableView', function () {
   });
 
   describe('sorting', function () {
-    it('should set aria-sort="none" on sortable column headers', function () {
+    it('should set the proper aria-describedby on sortable column headers', function () {
       let tree = render(
         <TableView aria-label="Table">
           <TableHeader>
@@ -3110,12 +3110,14 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
     });
 
-    it('should set aria-sort="ascending" on sorted column header', function () {
+    it('should set the proper aria-describedby on an ascending sorted column header', function () {
       let tree = render(
         <TableView aria-label="Table" sortDescriptor={{column: 'bar', direction: 'ascending'}}>
           <TableHeader>
@@ -3136,12 +3138,14 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'ascending');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, ascending');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
     });
 
-    it('should set aria-sort="descending" on sorted column header', function () {
+    it('should set the proper aria-describedby on an descending sorted column header', function () {
       let tree = render(
         <TableView aria-label="Table" sortDescriptor={{column: 'bar', direction: 'descending'}}>
           <TableHeader>
@@ -3162,9 +3166,11 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'descending');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, descending');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
     });
 
     it('should fire onSortChange when there is no existing sortDescriptor', function () {
@@ -3189,9 +3195,11 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[0]);
 
@@ -3221,9 +3229,11 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'ascending');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, ascending');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[0]);
 
@@ -3253,9 +3263,11 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'descending');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, descending');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[0]);
 
@@ -3285,9 +3297,11 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
-      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'ascending');
-      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
-      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(columnheaders[0]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, ascending');
+      expect(columnheaders[1]).toHaveAttribute('aria-describedby');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[1]);
 

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -151,6 +151,7 @@ describe('TableView', function () {
     expect(headers[2]).toHaveAttribute('aria-colindex', '3');
 
     for (let header of headers) {
+      expect(header).not.toHaveAttribute('aria-sort');
       expect(header).not.toHaveAttribute('aria-describedby');
     }
 
@@ -232,6 +233,7 @@ describe('TableView', function () {
     expect(headers[3]).toHaveAttribute('aria-colindex', '4');
 
     for (let header of headers) {
+      expect(header).not.toHaveAttribute('aria-sort');
       expect(header).not.toHaveAttribute('aria-describedby');
     }
 
@@ -3126,7 +3128,7 @@ describe('TableView', function () {
   });
 
   describe('sorting', function () {
-    it('should set the proper aria-describedby on sortable column headers', function () {
+    it('should set the proper aria-describedby and aria-sort on sortable column headers', function () {
       let tree = render(
         <TableView aria-label="Table">
           <TableHeader>
@@ -3147,10 +3149,13 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
     });
 
@@ -3175,10 +3180,13 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'ascending');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, ascending');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
     });
 
@@ -3203,10 +3211,13 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'descending');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, descending');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
     });
 
@@ -3232,10 +3243,13 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[0]);
@@ -3266,10 +3280,13 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'ascending');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, ascending');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[0]);
@@ -3301,9 +3318,12 @@ describe('TableView', function () {
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, descending');
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'descending');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[0]);
@@ -3334,10 +3354,13 @@ describe('TableView', function () {
       let table = tree.getByRole('grid');
       let columnheaders = within(table).getAllByRole('columnheader');
       expect(columnheaders).toHaveLength(3);
+      expect(columnheaders[0]).toHaveAttribute('aria-sort', 'ascending');
+      expect(columnheaders[1]).toHaveAttribute('aria-sort', 'none');
+      expect(columnheaders[2]).not.toHaveAttribute('aria-sort');
       expect(columnheaders[0]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column, ascending');
+      expect(document.getElementById(columnheaders[0].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[1]).toHaveAttribute('aria-describedby');
-      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable');
+      expect(document.getElementById(columnheaders[1].getAttribute('aria-describedby'))).toHaveTextContent('sortable column');
       expect(columnheaders[2]).not.toHaveAttribute('aria-describedby');
 
       triggerPress(columnheaders[1]);

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -2262,9 +2262,8 @@ describe('TableView', function () {
                 </Row>
               </TableBody>
             </TableView>
-          )
+          );
         }
-
 
         let tree = render(<ExampleSortTable />);
         let table = tree.getByRole('grid');
@@ -2279,7 +2278,7 @@ describe('TableView', function () {
         expect(announce).toHaveBeenLastCalledWith('sorted by column 1 in ascending order', 'assertive', 500);
         triggerPress(columnheaders[0]);
         expect(announce).toHaveBeenLastCalledWith('sorted by column 1 in descending order', 'assertive', 500);
-      })
+      });
     });
   });
 

--- a/packages/@react-stately/table/src/Column.ts
+++ b/packages/@react-stately/table/src/Column.ts
@@ -22,10 +22,15 @@ function Column<T>(props: ColumnProps<T>): ReactElement { // eslint-disable-line
 
 Column.getCollectionNode = function* getCollectionNode<T>(props: ColumnProps<T>, context: CollectionBuilderContext<T>): Generator<PartialNode<T>, void, GridNode<T>[]> {
   let {title, children, childColumns} = props;
+
+  let rendered = title || children;
+  let textValue = props.textValue || (typeof rendered === 'string' ? rendered : '');
+
   let fullNodes = yield {
     type: 'column',
     hasChildNodes: !!childColumns || (title && React.Children.count(children) > 0),
-    rendered: title || children,
+    rendered,
+    textValue,
     props,
     *childNodes() {
       if (childColumns) {

--- a/packages/@react-stately/table/src/Column.ts
+++ b/packages/@react-stately/table/src/Column.ts
@@ -24,7 +24,7 @@ Column.getCollectionNode = function* getCollectionNode<T>(props: ColumnProps<T>,
   let {title, children, childColumns} = props;
 
   let rendered = title || children;
-  let textValue = props.textValue || (typeof rendered === 'string' ? rendered : '');
+  let textValue = props.textValue || (typeof rendered === 'string' ? rendered : '') || props['aria-label'];
 
   let fullNodes = yield {
     type: 'column',

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -64,8 +64,9 @@ export interface ColumnProps<T> {
   /** Whether the column allows sorting. */
   allowsSorting?: boolean,
   /** Whether a column is a [row header](https://www.w3.org/TR/wai-aria-1.1/#rowheader) and should be announced by assistive technology during row navigation. */
-  isRowHeader?: boolean
-
+  isRowHeader?: boolean,
+  /** A string representation of the column's contents, used for accessibility announcements. */
+  textValue?: string
 }
 
 // TODO: how to support these in CollectionBuilder...


### PR DESCRIPTION
Closes #2063 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to tableview--async-loading story with VoiceOver/JAWS/NVDA
2. Navigate to the column headers and make sure their sortablity is announced
3. Change the sort order of the column and make sure it is announced


Known issues:
- Announcements of table sort order changes are quite flakey on iPhone/iPad VoiceOver. Either they cut out or don't announce at all.
- iOS VoiceOver doesn't announce the `aria-describedby` content of the table columns at all, happens with native `th` elements as well (https://xyi4e.csb.app/)
- You must tap on/navigate off of and back on the column header in iOS VoiceOver to hear the aria-sort of the current column  
## 🧢 Your Project:

RSP
