### PR TITLE
Disable red border on browser form validation

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
@@ -42,8 +42,7 @@ governing permissions and limitations under the License.
     border-color: var(--spectrum-dropdown-border-color-key-focus);
   }
 
-  &.spectrum-InputGroup--invalid,
-  &:invalid {
+  &.spectrum-InputGroup--invalid {
     .spectrum-FieldButton,
     .spectrum-InputGroup-input {
       border-color: var(--spectrum-dropdown-border-color-error);
@@ -62,8 +61,7 @@ governing permissions and limitations under the License.
     box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-key-focus);
   }
 
-  &.spectrum-InputGroup--invalid,
-  &:invalid {
+  &.spectrum-InputGroup--invalid {
     .spectrum-FieldButton,
     .spectrum-InputGroup-input {
       box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
@@ -91,7 +89,6 @@ governing permissions and limitations under the License.
     &:focus,
     &:active,
     &.is-selected,
-    &:invalid,
     &.spectrum-FieldButton--invalid {
       border-color: var(--spectrum-textfield-quiet-border-color);
     }
@@ -109,8 +106,7 @@ governing permissions and limitations under the License.
   }
 
   &.spectrum-InputGroup {
-    &.spectrum-InputGroup--invalid,
-    &:invalid {
+    &.spectrum-InputGroup--invalid {
       .spectrum-FieldButton,
       .spectrum-InputGroup-input {
         border-color: var(--spectrum-textfield-border-color-error);
@@ -122,8 +118,7 @@ governing permissions and limitations under the License.
         border-color: var(--spectrum-textfield-quiet-border-color-key-focus);
       }
 
-      &.spectrum-InputGroup--invalid,
-      &:invalid {
+      &.spectrum-InputGroup--invalid {
         .spectrum-FieldButton {
           border-color: var(--spectrum-textfield-border-color-error);
         }
@@ -140,8 +135,7 @@ governing permissions and limitations under the License.
         border-color: var(--spectrum-textfield-quiet-border-color-key-focus);
       }
 
-      &.spectrum-InputGroup--invalid,
-      &:invalid {
+      &.spectrum-InputGroup--invalid {
         .spectrum-InputGroup-input {
           box-shadow: 0 1px 0 var(--spectrum-textfield-border-color-error);
         }
@@ -171,7 +165,6 @@ governing permissions and limitations under the License.
   &:focus-ring {
     box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-key-focus);
 
-    &:invalid,
     &.spectrum-InputGroup--invalid {
       box-shadow: 0 0 0 1px var(--spectrum-dropdown-border-color-error);
 

--- a/packages/@adobe/spectrum-css-temp/components/stepper/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/stepper/skin.css
@@ -108,7 +108,7 @@ governing permissions and limitations under the License.
         border-color: var(--spectrum-textfield-border-color-disabled);
       }
     }
-    &.is-invalid, &:invalid {
+    &.is-invalid {
       &.focus-ring, &:focus-ring {
         box-shadow: 0 0 0 1px var(--spectrum-textfield-border-color-error);
       }
@@ -171,7 +171,7 @@ governing permissions and limitations under the License.
         border-color: var(--spectrum-textfield-quiet-border-color-disabled);
       }
     }
-    &.is-invalid, &:invalid {
+    &.is-invalid {
       &.focus-ring, &:focus-ring {
         box-shadow: 0 1px 0 0 var(--spectrum-textfield-quiet-border-color-error);
       }

--- a/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
@@ -80,7 +80,6 @@ governing permissions and limitations under the License.
     }
   }
 
-  &:invalid,
   &.spectrum-Textfield--invalid {
     border-color: var(--spectrum-textfield-border-color-error);
 
@@ -128,17 +127,6 @@ governing permissions and limitations under the License.
     &.is-disabled {
       background-color: var(--spectrum-textfield-quiet-background-color-disabled);
       border-color:  var(--spectrum-textfield-quiet-border-color-disabled);
-    }
-
-    &:invalid {
-      border-color: var(--spectrum-textfield-border-color-error);
-
-      &:focus-ring { /* might break things due to pre-defined focus-ring */
-        &:not(:active) {
-          border-color: var(--spectrum-textfield-border-color-error);
-          box-shadow: 0 1px 0 var(--spectrum-textfield-border-color-error);
-        }
-      }
     }
   }
 

--- a/packages/@react-spectrum/textfield/stories/Textfield.stories.js
+++ b/packages/@react-spectrum/textfield/stories/Textfield.stories.js
@@ -51,6 +51,14 @@ storiesOf('TextField', module)
     () => render({validationState: 'valid'})
   )
   .add(
+    'type: email',
+    () => render({type: 'email'})
+  )
+  .add(
+    'pattern: [0-9]+',
+    () => render({pattern: '[0-9]+'})
+  )
+  .add(
     'isReadOnly: true',
     () => render({isReadOnly: true})
   )


### PR DESCRIPTION
Noticed that some browsers apply form validation as you type when using the `type` or `pattern` attributes. This currently only shows the red border and not the error icon and is a bug I believe. Validation should only be shown when the `validationState` prop is set, so that apps can control validation behavior (i.e. only validate on submit rather than every keystroke).