### PR TITLE
Fix missing peer dependencies

### DIFF
--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -63,5 +63,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@react-aria/calendar/package.json
+++ b/packages/@react-aria/calendar/package.json
@@ -31,7 +31,8 @@
     "date-fns": "^1.30.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/color/package.json
+++ b/packages/@react-aria/color/package.json
@@ -30,7 +30,8 @@
     "@react-types/slider": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/combobox/package.json
+++ b/packages/@react-aria/combobox/package.json
@@ -35,7 +35,8 @@
     "@react-types/shared": "^3.7.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/datepicker/package.json
+++ b/packages/@react-aria/datepicker/package.json
@@ -32,7 +32,8 @@
     "@react-types/shared": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/grid/package.json
+++ b/packages/@react-aria/grid/package.json
@@ -30,7 +30,8 @@
     "@react-types/shared": "^3.7.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/numberfield/package.json
+++ b/packages/@react-aria/numberfield/package.json
@@ -31,7 +31,8 @@
     "@react-types/textfield": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -32,7 +32,8 @@
     "@react-types/shared": "^3.6.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/spinbutton/package.json
+++ b/packages/@react-aria/spinbutton/package.json
@@ -25,7 +25,8 @@
     "@react-types/shared": "^3.6.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -33,7 +33,8 @@
     "@react-types/table": "3.0.0-beta.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/tooltip/package.json
+++ b/packages/@react-aria/tooltip/package.json
@@ -20,15 +20,13 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/focus": "^3.3.0",
     "@react-aria/interactions": "^3.4.0",
-    "@react-aria/overlays": "^3.6.3",
     "@react-aria/utils": "^3.8.0",
     "@react-stately/tooltip": "^3.0.4",
     "@react-types/shared": "^3.6.0",
     "@react-types/tooltip": "^3.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1",
-    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/actionbar/package.json
+++ b/packages/@react-spectrum/actionbar/package.json
@@ -55,7 +55,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/actiongroup/package.json
+++ b/packages/@react-spectrum/actiongroup/package.json
@@ -57,7 +57,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.2.0"
+    "@react-spectrum/provider": "^3.2.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/breadcrumbs/package.json
+++ b/packages/@react-spectrum/breadcrumbs/package.json
@@ -50,7 +50,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -53,7 +53,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/color/package.json
+++ b/packages/@react-spectrum/color/package.json
@@ -55,7 +55,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/combobox/package.json
+++ b/packages/@react-spectrum/combobox/package.json
@@ -62,7 +62,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -56,7 +56,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/dialog/package.json
+++ b/packages/@react-spectrum/dialog/package.json
@@ -59,7 +59,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/list/package.json
+++ b/packages/@react-spectrum/list/package.json
@@ -62,7 +62,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.2.0"
+    "@react-spectrum/provider": "^3.2.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -56,7 +56,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.2.0"
+    "@react-spectrum/provider": "^3.2.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/menu/package.json
+++ b/packages/@react-spectrum/menu/package.json
@@ -63,7 +63,8 @@
   },
   "peerDependencies": {
     "@react-spectrum/provider": "^3.0.0",
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/numberfield/package.json
+++ b/packages/@react-spectrum/numberfield/package.json
@@ -56,7 +56,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -58,7 +58,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.1.4"
+    "@react-spectrum/provider": "^3.1.4",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/provider/package.json
+++ b/packages/@react-spectrum/provider/package.json
@@ -44,7 +44,8 @@
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/sidenav/package.json
+++ b/packages/@react-spectrum/sidenav/package.json
@@ -54,7 +54,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -59,7 +59,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/tabs/package.json
+++ b/packages/@react-spectrum/tabs/package.json
@@ -55,7 +55,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/theme-dark/package.json
+++ b/packages/@react-spectrum/theme-dark/package.json
@@ -39,5 +39,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@react-spectrum/theme-default/package.json
+++ b/packages/@react-spectrum/theme-default/package.json
@@ -39,5 +39,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@react-spectrum/theme-light/package.json
+++ b/packages/@react-spectrum/theme-light/package.json
@@ -39,5 +39,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@react-spectrum/tooltip/package.json
+++ b/packages/@react-spectrum/tooltip/package.json
@@ -51,7 +51,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1",
-    "@react-spectrum/provider": "^3.0.0"
+    "@react-spectrum/provider": "^3.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/tree/package.json
+++ b/packages/@react-spectrum/tree/package.json
@@ -47,7 +47,9 @@
     "@react-aria/tree": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0"
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1"

--- a/packages/@react-types/calendar/package.json
+++ b/packages/@react-types/calendar/package.json
@@ -14,5 +14,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@react-types/datepicker/package.json
+++ b/packages/@react-types/datepicker/package.json
@@ -14,5 +14,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@react-types/pagination/package.json
+++ b/packages/@react-types/pagination/package.json
@@ -14,5 +14,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1"
   }
 }

--- a/packages/@spectrum-icons/color/package.json
+++ b/packages/@spectrum-icons/color/package.json
@@ -19,7 +19,8 @@
     "@spectrum-icons/build-tools": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@spectrum-icons/ui/package.json
+++ b/packages/@spectrum-icons/ui/package.json
@@ -19,7 +19,8 @@
     "@spectrum-icons/build-tools": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@spectrum-icons/workflow/package.json
+++ b/packages/@spectrum-icons/workflow/package.json
@@ -19,7 +19,8 @@
     "@spectrum-icons/build-tools": "3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1",
+    "@react-spectrum/provider": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/addMissingPeers.js
+++ b/scripts/addMissingPeers.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Yarn 2 is very strict about peer dependencies. Peers declared in a package must also be
+// declared in all parent packages, recursively. This script adds the missing peer deps
+// to all packages following these requirements.
+
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').execSync;
+
+const workspacePackages = JSON.parse(exec('yarn workspaces info --json').toString().split('\n').slice(1, -2).join('\n'));
+const incomingDeps = new Map();
+
+for (let pkg in workspacePackages) {
+  for (let dep of workspacePackages[pkg].workspaceDependencies) {
+    if (!incomingDeps.has(dep)) {
+      incomingDeps.set(dep, new Set());
+    }
+
+    incomingDeps.get(dep).add(pkg);
+  }
+}
+
+for (let pkg in workspacePackages) {
+  let json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', workspacePackages[pkg].location, 'package.json'), 'utf8'));
+  if (!json.private && json.peerDependencies) {
+    for (let peer in json.peerDependencies) {
+      addPeers(pkg, peer, json.peerDependencies[peer]);
+    }
+  }
+}
+
+function addPeers(pkg, peer, range, seen = new Set()) {
+  if (seen.has(pkg)) {
+    return;
+  }
+
+  seen.add(pkg);
+
+  let pkgPath = path.join(__dirname, '..', workspacePackages[pkg].location, 'package.json');
+  let json = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+  if (!json.peerDependencies) {
+    json.peerDependencies = {};
+  }
+
+  if (!json.peerDependencies[peer] && !json.dependencies[peer]) {
+    console.log('Adding peer ' + peer + ' to package ' + pkg);
+    json.peerDependencies[peer] = range;
+    fs.writeFileSync(pkgPath, JSON.stringify(json, false, 2) + '\n');
+  }
+
+  let parents = incomingDeps.get(pkg);
+  if (parents) {
+    for (let parent of parents) {
+      addPeers(parent, peer, range);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2188.

Yarn 2 is very strict about peer dependencies. Peers declared in a package must also be declared in all parent packages, recursively. I wrote a script to add the missing peer deps to all packages following these requirements because it's too hard to do manually.