### PR TITLE
fix(#2330): TextField HelpText element loses id attribute when switching from description to errorMessage

### DIFF
--- a/packages/@react-aria/label/src/useField.ts
+++ b/packages/@react-aria/label/src/useField.ts
@@ -48,10 +48,10 @@ export function useField(props: AriaFieldProps): FieldAria {
   let descriptionProps: HTMLAttributes<HTMLElement> = {};
   let errorMessageProps: HTMLAttributes<HTMLElement> = {};
   if (description) {
-    descriptionProps.id = descriptionId;
+    descriptionProps.id = descriptionId || errorMessageId;
   }
   if (errorMessage) {
-    errorMessageProps.id = errorMessageId;
+    errorMessageProps.id = errorMessageId || descriptionId;
   }
 
   return {

--- a/packages/@react-spectrum/textfield/stories/Textfield.stories.js
+++ b/packages/@react-spectrum/textfield/stories/Textfield.stories.js
@@ -114,6 +114,10 @@ storiesOf('TextField', module)
     'with error message',
     () => render({errorMessage: 'Please enter a valid street address.', validationState: 'invalid'})
   )
+  .add(
+    'with description, error message and validation',
+    () => renderWithDescriptionErrorMessageAndValidation()
+  )
   .add('custom width',
     () => render({icon: <Info />, validationState: 'invalid', width: '300px'})
   )
@@ -144,4 +148,28 @@ function render(props = {}) {
       UNSAFE_className="custom_classname"
       {...props} />
   );
+}
+
+function renderWithDescriptionErrorMessageAndValidation() {
+  function Example() {
+    let [value, setValue] = React.useState('0');
+    let isValid = React.useMemo(() => /^\d$/.test(value), [value]);
+  
+    return (
+      <TextField
+        validationState={isValid ? 'valid' : 'invalid'}
+        value={value}
+        onChange={setValue}
+        label="Favorite number"
+        maxLength={1}
+        description="Enter a single digit number."
+        errorMessage={
+          value === ''
+            ? 'Empty input not allowed.'
+            : 'Single digit numbers are 0-9.'
+        } />
+    );
+  }
+
+  return <Example />;
 }

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {chain} from '@react-aria/utils';
 import Checkmark from '@spectrum-icons/workflow/Checkmark';
 import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
@@ -446,6 +447,58 @@ describe('Shared TextField behavior', () => {
     let errorMessage = tree.getByText('Remove special characters.');
     expect(errorMessage).toHaveAttribute('id');
     expect(input).toHaveAttribute('aria-describedby', `${errorMessage.id}`);
+  });
+
+  it.each`
+    Name                | Component
+    ${'v3 TextField'}   | ${TextField}
+    ${'v3 TextArea'}    | ${TextArea}
+    ${'v3 SearchField'} | ${SearchField}
+  `('$Name supports description or error message', ({Component}) => {
+    function Example(props) {
+      let [value, setValue] = React.useState('0');
+      let isValid = React.useMemo(() => /^\d$/.test(value), [value]);
+    
+      return (
+        <Component
+          {...props}
+          validationState={isValid ? 'valid' : 'invalid'}
+          value={value}
+          onChange={chain(props.onChange, setValue)}
+          label="Favorite number"
+          maxLength={1}
+          description="Enter a single digit number."
+          errorMessage={
+            value === ''
+              ? 'Empty input not allowed.'
+              : 'Single digit numbers are 0-9.'
+          } />
+      );
+    }
+    let tree = renderComponent(Example);
+    let input = tree.getByTestId(testId);
+    let helpText = tree.getByText('Enter a single digit number.');
+    expect(helpText).toHaveAttribute('id');
+    expect(input).toHaveAttribute('aria-describedby', `${helpText.id}`);
+    expect(input.value).toBe('0');
+    let newValue = 's';
+    fireEvent.change(input, {target: {value: newValue}});
+    expect(input.value).toBe(newValue);
+    helpText = tree.getByText('Single digit numbers are 0-9.');
+    expect(helpText).toHaveAttribute('id');
+    expect(input).toHaveAttribute('aria-describedby', `${helpText.id}`);
+    newValue = '';
+    fireEvent.change(input, {target: {value: newValue}});
+    expect(input.value).toBe(newValue);
+    helpText = tree.getByText('Empty input not allowed.');
+    expect(helpText).toHaveAttribute('id');
+    expect(input).toHaveAttribute('aria-describedby', `${helpText.id}`);
+    newValue = '4';
+    fireEvent.change(input, {target: {value: newValue}});
+    expect(input.value).toBe(newValue);
+    helpText = tree.getByText('Enter a single digit number.');
+    expect(helpText).toHaveAttribute('id');
+    expect(input).toHaveAttribute('aria-describedby', `${helpText.id}`);
   });
 
   it.each`


### PR DESCRIPTION
## 🐛 Bug Report

In the [TextField HelpText example](https://react-spectrum.adobe.com/react-spectrum/TextField.html#help-text), and any examples where the HelpText toggles between `descriptionProps` and `errorMessageProps`. The HelpText initializes with the `id` attribute present, but once the validation state changes and the description is swapped for the `errorMessage`, the `id` on the HelpText goes away, and the `aria-describedby` on the input is no longer valid.

### 🤔 Expected Behavior

`aria-describedby` on the `input` should include a reference to the description and/or the errorMessage slots by `id`.

### 😯 Current Behavior

If we display only the description or the errorMessage using HelpText, only one slot will be rendered to the DOM, and the second `id` created with `useSlotId` gets left on the cutting room floor. When we only render one slot, the HelpText should use whichever `id` renders first.

### 💁 Possible Solution

At https://github.com/adobe/react-spectrum/blob/058ce77164ac2b5fa9332634253d395d9c382ac4/packages/%40react-aria/label/src/useField.ts#L50-L55,
we can use:
```tsx
  if (description) {
    descriptionProps.id = descriptionId || errorMessageId;
  }
  if (errorMessage) {
    errorMessageProps.id = errorMessageId || descriptionId;
  }
```
which ensures that if one of the slots is not defined, the HelpText element will receive an `id`.

### 🔦 Context

Discovered while testing [TextField HelpText example](https://react-spectrum.adobe.com/react-spectrum/TextField.html#help-text) using VoiceOver on macOS.

### 💻 Code Sample
```tsx
function Example() {
  let [value, setValue] = React.useState('0');
  let isValid = React.useMemo(() => /^\d$/.test(value), [value]);

  return (
    <TextField
      validationState={isValid ? 'valid' : 'invalid'}
      value={value}
      onChange={setValue}
      label="Favorite number"
      maxLength={1}
      description="Enter a single digit number."
      errorMessage={
        value === ''
          ? 'Empty input not allowed.'
          : 'Single digit numbers are 0-9.'
      }
    />
  );
}
```
### 🌍 Your Environment

| Software         | Version(s) |
| ---------------- | ---------- |
| react-spectrum   |  3.2.0
| Browser          |  Chrome 93.0.4577.63 (Official Build) (x86_64)
| Operating System | MacOS Big Sur version 11.5.2 (20G95)

### 🧢 Your Company/Team

Adobe/Accessibility


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
