### PR TITLE
Fix autofocusing for long-lived dialog components

### DIFF
--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -51,7 +51,7 @@ export function useDialog(props: AriaDialogProps, ref: RefObject<HTMLElement>): 
         clearTimeout(timeout);
       };
     }
-  }, [ref]);
+  }, [ref.current]);
 
   // We do not use aria-modal due to a Safari bug which forces the first focusable element to be focused
   // on mount when inside an iframe, no matter which element we programmatically focus.

--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -36,20 +36,6 @@ export function useDialog(props: AriaDialogProps, ref: RefObject<HTMLElement>): 
   useEffect(() => {
     if (ref.current && !ref.current.contains(document.activeElement)) {
       focusSafely(ref.current);
-
-      // Safari on iOS does not move the VoiceOver cursor to the dialog
-      // or announce that it has opened until it has rendered. A workaround
-      // is to wait for half a second, then blur and re-focus the dialog.
-      let timeout = setTimeout(() => {
-        if (document.activeElement === ref.current) {
-          ref.current.blur();
-          focusSafely(ref.current);
-        }
-      }, 500);
-
-      return () => {
-        clearTimeout(timeout);
-      };
     }
   }, [ref.current]);
 

--- a/packages/@react-aria/dialog/test/useDialog.test.js
+++ b/packages/@react-aria/dialog/test/useDialog.test.js
@@ -20,6 +20,12 @@ function Example(props) {
   return <div ref={ref} {...dialogProps} data-testid="test">{props.children}</div>;
 }
 
+function ControlledExample(props) {
+  let ref = useRef();
+  let {dialogProps} = useDialog(props, ref);
+  return props.isOpen ? <div ref={ref} {...dialogProps} data-testid="test">{props.children}</div> : null;
+}
+
 describe('useDialog', function () {
   it('should have role="dialog" by default', function () {
     let res = render(<Example />);
@@ -40,11 +46,41 @@ describe('useDialog', function () {
     expect(document.activeElement).toBe(el);
   });
 
+  it('should focus the overlay on open', function () {
+    let res = render(<ControlledExample />);
+    res.rerender(<ControlledExample isOpen />);
+    // run the useEffect hook
+    res.rerender(<ControlledExample isOpen />);
+    let el = res.getByTestId('test');
+    expect(el).toHaveAttribute('tabIndex', '-1');
+    expect(document.activeElement).toBe(el);
+  });
+
   it('should not focus the overlay if something inside is auto focused', function () {
     let res = render(
       <Example>
         <input data-testid="input" autoFocus />
       </Example>
+    );
+    let input = res.getByTestId('input');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('should not focus the overlay on open if something inside is auto focused', function () {
+    let res = render(
+      <ControlledExample>
+        <input data-testid="input" autoFocus />
+      </ControlledExample>
+    );
+    res.rerender(
+      <ControlledExample isOpen>
+        <input data-testid="input" autoFocus />
+      </ControlledExample>
+    );
+    res.rerender(
+      <ControlledExample isOpen>
+        <input data-testid="input" autoFocus />
+      </ControlledExample>
     );
     let input = res.getByTestId('input');
     expect(document.activeElement).toBe(input);

--- a/packages/@react-spectrum/overlays/test/Tray.test.js
+++ b/packages/@react-spectrum/overlays/test/Tray.test.js
@@ -105,11 +105,8 @@ describe('Tray', function () {
 
     let dialog = await getByRole('dialog');
     expect(document.activeElement).toBe(dialog);
-    // The iOS Safari workaround blurs and refocuses the dialog after 0.5s
-    expect(onClose).toHaveBeenCalledTimes(1);
 
     act(() => {dialog.blur();});
-    // (The iOS Safari workaround) + (the actual onClose) = 2
-    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #2397

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

The scenario for `should focus the overlay on open` will fail without this change. For proof, revert
https://github.com/adobe/react-spectrum/blob/6b36d162a6634978740d0f60118c9fb6804850cf/packages/@react-aria/dialog/src/useDialog.ts#L54

and run

```console
$ yarn test packages/@react-aria/dialog
```

## 🧢 Your Project:

N/A
