### PR TITLE
Fix useListData remove method for all selection

### DIFF
--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -211,9 +211,12 @@ export function createListActions<T>(opts: ListOptions<T>, dispatch: (updater: (
         let keySet = new Set(keys);
         let items = state.items.filter(item => !keySet.has(getKey(item)));
 
-        let selection = new Set(state.selectedKeys);
-        for (let key of keys) {
-          selection.delete(key);
+        let selection: Selection = 'all';
+        if (state.selectedKeys !== 'all') {
+          selection = new Set(state.selectedKeys);
+          for (let key of keys) {
+            selection.delete(key);
+          }
         }
 
         return {

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -218,6 +218,9 @@ export function createListActions<T>(opts: ListOptions<T>, dispatch: (updater: (
             selection.delete(key);
           }
         }
+        if (selection === 'all' && items.length === 0) {
+          selection = new Set();
+        }
 
         return {
           ...state,

--- a/packages/@react-stately/data/test/useListData.test.js
+++ b/packages/@react-stately/data/test/useListData.test.js
@@ -225,6 +225,17 @@ describe('useListData', function () {
     expect(result.current.selectedKeys).toEqual(new Set(['Julia']));
   });
 
+  it('should preserve all selected value through a remove call', function () {
+    let {result} = renderHook(() => useListData({initialItems: initial, getKey, initialSelectedKeys: 'all'}));
+
+    act(() => {
+      result.current.remove('Sam"');
+    });
+
+    expect(result.current.selectedKeys).toEqual('all');
+  });
+
+
   it('should remove multiple items', function () {
     let {result} = renderHook(() => useListData({initialItems: initial, getKey, initialSelectedKeys: ['Sam', 'David', 'Julia']}));
     let initialResult = result.current;

--- a/packages/@react-stately/data/test/useListData.test.js
+++ b/packages/@react-stately/data/test/useListData.test.js
@@ -229,12 +229,23 @@ describe('useListData', function () {
     let {result} = renderHook(() => useListData({initialItems: initial, getKey, initialSelectedKeys: 'all'}));
 
     act(() => {
-      result.current.remove('Sam"');
+      result.current.remove('Sam');
     });
 
     expect(result.current.selectedKeys).toEqual('all');
   });
 
+  it('should change all selection to empty set if last item is removed', function () {
+    let {result} = renderHook(() => useListData({initialItems: initial, getKey, initialSelectedKeys: 'all'}));
+
+    act(() => {
+      result.current.remove('Sam');
+      result.current.remove('David');
+      result.current.remove('Julia');
+    });
+
+    expect(result.current.selectedKeys).toEqual(new Set());
+  });
 
   it('should remove multiple items', function () {
     let {result} = renderHook(() => useListData({initialItems: initial, getKey, initialSelectedKeys: ['Sam', 'David', 'Julia']}));


### PR DESCRIPTION
Followup to https://github.com/adobe/react-spectrum/pull/2200. 

Adds check to last method which refers to `selectedKeys`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
In the `TableView async loading` story, click the select all checkbox and then click the *Remove first item* button. Note selection remains selected for all

## 🧢 Your Project:

<!--- Company/project for pull request -->
