### PR TITLE
Fix eslint errors.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ let mocks = {};
 try {
   require.resolve('@react/react-spectrum/Button');
 } catch (err) {
-  mocks['^@react\/.*'] = 'identity-obj-proxy';
+  mocks['^@react/.*'] = 'identity-obj-proxy';
 }
 
 module.exports = {
@@ -101,7 +101,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
     '\\.(css|styl)$': 'identity-obj-proxy',
-    '\\.\./Icon/.*$': '<rootDir>/__mocks__/iconMock.js',
+    '\\.\\./Icon/.*$': '<rootDir>/__mocks__/iconMock.js',
     ...mocks
   },
 
@@ -172,13 +172,13 @@ module.exports = {
   // The glob patterns Jest uses to detect test files
   // see issue https://github.com/facebook/jest/issues/7108
   testMatch: [
-    "**/packages/**/*.test.[tj]s?(x)"
+    '**/packages/**/*.test.[tj]s?(x)'
   ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: [
-    "/node_modules/",
-    "\\.ssr\\.test\\.[tj]sx?$"
+    '/node_modules/',
+    '\\.ssr\\.test\\.[tj]sx?$'
   ]
 
   // The regexp pattern or array of patterns that Jest uses to detect test files

--- a/jest.ssr.config.js
+++ b/jest.ssr.config.js
@@ -22,7 +22,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
     '\\.(css|styl)$': 'identity-obj-proxy',
-    '\\.\./Icon/.*$': '<rootDir>/__mocks__/iconMock.js'
+    '\\.\\./Icon/.*$': '<rootDir>/__mocks__/iconMock.js'
   },
 
   // Run tests from one or more projects
@@ -43,6 +43,6 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
-    "**/packages/**/*.ssr.test.[tj]s?(x)"
+    '**/packages/**/*.ssr.test.[tj]s?(x)'
   ]
 };


### PR DESCRIPTION
When I was opening the jest config files in VSCode, eslint was complaining about a few errors. This PR tries to fix these errors.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
