### PR TITLE
Omitting aria-selected if grid or option doesn't support selection

### DIFF
--- a/packages/@react-aria/grid/src/useGridRow.ts
+++ b/packages/@react-aria/grid/src/useGridRow.ts
@@ -59,7 +59,7 @@ export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T
 
   let rowProps: HTMLAttributes<HTMLElement> = {
     role: 'row',
-    'aria-selected': isSelected,
+    'aria-selected': state.selectionManager.selectionMode !== 'none' ? isSelected : undefined,
     ...pressProps
   };
 

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -109,7 +109,7 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
   let optionProps = {
     role: 'option',
     'aria-disabled': isDisabled,
-    'aria-selected': isSelected
+    'aria-selected': state.selectionManager.selectionMode !== 'none' ? isSelected : undefined
   };
 
   // Safari with VoiceOver on macOS misreads options with aria-labelledby or aria-label as simply "text".

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -96,7 +96,7 @@ describe('ListBox', function () {
     let i = 1;
     for (let item of items) {
       expect(item).toHaveAttribute('tabindex');
-      expect(item).toHaveAttribute('aria-selected');
+      expect(item).not.toHaveAttribute('aria-selected');
       expect(item).toHaveAttribute('aria-disabled');
       expect(item).toHaveAttribute('aria-posinset', '' + i++);
       expect(item).toHaveAttribute('aria-setsize');
@@ -246,7 +246,7 @@ describe('ListBox', function () {
     });
 
     it('supports disabled items', function () {
-      let tree = renderComponent({onSelectionChange, disabledKeys: ['Baz'], autoFocus: 'first'});
+      let tree = renderComponent({onSelectionChange, selectionMode: 'single', disabledKeys: ['Baz'], autoFocus: 'first'});
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
 

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -195,7 +195,7 @@ describe('TableView', function () {
     expect(rowheader).toHaveTextContent('Foo 2');
     expect(rowheader).toHaveAttribute('aria-colindex', '1');
 
-    expect(rows[1]).toHaveAttribute('aria-selected', 'false');
+    expect(rows[1]).not.toHaveAttribute('aria-selected');
     expect(rows[1]).toHaveAttribute('aria-labelledby', rowheader.id);
 
 
@@ -355,7 +355,7 @@ describe('TableView', function () {
     expect(rowheader).toHaveTextContent('Foo 2');
     expect(rowheader).toHaveAttribute('aria-colindex', '1');
 
-    expect(rows[1]).toHaveAttribute('aria-selected', 'false');
+    expect(rows[1]).not.toHaveAttribute('aria-selected');
     expect(rows[1]).toHaveAttribute('aria-labelledby', rowheader.id);
 
     let cells = within(rowgroups[1]).getAllByRole('gridcell');


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Fixes erroneous announcement of row/option selected state by NVDA when those rows/options don't support selection

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to TableView/ListBox stories where selectionMode="none". Check that screen readers don't announce the rows/options as "not selected"

## 🧢 Your Project:

RSP
