### PR TITLE
Fixes visible sort icons in docs prod

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -25,7 +25,8 @@ governing permissions and limitations under the License.
   isolation: isolate;
 }
 
-.spectrum-Table-sortedIcon {
+/* specificity must be higher than `.spectrum-Icon` */
+svg.spectrum-Table-sortedIcon {
   display: none;
   margin-inline-start: var(--spectrum-table-header-sort-icon-gap);
   min-inline-size: var(--spectrum-icon-arrow-down-small-width);


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Fixes an issue seen in Docs prod where all sort icons are visible across all columns
Fixed in same manner as https://github.com/adobe/react-spectrum/pull/2023

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
