### PR TITLE
Make Flex take ReactNode children

### DIFF
--- a/packages/@react-types/layout/src/flex.d.ts
+++ b/packages/@react-types/layout/src/flex.d.ts
@@ -11,11 +11,11 @@
  */
 
 import {DOMProps, FlexStyleProps} from '@react-types/shared';
-import {ReactElement} from 'react';
+import {ReactNode} from 'react';
 
 export type Slots = {[key: string]: any};
 
 export interface FlexProps extends DOMProps, FlexStyleProps {
   /** Children of the flex container. */
-  children: ReactElement | ReactElement[]
+  children: ReactNode
 }


### PR DESCRIPTION
This PR changes the children for `Flex` to be `ReactNode` to support child expressions like:
```tsx
<Flex>
  <span>Hello</span>
  {name && <span>, {name}</span>}
</Flex>
```

Before, it used to complain:
`
Type 'boolean' is not assignable to type 'ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)>'.ts(2322)
`

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
```
yarn test
```

## 🧢 Your Project:

Adobe/RSP