### PR TITLE
Fix ActionMenu in Tooltip

### DIFF
--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -46,7 +46,7 @@ export function useMenuTrigger(props: MenuTriggerAriaProps, state: MenuTriggerSt
   let {triggerProps, overlayProps} = useOverlayTrigger({type}, state, ref);
 
   let onKeyDown = (e) => {
-    if ((typeof e.isDefaultPrevented === 'function' && e.isDefaultPrevented()) || e.defaultPrevented || isDisabled) {
+    if (isDisabled) {
       return;
     }
 

--- a/packages/@react-aria/menu/test/useMenuTrigger.test.js
+++ b/packages/@react-aria/menu/test/useMenuTrigger.test.js
@@ -83,49 +83,4 @@ describe('useMenuTrigger', function () {
     expect(setFocusStrategy).toHaveBeenCalledTimes(1);
     expect(setFocusStrategy).toHaveBeenCalledWith(null);
   });
-
-  // Comprehensive onKeyDown functionality is tested in MenuTrigger test
-  it('returns a onKeyDown that toggles the menu open state for specific key strokes', function () {
-    let props = {
-      type: 'menu'
-    };
-
-    let preventDefault = jest.fn();
-    let stopPropagation = jest.fn();
-
-    let {menuTriggerProps} = renderMenuTriggerHook(props, state, {current: {}});
-    expect(typeof menuTriggerProps.onKeyDown).toBe('function');
-
-    // doesn't trigger event if isDefaultPrevented returns true
-    menuTriggerProps.onKeyDown({
-      pointerType: 'not keyboard',
-      isDefaultPrevented: () => true,
-      key: 'ArrowUp'
-    });
-    expect(setOpen).toHaveBeenCalledTimes(0);
-    expect(setFocusStrategy).toHaveBeenCalledTimes(0);
-
-    // doesn't trigger event if defaultPrevented is true
-    menuTriggerProps.onKeyDown({
-      pointerType: 'not keyboard',
-      defaultPrevented: true,
-      key: 'ArrowUp'
-    });
-    expect(setOpen).toHaveBeenCalledTimes(0);
-    expect(setFocusStrategy).toHaveBeenCalledTimes(0);
-
-     // triggers event if defaultPrevented is not true and it matches one of the keys
-    menuTriggerProps.onKeyDown({
-      pointerType: 'not keyboard',
-      defaultPrevented: false,
-      key: 'ArrowUp',
-      preventDefault,
-      stopPropagation
-    });
-    expect(setOpen).toHaveBeenCalledTimes(1);
-    expect(setOpen).toHaveBeenCalledWith(!state.isOpen);
-    expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(setFocusStrategy).toHaveBeenCalledTimes(1);
-    expect(setFocusStrategy).toHaveBeenLastCalledWith('last');
-  });
 });

--- a/packages/@react-spectrum/menu/stories/ActionMenu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/ActionMenu.stories.tsx
@@ -19,6 +19,7 @@ import {Meta, Story} from '@storybook/react';
 import {Picker} from '../../picker';
 import React, {useState} from 'react';
 import {SpectrumActionMenuProps} from '@react-types/menu';
+import {Tooltip, TooltipTrigger} from '../../tooltip';
 
 const meta: Meta<SpectrumActionMenuProps<object>> = {
   title: 'ActionMenu',
@@ -103,9 +104,9 @@ function DirectionAlignment() {
     <Picker label="Direction" items={directionItems} selectedKey={direction} onSelectionChange={handleDirectionChange}>
       {(item) => <Item key={item.key}>{item.label}</Item>}
     </Picker>
-    <ActionMenu 
-      onAction={action('action')} 
-      align={align} 
+    <ActionMenu
+      onAction={action('action')}
+      align={align}
       direction={direction}>
       <Item key="one">One</Item>
       <Item key="two">Two</Item>
@@ -133,3 +134,14 @@ export const AutoFocus = Template().bind({});
 AutoFocus.args = {autoFocus: true};
 
 export const DirectionAlign = () => <DirectionAlignment />;
+
+export const WithTooltip = () => (
+  <TooltipTrigger delay={0}>
+    <ActionMenu>
+      <Item key="cut">Cut</Item>
+      <Item key="copy">Copy</Item>
+      <Item key="paste">Paste</Item>
+    </ActionMenu>
+    <Tooltip>Actions</Tooltip>
+  </TooltipTrigger>
+);

--- a/packages/@react-spectrum/menu/test/ActionMenu.test.js
+++ b/packages/@react-spectrum/menu/test/ActionMenu.test.js
@@ -10,13 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, render, within} from '@testing-library/react';
+import {act, fireEvent, render, within} from '@testing-library/react';
 import {ActionMenu, Item} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import {theme} from '@react-spectrum/theme-default';
 import {triggerPress} from '@react-spectrum/test-utils';
+import {Tooltip, TooltipTrigger} from '../../tooltip';
+import userEvent from '@testing-library/user-event';
 
+let CLOSE_TIME = 350;
 
 describe('ActionMenu', function () {
   let onActionSpy = jest.fn();
@@ -40,28 +43,28 @@ describe('ActionMenu', function () {
         <Item>Baz</Item>
       </ActionMenu>
     </Provider>);
-    
+
     let button = tree.getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'More actions');
     triggerPress(button);
-    
+
     let menu = tree.getByRole('menu');
     expect(menu).toBeTruthy();
     expect(menu).toHaveAttribute('aria-labelledby', button.id);
-    
-    
+
+
     let menuItem1 = within(menu).getByText('Foo');
     let menuItem2 = within(menu).getByText('Bar');
     let menuItem3 = within(menu).getByText('Baz');
     expect(menuItem1).toBeTruthy();
     expect(menuItem2).toBeTruthy();
     expect(menuItem3).toBeTruthy();
-    
+
     triggerPress(menuItem1);
     expect(onActionSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('cústom aria label', function () {
+  it('custom aria label', function () {
     let tree = render(<Provider theme={theme}>
       <ActionMenu aria-label="Custom Aria Label">
         <Item>Foo</Item>
@@ -73,7 +76,7 @@ describe('ActionMenu', function () {
     let button = tree.getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'Custom Aria Label');
   });
-  
+
   it('is disabled', function () {
     let tree = render(<Provider theme={theme}>
       <ActionMenu isDisabled>
@@ -82,11 +85,11 @@ describe('ActionMenu', function () {
         <Item>Baz</Item>
       </ActionMenu>
     </Provider>);
-    
+
     let button = tree.getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'More actions');
     triggerPress(button);
-    
+
     let menu = tree.queryByRole('menu');
     expect(menu).toBeNull();
   });
@@ -99,8 +102,79 @@ describe('ActionMenu', function () {
         <Item>Baz</Item>
       </ActionMenu>
     </Provider>);
-    
+
     let button = tree.getByRole('button');
     expect(document.activeElement).toBe(button);
+  });
+
+  describe('with tooltips', function () {
+    it('using mouse', function () {
+      let tree = render(
+        <Provider theme={theme}>
+          <TooltipTrigger delay={0}>
+            <ActionMenu>
+              <Item>Foo</Item>
+              <Item>Bar</Item>
+              <Item>Baz</Item>
+            </ActionMenu>
+            <Tooltip>A whale of a tale.</Tooltip>
+          </TooltipTrigger>
+        </Provider>
+      );
+
+      let button = tree.getByRole('button');
+      fireEvent.mouseDown(document.body);
+      fireEvent.mouseUp(document.body);
+
+      fireEvent.mouseEnter(button);
+      fireEvent.mouseMove(button);
+
+      let tooltip = tree.getByRole('tooltip');
+      expect(tooltip).toBeVisible();
+
+      fireEvent.mouseDown(button);
+      fireEvent.mouseUp(button);
+      act(() => {
+        jest.advanceTimersByTime(CLOSE_TIME);
+      });
+      expect(tooltip).not.toBeInTheDocument();
+
+      let menu = tree.getByRole('menu');
+      expect(menu).toBeTruthy();
+      expect(menu).toHaveAttribute('aria-labelledby', button.id);
+    });
+
+    it('using keyboard', function () {
+      let tree = render(
+        <Provider theme={theme}>
+          <TooltipTrigger delay={0}>
+            <ActionMenu>
+              <Item>Foo</Item>
+              <Item>Bar</Item>
+              <Item>Baz</Item>
+            </ActionMenu>
+            <Tooltip>A whale of a tale.</Tooltip>
+          </TooltipTrigger>
+        </Provider>
+      );
+
+      let button = tree.getByRole('button');
+      userEvent.tab();
+      expect(button).toBe(document.activeElement);
+
+      let tooltip = tree.getByRole('tooltip');
+      expect(tooltip).toBeVisible();
+
+      fireEvent.keyDown(button, {key: 'Enter'});
+      fireEvent.keyUp(button, {key: 'Enter'});
+      act(() => {
+        jest.advanceTimersByTime(CLOSE_TIME);
+      });
+      expect(tooltip).not.toBeInTheDocument();
+
+      let menu = tree.getByRole('menu');
+      expect(menu).toBeTruthy();
+      expect(menu).toHaveAttribute('aria-labelledby', button.id);
+    });
   });
 });


### PR DESCRIPTION
Remove ability to use preventDefault to prevent a menu from opening
This came from our old v2 code, I'm not sure it's relevant anymore given that the only tests were in the hooks. I can't figure out what the actual use case was, so happy to reconsider if that can be brought forward.
We can always use a controlled open state in order to prevent the menu from opening.

Closes https://github.com/adobe/react-spectrum/issues/2222

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
