### PR TITLE
Fix Field-field shrink behavior

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -88,6 +88,9 @@ governing permissions and limitations under the License.
 
     .spectrum-Field-field {
       flex: 1;
+      /* Setting `flex: 1;` is equivalent to `flex: 1 1 0;`, which means we expect to be able to shrink
+      * To be able to shrink, we must have a min-width that isn't 'auto' */
+      min-width: 0;
     }
 
     .spectrum-Field-field--multiline {

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -97,10 +97,6 @@ governing permissions and limitations under the License.
       height: 100%;
     }
   }
-
-  .spectrum-Field-field {
-    width: 100%;
-  }
 }
 
 /* topdoc
@@ -131,10 +127,6 @@ governing permissions and limitations under the License.
       width: auto;
       min-width: var(--spectrum-component-single-line-width);
     }
-  }
-
-  .spectrum-Field-field {
-    width: 100%;
   }
 
   /* With labelPosition=top, we use a normal flex stack */

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -122,7 +122,7 @@ governing permissions and limitations under the License.
       display: table-cell;
     }
 
-    .spectrum-Field-wrapper {
+    .spectrum-Field-field {
       display: table-cell;
       width: auto;
       min-width: var(--spectrum-component-single-line-width);

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -122,14 +122,10 @@ governing permissions and limitations under the License.
       display: table-cell;
     }
 
-    .spectrum-Field-wrapper {
+    .spectrum-Field-field {
       display: table-cell;
       width: auto;
       min-width: var(--spectrum-component-single-line-width);
-    }
-
-    .spectrum-Field-field {
-      width: 100%;
     }
   }
 

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -97,6 +97,10 @@ governing permissions and limitations under the License.
       height: 100%;
     }
   }
+
+  .spectrum-Field-field {
+    width: 100%;
+  }
 }
 
 /* topdoc
@@ -122,11 +126,15 @@ governing permissions and limitations under the License.
       display: table-cell;
     }
 
-    .spectrum-Field-field {
+    .spectrum-Field-wrapper {
       display: table-cell;
       width: auto;
       min-width: var(--spectrum-component-single-line-width);
     }
+  }
+
+  .spectrum-Field-field {
+    width: 100%;
   }
 
   /* With labelPosition=top, we use a normal flex stack */

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -122,10 +122,14 @@ governing permissions and limitations under the License.
       display: table-cell;
     }
 
-    .spectrum-Field-field {
+    .spectrum-Field-wrapper {
       display: table-cell;
       width: auto;
       min-width: var(--spectrum-component-single-line-width);
+    }
+
+    .spectrum-Field-field {
+      width: 100%;
     }
   }
 

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -122,14 +122,9 @@ governing permissions and limitations under the License.
       display: table-cell;
     }
 
-    .spectrum-Field-wrapper {
-      display: table-cell;
+    .spectrum-Field-field {
       width: auto;
       min-width: var(--spectrum-component-single-line-width);
-    }
-
-    .spectrum-Field-field {
-      width: 100%;
     }
   }
 

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -122,9 +122,14 @@ governing permissions and limitations under the License.
       display: table-cell;
     }
 
