### PR TITLE
Remove unsupported aria properties from radio

### DIFF
--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -18,17 +18,6 @@ import {RadioGroupState} from '@react-stately/radio';
 import {useFocusable} from '@react-aria/focus';
 import {usePress} from '@react-aria/interactions';
 
-interface RadioAriaProps extends AriaRadioProps {
-  /**
-   * Whether the Radio is required. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required).
-   */
-  isRequired?: boolean,
-  /**
-   * Whether the Radio can be interacted with but cannot have its selection state changed.
-   */
-  isReadOnly?: boolean
-}
-
 interface RadioAria {
   /** Props for the input element. */
   inputProps: InputHTMLAttributes<HTMLElement>
@@ -41,19 +30,15 @@ interface RadioAria {
  * @param state - State for the radio group, as returned by `useRadioGroupState`.
  * @param ref - Ref to the HTML input element.
  */
-export function useRadio(props: RadioAriaProps, state: RadioGroupState, ref: RefObject<HTMLElement>): RadioAria {
+export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: RefObject<HTMLElement>): RadioAria {
   let {
     value,
-    isRequired,
     children,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby
   } = props;
 
   const isDisabled = props.isDisabled || state.isDisabled;
-
-  // Individual radios cannot be readonly
-  const isReadOnly = state.isReadOnly;
 
   let hasChildren = children != null;
   let hasAriaLabel = ariaLabel != null || ariaLabelledby != null;
@@ -89,8 +74,6 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState, ref: Ref
       name: radioGroupNames.get(state),
       tabIndex,
       disabled: isDisabled,
-      'aria-readonly': isReadOnly || undefined,
-      'aria-required': isRequired || undefined,
       checked,
       value,
       onChange

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -271,10 +271,11 @@ describe('Radios', function () {
     let radioGroup = getByRole('radiogroup');
     let radios = getAllByRole('radio');
     expect(radioGroup).toBeTruthy();
+    expect(radioGroup).toHaveAttribute('aria-readonly', 'true');
     expect(radios.length).toBe(3);
-    expect(radios[0]).toHaveAttribute('aria-readonly', 'true');
-    expect(radios[1]).toHaveAttribute('aria-readonly', 'true');
-    expect(radios[2]).toHaveAttribute('aria-readonly', 'true');
+    for (let radio of radios) {
+      expect(radio).not.toHaveAttribute('aria-readonly');
+    }
 
     let cats = getByLabelText('Cats');
     userEvent.click(cats);
@@ -416,9 +417,14 @@ describe('Radios', function () {
   });
 
   it('v3 RadioGroup sets aria-required when isRequired is true', () => {
-    let {getByRole} = renderRadioGroup(RadioGroup, Radio, {label: 'Favorite Pet', isRequired: true}, []);
+    let {getByRole, getAllByRole} = renderRadioGroup(RadioGroup, Radio, {label: 'Favorite Pet', isRequired: true}, []);
     let radioGroup = getByRole('radiogroup');
     expect(radioGroup).toHaveAttribute('aria-required', 'true');
+
+    let radios = getAllByRole('radio');
+    for (let radio of radios) {
+      expect(radio).not.toHaveAttribute('aria-required');
+    }
   });
 
   it('v3 RadioGroup sets aria-disabled when isDisabled is true', () => {


### PR DESCRIPTION
The [radio](https://www.w3.org/TR/wai-aria-1.2/#radio) ARIA role does not support `aria-required` or `aria-readonly`. These should go on the parent `radiogroup` instead (and already do). This was causing a11y failures in Storybook.