### PR TITLE
Update useListData to handle select all w/ unloaded lists

### DIFF
--- a/packages/@react-stately/data/src/useAsyncList.ts
+++ b/packages/@react-stately/data/src/useAsyncList.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {createListActions, ListData, ListState, removeActions} from './useListData';
+import {createListActions, ListData, ListState} from './useListData';
 import {Key, Reducer, useEffect, useReducer} from 'react';
 import {LoadingState, Selection, SortDescriptor} from '@react-types/shared';
 
@@ -342,15 +342,8 @@ export function useAsyncList<T, C = string>(options: AsyncListOptions<T, C>): As
     sort(sortDescriptor: SortDescriptor) {
       dispatchFetch({type: 'sorting', sortDescriptor}, sort || load);
     },
-    ...createListActions({...options, getKey}, fn => {
+    ...createListActions({...options, getKey, cursor: data.cursor}, fn => {
       dispatch({type: 'update', updater: fn});
-    }),
-    ...removeActions({
-      dispatch: fn => {
-        dispatch({type: 'update', updater: fn});
-      },
-      getKey,
-      cursor: data.cursor
     }),
     setFilterText(filterText: string) {
       dispatchFetch({type: 'filtering', filterText}, load);

--- a/packages/@react-stately/data/src/useAsyncList.ts
+++ b/packages/@react-stately/data/src/useAsyncList.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {createListActions, ListData, ListState} from './useListData';
+import {createListActions, ListData, ListState, removeActions} from './useListData';
 import {Key, Reducer, useEffect, useReducer} from 'react';
 import {LoadingState, Selection, SortDescriptor} from '@react-types/shared';
 
@@ -344,6 +344,13 @@ export function useAsyncList<T, C = string>(options: AsyncListOptions<T, C>): As
     },
     ...createListActions({...options, getKey}, fn => {
       dispatch({type: 'update', updater: fn});
+    }),
+    ...removeActions({
+      dispatch: fn => {
+        dispatch({type: 'update', updater: fn});
+      },
+      getKey,
+      cursor: data.cursor
     }),
     setFilterText(filterText: string) {
       dispatchFetch({type: 'filtering', filterText}, load);

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -240,7 +240,7 @@ export function createListActions<T, C>(opts: CreateListOptions<T, C>, dispatch:
           return {
             ...state,
             items: [],
-            selectedKeys: cursor != null ? 'all' : new Set()
+            selectedKeys: new Set()
           };
         }
 

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -236,7 +236,6 @@ export function createListActions<T, C>(opts: CreateListOptions<T, C>, dispatch:
     removeSelectedItems() {
       dispatch(state => {
         if (state.selectedKeys === 'all') {
-          // return 'all' value if there still exists unloaded items (i.e. cursor is not null)
           return {
             ...state,
             items: [],

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -162,6 +162,61 @@ export function useListData<T>(options: ListOptions<T>): ListData<T> {
   };
 }
 
+interface ListRemoveOpts<T> {
+  dispatch,
+  getKey,
+  cursor?
+}
+
+export function removeActions<T>(opts: ListRemoveOpts<T>) {
+  let {cursor, dispatch, getKey} = opts;
+  return {
+    remove(...keys: Key[]) {
+      dispatch(state => {
+        let keySet = new Set(keys);
+        let items = state.items.filter(item => !keySet.has(getKey(item)));
+
+        let selection: Selection = 'all';
+        if (state.selectedKeys !== 'all') {
+          selection = new Set(state.selectedKeys);
+          for (let key of keys) {
+            selection.delete(key);
+          }
+        }
+        if (cursor == null && items.length === 0) {
+          selection = new Set();
+        }
+
+        return {
+          ...state,
+          items,
+          selectedKeys: selection
+        };
+      });
+    },
+    removeSelectedItems() {
+      dispatch(state => {
+        if (state.selectedKeys === 'all') {
+          // return 'all' value if still unloaded items (i.e. cursor is not null)
+          return {
+            ...state,
+            items: [],
+            selectedKeys: cursor != null ? 'all' : new Set()
+          };
+        }
+
+        let selectedKeys = state.selectedKeys;
+        let items = state.items.filter(item => !selectedKeys.has(getKey(item)));
+        return {
+          ...state,
+          items,
+          selectedKeys: new Set()
+        };
+      });
+    }
+  };
+}
+
 export function createListActions<T>(opts: ListOptions<T>, dispatch: (updater: (state: ListState<T>) => ListState<T>) => void): Omit<ListData<T>, 'items' | 'selectedKeys' | 'getItem' | 'filterText'> {
   let {getKey} = opts;
   return {
@@ -206,48 +261,7 @@ export function createListActions<T>(opts: ListOptions<T>, dispatch: (updater: (
     append(...values: T[]) {
       dispatch(state => insert(state, state.items.length, ...values));
     },
-    remove(...keys: Key[]) {
-      dispatch(state => {
-        let keySet = new Set(keys);
-        let items = state.items.filter(item => !keySet.has(getKey(item)));
-
-        let selection: Selection = 'all';
-        if (state.selectedKeys !== 'all') {
-          selection = new Set(state.selectedKeys);
-          for (let key of keys) {
-            selection.delete(key);
-          }
-        }
-        if (selection === 'all' && items.length === 0) {
-          selection = new Set();
-        }
-
-        return {
-          ...state,
-          items,
-          selectedKeys: selection
-        };
-      });
-    },
-    removeSelectedItems() {
-      dispatch(state => {
-        if (state.selectedKeys === 'all') {
-          return {
-            ...state,
-            items: [],
-            selectedKeys: new Set()
-          };
-        }
-
-        let selectedKeys = state.selectedKeys;
-        let items = state.items.filter(item => !selectedKeys.has(getKey(item)));
-        return {
-          ...state,
-          items,
-          selectedKeys: new Set()
-        };
-      });
-    },
+    ...removeActions({dispatch, getKey}),
     move(key: Key, toIndex: number) {
       dispatch(state => {
         let index = state.items.findIndex(item => getKey(item) === key);

--- a/packages/@react-stately/data/test/useAsyncList.test.js
+++ b/packages/@react-stately/data/test/useAsyncList.test.js
@@ -29,6 +29,12 @@ function getItems2() {
   });
 }
 
+function getItemsEnd() {
+  return new Promise(resolve => {
+    setTimeout(() => resolve({items: [], cursor: null}), 100);
+  });
+}
+
 describe('useAsyncList', () => {
   beforeAll(() => {
     jest.useFakeTimers();
@@ -868,6 +874,40 @@ describe('useAsyncList', () => {
       () => useAsyncList({load, initialSelectedKeys: 'all'})
     );
     expect(result.current.selectedKeys).toEqual('all');
+  });
+
+  it('should maintain selected all key through remove if unloaded items still exist', async () => {
+    let load = jest.fn()
+      .mockImplementationOnce(getItems);
+    let {result, waitForNextUpdate} = renderHook(
+      () => useAsyncList({load})
+    );
+    await act(async () => {
+      result.current.loadMore();
+      jest.runAllTimers();
+      await waitForNextUpdate();
+      result.current.setSelectedKeys('all');
+      result.current.removeSelectedItems();
+      jest.runAllTimers();
+    });
+    expect(result.current.selectedKeys).toEqual('all');
+  });
+
+  it('should changed selection to empty set if all items removed and no more items to load', async () => {
+    let load = jest.fn()
+      .mockImplementationOnce(getItemsEnd);
+    let {result, waitForNextUpdate} = renderHook(
+      () => useAsyncList({load})
+    );
+    await act(async () => {
+      result.current.loadMore();
+      jest.runAllTimers();
+      await waitForNextUpdate();
+      result.current.setSelectedKeys('all');
+      result.current.removeSelectedItems();
+      jest.runAllTimers();
+    });
+    expect(result.current.selectedKeys).toEqual(new Set());
   });
 
   describe('filtering', function () {

--- a/packages/@react-stately/data/test/useAsyncList.test.js
+++ b/packages/@react-stately/data/test/useAsyncList.test.js
@@ -31,7 +31,7 @@ function getItems2() {
 
 function getItemsEnd() {
   return new Promise(resolve => {
-    setTimeout(() => resolve({items: [], cursor: null}), 100);
+    setTimeout(() => resolve({items: ITEMS, cursor: null}), 100);
   });
 }
 
@@ -876,7 +876,7 @@ describe('useAsyncList', () => {
     expect(result.current.selectedKeys).toEqual('all');
   });
 
-  it('should maintain selected all key through remove if unloaded items still exist', async () => {
+  it('should maintain all selection if last visible item removed and unloaded items still exist', async () => {
     let load = jest.fn()
       .mockImplementationOnce(getItems);
     let {result, waitForNextUpdate} = renderHook(
@@ -887,13 +887,32 @@ describe('useAsyncList', () => {
       jest.runAllTimers();
       await waitForNextUpdate();
       result.current.setSelectedKeys('all');
-      result.current.removeSelectedItems();
+      result.current.remove(1);
+      result.current.remove(2);
       jest.runAllTimers();
     });
     expect(result.current.selectedKeys).toEqual('all');
   });
 
-  it('should changed selection to empty set if all items removed and no more items to load', async () => {
+  it('should change selection to empty set if last item removed with no unloaded items left', async () => {
+    let load = jest.fn()
+      .mockImplementationOnce(getItemsEnd);
+    let {result, waitForNextUpdate} = renderHook(
+      () => useAsyncList({load})
+    );
+    await act(async () => {
+      result.current.loadMore();
+      jest.runAllTimers();
+      await waitForNextUpdate();
+      result.current.setSelectedKeys('all');
+      result.current.remove(1);
+      result.current.remove(2);
+      jest.runAllTimers();
+    });
+    expect(result.current.selectedKeys).toEqual(new Set());
+  });
+
+  it('should change selection to empty set if all items removed', async () => {
     let load = jest.fn()
       .mockImplementationOnce(getItemsEnd);
     let {result, waitForNextUpdate} = renderHook(


### PR DESCRIPTION
If list data has unloaded items, removing the last visible selected item will keep the selection at the `all` value. If all items have been loaded, removing the last visible selected item will change selection to an empty set.

If list data has unloaded items, a remove `all` selected items will remain at the `all` value. If all items have been loaded, a remove `all` will change selection to an empty set.