-    .spectrum-Field-field {
+    .spectrum-Field-wrapper {
+      display: table-cell;
       width: auto;
       min-width: var(--spectrum-component-single-line-width);
+    }
+
+    .spectrum-Field-field {
+      width: 100%;
     }
   }
 

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -64,11 +64,11 @@ governing permissions and limitations under the License.
  * and this causes both the label and inner field to resize as well. */
 .spectrum-Field {
   --spectrum-field-default-width: var(--spectrum-component-single-line-width);
-  width: var(--spectrum-field-default-width);
 
   &.spectrum-Field--positionTop {
     display: inline-flex;
     flex-direction: column;
+    width: var(--spectrum-field-default-width);
 
     .spectrum-Field-field {
       /* If the user overrides the width of the field, propagate to the inner component */

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -64,11 +64,11 @@ governing permissions and limitations under the License.
  * and this causes both the label and inner field to resize as well. */
 .spectrum-Field {
   --spectrum-field-default-width: var(--spectrum-component-single-line-width);
+  width: var(--spectrum-field-default-width);
 
   &.spectrum-Field--positionTop {
     display: inline-flex;
     flex-direction: column;
-    width: var(--spectrum-field-default-width);
 
     .spectrum-Field-field {
       /* If the user overrides the width of the field, propagate to the inner component */

--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -64,3 +64,12 @@ governing permissions and limitations under the License.
     }
   }
 }
+
+/* this is specific to handling default width */
+.spectrum-SearchWithin-container {
+  /* ensure we have higher specificity than .spectrum-Field */
+  &.spectrum-SearchWithin-container {
+     /* override the default width of the field container, only with labelPosition=top. */
+     --spectrum-field-default-width: var(--spectrum-global-dimension-size-3000);
+  }
+}

--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -26,9 +26,6 @@ governing permissions and limitations under the License.
   display: inline-flex;
   position: relative;
 }
-.spectrum-SearchWithin.spectrum-SearchWithin {
-  inline-size: var(--spectrum-searchwithin-width);
-}
 
 .spectrum-SearchWithin-picker {
   inline-size: auto;

--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -26,6 +26,9 @@ governing permissions and limitations under the License.
   display: inline-flex;
   position: relative;
 }
+.spectrum-SearchWithin.spectrum-SearchWithin {
+  inline-size: var(--spectrum-searchwithin-width);
+}
 
 .spectrum-SearchWithin-picker {
   inline-size: auto;

--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -71,5 +71,6 @@ governing permissions and limitations under the License.
   &.spectrum-SearchWithin-container {
      /* override the default width of the field container, only with labelPosition=top. */
      --spectrum-field-default-width: var(--spectrum-global-dimension-size-3000);
+    min-inline-size: var(--spectrum-global-dimension-size-3000);
   }
 }

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -47,7 +47,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
     );
 
     children = React.cloneElement(children, mergeProps(children.props, {
-      className: classNames(labelStyles, 'spectrum-Field-field')
+      style: {width: '100%'}
     }));
 
     return (
@@ -68,7 +68,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
         <div
           className={classNames(
             labelStyles,
-            'spectrum-Field-wrapper'
+            'spectrum-Field-field'
           )}>
           {children}
         </div>

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -47,7 +47,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
     );
 
     children = React.cloneElement(children, mergeProps(children.props, {
-      style: {width: '100%'}
+      className: classNames(labelStyles, 'spectrum-Field-field')
     }));
 
     return (
@@ -68,7 +68,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
         <div
           className={classNames(
             labelStyles,
-            'spectrum-Field-field'
+            'spectrum-Field-wrapper'
           )}>
           {children}
         </div>

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -65,7 +65,13 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
           elementType={elementType}>
           {label}
         </Label>
-        {children}
+        <div
+          className={classNames(
+            labelStyles,
+            'spectrum-Field-wrapper'
+          )}>
+          {children}
+        </div>
       </div>
     );
   }

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -65,13 +65,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
           elementType={elementType}>
           {label}
         </Label>
-        <div
-          className={classNames(
-            labelStyles,
-            'spectrum-Field-wrapper'
-          )}>
-          {children}
-        </div>
+        {children}
       </div>
     );
   }

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -47,7 +47,10 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
     );
 
     children = React.cloneElement(children, mergeProps(children.props, {
-      className: classNames(labelStyles, 'spectrum-Field-field')
+      className: classNames(
+        labelStyles,
+        'spectrum-Field-field'
+      )
     }));
 
     return (
@@ -65,13 +68,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
           elementType={elementType}>
           {label}
         </Label>
-        <div
-          className={classNames(
-            labelStyles,
-            'spectrum-Field-wrapper'
-          )}>
-          {children}
-        </div>
+        {children}
       </div>
     );
   }

