### PR TITLE
Revert "fix(#2101): TooltipTrigger: Tooltip should remain hidden in the DOM to provide an IDREF for aria-describedby on trigger element"

### DIFF
--- a/packages/@react-aria/tooltip/docs/useTooltipTrigger.mdx
+++ b/packages/@react-aria/tooltip/docs/useTooltipTrigger.mdx
@@ -82,8 +82,6 @@ This example implements a Tooltip that renders in an absolute position next to i
 
 Two instances of the example are rendered to demonstrate the behavior of the delay on hover. If you hover over the first button, the tooltip will be shown after a delay. Hovering over the second button shows the tooltip immediately. If you wait for a delay before hovering another element, the delay restarts.
 
-**Note**: The Tooltip is always rendered to the DOM, even when not visible, using the `hidden` prop. This ensures that assistive technology can always read the Tooltip description, regardless of whether the trigger is focused (e.g. browse mode).
-
 ```tsx example
 import {useTooltipTriggerState} from '@react-stately/tooltip';
 import {mergeProps} from '@react-aria/utils';
@@ -118,9 +116,11 @@ function Example(props) {
   return (
     <span style={{position: 'relative'}}>
       <button ref={ref} {...triggerProps}>I have a tooltip</button>
-      <Tooltip hidden={!state.isOpen} state={state} {...tooltipProps}>
-        And the tooltip tells you more information.
-      </Tooltip>
+      {state.isOpen && (
+        <Tooltip state={state} {...tooltipProps}>
+          And the tooltip tells you more information.
+        </Tooltip>
+      )}
     </span>
   );
 }

--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -139,7 +139,7 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
 
   return {
     triggerProps: {
-      'aria-describedby': !isDisabled ? tooltipId : undefined,
+      'aria-describedby': state.isOpen ? tooltipId : undefined,
       ...mergeProps(focusableProps, hoverProps, pressProps)
     },
     tooltipProps: {

--- a/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
+++ b/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
@@ -444,7 +444,7 @@ function renderTooltips(props, items: any = docItems) {
         items.map((itemProps) => {
           let IconElement = iconMap[itemProps.children];
           return (
-            <TooltipTrigger key={`${itemProps.name}-tooltipTrigger`} >
+            <TooltipTrigger>
               <Item key={itemProps.name} textValue={itemProps.children} aria-label={itemProps.children}>
                 <IconElement />
               </Item>

--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -69,10 +69,6 @@ function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
         <Overlay isOpen={state.isOpen}>
           {tooltip}
         </Overlay>
-        { 
-          /* hidden tooltip for aria-describedby IDREF */
-          !state.isOpen && !isDisabled && <div hidden>{tooltip}</div>
-        }
       </TooltipContext.Provider>
     </FocusableProvider>
   );

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -645,7 +645,7 @@ describe('TooltipTrigger', function () {
       });
       let goodTooltip = getByText(helpfulText);
       expect(goodTooltip).toBeVisible();
-      expect(getByText(unHelpfulText)).not.toBeVisible();
+      expect(() => getByText(unHelpfulText)).toThrow();
       act(() => {
         goodButton.blur();
       });
@@ -654,7 +654,7 @@ describe('TooltipTrigger', function () {
       });
       let badTooltip = getByText(unHelpfulText);
       expect(badTooltip).toBeVisible();
-      expect(getByText(helpfulText)).not.toBeVisible();
+      expect(() => getByText(helpfulText)).toThrow();
       act(() => {
         badButton.blur();
       });
@@ -684,21 +684,21 @@ describe('TooltipTrigger', function () {
         jest.advanceTimersByTime(TOOLTIP_DELAY / 2);
       });
       fireEvent.mouseLeave(goodButton);
-      expect(getByText(helpfulText)).not.toBeVisible();
-      expect(getByText(unHelpfulText)).not.toBeVisible();
+      expect(() => getByText(helpfulText)).toThrow();
+      expect(() => getByText(unHelpfulText)).toThrow();
       fireEvent.mouseEnter(badButton);
       fireEvent.mouseMove(badButton);
       act(() => {
         jest.advanceTimersByTime(TOOLTIP_DELAY / 2);
       });
-      expect(getByText(helpfulText)).not.toBeVisible();
-      expect(getByText(unHelpfulText)).not.toBeVisible();
+      expect(() => getByText(helpfulText)).toThrow();
+      expect(() => getByText(unHelpfulText)).toThrow();
       act(() => {
         jest.advanceTimersByTime(TOOLTIP_DELAY / 2);
       });
       let badTooltip = getByText(unHelpfulText);
       expect(badTooltip).toBeVisible();
-      expect(getByText(helpfulText)).not.toBeVisible();
+      expect(() => getByText(helpfulText)).toThrow();
       fireEvent.mouseLeave(badButton);
     });
   });
@@ -837,7 +837,7 @@ describe('TooltipTrigger', function () {
       fireEvent.mouseEnter(badButton);
       fireEvent.mouseMove(badButton);
 
-      expect(getByText(helpfulText)).not.toBeVisible();
+      expect(() => getByText(helpfulText)).toThrow();
       expect(getByText(unHelpfulText)).toBeVisible();
     });
 
@@ -911,7 +911,7 @@ describe('TooltipTrigger', function () {
 
   describe('accessibility', () => {
     it('has a trigger described by the tooltip when open', () => {
-      let {getByRole, getByLabelText, getByText} = render(
+      let {getByRole, getByLabelText} = render(
         <Provider theme={theme}>
           <TooltipTrigger delay={0}>
             <ActionButton aria-label="trigger" />
@@ -921,20 +921,14 @@ describe('TooltipTrigger', function () {
       );
       fireEvent.mouseMove(document.body);
       let button = getByLabelText('trigger');
-      let tooltip = getByText('Helpful information.').parentElement;
-      expect(tooltip).not.toBeVisible();
-      expect(button).toHaveAttribute('aria-describedBy', tooltip.id);
-
+      expect(button).not.toHaveAttribute('aria-describedBy');
       fireEvent.mouseEnter(button);
       fireEvent.mouseMove(button);
-      tooltip = getByRole('tooltip');
+      let tooltip = getByRole('tooltip');
       expect(button).toHaveAttribute('aria-describedBy', tooltip.id);
-      expect(tooltip.parentElement.hidden).toBe(false);
       fireEvent.mouseLeave(button);
       act(jest.runAllTimers);
-      tooltip = getByText('Helpful information.').parentElement;
-      expect(tooltip).not.toBeVisible();
-      expect(button).toHaveAttribute('aria-describedBy', tooltip.id);
+      expect(button).not.toHaveAttribute('aria-describedBy');
     });
   });
 


### PR DESCRIPTION
Reverts adobe/react-spectrum#2102
This is because it has added a dom node to several components and they can't handle the extra nodes in their calculations at this point. Because we don't know everything affected, we're reverting this and we'll try a different method to handle it, potentially portalling them to the end of the document body