### PR TITLE
Fixup null reference access in Breadcrumbs `computeVisibleItems`.

### DIFF
--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -56,7 +56,7 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
 
   let updateOverflow = useCallback(() => {
     let computeVisibleItems = (visibleItems: number) => {
-      // N.B. refs can be null at runtime.
+      // Refs can be null at runtime.
       let currListRef: HTMLUListElement | null = listRef.current;
       if (!currListRef) {
         return;

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -56,8 +56,14 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
 
   let updateOverflow = useCallback(() => {
     let computeVisibleItems = (visibleItems: number) => {
-      let listItems = Array.from(listRef.current.children) as HTMLLIElement[];
-      let containerWidth = listRef.current.offsetWidth;
+      // N.B. refs can be null at runtime.
+      let currListRef: HTMLUListElement | null = listRef.current;
+      if (!currListRef) {
+        return;
+      }
+
+      let listItems = Array.from(currListRef.children) as HTMLLIElement[];
+      let containerWidth = currListRef.offsetWidth;
       let isShowingMenu = childArray.length > visibleItems;
       let calculatedWidth = 0;
       let newVisibleItems = 0;


### PR DESCRIPTION
TL;DR the `current` field on a ref is `T | null` not `T` and we must
guard against invalid access by first interrogating `current`.

Since refs are initialized as null and can become null at runtime, blind
access to `current` can lead `TypeError`s (as cited in #1979).

In practice it seems this _can happen reliably_ in situations where a
`Breadcrumb` component is being unmounted as part of a larger component
tree.

Unfortunately, I have not been able to reduce this error case to a small
reproduction, therefore I have not been able to add a test explicitly
to signal regressions.

Still, and this is quite troubling, the Typescript compiler should be
flagging invalid access such as this. I'm not sure if something has been
disarmed in the tsconfig to assume `T | null` is `T` in this case, but
a similar access in a [TS playground](https://www.typescriptlang.org/play?ts=3.8.3#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4AoczAVwDsNgJbElMBJWzJI+pACgCUcAN7k4cMXDRMAzvCKY4AXhboYAOmoykyTAB4AEgBUAsgBkAqmeByAogBskIJLRgA+PrWr37AiuMkAekCWTBkpFGYAIyQ4Lx84FHk6GFAkdUlpWjkpAAtgewATHmU4BXU0aigeDTR8op4KSSIYKuZ4+woAX3IgA)
is flagged as an error.

This aims to fix #1979.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
