### PR TITLE
TableView - preventing a divider from showing on the last cell of a table row

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -250,6 +250,10 @@ governing permissions and limitations under the License.
   &.is-drop-target {
     @inherit: %drop-target;
   }
+
+  .spectrum-Table-cellWrapper:last-child .spectrum-Table-cell--divider {
+    border-inline-end-width: 0;
+  }
 }
 
 /* the CSS logical properties postcss plugin doesn't seem to work with :focus-ring. */

--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -250,10 +250,6 @@ governing permissions and limitations under the License.
   &.is-drop-target {
     @inherit: %drop-target;
   }
-
-  .spectrum-Table-cellWrapper:last-child .spectrum-Table-cell--divider {
-    border-inline-end-width: 0;
-  }
 }
 
 /* the CSS logical properties postcss plugin doesn't seem to work with :focus-ring. */

--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -462,10 +462,10 @@ function TableSelectAllCell({column}) {
           )
         }>
         {
-          /* 
-            In single selection mode, the checkbox will be hidden. 
-            So to avoid leaving a column header with no accessible content, 
-            we use a VisuallyHidden component to include the aria-label from the checkbox, 
+          /*
+            In single selection mode, the checkbox will be hidden.
+            So to avoid leaving a column header with no accessible content,
+            we use a VisuallyHidden component to include the aria-label from the checkbox,
             which for single selection will be "Select."
           */
           isSingleSelectionMode &&
@@ -618,7 +618,7 @@ function TableCell({cell}) {
             styles,
             'spectrum-Table-cell',
             {
-              'spectrum-Table-cell--divider': columnProps.showDivider,
+              'spectrum-Table-cell--divider': columnProps.showDivider && cell.column.nextKey !== null,
               'spectrum-Table-cell--hideHeader': columnProps.hideHeader,
               'is-disabled': isDisabled
             },


### PR DESCRIPTION
no github issue, found during a testing session

decided to go with a CSS solution rather then preventing a divider class from being added to the last cell

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

goto stoybook and check that their is no divider on the last cell of table row
once https://github.com/adobe/react-spectrum/pull/2163 is merged we can test this in those stories

## 🧢 Your Project:
RSP