### PR TITLE
Add tested PR comment workflow action

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,35 @@
+name: PR comment
+on: issue_comment
+
+jobs:
+  pr_commented:
+    name: PR comment workflow
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout source code https://github.com/actions/checkout/issues/331#issuecomment-925405415
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout Pull Request
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Use Node 14
+        uses: actions/setup-node@v2
+        with:
+          node_version: '14.16.1'
+      - name: install
+        run: yarn install
+      - name: Configure CI Git User
+        run: |
+          git remote rm origin
+          git remote add origin "https://github-actions:$GITHUB_TOKEN@github.com/adobe/react-spectrum.git"
+          git fetch
+          git config --global user.email octobot@github.com
+          git config --global user.name GitHub Actions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Diff TS
+        run: |
+          yarn check-apis


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2390

Questions, what should the phrase be?
Who should be able to run this comment driven action?

Uses GitHub actions because we have some number of minutes free with them and I don't need the CircleCI token to run it.
CircleCI has no ability to be triggered from a PR comment, so we'd need a GitHub Action anyways to kick off the CircleCI.
We may still want to move to using CircleCI down the road when we get the token so as to speed up this Action because then we could use the branches CircleCI cached data.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
