### PR TITLE
Removing allowsCellSelection from useGridState

### DIFF
--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -80,16 +80,24 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let gridCollection = useMemo(() => new GridCollection({
     columnCount: 1,
-    items: [...collection].map(item => ({
-      type: 'item',
-      key: item.key,
-      childNodes: [{
+    items: [...collection].map(item => {
+      return {
         ...item,
-        index: 0,
-        type: 'cell',
-        key: `cell-${item.key}`
-      }]
-    }))
+        hasChildNodes: true,
+        childNodes: [{
+          key: `cell-${item.key}`,
+          type: 'cell',
+          index: 0,
+          value: null,
+          level: 0,
+          rendered: null,
+          textValue: item.textValue,
+          hasChildNodes: false,
+          childNodes: []
+
+        }]
+      }
+    })
   }), [collection]);
   let state = useGridState({
     ...props,
@@ -112,7 +120,6 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
 
   // Sync loading state into the layout.
   layout.isLoading = loadingState === 'loading';
-
   return (
     <ListViewContext.Provider value={{state, keyboardDelegate}}>
       <Virtualizer
@@ -133,7 +140,7 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
           )
         }
         layout={layout}
-        collection={collection}
+        collection={gridCollection}
         transitionDuration={transitionDuration}>
         {(type, item) => {
           if (type === 'item') {

--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -82,17 +82,18 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
     columnCount: 1,
     items: [...collection].map(item => ({
       type: 'item',
+      key: item.key,
       childNodes: [{
         ...item,
         index: 0,
-        type: 'cell'
+        type: 'cell',
+        key: `cell-${item.key}`
       }]
     }))
   }), [collection]);
   let state = useGridState({
     ...props,
-    collection: gridCollection,
-    allowsCellSelection: true
+    collection: gridCollection
   });
   let layout = useListLayout(state);
   let keyboardDelegate = useMemo(() => new GridKeyboardDelegate({
@@ -101,7 +102,7 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
     ref: domRef,
     direction,
     collator,
-    focusMode: 'cell'
+    focusMode: 'row'
   }), [state, domRef, direction, collator]);
   let {gridProps} = useGrid({
     ...props,

--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -107,7 +107,7 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
     ref: domRef,
     direction,
     collator,
-    focusMode: 'row'
+    focusMode: 'cell'
   }), [state, domRef, direction, collator]);
   let {gridProps} = useGrid({
     ...props,
@@ -117,13 +117,20 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
 
   // Sync loading state into the layout.
   layout.isLoading = loadingState === 'loading';
+
+  let focusedKey = state.selectionManager.focusedKey;
+  let focusedItem = gridCollection.getItem(state.selectionManager.focusedKey);
+  if (focusedItem?.parentKey != null) {
+    focusedKey = focusedItem.parentKey;
+  }
+
   return (
     <ListViewContext.Provider value={{state, keyboardDelegate}}>
       <Virtualizer
         {...gridProps}
         {...styleProps}
         ref={domRef}
-        focusedKey={state.selectionManager.focusedKey}
+        focusedKey={focusedKey}
         scrollDirection="vertical"
         className={
           classNames(

--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -80,24 +80,21 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let gridCollection = useMemo(() => new GridCollection({
     columnCount: 1,
-    items: [...collection].map(item => {
-      return {
-        ...item,
-        hasChildNodes: true,
-        childNodes: [{
-          key: `cell-${item.key}`,
-          type: 'cell',
-          index: 0,
-          value: null,
-          level: 0,
-          rendered: null,
-          textValue: item.textValue,
-          hasChildNodes: false,
-          childNodes: []
-
-        }]
-      }
-    })
+    items: [...collection].map(item => ({
+      ...item,
+      hasChildNodes: true,
+      childNodes: [{
+        key: `cell-${item.key}`,
+        type: 'cell',
+        index: 0,
+        value: null,
+        level: 0,
+        rendered: null,
+        textValue: item.textValue,
+        hasChildNodes: false,
+        childNodes: []
+      }]
+    }))
   }), [collection]);
   let state = useGridState({
     ...props,

--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -28,9 +28,11 @@ export function ListViewItem(props) {
   let {
     item
   } = props;
+  let cellNode = [...item.childNodes][0];
   let {state} = useContext(ListViewContext);
   let {direction} = useLocale();
-  let ref = useRef<HTMLDivElement>();
+  let rowRef = useRef<HTMLDivElement>();
+  let cellRef =  useRef<HTMLDivElement>();
   let {
     isFocusVisible: isFocusVisibleWithin,
     focusProps: focusWithinProps
@@ -41,13 +43,13 @@ export function ListViewItem(props) {
   let {rowProps} = useGridRow({
     node: item,
     isVirtualized: true
-  }, state, ref);
+  }, state, rowRef);
   let {gridCellProps} = useGridCell({
-    node: item,
-    focusMode: 'cell'
-  }, state, ref);
+    node: cellNode,
+    focusMode: 'child'
+  }, state, cellRef);
   const mergedProps = mergeProps(
-    gridCellProps,
+    rowProps,
     hoverProps,
     focusWithinProps,
     focusProps
@@ -72,7 +74,8 @@ export function ListViewItem(props) {
   let showCheckbox = state.selectionManager.selectionMode !== 'none';
   return (
     <div
-      {...rowProps}>
+      {...mergedProps}
+      ref={rowRef}>
       <div
         className={
           classNames(
@@ -85,8 +88,8 @@ export function ListViewItem(props) {
             }
           )
         }
-        ref={ref}
-        {...mergedProps}>
+        ref={cellRef}
+        {...gridCellProps}>
         <Grid UNSAFE_className={listStyles['react-spectrum-ListViewItem-grid']}>
           {showCheckbox && (
             <Checkbox

--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -46,7 +46,7 @@ export function ListViewItem(props) {
   }, state, rowRef);
   let {gridCellProps} = useGridCell({
     node: cellNode,
-    focusMode: 'child'
+    focusMode: 'cell'
   }, state, cellRef);
   const mergedProps = mergeProps(
     rowProps,

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -133,7 +133,7 @@ describe('ListView', function () {
     let moveFocus = (key, opts = {}) => {fireEvent.keyDown(document.activeElement, {key, ...opts});};
 
     describe('ArrowRight', function () {
-      it('should not move focus if no focusables present', function () {
+      it.skip('should not move focus if no focusables present', function () {
         let tree = renderList();
         let start = getCell(tree, 'Foo');
         act(() => start.focus());
@@ -141,7 +141,7 @@ describe('ListView', function () {
         expect(document.activeElement).toBe(start);
       });
 
-      describe('with cell focusables', function () {
+      describe.skip('with cell focusables', function () {
         it('should move focus to next cell and back to row', function () {
           let tree = renderListWithFocusables();
           let focusables = within(tree.getAllByRole('row')[0]).getAllByRole('button');
@@ -167,7 +167,7 @@ describe('ListView', function () {
     });
 
     describe('ArrowLeft', function () {
-      it('should not move focus if no focusables present', function () {
+      it.skip('should not move focus if no focusables present', function () {
         let tree = renderList();
         let start = getCell(tree, 'Foo');
         act(() => start.focus());
@@ -176,7 +176,7 @@ describe('ListView', function () {
       });
 
       describe('with cell focusables', function () {
-        it('should move focus to previous cell and back to row', function () {
+        it.skip('should move focus to previous cell and back to row', function () {
           let tree = renderListWithFocusables();
           let focusables = within(tree.getAllByRole('row')[0]).getAllByRole('button');
           let start = getCell(tree, 'Foo');

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -133,7 +133,7 @@ describe('ListView', function () {
     let moveFocus = (key, opts = {}) => {fireEvent.keyDown(document.activeElement, {key, ...opts});};
 
     describe('ArrowRight', function () {
-      it.skip('should not move focus if no focusables present', function () {
+      it('should not move focus if no focusables present', function () {
         let tree = renderList();
         let start = getCell(tree, 'Foo');
         act(() => start.focus());
@@ -141,7 +141,7 @@ describe('ListView', function () {
         expect(document.activeElement).toBe(start);
       });
 
-      describe.skip('with cell focusables', function () {
+      describe('with cell focusables', function () {
         it('should move focus to next cell and back to row', function () {
           let tree = renderListWithFocusables();
           let focusables = within(tree.getAllByRole('row')[0]).getAllByRole('button');
@@ -157,17 +157,20 @@ describe('ListView', function () {
 
         it('should move focus to previous cell in RTL', function () {
           let tree = renderListWithFocusables('ar-AE');
-          let start = within(tree.getAllByRole('row')[0]).getAllByRole('button')[0];
-          let end = within(tree.getAllByRole('row')[0]).getAllByRole('button')[1];
+          // Should move from button two to button one
+          let start = within(tree.getAllByRole('row')[0]).getAllByRole('button')[1];
+          let end = within(tree.getAllByRole('row')[0]).getAllByRole('button')[0];
           act(() => start.focus());
+          expect(document.activeElement).toHaveTextContent('button2 Foo');
           moveFocus('ArrowRight');
           expect(document.activeElement).toBe(end);
+          expect(document.activeElement).toHaveTextContent('button1 Foo');
         });
       });
     });
 
     describe('ArrowLeft', function () {
-      it.skip('should not move focus if no focusables present', function () {
+      it('should not move focus if no focusables present', function () {
         let tree = renderList();
         let start = getCell(tree, 'Foo');
         act(() => start.focus());
@@ -176,7 +179,7 @@ describe('ListView', function () {
       });
 
       describe('with cell focusables', function () {
-        it.skip('should move focus to previous cell and back to row', function () {
+        it('should move focus to previous cell and back to row', function () {
           let tree = renderListWithFocusables();
           let focusables = within(tree.getAllByRole('row')[0]).getAllByRole('button');
           let start = getCell(tree, 'Foo');
@@ -192,11 +195,14 @@ describe('ListView', function () {
 
         it('should move focus to next cell in RTL', function () {
           let tree = renderListWithFocusables('ar-AE');
-          let start = within(tree.getAllByRole('row')[0]).getAllByRole('button')[1];
-          let end = within(tree.getAllByRole('row')[0]).getAllByRole('button')[0];
+          // Should move from button one to button two
+          let start = within(tree.getAllByRole('row')[0]).getAllByRole('button')[0];
+          let end = within(tree.getAllByRole('row')[0]).getAllByRole('button')[1];
           act(() => start.focus());
+          expect(document.activeElement).toHaveTextContent('button1 Foo');
           moveFocus('ArrowLeft');
           expect(document.activeElement).toBe(end);
+          expect(document.activeElement).toHaveTextContent('button2 Foo');
         });
       });
     });

--- a/packages/@react-stately/grid/src/useGridState.ts
+++ b/packages/@react-stately/grid/src/useGridState.ts
@@ -14,15 +14,14 @@ export interface GridState<T, C extends GridCollection<T>> {
 interface GridStateOptions<T, C extends GridCollection<T>> extends MultipleSelection {
   collection: C,
   disabledKeys?: Iterable<Key>,
-  focusMode?: 'row' | 'cell',
-  allowsCellSelection?: boolean
+  focusMode?: 'row' | 'cell'
 }
 
 /**
  * Provides state management for a grid component. Handles row selection and focusing a grid cell's focusable child if applicable.
  */
 export function useGridState<T extends object, C extends GridCollection<T>>(props: GridStateOptions<T, C>): GridState<T, C> {
-  let {collection, focusMode, allowsCellSelection = false} = props;
+  let {collection, focusMode} = props;
   let selectionState = useMultipleSelectionState(props);
   let disabledKeys = useMemo(() =>
       props.disabledKeys ? new Set(props.disabledKeys) : new Set<Key>()
@@ -56,6 +55,6 @@ export function useGridState<T extends object, C extends GridCollection<T>>(prop
   return {
     collection,
     disabledKeys,
-    selectionManager: new SelectionManager(collection, selectionState, {allowsCellSelection})
+    selectionManager: new SelectionManager(collection, selectionState)
   };
 }


### PR DESCRIPTION
Selection is pretty iffy even with this change (shift + keyboard/mouse doesn't range select) and now that I thought about it more, I don't think this is really a correct usage of `allowsCellSelection` so gonna revert my suggestion and apply a different approach that fixes selection. This way we won't be adding a new prop to useGridState to enable behavior that I'm not 100% on

NOTE: This does break keyboard navigation for the ListView, but IMO better that than release a new prop on useGridState for now

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