--- a/packages/@react-spectrum/searchwithin/chromatic/SearchWithin.chromatic.tsx
+++ b/packages/@react-spectrum/searchwithin/chromatic/SearchWithin.chromatic.tsx
@@ -81,7 +81,7 @@ const Template: Story<SpectrumSearchWithinProps> = (args) => (
 
 // Chromatic can't handle the size of the side label story so removed some extraneous props that don't matter for side label case.
 const TemplateSideLabel: Story<SpectrumSearchWithinProps> = (args) => (
-  <Grid columns={repeat(2, '1fr')} autoFlow="row" gap="size-200" width={900}>
+  <Grid columns={repeat(2, '1fr')} autoFlow="row" gap="size-200">
     {combinations.map(c => {
       let key = Object.keys(c).map(k => shortName(k)).join(' ');
       if (!key) {

--- a/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
+++ b/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
@@ -22,12 +22,7 @@ import {useProvider, useProviderProps} from '@react-spectrum/provider';
 
 function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);
-  let formProps = useFormProps({});
-  let inForm = false;
-  if (Object.keys(formProps).length > 0) {
-    inForm = true;
-  }
-  props = {...props, ...formProps};
+  props = useFormProps(props);
   let {styleProps} = useStyleProps(props);
   let {labelProps, fieldProps} = useLabel(props);
   let {
@@ -74,7 +69,7 @@ function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLEl
   let pickerClassName = classNames(styles, 'spectrum-SearchWithin-picker');
   let slots = {
     searchfield: {UNSAFE_className: searchFieldClassName, ...fieldProps, ...defaultSlotValues},
-    picker: {UNSAFE_className: pickerClassName, menuWidth, align: 'end', width: inForm ? 'size-1200' : undefined, ...defaultSlotValues}
+    picker: {UNSAFE_className: pickerClassName, menuWidth, align: 'end', ...defaultSlotValues}
   };
 
   if (!label && !ariaLabel && !ariaLabelledby) {

--- a/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
+++ b/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
@@ -18,7 +18,6 @@ import {SpectrumSearchWithinProps} from '@react-types/searchwithin';
 import styles from '@adobe/spectrum-css-temp/components/searchwithin/vars.css';
 import {useLabel} from '@react-aria/label';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
-import stepperStyle from '@adobe/spectrum-css-temp/components/stepper/vars.css';
 
 function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);

--- a/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
+++ b/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
@@ -18,6 +18,7 @@ import {SpectrumSearchWithinProps} from '@react-types/searchwithin';
 import styles from '@adobe/spectrum-css-temp/components/searchwithin/vars.css';
 import {useLabel} from '@react-aria/label';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
+import stepperStyle from '@adobe/spectrum-css-temp/components/stepper/vars.css';
 
 function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);
@@ -69,7 +70,11 @@ function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLEl
     <Field
       {...props}
       labelProps={labelProps}
-      ref={domRef}>
+      ref={domRef}
+      wrapperClassName={classNames(
+        styles,
+        'spectrum-SearchWithin-container'
+      )}>
       <div
         role="group"
         aria-labelledby={labelProps.id || ariaLabel}

--- a/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
+++ b/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
@@ -22,7 +22,12 @@ import {useProvider, useProviderProps} from '@react-spectrum/provider';
 
 function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);
-  props = useFormProps(props);
+  let formProps = useFormProps({});
+  let inForm = false;
+  if (Object.keys(formProps).length > 0) {
+    inForm = true;
+  }
+  props = {...props, ...formProps};
   let {styleProps} = useStyleProps(props);
   let {labelProps, fieldProps} = useLabel(props);
   let {
@@ -69,7 +74,7 @@ function SearchWithin(props: SpectrumSearchWithinProps, ref: FocusableRef<HTMLEl
   let pickerClassName = classNames(styles, 'spectrum-SearchWithin-picker');
   let slots = {
     searchfield: {UNSAFE_className: searchFieldClassName, ...fieldProps, ...defaultSlotValues},
-    picker: {UNSAFE_className: pickerClassName, menuWidth, align: 'end', ...defaultSlotValues}
+    picker: {UNSAFE_className: pickerClassName, menuWidth, align: 'end', width: inForm ? 'size-1200' : undefined, ...defaultSlotValues}
   };
 
   if (!label && !ariaLabel && !ariaLabelledby) {


### PR DESCRIPTION
Closes <!-- Github issue # here -->
As found here: https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=93
and as shown fixed here: https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=94

And also fixes SearchWithin label position side where changing the scope changed the overall width of the component

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
