### PR TITLE
TableView new stories to test selected keys and dividers

### DIFF
--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -247,6 +247,40 @@ storiesOf('TableView', module)
     )
   )
   .add(
+    'defaultSelectedKeys, dynamic, multiple selection, showDivider',
+    () => (
+      <TableView defaultSelectedKeys={['Foo 1', 'Foo 3']} onSelectionChange={s => onSelectionChange([...s])} selectionMode="multiple" aria-label="TableView with dynamic contents" width={300} height={200}>
+        <TableHeader columns={columns}>
+          {column => <Column showDivider>{column.name}</Column>}
+        </TableHeader>
+        <TableBody items={items}>
+          {item =>
+            (<Row key={item.foo}>
+              {key => <Cell>{item[key]}</Cell>}
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    )
+  )
+  .add(
+    'selectedKeys, dynamic, multiple selection, quiet, showDider',
+    () => (
+      <TableView isQuiet selectedKeys={['Foo 1', 'Foo 3']} onSelectionChange={s => onSelectionChange([...s])} selectionMode="multiple" aria-label="TableView with dynamic contents" width={300} height={200}>
+        <TableHeader columns={columns}>
+          {column => <Column showDivider>{column.name}</Column>}
+        </TableHeader>
+        <TableBody items={items}>
+          {item =>
+            (<Row key={item.foo}>
+              {key => <Cell>{item[key]}</Cell>}
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    )
+  )
+  .add(
     // For testing https://github.com/adobe/react-spectrum/issues/1885
     'swap selection mode',
     () => (


### PR DESCRIPTION
No jira - added two stories to better test defaultSelectedKeys, selectedKeys, and showDivder.

There are a couple issues with these related to dividers and selection, but they are existing issues and recorded in the testing spreadsheet. I'm not sure if fixes should be included in this PR.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

New stories
- defaultSelectedKeys, dynamic, multiple selection, showDivider
- selectedKeys, dynamic, multiple selection, quiet, showDivider

## 🧢 Your Project:
RSP