### PR TITLE
adding helptext stories to combobox and numberfield

### DIFF
--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -233,6 +233,14 @@ storiesOf('ComboBox', module)
     )
   )
   .add(
+    'with descrption, labelAlign: end',
+    () => render({description: 'Please select your spirit animal.', labelAlign: 'end'})
+  )
+  .add(
+    'with error message, labelPosition: side',
+    () => render({errorMessage: 'You did not select a valid spirit animal.', validationState: 'invalid', labelPosition: 'side'})
+  )
+  .add(
     'isRequired',
     () => render({isRequired: true})
   )

--- a/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
@@ -182,6 +182,14 @@ storiesOf('NumberField', module)
     )
   )
   .add(
+    'with description, no visible label',
+    () => renderNoLabel({'aria-label': 'Age', description: 'Please select your age.'})
+  )
+  .add(
+    'with error message, labelPosition: side',
+    () => render({labelPosition: 'side', errorMessage: 'Please enter a positive number.', validationState: 'invalid'})
+  )
+  .add(
     'custom width',
     () => render({width: 'size-3000'})
   )


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
There are now with description and with error message stories for combobox and numberfield.

## 🧢 Your Project:
RSP