### PR TITLE
Calendar and TimeField integration into DatePicker

### DIFF
--- a/packages/@internationalized/date/src/CalendarDate.ts
+++ b/packages/@internationalized/date/src/CalendarDate.ts
@@ -80,8 +80,8 @@ export class CalendarDate {
     return subtract(this, duration);
   }
 
-  set(fields: DateFields, behavior?: OverflowBehavior) {
-    return set(this, fields, behavior);
+  set(fields: DateFields) {
+    return set(this, fields);
   }
 
   cycle(field: DateField, amount: number, options?: CycleOptions) {
@@ -124,8 +124,8 @@ export class Time {
     return subtractTime(this, duration);
   }
 
-  set(fields: TimeFields, behavior?: OverflowBehavior) {
-    return setTime(this, fields, behavior);
+  set(fields: TimeFields) {
+    return setTime(this, fields);
   }
 
   cycle(field: TimeField, amount: number, options?: CycleTimeOptions) {
@@ -191,8 +191,8 @@ export class CalendarDateTime {
     return subtract(this, duration);
   }
 
-  set(fields: DateFields & TimeFields, behavior?: OverflowBehavior) {
-    return set(setTime(this, fields, behavior), fields, behavior);
+  set(fields: DateFields & TimeFields) {
+    return set(setTime(this, fields), fields);
   }
 
   cycle(field: DateField | TimeField, amount: number, options?: CycleTimeOptions) {
@@ -281,8 +281,8 @@ export class ZonedDateTime {
     return subtractZoned(this, duration);
   }
 
-  set(fields: DateFields & TimeFields, behavior?: OverflowBehavior, disambiguation?: Disambiguation) {
-    return setZoned(this, fields, behavior, disambiguation);
+  set(fields: DateFields & TimeFields, disambiguation?: Disambiguation) {
+    return setZoned(this, fields, disambiguation);
   }
 
   cycle(field: DateField | TimeField, amount: number, options?: CycleTimeOptions) {

--- a/packages/@internationalized/date/src/CalendarDate.ts
+++ b/packages/@internationalized/date/src/CalendarDate.ts
@@ -11,7 +11,7 @@
  */
 
 import {add, addTime, addZoned, cycleDate, cycleTime, cycleZoned, set, setTime, setZoned, subtract, subtractTime, subtractZoned} from './manipulation';
-import {Calendar, CycleOptions, CycleTimeOptions, DateField, DateFields, Disambiguation, Duration, OverflowBehavior, TimeField, TimeFields} from './types';
+import {AnyCalendarDate, AnyTime, Calendar, CycleOptions, CycleTimeOptions, DateField, DateFields, Disambiguation, Duration, OverflowBehavior, TimeField, TimeFields} from './types';
 import {compareDate, compareTime} from './queries';
 import {dateTimeToString, dateToString, timeToString, zonedDateTimeToString} from './string';
 import {GregorianCalendar} from './calendars/GregorianCalendar';
@@ -38,6 +38,10 @@ function shiftArgs(args: any[]) {
 }
 
 export class CalendarDate {
+  // This prevents TypeScript from allowing other types with the same fields to match.
+  // i.e. a ZonedDateTime should be be passable to a parameter that expects CalendarDate.
+  // If that behavior is desired, use the AnyCalendarDate interface instead.
+  #type;
   public readonly calendar: Calendar;
   public readonly era: string;
   public readonly year: number;
@@ -92,12 +96,15 @@ export class CalendarDate {
     return dateToString(this);
   }
 
-  compare(b: CalendarDate) {
+  compare(b: AnyCalendarDate) {
     return compareDate(this, b);
   }
 }
 
 export class Time {
+  // This prevents TypeScript from allowing other types with the same fields to match.
+  #type;
+
   constructor(
     public readonly hour: number = 0,
     public readonly minute: number = 0,
@@ -129,12 +136,19 @@ export class Time {
     return timeToString(this);
   }
 
-  compare(b: Time) {
+  compare(b: AnyTime) {
     return compareTime(this, b);
   }
 }
 
-export class CalendarDateTime extends CalendarDate {
+export class CalendarDateTime {
+  // This prevents TypeScript from allowing other types with the same fields to match.
+  #type;
+  public readonly calendar: Calendar;
+  public readonly era: string;
+  public readonly year: number;
+  public readonly month: number;
+  public readonly day: number;
   public readonly hour: number;
   public readonly minute: number;
   public readonly second: number;
@@ -145,7 +159,16 @@ export class CalendarDateTime extends CalendarDate {
   constructor(calendar: Calendar, era: string, year: number, month: number, day: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(...args: any[]) {
     let [calendar, era, year, month, day] = shiftArgs(args);
-    super(calendar, era, year, month, day);
+    this.calendar = calendar;
+    this.era = era;
+    this.year = year;
+    this.month = month;
+    this.day = day;
+
+    if (this.calendar.balanceDate) {
+      this.calendar.balanceDate(this);
+    }
+
     this.hour = args.shift() || 0;
     this.minute = args.shift() || 0;
     this.second = args.shift() || 0;
@@ -158,6 +181,14 @@ export class CalendarDateTime extends CalendarDate {
     } else {
       return new CalendarDateTime(this.calendar, this.year, this.month, this.day, this.hour, this.minute, this.second, this.millisecond);
     }
+  }
+
+  add(duration: Duration) {
+    return add(this, duration);
+  }
+
+  subtract(duration: Duration) {
+    return subtract(this, duration);
   }
 
   set(fields: DateFields & TimeFields, behavior?: OverflowBehavior) {
@@ -176,11 +207,15 @@ export class CalendarDateTime extends CalendarDate {
     }
   }
 
+  toDate(timeZone: string) {
+    return toDate(this, timeZone);
+  }
+
   toString() {
     return dateTimeToString(this);
   }
 
-  compare(b: CalendarDate | CalendarDateTime) {
+  compare(b: CalendarDate | CalendarDateTime | ZonedDateTime) {
     let res = compareDate(this, b);
     if (res === 0) {
       return compareTime(this, toCalendarDateTime(b));
@@ -190,7 +225,18 @@ export class CalendarDateTime extends CalendarDate {
   }
 }
 
-export class ZonedDateTime extends CalendarDateTime {
+export class ZonedDateTime {
+  // This prevents TypeScript from allowing other types with the same fields to match.
+  #type;
+  public readonly calendar: Calendar;
+  public readonly era: string;
+  public readonly year: number;
+  public readonly month: number;
+  public readonly day: number;
+  public readonly hour: number;
+  public readonly minute: number;
+  public readonly second: number;
+  public readonly millisecond: number;
   public readonly timeZone: string;
   public readonly offset: number;
 
@@ -201,9 +247,22 @@ export class ZonedDateTime extends CalendarDateTime {
     let [calendar, era, year, month, day] = shiftArgs(args);
     let timeZone = args.shift();
     let offset = args.shift();
-    super(calendar, era, year, month, day, ...args);
+    this.calendar = calendar;
+    this.era = era;
+    this.year = year;
+    this.month = month;
+    this.day = day;
+
+    if (this.calendar.balanceDate) {
+      this.calendar.balanceDate(this);
+    }
+
     this.timeZone = timeZone;
     this.offset = offset;
+    this.hour = args.shift() || 0;
+    this.minute = args.shift() || 0;
+    this.second = args.shift() || 0;
+    this.millisecond = args.shift() || 0;
   }
 
   copy(): ZonedDateTime {
@@ -244,6 +303,6 @@ export class ZonedDateTime extends CalendarDateTime {
 
   compare(b: CalendarDate | CalendarDateTime | ZonedDateTime) {
     // TODO: Is this a bad idea??
-    return this.toDate() - toZoned(b, this.timeZone).toDate();
+    return this.toDate().getTime() - toZoned(b, this.timeZone).toDate().getTime();
   }
 }

--- a/packages/@internationalized/date/src/DateFormatter.ts
+++ b/packages/@internationalized/date/src/DateFormatter.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+let formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+interface ResolvedDateTimeFormatOptions extends Intl.ResolvedDateTimeFormatOptions {
+  hourCycle?: Intl.DateTimeFormatOptions['hourCycle']
+}
+
+export class DateFormatter implements Intl.DateTimeFormat {
+  private formatter: Intl.DateTimeFormat;
+  private options: Intl.DateTimeFormatOptions;
+  private resolvedHourCycle: Intl.DateTimeFormatOptions['hourCycle'];
+
+  constructor(locale: string, options: Intl.DateTimeFormatOptions = {}) {
+    this.formatter = getCachedDateFormatter(locale, options);
+    this.options = options;
+  }
+
+  format(value: Date): string {
+    return this.formatter.format(value);
+  }
+
+  formatToParts(value: Date): Intl.DateTimeFormatPart[] {
+    return this.formatter.formatToParts(value);
+  }
+
+  formatRange(start: Date, end: Date) {
+    // @ts-ignore
+    if (typeof this.formatter.formatRange === 'function') {
+      // @ts-ignore
+      return this.formatter.formatRange(start, end);
+    }
+
+    if (end < start) {
+      throw new RangeError('End date must be >= start date');
+    }
+
+    // Very basic fallback for old browsers.
+    return `${this.formatter.format(start)} – ${this.formatter.format(end)}`;
+  }
+
+  formatRangeToParts(start: Date, end: Date) {
+    // @ts-ignore
+    if (typeof this.formatter.formatRangeToParts === 'function') {
+      // @ts-ignore
+      return this.formatter.formatRangeToParts(start, end);
+    }
+
+    if (end < start) {
+      throw new RangeError('End date must be >= start date');
+    }
+
+    let startParts = this.formatter.formatToParts(start);
+    let endParts = this.formatter.formatToParts(end);
+    return [
+      ...startParts.map(p => ({...p, source: 'startRange'})),
+      {type: 'literal', value: ' – ', source: 'shared'},
+      ...endParts.map(p => ({...p, source: 'endRange'}))
+    ];
+  }
+
+  resolvedOptions(): ResolvedDateTimeFormatOptions {
+    let resolvedOptions = this.formatter.resolvedOptions() as ResolvedDateTimeFormatOptions;
+    if (hasBuggyResolvedHourCycle()) {
+      if (!this.resolvedHourCycle) {
+        this.resolvedHourCycle = getResolvedHourCycle(resolvedOptions.locale, this.options);
+      }
+      resolvedOptions.hourCycle = this.resolvedHourCycle;
+      resolvedOptions.hour12 = this.resolvedHourCycle === 'h11' || this.resolvedHourCycle === 'h12';
+    }
+
+    return resolvedOptions;
+  }
+}
+
+// There are multiple bugs involving the hour12 and hourCycle options in various browser engines.
+//   - Chrome [1] (and the ECMA 402 spec [2]) resolve hour12: false in English and other locales to h24 (24:00 - 23:59)
+//     rather than h23 (00:00 - 23:59). Same can happen with hour12: true in French, which Chrome resolves to h11 (00:00 - 11:59)
+//     rather than h12 (12:00 - 11:59).
+//   - WebKit returns an incorrect hourCycle resolved option in the French locale due to incorrect parsing of 'h' literal
+//     in the resolved pattern. It also formats incorrectly when specifying the hourCycle option for the same reason. [3]
+// [1] https://bugs.chromium.org/p/chromium/issues/detail?id=1045791
+// [2] https://github.com/tc39/ecma402/issues/402
+// [3] https://bugs.webkit.org/show_bug.cgi?id=229313
+
+// https://github.com/unicode-org/cldr/blob/018b55eff7ceb389c7e3fc44e2f657eae3b10b38/common/supplemental/supplementalData.xml#L4774-L4802
+const hour12Preferences = {
+  true: {
+    // Only Japanese uses the h11 style for 12 hour time. All others use h12.
+    ja: 'h11'
+  },
+  false: {
+    // All locales use h23 for 24 hour time. None use h24.
+  }
+};
+
+function getCachedDateFormatter(locale: string, options: Intl.DateTimeFormatOptions = {}): Intl.DateTimeFormat {
+  // Work around buggy hour12 behavior in Chrome / ECMA 402 spec by using hourCycle instead.
+  // Only apply the workaround if the issue is detected, because the hourCycle option is buggy in Safari.
+  if (typeof options.hour12 === 'boolean' && hasBuggyHour12Behavior()) {
+    options = {...options};
+    let pref = hour12Preferences[String(options.hour12)][locale.split('-')[0]];
+    let defaultHourCycle = options.hour12 ? 'h12' : 'h23';
+    options.hourCycle = pref ?? defaultHourCycle;
+    delete options.hour12;
+  }
+
+  let cacheKey = locale + (options ? Object.entries(options).sort((a, b) => a[0] < b[0] ? -1 : 1).join() : '');
+  if (formatterCache.has(cacheKey)) {
+    return formatterCache.get(cacheKey);
+  }
+
+  let numberFormatter = new Intl.DateTimeFormat(locale, options);
+  formatterCache.set(cacheKey, numberFormatter);
+  return numberFormatter;
+}
+
+let _hasBuggyHour12Behavior: boolean = null;
+function hasBuggyHour12Behavior() {
+  if (_hasBuggyHour12Behavior == null) {
+    _hasBuggyHour12Behavior = new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      hour12: false
+    }).format(new Date(2020, 2, 3, 0)) === '24';
+  }
+
+  return _hasBuggyHour12Behavior;
+}
+
+let _hasBuggyResolvedHourCycle: boolean = null;
+function hasBuggyResolvedHourCycle() {
+  if (_hasBuggyResolvedHourCycle == null) {
+    _hasBuggyResolvedHourCycle = (new Intl.DateTimeFormat('fr', {
+      hour: 'numeric',
+      hour12: false
+    }).resolvedOptions() as ResolvedDateTimeFormatOptions).hourCycle === 'h12';
+  }
+
+  return _hasBuggyResolvedHourCycle;
+}
+
+function getResolvedHourCycle(locale: string, options: Intl.DateTimeFormatOptions) {
+  // Work around buggy results in resolved hourCycle and hour12 options in WebKit.
+  // Format the minimum possible hour and maximum possible hour in a day and parse the results.
+  locale = locale.replace(/(-u-)?-nu-[a-zA-Z0-9]+/, '');
+  locale += (locale.includes('-u-') ? '' : '-u') + '-nu-latn';
+  let formatter = getCachedDateFormatter(locale, {...options, timeZone: 'America/Los_Angeles'});
+
+  let min = parseInt(formatter.formatToParts(new Date(2020, 2, 3, 0)).find(p => p.type === 'hour').value, 10);
+  let max = parseInt(formatter.formatToParts(new Date(2020, 2, 3, 23)).find(p => p.type === 'hour').value, 10);
+
+  if (min === 0 && max === 23) {
+    return 'h23';
+  }
+
+  if (min === 24 && max === 23) {
+    return 'h24';
+  }
+
+  if (min === 0 && max === 11) {
+    return 'h11';
+  }
+
+  if (min === 12 && max === 11) {
+    return 'h12';
+  }
+
+  throw new Error('Unexpected hour cycle result');
+}

--- a/packages/@internationalized/date/src/calendars/BuddhistCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/BuddhistCalendar.ts
@@ -13,6 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
+import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {GregorianCalendar} from './GregorianCalendar';
 import {Mutable} from '../utils';
@@ -25,10 +26,10 @@ export class BuddhistCalendar extends GregorianCalendar {
   fromJulianDay(jd: number): CalendarDate {
     let date = super.fromJulianDay(jd) as Mutable<CalendarDate>;
     date.year -= BUDDHIST_ERA_START;
-    return date;
+    return date as CalendarDate;
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     return super.toJulianDay(
       new CalendarDate(
         date.year + BUDDHIST_ERA_START,

--- a/packages/@internationalized/date/src/calendars/EthiopicCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/EthiopicCalendar.ts
@@ -13,7 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {Calendar} from '../types';
+import {AnyCalendarDate, Calendar} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {Mutable} from '../utils';
 
@@ -73,10 +73,10 @@ export class EthiopicCalendar implements Calendar {
       date.year += AMETE_MIHRET_DELTA;
     }
 
-    return date;
+    return date as CalendarDate;
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     let year = date.year;
     if (date.era === 'AA') {
       year -= AMETE_MIHRET_DELTA;
@@ -85,7 +85,7 @@ export class EthiopicCalendar implements Calendar {
     return ceToJulianDay(ETHIOPIC_EPOCH, year, date.month, date.day);
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     let year = date.year;
     if (date.era === 'AA') {
       year -= AMETE_MIHRET_DELTA;
@@ -98,7 +98,7 @@ export class EthiopicCalendar implements Calendar {
     return 13;
   }
 
-  getDaysInYear(date: CalendarDate): number {
+  getDaysInYear(date: AnyCalendarDate): number {
     return 365 + getLeapDay(date.year);
   }
 
@@ -118,7 +118,7 @@ export class EthiopicAmeteAlemCalendar extends EthiopicCalendar {
     let date = julianDayToCE(this, ETHIOPIC_EPOCH, jd);
     date.era = 'AA';
     date.year += AMETE_MIHRET_DELTA;
-    return date;
+    return date as CalendarDate;
   }
 
   getEras() {
@@ -138,10 +138,10 @@ export class CopticCalendar extends EthiopicCalendar {
       date.era = 'CE';
     }
 
-    return date;
+    return date as CalendarDate;
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     let year = date.year;
     if (date.era === 'BCE') {
       year = 1 - year;
@@ -150,7 +150,7 @@ export class CopticCalendar extends EthiopicCalendar {
     return ceToJulianDay(COPTIC_EPOCH, year, date.month, date.day);
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     let year = date.year;
     if (date.era === 'BCE') {
       year = 1 - year;
@@ -159,7 +159,7 @@ export class CopticCalendar extends EthiopicCalendar {
     return getDaysInMonth(year, date.month);
   }
 
-  addYears(date: Mutable<CalendarDate>, years: number) {
+  addYears(date: Mutable<AnyCalendarDate>, years: number) {
     if (date.era === 'BCE') {
       years = -years;
     }

--- a/packages/@internationalized/date/src/calendars/GregorianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/GregorianCalendar.ts
@@ -83,7 +83,8 @@ export class GregorianCalendar implements Calendar {
     return daysInMonth[isLeapYear(date.year) ? 'leapyear' : 'standard'][date.month - 1];
   }
 
-  getMonthsInYear(): number {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getMonthsInYear(date: AnyCalendarDate): number {
     return 12;
   }
 

--- a/packages/@internationalized/date/src/calendars/GregorianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/GregorianCalendar.ts
@@ -13,7 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {Calendar} from '../types';
+import {AnyCalendarDate, Calendar} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {mod} from '../utils';
 
@@ -75,11 +75,11 @@ export class GregorianCalendar implements Calendar {
     return new CalendarDate(this, year, month, day);
   }
 
-  toJulianDay(date: CalendarDate): number {
+  toJulianDay(date: AnyCalendarDate): number {
     return gregorianToJulianDay(date.year, date.month, date.day);
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     return daysInMonth[isLeapYear(date.year) ? 'leapyear' : 'standard'][date.month - 1];
   }
 
@@ -87,12 +87,12 @@ export class GregorianCalendar implements Calendar {
     return 12;
   }
 
-  getDaysInYear(date: CalendarDate): number {
+  getDaysInYear(date: AnyCalendarDate): number {
     return isLeapYear(date.year) ? 366 : 365;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getYearsInEra(date: CalendarDate): number {
+  getYearsInEra(date: AnyCalendarDate): number {
     return 9999;
   }
 

--- a/packages/@internationalized/date/src/calendars/HebrewCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/HebrewCalendar.ts
@@ -13,7 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {Calendar} from '../types';
+import {AnyCalendarDate, Calendar} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {mod, Mutable} from '../utils';
 
@@ -154,7 +154,7 @@ export class HebrewCalendar implements Calendar {
     return new CalendarDate(this, year, month, day);
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     let jd = startOfYear(date.year);
     for (let month = 1; month < date.month; month++) {
       jd += getDaysInMonth(date.year, month);
@@ -163,15 +163,15 @@ export class HebrewCalendar implements Calendar {
     return jd + date.day + HEBREW_EPOCH;
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     return getDaysInMonth(date.year, date.month);
   }
 
-  getMonthsInYear(date: CalendarDate): number {
+  getMonthsInYear(date: AnyCalendarDate): number {
     return isLeapYear(date.year) ? 13 : 12;
   }
 
-  getDaysInYear(date: CalendarDate): number {
+  getDaysInYear(date: AnyCalendarDate): number {
     return getDaysInYear(date.year);
   }
 
@@ -183,7 +183,7 @@ export class HebrewCalendar implements Calendar {
     return ['AM'];
   }
 
-  addYears(date: Mutable<CalendarDate>, years: number) {
+  addYears(date: Mutable<AnyCalendarDate>, years: number) {
     // Keep date in the same month when switching between leap years and non leap years
     let nextYear = date.year + years;
     if (isLeapYear(date.year) && !isLeapYear(nextYear) && date.month > 6) {

--- a/packages/@internationalized/date/src/calendars/IndianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/IndianCalendar.ts
@@ -13,6 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
+import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {GregorianCalendar, gregorianToJulianDay, isLeapYear} from './GregorianCalendar';
 import {Mutable} from '../utils';
@@ -70,7 +71,7 @@ export class IndianCalendar extends GregorianCalendar {
     return new CalendarDate(this, indianYear, indianMonth, indianDay);
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     let year = date.year + INDIAN_ERA_START;
 
     let leapMonth: number;
@@ -97,7 +98,7 @@ export class IndianCalendar extends GregorianCalendar {
     return jd;
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     if (date.month === 1 && isLeapYear(date.year + INDIAN_ERA_START)) {
       return 31;
     }

--- a/packages/@internationalized/date/src/calendars/IslamicCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/IslamicCalendar.ts
@@ -13,7 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {Calendar} from '../types';
+import {AnyCalendarDate, Calendar} from '../types';
 import {CalendarDate} from '../CalendarDate';
 
 const CIVIL_EPOC = 1948440; // CE 622 July 16 Friday (Julian calendar) / CE 622 July 19 (Gregorian calendar)
@@ -49,11 +49,11 @@ export class IslamicCivilCalendar implements Calendar {
     return julianDayToIslamic(this, CIVIL_EPOC, jd);
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     return islamicToJulianDay(CIVIL_EPOC, date.year, date.month, date.day);
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     let length = 29 + date.month % 2;
     if (date.month === 12 && isLeapYear(date.year)) {
       length++;
@@ -66,7 +66,7 @@ export class IslamicCivilCalendar implements Calendar {
     return 12;
   }
 
-  getDaysInYear(date: CalendarDate): number {
+  getDaysInYear(date: AnyCalendarDate): number {
     return isLeapYear(date.year) ? 355 : 354;
   }
 
@@ -86,7 +86,7 @@ export class IslamicTabularCalendar extends IslamicCivilCalendar {
     return julianDayToIslamic(this, ASTRONOMICAL_EPOC, jd);
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     return islamicToJulianDay(ASTRONOMICAL_EPOC, date.year, date.month, date.day);
   }
 }
@@ -177,7 +177,7 @@ export class IslamicUmalquraCalendar extends IslamicCivilCalendar {
     }
   }
 
-  toJulianDay(date: CalendarDate): number {
+  toJulianDay(date: AnyCalendarDate): number {
     if (date.year < UMALQURA_YEAR_START || date.year > UMALQURA_YEAR_END) {
       return super.toJulianDay(date);
     }
@@ -185,7 +185,7 @@ export class IslamicUmalquraCalendar extends IslamicCivilCalendar {
     return CIVIL_EPOC + umalquraMonthStart(date.year, date.month) + (date.day - 1);
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     if (date.year < UMALQURA_YEAR_START || date.year > UMALQURA_YEAR_END) {
       return super.getDaysInMonth(date);
     }
@@ -193,7 +193,7 @@ export class IslamicUmalquraCalendar extends IslamicCivilCalendar {
     return umalquraMonthLength(date.year, date.month);
   }
 
-  getDaysInYear(date: CalendarDate): number {
+  getDaysInYear(date: AnyCalendarDate): number {
     if (date.year < UMALQURA_YEAR_START || date.year > UMALQURA_YEAR_END) {
       return super.getDaysInYear(date);
     }

--- a/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
@@ -13,6 +13,7 @@
 // Portions of the code in this file are based on code from the TC39 Temporal proposal.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
+import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {GregorianCalendar} from './GregorianCalendar';
 import {Mutable} from '../utils';
@@ -21,7 +22,7 @@ const ERA_START_DATES = [[1868, 9, 8], [1912, 7, 30], [1926, 12, 25], [1989, 1, 
 const ERA_ADDENDS = [1867, 1911, 1925, 1988, 2018];
 const ERA_NAMES = ['meiji', 'taisho', 'showa', 'heisei', 'reiwa'];
 
-function findEraFromGregorianDate(date: CalendarDate) {
+function findEraFromGregorianDate(date: AnyCalendarDate) {
   const idx = ERA_START_DATES.findIndex(([year, month, day]) => {
     if (date.year < year) {
       return true;
@@ -49,7 +50,7 @@ function findEraFromGregorianDate(date: CalendarDate) {
   return idx - 1;
 }
 
-function toGregorian(date: CalendarDate) {
+function toGregorian(date: AnyCalendarDate) {
   let eraAddend = ERA_ADDENDS[ERA_NAMES.indexOf(date.era)];
   if (!eraAddend) {
     throw new Error('Unknown era: ' + date.era);
@@ -71,14 +72,14 @@ export class JapaneseCalendar extends GregorianCalendar {
     let era = findEraFromGregorianDate(date);
     date.era = ERA_NAMES[era];
     date.year -= ERA_ADDENDS[era];
-    return date;
+    return date as CalendarDate;
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     return super.toJulianDay(toGregorian(date));
   }
 
-  balanceDate(date: Mutable<CalendarDate>) {
+  balanceDate(date: Mutable<AnyCalendarDate>) {
     let gregorianDate = toGregorian(date);
     let era = findEraFromGregorianDate(gregorianDate);
 
@@ -92,7 +93,7 @@ export class JapaneseCalendar extends GregorianCalendar {
     return ERA_NAMES;
   }
 
-  getYearsInEra(date: CalendarDate): number {
+  getYearsInEra(date: AnyCalendarDate): number {
     let gregorianDate = toGregorian(date);
     let era = findEraFromGregorianDate(gregorianDate);
     let next = ERA_START_DATES[era + 1];

--- a/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
@@ -19,6 +19,7 @@ import {GregorianCalendar} from './GregorianCalendar';
 import {Mutable} from '../utils';
 
 const ERA_START_DATES = [[1868, 9, 8], [1912, 7, 30], [1926, 12, 25], [1989, 1, 8], [2019, 5, 1]];
+const ERA_END_DATES = [[1912, 7, 29], [1926, 12, 24], [1989, 1, 7], [2019, 4, 31]];
 const ERA_ADDENDS = [1867, 1911, 1925, 1988, 2018];
 const ERA_NAMES = ['meiji', 'taisho', 'showa', 'heisei', 'reiwa'];
 
@@ -86,6 +87,17 @@ export class JapaneseCalendar extends GregorianCalendar {
     if (ERA_NAMES[era] !== date.era) {
       date.era = ERA_NAMES[era];
       date.year = gregorianDate.year - ERA_ADDENDS[era];
+    }
+  }
+
+  constrainDate(date: Mutable<AnyCalendarDate>) {
+    let idx = ERA_NAMES.indexOf(date.era);
+    let end = ERA_END_DATES[idx];
+    if (end != null) {
+      let [year, month, day] = end;
+      date.year = Math.max(1, Math.min(year - ERA_ADDENDS[idx], date.year));
+      date.month = Math.max(1, Math.min(month, date.month));
+      date.day = Math.max(1, Math.min(day, date.day));
     }
   }
 

--- a/packages/@internationalized/date/src/calendars/PersianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/PersianCalendar.ts
@@ -13,7 +13,7 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {Calendar} from '../types';
+import {AnyCalendarDate, Calendar} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {mod} from '../utils';
 
@@ -62,7 +62,7 @@ export class PersianCalendar implements Calendar {
     return new CalendarDate(this, year, month, day);
   }
 
-  toJulianDay(date: CalendarDate): number {
+  toJulianDay(date: AnyCalendarDate): number {
     return persianToJulianDay(date.year, date.month, date.day);
   }
 
@@ -70,7 +70,7 @@ export class PersianCalendar implements Calendar {
     return 12;
   }
 
-  getDaysInMonth(date: CalendarDate): number {
+  getDaysInMonth(date: AnyCalendarDate): number {
     if (date.month <= 6) {
       return 31;
     }

--- a/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
@@ -13,19 +13,20 @@
 // Portions of the code in this file are based on code from ICU.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
+import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
 import {GregorianCalendar} from './GregorianCalendar';
 import {Mutable} from '../utils';
 
 const TAIWAN_ERA_START = 1911;
 
-function gregorianYear(date: CalendarDate) {
+function gregorianYear(date: AnyCalendarDate) {
   return date.era === 'minguo'
     ? date.year + TAIWAN_ERA_START
     : 1 - date.year + TAIWAN_ERA_START;
 }
 
-function gregorianToTaiwan(year: number, date: Mutable<CalendarDate>) {
+function gregorianToTaiwan(year: number, date: Mutable<AnyCalendarDate>) {
   let y = year - TAIWAN_ERA_START;
   if (y > 0) {
     date.era = 'minguo';
@@ -40,12 +41,12 @@ export class TaiwanCalendar extends GregorianCalendar {
   identifier = 'roc'; // Republic of China
 
   fromJulianDay(jd: number): CalendarDate {
-    let date = super.fromJulianDay(jd) as Mutable<CalendarDate>;
+    let date: Mutable<CalendarDate> = super.fromJulianDay(jd);
     gregorianToTaiwan(date.year, date);
-    return date;
+    return date as CalendarDate;
   }
 
-  toJulianDay(date: CalendarDate) {
+  toJulianDay(date: AnyCalendarDate) {
     return super.toJulianDay(
       new CalendarDate(
         gregorianYear(date),
@@ -59,11 +60,11 @@ export class TaiwanCalendar extends GregorianCalendar {
     return ['before_minguo', 'minguo'];
   }
 
-  balanceDate(date: Mutable<CalendarDate>) {
+  balanceDate(date: Mutable<AnyCalendarDate>) {
     gregorianToTaiwan(gregorianYear(date), date);
   }
 
-  addYears(date: Mutable<CalendarDate>, years: number) {
+  addYears(date: Mutable<AnyCalendarDate>, years: number) {
     if (date.era === 'before_minguo') {
       years = -years;
     }

--- a/packages/@internationalized/date/src/conversion.ts
+++ b/packages/@internationalized/date/src/conversion.ts
@@ -13,13 +13,13 @@
 // Portions of the code in this file are based on code from the TC39 Temporal proposal.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {Calendar, Disambiguation} from './types';
+import {AnyCalendarDate, AnyDateTime, Calendar, Disambiguation} from './types';
 import {CalendarDate, CalendarDateTime, Time, ZonedDateTime} from './CalendarDate';
 import {getLocalTimeZone} from './queries';
 import {GregorianCalendar} from './calendars/GregorianCalendar';
 import {Mutable} from './utils';
 
-export function epochFromDate(date: CalendarDateTime) {
+export function epochFromDate(date: AnyDateTime) {
   date = toCalendar(date, new GregorianCalendar());
   return epochFromParts(date.year, date.month, date.day, date.hour, date.minute, date.second, date.millisecond);
 }
@@ -101,7 +101,7 @@ function isValidWallTime(date: CalendarDateTime, timeZone: string, absolute: num
     && date.second === parts.second;
 }
 
-export function toAbsolute(date: CalendarDate, timeZone: string, disambiguation: Disambiguation = 'compatible'): number {
+export function toAbsolute(date: CalendarDate | CalendarDateTime, timeZone: string, disambiguation: Disambiguation = 'compatible'): number {
   let dateTime = toCalendarDateTime(date);
   let ms = epochFromDate(dateTime);
   let offsetBefore = getTimeZoneOffset(ms - DAYMILLIS, timeZone);
@@ -137,7 +137,7 @@ export function toAbsolute(date: CalendarDate, timeZone: string, disambiguation:
   }
 }
 
-export function toDate(dateTime: CalendarDate, timeZone: string, disambiguation: Disambiguation = 'compatible'): Date {
+export function toDate(dateTime: CalendarDate | CalendarDateTime, timeZone: string, disambiguation: Disambiguation = 'compatible'): Date {
   return new Date(toAbsolute(dateTime, timeZone, disambiguation));
 }
 
@@ -163,18 +163,13 @@ export function fromDateToLocal(date: Date): ZonedDateTime {
   return fromDate(date, getLocalTimeZone());
 }
 
-export function toCalendarDate(dateTime: CalendarDateTime): CalendarDate {
+export function toCalendarDate(dateTime: AnyCalendarDate): CalendarDate {
   return new CalendarDate(dateTime.calendar, dateTime.era, dateTime.year, dateTime.month, dateTime.day);
 }
 
-/* eslint-disable no-redeclare */
-export function toCalendarDateTime(date: ZonedDateTime, time?: Time): CalendarDateTime;
-export function toCalendarDateTime(date: CalendarDateTime, time?: Time): CalendarDateTime;
-export function toCalendarDateTime(date: CalendarDate, time?: Time): CalendarDateTime;
-export function toCalendarDateTime(date: CalendarDate | CalendarDateTime | ZonedDateTime, time?: Time) {
-/* eslint-enable no-redeclare */
+export function toCalendarDateTime(date: CalendarDate | CalendarDateTime | ZonedDateTime, time?: Time): CalendarDateTime {
   let hour = 0, minute = 0, second = 0, millisecond = 0;
-  if ('timeZone' in date && !time) {
+  if ('timeZone' in date) {
     ({hour, minute, second, millisecond} = date);
   } else if ('hour' in date && !time) {
     return date;
@@ -201,31 +196,22 @@ export function toTime(dateTime: CalendarDateTime): Time {
   return new Time(dateTime.hour, dateTime.minute, dateTime.second, dateTime.millisecond);
 }
 
-/* eslint-disable no-redeclare */
-export function toCalendar(date: ZonedDateTime, calendar: Calendar): ZonedDateTime;
-export function toCalendar(date: CalendarDateTime, calendar: Calendar): CalendarDateTime;
-export function toCalendar(date: CalendarDate, calendar: Calendar): CalendarDate;
-export function toCalendar(date: CalendarDate | CalendarDateTime | ZonedDateTime, calendar: Calendar) {
-/* eslint-enable no-redeclare */
+export function toCalendar<T extends AnyCalendarDate>(date: T, calendar: Calendar): T {
   if (date.calendar.identifier === calendar.identifier) {
     return date;
   }
 
   let calendarDate = calendar.fromJulianDay(date.calendar.toJulianDay(date));
-  if ('hour' in date) {
-    let copy: Mutable<CalendarDateTime> = date.copy();
-    copy.calendar = calendar;
-    copy.era = calendarDate.era;
-    copy.year = calendarDate.year;
-    copy.month = calendarDate.month;
-    copy.day = calendarDate.day;
-    return copy;
-  }
-
-  return calendarDate;
+  let copy: Mutable<T> = date.copy();
+  copy.calendar = calendar;
+  copy.era = calendarDate.era;
+  copy.year = calendarDate.year;
+  copy.month = calendarDate.month;
+  copy.day = calendarDate.day;
+  return copy;
 }
 
-export function toZoned(date: CalendarDate | CalendarDateTime, timeZone: string, disambiguation?: Disambiguation) {
+export function toZoned(date: CalendarDate | CalendarDateTime | ZonedDateTime, timeZone: string, disambiguation?: Disambiguation) {
   if (date instanceof ZonedDateTime) {
     if (date.timeZone === timeZone) {
       return date;

--- a/packages/@internationalized/date/src/conversion.ts
+++ b/packages/@internationalized/date/src/conversion.ts
@@ -13,7 +13,7 @@
 // Portions of the code in this file are based on code from the TC39 Temporal proposal.
 // Original licensing can be found in the NOTICE file in the root directory of this source tree.
 
-import {AnyCalendarDate, AnyDateTime, Calendar, Disambiguation} from './types';
+import {AnyCalendarDate, AnyDateTime, AnyTime, Calendar, DateFields, Disambiguation, TimeFields} from './types';
 import {CalendarDate, CalendarDateTime, Time, ZonedDateTime} from './CalendarDate';
 import {getLocalTimeZone} from './queries';
 import {GregorianCalendar} from './calendars/GregorianCalendar';
@@ -167,7 +167,25 @@ export function toCalendarDate(dateTime: AnyCalendarDate): CalendarDate {
   return new CalendarDate(dateTime.calendar, dateTime.era, dateTime.year, dateTime.month, dateTime.day);
 }
 
-export function toCalendarDateTime(date: CalendarDate | CalendarDateTime | ZonedDateTime, time?: Time): CalendarDateTime {
+export function toDateFields(date: AnyCalendarDate): DateFields {
+  return {
+    era: date.era,
+    year: date.year,
+    month: date.month,
+    day: date.day
+  };
+}
+
+export function toTimeFields(date: AnyTime): TimeFields {
+  return {
+    hour: date.hour,
+    minute: date.minute,
+    second: date.second,
+    millisecond: date.millisecond
+  };
+}
+
+export function toCalendarDateTime(date: CalendarDate | CalendarDateTime | ZonedDateTime, time?: AnyTime): CalendarDateTime {
   let hour = 0, minute = 0, second = 0, millisecond = 0;
   if ('timeZone' in date) {
     ({hour, minute, second, millisecond} = date);

--- a/packages/@internationalized/date/src/index.ts
+++ b/packages/@internationalized/date/src/index.ts
@@ -21,7 +21,6 @@ export {IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar} f
 export {HebrewCalendar} from './calendars/HebrewCalendar';
 export {EthiopicCalendar, EthiopicAmeteAlemCalendar, CopticCalendar} from './calendars/EthiopicCalendar';
 export {createCalendar} from './createCalendar';
-export * from './manipulation';
 export * from './conversion';
 export * from './queries';
 export * from './types';

--- a/packages/@internationalized/date/src/index.ts
+++ b/packages/@internationalized/date/src/index.ts
@@ -25,3 +25,4 @@ export * from './conversion';
 export * from './queries';
 export * from './types';
 export * from './string';
+export * from './DateFormatter';

--- a/packages/@internationalized/date/src/manipulation.ts
+++ b/packages/@internationalized/date/src/manipulation.ts
@@ -25,7 +25,7 @@ export function add(date: CalendarDate | CalendarDateTime, duration: Duration): 
 export function add(date: CalendarDate | CalendarDateTime, duration: Duration) {
 /* eslint-enable no-redeclare */
   let mutableDate: Mutable<AnyCalendarDate> = date.copy();
-  let days = addTimeFields(toCalendarDateTime(date), duration);
+  let days = 'hour' in date ? addTimeFields(date, duration) : 0;
 
   addYears(mutableDate, duration.years || 0);
   mutableDate.month += duration.months || 0;

--- a/packages/@internationalized/date/src/manipulation.ts
+++ b/packages/@internationalized/date/src/manipulation.ts
@@ -460,7 +460,15 @@ export function cycleZoned(dateTime: ZonedDateTime, field: DateField | TimeField
 export function setZoned(dateTime: ZonedDateTime, fields: DateFields & TimeFields, behavior?: OverflowBehavior, disambiguation?: Disambiguation): ZonedDateTime {
   // Set the date/time fields, and recompute the UTC offset to account for DST changes.
   // We also need to validate by converting back to a local time in case hours are skipped during forward DST transitions.
-  let res = setTime(set(toCalendarDateTime(dateTime), fields, behavior), fields, behavior);
+  let plainDateTime = toCalendarDateTime(dateTime);
+  let res = setTime(set(plainDateTime, fields, behavior), fields, behavior);
+
+  // If the resulting plain date time values are equal, return the original time.
+  // We don't want to change the offset when setting the time to the same value.
+  if (res.compare(plainDateTime) === 0) {
+    return dateTime;
+  }
+
   let ms = toAbsolute(res, dateTime.timeZone, disambiguation);
   return toCalendar(fromAbsolute(ms, dateTime.timeZone), dateTime.calendar);
 }

--- a/packages/@internationalized/date/src/queries.ts
+++ b/packages/@internationalized/date/src/queries.ts
@@ -81,6 +81,7 @@ export function getLocalTimeZone(): string {
 
 export function startOfMonth<T extends AnyCalendarDate>(date: T): T {
   let mutableDate: Mutable<T> = date.copy();
+  // TODO: should this use getMinimumDayInMonth? That breaks Calendar...
   mutableDate.day = 1;
   return mutableDate;
 }

--- a/packages/@internationalized/date/src/queries.ts
+++ b/packages/@internationalized/date/src/queries.ts
@@ -13,6 +13,7 @@
 import {AnyCalendarDate, AnyTime} from './types';
 import {CalendarDate, ZonedDateTime} from './CalendarDate';
 import {fromAbsolute, toAbsolute, toCalendar, toCalendarDate} from './conversion';
+import {Mutable} from './utils';
 
 export function isSameDay(a: AnyCalendarDate, b: AnyCalendarDate): boolean {
   b = toCalendar(b, a.calendar);
@@ -76,4 +77,32 @@ export function getHoursInDay(a: CalendarDate, timeZone: string): number {
 export function getLocalTimeZone(): string {
   // TODO: cache? but how to invalidate...
   return new Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+export function startOfMonth<T extends AnyCalendarDate>(date: T): T {
+  let mutableDate: Mutable<T> = date.copy();
+  mutableDate.day = 1;
+  return mutableDate;
+}
+
+export function endOfMonth<T extends AnyCalendarDate>(date: T): T {
+  let mutableDate: Mutable<T> = date.copy();
+  mutableDate.day = date.calendar.getDaysInMonth(date);
+  return mutableDate;
+}
+
+export function getMinimumMonthInYear(date: AnyCalendarDate) {
+  if (date.calendar.getMinimumMonthInYear) {
+    return date.calendar.getMinimumMonthInYear(date);
+  }
+
+  return 1;
+}
+
+export function getMinimumDayInMonth(date: AnyCalendarDate) {
+  if (date.calendar.getMinimumDayInMonth) {
+    return date.calendar.getMinimumDayInMonth(date);
+  }
+
+  return 1;
 }

--- a/packages/@internationalized/date/src/queries.ts
+++ b/packages/@internationalized/date/src/queries.ts
@@ -10,29 +10,30 @@
  * governing permissions and limitations under the License.
  */
 
-import {CalendarDate, CalendarDateTime, Time, ZonedDateTime} from './CalendarDate';
+import {AnyCalendarDate, AnyTime} from './types';
+import {CalendarDate, ZonedDateTime} from './CalendarDate';
 import {fromAbsolute, toAbsolute, toCalendar, toCalendarDate} from './conversion';
 
-export function isSameDay(a: CalendarDate, b: CalendarDate): boolean {
+export function isSameDay(a: AnyCalendarDate, b: AnyCalendarDate): boolean {
   b = toCalendar(b, a.calendar);
   return a.era === b.era && a.year === b.year && a.month === b.month && a.day === b.day;
 }
 
-export function isSameMonth(a: CalendarDate, b: CalendarDate): boolean {
+export function isSameMonth(a: AnyCalendarDate, b: AnyCalendarDate): boolean {
   b = toCalendar(b, a.calendar);
   return a.era === b.era && a.year === b.year && a.month === b.month;
 }
 
-export function isSameYear(a: CalendarDate, b: CalendarDate): boolean {
+export function isSameYear(a: AnyCalendarDate, b: AnyCalendarDate): boolean {
   b = toCalendar(b, a.calendar);
   return a.era === b.era && a.year === b.year;
 }
 
-export function isToday(date: CalendarDate, timeZone: string): boolean {
+export function isToday(date: AnyCalendarDate, timeZone: string): boolean {
   return isSameDay(date, today(timeZone));
 }
 
-export function getDayOfWeek(date: CalendarDate) {
+export function getDayOfWeek(date: AnyCalendarDate) {
   let julian = date.calendar.toJulianDay(date);
 
   // If julian is negative, then julian % 7 will be negative, so we adjust
@@ -53,15 +54,15 @@ export function today(timeZone: string): CalendarDate {
   return toCalendarDate(now(timeZone));
 }
 
-export function compareDate(a: CalendarDate, b: CalendarDate): number {
+export function compareDate(a: AnyCalendarDate, b: AnyCalendarDate): number {
   return a.calendar.toJulianDay(a) - b.calendar.toJulianDay(b);
 }
 
-export function compareTime(a: Time | CalendarDateTime, b: Time | CalendarDateTime): number {
+export function compareTime(a: AnyTime, b: AnyTime): number {
   return timeToMs(a) - timeToMs(b);
 }
 
-function timeToMs(a: Time | CalendarDateTime): number {
+function timeToMs(a: AnyTime): number {
   return a.hour * 60 * 60 * 1000 + a.minute * 60 * 1000 + a.second * 1000 + a.millisecond;
 }
 

--- a/packages/@internationalized/date/src/types.ts
+++ b/packages/@internationalized/date/src/types.ts
@@ -40,12 +40,15 @@ export interface Calendar {
   getDaysInMonth(date: AnyCalendarDate): number,
   getMonthsInYear(date: AnyCalendarDate): number,
   getYearsInEra(date: AnyCalendarDate): number,
-
   getEras(): string[],
 
+  getMinimumMonthInYear?(date: AnyCalendarDate): number,
+  getMinimumDayInMonth?(date: AnyCalendarDate): number,
+
   balanceDate?(date: AnyCalendarDate): void,
-  addYears?(date: AnyCalendarDate, years: number): void
-  constrainDate?(date: AnyCalendarDate): void,
+  addYears?(date: AnyCalendarDate, years: number): void,
+  add?(date: AnyCalendarDate, duration: Duration): CalendarDate,
+  constrainDate?(date: AnyCalendarDate): void
 }
 
 export interface Duration {

--- a/packages/@internationalized/date/src/types.ts
+++ b/packages/@internationalized/date/src/types.ts
@@ -12,20 +12,39 @@
 
 import {CalendarDate} from './CalendarDate';
 
+export interface AnyCalendarDate {
+  readonly calendar: Calendar,
+  readonly era: string,
+  readonly year: number,
+  readonly month: number,
+  readonly day: number,
+  copy(): this
+}
+
+export interface AnyTime {
+  readonly hour: number,
+  readonly minute: number,
+  readonly second: number,
+  readonly millisecond: number,
+  copy(): this
+}
+
+export interface AnyDateTime extends AnyCalendarDate, AnyTime {}
+
 export interface Calendar {
   identifier: string,
 
   fromJulianDay(jd: number): CalendarDate,
-  toJulianDay(date: CalendarDate): number,
+  toJulianDay(date: AnyCalendarDate): number,
 
-  getDaysInMonth(date: CalendarDate): number,
-  getMonthsInYear(date: CalendarDate): number,
-  getYearsInEra(date: CalendarDate): number,
+  getDaysInMonth(date: AnyCalendarDate): number,
+  getMonthsInYear(date: AnyCalendarDate): number,
+  getYearsInEra(date: AnyCalendarDate): number,
 
   getEras(): string[],
 
-  balanceDate?(date: CalendarDate): void,
-  addYears?(date: CalendarDate, years: number): void
+  balanceDate?(date: AnyCalendarDate): void,
+  addYears?(date: AnyCalendarDate, years: number): void
 }
 
 export interface Duration {

--- a/packages/@internationalized/date/src/types.ts
+++ b/packages/@internationalized/date/src/types.ts
@@ -45,6 +45,7 @@ export interface Calendar {
 
   balanceDate?(date: AnyCalendarDate): void,
   addYears?(date: AnyCalendarDate, years: number): void
+  constrainDate?(date: AnyCalendarDate): void,
 }
 
 export interface Duration {
@@ -75,7 +76,6 @@ export interface TimeFields {
 export type DateField = keyof DateFields;
 export type TimeField = keyof TimeFields;
 
-export type OverflowBehavior = 'balance' | 'constrain';
 export type Disambiguation = 'compatible' | 'earlier' | 'later' | 'reject';
 
 export interface CycleOptions {

--- a/packages/@internationalized/date/tests/DateFormatter.test.js
+++ b/packages/@internationalized/date/tests/DateFormatter.test.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {DateFormatter} from '..';
+
+describe('DateFormatter', function () {
+  beforeAll(function () {
+    // Mock to ensure buggy WebKit behavior
+    let resolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+    jest.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockImplementation(function () {
+      let s = resolvedOptions.call(this);
+      if (s.locale === 'fr' && s.hour12 === false) {
+        s.hour12 = true;
+        s.hourCycle = 'h12';
+      }
+      return s;
+    });
+  });
+
+  it('should format a basic date', function () {
+    let formatter = new DateFormatter('en-US');
+    expect(formatter.format(new Date(2020, 1, 3))).toBe('2/3/2020');
+  });
+
+  it('should format to parts', function () {
+    let formatter = new DateFormatter('en-US');
+    expect(formatter.formatToParts(new Date(2020, 1, 3))).toEqual([
+      {type: 'month', value: '2'},
+      {type: 'literal', value: '/'},
+      {type: 'day', value: '3'},
+      {type: 'literal', value: '/'},
+      {type: 'year', value: '2020'}
+    ]);
+  });
+
+  it('should format a range', function () {
+    let formatter = new DateFormatter('en-US');
+    // Test fallback
+    formatter.formatter.formatRange = null;
+    expect(formatter.formatRange(new Date(2020, 1, 3), new Date(2020, 1, 5))).toBe('2/3/2020 – 2/5/2020');
+  });
+
+  it('should format a range to parts', function () {
+    let formatter = new DateFormatter('en-US');
+    // Test fallback
+    formatter.formatter.formatRangeToParts = null;
+    expect(formatter.formatRangeToParts(new Date(2020, 1, 3), new Date(2020, 1, 5))).toEqual([
+      {type: 'month', value: '2', source: 'startRange'},
+      {type: 'literal', value: '/', source: 'startRange'},
+      {type: 'day', value: '3', source: 'startRange'},
+      {type: 'literal', value: '/', source: 'startRange'},
+      {type: 'year', value: '2020', source: 'startRange'},
+      {type: 'literal', value: ' – ', source: 'shared'},
+      {type: 'month', value: '2', source: 'endRange'},
+      {type: 'literal', value: '/', source: 'endRange'},
+      {type: 'day', value: '5', source: 'endRange'},
+      {type: 'literal', value: '/', source: 'endRange'},
+      {type: 'year', value: '2020', source: 'endRange'}
+    ]);
+  });
+
+  it('should work around buggy hour12 behavior', function () {
+    let formatter = new DateFormatter('en-US', {timeStyle: 'short', hour12: false});
+    expect(formatter.format(new Date(2020, 1, 3, 0))).toBe('00:00');
+    expect(formatter.resolvedOptions().hourCycle).toBe('h23');
+
+    formatter = new DateFormatter('fr-CA', {hour: 'numeric', hour12: true});
+    expect(formatter.format(new Date(2020, 1, 3, 0))).toBe('12 h a.m.');
+    expect(formatter.resolvedOptions().hourCycle).toBe('h12');
+
+    formatter = new DateFormatter('ja', {hour: 'numeric', hour12: true});
+    expect(formatter.format(new Date(2020, 1, 3, 0))).toBe('午前0時');
+    expect(formatter.resolvedOptions().hourCycle).toBe('h11');
+  });
+
+  it('should work around buggy resolved hour cycle', function () {
+    let formatter = new DateFormatter('fr', {hour: 'numeric', hour12: false});
+    expect(formatter.resolvedOptions().hour12).toBe(false);
+    expect(formatter.resolvedOptions().hourCycle).toBe('h23');
+  });
+});

--- a/packages/@internationalized/date/tests/ZonedDateTime.test.js
+++ b/packages/@internationalized/date/tests/ZonedDateTime.test.js
@@ -238,5 +238,10 @@ describe('ZonedDateTime', function () {
       expect(zoned.offset).not.toBe(expected.offset);
       expect(zoned.set({month: 3})).toEqual(expected);
     });
+
+    it('should preserve the offset if setting identical fields', function () {
+      let zoned = toZoned(new CalendarDateTime(2021, 11, 7, 1), 'America/Los_Angeles', 'later');
+      expect(zoned.set({hour: 1})).toBe(zoned);
+    });
   });
 });

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -338,11 +338,20 @@ describe('CalendarDate manipulation', function () {
         let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 30, 4, 30);
         expect(date.set({year: 35})).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30));
 
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 6);
+        expect(date.set({year: 72})).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 6));
+
         date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 2, 30);
         expect(date.set({month: 5})).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30));
 
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 30);
+        expect(date.set({month: 5})).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 30));
+
         date = new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 6);
         expect(date.set({day: 8})).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 7));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 30);
+        expect(date.set({day: 5})).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 25));
       });
     });
 
@@ -350,6 +359,117 @@ describe('CalendarDate manipulation', function () {
       it('should constrain year in era', function () {
         let date = new CalendarDate(new TaiwanCalendar(), 'before_minguo', 5, 4, 30);
         expect(date.set({year: -2})).toEqual(new CalendarDate(new TaiwanCalendar(), 'before_minguo', 1, 4, 30));
+      });
+    });
+  });
+
+  describe('cycle', function () {
+    describe('era', function () {
+      it('should cycle the era', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 10, 4, 30);
+        expect(date.cycle('era', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 10, 4, 30));
+        expect(date.cycle('era', -1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 10, 4, 30));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 10, 4, 30);
+        expect(date.cycle('era', 2)).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 10, 4, 30));
+        expect(date.cycle('era', 3)).toEqual(new CalendarDate(new JapaneseCalendar(), 'meiji', 10, 4, 30));
+      });
+
+      it('should constrain the date within the era', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 6);
+        expect(date.cycle('era', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 1, 6));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 63, 7, 6);
+        expect(date.cycle('era', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 6));
+      });
+    });
+
+    describe('year', function () {
+      it('should cycle the year', function () {
+        let date = new CalendarDate(2020, 9, 3);
+        expect(date.cycle('year', 1)).toEqual(new CalendarDate(2021, 9, 3));
+        expect(date.cycle('year', -1)).toEqual(new CalendarDate(2019, 9, 3));
+        expect(date.cycle('year', 5)).toEqual(new CalendarDate(2025, 9, 3));
+        expect(date.cycle('year', -5)).toEqual(new CalendarDate(2015, 9, 3));
+      });
+
+      it('should cycle the year with rounding', function () {
+        let date = new CalendarDate(2019, 9, 3);
+        expect(date.cycle('year', 5, {round: true})).toEqual(new CalendarDate(2020, 9, 3));
+        expect(date.cycle('year', -5, {round: true})).toEqual(new CalendarDate(2015, 9, 3));
+      });
+
+      it('should constrain the day on leap years', function () {
+        let date = new CalendarDate(2020, 2, 29);
+        expect(date.cycle('year', 1)).toEqual(new CalendarDate(2021, 2, 28));
+      });
+
+      it('should constrain the year within the era', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30);
+        expect(date.cycle('year', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 1, 4, 30));
+        expect(date.cycle('year', 5)).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 5, 4, 30));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 2, 8, 5);
+        expect(date.cycle('year', -1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 25));
+      });
+    });
+
+    describe('month', function () {
+      it('should cycle the month', function () {
+        let date = new CalendarDate(2020, 9, 3);
+        expect(date.cycle('month', 1)).toEqual(new CalendarDate(2020, 10, 3));
+        expect(date.cycle('month', -1)).toEqual(new CalendarDate(2020, 8, 3));
+        expect(date.cycle('month', 4)).toEqual(new CalendarDate(2020, 1, 3));
+        expect(date.cycle('month', -10)).toEqual(new CalendarDate(2020, 11, 3));
+      });
+
+      it('should cycle the month with rounding', function () {
+        let date = new CalendarDate(2020, 8, 3);
+        expect(date.cycle('month', 5, {round: true})).toEqual(new CalendarDate(2020, 10, 3));
+        expect(date.cycle('month', -5, {round: true})).toEqual(new CalendarDate(2020, 5, 3));
+      });
+
+      it('should constrain the day', function () {
+        let date = new CalendarDate(2020, 1, 31);
+        expect(date.cycle('month', 1)).toEqual(new CalendarDate(2020, 2, 29));
+
+        date = new CalendarDate(2021, 1, 31);
+        expect(date.cycle('month', 1)).toEqual(new CalendarDate(2021, 2, 28));
+      });
+
+      it('should constrain the month within the era', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30);
+        expect(date.cycle('month', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 1, 30));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 1, 30);
+        expect(date.cycle('month', -1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 25);
+        expect(date.cycle('month', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 25));
+      });
+    });
+
+    describe('day', function () {
+      it('should cycle the day', function () {
+        let date = new CalendarDate(2020, 9, 3);
+        expect(date.cycle('day', 1)).toEqual(new CalendarDate(2020, 9, 4));
+        expect(date.cycle('day', -1)).toEqual(new CalendarDate(2020, 9, 2));
+        expect(date.cycle('day', 28)).toEqual(new CalendarDate(2020, 9, 1));
+        expect(date.cycle('day', -4)).toEqual(new CalendarDate(2020, 9, 29));
+      });
+
+      it('should cycle the day with rounding', function () {
+        let date = new CalendarDate(2020, 8, 3);
+        expect(date.cycle('day', 5, {round: true})).toEqual(new CalendarDate(2020, 8, 5));
+        expect(date.cycle('day', -5, {round: true})).toEqual(new CalendarDate(2020, 8, 1));
+      });
+
+      it('should constrain the day within the era', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 7);
+        expect(date.cycle('day', 1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 1));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 25);
+        expect(date.cycle('day', -1)).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 31));
       });
     });
   });

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -289,24 +289,14 @@ describe('CalendarDate manipulation', function () {
       expect(date.set({month: 5})).toEqual(new CalendarDate(2020, 5, 3));
     });
 
-    it('should balance month', function () {
-      let date = new CalendarDate(2020, 2, 3);
-      expect(date.set({month: 13})).toEqual(new CalendarDate(2021, 1, 3));
-    });
-
     it('should constrain month', function () {
       let date = new CalendarDate(2020, 2, 3);
-      expect(date.set({month: 13}, 'constrain')).toEqual(new CalendarDate(2020, 12, 3));
-    });
-
-    it('should set month and balance day', function () {
-      let date = new CalendarDate(2020, 2, 31);
-      expect(date.set({month: 9})).toEqual(new CalendarDate(2020, 10, 1));
+      expect(date.set({month: 13})).toEqual(new CalendarDate(2020, 12, 3));
     });
 
     it('should set month and constrain day', function () {
       let date = new CalendarDate(2020, 2, 31);
-      expect(date.set({month: 9}, 'constrain')).toEqual(new CalendarDate(2020, 9, 30));
+      expect(date.set({month: 9})).toEqual(new CalendarDate(2020, 9, 30));
     });
 
     it('should set day', function () {
@@ -314,43 +304,36 @@ describe('CalendarDate manipulation', function () {
       expect(date.set({day: 9})).toEqual(new CalendarDate(2020, 2, 9));
     });
 
-    it('should balance day', function () {
-      let date = new CalendarDate(2020, 9, 3);
-      expect(date.set({day: 31})).toEqual(new CalendarDate(2020, 10, 1));
-    });
-
     it('should constrain day', function () {
       let date = new CalendarDate(2020, 9, 3);
-      expect(date.set({day: 31}, 'constrain')).toEqual(new CalendarDate(2020, 9, 30));
-    });
-
-    it('should balance day on leap years', function () {
-      let date = new CalendarDate(2020, 2, 3);
-      expect(date.set({day: 31})).toEqual(new CalendarDate(2020, 3, 2));
-
-      date = new CalendarDate(2019, 2, 3);
-      expect(date.set({day: 31})).toEqual(new CalendarDate(2019, 3, 3));
+      expect(date.set({day: 31})).toEqual(new CalendarDate(2020, 9, 30));
     });
 
     it('should constrain day on leap years', function () {
       let date = new CalendarDate(2020, 2, 3);
-      expect(date.set({day: 31}, 'constrain')).toEqual(new CalendarDate(2020, 2, 29));
+      expect(date.set({day: 31})).toEqual(new CalendarDate(2020, 2, 29));
 
       date = new CalendarDate(2019, 2, 3);
-      expect(date.set({day: 31}, 'constrain')).toEqual(new CalendarDate(2019, 2, 28));
+      expect(date.set({day: 31})).toEqual(new CalendarDate(2019, 2, 28));
     });
 
     describe('Japanese calendar', function () {
-      it('should rebalance era', function () {
-        let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30);
-        expect(date.set({month: 5})).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 1, 5, 30));
+      it('should constrain date in era', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 30, 4, 30);
+        expect(date.set({year: 35})).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 2, 30);
+        expect(date.set({month: 5})).toEqual(new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 6);
+        expect(date.set({day: 8})).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 63, 1, 7));
       });
     });
 
     describe('Taiwan calendar', function () {
-      it('should rebalance era', function () {
+      it('should constrain year in era', function () {
         let date = new CalendarDate(new TaiwanCalendar(), 'before_minguo', 5, 4, 30);
-        expect(date.set({year: -2})).toEqual(new CalendarDate(new TaiwanCalendar(), 'minguo', 3, 4, 30));
+        expect(date.set({year: -2})).toEqual(new CalendarDate(new TaiwanCalendar(), 'before_minguo', 1, 4, 30));
       });
     });
   });

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -85,6 +85,14 @@ describe('CalendarDate manipulation', function () {
       expect(date.add({years: 2, months: 3, days: 10})).toEqual(new CalendarDate(2023, 2, 4));
     });
 
+    it('should ignore time when adding to a date', function () {
+      let date = new CalendarDate(2020, 10, 25);
+      expect(date.add({hours: 36})).toEqual(date);
+      expect(date.add({minutes: 500})).toEqual(date);
+      expect(date.add({seconds: 5000000})).toEqual(date);
+      expect(date.add({milliseconds: 50000000000})).toEqual(date);
+    });
+
     describe('Japanese calendar', function () {
       it('should add years and rebalance era', function () {
         let date = new CalendarDate(new JapaneseCalendar(), 'heisei', 31, 4, 30);
@@ -213,6 +221,14 @@ describe('CalendarDate manipulation', function () {
     it('should subtract weeks', function () {
       let date = new CalendarDate(2020, 10, 6);
       expect(date.subtract({weeks: 5})).toEqual(new CalendarDate(2020, 9, 1));
+    });
+
+    it('should ignore time when subtracting from a date', function () {
+      let date = new CalendarDate(2020, 10, 25);
+      expect(date.subtract({hours: 36})).toEqual(date);
+      expect(date.subtract({minutes: 500})).toEqual(date);
+      expect(date.subtract({seconds: 5000000})).toEqual(date);
+      expect(date.subtract({milliseconds: 50000000000})).toEqual(date);
     });
 
     describe('Japanese calendar', function () {

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {CalendarDate, endOfMonth, getMinimumDayInMonth, getMinimumMonthInYear, IslamicUmalquraCalendar, isSameDay, isSameMonth, isSameYear, JapaneseCalendar, startOfMonth} from '..';
+
+describe('queries', function () {
+  describe('isSameDay', function () {
+    it('works with two dates in the same calendar', function () {
+      expect(isSameDay(new CalendarDate(2020, 2, 3), new CalendarDate(2020, 2, 3))).toBe(true);
+      expect(isSameDay(new CalendarDate(2019, 2, 3), new CalendarDate(2020, 2, 3))).toBe(false);
+      expect(isSameDay(new CalendarDate(2020, 3, 3), new CalendarDate(2020, 2, 3))).toBe(false);
+      expect(isSameDay(new CalendarDate(2020, 2, 4), new CalendarDate(2020, 2, 3))).toBe(false);
+    });
+
+    it('works with two dates in different calendars', function () {
+      expect(isSameDay(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(true);
+      expect(isSameDay(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4), new CalendarDate(2021, 4, 16))).toBe(true);
+      expect(isSameDay(new CalendarDate(2019, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
+      expect(isSameDay(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1441, 9, 4))).toBe(false);
+      expect(isSameDay(new CalendarDate(2021, 5, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
+      expect(isSameDay(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 10, 4))).toBe(false);
+      expect(isSameDay(new CalendarDate(2021, 4, 17), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
+      expect(isSameDay(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 3))).toBe(false);
+    });
+  });
+
+  describe('isSameMonth', function () {
+    it('works with two dates in the same calendar', function () {
+      expect(isSameMonth(new CalendarDate(2020, 2, 3), new CalendarDate(2020, 2, 3))).toBe(true);
+      expect(isSameMonth(new CalendarDate(2019, 2, 3), new CalendarDate(2020, 2, 3))).toBe(false);
+      expect(isSameMonth(new CalendarDate(2020, 3, 3), new CalendarDate(2020, 2, 3))).toBe(false);
+      expect(isSameMonth(new CalendarDate(2020, 2, 4), new CalendarDate(2020, 2, 3))).toBe(true);
+    });
+
+    it('works with two dates in different calendars', function () {
+      expect(isSameMonth(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(true);
+      expect(isSameMonth(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4), new CalendarDate(2021, 4, 16))).toBe(true);
+      expect(isSameMonth(new CalendarDate(2019, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
+      expect(isSameMonth(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1441, 9, 4))).toBe(false);
+      expect(isSameMonth(new CalendarDate(2021, 5, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
+      expect(isSameMonth(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 10, 4))).toBe(false);
+      expect(isSameMonth(new CalendarDate(2021, 4, 17), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(true);
+      expect(isSameMonth(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 3))).toBe(true);
+    });
+  });
+
+  describe('isSameYear', function () {
+    it('works with two dates in the same calendar', function () {
+      expect(isSameYear(new CalendarDate(2020, 2, 3), new CalendarDate(2020, 2, 3))).toBe(true);
+      expect(isSameYear(new CalendarDate(2019, 2, 3), new CalendarDate(2020, 2, 3))).toBe(false);
+      expect(isSameYear(new CalendarDate(2020, 3, 3), new CalendarDate(2020, 2, 3))).toBe(true);
+      expect(isSameYear(new CalendarDate(2020, 2, 4), new CalendarDate(2020, 2, 3))).toBe(true);
+    });
+
+    it('works with two dates in different calendars', function () {
+      expect(isSameYear(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(true);
+      expect(isSameYear(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4), new CalendarDate(2021, 4, 16))).toBe(true);
+      expect(isSameYear(new CalendarDate(2019, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
+      expect(isSameYear(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1441, 9, 4))).toBe(false);
+      expect(isSameYear(new CalendarDate(2021, 5, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(true);
+      expect(isSameYear(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 10, 4))).toBe(true);
+      expect(isSameYear(new CalendarDate(2021, 4, 17), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(true);
+      expect(isSameYear(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 3))).toBe(true);
+    });
+  });
+
+  describe('startOfMonth', function () {
+    it('moves the day to the first of the month', function () {
+      expect(startOfMonth(new CalendarDate(2020, 2, 3))).toEqual(new CalendarDate(2020, 2, 1));
+      expect(startOfMonth(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toEqual(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 1));
+    });
+  });
+
+  describe('endOfMonth', function () {
+    it('moves the day to the last day of the month', function () {
+      expect(endOfMonth(new CalendarDate(2020, 2, 3))).toEqual(new CalendarDate(2020, 2, 29));
+      expect(endOfMonth(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toEqual(new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 30));
+    });
+  });
+
+  describe('getMinimumMonthInYear', function () {
+    it('returns the minimum month of the year', function () {
+      expect(getMinimumMonthInYear(new CalendarDate(2020, 2, 3))).toBe(1);
+    });
+
+    it('returns the minimum month of the year in japanese eras', function () {
+      expect(getMinimumMonthInYear(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 30))).toBe(12);
+      expect(getMinimumMonthInYear(new CalendarDate(new JapaneseCalendar(), 'showa', 2, 12, 30))).toBe(1);
+    });
+  });
+
+  describe('getMinimumDayInMonth', function () {
+    it('returns the minimum day in a month', function () {
+      expect(getMinimumDayInMonth(new CalendarDate(2020, 2, 3))).toBe(1);
+    });
+
+    it('returns the minimum day in a month in japanese eras', function () {
+      expect(getMinimumDayInMonth(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 30))).toBe(25);
+      expect(getMinimumDayInMonth(new CalendarDate(new JapaneseCalendar(), 'showa', 2, 12, 30))).toBe(1);
+    });
+  });
+});

--- a/packages/@react-aria/calendar/src/useCalendar.ts
+++ b/packages/@react-aria/calendar/src/useCalendar.ts
@@ -11,20 +11,19 @@
  */
 
 import {CalendarAria} from './types';
-import {CalendarProps} from '@react-types/calendar';
+import {CalendarProps, DateValue} from '@react-types/calendar';
 import {CalendarState} from '@react-stately/calendar';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {toDate} from '@internationalized/date';
 import {useCalendarBase} from './useCalendarBase';
 import {useMemo} from 'react';
 import {useMessageFormatter} from '@react-aria/i18n';
 
-export function useCalendar(props: CalendarProps, state: CalendarState): CalendarAria {
+export function useCalendar<T extends DateValue>(props: CalendarProps<T>, state: CalendarState): CalendarAria {
   // Compute localized message for the selected date
   let formatMessage = useMessageFormatter(intlMessages);
   let selectedDateDescription = useMemo(
-    () => state.value ? formatMessage('selectedDateDescription', {date: toDate(state.value, state.timeZone)}) : '',
+    () => state.value ? formatMessage('selectedDateDescription', {date: state.value.toDate(state.timeZone)}) : '',
     [formatMessage, state.value, state.timeZone]
   );
 

--- a/packages/@react-aria/calendar/src/useCalendarBase.ts
+++ b/packages/@react-aria/calendar/src/useCalendarBase.ts
@@ -19,7 +19,6 @@ import {filterDOMProps, mergeProps, useId, useLabels, useUpdateEffect} from '@re
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {KeyboardEvent, useRef} from 'react';
-import {toDate} from '@internationalized/date';
 import {useDateFormatter, useLocale, useMessageFormatter} from '@react-aria/i18n';
 
 export function useCalendarBase(props: CalendarPropsBase & DOMProps, state: CalendarStateBase, selectedDateDescription: string): CalendarAria {
@@ -41,7 +40,7 @@ export function useCalendarBase(props: CalendarPropsBase & DOMProps, state: Cale
   useUpdateEffect(() => {
     // announce the new month with a change from the Previous or Next button
     if (!state.isFocused) {
-      announce(monthFormatter.format(toDate(state.currentMonth, state.timeZone)));
+      announce(monthFormatter.format(state.currentMonth.toDate(state.timeZone)));
     }
     // handle an update to the current month from the Previous or Next button
     // rather than move focus, we announce the new month value

--- a/packages/@react-aria/calendar/src/useCalendarCell.ts
+++ b/packages/@react-aria/calendar/src/useCalendarCell.ts
@@ -15,7 +15,7 @@ import {CalendarState, RangeCalendarState} from '@react-stately/calendar';
 import {HTMLAttributes, RefObject, useEffect} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {PressProps, usePress} from '@react-aria/interactions';
+import {PressProps, useHover, usePress} from '@react-aria/interactions';
 import {useDateFormatter, useMessageFormatter} from '@react-aria/i18n';
 
 export interface AriaCalendarCellProps {
@@ -78,19 +78,31 @@ export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarSta
   }
 
   let {pressProps} = usePress({
-    onPress: () => {
+    onPress: (e) => {
       if (!isDisabled) {
         state.selectDate(date);
-        state.setFocusedDate(date);
+
+        // For range selection, auto-advance the focused date by one if the pointer type is keyboard or touch.
+        // This gives an indication that you're selecting a range rather than a single date.
+        // For mouse, this is unnecessary because users will see the indication on hover. For screen readers,
+        // there will be an announcement to "click to finish selecting range" (above).
+        if ((e.pointerType === 'keyboard' || e.pointerType === 'touch') && 'anchorDate' in state && !state.anchorDate) {
+          state.setFocusedDate(date.add({days: 1}));
+        } else {
+          state.setFocusedDate(date);
+        }
       }
     }
   });
 
-  let onMouseEnter = () => {
-    if ('highlightDate' in state) {
-      state.highlightDate(date);
+  let {hoverProps} = useHover({
+    isDisabled,
+    onHoverStart() {
+      if ('highlightDate' in state) {
+        state.highlightDate(date);
+      }
     }
-  };
+  });
 
   let tabIndex = null;
   if (!isDisabled) {
@@ -106,7 +118,7 @@ export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarSta
 
   return {
     cellProps: {
-      onMouseEnter: isDisabled ? null : onMouseEnter,
+      ...hoverProps,
       role: 'gridcell',
       'aria-colindex': colIndex,
       'aria-disabled': isDisabled || null,

--- a/packages/@react-aria/calendar/src/useCalendarCell.ts
+++ b/packages/@react-aria/calendar/src/useCalendarCell.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {CalendarDate, isSameDay, isToday, toDate} from '@internationalized/date';
+import {CalendarDate, isSameDay, isToday} from '@internationalized/date';
 import {CalendarState, RangeCalendarState} from '@react-stately/calendar';
 import {HTMLAttributes, RefObject, useEffect} from 'react';
 // @ts-ignore
@@ -44,7 +44,7 @@ export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarSta
   let isDisabled = state.isCellDisabled(date);
 
   // aria-label should be localize Day of week, Month, Day and Year without Time.
-  let nativeDate = toDate(date, state.timeZone);
+  let nativeDate = date.toDate(state.timeZone);
   let label = dateFormatter.format(nativeDate);
   if (isToday(date, state.timeZone)) {
     // If date is today, set appropriate string depending on selected state:

--- a/packages/@react-aria/calendar/src/useRangeCalendar.ts
+++ b/packages/@react-aria/calendar/src/useRangeCalendar.ts
@@ -11,17 +11,17 @@
  */
 
 import {CalendarAria} from './types';
+import {DateValue, RangeCalendarProps} from '@react-types/calendar';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {isSameDay, toDate} from '@internationalized/date';
+import {isSameDay} from '@internationalized/date';
 import {mergeProps} from '@react-aria/utils';
-import {RangeCalendarProps} from '@react-types/calendar';
 import {RangeCalendarState} from '@react-stately/calendar';
 import {useCalendarBase} from './useCalendarBase';
 import {useMemo} from 'react';
 import {useMessageFormatter} from '@react-aria/i18n';
 
-export function useRangeCalendar(props: RangeCalendarProps, state: RangeCalendarState): CalendarAria {
+export function useRangeCalendar<T extends DateValue>(props: RangeCalendarProps<T>, state: RangeCalendarState): CalendarAria {
   // Compute localized message for the selected date or range
   let formatMessage = useMessageFormatter(intlMessages);
   let {start, end} = state.highlightedRange || {start: null, end: null};
@@ -31,9 +31,9 @@ export function useRangeCalendar(props: RangeCalendarProps, state: RangeCalendar
       // Use a single date message if the start and end dates are the same day,
       // otherwise include both dates.
       if (isSameDay(start, end)) {
-        return formatMessage('selectedDateDescription', {date: toDate(start, state.timeZone)});
+        return formatMessage('selectedDateDescription', {date: start.toDate(state.timeZone)});
       } else {
-        return formatMessage('selectedRangeDescription', {start: toDate(start, state.timeZone), end: toDate(end, state.timeZone)});
+        return formatMessage('selectedRangeDescription', {start: start.toDate(state.timeZone), end: end.toDate(state.timeZone)});
       }
     }
     return '';

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaDatePickerProps} from '@react-types/datepicker';
+import {AriaDatePickerProps, DateValue} from '@react-types/datepicker';
 import {createFocusManager} from '@react-aria/focus';
 import {DatePickerFieldState} from '@react-stately/datepicker';
 import {HTMLAttributes, LabelHTMLAttributes, RefObject} from 'react';
@@ -26,7 +26,7 @@ interface DateFieldAria {
 
 export const labelIds = new WeakMap<DatePickerFieldState, string>();
 
-export function useDateField(props: AriaDatePickerProps, state: DatePickerFieldState, ref: RefObject<HTMLElement>): DateFieldAria {
+export function useDateField<T extends DateValue>(props: AriaDatePickerProps<T>, state: DatePickerFieldState, ref: RefObject<HTMLElement>): DateFieldAria {
   let {labelProps, fieldProps} = useLabel({
     ...props,
     labelElementType: 'span'

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
-import {AriaDatePickerProps} from '@react-types/datepicker';
+import {AriaDatePickerProps, DateValue} from '@react-types/datepicker';
 import {AriaDialogProps} from '@react-types/dialog';
 import {createFocusManager} from '@react-aria/focus';
 import {DatePickerState} from '@react-stately/datepicker';
@@ -22,15 +22,15 @@ import {mergeProps, useDescription, useId} from '@react-aria/utils';
 import {useLabel} from '@react-aria/label';
 import {useLocale, useMessageFormatter} from '@react-aria/i18n';
 
-interface DatePickerAria {
+interface DatePickerAria<T extends DateValue> {
   groupProps: HTMLAttributes<HTMLElement>,
   labelProps: LabelHTMLAttributes<HTMLLabelElement>,
-  fieldProps: AriaDatePickerProps,
+  fieldProps: AriaDatePickerProps<T>,
   buttonProps: AriaButtonProps,
   dialogProps: AriaDialogProps
 }
 
-export function useDatePicker(props: AriaDatePickerProps, state: DatePickerState, ref: RefObject<HTMLElement>): DatePickerAria {
+export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>, state: DatePickerState, ref: RefObject<HTMLElement>): DatePickerAria<T> {
   let buttonId = useId();
   let dialogId = useId();
   let formatMessage = useMessageFormatter(intlMessages);

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -52,7 +52,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
   let labelledBy = fieldProps['aria-labelledby'] || fieldProps.id;
 
   let {locale} = useLocale();
-  let descriptionProps = useDescription(state.dateValue ? state.formatValue(locale, {month: 'long'}) : null);
+  let descriptionProps = useDescription(state.formatValue(locale, {month: 'long'}));
 
   return {
     groupProps: mergeProps(descriptionProps, {

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
-import {AriaDatePickerProps, AriaDateRangePickerProps} from '@react-types/datepicker';
+import {AriaDatePickerProps, AriaDateRangePickerProps, DateValue} from '@react-types/datepicker';
 import {AriaDialogProps} from '@react-types/dialog';
 import {createFocusManager} from '@react-aria/focus';
 import {DateRangePickerState} from '@react-stately/datepicker';
@@ -23,16 +23,16 @@ import {mergeProps, useDescription, useId, useLabels} from '@react-aria/utils';
 import {useLabel} from '@react-aria/label';
 import {useLocale, useMessageFormatter} from '@react-aria/i18n';
 
-interface DateRangePickerAria {
+interface DateRangePickerAria<T extends DateValue> {
   labelProps: LabelHTMLAttributes<HTMLLabelElement>,
   groupProps: HTMLAttributes<HTMLElement>,
-  startFieldProps: AriaDatePickerProps,
-  endFieldProps: AriaDatePickerProps,
+  startFieldProps: AriaDatePickerProps<T>,
+  endFieldProps: AriaDatePickerProps<T>,
   buttonProps: AriaButtonProps,
   dialogProps:  AriaDialogProps
 }
 
-export function useDateRangePicker(props: AriaDateRangePickerProps, state: DateRangePickerState, ref: RefObject<HTMLElement>): DateRangePickerAria {
+export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePickerProps<T>, state: DateRangePickerState, ref: RefObject<HTMLElement>): DateRangePickerAria<T> {
   let formatMessage = useMessageFormatter(intlMessages);
   let {labelProps, fieldProps} = useLabel({
     ...props,

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -11,7 +11,7 @@
  */
 
 import {DatePickerFieldState, DateSegment} from '@react-stately/datepicker';
-import {DatePickerProps} from '@react-types/datepicker';
+import {DatePickerProps, DateValue} from '@react-types/datepicker';
 import {DOMProps} from '@react-types/shared';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -28,7 +28,7 @@ interface DateSegmentAria {
   segmentProps: HTMLAttributes<HTMLDivElement>
 }
 
-export function useDateSegment(props: DatePickerProps & DOMProps, segment: DateSegment, state: DatePickerFieldState, ref: RefObject<HTMLElement>): DateSegmentAria {
+export function useDateSegment<T extends DateValue>(props: DatePickerProps<T> & DOMProps, segment: DateSegment, state: DatePickerFieldState, ref: RefObject<HTMLElement>): DateSegmentAria {
   let enteredKeys = useRef('');
   let {locale, direction} = useLocale();
   let messageFormatter = useMessageFormatter(intlMessages);

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -38,6 +38,7 @@
     "@react-aria/focus": "^3.1.0",
     "@react-aria/i18n": "^3.1.0",
     "@react-aria/interactions": "^3.1.0",
+    "@react-aria/utils": "^3.8.2",
     "@react-aria/visually-hidden": "^3.1.0",
     "@react-spectrum/button": "^3.1.0",
     "@react-spectrum/utils": "^3.1.0",

--- a/packages/@react-spectrum/calendar/src/Calendar.tsx
+++ b/packages/@react-spectrum/calendar/src/Calendar.tsx
@@ -12,12 +12,12 @@
 
 import {CalendarBase} from './CalendarBase';
 import {createCalendar} from '@internationalized/date';
+import {DateValue, SpectrumCalendarProps} from '@react-types/calendar';
 import React from 'react';
-import {SpectrumCalendarProps} from '@react-types/calendar';
 import {useCalendar} from '@react-aria/calendar';
 import {useCalendarState} from '@react-stately/calendar';
 
-export function Calendar(props: SpectrumCalendarProps) {
+export function Calendar<T extends DateValue>(props: SpectrumCalendarProps<T>) {
   let state = useCalendarState({
     ...props,
     createCalendar

--- a/packages/@react-spectrum/calendar/src/CalendarCell.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarCell.tsx
@@ -14,9 +14,11 @@ import {AriaCalendarCellProps, useCalendarCell} from '@react-aria/calendar';
 import {CalendarState, RangeCalendarState} from '@react-stately/calendar';
 import {classNames} from '@react-spectrum/utils';
 import {getDayOfWeek, isSameDay, isSameMonth, isToday, toDate} from '@internationalized/date';
+import {mergeProps} from '@react-aria/utils';
 import React, {useRef} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/calendar/vars.css';
 import {useDateFormatter} from '@react-aria/i18n';
+import {useFocusRing} from '@react-aria/focus';
 import {useHover} from '@react-aria/interactions';
 
 interface CalendarCellProps extends AriaCalendarCellProps {
@@ -39,19 +41,19 @@ export function CalendarCell({state, ...props}: CalendarCellProps) {
   let dayOfWeek = getDayOfWeek(props.date);
   let isRangeStart = isSelected && (dayOfWeek === 0 || props.date.day === 1);
   let isRangeEnd = isSelected && (dayOfWeek === 6 || props.date.day === state.daysInMonth);
+  let {focusProps, isFocusVisible} = useFocusRing();
 
   return (
     <td
       {...cellProps}
       className={classNames(styles, 'spectrum-Calendar-tableCell')}>
       <span
-        {...buttonProps}
-        {...hoverProps}
+        {...mergeProps(buttonProps, hoverProps, focusProps)}
         ref={ref}
         className={classNames(styles, 'spectrum-Calendar-date', {
           'is-today': isToday(props.date, state.timeZone),
           'is-selected': isSelected,
-          'is-focused': state.isCellFocused(props.date),
+          'is-focused': state.isCellFocused(props.date) && isFocusVisible,
           'is-disabled': state.isCellDisabled(props.date),
           'is-outsideMonth': !isSameMonth(props.date, state.currentMonth),
           'is-range-start': isRangeStart,

--- a/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
+++ b/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
@@ -12,12 +12,12 @@
 
 import {CalendarBase} from './CalendarBase';
 import {createCalendar} from '@internationalized/date';
+import {DateValue, SpectrumRangeCalendarProps} from '@react-types/calendar';
 import React from 'react';
-import {SpectrumRangeCalendarProps} from '@react-types/calendar';
 import {useRangeCalendar} from '@react-aria/calendar';
 import {useRangeCalendarState} from '@react-stately/calendar';
 
-export function RangeCalendar(props: SpectrumRangeCalendarProps) {
+export function RangeCalendar<T extends DateValue>(props: SpectrumRangeCalendarProps<T>) {
   let state = useRangeCalendarState({
     ...props,
     createCalendar

--- a/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
+++ b/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
@@ -11,13 +11,14 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {addWeeks} from 'date-fns';
 import {Calendar} from '../';
+import {CalendarDate, CalendarDateTime, getLocalTimeZone, parseZonedDateTime, today, ZonedDateTime} from '@internationalized/date';
 import {Flex} from '@react-spectrum/layout';
 import {Item, Picker, Section} from '@react-spectrum/picker';
 import {Provider} from '@react-spectrum/provider';
-import React from 'react';
+import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
+import {TimeField} from '@react-spectrum/datepicker';
 import {useLocale} from '@react-aria/i18n';
 
 storiesOf('Date and Time/Calendar', module)
@@ -27,31 +28,39 @@ storiesOf('Date and Time/Calendar', module)
   )
   .add(
     'defaultValue',
-    () => render({defaultValue: new Date(2019, 5, 5)})
+    () => render({defaultValue: new CalendarDate(2019, 6, 5)})
   )
   .add(
     'controlled value',
-    () => render({value: new Date(2019, 5, 5)})
+    () => render({value: new CalendarDate(2019, 5, 5)})
+  )
+  .add(
+    'with time',
+    () => <CalendarWithTime />
+  )
+  .add(
+    'with zoned time',
+    () => <CalendarWithZonedTime />
   )
   .add(
     'minValue: today, maxValue: 1 week from now',
-    () => render({minValue: new Date(), maxValue: addWeeks(new Date(), 1)})
+    () => render({minValue: today(getLocalTimeZone()), maxValue: today(getLocalTimeZone()).add({weeks: 1})})
   )
   .add(
     'defaultValue + minValue + maxValue',
-    () => render({defaultValue: new Date(2019, 5, 10), minValue: new Date(2019, 5, 5), maxValue: new Date(2019, 5, 20)})
+    () => render({defaultValue: new CalendarDate(2019, 6, 10), minValue: new CalendarDate(2019, 6, 5), maxValue: new CalendarDate(2019, 6, 20)})
   )
   .add(
     'isDisabled',
-    () => render({defaultValue: new Date(2019, 5, 5), isDisabled: true})
+    () => render({defaultValue: new CalendarDate(2019, 6, 5), isDisabled: true})
   )
   .add(
     'isReadOnly',
-    () => render({defaultValue: new Date(2019, 5, 5), isReadOnly: true})
+    () => render({defaultValue: new CalendarDate(2019, 6, 5), isReadOnly: true})
   )
   .add(
     'autoFocus',
-    () => render({defaultValue: new Date(2019, 5, 5), autoFocus: true})
+    () => render({defaultValue: new CalendarDate(2019, 6, 5), autoFocus: true})
   );
 
 function render(props = {}) {
@@ -125,6 +134,36 @@ function Example(props) {
       <Provider locale={(locale || defaultLocale) + (calendar && calendar !== preferredCalendars[0].key ? '-u-ca-' + calendar : '')}>
         <Calendar {...props} />
       </Provider>
+    </Flex>
+  );
+}
+
+function CalendarWithTime() {
+  let [value, setValue] = useState(new CalendarDateTime(2019, 6, 5, 8));
+  let onChange = (v: CalendarDateTime) => {
+    setValue(v);
+    action('onChange')(v);
+  };
+
+  return (
+    <Flex direction="column">
+      <Calendar value={value} onChange={onChange} />
+      <TimeField label="Time" value={value} onChange={onChange} />
+    </Flex>
+  );
+}
+
+function CalendarWithZonedTime() {
+  let [value, setValue] = useState(parseZonedDateTime('2021-03-14T00:45-08:00[America/Los_Angeles]'));
+  let onChange = (v: ZonedDateTime) => {
+    setValue(v);
+    action('onChange')(v);
+  };
+
+  return (
+    <Flex direction="column">
+      <Calendar value={value} onChange={onChange} />
+      <TimeField label="Time" value={value} onChange={onChange} />
     </Flex>
   );
 }

--- a/packages/@react-spectrum/calendar/stories/RangeCalendar.stories.tsx
+++ b/packages/@react-spectrum/calendar/stories/RangeCalendar.stories.tsx
@@ -11,10 +11,12 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {addWeeks} from 'date-fns';
+import {CalendarDate, CalendarDateTime, getLocalTimeZone, parseZonedDateTime, today} from '@internationalized/date';
+import {Flex} from '@react-spectrum/layout';
 import {RangeCalendar} from '../';
-import React from 'react';
+import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
+import {TimeField} from '@react-spectrum/datepicker';
 
 storiesOf('Date and Time/RangeCalendar', module)
   .add(
@@ -23,33 +25,69 @@ storiesOf('Date and Time/RangeCalendar', module)
   )
   .add(
     'defaultValue',
-    () => render({defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}})
+    () => render({defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}})
   )
   .add(
     'controlled value',
-    () => render({value: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}})
+    () => render({value: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}})
+  )
+  .add(
+    'with time',
+    () => <RangeCalendarWithTime />
+  )
+  .add(
+    'with zoned time',
+    () => <RangeCalendarWithZonedTime />
   )
   .add(
     'minValue: today, maxValue: 1 week from now',
-    () => render({minValue: new Date(), maxValue: addWeeks(new Date(), 1)})
+    () => render({minValue: today(getLocalTimeZone()), maxValue: today(getLocalTimeZone()).add({weeks: 1})})
   )
   .add(
     'defaultValue + minValue + maxValue',
-    () => render({defaultValue: {start: new Date(2019, 5, 10), end: new Date(2019, 5, 12)}, minValue: new Date(2019, 5, 5), maxValue: new Date(2019, 5, 20)})
+    () => render({defaultValue: {start: new CalendarDate(2019, 6, 10), end: new CalendarDate(2019, 6, 12)}, minValue: new CalendarDate(2019, 6, 5), maxValue: new CalendarDate(2019, 6, 20)})
   )
   .add(
     'isDisabled',
-    () => render({defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}, isDisabled: true})
+    () => render({defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}, isDisabled: true})
   )
   .add(
     'isReadOnly',
-    () => render({defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}, isReadOnly: true})
+    () => render({defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}, isReadOnly: true})
   )
   .add(
     'autoFocus',
-    () => render({defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}, autoFocus: true})
+    () => render({defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}, autoFocus: true})
   );
 
 function render(props = {}) {
   return <RangeCalendar onChange={action('change')} {...props} />;
+}
+
+function RangeCalendarWithTime() {
+  let [value, setValue] = useState({start: new CalendarDateTime(2019, 6, 5, 8), end: new CalendarDateTime(2019, 6, 10, 12)});
+
+  return (
+    <Flex direction="column">
+      <RangeCalendar value={value} onChange={setValue} />
+      <Flex gap="size-100">
+        <TimeField label="Start time" value={value.start} onChange={v => setValue({...value, start: v})} />
+        <TimeField label="End time" value={value.end} onChange={v => setValue({...value, end: v})} />
+      </Flex>
+    </Flex>
+  );
+}
+
+function RangeCalendarWithZonedTime() {
+  let [value, setValue] = useState({start: parseZonedDateTime('2021-03-10T00:45-05:00[America/New_York]'), end: parseZonedDateTime('2021-03-26T18:05-07:00[America/Los_Angeles]')});
+
+  return (
+    <Flex direction="column">
+      <RangeCalendar value={value} onChange={setValue} />
+      <Flex gap="size-100">
+        <TimeField label="Start time" value={value.start} onChange={v => setValue({...value, start: v})} />
+        <TimeField label="End time" value={value.end} onChange={v => setValue({...value, end: v})} />
+      </Flex>
+    </Flex>
+  );
 }

--- a/packages/@react-spectrum/calendar/test/Calendar.test.js
+++ b/packages/@react-spectrum/calendar/test/Calendar.test.js
@@ -13,10 +13,10 @@
 jest.mock('@react-aria/live-announcer');
 import {announce} from '@react-aria/live-announcer';
 import {Calendar} from '../';
+import {CalendarDate} from '@internationalized/date';
 import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 import {triggerPress} from '@react-spectrum/test-utils';
-import V2Calendar from '@react/react-spectrum/Calendar';
 
 let keyCodes = {'Enter': 13, ' ': 32, 'PageUp': 33, 'PageDown': 34, 'End': 35, 'Home': 36, 'ArrowLeft': 37, 'ArrowUp': 38, 'ArrowRight': 39, 'ArrowDown': 40};
 
@@ -33,10 +33,8 @@ describe('Calendar', () => {
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
-      ${'v2'}   | ${V2Calendar}
     `('$Name should render a calendar with a defaultValue', ({Calendar}) => {
-      let isV2 = Calendar === V2Calendar;
-      let {getByLabelText, getByRole, getAllByRole} = render(<Calendar defaultValue={new Date(2019, 5, 5)} />);
+      let {getByLabelText, getByRole, getAllByRole} = render(<Calendar defaultValue={new CalendarDate(2019, 6, 5)} />);
 
       let heading = getByRole('heading');
       expect(heading).toHaveTextContent('June 2019');
@@ -45,18 +43,16 @@ describe('Calendar', () => {
       expect(gridCells.length).toBe(30);
 
       let selectedDate = getByLabelText('Selected', {exact: false});
-      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('role', 'gridcell');
-      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('aria-selected', 'true');
+      expect(selectedDate.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(selectedDate.parentElement).toHaveAttribute('aria-selected', 'true');
       expect(selectedDate).toHaveAttribute('aria-label', 'Wednesday, June 5, 2019 selected');
     });
 
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
-      ${'v2'}   | ${V2Calendar}
     `('$Name should render a calendar with a value', ({Calendar}) => {
-      let isV2 = Calendar === V2Calendar;
-      let {getByLabelText, getByRole, getAllByRole} = render(<Calendar value={new Date(2019, 5, 5)} />);
+      let {getByLabelText, getByRole, getAllByRole} = render(<Calendar value={new CalendarDate(2019, 6, 5)} />);
 
       let heading = getByRole('heading');
       expect(heading).toHaveTextContent('June 2019');
@@ -65,32 +61,24 @@ describe('Calendar', () => {
       expect(gridCells.length).toBe(30);
 
       let selectedDate = getByLabelText('Selected', {exact: false});
-      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('role', 'gridcell');
-      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('aria-selected', 'true');
+      expect(selectedDate.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(selectedDate.parentElement).toHaveAttribute('aria-selected', 'true');
       expect(selectedDate).toHaveAttribute('aria-label', 'Wednesday, June 5, 2019 selected');
     });
 
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
-      ${'v2'}   | ${V2Calendar}
     `('$Name should focus the selected date if autoFocus is set', ({Calendar}) => {
-      let {getByRole, getByLabelText} = render(<Calendar value={new Date(2019, 1, 3)} autoFocus />);
+      let {getByRole, getByLabelText} = render(<Calendar value={new CalendarDate(2019, 2, 3)} autoFocus />);
 
       let cell = getByLabelText('selected', {exact: false});
 
       let grid = getByRole('grid');
-      if (Calendar === V2Calendar) {
-        expect(cell).toHaveAttribute('role', 'gridcell');
-        expect(cell).toHaveAttribute('aria-selected', 'true');
-        expect(grid).toHaveFocus();
-        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
-      } else {
-        expect(cell.parentElement).toHaveAttribute('role', 'gridcell');
-        expect(cell.parentElement).toHaveAttribute('aria-selected', 'true');
-        expect(cell).toHaveFocus();
-        expect(grid).not.toHaveAttribute('aria-activedescendant');
-      }
+      expect(cell.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(cell.parentElement).toHaveAttribute('aria-selected', 'true');
+      expect(cell).toHaveFocus();
+      expect(grid).not.toHaveAttribute('aria-activedescendant');
     });
   });
 
@@ -98,12 +86,11 @@ describe('Calendar', () => {
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
-      ${'v2'}   | ${V2Calendar}
     `('$Name selects a date on keyDown Enter/Space (uncontrolled)', ({Calendar}) => {
       let onChange = jest.fn();
       let {getByLabelText, getByRole} = render(
         <Calendar
-          defaultValue={new Date(2019, 5, 5)}
+          defaultValue={new CalendarDate(2019, 6, 5)}
           autoFocus
           onChange={onChange} />
       );
@@ -118,25 +105,24 @@ describe('Calendar', () => {
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('4');
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange.mock.calls[0][0].valueOf()).toBe(new Date(2019, 5, 4).valueOf()); // v2 returns a moment object
+      expect(onChange.mock.calls[0][0]).toEqual(new CalendarDate(2019, 6, 4));
 
       fireEvent.keyDown(grid, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
       fireEvent.keyDown(grid, {key: ' ', keyCode: keyCodes[' ']});
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('3');
       expect(onChange).toHaveBeenCalledTimes(2);
-      expect(onChange.mock.calls[1][0].valueOf()).toBe(new Date(2019, 5, 3).valueOf()); // v2 returns a moment object
+      expect(onChange.mock.calls[1][0]).toEqual(new CalendarDate(2019, 6, 3));
     });
 
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
-      ${'v2'}   | ${V2Calendar}
     `('$Name selects a date on keyDown Enter/Space (controlled)', ({Calendar}) => {
       let onChange = jest.fn();
       let {getByLabelText, getByRole} = render(
         <Calendar
-          value={new Date(2019, 5, 5)}
+          value={new CalendarDate(2019, 6, 5)}
           autoFocus
           onChange={onChange} />
       );
@@ -151,21 +137,16 @@ describe('Calendar', () => {
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5'); // controlled
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange.mock.calls[0][0].valueOf()).toBe(new Date(2019, 5, 4).valueOf()); // v2 returns a moment object
+      expect(onChange.mock.calls[0][0]).toEqual(new CalendarDate(2019, 6, 4));
 
       fireEvent.keyDown(grid, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
       fireEvent.keyDown(grid, {key: ' ', keyCode: keyCodes[' ']});
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5'); // controlled
       expect(onChange).toHaveBeenCalledTimes(2);
-      expect(onChange.mock.calls[1][0].valueOf()).toBe(new Date(2019, 5, 3).valueOf()); // v2 returns a moment object
+      expect(onChange.mock.calls[1][0]).toEqual(new CalendarDate(2019, 6, 3));
     });
 
-    // v2 tests disabled until next release
-    // it.each`
-    //   Name      | Calendar      | props
-    //   ${'v3'}   | ${Calendar}   | ${{isReadOnly: true}}
-    //   ${'v2'}   | ${V2Calendar} | ${{readOnly: true}}
     it.each`
       Name      | Calendar      | props
       ${'v3'}   | ${Calendar}   | ${{isReadOnly: true}}
@@ -173,7 +154,7 @@ describe('Calendar', () => {
       let onChange = jest.fn();
       let {getByLabelText} = render(
         <Calendar
-          defaultValue={new Date(2019, 5, 5)}
+          defaultValue={new CalendarDate(2019, 6, 5)}
           autoFocus
           onChange={onChange}
           {...props} />
@@ -195,11 +176,6 @@ describe('Calendar', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
-    // v2 tests disabled until next release
-    // it.each`
-    //   Name      | Calendar
-    //   ${'v3'}   | ${Calendar}
-    //   ${'v2'}   | ${V2Calendar}
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
@@ -207,7 +183,7 @@ describe('Calendar', () => {
       let onChange = jest.fn();
       let {getByLabelText, getByText} = render(
         <Calendar
-          defaultValue={new Date(2019, 5, 5)}
+          defaultValue={new CalendarDate(2019, 6, 5)}
           onChange={onChange} />
       );
 
@@ -217,18 +193,17 @@ describe('Calendar', () => {
       let selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('17');
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange.mock.calls[0][0].valueOf()).toBe(new Date(2019, 5, 17).valueOf()); // v2 returns a moment object
+      expect(onChange.mock.calls[0][0]).toEqual(new CalendarDate(2019, 6, 17));
     });
 
     it.each`
       Name      | Calendar
       ${'v3'}   | ${Calendar}
-      ${'v2'}   | ${V2Calendar}
     `('$Name selects a date on click (controlled)', ({Calendar}) => {
       let onChange = jest.fn();
       let {getByLabelText, getByText} = render(
         <Calendar
-          value={new Date(2019, 5, 5)}
+          value={new CalendarDate(2019, 6, 5)}
           onChange={onChange} />
       );
 
@@ -238,18 +213,17 @@ describe('Calendar', () => {
       let selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5');
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange.mock.calls[0][0].valueOf()).toBe(new Date(2019, 5, 17).valueOf()); // v2 returns a moment object
+      expect(onChange.mock.calls[0][0]).toEqual(new CalendarDate(2019, 6, 17));
     });
 
     it.each`
       Name      | Calendar      | props
       ${'v3'}   | ${Calendar}   | ${{isDisabled: true}}
-      ${'v2'}   | ${V2Calendar} | ${{disabled: true}}
     `('$Name does not select a date on click if isDisabled', ({Calendar, props}) => {
       let onChange = jest.fn();
       let {getByLabelText, getByText} = render(
         <Calendar
-          value={new Date(2019, 5, 5)}
+          value={new CalendarDate(2019, 6, 5)}
           onChange={onChange}
           {...props} />
       );
@@ -262,11 +236,6 @@ describe('Calendar', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
-    // v2 tests disabled until next release
-    // it.each`
-    //   Name      | Calendar      | props
-    //   ${'v3'}   | ${Calendar}   | ${{isReadOnly: true}}
-    //   ${'v2'}   | ${V2Calendar} | ${{readOnly: true}}
     it.each`
       Name      | Calendar      | props
       ${'v3'}   | ${Calendar}   | ${{isReadOnly: true}}
@@ -274,7 +243,7 @@ describe('Calendar', () => {
       let onChange = jest.fn();
       let {getByLabelText, getByText} = render(
         <Calendar
-          value={new Date(2019, 5, 5)}
+          value={new CalendarDate(2019, 6, 5)}
           onChange={onChange}
           {...props} />
       );
@@ -289,8 +258,7 @@ describe('Calendar', () => {
 
     it.each`
       Name      | Calendar      | props
-      ${'v3'}   | ${Calendar}   | ${{defaultValue: new Date(2019, 1, 8), minValue: new Date(2019, 1, 5), maxValue: new Date(2019, 1, 15)}}
-      ${'v2'}   | ${V2Calendar} | ${{defaultValue: new Date(2019, 1, 8), min: new Date(2019, 1, 5), max: new Date(2019, 1, 15)}}
+      ${'v3'}   | ${Calendar}   | ${{defaultValue: new CalendarDate(2019, 2, 8), minValue: new CalendarDate(2019, 2, 5), maxValue: new CalendarDate(2019, 2, 15)}}
     `('$Name does not select a date on click if outside the valid date range', ({Calendar, props}) => {
       let onChange = jest.fn();
       let {getByLabelText} = render(
@@ -328,7 +296,7 @@ describe('Calendar', () => {
   // These tests only work against v3
   describe('announcing', () => {
     it('announces when the current month changes', () => {
-      let {getByLabelText} = render(<Calendar defaultValue={new Date(2019, 5, 5)} />);
+      let {getByLabelText} = render(<Calendar defaultValue={new CalendarDate(2019, 6, 5)} />);
 
       let nextButton = getByLabelText('Next');
       triggerPress(nextButton);
@@ -338,7 +306,7 @@ describe('Calendar', () => {
     });
 
     it('announces when the selected date changes', () => {
-      let {getByText} = render(<Calendar defaultValue={new Date(2019, 5, 5)} />);
+      let {getByText} = render(<Calendar defaultValue={new CalendarDate(2019, 6, 5)} />);
 
       let newDate = getByText('17');
       triggerPress(newDate);
@@ -348,7 +316,7 @@ describe('Calendar', () => {
     });
 
     it('ensures that the active descendant is announced when the focused date changes', () => {
-      let {getByRole, getByLabelText} = render(<Calendar defaultValue={new Date(2019, 5, 5)} autoFocus />);
+      let {getByRole, getByLabelText} = render(<Calendar defaultValue={new CalendarDate(2019, 6, 5)} autoFocus />);
 
       let grid = getByRole('grid');
       let selectedDate = getByLabelText('selected', {exact: false});
@@ -359,7 +327,7 @@ describe('Calendar', () => {
     });
 
     it('renders a caption with the selected date', () => {
-      let {getByText, getByRole} = render(<Calendar defaultValue={new Date(2019, 5, 5)} />);
+      let {getByText, getByRole} = render(<Calendar defaultValue={new CalendarDate(2019, 6, 5)} />);
 
       let grid = getByRole('grid');
       let caption = document.getElementById(grid.getAttribute('aria-describedby'));

--- a/packages/@react-spectrum/calendar/test/CalendarBase.test.js
+++ b/packages/@react-spectrum/calendar/test/CalendarBase.test.js
@@ -12,12 +12,12 @@
 
 import {act, fireEvent, render} from '@testing-library/react';
 import {Calendar, RangeCalendar} from '../';
+import {CalendarDate} from '@internationalized/date';
 import {getDaysInMonth} from 'date-fns';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import {theme} from '@react-spectrum/theme-default';
 import {triggerPress} from '@react-spectrum/test-utils';
-import V2Calendar from '@react/react-spectrum/Calendar';
 
 let cellFormatter = new Intl.DateTimeFormat('en-US', {weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'});
 let headingFormatter = new Intl.DateTimeFormat('en-US', {month: 'long', year: 'numeric'});
@@ -46,10 +46,7 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name shows the current month by default', ({Calendar, props}) => {
-      const isV2 = Calendar === V2Calendar;
       let {getByLabelText, getByRole, getAllByRole} = render(<Calendar {...props} />);
 
       let calendar = getByRole('group');
@@ -59,17 +56,12 @@ describe('CalendarBase', () => {
       expect(heading).toHaveTextContent(headingFormatter.format(new Date()));
 
       let grid = getByRole('grid');
-
-      if (isV2) {
-        expect(grid).toHaveAttribute('tabIndex', '0');
-      } else {
-        expect(grid).not.toHaveAttribute('tabIndex');
-      }
+      expect(grid).not.toHaveAttribute('tabIndex');
 
       let today = getByLabelText('today', {exact: false});
-      expect(isV2 ? today : today.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(today.parentElement).toHaveAttribute('role', 'gridcell');
       expect(today).toHaveAttribute('aria-label', `Today, ${cellFormatter.format(new Date())}`);
-      expect(today).toHaveAttribute('tabIndex', !isV2 ? '0' : '-1');
+      expect(today).toHaveAttribute('tabIndex', '0');
 
       expect(getByLabelText('Previous')).toBeVisible();
       expect(getByLabelText('Next')).toBeVisible();
@@ -77,7 +69,7 @@ describe('CalendarBase', () => {
       let gridCells = getAllByRole('gridcell').filter(cell => cell.getAttribute('aria-disabled') !== 'true');
       expect(gridCells.length).toBe(getDaysInMonth(new Date()));
       for (let cell of gridCells) {
-        expect(isV2 ? cell : cell.children[0]).toHaveAttribute('aria-label');
+        expect(cell.children[0]).toHaveAttribute('aria-label');
       }
     });
 
@@ -85,8 +77,6 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{isDisabled: true}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{isDisabled: true}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{disabled: true}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range', disabled: true}}
     `('$Name should set aria-disabled when isDisabled', ({Calendar, props}) => {
       let {getByRole, getAllByRole, getByLabelText} = render(<Calendar {...props} />);
 
@@ -107,46 +97,29 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{isReadOnly: true}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{isReadOnly: true}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{readOnly: true}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range', readOnly: true}}
     `('$Name should set aria-readonly when isReadOnly', ({Calendar, props}) => {
-      const isV2 = Calendar === V2Calendar;
       let {getByRole} = render(<Calendar {...props} />);
       let grid = getByRole('grid');
       expect(grid).toHaveAttribute('aria-readonly', 'true');
-      if (isV2) {
-        expect(grid).toHaveAttribute('tabIndex', '0');
-      } else {
-        expect(grid).not.toHaveAttribute('tabIndex');
-      }
+      expect(grid).not.toHaveAttribute('tabIndex');
     });
 
     it.each`
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name should focus today if autoFocus is set and there is no selected value', ({Name, Calendar}) => {
-      const isV2 = Calendar === V2Calendar;
-      let {getByRole, getByLabelText} = render(<Calendar autoFocus />);
+      let {getByLabelText} = render(<Calendar autoFocus />);
 
       let cell = getByLabelText('today', {exact: false});
-      expect(isV2 ? cell : cell.parentElement).toHaveAttribute('role', 'gridcell');
-
-      let grid = getByRole('grid');
-      expect(isV2 ? grid : cell).toHaveFocus();
-      if (isV2) {
-        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
-      }
+      expect(cell.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(cell).toHaveFocus();
     });
 
     it.each`
       Name                    | Calendar              | props
-      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new Date(2019, 1, 10), minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 1, 20)}}
-      ${'v2 Calendar'}        | ${V2Calendar}         | ${{defaultValue: new Date(2019, 1, 10), min: new Date(2019, 1, 3), max: new Date(2019, 1, 20)}}
-      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new Date(2019, 1, 10), end: new Date(2019, 1, 15)}, minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 1, 20)}}
-      ${'v2 range Calendar'}  | ${V2Calendar}         | ${{selectionType: 'range', defaultValue: [new Date(2019, 1, 10), new Date(2019, 1, 15)], min: new Date(2019, 1, 3), max: new Date(2019, 1, 20)}}
+      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new CalendarDate(2019, 2, 10), minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 2, 20)}}
+      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new CalendarDate(2019, 2, 10), end: new CalendarDate(2019, 2, 15)}, minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 2, 20)}}
     `('$Name should set aria-disabled on cells outside the valid date range', ({Calendar, props}) => {
       let {getAllByRole} = render(<Calendar {...props} />);
 
@@ -156,8 +129,8 @@ describe('CalendarBase', () => {
 
     it.each`
       Name                    | Calendar              | props
-      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new Date(2019, 1, 10), minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 2, 20)}}
-      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new Date(2019, 1, 10), end: new Date(2019, 1, 15)}, minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 2, 20)}}
+      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new CalendarDate(2019, 2, 10), minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 3, 20)}}
+      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new CalendarDate(2019, 2, 10), end: new CalendarDate(2019, 2, 15)}, minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 3, 20)}}
     `('$Name should disable the previous button if outside valid date range', ({Calendar, props}) => {
       let {getByLabelText} = render(<Calendar {...props} />);
 
@@ -167,8 +140,8 @@ describe('CalendarBase', () => {
 
     it.each`
       Name                    | Calendar              | props
-      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new Date(2019, 2, 10), minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 2, 20)}}
-      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new Date(2019, 2, 10), end: new Date(2019, 2, 15)}, minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 2, 20)}}
+      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new CalendarDate(2019, 3, 10), minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 3, 20)}}
+      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new CalendarDate(2019, 3, 10), end: new CalendarDate(2019, 3, 15)}, minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 3, 20)}}
     `('$Name should disable the next button if outside valid date range', ({Calendar, props}) => {
       let {getByLabelText} = render(<Calendar {...props} />);
 
@@ -178,8 +151,8 @@ describe('CalendarBase', () => {
 
     it.each`
       Name                    | Calendar              | props
-      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new Date(2019, 2, 10), minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 1, 20)}}
-      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new Date(2019, 2, 10), end: new Date(2019, 2, 15)}, minValue: new Date(2019, 1, 3), maxValue: new Date(2019, 1, 20)}}
+      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new CalendarDate(2019, 3, 10), minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 2, 20)}}
+      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new CalendarDate(2019, 3, 10), end: new CalendarDate(2019, 3, 15)}, minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 2, 20)}}
     `('$Name should disable both the next and previous buttons if outside valid date range', ({Calendar, props}) => {
       let {getByLabelText} = render(<Calendar {...props} />);
 
@@ -189,10 +162,8 @@ describe('CalendarBase', () => {
 
     it.each`
       Name                   | Calendar         | props
-      ${'v3 Calendar'}       | ${Calendar}      | ${{defaultValue: new Date(2019, 5, 5)}}
-      ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{defaultValue: new Date(2019, 5, 5)}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range', defaultValue: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3 Calendar'}       | ${Calendar}      | ${{defaultValue: new CalendarDate(2019, 6, 5)}}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name should change the month when previous or next buttons are clicked', ({Calendar, props}) => {
       let {getByRole, getByLabelText, getAllByLabelText, getAllByRole} = render(<Calendar {...props} />);
 
@@ -230,10 +201,8 @@ describe('CalendarBase', () => {
   describe('labeling', () => {
     it.each`
       Name                   | Calendar         | props
-      ${'v3 Calendar'}       | ${Calendar}      | ${{defaultValue: new Date(2019, 5, 5)}}}
-      ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 5)}}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{defaultValue: new Date(2019, 5, 5)}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{defaultValue: new Date(2019, 5, 5), selectionType: 'range'}}
+      ${'v3 Calendar'}       | ${Calendar}      | ${{defaultValue: new CalendarDate(2019, 6, 5)}}}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 5)}}}
     `('$Name should be labeled by month heading by default', async ({Calendar, props}) => {
       let {getByRole} = render(<Calendar  {...props} />);
       let calendar = getByRole('group');
@@ -248,8 +217,6 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name should support labeling with aria-label', ({Calendar, props}) => {
       let {getByRole} = render(<Calendar {...props} aria-label="foo" />);
       let calendar = getByRole('group');
@@ -265,8 +232,6 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name should support labeling with aria-labelledby', ({Calendar, props}) => {
       let {getByRole} = render(<Calendar {...props} aria-labelledby="foo" />);
       let calendar = getByRole('group');
@@ -281,8 +246,6 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name should support labeling with aria-labelledby and aria-label', ({Calendar, props}) => {
       let {getByRole} = render(<Calendar {...props} aria-label="cal" aria-labelledby="foo" />);
       let calendar = getByRole('group');
@@ -298,8 +261,6 @@ describe('CalendarBase', () => {
       Name                   | Calendar         | props
       ${'v3 Calendar'}       | ${Calendar}      | ${{}}
       ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{}}
-      ${'v2 Calendar'}       | ${V2Calendar}    | ${{}}
-      ${'v2 range Calendar'} | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name should support labeling with a custom id', ({Calendar, props}) => {
       let {getByRole} = render(<Calendar {...props} id="hi" aria-label="cal" aria-labelledby="foo" />);
       let calendar = getByRole('group');
@@ -314,36 +275,24 @@ describe('CalendarBase', () => {
 
   describe('keyboard navigation', () => {
     async function testKeyboard(Calendar, defaultValue, key, value, month, props, opts) {
-      let isV2 = Calendar === V2Calendar;
-
       // For range calendars, convert the value to a range of one day
       if (Calendar === RangeCalendar) {
         defaultValue = {start: defaultValue, end: defaultValue};
-      } else if (isV2 && props && props.selectionType === 'range') {
-        defaultValue = [defaultValue, defaultValue];
       }
 
       let {getByRole, getAllByRole, getByLabelText, getAllByLabelText, unmount} = render(<Calendar defaultValue={defaultValue} autoFocus {...props} />);
       let grid = getAllByRole('grid')[0]; // get by role will see two, role=grid and implicit <table> which also has role=grid
 
       let cell = getAllByLabelText('selected', {exact: false}).filter(cell => cell.role !== 'grid')[0];
-      if (isV2) {
-        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
-      } else {
-        expect(grid).not.toHaveAttribute('aria-activedescendant');
-        expect(document.activeElement).toBe(cell);
-      }
+      expect(grid).not.toHaveAttribute('aria-activedescendant');
+      expect(document.activeElement).toBe(cell);
 
       fireEvent.keyDown(document.activeElement, {key, keyCode: keyCodes[key], ...opts});
       fireEvent.keyUp(document.activeElement, {key, keyCode: keyCodes[key], ...opts});
 
       cell = getByLabelText(value, {exact: false});
-      if (isV2) {
-        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
-      } else {
-        expect(grid).not.toHaveAttribute('aria-activedescendant');
-        expect(document.activeElement).toBe(cell);
-      }
+      expect(grid).not.toHaveAttribute('aria-activedescendant');
+      expect(document.activeElement).toBe(cell);
 
       let heading = getByRole('heading');
       expect(heading).toHaveTextContent(month);
@@ -360,85 +309,68 @@ describe('CalendarBase', () => {
       Name                    | Calendar          | props
       ${'v3 Calendar'}        | ${Calendar}       | ${{}}
       ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{}}
-      ${'v2 Calendar'}        | ${V2Calendar}     | ${{}}
-      ${'v2 range Calendar'}  | ${V2Calendar}     | ${{selectionType: 'range'}}
     `('$Name should move the focused date by one day with the left/right arrows', async ({Calendar, props}) => {
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'ArrowLeft', 'Tuesday, June 4, 2019', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'ArrowRight', 'Thursday, June 6, 2019', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'ArrowLeft', 'Tuesday, June 4, 2019', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'ArrowRight', 'Thursday, June 6, 2019', 'June 2019', props);
 
-      await testKeyboard(Calendar, new Date(2019, 5, 1), 'ArrowLeft', 'Friday, May 31, 2019', 'May 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 30), 'ArrowRight', 'Monday, July 1, 2019', 'July 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 1), 'ArrowLeft', 'Friday, May 31, 2019', 'May 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 30), 'ArrowRight', 'Monday, July 1, 2019', 'July 2019', props);
     });
 
     it.each`
       Name                    | Calendar          | props
       ${'v3 Calendar'}        | ${Calendar}       | ${{}}
       ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{}}
-      ${'v2 Calendar'}        | ${V2Calendar}     | ${{}}
-      ${'v2 range Calendar'}  | ${V2Calendar}     | ${{selectionType: 'range'}}
     `('$Name should move the focused date by one week with the up/down arrows', async ({Calendar, props}) => {
-      await testKeyboard(Calendar, new Date(2019, 5, 12), 'ArrowUp', 'Wednesday, June 5, 2019', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 12), 'ArrowDown', 'Wednesday, June 19, 2019', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 12), 'ArrowUp', 'Wednesday, June 5, 2019', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 12), 'ArrowDown', 'Wednesday, June 19, 2019', 'June 2019', props);
 
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'ArrowUp', 'Wednesday, May 29, 2019', 'May 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 26), 'ArrowDown', 'Wednesday, July 3, 2019', 'July 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'ArrowUp', 'Wednesday, May 29, 2019', 'May 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 26), 'ArrowDown', 'Wednesday, July 3, 2019', 'July 2019', props);
     });
 
     it.each`
       Name                    | Calendar          | props
       ${'v3 Calendar'}        | ${Calendar}       | ${{}}
       ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{}}
-      ${'v2 Calendar'}        | ${V2Calendar}     | ${{}}
-      ${'v2 range Calendar'}  | ${V2Calendar}     | ${{selectionType: 'range'}}
     `('$Name should move the focused date to the start or end of the month with the home/end keys', async ({Calendar, props}) => {
-      await testKeyboard(Calendar, new Date(2019, 5, 12), 'Home', 'Saturday, June 1, 2019', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 12), 'End', 'Sunday, June 30, 2019', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 12), 'Home', 'Saturday, June 1, 2019', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 12), 'End', 'Sunday, June 30, 2019', 'June 2019', props);
     });
 
     it.each`
       Name                    | Calendar          | props
       ${'v3 Calendar'}        | ${Calendar}       | ${{}}
       ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{}}
-      ${'v2 Calendar'}        | ${V2Calendar}     | ${{}}
-      ${'v2 range Calendar'}  | ${V2Calendar}     | ${{selectionType: 'range'}}
     `('$Name should move the focused date by one month with the page up/page down keys', async ({Calendar, props}) => {
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageUp', 'Sunday, May 5, 2019', 'May 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageDown', 'Friday, July 5, 2019', 'July 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageUp', 'Sunday, May 5, 2019', 'May 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageDown', 'Friday, July 5, 2019', 'July 2019', props);
     });
 
-    // v2 tests disabled until next release
-    // it.each`
-    //   Name                    | Calendar          | props
-    //   ${'v3 Calendar'}        | ${Calendar}       | ${{}}
-    //   ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{}}
-    //   ${'v2 Calendar'}        | ${V2Calendar}     | ${{}}
-    //   ${'v2 range Calendar'}  | ${V2Calendar}     | ${{selectionType: 'range'}}
     it.each`
       Name                    | Calendar          | props
       ${'v3 Calendar'}        | ${Calendar}       | ${{}}
       ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{}}
     `('$Name should move the focused date by one year with the shift + page up/shift + page down keys', async ({Calendar, props}) => {
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageUp', 'Tuesday, June 5, 2018', 'June 2018', props, {shiftKey: true});
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageDown', 'Friday, June 5, 2020', 'June 2020', props, {shiftKey: true});
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageUp', 'Tuesday, June 5, 2018', 'June 2018', props, {shiftKey: true});
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageDown', 'Friday, June 5, 2020', 'June 2020', props, {shiftKey: true});
     });
 
     it.each`
       Name                    | Calendar          | props
-      ${'v3 Calendar'}        | ${Calendar}       | ${{minValue: new Date(2019, 5, 2), maxValue: new Date(2019, 5, 8)}}
-      ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{minValue: new Date(2019, 5, 2), maxValue: new Date(2019, 5, 8)}}
-      ${'v2 Calendar'}        | ${V2Calendar}     | ${{min: new Date(2019, 5, 5), max: new Date(2019, 5, 8)}}
-      ${'v2 range Calendar'}  | ${V2Calendar}     | ${{selectionType: 'range', min: new Date(2019, 5, 5), max: new Date(2019, 5, 8)}}
+      ${'v3 Calendar'}        | ${Calendar}       | ${{minValue: new CalendarDate(2019, 6, 2), maxValue: new CalendarDate(2019, 6, 8)}}
+      ${'v3 RangeCalendar'}   | ${RangeCalendar}  | ${{minValue: new CalendarDate(2019, 6, 2), maxValue: new CalendarDate(2019, 6, 8)}}
     `('$Name should not move the focused date outside the valid range', async ({Calendar, props}) => {
-      await testKeyboard(Calendar, new Date(2019, 5, 2), 'ArrowLeft', 'Sunday, June 2, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 8), 'ArrowRight', 'Saturday, June 8, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'ArrowUp', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'ArrowDown', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'Home', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'End', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageUp', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageDown', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageUp', 'Wednesday, June 5, 2019 selected', 'June 2019', props, {shiftKey: true});
-      await testKeyboard(Calendar, new Date(2019, 5, 5), 'PageDown', 'Wednesday, June 5, 2019 selected', 'June 2019', props, {shiftKey: true});
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 2), 'ArrowLeft', 'Sunday, June 2, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 8), 'ArrowRight', 'Saturday, June 8, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'ArrowUp', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'ArrowDown', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'Home', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'End', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageUp', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageDown', 'Wednesday, June 5, 2019 selected', 'June 2019', props);
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageUp', 'Wednesday, June 5, 2019 selected', 'June 2019', props, {shiftKey: true});
+      await testKeyboard(Calendar, new CalendarDate(2019, 6, 5), 'PageDown', 'Wednesday, June 5, 2019 selected', 'June 2019', props, {shiftKey: true});
     });
   });
 
@@ -470,8 +402,8 @@ describe('CalendarBase', () => {
 
     it.each`
       Name                   | Calendar         | props
-      ${'v3 Calendar'}       | ${Calendar}      | ${{defaultValue: new Date(2019, 5, 5)}}
-      ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
+      ${'v3 Calendar'}       | ${Calendar}      | ${{defaultValue: new CalendarDate(2019, 6, 5)}}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name should mirror arrow key movement in an RTL locale', ({Calendar, props}) => {
       // LTR
       let {getByRole, getAllByRole, rerender} = render(

--- a/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
+++ b/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
@@ -12,12 +12,11 @@
 
 jest.mock('@react-aria/live-announcer');
 import {announce} from '@react-aria/live-announcer';
+import {CalendarDate} from '@internationalized/date';
 import {fireEvent, render} from '@testing-library/react';
 import {RangeCalendar} from '../';
 import React from 'react';
-import {startOfDay} from 'date-fns';
 import {triggerPress} from '@react-spectrum/test-utils';
-import V2Calendar from '@react/react-spectrum/Calendar';
 
 let cellFormatter = new Intl.DateTimeFormat('en-US', {weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'});
 let keyCodes = {'Enter': 13, ' ': 32, 'PageUp': 33, 'PageDown': 34, 'End': 35, 'Home': 36, 'ArrowLeft': 37, 'ArrowUp': 38, 'ArrowRight': 39, 'ArrowDown': 40, Escape: 27};
@@ -34,10 +33,8 @@ describe('RangeCalendar', () => {
   describe('basics', () => {
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', defaultValue: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name should render a calendar with a defaultValue', ({RangeCalendar, props}) => {
-      let isV2 = RangeCalendar === V2Calendar;
       let {getAllByLabelText, getByRole, getAllByRole} = render(<RangeCalendar {...props} />);
 
       let heading = getByRole('heading');
@@ -59,18 +56,16 @@ describe('RangeCalendar', () => {
 
       let i = 0;
       for (let cell of selectedDates) {
-        expect(isV2 ? cell : cell.parentElement).toHaveAttribute('role', 'gridcell');
-        expect(isV2 ? cell : cell.parentElement).toHaveAttribute('aria-selected', 'true');
+        expect(cell.parentElement).toHaveAttribute('role', 'gridcell');
+        expect(cell.parentElement).toHaveAttribute('aria-selected', 'true');
         expect(cell).toHaveAttribute('aria-label', labels[i++]);
       }
     });
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', value: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name should render a calendar with a value', ({RangeCalendar, props}) => {
-      let isV2 = RangeCalendar === V2Calendar;
       let {getAllByLabelText, getByRole, getAllByRole} = render(<RangeCalendar {...props} />);
 
       let heading = getByRole('heading');
@@ -92,38 +87,30 @@ describe('RangeCalendar', () => {
 
       let i = 0;
       for (let cell of selectedDates) {
-        expect(isV2 ? cell : cell.parentElement).toHaveAttribute('role', 'gridcell');
-        expect(isV2 ? cell : cell.parentElement).toHaveAttribute('aria-selected', 'true');
+        expect(cell.parentElement).toHaveAttribute('role', 'gridcell');
+        expect(cell.parentElement).toHaveAttribute('aria-selected', 'true');
         expect(cell).toHaveAttribute('aria-label', labels[i++]);
       }
     });
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new Date(2019, 1, 3), end: new Date(2019, 1, 18)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', value: [new Date(2019, 1, 3), new Date(2019, 1, 18)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 2, 18)}}}
     `('$Name should focus the first selected date if autoFocus is set', ({RangeCalendar, props}) => {
       let {getByRole, getAllByLabelText} = render(<RangeCalendar {...props} autoFocus />);
 
       let cells = getAllByLabelText('selected', {exact: false});
       let grid = getByRole('grid');
 
-      if (RangeCalendar === V2Calendar) {
-        expect(cells[0]).toHaveAttribute('role', 'gridcell');
-        expect(cells[0]).toHaveAttribute('aria-selected', 'true');
-        expect(grid).toHaveFocus();
-        expect(grid).toHaveAttribute('aria-activedescendant', cells[0].id);
-      } else {
-        expect(cells[0].parentElement).toHaveAttribute('role', 'gridcell');
-        expect(cells[0].parentElement).toHaveAttribute('aria-selected', 'true');
-        expect(cells[0]).toHaveFocus();
-        expect(grid).not.toHaveAttribute('aria-activedescendant');
-      }
+      expect(cells[0].parentElement).toHaveAttribute('role', 'gridcell');
+      expect(cells[0].parentElement).toHaveAttribute('aria-selected', 'true');
+      expect(cells[0]).toHaveFocus();
+      expect(grid).not.toHaveAttribute('aria-activedescendant');
     });
 
     // v2 doesn't pass this test - it starts by showing the end date instead of the start date.
     it('should show selected dates across multiple months', () => {
-      let {getByRole, getByLabelText, getAllByLabelText, getAllByRole} = render(<RangeCalendar value={{start: new Date(2019, 5, 20), end: new Date(2019, 6, 10)}} />);
+      let {getByRole, getByLabelText, getAllByLabelText, getAllByRole} = render(<RangeCalendar value={{start: new CalendarDate(2019, 6, 20), end: new CalendarDate(2019, 7, 10)}} />);
 
       let heading = getByRole('heading');
       expect(heading).toHaveTextContent('June 2019');
@@ -206,35 +193,24 @@ describe('RangeCalendar', () => {
     it.each`
       Name          | RangeCalendar    | props
       ${'v3'}       | ${RangeCalendar} | ${{}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range'}}
     `('$Name adds a range selection prompt to the focused cell', ({RangeCalendar, props}) => {
-      const isV2 = RangeCalendar === V2Calendar;
       let {getByRole, getByLabelText} = render(<RangeCalendar {...props} autoFocus />);
 
       let grid = getByRole('grid');
       let cell = getByLabelText('today', {exact: false});
-      if (isV2) {
-        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
-      } else {
-        expect(grid).not.toHaveAttribute('aria-activedescendant');
-      }
+      expect(grid).not.toHaveAttribute('aria-activedescendant');
       expect(cell).toHaveAttribute('aria-label', `Today, ${cellFormatter.format(new Date())} (Click to start selecting date range)`);
 
       // enter selection mode
       fireEvent.keyDown(grid, {key: 'Enter', keyCode: keyCodes.Enter});
-      if (isV2) {
-        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
-      } else {
-        expect(grid).not.toHaveAttribute('aria-activedescendant');
-      }
-      expect(isV2 ? cell : cell.parentElement).toHaveAttribute('aria-selected');
+      expect(grid).not.toHaveAttribute('aria-activedescendant');
+      expect(cell.parentElement).toHaveAttribute('aria-selected');
       expect(cell).toHaveAttribute('aria-label', `Today, ${cellFormatter.format(new Date())} selected (Click to finish selecting date range)`);
     });
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', defaultValue: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name can select a range with the keyboard (uncontrolled)', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getAllByLabelText, getByRole} = render(
@@ -273,22 +249,14 @@ describe('RangeCalendar', () => {
       expect(selectedDates[selectedDates.length - 1].textContent).toBe('8');
       expect(onChange).toHaveBeenCalledTimes(1);
 
-      let value = onChange.mock.calls[0][0];
-      let start, end;
-      if (Array.isArray(value)) { // v2
-        [start, end] = value;
-      } else { // v3
-        ({start, end} = value);
-      }
-
-      expect(start.valueOf()).toBe(new Date(2019, 5, 4).valueOf()); // v2 returns a moment object
-      expect(startOfDay(end).valueOf()).toBe(new Date(2019, 5, 8).valueOf()); // v2 returns a moment object
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 4));
+      expect(end).toEqual(new CalendarDate(2019, 6, 8));
     });
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', value: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name can select a range with the keyboard (controlled)', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getAllByLabelText, getByRole} = render(
@@ -327,19 +295,11 @@ describe('RangeCalendar', () => {
       expect(selectedDates[selectedDates.length - 1].textContent).toBe('10');
       expect(onChange).toHaveBeenCalledTimes(1);
 
-      let value = onChange.mock.calls[0][0];
-      let start, end;
-      if (Array.isArray(value)) { // v2
-        [start, end] = value;
-      } else { // v3
-        ({start, end} = value);
-      }
-
-      expect(start.valueOf()).toBe(new Date(2019, 5, 4).valueOf()); // v2 returns a moment object
-      expect(startOfDay(end).valueOf()).toBe(new Date(2019, 5, 8).valueOf()); // v2 returns a moment object
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 4));
+      expect(end).toEqual(new CalendarDate(2019, 6, 8));
     });
 
-    // v2 does not pass this test.
     it('does not enter selection mode with the keyboard if isReadOnly', () => {
       let {getByRole, getByLabelText} = render(<RangeCalendar isReadOnly autoFocus />);
 
@@ -359,8 +319,7 @@ describe('RangeCalendar', () => {
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', defaultValue: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name selects a range with the mouse (uncontrolled)', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getAllByLabelText, getByText} = render(
@@ -391,22 +350,14 @@ describe('RangeCalendar', () => {
       expect(selectedDates[selectedDates.length - 1].textContent).toBe('17');
       expect(onChange).toHaveBeenCalledTimes(1);
 
-      let value = onChange.mock.calls[0][0];
-      let start, end;
-      if (Array.isArray(value)) { // v2
-        [start, end] = value;
-      } else { // v3
-        ({start, end} = value);
-      }
-
-      expect(start.valueOf()).toBe(new Date(2019, 5, 7).valueOf()); // v2 returns a moment object
-      expect(startOfDay(end).valueOf()).toBe(new Date(2019, 5, 17).valueOf()); // v2 returns a moment object
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 7));
+      expect(end).toEqual(new CalendarDate(2019, 6, 17));
     });
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', value: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name selects a range with the mouse (controlled)', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getAllByLabelText, getByText} = render(
@@ -437,19 +388,11 @@ describe('RangeCalendar', () => {
       expect(selectedDates[selectedDates.length - 1].textContent).toBe('10');
       expect(onChange).toHaveBeenCalledTimes(1);
 
-      let value = onChange.mock.calls[0][0];
-      let start, end;
-      if (Array.isArray(value)) { // v2
-        [start, end] = value;
-      } else { // v3
-        ({start, end} = value);
-      }
-
-      expect(start.valueOf()).toBe(new Date(2019, 5, 7).valueOf()); // v2 returns a moment object
-      expect(startOfDay(end).valueOf()).toBe(new Date(2019, 5, 17).valueOf()); // v2 returns a moment object
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 7));
+      expect(end).toEqual(new CalendarDate(2019, 6, 17));
     });
 
-    // v2 does not pass this test.
     it('does not enter selection mode with the mouse if isReadOnly', () => {
       let {getByRole, getByLabelText, getByText} = render(<RangeCalendar isReadOnly autoFocus />);
 
@@ -469,7 +412,6 @@ describe('RangeCalendar', () => {
     it.each`
       Name          | RangeCalendar    | props
       ${'v3'}       | ${RangeCalendar} | ${{isDisabled: true}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', disabled: true}}
     `('$Name does not select a date on click if isDisabled', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getAllByLabelText, getByText} = render(
@@ -489,8 +431,7 @@ describe('RangeCalendar', () => {
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new Date(2019, 1, 8), end: new Date(2019, 1, 15)}, minValue: new Date(2019, 1, 5), maxValue: new Date(2019, 1, 15)}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', defaultValue: [new Date(2019, 1, 8), new Date(2019, 1, 15)], min: new Date(2019, 1, 5), max: new Date(2019, 1, 15)}}
+      ${'v3'}       | ${RangeCalendar} | ${{defaultValue: {start: new CalendarDate(2019, 2, 8), end: new CalendarDate(2019, 2, 15)}, minValue: new CalendarDate(2019, 2, 5), maxValue: new CalendarDate(2019, 2, 15)}}
     `('$Name does not select a date on click if outside the valid date range', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getByLabelText, getAllByLabelText} = render(
@@ -530,8 +471,7 @@ describe('RangeCalendar', () => {
 
     it.each`
       Name          | RangeCalendar    | props
-      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}}}
-      ${'v2'}       | ${V2Calendar}    | ${{selectionType: 'range', value: [new Date(2019, 5, 5), new Date(2019, 5, 10)]}}
+      ${'v3'}       | ${RangeCalendar} | ${{value: {start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}}}
     `('$Name cancels the selection when the escape key is pressed', ({RangeCalendar, props}) => {
       let onChange = jest.fn();
       let {getByText, getAllByLabelText} = render(
@@ -570,7 +510,7 @@ describe('RangeCalendar', () => {
   // These tests only work against v3
   describe('announcing', () => {
     it('announces when the current month changes', () => {
-      let {getByLabelText} = render(<RangeCalendar defaultValue={{start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}} />);
+      let {getByLabelText} = render(<RangeCalendar defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} />);
 
       let nextButton = getByLabelText('Next');
       triggerPress(nextButton);
@@ -580,7 +520,7 @@ describe('RangeCalendar', () => {
     });
 
     it('announces when the selected date range changes', () => {
-      let {getByText} = render(<RangeCalendar defaultValue={{start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}} />);
+      let {getByText} = render(<RangeCalendar defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} />);
 
       triggerPress(getByText('17'));
       triggerPress(getByText('10'));
@@ -590,7 +530,7 @@ describe('RangeCalendar', () => {
     });
 
     it('ensures that the active descendant is announced when the focused date changes', () => {
-      let {getByRole, getAllByLabelText} = render(<RangeCalendar defaultValue={{start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}} autoFocus />);
+      let {getByRole, getAllByLabelText} = render(<RangeCalendar defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} autoFocus />);
 
       let grid = getByRole('grid');
 
@@ -603,7 +543,7 @@ describe('RangeCalendar', () => {
     });
 
     it('renders a caption with the selected date range', () => {
-      let {getByText, getByRole} = render(<RangeCalendar defaultValue={{start: new Date(2019, 5, 5), end: new Date(2019, 5, 10)}} />);
+      let {getByText, getByRole} = render(<RangeCalendar defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} />);
 
       let grid = getByRole('grid');
       let caption = document.getElementById(grid.getAttribute('aria-describedby'));

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -44,6 +44,7 @@
     "@react-spectrum/calendar": "3.0.0-alpha.1",
     "@react-spectrum/dialog": "^3.1.0",
     "@react-spectrum/label": "^3.3.4",
+    "@react-spectrum/layout": "^3.2.1",
     "@react-spectrum/utils": "^3.1.0",
     "@react-spectrum/view": "^3.1.1",
     "@react-stately/datepicker": "3.0.0-alpha.1",

--- a/packages/@react-spectrum/datepicker/src/DateField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateField.tsx
@@ -10,9 +10,21 @@
  * governing permissions and limitations under the License.
  */
 
-/// <reference types="css-module-types" />
+import {DatePickerField} from './DatePickerField';
+import {DateValue, SpectrumDatePickerProps} from '@react-types/datepicker';
+import {FocusScope} from '@react-aria/focus';
+import React from 'react';
+import {useProviderProps} from '@react-spectrum/provider';
 
-export * from './DatePicker';
-export * from './DateRangePicker';
-export * from './TimeField';
-export * from './DateField';
+export function DateField<T extends DateValue>(props: SpectrumDatePickerProps<T>) {
+  props = useProviderProps(props);
+  let {
+    autoFocus
+  } = props;
+
+  return (
+    <FocusScope autoFocus={autoFocus}>
+      <DatePickerField {...props} />
+    </FocusScope>
+  );
+}

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -16,7 +16,7 @@ import {classNames} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
-import {DateValue, SpectrumDatePickerProps} from '@react-types/datepicker';
+import {DateValue, SpectrumDatePickerProps, TimeValue} from '@react-types/datepicker';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Field} from '@react-spectrum/label';
 import {FieldButton} from '@react-spectrum/button';
@@ -25,6 +25,7 @@ import {mergeProps} from '@react-aria/utils';
 import React, {useRef} from 'react';
 import '@adobe/spectrum-css-temp/components/textfield/vars.css'; // HACK: must be included BEFORE inputgroup
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
+import {TimeField} from './TimeField';
 import {useDatePicker} from '@react-aria/datepicker';
 import {useDatePickerState} from '@react-stately/datepicker';
 import {useHover} from '@react-aria/interactions';
@@ -46,7 +47,7 @@ export function DatePicker<T extends DateValue>(props: SpectrumDatePickerProps<T
   let targetRef = useRef<HTMLDivElement>();
   let state = useDatePickerState(props);
   let {groupProps, labelProps, fieldProps, buttonProps, dialogProps} = useDatePicker(props, state, targetRef);
-  let {value, setValue, selectDate, isOpen, setOpen} = state;
+  let {value, setValue, isOpen, setOpen} = state;
   let {direction} = useLocale();
 
   let {isFocused, isFocusVisible, focusProps} = useFocusRing({
@@ -86,6 +87,13 @@ export function DatePicker<T extends DateValue>(props: SpectrumDatePickerProps<T
 
   //   return s.type;
   // }).join(' ') : '';
+
+  let v = state.value || props.placeholderValue;
+  let timePlaceholder: TimeValue = props.placeholderValue && 'hour' in props.placeholderValue ? props.placeholderValue : null;
+  let timeMinValue: TimeValue = props.minValue && 'hour' in props.minValue ? props.minValue : null;
+  let timeMaxValue: TimeValue = props.maxValue && 'hour' in props.maxValue ? props.maxValue : null;
+  let timeGranularity = props.granularity === 'hour' || props.granularity === 'minute' || props.granularity === 'second' || props.granularity === 'millisecond' ? props.granularity : null;
+  let showTimeField = (v && 'hour' in v) || !!timeGranularity;
 
   return (
     <Field {...props} labelProps={labelProps}>
@@ -131,8 +139,20 @@ export function DatePicker<T extends DateValue>(props: SpectrumDatePickerProps<T
             <Content>
               <Calendar
                 autoFocus
-                value={state.value}
-                onChange={selectDate} />
+                value={state.dateValue}
+                onChange={state.setDateValue} />
+              {showTimeField &&
+                <TimeField
+                  label="Time"
+                  value={state.timeValue}
+                  onChange={state.setTimeValue}
+                  placeholderValue={timePlaceholder}
+                  granularity={timeGranularity}
+                  minValue={timeMinValue}
+                  maxValue={timeMaxValue}
+                  hourCycle={props.hourCycle}
+                  hideTimeZone={props.hideTimeZone} />
+              }
             </Content>
           </Dialog>
         </DialogTrigger>

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -16,14 +16,13 @@ import {classNames} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
+import {DateValue, SpectrumDatePickerProps} from '@react-types/datepicker';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Field} from '@react-spectrum/label';
 import {FieldButton} from '@react-spectrum/button';
 import {FocusScope, useFocusRing} from '@react-aria/focus';
-import {fromDateToLocal, getLocalTimeZone, toCalendarDate} from '@internationalized/date';
 import {mergeProps} from '@react-aria/utils';
 import React, {useRef} from 'react';
-import {SpectrumDatePickerProps} from '@react-types/datepicker';
 import '@adobe/spectrum-css-temp/components/textfield/vars.css'; // HACK: must be included BEFORE inputgroup
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
 import {useDatePicker} from '@react-aria/datepicker';
@@ -32,7 +31,7 @@ import {useHover} from '@react-aria/interactions';
 import {useLocale} from '@react-aria/i18n';
 import {useProviderProps} from '@react-spectrum/provider';
 
-export function DatePicker(props: SpectrumDatePickerProps) {
+export function DatePicker<T extends DateValue>(props: SpectrumDatePickerProps<T>) {
   props = useProviderProps(props);
   let {
     autoFocus,
@@ -132,9 +131,8 @@ export function DatePicker(props: SpectrumDatePickerProps) {
             <Content>
               <Calendar
                 autoFocus
-                value={state.value ? state.value.toDate(getLocalTimeZone()) : null}
-                // @ts-ignore
-                onChange={date => selectDate(toCalendarDate(fromDateToLocal(date)))} />
+                value={state.value}
+                onChange={selectDate} />
             </Content>
           </Dialog>
         </DialogTrigger>

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -23,6 +23,7 @@ import React, {useRef} from 'react';
 import textfieldStyles from '@adobe/spectrum-css-temp/components/textfield/vars.css';
 import {useDateField} from '@react-aria/datepicker';
 import {useDatePickerFieldState} from '@react-stately/datepicker';
+import {useLocale} from '@react-aria/i18n';
 
 interface DatePickerFieldProps<T extends DateValue> extends SpectrumDatePickerProps<T> {
   inputClassName?: string,
@@ -40,8 +41,10 @@ export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps
     hideValidationIcon
   } = props;
   let ref = useRef();
+  let {locale} = useLocale();
   let state = useDatePickerFieldState({
     ...props,
+    locale,
     createCalendar
   });
 

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -16,21 +16,21 @@ import {classNames} from '@react-spectrum/utils';
 import {createCalendar} from '@internationalized/date';
 import {DatePickerSegment} from './DatePickerSegment';
 import datepickerStyles from './index.css';
+import {DateValue, SpectrumDatePickerProps} from '@react-types/datepicker';
 import {Field} from '@react-spectrum/label';
 import {FocusRing} from '@react-aria/focus';
 import React, {useRef} from 'react';
-import {SpectrumDatePickerProps} from '@react-types/datepicker';
 import textfieldStyles from '@adobe/spectrum-css-temp/components/textfield/vars.css';
 import {useDateField} from '@react-aria/datepicker';
 import {useDatePickerFieldState} from '@react-stately/datepicker';
 
-interface DatePickerFieldProps extends SpectrumDatePickerProps {
+interface DatePickerFieldProps<T extends DateValue> extends SpectrumDatePickerProps<T> {
   inputClassName?: string,
   hideValidationIcon?: boolean,
-  maxGranularity?: SpectrumDatePickerProps['granularity']
+  maxGranularity?: SpectrumDatePickerProps<T>['granularity']
 }
 
-export function DatePickerField(props: DatePickerFieldProps) {
+export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps<T>) {
   let {
     isDisabled,
     isReadOnly,

--- a/packages/@react-spectrum/datepicker/src/DatePickerSegment.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerSegment.tsx
@@ -11,7 +11,7 @@
  */
 
 import {classNames} from '@react-spectrum/utils';
-import {DatePickerBase} from '@react-types/datepicker';
+import {DatePickerBase, DateValue} from '@react-types/datepicker';
 import {DatePickerFieldState, DateSegment} from '@react-stately/datepicker';
 import {NumberParser} from '@internationalized/number';
 import React, {useMemo, useRef} from 'react';
@@ -21,7 +21,7 @@ import {useFocusManager} from '@react-aria/focus';
 import {useLocale} from '@react-aria/i18n';
 import {usePress} from '@react-aria/interactions';
 
-interface DatePickerSegmentProps extends DatePickerBase {
+interface DatePickerSegmentProps extends DatePickerBase<DateValue> {
   segment: DateSegment,
   state: DatePickerFieldState
 }

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -15,15 +15,17 @@ import {classNames, useStyleProps} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
-import {DateValue, SpectrumDateRangePickerProps} from '@react-types/datepicker';
+import {DateValue, SpectrumDateRangePickerProps, TimeValue} from '@react-types/datepicker';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Field} from '@react-spectrum/label';
 import {FieldButton} from '@react-spectrum/button';
+import {Flex} from '@react-spectrum/layout';
 import {FocusScope, useFocusManager, useFocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
 import {RangeCalendar} from '@react-spectrum/calendar';
 import React, {useRef} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
+import {TimeField} from './TimeField';
 import {useDateRangePicker} from '@react-aria/datepicker';
 import {useDateRangePickerState} from '@react-stately/datepicker';
 import {useHover, usePress} from '@react-aria/interactions';
@@ -46,7 +48,7 @@ export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePic
   let targetRef = useRef<HTMLDivElement>();
   let state = useDateRangePickerState(props);
   let {labelProps, groupProps, buttonProps, dialogProps, startFieldProps, endFieldProps} = useDateRangePicker(props, state, targetRef);
-  let {value, setDate, selectDateRange, isOpen, setOpen} = state;
+  let {value, isOpen, setOpen} = state;
   let {direction} = useLocale();
 
   let {isFocused, isFocusVisible, focusProps} = useFocusRing({
@@ -80,6 +82,13 @@ export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePic
     }
   );
 
+  let v = state.value?.start || props.placeholderValue;
+  let timePlaceholder: TimeValue = props.placeholderValue && 'hour' in props.placeholderValue ? props.placeholderValue : null;
+  let timeMinValue: TimeValue = props.minValue && 'hour' in props.minValue ? props.minValue : null;
+  let timeMaxValue: TimeValue = props.maxValue && 'hour' in props.maxValue ? props.maxValue : null;
+  let timeGranularity = props.granularity === 'hour' || props.granularity === 'minute' || props.granularity === 'second' || props.granularity === 'millisecond' ? props.granularity : null;
+  let showTimeField = (v && 'hour' in v) || !!timeGranularity;
+
   return (
     <Field width="auto" {...props} labelProps={labelProps}>
       <div
@@ -99,7 +108,7 @@ export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePic
             placeholderValue={placeholderValue}
             value={value.start}
             defaultValue={null}
-            onChange={start => setDate('start', start)}
+            onChange={start => state.setValue({...value, start})}
             granularity={props.granularity}
             hourCycle={props.hourCycle}
             UNSAFE_className={classNames(datepickerStyles, 'react-spectrum-Datepicker-startField')}
@@ -115,7 +124,7 @@ export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePic
             placeholderValue={placeholderValue}
             value={value.end}
             defaultValue={null}
-            onChange={end => setDate('end', end)}
+            onChange={end => state.setValue({...value, end})}
             granularity={props.granularity}
             hourCycle={props.hourCycle}
             UNSAFE_className={classNames(
@@ -148,8 +157,32 @@ export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePic
             <Content>
               <RangeCalendar
                 autoFocus
-                value={value}
-                onChange={selectDateRange} />
+                value={state.dateRange}
+                onChange={state.setDateRange} />
+              {showTimeField &&
+                <Flex gap="size-100">
+                  <TimeField
+                    label="Start time"
+                    value={state.timeRange?.start || null}
+                    onChange={v => state.setTime('start', v)}
+                    placeholderValue={timePlaceholder}
+                    granularity={timeGranularity}
+                    minValue={timeMinValue}
+                    maxValue={timeMaxValue}
+                    hourCycle={props.hourCycle}
+                    hideTimeZone={props.hideTimeZone} />
+                  <TimeField
+                    label="End time"
+                    value={state.timeRange?.end || null}
+                    onChange={v => state.setTime('end', v)}
+                    placeholderValue={timePlaceholder}
+                    granularity={timeGranularity}
+                    minValue={timeMinValue}
+                    maxValue={timeMaxValue}
+                    hourCycle={props.hourCycle}
+                    hideTimeZone={props.hideTimeZone} />
+                </Flex>
+              }
             </Content>
           </Dialog>
         </DialogTrigger>

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -15,15 +15,13 @@ import {classNames, useStyleProps} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
-import {DateRange, SpectrumDateRangePickerProps} from '@react-types/datepicker';
+import {DateValue, SpectrumDateRangePickerProps} from '@react-types/datepicker';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Field} from '@react-spectrum/label';
 import {FieldButton} from '@react-spectrum/button';
 import {FocusScope, useFocusManager, useFocusRing} from '@react-aria/focus';
-import {fromDateToLocal, getLocalTimeZone, toCalendarDate} from '@internationalized/date';
 import {mergeProps} from '@react-aria/utils';
 import {RangeCalendar} from '@react-spectrum/calendar';
-import {RangeValue} from '@react-types/shared';
 import React, {useRef} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
 import {useDateRangePicker} from '@react-aria/datepicker';
@@ -32,7 +30,7 @@ import {useHover, usePress} from '@react-aria/interactions';
 import {useLocale} from '@react-aria/i18n';
 import {useProviderProps} from '@react-spectrum/provider';
 
-export function DateRangePicker(props: SpectrumDateRangePickerProps) {
+export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePickerProps<T>) {
   props = useProviderProps(props);
   let {
     isQuiet,
@@ -150,9 +148,8 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
             <Content>
               <RangeCalendar
                 autoFocus
-                value={rangeToCalendarRage(value)}
-                // @ts-ignore
-                onChange={range => selectDateRange(calendarRangeToRange(range))} />
+                value={value}
+                onChange={selectDateRange} />
             </Content>
           </Dialog>
         </DialogTrigger>
@@ -178,23 +175,4 @@ function DateRangeDash() {
       className={classNames(styles, 'spectrum-Datepicker--rangeDash')}
       {...pressProps} />
   );
-}
-
-// TODO: remove once calendar API is converted over...
-function rangeToCalendarRage(range: DateRange) {
-  return {
-    start: range.start?.toDate(getLocalTimeZone()),
-    end: range.end?.toDate(getLocalTimeZone())
-  };
-}
-
-function calendarRangeToRange(range: RangeValue<Date>) {
-  if (!range) {
-    return null;
-  }
-
-  return {
-    start: toCalendarDate(fromDateToLocal(range.start)),
-    end: toCalendarDate(fromDateToLocal(range.end))
-  };
 }

--- a/packages/@react-spectrum/datepicker/src/TimeField.tsx
+++ b/packages/@react-spectrum/datepicker/src/TimeField.tsx
@@ -10,15 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-import {CalendarDateTime, getLocalTimeZone, Time, toCalendarDateTime, today, toTime, ZonedDateTime} from '@internationalized/date';
 import {DatePickerField} from './DatePickerField';
+import {DateValue, SpectrumTimePickerProps, TimeValue} from '@react-types/datepicker';
 import {FocusScope} from '@react-aria/focus';
+import {getLocalTimeZone, Time, toCalendarDateTime, today, toTime} from '@internationalized/date';
 import React, {useMemo} from 'react';
-import {SpectrumTimePickerProps} from '@react-types/datepicker';
 import {useControlledState} from '@react-stately/utils';
 import {useProviderProps} from '@react-spectrum/provider';
 
-export function TimeField(props: SpectrumTimePickerProps) {
+export function TimeField<T extends TimeValue>(props: SpectrumTimePickerProps<T>) {
   props = useProviderProps(props);
   let {
     autoFocus,
@@ -27,7 +27,7 @@ export function TimeField(props: SpectrumTimePickerProps) {
     maxValue
   } = props;
 
-  let [value, setValue] = useControlledState(
+  let [value, setValue] = useControlledState<TimeValue>(
     props.value,
     props.defaultValue,
     props.onChange
@@ -60,7 +60,7 @@ export function TimeField(props: SpectrumTimePickerProps) {
   );
 }
 
-function convertValue(value: Time | CalendarDateTime | ZonedDateTime, date = today(getLocalTimeZone())) {
+function convertValue(value: TimeValue, date: DateValue = today(getLocalTimeZone())) {
   if (!value) {
     return null;
   }

--- a/packages/@react-spectrum/datepicker/stories/DateField.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DateField.stories.tsx
@@ -41,10 +41,6 @@ storiesOf('Date and Time/DateField', module)
     () => render({defaultValue: toZoned(parseDate('2020-02-03'), 'America/Los_Angeles')})
   )
   .add(
-    'granularity: month',
-    () => render({granularity: 'month'})
-  )
-  .add(
     'granularity: minute',
     () => render({granularity: 'minute'})
   )

--- a/packages/@react-spectrum/datepicker/stories/DateField.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DateField.stories.tsx
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {action} from '@storybook/addon-actions';
+import {CalendarDate, CalendarDateTime, parseAbsolute, parseAbsoluteToLocal, parseDate, parseDateTime, parseZonedDateTime, toZoned} from '@internationalized/date';
+import {DateField} from '../';
+import {Flex} from '@react-spectrum/layout';
+import {Item, Picker, Section} from '@react-spectrum/picker';
+import {Provider} from '@react-spectrum/provider';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {useLocale} from '@react-aria/i18n';
+
+const BlockDecorator = storyFn => <div>{storyFn()}</div>;
+
+storiesOf('Date and Time/DateField', module)
+  .addDecorator(BlockDecorator)
+  .add(
+    'default',
+    () => render()
+  )
+  .add(
+    'defaultValue',
+    () => render({defaultValue: parseDate('2020-02-03')})
+  )
+  .add(
+    'controlled value',
+    () => render({value: new CalendarDate(2020, 2, 3)})
+  )
+  .add(
+    'defaultValue, zoned',
+    () => render({defaultValue: toZoned(parseDate('2020-02-03'), 'America/Los_Angeles')})
+  )
+  .add(
+    'granularity: month',
+    () => render({granularity: 'month'})
+  )
+  .add(
+    'granularity: minute',
+    () => render({granularity: 'minute'})
+  )
+  .add(
+    'granularity: second',
+    () => render({granularity: 'second'})
+  )
+  .add(
+    'hourCycle: 12',
+    () => render({granularity: 'minute', hourCycle: 12})
+  )
+  .add(
+    'hourCycle: 24',
+    () => render({granularity: 'minute', hourCycle: 24})
+  )
+  .add(
+    'granularity: minute, defaultValue',
+    () => render({granularity: 'minute', defaultValue: parseDateTime('2021-03-14T08:45')})
+  )
+  .add(
+    'granularity: minute, defaultValue, zoned',
+    () => render({granularity: 'minute', defaultValue: parseZonedDateTime('2021-11-07T00:45-07:00[America/Los_Angeles]')})
+  )
+  .add('granularity: minute, defaultValue, zoned, absolute',
+    () => render({granularity: 'minute', defaultValue: parseAbsoluteToLocal('2021-11-07T07:45:00Z')})
+  )
+  .add('granularity: minute, defaultValue, zoned, absolute, timeZone',
+    () => render({granularity: 'minute', defaultValue: parseAbsolute('2021-11-07T07:45:00Z', 'America/New_York')})
+  )
+  .add(
+    'defaultValue with time, granularity: day',
+    () => render({granularity: 'day', defaultValue: parseDateTime('2021-03-14T08:45')})
+  )
+  .add(
+    'hideTimeZone',
+    () => render({granularity: 'minute', defaultValue: parseZonedDateTime('2021-11-07T00:45-07:00[America/Los_Angeles]'), hideTimeZone: true})
+  )
+  .add(
+    'isDisabled',
+    () => render({isDisabled: true, value: new CalendarDate(2020, 2, 3)})
+  )
+  .add(
+    'isQuiet, isDisabled',
+    () => render({isQuiet: true, isDisabled: true, value: new CalendarDate(2020, 2, 3)})
+  )
+  .add(
+    'isReadOnly',
+    () => render({isReadOnly: true, value: new CalendarDate(2020, 2, 3)})
+  )
+  .add(
+    'autoFocus',
+    () => render({autoFocus: true})
+  )
+  .add(
+    'validationState: invalid',
+    () => render({validationState: 'invalid', value: new CalendarDate(2020, 2, 3)})
+  )
+  .add(
+    'validationState: valid',
+    () => render({validationState: 'valid', value: new CalendarDate(2020, 2, 3)})
+  )
+  .add(
+    'minValue: 2010/1/1, maxValue: 2020/1/1',
+    () => render({minValue: new CalendarDate(2010, 0, 1), maxValue: new CalendarDate(2020, 0, 1)})
+  )
+  .add(
+    'placeholderValue: 1980/1/1',
+    () => render({placeholderValue: new CalendarDate(1980, 1, 1)})
+  )
+  .add(
+    'placeholderValue: 1980/1/1 8 AM',
+    () => render({placeholderValue: new CalendarDateTime(1980, 1, 1, 8)})
+  )
+  .add(
+    'placeholderValue: 1980/1/1, zoned',
+    () => render({placeholderValue: toZoned(new CalendarDate(1980, 1, 1), 'America/Los_Angeles')})
+  );
+
+storiesOf('Date and Time/DateField/styling', module)
+  .addDecorator(BlockDecorator)
+  .add(
+    'isQuiet',
+    () => render({isQuiet: true})
+  )
+  .add(
+    'labelPosition: side',
+    () => render({labelPosition: 'side'})
+  )
+  .add(
+    'labelAlign: end',
+    () => render({labelPosition: 'top', labelAlign: 'end'})
+  )
+  .add(
+    'required',
+    () => render({isRequired: true})
+  )
+  .add(
+    'required with label',
+    () => render({isRequired: true, necessityIndicator: 'label'})
+  )
+  .add(
+    'optional',
+    () => render({necessityIndicator: 'label'})
+  )
+  .add(
+    'no visible label',
+    () => render({'aria-label': 'Date', label: null})
+  )
+  .add(
+    'quiet no visible label',
+    () => render({isQuiet: true, 'aria-label': 'Date', label: null})
+  )
+  .add(
+    'custom width',
+    () => render({width: 'size-3000'})
+  )
+  .add(
+    'quiet custom width',
+    () => render({isQuiet: true, width: 'size-3000'})
+  )
+  .add(
+    'custom width no visible label',
+    () => render({width: 'size-3000', label: null, 'aria-label': 'Date'})
+  )
+  .add(
+    'custom width, labelPosition=side',
+    () => render({width: 'size-3000', labelPosition: 'side'})
+  );
+
+function render(props = {}) {
+  return (
+    <Example
+      label="Date"
+      onChange={action('change')}
+      {...props} />
+  );
+}
+
+// https://github.com/unicode-org/cldr/blob/22af90ae3bb04263f651323ce3d9a71747a75ffb/common/supplemental/supplementalData.xml#L4649-L4664
+const preferences = [
+  {locale: '', label: 'Default', ordering: 'gregory'},
+  {label: 'Arabic (Algeria)', locale: 'ar-DZ', territories: 'DJ DZ EH ER IQ JO KM LB LY MA MR OM PS SD SY TD TN YE', ordering: 'gregory islamic islamic-civil islamic-tbla'},
+  {label: 'Arabic (United Arab Emirates)', locale: 'ar-AE', territories: 'AE BH KW QA', ordering: 'gregory islamic-umalqura islamic islamic-civil islamic-tbla'},
+  {label: 'Arabic (Egypt)', locale: 'AR-EG', territories: 'EG', ordering: 'gregory coptic islamic islamic-civil islamic-tbla'},
+  {label: 'Arabic (Saudi Arabia)', locale: 'ar-SA', territories: 'SA', ordering: 'islamic-umalqura gregory islamic islamic-rgsa'},
+  {label: 'Farsi (Afghanistan)', locale: 'fa-AF', territories: 'AF IR', ordering: 'persian gregory islamic islamic-civil islamic-tbla'},
+  // {territories: 'CN CX HK MO SG', ordering: 'gregory chinese'},
+  {label: 'Amharic (Ethiopia)', locale: 'am-ET', territories: 'ET', ordering: 'gregory ethiopic ethioaa'},
+  {label: 'Hebrew (Israel)', locale: 'he-IL', territories: 'IL', ordering: 'gregory hebrew islamic islamic-civil islamic-tbla'},
+  {label: 'Hindi (India)', locale: 'hi-IN', territories: 'IN', ordering: 'gregory indian'},
+  // {label: 'Marathi (India)', locale: 'mr-IN', territories: 'IN', ordering: 'gregory indian'},
+  {label: 'Bengali (India)', locale: 'bn-IN', territories: 'IN', ordering: 'gregory indian'},
+  {label: 'Japanese (Japan)', locale: 'ja-JP', territories: 'JP', ordering: 'gregory japanese'},
+  // {territories: 'KR', ordering: 'gregory dangi'},
+  {label: 'Thai (Thailand)', locale: 'th-TH', territories: 'TH', ordering: 'buddhist gregory'},
+  {label: 'Chinese (Taiwan)', locale: 'zh-TW', territories: 'TW', ordering: 'gregory roc chinese'}
+];
+
+const calendars = [
+  {key: 'gregory', name: 'Gregorian'},
+  {key: 'japanese', name: 'Japanese'},
+  {key: 'buddhist', name: 'Buddhist'},
+  {key: 'roc', name: 'Taiwan'},
+  {key: 'persian', name: 'Persian'},
+  {key: 'indian', name: 'Indian'},
+  {key: 'islamic-umalqura', name: 'Islamic (Umm al-Qura)'},
+  {key: 'islamic-civil', name: 'Islamic Civil'},
+  {key: 'islamic-tbla', name: 'Islamic Tabular'},
+  {key: 'hebrew', name: 'Hebrew'},
+  {key: 'coptic', name: 'Coptic'},
+  {key: 'ethiopic', name: 'Ethiopic'},
+  {key: 'ethioaa', name: 'Ethiopic (Amete Alem)'}
+];
+
+function Example(props) {
+  let [locale, setLocale] = React.useState('');
+  let [calendar, setCalendar] = React.useState<React.Key>(calendars[0].key);
+  let {locale: defaultLocale} = useLocale();
+
+  let pref = preferences.find(p => p.locale === locale);
+  let preferredCalendars = React.useMemo(() => pref ? pref.ordering.split(' ').map(p => calendars.find(c => c.key === p)).filter(Boolean) : [calendars[0]], [pref]);
+  let otherCalendars = React.useMemo(() => calendars.filter(c => !preferredCalendars.some(p => p.key === c.key)), [preferredCalendars]);
+
+  let updateLocale = locale => {
+    setLocale(locale);
+    let pref = preferences.find(p => p.locale === locale);
+    setCalendar(pref.ordering.split(' ')[0]);
+  };
+
+  return (
+    <Flex direction="column" gap="size-600" alignItems="center">
+      <Flex direction="row" gap="size-150" wrap justifyContent="center">
+        <Picker label="Locale" items={preferences} selectedKey={locale} onSelectionChange={updateLocale}>
+          {item => <Item key={item.locale}>{item.label}</Item>}
+        </Picker>
+        <Picker label="Calendar" selectedKey={calendar} onSelectionChange={setCalendar}>
+          <Section title="Preferred" items={preferredCalendars}>
+            {item => <Item>{item.name}</Item>}
+          </Section>
+          <Section title="Other" items={otherCalendars}>
+            {item => <Item>{item.name}</Item>}
+          </Section>
+        </Picker>
+      </Flex>
+      <Provider locale={(locale || defaultLocale) + (calendar && calendar !== preferredCalendars[0].key ? '-u-ca-' + calendar : '')}>
+        <DateField {...props} />
+      </Provider>
+    </Flex>
+  );
+}

--- a/packages/@react-spectrum/datepicker/stories/DatePicker.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DatePicker.stories.tsx
@@ -41,10 +41,6 @@ storiesOf('Date and Time/DatePicker', module)
     () => render({defaultValue: toZoned(parseDate('2020-02-03'), 'America/Los_Angeles')})
   )
   .add(
-    'granularity: month',
-    () => render({granularity: 'month'})
-  )
-  .add(
     'granularity: minute',
     () => render({granularity: 'minute'})
   )

--- a/packages/@react-spectrum/datepicker/stories/DatePicker.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DatePicker.stories.tsx
@@ -75,6 +75,10 @@ storiesOf('Date and Time/DatePicker', module)
     () => render({granularity: 'minute', defaultValue: parseAbsolute('2021-11-07T07:45:00Z', 'America/New_York')})
   )
   .add(
+    'defaultValue with time, granularity: day',
+    () => render({granularity: 'day', defaultValue: parseDateTime('2021-03-14T08:45')})
+  )
+  .add(
     'hideTimeZone',
     () => render({granularity: 'minute', defaultValue: parseZonedDateTime('2021-11-07T00:45-07:00[America/Los_Angeles]'), hideTimeZone: true})
   )

--- a/packages/@react-spectrum/datepicker/stories/DateRangePicker.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DateRangePicker.stories.tsx
@@ -41,6 +41,10 @@ storiesOf('Date and Time/DateRangePicker', module)
     () => render({granularity: 'minute'})
   )
   .add(
+    'granularity: second',
+    () => render({granularity: 'second'})
+  )
+  .add(
     'hourCycle: 12',
     () => render({granularity: 'minute', hourCycle: 12})
   )

--- a/packages/@react-spectrum/datepicker/stories/TimeField.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/TimeField.stories.tsx
@@ -38,11 +38,19 @@ storiesOf('Date and Time/TimeField', module)
   )
   .add(
     'hourCycle: 12',
-    () => render({hourCycle: 12})
+    () => render({hourCycle: 12, defaultValue: parseTime('00:00')})
   )
   .add(
     'hourCycle: 24',
-    () => render({hourCycle: 24})
+    () => render({hourCycle: 24, defaultValue: parseTime('00:00')})
+  )
+  .add(
+    'hourCycle: 12, granularity: hour',
+    () => render({hourCycle: 12, granularity: 'hour'})
+  )
+  .add(
+    'hourCycle: 24, granularity: hour',
+    () => render({hourCycle: 24, granularity: 'hour'})
   )
   .add(
     'zoned',

--- a/packages/@react-stately/calendar/src/types.ts
+++ b/packages/@react-stately/calendar/src/types.ts
@@ -11,6 +11,7 @@
  */
 
 import {CalendarDate} from '@internationalized/date';
+import {DateValue} from '@react-types/calendar';
 import {RangeValue} from '@react-types/shared';
 
 export interface CalendarStateBase {
@@ -49,12 +50,12 @@ export interface CalendarStateBase {
 
 export interface CalendarState extends CalendarStateBase {
   value: CalendarDate,
-  setValue(value: Date): void
+  setValue(value: CalendarDate): void
 }
 
 export interface RangeCalendarState extends CalendarStateBase {
-  value: RangeValue<CalendarDate>,
-  setValue(value: RangeValue<Date>): void,
+  value: RangeValue<DateValue>,
+  setValue(value: RangeValue<DateValue>): void,
   highlightDate(date: CalendarDate): void,
   anchorDate: CalendarDate | null,
   setAnchorDate(date: CalendarDate | null): void,

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -104,7 +104,7 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
 
   let weekDays = useMemo(() => (
     [...new Array(7).keys()]
-      .map(index => currentMonth.set({day: index - monthStartsAt + 1}))
+      .map(index => startOfMonth(currentMonth).add({days: index - monthStartsAt}))
   ), [currentMonth, monthStartsAt]);
 
   return {
@@ -159,8 +159,8 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
     daysInMonth: currentMonth.calendar.getDaysInMonth(currentMonth),
     weekDays,
     getCellDate(weekIndex, dayIndex) {
-      let day = (weekIndex * 7 + dayIndex) - monthStartsAt + 1;
-      return currentMonth.set({day});
+      let days = (weekIndex * 7 + dayIndex) - monthStartsAt;
+      return startOfMonth(currentMonth).add({days});
     },
     isInvalid(date) {
       return isInvalid(date, minDate, maxDate);

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -13,10 +13,9 @@
 import {
   Calendar,
   CalendarDate,
-  compareDate,
   endOfMonth,
-  fromAbsolute,
   getDayOfWeek,
+  GregorianCalendar,
   isSameDay,
   isSameMonth,
   startOfMonth,
@@ -24,18 +23,18 @@ import {
   toCalendarDate,
   today
 } from '@internationalized/date';
-import {CalendarProps} from '@react-types/calendar';
+import {CalendarProps, DateValue} from '@react-types/calendar';
 import {CalendarState} from './types';
 import {useControlledState} from '@react-stately/utils';
 import {useDateFormatter} from '@react-aria/i18n';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {useWeekStart} from './useWeekStart';
 
-interface CalendarStateOptions extends CalendarProps {
+interface CalendarStateOptions<T extends DateValue> extends CalendarProps<T> {
   createCalendar: (name: string) => Calendar
 }
 
-export function useCalendarState(props: CalendarStateOptions): CalendarState {
+export function useCalendarState<T extends DateValue>(props: CalendarStateOptions<T>): CalendarState {
   let defaultFormatter = useDateFormatter();
   let resolvedOptions = useMemo(() => defaultFormatter.resolvedOptions(), [defaultFormatter]);
   let {
@@ -45,9 +44,8 @@ export function useCalendarState(props: CalendarStateOptions): CalendarState {
 
   let calendar = useMemo(() => createCalendar(resolvedOptions.calendar), [createCalendar, resolvedOptions.calendar]);
 
-  let [value, setControlledValue] = useControlledState(props.value || undefined, props.defaultValue, props.onChange);
-  let dateValue = useMemo(() => value ? new Date(value) : null, [value]);
-  let calendarDateValue = useMemo(() => dateValue ? toCalendar(toCalendarDate(fromAbsolute(dateValue.getTime(), timeZone)), calendar) : null, [dateValue, timeZone, calendar]);
+  let [value, setControlledValue] = useControlledState<DateValue>(props.value || undefined, props.defaultValue, props.onChange);
+  let calendarDateValue = useMemo(() => value ? toCalendar(toCalendarDate(value), calendar) : null, [value, calendar]);
   let defaultMonth = calendarDateValue || toCalendar(today(timeZone), calendar);
   let [currentMonth, setCurrentMonth] = useState(defaultMonth); // TODO: does this need to be in state at all??
   let [focusedDate, setFocusedDate] = useState(defaultMonth);
@@ -71,8 +69,8 @@ export function useCalendarState(props: CalendarStateOptions): CalendarState {
 
   let days = currentMonth.calendar.getDaysInMonth(currentMonth);
   let weeksInMonth = Math.ceil((monthStartsAt + days) / 7);
-  let minDate = useMemo(() => props.minValue ? toCalendar(toCalendarDate(fromAbsolute(new Date(props.minValue).getTime(), timeZone)), calendar) : null, [calendar, props.minValue, timeZone]);
-  let maxDate = useMemo(() => props.maxValue ? toCalendar(toCalendarDate(fromAbsolute(new Date(props.maxValue).getTime(), timeZone)), calendar) : null, [calendar, props.maxValue, timeZone]);
+  let minDate = props.minValue;
+  let maxDate = props.maxValue;
 
   // Sets focus to a specific cell date
   function focusCell(date: CalendarDate) {
@@ -89,9 +87,18 @@ export function useCalendarState(props: CalendarStateOptions): CalendarState {
     setFocusedDate(date);
   }
 
-  function setValue(value: Date) {
+  function setValue(newValue: CalendarDate) {
     if (!props.isDisabled && !props.isReadOnly) {
-      setControlledValue(value);
+      // The display calendar should not have any effect on the emitted value.
+      // Emit dates in the same calendar as the original value, if any, otherwise gregorian.
+      newValue = toCalendar(newValue, value?.calendar || new GregorianCalendar());
+
+      // Preserve time if the input value had one.
+      if (value && 'hour' in value) {
+        setControlledValue(value.set(newValue));
+      } else {
+        setControlledValue(newValue);
+      }
     }
   }
 
@@ -140,10 +147,10 @@ export function useCalendarState(props: CalendarStateOptions): CalendarState {
       focusCell(focusedDate.subtract({years: 1}));
     },
     selectFocusedDate() {
-      setValue(focusedDate.toDate(timeZone));
+      setValue(focusedDate);
     },
     selectDate(date) {
-      setValue(date.toDate(timeZone));
+      setValue(date);
     },
     isFocused,
     setFocused,
@@ -176,7 +183,7 @@ export function useCalendarState(props: CalendarStateOptions): CalendarState {
   };
 }
 
-function isInvalid(date: CalendarDate, minDate: CalendarDate, maxDate: CalendarDate) {
-  return (minDate != null && compareDate(date, minDate) < 0) ||
-    (maxDate != null && compareDate(date, maxDate) > 0);
+function isInvalid(date: CalendarDate, minDate: DateValue, maxDate: DateValue) {
+  return (minDate != null && date.compare(minDate) < 0) ||
+    (maxDate != null && date.compare(maxDate) > 0);
 }

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -44,7 +44,7 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
 
   let calendar = useMemo(() => createCalendar(resolvedOptions.calendar), [createCalendar, resolvedOptions.calendar]);
 
-  let [value, setControlledValue] = useControlledState<DateValue>(props.value || undefined, props.defaultValue, props.onChange);
+  let [value, setControlledValue] = useControlledState<DateValue>(props.value, props.defaultValue, props.onChange);
   let calendarDateValue = useMemo(() => value ? toCalendar(toCalendarDate(value), calendar) : null, [value, calendar]);
   let defaultMonth = calendarDateValue || toCalendar(today(timeZone), calendar);
   let [currentMonth, setCurrentMonth] = useState(defaultMonth); // TODO: does this need to be in state at all??

--- a/packages/@react-stately/datepicker/package.json
+++ b/packages/@react-stately/datepicker/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@internationalized/date": "3.0.0-alpha.1",
-    "@react-aria/i18n": "^3.1.0",
     "@react-stately/utils": "^3.1.0",
     "@react-types/datepicker": "3.0.0-alpha.1",
     "@react-types/shared": "^3.1.0",

--- a/packages/@react-stately/datepicker/src/useDatePickerFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerFieldState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Calendar, CalendarDateTime, GregorianCalendar, now, toCalendar, toCalendarDate, toCalendarDateTime} from '@internationalized/date';
+import {Calendar, CalendarDateTime, getMinimumDayInMonth, getMinimumMonthInYear, GregorianCalendar, now, toCalendar, toCalendarDate, toCalendarDateTime} from '@internationalized/date';
 import {DatePickerProps, DateValue} from '@react-types/datepicker';
 import {FieldOptions, getFormatOptions, isInvalid} from './utils';
 import {useControlledState} from '@react-stately/utils';
@@ -157,11 +157,10 @@ export function useDatePickerFieldState<T extends DateValue>(props: DatePickerFi
       return;
     }
 
-    // The display calendar should not have any effect on the emitted value.
-    // Emit dates in the same calendar as the original value, if any, otherwise gregorian.
-    newValue = toCalendar(newValue, v?.calendar || new GregorianCalendar());
-
     if (Object.keys(validSegments).length >= numSegments) {
+      // The display calendar should not have any effect on the emitted value.
+      // Emit dates in the same calendar as the original value, if any, otherwise gregorian.
+      newValue = toCalendar(newValue, v?.calendar || new GregorianCalendar());
       setDate(newValue);
     } else {
       setPlaceholderDate(newValue);
@@ -249,13 +248,13 @@ function getSegmentLimits(date: DateValue, type: string, options: Intl.ResolvedD
     case 'month':
       return {
         value: date.month,
-        minValue: 1,
+        minValue: getMinimumMonthInYear(date),
         maxValue: date.calendar.getMonthsInYear(date)
       };
     case 'day':
       return {
         value: date.day,
-        minValue: 1,
+        minValue: getMinimumDayInMonth(date),
         maxValue: date.calendar.getDaysInMonth(date)
       };
   }

--- a/packages/@react-stately/datepicker/src/useDatePickerFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerFieldState.ts
@@ -10,11 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import {Calendar, CalendarDateTime, getMinimumDayInMonth, getMinimumMonthInYear, GregorianCalendar, now, toCalendar, toCalendarDate, toCalendarDateTime} from '@internationalized/date';
+import {Calendar, CalendarDateTime, DateFormatter, getMinimumDayInMonth, getMinimumMonthInYear, GregorianCalendar, now, toCalendar, toCalendarDate, toCalendarDateTime} from '@internationalized/date';
 import {DatePickerProps, DateValue} from '@react-types/datepicker';
 import {FieldOptions, getFormatOptions, isInvalid} from './utils';
 import {useControlledState} from '@react-stately/utils';
-import {useDateFormatter} from '@react-aria/i18n';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {ValidationState} from '@react-types/shared';
 
@@ -32,7 +31,7 @@ export interface DatePickerFieldState {
   dateValue: Date,
   setValue: (value: CalendarDateTime) => void,
   segments: DateSegment[],
-  dateFormatter: Intl.DateTimeFormat,
+  dateFormatter: DateFormatter,
   validationState: ValidationState,
   increment: (type: Intl.DateTimeFormatPartTypes) => void,
   decrement: (type: Intl.DateTimeFormatPartTypes) => void,
@@ -70,11 +69,13 @@ const TYPE_MAPPING = {
 
 interface DatePickerFieldProps<T extends DateValue> extends DatePickerProps<T> {
   maxGranularity?: DatePickerProps<T>['granularity'],
+  locale: string,
   createCalendar: (name: string) => Calendar
 }
 
 export function useDatePickerFieldState<T extends DateValue>(props: DatePickerFieldProps<T>): DatePickerFieldState {
   let {
+    locale,
     createCalendar,
     hideTimeZone
   } = props;
@@ -102,7 +103,7 @@ export function useDatePickerFieldState<T extends DateValue>(props: DatePickerFi
   }), [props.maxGranularity, granularity, props.hourCycle, defaultTimeZone, hideTimeZone]);
   let opts = useMemo(() => getFormatOptions({}, formatOpts), [formatOpts]);
 
-  let dateFormatter = useDateFormatter(opts);
+  let dateFormatter = useMemo(() => new DateFormatter(locale, opts), [locale, opts]);
   let resolvedOptions = useMemo(() => dateFormatter.resolvedOptions(), [dateFormatter]);
   let calendar = useMemo(() => createCalendar(resolvedOptions.calendar), [createCalendar, resolvedOptions.calendar]);
 

--- a/packages/@react-stately/datepicker/src/useDatePickerFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerFieldState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Calendar, CalendarDateTime, GregorianCalendar, now, toCalendar, toCalendarDate, toCalendarDateTime, ZonedDateTime} from '@internationalized/date';
+import {Calendar, CalendarDateTime, GregorianCalendar, now, toCalendar, toCalendarDate, toCalendarDateTime} from '@internationalized/date';
 import {DatePickerProps, DateValue} from '@react-types/datepicker';
 import {FieldOptions, getFormatOptions, isInvalid} from './utils';
 import {useControlledState} from '@react-stately/utils';
@@ -28,7 +28,7 @@ export interface DateSegment {
 }
 
 export interface DatePickerFieldState {
-  value: CalendarDateTime,
+  value: DateValue,
   dateValue: Date,
   setValue: (value: CalendarDateTime) => void,
   segments: DateSegment[],
@@ -68,12 +68,12 @@ const TYPE_MAPPING = {
   dayperiod: 'dayPeriod'
 };
 
-interface DatePickerFieldProps extends DatePickerProps {
-  maxGranularity?: DatePickerProps['granularity'],
+interface DatePickerFieldProps<T extends DateValue> extends DatePickerProps<T> {
+  maxGranularity?: DatePickerProps<T>['granularity'],
   createCalendar: (name: string) => Calendar
 }
 
-export function useDatePickerFieldState(props: DatePickerFieldProps): DatePickerFieldState {
+export function useDatePickerFieldState<T extends DateValue>(props: DatePickerFieldProps<T>): DatePickerFieldState {
   let {
     createCalendar,
     hideTimeZone
@@ -83,6 +83,11 @@ export function useDatePickerFieldState(props: DatePickerFieldProps): DatePicker
   let defaultTimeZone = (v && 'timeZone' in v ? v.timeZone : undefined);
   let timeZone = defaultTimeZone || 'UTC';
   let granularity = props.granularity || (v && 'minute' in v ? 'minute' : 'day');
+
+  // props.granularity must actually exist in the value if one is provided.
+  if (v && !(granularity in v)) {
+    throw new Error('Invalid granularity ' + granularity + ' for value ' + v.toString());
+  }
 
   let [validSegments, setValidSegments] = useState<Partial<typeof EDITABLE_SEGMENTS>>(
     props.value || props.defaultValue ? {...EDITABLE_SEGMENTS} : {}
@@ -121,59 +126,58 @@ export function useDatePickerFieldState(props: DatePickerFieldProps): DatePicker
   let [placeholderDate, setPlaceholderDate] = useState(
     props.placeholderValue
       ? convertValue(props.placeholderValue, calendar)
-      : createPlaceholderDate(calendar, defaultTimeZone)
+      : createPlaceholderDate(granularity, calendar, defaultTimeZone)
   );
 
-  let [date, setDate] = useControlledState(
-    convertValue(props.value, calendar),
-    convertValue(props.defaultValue, calendar),
-    value => {
-      if (props.onChange) {
-        let hasTime = granularity === 'hour' || granularity === 'minute' || granularity === 'second';
-        let gregorianDate = toCalendar(value, new GregorianCalendar());
-        props.onChange(hasTime || defaultTimeZone ? gregorianDate : toCalendarDate(gregorianDate));
-      }
-    }
-  );
-
-  // Reset date and placeholder when calendar changes
+  // Reset placeholder when calendar changes
   let lastCalendarIdentifier = useRef(calendar.identifier);
   useEffect(() => {
     if (calendar.identifier !== lastCalendarIdentifier.current) {
-      let isValid = Object.keys(validSegments).length >= numSegments;
-      if (isValid) {
-        setDate(date => toCalendar(date, calendar));
-      } else {
-        setPlaceholderDate(placeholder => Object.keys(validSegments).length > 0 ? toCalendar(placeholder, calendar) : createPlaceholderDate(calendar, defaultTimeZone));
-      }
       lastCalendarIdentifier.current = calendar.identifier;
+      setPlaceholderDate(placeholder =>
+        Object.keys(validSegments).length > 0
+          ? toCalendar(placeholder, calendar)
+          : createPlaceholderDate(granularity, calendar, defaultTimeZone)
+      );
     }
-  }, [calendar, setDate, validSegments, defaultTimeZone, numSegments]);
+  }, [calendar, granularity, validSegments, defaultTimeZone]);
+
+  let [value, setDate] = useControlledState<DateValue>(
+    props.value,
+    props.defaultValue,
+    props.onChange
+  );
+
+  let calendarValue = convertValue(value, calendar);
 
   // If all segments are valid, use the date from state, otherwise use the placeholder date.
-  let value = date && Object.keys(validSegments).length >= numSegments ? date : placeholderDate;
-  let setValue = (value: CalendarDateTime) => {
+  let displayValue = calendarValue && Object.keys(validSegments).length >= numSegments ? calendarValue : placeholderDate;
+  let setValue = (newValue: DateValue) => {
     if (props.isDisabled || props.isReadOnly) {
       return;
     }
 
+    // The display calendar should not have any effect on the emitted value.
+    // Emit dates in the same calendar as the original value, if any, otherwise gregorian.
+    newValue = toCalendar(newValue, v?.calendar || new GregorianCalendar());
+
     if (Object.keys(validSegments).length >= numSegments) {
-      setDate(value);
+      setDate(newValue);
     } else {
-      setPlaceholderDate(value);
+      setPlaceholderDate(newValue);
     }
   };
 
-  let dateValue = useMemo(() => value.toDate(timeZone), [value, timeZone]);
+  let dateValue = useMemo(() => displayValue.toDate(timeZone), [displayValue, timeZone]);
   let segments = useMemo(() =>
     dateFormatter.formatToParts(dateValue)
       .map(segment => ({
         type: TYPE_MAPPING[segment.type] || segment.type,
         text: segment.value,
-        ...getSegmentLimits(value, segment.type, resolvedOptions),
+        ...getSegmentLimits(displayValue, segment.type, resolvedOptions),
         isPlaceholder: !validSegments[segment.type]
       } as DateSegment))
-  , [dateValue, validSegments, dateFormatter, resolvedOptions, value]);
+  , [dateValue, validSegments, dateFormatter, resolvedOptions, displayValue]);
 
   let hasEra = useMemo(() => segments.some(s => s.type === 'era'), [segments]);
 
@@ -187,14 +191,14 @@ export function useDatePickerFieldState(props: DatePickerFieldProps): DatePicker
 
   let adjustSegment = (type: Intl.DateTimeFormatPartTypes, amount: number) => {
     markValid(type);
-    setValue(addSegment(value, type, amount, resolvedOptions));
+    setValue(addSegment(displayValue, type, amount, resolvedOptions));
   };
 
   let validationState: ValidationState = props.validationState ||
-    (isInvalid(date, props.minValue, props.maxValue) ? 'invalid' : null);
+    (isInvalid(calendarValue, props.minValue, props.maxValue) ? 'invalid' : null);
 
   return {
-    value: date,
+    value: calendarValue,
     dateValue,
     setValue,
     segments,
@@ -214,11 +218,11 @@ export function useDatePickerFieldState(props: DatePickerFieldProps): DatePicker
     },
     setSegment(part, v) {
       markValid(part);
-      setValue(setSegment(value, part, v, resolvedOptions));
+      setValue(setSegment(displayValue, part, v, resolvedOptions));
     },
     confirmPlaceholder(part) {
       markValid(part);
-      setValue(value.copy());
+      setValue(displayValue.copy());
     },
     getFormatOptions(fieldOptions: FieldOptions) {
       return getFormatOptions(fieldOptions, formatOpts);
@@ -226,125 +230,144 @@ export function useDatePickerFieldState(props: DatePickerFieldProps): DatePicker
   };
 }
 
-function getSegmentLimits(date: CalendarDateTime, type: string, options: Intl.ResolvedDateTimeFormatOptions) {
-  let value, minValue, maxValue;
+function getSegmentLimits(date: DateValue, type: string, options: Intl.ResolvedDateTimeFormatOptions) {
   switch (type) {
     case 'era': {
       let eras = date.calendar.getEras();
-      value = eras.indexOf(date.era);
-      minValue = 0;
-      maxValue = eras.length - 1;
-      break;
+      return {
+        value: eras.indexOf(date.era),
+        minValue: 0,
+        maxValue: eras.length - 1
+      };
     }
     case 'year':
-      value = date.year;
-      minValue = 1;
-      maxValue = date.calendar.getYearsInEra(date);
-      break;
+      return {
+        value: date.year,
+        minValue: 1,
+        maxValue: date.calendar.getYearsInEra(date)
+      };
     case 'month':
-      value = date.month;
-      minValue = 1;
-      maxValue = date.calendar.getMonthsInYear(date);
-      break;
+      return {
+        value: date.month,
+        minValue: 1,
+        maxValue: date.calendar.getMonthsInYear(date)
+      };
     case 'day':
-      value = date.day;
-      minValue = 1;
-      maxValue = date.calendar.getDaysInMonth(date);
-      break;
-    case 'dayPeriod':
-      value = date.hour >= 12 ? 12 : 0;
-      minValue = 0;
-      maxValue = 12;
-      break;
-    case 'hour':
-      value = date.hour;
-      if (options.hour12) {
-        let isPM = value >= 12;
-        minValue = isPM ? 12 : 0;
-        maxValue = isPM ? 23 : 11;
-      } else {
-        minValue = 0;
-        maxValue = 23;
-      }
-      break;
-    case 'minute':
-      value = date.minute;
-      minValue = 0;
-      maxValue = 59;
-      break;
-    case 'second':
-      value = date.second;
-      minValue = 0;
-      maxValue = 59;
-      break;
-    default:
-      return {};
+      return {
+        value: date.day,
+        minValue: 1,
+        maxValue: date.calendar.getDaysInMonth(date)
+      };
   }
 
-  return {
-    value,
-    minValue,
-    maxValue
-  };
+  if ('hour' in date) {
+    switch (type) {
+      case 'dayPeriod':
+        return {
+          value: date.hour >= 12 ? 12 : 0,
+          minValue: 0,
+          maxValue: 12
+        };
+      case 'hour':
+        if (options.hour12) {
+          let isPM = date.hour >= 12;
+          return {
+            value: date.hour,
+            minValue: isPM ? 12 : 0,
+            maxValue: isPM ? 23 : 11
+          };
+        }
+
+        return {
+          value: date.hour,
+          minValue: 0,
+          maxValue: 23
+        };
+      case 'minute':
+        return {
+          value: date.minute,
+          minValue: 0,
+          maxValue: 59
+        };
+      case 'second':
+        return {
+          value: date.second,
+          minValue: 0,
+          maxValue: 59
+        };
+    }
+  }
+
+  return {};
 }
 
-function addSegment(value: CalendarDateTime, part: string, amount: number, options: Intl.ResolvedDateTimeFormatOptions) {
+function addSegment(value: DateValue, part: string, amount: number, options: Intl.ResolvedDateTimeFormatOptions) {
   switch (part) {
     case 'era':
     case 'year':
     case 'month':
     case 'day':
       return value.cycle(part, amount, {round: part === 'year'});
-    case 'dayPeriod': {
-      let hours = value.hour;
-      let isPM = hours >= 12;
-      return value.set({hour: isPM ? hours - 12 : hours + 12});
+  }
+
+  if ('hour' in value) {
+    switch (part) {
+      case 'dayPeriod': {
+        let hours = value.hour;
+        let isPM = hours >= 12;
+        return value.set({hour: isPM ? hours - 12 : hours + 12});
+      }
+      case 'hour':
+      case 'minute':
+      case 'second':
+        return value.cycle(part, amount, {
+          round: part !== 'hour',
+          hourCycle: options.hour12 ? 12 : 24
+        });
     }
-    case 'hour':
-    case 'minute':
-    case 'second':
-      return value.cycle(part, amount, {
-        round: part !== 'hour',
-        hourCycle: options.hour12 ? 12 : 24
-      });
   }
 }
 
-function setSegment(value: CalendarDateTime, part: string, segmentValue: number, options: Intl.ResolvedDateTimeFormatOptions) {
+function setSegment(value: DateValue, part: string, segmentValue: number, options: Intl.ResolvedDateTimeFormatOptions) {
   switch (part) {
     case 'day':
     case 'month':
     case 'year':
       return value.set({[part]: segmentValue});
-    case 'dayPeriod': {
-      let hours = value.hour;
-      let wasPM = hours >= 12;
-      let isPM = segmentValue >= 12;
-      if (isPM === wasPM) {
-        return value;
-      }
-      return value.set({hour: wasPM ? hours - 12 : hours + 12});
-    }
-    case 'hour':
-      // In 12 hour time, ensure that AM/PM does not change
-      if (options.hour12) {
+  }
+
+  if ('hour' in value) {
+    switch (part) {
+      case 'dayPeriod': {
         let hours = value.hour;
         let wasPM = hours >= 12;
-        if (!wasPM && segmentValue === 12) {
-          segmentValue = 0;
+        let isPM = segmentValue >= 12;
+        if (isPM === wasPM) {
+          return value;
         }
-        if (wasPM && segmentValue < 12) {
-          segmentValue += 12;
-        }
+        return value.set({hour: wasPM ? hours - 12 : hours + 12});
       }
-      // fallthrough
-    case 'minute':
-    case 'second':
-      return value.set({[part]: segmentValue});
+      case 'hour':
+        // In 12 hour time, ensure that AM/PM does not change
+        if (options.hour12) {
+          let hours = value.hour;
+          let wasPM = hours >= 12;
+          if (!wasPM && segmentValue === 12) {
+            segmentValue = 0;
+          }
+          if (wasPM && segmentValue < 12) {
+            segmentValue += 12;
+          }
+        }
+        // fallthrough
+      case 'minute':
+      case 'second':
+        return value.set({[part]: segmentValue});
+    }
   }
 }
 
-function convertValue(value: DateValue, calendar: Calendar): CalendarDateTime | ZonedDateTime {
+function convertValue(value: DateValue, calendar: Calendar): DateValue {
   if (value === null) {
     return null;
   }
@@ -353,20 +376,20 @@ function convertValue(value: DateValue, calendar: Calendar): CalendarDateTime | 
     return undefined;
   }
 
-  if ('hour' in value) {
-    return toCalendar(value, calendar);
-  }
-
-  return toCalendar(toCalendarDateTime(value), calendar);
+  return toCalendar(value, calendar);
 }
 
-function createPlaceholderDate(calendar, timeZone) {
+function createPlaceholderDate(granularity, calendar, timeZone) {
   let date = toCalendar(now(timeZone), calendar).set({
     hour: 12,
     minute: 0,
     second: 0,
     millisecond: 0
   });
+
+  if (granularity === 'year' || granularity === 'month' || granularity === 'day') {
+    return toCalendarDate(date);
+  }
 
   if (!timeZone) {
     return toCalendarDateTime(date);

--- a/packages/@react-stately/datepicker/src/useDatePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {CalendarDate, toCalendarDateTime, toDateFields} from '@internationalized/date';
+import {CalendarDate, DateFormatter, toCalendarDateTime, toDateFields} from '@internationalized/date';
 import {DatePickerProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {FieldOptions, getFormatOptions} from './utils';
 import {isInvalid} from './utils';
@@ -110,8 +110,7 @@ export function useDatePickerState<T extends DateValue>(props: DatePickerProps<T
         hourCycle: props.hourCycle
       });
 
-      // TODO: cache
-      let formatter = new Intl.DateTimeFormat(locale, formatOptions);
+      let formatter = new DateFormatter(locale, formatOptions);
       return formatter.format(dateValue);
     }
   };

--- a/packages/@react-stately/datepicker/src/useDatePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerState.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {CalendarDate} from '@internationalized/date';
-import {DatePickerProps, DateValue} from '@react-types/datepicker';
+import {CalendarDate, toCalendarDateTime, toDateFields} from '@internationalized/date';
+import {DatePickerProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {FieldOptions, getFormatOptions} from './utils';
 import {isInvalid} from './utils';
 import {useControlledState} from '@react-stately/utils';
@@ -20,9 +20,11 @@ import {ValidationState} from '@react-types/shared';
 
 export interface DatePickerState {
   value: DateValue,
-  dateValue: Date,
   setValue: (value: DateValue) => void,
-  selectDate: (value: CalendarDate) => void,
+  dateValue: DateValue,
+  setDateValue: (value: CalendarDate) => void,
+  timeValue: TimeValue,
+  setTimeValue: (value: TimeValue) => void,
   isOpen: boolean,
   setOpen: (isOpen: boolean) => void,
   validationState: ValidationState,
@@ -37,15 +39,50 @@ export function useDatePickerState<T extends DateValue>(props: DatePickerProps<T
   let defaultTimeZone = (v && 'timeZone' in v ? v.timeZone : undefined);
   let granularity = props.granularity || (v && 'minute' in v ? 'minute' : 'day');
   let dateValue = value != null ? value.toDate(defaultTimeZone ?? 'UTC') : null;
+  let hasTime = granularity === 'hour' || granularity === 'minute' || granularity === 'second' || granularity === 'millisecond';
+
+  let [selectedDate, setSelectedDate] = useState<DateValue>(null);
+  let [selectedTime, setSelectedTime] = useState<TimeValue>(null);
+
+  if (value) {
+    selectedDate = value;
+    if ('hour' in value) {
+      selectedTime = value;
+    }
+  }
+
+  // props.granularity must actually exist in the value if one is provided.
+  if (v && !(granularity in v)) {
+    throw new Error('Invalid granularity ' + granularity + ' for value ' + v.toString());
+  }
+
+  let commitValue = (date: DateValue, time: TimeValue) => {
+    setValue('timeZone' in time ? time.set(toDateFields(date)) : toCalendarDateTime(date, time));
+  };
 
   // Intercept setValue to make sure the Time section is not changed by date selection in Calendar
   let selectDate = (newValue: CalendarDate) => {
-    if (value && 'hour' in value) {
-      setValue(value.set(newValue));
+    if (hasTime) {
+      if (selectedTime) {
+        commitValue(newValue, selectedTime);
+      } else {
+        setSelectedDate(newValue);
+      }
     } else {
       setValue(newValue);
     }
-    setOpen(false);
+
+    if (!hasTime) {
+      setOpen(false);
+    }
+  };
+
+  let selectTime = (newValue: TimeValue) => {
+    if (selectedDate) {
+      commitValue(selectedDate, newValue);
+    } else {
+      setSelectedTime(newValue);
+    }
   };
 
   let validationState: ValidationState = props.validationState ||
@@ -53,13 +90,19 @@ export function useDatePickerState<T extends DateValue>(props: DatePickerProps<T
 
   return {
     value,
-    dateValue,
     setValue,
-    selectDate,
+    dateValue: selectedDate,
+    timeValue: selectedTime,
+    setDateValue: selectDate,
+    setTimeValue: selectTime,
     isOpen,
     setOpen,
     validationState,
     formatValue(locale, fieldOptions) {
+      if (!dateValue) {
+        return '';
+      }
+
       let formatOptions = getFormatOptions(fieldOptions, {
         granularity,
         timeZone: defaultTimeZone,

--- a/packages/@react-stately/datepicker/src/useDatePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerState.ts
@@ -29,9 +29,9 @@ export interface DatePickerState {
   formatValue(locale: string, fieldOptions: FieldOptions): string
 }
 
-export function useDatePickerState(props: DatePickerProps): DatePickerState {
+export function useDatePickerState<T extends DateValue>(props: DatePickerProps<T>): DatePickerState {
   let [isOpen, setOpen] = useState(false);
-  let [value, setValue] = useControlledState(props.value, props.defaultValue || null, props.onChange);
+  let [value, setValue] = useControlledState<DateValue>(props.value, props.defaultValue || null, props.onChange);
 
   let v = (value || props.placeholderValue);
   let defaultTimeZone = (v && 'timeZone' in v ? v.timeZone : undefined);
@@ -41,9 +41,10 @@ export function useDatePickerState(props: DatePickerProps): DatePickerState {
   // Intercept setValue to make sure the Time section is not changed by date selection in Calendar
   let selectDate = (newValue: CalendarDate) => {
     if (value && 'hour' in value) {
-      newValue = value.set(newValue);
+      setValue(value.set(newValue));
+    } else {
+      setValue(newValue);
     }
-    setValue(newValue);
     setOpen(false);
   };
 

--- a/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
@@ -28,7 +28,7 @@ export interface DateRangePickerState {
   formatValue(locale: string, fieldOptions: FieldOptions): string
 }
 
-export function useDateRangePickerState(props: DateRangePickerProps): DateRangePickerState {
+export function useDateRangePickerState<T extends DateValue>(props: DateRangePickerProps<T>): DateRangePickerState {
   let [isOpen, setOpen] = useState(false);
   let onChange = value => {
     if (value.start && value.end && props.onChange) {
@@ -45,12 +45,13 @@ export function useDateRangePickerState(props: DateRangePickerProps): DateRangeP
   // Intercept setValue to make sure the Time section is not changed by date selection in Calendar
   let selectDateRange = (range: RangeValue<CalendarDate>) => {
     if (range && value?.start && 'hour' in value.start) {
-      range = {
+      setValue({
         start: value.start.set(range.start),
         end: value.end.set(range.end)
-      };
+      });
+    } else {
+      setValue(range);
     }
-    setValue(range);
     setOpen(false);
   };
 

--- a/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
+import {DateFormatter, toCalendarDateTime, toDateFields} from '@internationalized/date';
 import {DateRange, DateRangePickerProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {FieldOptions, getFormatOptions, isInvalid} from './utils';
 import {RangeValue, ValidationState} from '@react-types/shared';
-import {toCalendarDateTime, toDateFields} from '@internationalized/date';
 import {useControlledState} from '@react-stately/utils';
 import {useState} from 'react';
 
@@ -136,20 +136,16 @@ export function useDateRangePickerState<T extends DateValue>(props: DateRangePic
         hourCycle: props.hourCycle
       });
 
-      // TODO: cache
-      let startFormatter = new Intl.DateTimeFormat(locale, startOptions);
+      let startFormatter = new DateFormatter(locale, startOptions);
       let endFormatter: Intl.DateTimeFormat;
       if (startTimeZone === endTimeZone && startGranularity === endGranularity) {
-        // Use formatRange if available, as it results in shorter output when some of the fields
+        // Use formatRange, as it results in shorter output when some of the fields
         // are shared between the start and end dates (e.g. the same month).
-        if ('formatRange' in startFormatter) {
-          // Formatting will fail if the end date is before the start date. Fall back below when that happens.
-          try {
-            // @ts-ignore
-            return startFormatter.formatRange(value.start.toDate(startTimeZone), value.end.toDate(endTimeZone));
-          } catch (e) {
-            // ignore
-          }
+        // Formatting will fail if the end date is before the start date. Fall back below when that happens.
+        try {
+          return startFormatter.formatRange(value.start.toDate(startTimeZone), value.end.toDate(endTimeZone));
+        } catch (e) {
+          // ignore
         }
 
         endFormatter = startFormatter;
@@ -161,7 +157,7 @@ export function useDateRangePickerState<T extends DateValue>(props: DateRangePic
           hourCycle: props.hourCycle
         });
 
-        endFormatter = new Intl.DateTimeFormat(locale, endOptions);
+        endFormatter = new DateFormatter(locale, endOptions);
       }
 
       return `${startFormatter.format(value.start.toDate(startTimeZone))} – ${endFormatter.format(value.end.toDate(endTimeZone))}`;

--- a/packages/@react-types/calendar/package.json
+++ b/packages/@react-types/calendar/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@internationalized/date": "3.0.0-alpha.1",
     "@react-types/shared": "^3.1.0"
   },
   "publishConfig": {

--- a/packages/@react-types/calendar/src/index.d.ts
+++ b/packages/@react-types/calendar/src/index.d.ts
@@ -10,9 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
+import {CalendarDate, CalendarDateTime, ZonedDateTime} from '@internationalized/date';
 import {DOMProps, RangeValue, StyleProps, ValueBase} from '@react-types/shared';
 
-export type DateValue = string | number | Date;
+export type DateValue = CalendarDate | CalendarDateTime | ZonedDateTime;
+type MappedDateValue<T> =
+  T extends ZonedDateTime ? ZonedDateTime :
+  T extends CalendarDateTime ? CalendarDateTime :
+  T extends CalendarDate ? CalendarDate :
+  never;
+
 export interface CalendarPropsBase {
   timeZone?: string,
   minValue?: DateValue,
@@ -23,8 +30,8 @@ export interface CalendarPropsBase {
 }
 
 export type DateRange = RangeValue<DateValue>;
-export interface CalendarProps extends CalendarPropsBase, ValueBase<DateValue> {}
-export interface RangeCalendarProps extends CalendarPropsBase, ValueBase<DateRange> {}
+export interface CalendarProps<T extends DateValue> extends CalendarPropsBase, ValueBase<T, MappedDateValue<T>> {}
+export interface RangeCalendarProps<T extends DateValue> extends CalendarPropsBase, ValueBase<RangeValue<T>, RangeValue<MappedDateValue<T>>> {}
 
-export interface SpectrumCalendarProps extends CalendarProps, DOMProps, StyleProps {}
-export interface SpectrumRangeCalendarProps extends RangeCalendarProps, DOMProps, StyleProps {}
+export interface SpectrumCalendarProps<T extends DateValue> extends CalendarProps<T>, DOMProps, StyleProps {}
+export interface SpectrumRangeCalendarProps<T extends DateValue> extends RangeCalendarProps<T>, DOMProps, StyleProps {}

--- a/packages/@react-types/datepicker/src/index.d.ts
+++ b/packages/@react-types/datepicker/src/index.d.ts
@@ -25,42 +25,54 @@ import {
 import {CalendarDate, CalendarDateTime, Time, ZonedDateTime} from '@internationalized/date';
 
 export type DateValue = CalendarDate | CalendarDateTime | ZonedDateTime;
-interface DatePickerBase extends InputBase, Validation, FocusableProps, LabelableProps {
+type MappedDateValue<T> =
+  T extends ZonedDateTime ? ZonedDateTime :
+  T extends CalendarDateTime ? CalendarDateTime :
+  T extends CalendarDate ? CalendarDate :
+  never;
+
+interface DatePickerBase<T extends DateValue> extends InputBase, Validation, FocusableProps, LabelableProps {
   minValue?: DateValue,
   maxValue?: DateValue,
-  placeholderValue?: DateValue,
+  placeholderValue?: T,
   hourCycle?: 12 | 24,
   granularity?: 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond',
   hideTimeZone?: boolean
 }
 
-export interface AriaDatePickerBaseProps extends DatePickerBase, AriaLabelingProps, DOMProps {}
+export interface AriaDatePickerBaseProps<T extends DateValue> extends DatePickerBase<T>, AriaLabelingProps, DOMProps {}
 
-export interface DatePickerProps extends DatePickerBase, ValueBase<DateValue> {}
-export interface AriaDatePickerProps extends AriaDatePickerBaseProps, DatePickerProps {}
+export interface DatePickerProps<T extends DateValue> extends DatePickerBase<T>, ValueBase<T, MappedDateValue<T>> {}
+export interface AriaDatePickerProps<T extends DateValue> extends AriaDatePickerBaseProps<T>, DatePickerProps<T> {}
 
 export type DateRange = RangeValue<DateValue>;
-export interface DateRangePickerProps extends DatePickerBase, ValueBase<DateRange> {}
-export interface AriaDateRangePickerProps extends AriaDatePickerBaseProps, DateRangePickerProps {}
+export interface DateRangePickerProps<T extends DateValue> extends DatePickerBase<T>, ValueBase<RangeValue<T>, RangeValue<MappedDateValue<T>>> {}
+export interface AriaDateRangePickerProps<T extends DateValue> extends AriaDatePickerBaseProps<T>, DateRangePickerProps<T> {}
 
-interface SpectrumDatePickerBase extends AriaDatePickerBaseProps, SpectrumLabelableProps, StyleProps {
+interface SpectrumDatePickerBase<T extends DateValue> extends AriaDatePickerBaseProps<T>, SpectrumLabelableProps, StyleProps {
   isQuiet?: boolean,
   showFormatHelpText?: boolean
 }
 
-export interface SpectrumDatePickerProps extends DatePickerProps, SpectrumDatePickerBase {}
-export interface SpectrumDateRangePickerProps extends DateRangePickerProps, SpectrumDatePickerBase {}
+export interface SpectrumDatePickerProps<T extends DateValue> extends DatePickerProps<T>, SpectrumDatePickerBase<T> {}
+export interface SpectrumDateRangePickerProps<T extends DateValue> extends DateRangePickerProps<T>, SpectrumDatePickerBase<T> {}
 
 export type TimeValue = Time | CalendarDateTime | ZonedDateTime;
-interface TimePickerProps extends InputBase, Validation, FocusableProps, LabelableProps, ValueBase<TimeValue> {
+type MappedTimeValue<T> =
+  T extends ZonedDateTime ? ZonedDateTime :
+  T extends CalendarDateTime ? CalendarDateTime :
+  T extends Time ? Time :
+  never;
+
+export interface TimePickerProps<T extends TimeValue> extends InputBase, Validation, FocusableProps, LabelableProps, ValueBase<T, MappedTimeValue<T>> {
   hourCycle?: 12 | 24,
   granularity?: 'hour' | 'minute' | 'second' | 'millisecond',
   hideTimeZone?: boolean,
-  placeholderValue?: TimeValue,
+  placeholderValue?: T,
   minValue?: TimeValue,
   maxValue?: TimeValue
 }
 
-interface SpectrumTimePickerProps extends TimePickerProps, SpectrumLabelableProps, DOMProps, StyleProps {
+export interface SpectrumTimePickerProps<T extends TimeValue> extends TimePickerProps<T>, SpectrumLabelableProps, DOMProps, StyleProps {
   isQuiet?: boolean
 }

--- a/packages/@react-types/datepicker/src/index.d.ts
+++ b/packages/@react-types/datepicker/src/index.d.ts
@@ -36,7 +36,7 @@ interface DatePickerBase<T extends DateValue> extends InputBase, Validation, Foc
   maxValue?: DateValue,
   placeholderValue?: T,
   hourCycle?: 12 | 24,
-  granularity?: 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond',
+  granularity?: 'day' | 'hour' | 'minute' | 'second' | 'millisecond',
   hideTimeZone?: boolean
 }
 

--- a/packages/@react-types/shared/src/inputs.d.ts
+++ b/packages/@react-types/shared/src/inputs.d.ts
@@ -29,13 +29,13 @@ export interface InputBase {
   isReadOnly?: boolean
 }
 
-export interface ValueBase<T> {
+export interface ValueBase<T, C = T> {
   /** The current value (controlled). */
   value?: T,
   /** The default value (uncontrolled). */
   defaultValue?: T,
   /** Handler that is called when the value changes. */
-  onChange?: (value: T) => void
+  onChange?: (value: C) => void
 }
 
 export interface TextInputBase {


### PR DESCRIPTION
* Updates the TypeScript definitions of the date/time types in @internationalized/date to be more strict. This will now allow you to assign a CalendarDateTime to a CalendarDate variable for example. Also uses conditional types to ensure that onChange always has the same type as you put in via `value` or `defaultValue`.

_more description coming_