### PR TITLE
Revert "Fix field label overriding display property"

### DIFF
--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -47,7 +47,10 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
     );
 
     children = React.cloneElement(children, mergeProps(children.props, {
-      style: {width: '100%'}
+      className: classNames(
+        labelStyles,
+        'spectrum-Field-field'
+      )
     }));
 
     return (
@@ -65,13 +68,7 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
           elementType={elementType}>
           {label}
         </Label>
-        <div
-          className={classNames(
-            labelStyles,
-            'spectrum-Field-field'
-          )}>
-          {children}
-        </div>
+        {children}
       </div>
     );
   }


### PR DESCRIPTION
Reverts adobe/react-spectrum#2164

This is causing more issues than it solves at the moment. We'll need to fix another way.