### PR TITLE
Make plop pick current year

### DIFF
--- a/plop-templates/@react-aria/docs/useComponent.mdx.hbs
+++ b/plop-templates/@react-aria/docs/useComponent.mdx.hbs
@@ -1,4 +1,4 @@
-<!-- Copyright 2020 Adobe. All rights reserved.
+<!-- Copyright {{currentYear}} Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-aria/index.ts.hbs
+++ b/plop-templates/@react-aria/index.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-aria/src/index.ts.hbs
+++ b/plop-templates/@react-aria/src/index.ts.hbs
@@ -1,9 +1,9 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language

--- a/plop-templates/@react-aria/src/useComponent.ts.hbs
+++ b/plop-templates/@react-aria/src/useComponent.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-aria/test/useComponent.test.js.hbs
+++ b/plop-templates/@react-aria/test/useComponent.test.js.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
+++ b/plop-templates/@react-spectrum/chromatic/Component.chromatic.tsx.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/docs/Component.mdx.hbs
+++ b/plop-templates/@react-spectrum/docs/Component.mdx.hbs
@@ -1,4 +1,4 @@
-<!-- Copyright 2020 Adobe. All rights reserved.
+<!-- Copyright {{currentYear}} Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/index.ts.hbs
+++ b/plop-templates/@react-spectrum/index.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/src/Component.tsx.hbs
+++ b/plop-templates/@react-spectrum/src/Component.tsx.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/src/index.ts.hbs
+++ b/plop-templates/@react-spectrum/src/index.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
+++ b/plop-templates/@react-spectrum/stories/Component.stories.tsx.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-spectrum/test/Component.test.js.hbs
+++ b/plop-templates/@react-spectrum/test/Component.test.js.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
+++ b/plop-templates/@react-stately/docs/useComponentState.mdx.hbs
@@ -1,4 +1,4 @@
-<!-- Copyright 2020 Adobe. All rights reserved.
+<!-- Copyright {{currentYear}} Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-stately/index.ts.hbs
+++ b/plop-templates/@react-stately/index.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-stately/src/index.ts.hbs
+++ b/plop-templates/@react-stately/src/index.ts.hbs
@@ -1,9 +1,9 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language

--- a/plop-templates/@react-stately/src/useComponentState.ts.hbs
+++ b/plop-templates/@react-stately/src/useComponentState.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@react-types/src/index.d.ts.hbs
+++ b/plop-templates/@react-types/src/index.d.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@scope/index.ts.hbs
+++ b/plop-templates/@scope/index.ts.hbs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/plop-templates/@scope/src/index.ts.hbs
+++ b/plop-templates/@scope/src/index.ts.hbs
@@ -1,9 +1,9 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright {{currentYear}} Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language

--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -16,6 +16,10 @@ let otherProject = 'other';
 
 module.exports = function (plop) {
   plop.setActionType('renameMany', require('../plop-actions/renameMany'));
+
+  const currentYear = new Date(Date.now()).getUTCFullYear();
+  plop.setHelper('currentYear', () => currentYear);
+
   plop.setHelper('replace', function (match, replacement, options) {
     let string = options.fn(this);
     return string.replace(match, replacement);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2147

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
1. Run `yarn plop`
2. Do the needful
3. Inspect license header in generated files
4. Should pick current year (2021 as of the year of authoring this PR)

## 🧢 Your Project:
Adobe/RSP