### PR TITLE
Fix FocusScope issues

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -95,6 +95,9 @@ export function FocusScope(props: FocusScopeProps) {
     }
 
     scopeRef.current = nodes;
+  }, [children, parentScope]);
+
+  useLayoutEffect(() => {
     scopes.set(scopeRef, parentScope);
     return () => {
       if (activeScope === scopeRef) {
@@ -102,7 +105,7 @@ export function FocusScope(props: FocusScopeProps) {
       }
       scopes.delete(scopeRef);
     };
-  }, [children, parentScope]);
+  }, [scopeRef, parentScope]);
 
   useFocusContainment(scopeRef, contain);
   useRestoreFocus(scopeRef, restoreFocus, contain);
@@ -196,7 +199,7 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
   let focusedNode = useRef<HTMLElement>();
 
   let raf = useRef(null);
-  useEffect(() => {
+  useLayoutEffect(() => {
     let scope = scopeRef.current;
     if (!contain) {
       return;
@@ -241,6 +244,8 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
         } else if (activeScope) {
           focusFirstInScope(activeScope.current);
         }
+      } else if (scopeRef === activeScope) {
+        focusedNode.current = e.target;
       }
     };
 

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -54,10 +54,16 @@ interface FocusManager {
   focusPrevious(opts?: FocusManagerOptions): HTMLElement
 }
 
-const FocusContext = React.createContext<FocusManager>(null);
+type ScopeRef = RefObject<HTMLElement[]>;
+interface IFocusContext {
+  scopeRef: ScopeRef,
+  focusManager: FocusManager
+}
 
-let activeScope: RefObject<HTMLElement[]> = null;
-let scopes: Set<RefObject<HTMLElement[]>> = new Set();
+const FocusContext = React.createContext<IFocusContext>(null);
+
+let activeScope: ScopeRef = null;
+let scopes: Map<ScopeRef, ScopeRef | null> = new Map();
 
 // This is a hacky DOM-based implementation of a FocusScope until this RFC lands in React:
 // https://github.com/reactjs/rfcs/pull/109
@@ -76,6 +82,8 @@ export function FocusScope(props: FocusScopeProps) {
   let startRef = useRef<HTMLSpanElement>();
   let endRef = useRef<HTMLSpanElement>();
   let scopeRef = useRef<HTMLElement[]>([]);
+  let ctx = useContext(FocusContext);
+  let parentScope = ctx?.scopeRef;
 
   useLayoutEffect(() => {
     // Find all rendered nodes between the sentinels and add them to the scope.
@@ -87,11 +95,14 @@ export function FocusScope(props: FocusScopeProps) {
     }
 
     scopeRef.current = nodes;
-    scopes.add(scopeRef);
+    scopes.set(scopeRef, parentScope);
     return () => {
+      if (activeScope === scopeRef) {
+        activeScope = parentScope;
+      }
       scopes.delete(scopeRef);
     };
-  }, [children]);
+  }, [children, parentScope]);
 
   useFocusContainment(scopeRef, contain);
   useRestoreFocus(scopeRef, restoreFocus, contain);
@@ -100,7 +111,7 @@ export function FocusScope(props: FocusScopeProps) {
   let focusManager = createFocusManagerForScope(scopeRef);
 
   return (
-    <FocusContext.Provider value={focusManager}>
+    <FocusContext.Provider value={{scopeRef, focusManager}}>
       <span data-focus-scope-start hidden ref={startRef} />
       {children}
       <span data-focus-scope-end hidden ref={endRef} />
@@ -114,7 +125,7 @@ export function FocusScope(props: FocusScopeProps) {
  * a FocusScope, e.g. in response to user events like keyboard navigation.
  */
 export function useFocusManager(): FocusManager {
-  return useContext(FocusContext);
+  return useContext(FocusContext)?.focusManager;
 }
 
 function createFocusManagerForScope(scopeRef: React.RefObject<HTMLElement[]>): FocusManager {
@@ -193,7 +204,7 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
 
     // Handle the Tab key to contain focus within the scope
     let onKeyDown = (e) => {
-      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey) {
+      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || scopeRef !== activeScope) {
         return;
       }
 
@@ -217,18 +228,19 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
     };
 
     let onFocus = (e) => {
-      // If a focus event occurs outside the active scope (e.g. user tabs from browser location bar),
-      // restore focus to the previously focused node or the first tabbable element in the active scope.
-      let isInAnyScope = isElementInAnyScope(e.target, scopes);
-      if (!isInAnyScope) {
+      // If focusing an element in a child scope of the currently active scope, the child becomes active.
+      // Moving out of the active scope to an ancestor is not allowed.
+      if (!activeScope || isAncestorScope(activeScope, scopeRef)) {
+        activeScope = scopeRef;
+        focusedNode.current = e.target;
+      } else if (scopeRef === activeScope && !isElementInScope(e.target, scopeRef.current)) {
+        // If a focus event occurs outside the active scope (e.g. user tabs from browser location bar),
+        // restore focus to the previously focused node or the first tabbable element in the active scope.
         if (focusedNode.current) {
           focusedNode.current.focus();
         } else if (activeScope) {
           focusFirstInScope(activeScope.current);
         }
-      } else {
-        activeScope = scopeRef;
-        focusedNode.current = e.target;
       }
     };
 
@@ -236,9 +248,7 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
       // Firefox doesn't shift focus back to the Dialog properly without this
       raf.current = requestAnimationFrame(() => {
         // Use document.activeElement instead of e.relatedTarget so we can tell if user clicked into iframe
-        let isInAnyScope = isElementInAnyScope(document.activeElement, scopes);
-
-        if (!isInAnyScope) {
+        if (scopeRef === activeScope && !isElementInScope(document.activeElement, scopeRef.current)) {
           activeScope = scopeRef;
           focusedNode.current = e.target;
           focusedNode.current.focus();
@@ -264,8 +274,8 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
   }, [raf]);
 }
 
-function isElementInAnyScope(element: Element, scopes: Set<RefObject<HTMLElement[]>>) {
-  for (let scope of scopes.values()) {
+function isElementInAnyScope(element: Element) {
+  for (let scope of scopes.keys()) {
     if (isElementInScope(element, scope.current)) {
       return true;
     }
@@ -273,25 +283,21 @@ function isElementInAnyScope(element: Element, scopes: Set<RefObject<HTMLElement
   return false;
 }
 
-const focusScopeDataAttrNames = [
-  'data-focus-scope-start',
-  'data-focus-scope-end'
-];
-
-function isFocusScopeDirectChild(scope: HTMLElement) {
-  return focusScopeDataAttrNames.some(name => scope.getAttribute(name) !== null);
-}
-
-function isFocusScopeNestedChild(scope: HTMLElement) {
-  return focusScopeDataAttrNames.some(name => scope.querySelector(`[${name}]`));
-}
-
-function isFocusScopeInScope(scopes: HTMLElement[]) {
-  return scopes.some(scope => isFocusScopeDirectChild(scope) || isFocusScopeNestedChild(scope));
-}
-
 function isElementInScope(element: Element, scope: HTMLElement[]) {
-  return !isFocusScopeInScope(scope) && scope.some(node => node.contains(element));
+  return scope.some(node => node.contains(element));
+}
+
+function isAncestorScope(ancestor: ScopeRef, scope: ScopeRef) {
+  let parent = scopes.get(scope);
+  if (!parent) {
+    return false;
+  }
+
+  if (parent === ancestor) {
+    return true;
+  }
+
+  return isAncestorScope(parent, scope);
 }
 
 function focusElement(element: HTMLElement | null, scroll = false) {
@@ -379,7 +385,7 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
            // If there is no next element and the nodeToRestore isn't within a FocusScope (i.e. we are leaving the top level focus scope)
            // then move focus to the body.
            // Otherwise restore focus to the nodeToRestore (e.g menu within a popover -> tabbing to close the menu should move focus to menu trigger)
-          if (!isElementInAnyScope(nodeToRestore, scopes)) {
+          if (!isElementInAnyScope(nodeToRestore)) {
             focusedElement.blur();
           } else {
             focusElement(nodeToRestore, true);

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -339,6 +339,10 @@ function useAutoFocus(scopeRef: RefObject<HTMLElement[]>, autoFocus: boolean) {
 function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boolean, contain: boolean) {
   // useLayoutEffect instead of useEffect so the active element is saved synchronously instead of asynchronously.
   useLayoutEffect(() => {
+    if (!restoreFocus) {
+      return;
+    }
+
     let scope = scopeRef.current;
     let nodeToRestore = document.activeElement as HTMLElement;
 

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -186,8 +186,6 @@ describe('FocusScope', function () {
       let input2 = getByTestId('input2');
       let input3 = getByTestId('input3');
       let input4 = getByTestId('input4');
-      let input5 = getByTestId('input5');
-      let input6 = getByTestId('input6');
 
       act(() => {input1.focus();});
       expect(document.activeElement).toBe(input1);
@@ -211,25 +209,7 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(input1);
 
       act(() => {input4.focus();});
-      expect(document.activeElement).toBe(input4);
-
-      userEvent.tab();
-      expect(document.activeElement).toBe(input5);
-
-      userEvent.tab();
-      expect(document.activeElement).toBe(input6);
-
-      userEvent.tab();
-      expect(document.activeElement).toBe(input4);
-
-      userEvent.tab({shift: true});
-      expect(document.activeElement).toBe(input6);
-
-      userEvent.tab({shift: true});
-      expect(document.activeElement).toBe(input5);
-
-      userEvent.tab({shift: true});
-      expect(document.activeElement).toBe(input4);
+      expect(document.activeElement).toBe(input1);
     });
 
     it('should restore focus to the last focused element in the scope when re-entering the browser', function () {
@@ -783,7 +763,7 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(item1);
 
       fireEvent.mouseDown(group1);
-      // focus should remain unchanged, 
+      // focus should remain unchanged,
       // because there is no focusable element in scope before group1,
       // and wrap is false
       expect(document.activeElement).toBe(item1);
@@ -899,6 +879,46 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(child3);
       userEvent.tab();
       expect(document.activeElement).toBe(child1);
+      userEvent.tab({shift: true});
+      expect(document.activeElement).toBe(child3);
+    });
+
+    it('should not lock tab navigation inside a nested focus scope without contain', function () {
+      function Test() {
+        return (
+          <div>
+            <input data-testid="outside" />
+            <FocusScope autoFocus restoreFocus contain>
+              <input data-testid="parent" />
+              <div>
+                <div>
+                  <FocusScope>
+                    <input data-testid="child1" />
+                    <input data-testid="child2" />
+                    <input data-testid="child3" />
+                  </FocusScope>
+                </div>
+              </div>
+            </FocusScope>
+          </div>
+        );
+      }
+
+      let {getByTestId} = render(<Test />);
+      let parent = getByTestId('parent');
+      let child1 = getByTestId('child1');
+      let child2 = getByTestId('child2');
+      let child3 = getByTestId('child3');
+
+      expect(document.activeElement).toBe(parent);
+      userEvent.tab();
+      expect(document.activeElement).toBe(child1);
+      userEvent.tab();
+      expect(document.activeElement).toBe(child2);
+      userEvent.tab();
+      expect(document.activeElement).toBe(child3);
+      userEvent.tab();
+      expect(document.activeElement).toBe(parent);
       userEvent.tab({shift: true});
       expect(document.activeElement).toBe(child3);
     });

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -432,6 +432,42 @@ describe('FocusScope', function () {
       userEvent.tab();
       expect(document.activeElement).toBe(getByTestId('after'));
     });
+
+    it('should not handle tabbing if the focus scope does not restore focus', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <button data-testid="trigger" />
+            <input data-testid="after-trigger" />
+            {show &&
+              <FocusScope autoFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+            <input data-testid="after" />
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      act(() => {trigger.focus();});
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      let input3 = getByTestId('input3');
+      act(() => {input3.focus();});
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
   });
 
   describe('auto focus', function () {

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -1029,6 +1029,72 @@ describe('FocusScope', function () {
       act(() => parent.focus());
       expect(document.activeElement).toBe(child1);
     });
+
+    it('should not lock focus inside a focus scope with a child scope in a portal', function () {
+      function Portal(props) {
+        return ReactDOM.createPortal(props.children, document.body);
+      }
+
+      function Test() {
+        return (
+          <div>
+            <FocusScope autoFocus restoreFocus contain>
+              <input data-testid="parent" />
+              <div>
+                <Portal>
+                  <FocusScope>
+                    <input data-testid="child" />
+                  </FocusScope>
+                </Portal>
+              </div>
+            </FocusScope>
+          </div>
+        );
+      }
+
+      let {getByTestId} = render(<Test />);
+      let parent = getByTestId('parent');
+      let child = getByTestId('child');
+
+      expect(document.activeElement).toBe(parent);
+      act(() => child.focus());
+      expect(document.activeElement).toBe(child);
+      act(() => parent.focus());
+      expect(document.activeElement).toBe(parent);
+    });
+
+    it('should lock focus inside a child focus scope with contain in a portal', function () {
+      function Portal(props) {
+        return ReactDOM.createPortal(props.children, document.body);
+      }
+
+      function Test() {
+        return (
+          <div>
+            <FocusScope autoFocus restoreFocus contain>
+              <input data-testid="parent" />
+              <div>
+                <Portal>
+                  <FocusScope contain>
+                    <input data-testid="child" />
+                  </FocusScope>
+                </Portal>
+              </div>
+            </FocusScope>
+          </div>
+        );
+      }
+
+      let {getByTestId} = render(<Test />);
+      let parent = getByTestId('parent');
+      let child = getByTestId('child');
+
+      expect(document.activeElement).toBe(parent);
+      act(() => child.focus());
+      expect(document.activeElement).toBe(child);
+      act(() => parent.focus());
+      expect(document.activeElement).toBe(child);
+    });
   });
 
   describe('scope child of document.body', function () {

--- a/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
@@ -965,7 +965,7 @@ describe('DialogTrigger', function () {
       expect(outerDialog).toBeVisible();
     }); // wait for animation
     let innerButton = getByTestId('innerButton');
-    userEvent.tab();
+    act(() => innerButton.focus());
     fireEvent.keyDown(document.activeElement, {key: 'Enter'});
     fireEvent.keyUp(document.activeElement, {key: 'Enter'});
 

--- a/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
@@ -965,6 +965,7 @@ describe('DialogTrigger', function () {
       expect(outerDialog).toBeVisible();
     }); // wait for animation
     let innerButton = getByTestId('innerButton');
+    // Focus manually - userEvent.tab is buggy when starting from an element with tabIndex="-1"
     act(() => innerButton.focus());
     fireEvent.keyDown(document.activeElement, {key: 'Enter'});
     fireEvent.keyUp(document.activeElement, {key: 'Enter'});


### PR DESCRIPTION
This fixes a few FocusScope issues found while working on DatePicker.

* In #2139, we added a check if a FocusScope container another nested one to prevent them from clashing. However, this DOM check only checked if one was contained inside another, not that the active element was actually inside it. For example, a focus scope could be a sibling of another focusable element. Focus scopes can also not have the `contain` property set, in which case this also doesn't apply.
* If you didn't have `restoreFocus` enabled, we still handled the Tab key rather than leaving it to the browser.

The fix is to track which the focus scope hierarchy in a tree so we can allow the correct one to handle focus/blur events rather than all of them. This is done in a map, and via context. Moving to a child focus scope from a parent is allowed, but moving from a child to a parent or sibling is not.