### PR TITLE
Use aria-invalid in Picker

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -14,6 +14,7 @@ import React, {ReactNode, RefObject} from 'react';
 import {SelectState} from '@react-stately/select';
 import {useInteractionModality} from '@react-aria/interactions';
 import {useVisuallyHidden} from '@react-aria/visually-hidden';
+import {ValidationState} from '@react-types/shared';
 
 interface AriaHiddenSelectProps {
   /** The text label for the select. */
@@ -23,7 +24,10 @@ interface AriaHiddenSelectProps {
   name?: string,
 
   /** Sets the disabled state of the select and input. */
-  isDisabled?: boolean
+  isDisabled?: boolean,
+
+  /** Whether the input should display as "invalid".  */
+  validationState?: ValidationState
 }
 
 interface HiddenSelectProps<T> extends AriaHiddenSelectProps {
@@ -72,7 +76,8 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectProps, state: SelectSt
       tabIndex: modality == null || state.isFocused || state.isOpen ? -1 : 0,
       style: {fontSize: 16},
       onFocus: () => triggerRef.current.focus(),
-      disabled: isDisabled
+      disabled: isDisabled,
+      'aria-invalid': props.validationState === 'invalid' ? true : undefined
     },
     selectProps: {
       tabIndex: -1,
@@ -80,7 +85,8 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectProps, state: SelectSt
       name,
       size: state.collection.size,
       value: state.selectedKey ?? '',
-      onChange: (e: React.ChangeEvent<HTMLSelectElement>) => state.setSelectedKey(e.target.value)
+      onChange: (e: React.ChangeEvent<HTMLSelectElement>) => state.setSelectedKey(e.target.value),
+      'aria-invalid': props.validationState === 'invalid' ? true : undefined
     }
   };
 }
@@ -126,6 +132,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         type="hidden"
         name={name}
         disabled={isDisabled}
+        aria-invalid={props.validationState === 'invalid' ? true : undefined}
         value={state.selectedKey} />
     );
   }

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -207,6 +207,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         )
       }>
       <HiddenSelect
+        validationState={props.validationState}
         isDisabled={isDisabled}
         state={state}
         triggerRef={unwrappedTriggerRef}


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Do we want/need to put aria-invalid on picker's hidden elements?

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
