### PR TITLE
Fix decimals in `percent` number fields without `minimumFractionDigits`

### DIFF
--- a/packages/@internationalized/number/src/NumberParser.ts
+++ b/packages/@internationalized/number/src/NumberParser.ts
@@ -193,8 +193,8 @@ const nonLiteralParts = new Set(['decimal', 'fraction', 'integer', 'minusSign', 
 
 function getSymbols(formatter: Intl.NumberFormat, intlOptions: Intl.ResolvedNumberFormatOptions, originalOptions: Intl.NumberFormatOptions): Symbols {
   // Note: some locale's don't add a group symbol until there is a ten thousands place
-  let allParts = formatter.formatToParts(-10000.1);
-  let posAllParts = formatter.formatToParts(10000.1);
+  let allParts = formatter.formatToParts(-10000.111);
+  let posAllParts = formatter.formatToParts(10000.111);
   let singularParts = formatter.formatToParts(1);
 
   let minusSign = allParts.find(p => p.type === 'minusSign')?.value ?? '-';

--- a/packages/@internationalized/number/test/NumberParser.test.js
+++ b/packages/@internationalized/number/test/NumberParser.test.js
@@ -251,9 +251,11 @@ describe('NumberParser', function () {
       expect(new NumberParser('en-US', {style: 'percent'}).isValidPartialNumber('10')).toBe(true);
       expect(new NumberParser('en-US', {style: 'percent'}).isValidPartialNumber('10.5')).toBe(false);
       expect(new NumberParser('en-US', {style: 'percent', minimumFractionDigits: 2}).isValidPartialNumber('10.5')).toBe(true);
+      expect(new NumberParser('en-US', {style: 'percent', maximumFractionDigits: 2}).isValidPartialNumber('10.5')).toBe(true);
       expect(new NumberParser('en-US', {style: 'percent'}).isValidPartialNumber('10%')).toBe(true);
       expect(new NumberParser('en-US', {style: 'percent'}).isValidPartialNumber('10.5%')).toBe(false);
       expect(new NumberParser('en-US', {style: 'percent', minimumFractionDigits: 2}).isValidPartialNumber('10.5%')).toBe(true);
+      expect(new NumberParser('en-US', {style: 'percent', maximumFractionDigits: 2}).isValidPartialNumber('10.5%')).toBe(true);
       expect(new NumberParser('en-US', {style: 'percent'}).isValidPartialNumber('%')).toBe(true);
       expect(new NumberParser('en-US', {style: 'percent'}).isValidPartialNumber('10 %')).toBe(true);
     });


### PR DESCRIPTION
We ran into a bug with number fields formatted as `style: percent` — regardless of other formatting settings, the decimal character is considered invalid unless `minimumFractionDigits` is greater than `0`. For example, even with `maximumFractionDigits: 1`, you can't type the decimal character in a number field.

The values used for determining valid characters only have a single decimal place, but percent formatting multiplies this by 100, removing the decimal unless `minimumFractionDigits` is set.  This PR pads the decimal out to 3 places, fixing the issue.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
  - I can file an issue if that's preferred, but the fix is simple enough that I figured I'd get a PR up
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

I added two test cases to cover this issue. Both failed before this change and pass with this PR.

## 🧢 Your Project:

<!--- Company/project for pull request -->
