### PR TITLE
Fix textarea can be shrunk horizontally

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -56,9 +56,9 @@ governing permissions and limitations under the License.
   /* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
   text-indent: 0;
 
-  min-inline-size: 100%;
   inline-size: 100%;
   height: var(--spectrum-textfield-height);
+  resize: vertical;
 
   vertical-align: top; /* used to align them correctly in forms. */
 

--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -56,7 +56,8 @@ governing permissions and limitations under the License.
   /* Use padding instead of text-indent because text-indent does not left align the text in Edge browser  */
   text-indent: 0;
 
-  width: 100%;
+  min-inline-size: 100%;
+  inline-size: 100%;
   height: var(--spectrum-textfield-height);
 
   vertical-align: top; /* used to align them correctly in forms. */


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Turns off horizontal resizing because if we use min-width, you can expand a textarea but never shrink it

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
