### PR TITLE
Fix SearchWithin picker so that it doesn't overflow the component width

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -30,7 +30,7 @@ governing permissions and limitations under the License.
 .spectrum-SearchWithin-picker {
   inline-size: auto;
   min-inline-size: var(--spectrum-global-dimension-size-900);
-  flex-shrink: 0;
+  flex-shrink: 1;
 
   > button {
     contain: unset;

--- a/packages/@react-spectrum/searchwithin/stories/SearchWithin.stories.tsx
+++ b/packages/@react-spectrum/searchwithin/stories/SearchWithin.stories.tsx
@@ -33,6 +33,7 @@ function render(props: Omit<SpectrumSearchWithinProps, 'children'> = {}, searchF
         <Item key="campaigns">Campaigns</Item>
         <Item key="audiences">Audiences</Item>
         <Item key="tags">Tags</Item>
+        <Item key="long">This item is very long and word wraps poorly</Item>
       </Picker>
     </SearchWithin>
   );
@@ -46,6 +47,7 @@ function renderReverse(props: Omit<SpectrumSearchWithinProps, 'children'> = {}, 
         <Item key="campaigns">Campaigns</Item>
         <Item key="audiences">Audiences</Item>
         <Item key="tags">Tags</Item>
+        <Item key="long">This item is very long and word wraps poorly</Item>
       </Picker>
       <SearchField placeholder="Search" {...searchFieldProps} onChange={action('change')} onSubmit={action('submit')} />
     </SearchWithin>
@@ -65,6 +67,7 @@ function ResizeSearchWithinApp(props) {
             <Item key="campaigns">Campaigns</Item>
             <Item key="audiences">Audiences</Item>
             <Item key="tags">Tags</Item>
+            <Item key="long">This item is very long and word wraps poorly</Item>
           </Picker>
         </SearchWithin>
       </div>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
