### PR TITLE
fix: useHover always returns currentTarget

### DIFF
--- a/packages/@react-aria/interactions/src/useHover.ts
+++ b/packages/@react-aria/interactions/src/useHover.ts
@@ -109,7 +109,7 @@ export function useHover(props: HoverProps): HoverResult {
       }
 
       state.isHovered = true;
-      let target = event.target;
+      let target = event.currentTarget;
       state.target = target;
 
       if (onHoverStart) {


### PR DESCRIPTION
Closes #2355

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Logging the DOM element `from`:  https://github.com/cedeber/premio/blob/8f0b2301b753528ac79decd3d71aa0e3f40a0445/app-src/components/Menu.tsx#L48

It was easy to see that sometimes a single letter or the emoticon was returned instead of the element which the events are attached to.

## 🧢 Your Project:

https://github.com/cedeber/premio
