### PR TITLE
Fix "overflowMode: wrap" TableViews so that the selection checkbox cells have the proper z-index

### DIFF
--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3638,6 +3638,22 @@ describe('TableView', function () {
         act(() => jest.runAllTimers());
         expect(tree.queryByRole('checkbox')).toBeNull();
       });
+
+      it('should return the proper cell z-indexes for overflowMode="wrap"', function () {
+        let tree = renderTable({overflowMode: 'wrap', selectionMode: 'multiple'});
+        let rows = tree.getAllByRole('row');
+        expect(rows).toHaveLength(3);
+
+        for (let row of rows) {
+          for (let [index, cell] of row.childNodes.entries()) {
+            if (index === 0) {
+              expect(cell.style.zIndex).toBe('2');
+            } else {
+              expect(cell.style.zIndex).toBe('1');
+            }
+          }
+        }
+      });
     });
 
     describe('column widths', function () {

--- a/packages/@react-stately/virtualizer/src/LayoutInfo.ts
+++ b/packages/@react-stately/virtualizer/src/LayoutInfo.ts
@@ -94,6 +94,7 @@ export class LayoutInfo {
     res.transform = this.transform;
     res.parentKey = this.parentKey;
     res.isSticky = this.isSticky;
+    res.zIndex = this.zIndex;
     return res;
   }
 }

--- a/packages/@react-stately/virtualizer/test/LayoutInfo.test.tsx
+++ b/packages/@react-stately/virtualizer/test/LayoutInfo.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {LayoutInfo, Rect} from '../';
+
+describe('LayoutInfo', () => {
+  it('should return a copy of the current LayoutInfo after calling copy()', () => {
+    let layoutInfo = new LayoutInfo('loader', 'key', new Rect(10, 10, 10, 10));
+    layoutInfo.parentKey = 'parent key';
+    layoutInfo.estimatedSize = true;
+    layoutInfo.isSticky = true;
+    layoutInfo.opacity = 3;
+    layoutInfo.transform = 'scale3d(0.8, 0.8, 0.8)';
+    layoutInfo.zIndex = 5;
+    // Cursory check that layoutInfo has been changed
+    expect(layoutInfo.zIndex).toBe(5);
+
+    let copy = layoutInfo.copy();
+    expect(copy).toEqual(layoutInfo);
+
+  });
+})

--- a/packages/@react-stately/virtualizer/test/LayoutInfo.test.tsx
+++ b/packages/@react-stately/virtualizer/test/LayoutInfo.test.tsx
@@ -28,4 +28,4 @@ describe('LayoutInfo', () => {
     expect(copy).toEqual(layoutInfo);
 
   });
-})
+});


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Fixes issue where overflowMode="wrap" TableViews would have their selection checkbox cells covered by the other TableView cell when scrolling to the right.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to TableView's "overflowMode: wrap" story in storybook
2.  Shrink your window so that you can scroll the contents of the TableView
3. Scroll to the right. Note that the contents of the table slide under the selection checkbox cell rather than covering them up.

## 🧢 Your Project:

RSP
