### PR TITLE
POC checkbox stories for indeterminate to selected bug

### DIFF
--- a/packages/@react-spectrum/checkbox/stories/Checkbox.stories.tsx
+++ b/packages/@react-spectrum/checkbox/stories/Checkbox.stories.tsx
@@ -11,8 +11,10 @@
  */
 
 import {action} from '@storybook/addon-actions';
+import {Button} from '@react-spectrum/button';
 import {Checkbox} from '../';
-import React from 'react';
+import {Flex} from '@react-spectrum/layout';
+import React, {useEffect, useState} from 'react';
 import {storiesOf} from '@storybook/react';
 
 storiesOf('Checkbox', module)
@@ -89,6 +91,82 @@ storiesOf('Checkbox', module)
   .add(
     'no label',
     () => renderNoLabel({'aria-label': 'This checkbox has no visible label'})
+  )
+  .add(
+    'isEmphasized: true, isSelected: true, isIndeterminate: toggle ',
+    () => {
+      let [isIndeterminate, setIndeterminate] = useState(false);
+      return (<Checkbox
+        onChange={() => {setIndeterminate(!isIndeterminate);}}
+        isEmphasized
+        isSelected
+        isIndeterminate={isIndeterminate} />);
+    }
+  )
+  .add(
+    'toggle isIndeterminate, isSelected: true, isEmphasized: true',
+    () => {
+      let [isIndeterminate, setIndeterminate] = useState(false);
+      let [isSelected, setSelected] = useState(false);
+      return (
+        <Flex direction="column" gap="size-100">
+          <Button variant="primary" onPress={() => {setIndeterminate(!isIndeterminate);}}>Toggle Indeterminate</Button>
+          <Button variant="primary" onPress={() => {setSelected(!isSelected);}}>Toggle Selected</Button>
+          <Checkbox
+            isEmphasized
+            isSelected={isSelected}
+            isIndeterminate={isIndeterminate} />
+        </Flex>
+      );
+    }
+  )
+  .add(
+    'master selection checkbox',
+    () => {
+      let [isIndeterminate, setIndeterminate] = useState(false);
+      let [isSelected, setSelected] = useState(false);
+      let [isApple, setApple] = useState(false);
+      let [isOrange, setOrange] = useState(false);
+
+      useEffect(() => {
+        if (isApple && isOrange && !isSelected) {
+          setIndeterminate(false);
+          setSelected(true);
+        } else if (!isApple && !isOrange) {
+          setIndeterminate(false);
+          setSelected(false);
+        } else if (isApple || isOrange) {
+          setIndeterminate(true);
+          setSelected(false);
+        }
+      }, [isApple, isOrange]);
+
+      return (
+        <Flex direction="column" gap="size-100">
+          <div>isIndeterminate: {isIndeterminate ? 'true': 'false'}</div>
+          <div>isSelected: {isSelected ? 'true': 'false'}</div>
+          <Checkbox
+            onChange={(value) => {setApple(value); setOrange(value); setIndeterminate(false); setSelected(value);}}
+            isEmphasized
+            isSelected={isSelected}
+            isIndeterminate={isIndeterminate} />
+          <Checkbox
+            onChange={(value) => {setApple(value);}}
+            isSelected={isApple}
+            isEmphasized>
+            Apple
+          </Checkbox>
+          <Checkbox
+            onChange={(value) => {setOrange(value);}}
+            isSelected={isOrange}
+            isEmphasized>
+            Orange
+          </Checkbox>
+          <Button variant="primary" onPress={() => {setApple(!isApple);}}>Toggle Apple</Button>
+          <Button variant="primary" onPress={() => {setOrange(!isOrange);}}>Toggle Orange</Button>
+        </Flex>
+      );
+    }
   );
 
 function render(props = {}) {

--- a/packages/@react-spectrum/checkbox/stories/Checkbox.stories.tsx
+++ b/packages/@react-spectrum/checkbox/stories/Checkbox.stories.tsx
@@ -143,8 +143,8 @@ storiesOf('Checkbox', module)
 
       return (
         <Flex direction="column" gap="size-100">
-          <div>isIndeterminate: {isIndeterminate ? 'true': 'false'}</div>
-          <div>isSelected: {isSelected ? 'true': 'false'}</div>
+          <div>isIndeterminate: {isIndeterminate ? 'true' : 'false'}</div>
+          <div>isSelected: {isSelected ? 'true' : 'false'}</div>
           <Checkbox
             onChange={(value) => {setApple(value); setOrange(value); setIndeterminate(false); setSelected(value);}}
             isEmphasized


### PR DESCRIPTION
Exploration to reproduce #1834 outside of Table.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Three new stories:
* isemphasized-true-isselected-true-isindeterminate-toggle - Changing state from indeterminate to selected - works
* toggle-isindeterminate-isselected-true-isemphasized-true - Using toggle buttons to change indeterminate and selected state - works
* master-selection-checkbox - simplistic replication of the select all checkbox which gets its state changed and reflected in children checkboxes and toggle buttons (which represent clicking on a row) - Clicking on the checkboxes and labels work, using the toggle buttons see the bug.

Do not see the issue in the table example in https://react-spectrum.adobe.com/react-aria/useTable.html

## 🧢 Your Project:
RSP