### PR TITLE
removed e.stopPropagation() from onKeyDown

### DIFF
--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -56,12 +56,10 @@ export function useMenuTrigger(props: MenuTriggerAriaProps, state: MenuTriggerSt
         case 'Enter':
         case ' ':
           e.preventDefault();
-          e.stopPropagation();
           state.toggle('first');
           break;
         case 'ArrowUp':
           e.preventDefault();
-          e.stopPropagation();
           state.toggle('last');
           break;
       }


### PR DESCRIPTION
Closes #2263

## ✅ Pull Request Checklist:

- [ ] https://github.com/adobe/react-spectrum/issues/2263

## 📝 Test Instructions:

In order to test the PR, you can go the this [link](https://react-spectrum.adobe.com/react-aria/useSelect.html) and try accessing the select box with arrow keys on the keyboard. Keep the terminal open along with this to check if it logs any errors. 
This PR fixes the error mentioned in the issue.
