### PR TITLE
Bump peer dependency version of provider for all packages

### DIFF
--- a/packages/@react-spectrum/accordion/package.json
+++ b/packages/@react-spectrum/accordion/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/actionbar/package.json
+++ b/packages/@react-spectrum/actionbar/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/actiongroup/package.json
+++ b/packages/@react-spectrum/actiongroup/package.json
@@ -41,7 +41,6 @@
     "@react-spectrum/button": "^3.5.0",
     "@react-spectrum/form": "^3.2.2",
     "@react-spectrum/menu": "^3.3.0",
-    "@react-spectrum/provider": "^3.2.0",
     "@react-spectrum/text": "^3.1.2",
     "@react-spectrum/tooltip": "^3.1.3",
     "@react-spectrum/utils": "^3.6.0",
@@ -58,7 +57,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/alert/package.json
+++ b/packages/@react-spectrum/alert/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/breadcrumbs/package.json
+++ b/packages/@react-spectrum/breadcrumbs/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/buttongroup/package.json
+++ b/packages/@react-spectrum/buttongroup/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/checkbox/package.json
+++ b/packages/@react-spectrum/checkbox/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/color/package.json
+++ b/packages/@react-spectrum/color/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/combobox/package.json
+++ b/packages/@react-spectrum/combobox/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/dialog/package.json
+++ b/packages/@react-spectrum/dialog/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/form/package.json
+++ b/packages/@react-spectrum/form/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/icon/package.json
+++ b/packages/@react-spectrum/icon/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/illustratedmessage/package.json
+++ b/packages/@react-spectrum/illustratedmessage/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/image/package.json
+++ b/packages/@react-spectrum/image/package.json
@@ -41,7 +41,7 @@
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "@react-spectrum/provider": "^3.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0",
     "react": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {

--- a/packages/@react-spectrum/label/package.json
+++ b/packages/@react-spectrum/label/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/layout/package.json
+++ b/packages/@react-spectrum/layout/package.json
@@ -43,7 +43,7 @@
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "@react-spectrum/provider": "^3.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0",
     "react": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {

--- a/packages/@react-spectrum/link/package.json
+++ b/packages/@react-spectrum/link/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/list/package.json
+++ b/packages/@react-spectrum/list/package.json
@@ -44,7 +44,6 @@
     "@react-spectrum/layout": "^3.2.0",
     "@react-spectrum/listbox": "^3.4.3",
     "@react-spectrum/progress": "^3.1.1",
-    "@react-spectrum/provider": "^3.2.0",
     "@react-spectrum/text": "^3.1.1",
     "@react-spectrum/textfield": "^3.1.5",
     "@react-spectrum/utils": "^3.6.1",
@@ -63,7 +62,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -41,7 +41,6 @@
     "@react-aria/virtualizer": "^3.3.3",
     "@react-spectrum/layout": "^3.2.0",
     "@react-spectrum/progress": "^3.1.2",
-    "@react-spectrum/provider": "^3.2.0",
     "@react-spectrum/text": "^3.1.2",
     "@react-spectrum/utils": "^3.6.0",
     "@react-stately/collections": "^3.3.2",
@@ -57,7 +56,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/menu/package.json
+++ b/packages/@react-spectrum/menu/package.json
@@ -62,7 +62,7 @@
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "@react-spectrum/provider": "^3.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0",
     "react": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {

--- a/packages/@react-spectrum/meter/package.json
+++ b/packages/@react-spectrum/meter/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/numberfield/package.json
+++ b/packages/@react-spectrum/numberfield/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/overlays/package.json
+++ b/packages/@react-spectrum/overlays/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
     "react-dom": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/pagination/package.json
+++ b/packages/@react-spectrum/pagination/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -44,7 +44,6 @@
     "@react-spectrum/listbox": "^3.5.0",
     "@react-spectrum/overlays": "^3.4.1",
     "@react-spectrum/progress": "^3.1.2",
-    "@react-spectrum/provider": "^3.1.4",
     "@react-spectrum/text": "^3.1.2",
     "@react-spectrum/utils": "^3.5.2",
     "@react-stately/collections": "^3.3.2",
@@ -59,7 +58,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/progress/package.json
+++ b/packages/@react-spectrum/progress/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/radio/package.json
+++ b/packages/@react-spectrum/radio/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/searchfield/package.json
+++ b/packages/@react-spectrum/searchfield/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/sidenav/package.json
+++ b/packages/@react-spectrum/sidenav/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/slider/package.json
+++ b/packages/@react-spectrum/slider/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/statuslight/package.json
+++ b/packages/@react-spectrum/statuslight/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/switch/package.json
+++ b/packages/@react-spectrum/switch/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/tabs/package.json
+++ b/packages/@react-spectrum/tabs/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/tag/package.json
+++ b/packages/@react-spectrum/tag/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/text/package.json
+++ b/packages/@react-spectrum/text/package.json
@@ -41,7 +41,7 @@
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "@react-spectrum/provider": "^3.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0",
     "react": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {

--- a/packages/@react-spectrum/textfield/package.json
+++ b/packages/@react-spectrum/textfield/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/toast/package.json
+++ b/packages/@react-spectrum/toast/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/tooltip/package.json
+++ b/packages/@react-spectrum/tooltip/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/view/package.json
+++ b/packages/@react-spectrum/view/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plop-templates/@react-spectrum/package.json.hbs
+++ b/plop-templates/@react-spectrum/package.json.hbs
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumping peer dependency version of `@react-spectrum/provider` as `rc-1` was causing yarn to output a warning. 
