### PR TITLE
Add min width to Searchwithin

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -22,6 +22,7 @@ governing permissions and limitations under the License.
 
 .spectrum-SearchWithin {
   inline-size: var(--spectrum-searchwithin-width);
+  min-inline-size: var(--spectrum-searchwithin-width);
   display: inline-flex;
   position: relative;
 }


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify Searchwithin default and min width of size-3000.

## 🧢 Your Project:

RSP
