### PR TITLE
Revert latest useTextField docs change

### DIFF
--- a/packages/@react-aria/textfield/docs/useTextField.mdx
+++ b/packages/@react-aria/textfield/docs/useTextField.mdx
@@ -69,7 +69,7 @@ input via the `aria-describedby` attribute.
 `useTextField` returns props that you should spread onto the appropriate element:
 
 <TypeContext.Provider value={docs.links}>
-  <InterfaceType properties={docs.links[docs.exports.useTextField.return.base.id].properties} />
+  <InterfaceType properties={docs.links[docs.exports.useTextField.return.base?.id ?? docs.exports.useTextField.return.id].properties} />
 </TypeContext.Provider>
 
 If there is no visual label, an `aria-label` or `aria-labelledby` prop must be passed instead


### PR DESCRIPTION
Closes N/A

This PR reverts the latest change to `useTextField.mdx`. It was a change that was introduced when `useTextField` was implemented in 197aadeae30ab84fca33d517804c3d344cb6808e using a function overloading approach. Later, `useTextField` was refactored in c64d473c1ceea9b55c29726ea77d0399e5317758 to use generics, but the change to `useTextField.mdx` was not necessary and was not reverted.

<details>
<summary>Local production website build log (very long)</summary>

```
$ make website-production
node scripts/buildWebsite.js
Building into /tmp/c175ace0a06c30a190cb83b645f5cf9f...
yarn install v1.22.5
[1/4] Resolving packages...
warning Resolution field "postcss-calc@6.0.2" is incompatible with requested version "postcss-calc@^7.0.1"
warning Resolution field "jsdom@16.3.0" is incompatible with requested version "jsdom@^14.1.0"
warning Resolution field "@babel/core@7.12.10" is incompatible with requested version "@babel/core@7.8.0"
warning Resolution field "@babel/core@7.12.10" is incompatible with requested version "@babel/core@7.8.4"
[2/4] Fetching packages...
warning Pattern ["@parcel/plugin@nightly"] is trying to unpack in the same destination "/home/tsoliman/.cache/yarn/v6/npm-@parcel-plugin-2.0.0-nightly.359-0feeace48ad1586a91cd3ea313a1059ec919517d-integrity/node_modules/@parcel/plugin" as pattern ["@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d","@parcel/plugin@2.0.0-nightly.359+6231ca1d"]. This could result in non-deterministic behavior, skipping.
warning Pattern ["@parcel/utils@nightly"] is trying to unpack in the same destination "/home/tsoliman/.cache/yarn/v6/npm-@parcel-utils-2.0.0-nightly.359-d5a0d92a62a592acc1d44a2de8a11c2a99ed12a6-integrity/node_modules/@parcel/utils" as pattern ["@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d","@parcel/utils@2.0.0-nightly.359+6231ca1d"]. This could result in non-deterministic behavior, skipping.
warning Pattern ["@parcel/node-resolver-core@nightly"] is trying to unpack in the same destination "/home/tsoliman/.cache/yarn/v6/npm-@parcel-node-resolver-core-2.0.0-nightly.1981-54340f7ea2ef9b01bbfdd966607d49e6cfc69bb7-integrity/node_modules/@parcel/node-resolver-core" as pattern ["@parcel/node-resolver-core@2.0.0-nightly.1981+6231ca1d"]. This could result in non-deterministic behavior, skipping.
info fsevents@1.2.12: The platform "linux" is incompatible with this module.
info "fsevents@1.2.12" is an optional dependency and failed compatibility check. Excluding it from installation.
warning @atom-languages/language-typescript@0.6.2: The engine "atom" appears to be invalid.
warning @atom-languages/language-css@0.44.4: The engine "atom" appears to be invalid.
[3/4] Linking dependencies...
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/aria-modal-polyfill@3.4.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/aria-modal-polyfill > @react-types/shared@3.9.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/autocomplete@3.0.0-alpha.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/listbox@3.3.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/i18n@3.3.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-aria/selection@3.6.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/menu@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/menu@3.2.3" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/overlays@3.7.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/overlays@3.7.2" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/combobox@3.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/combobox@3.1.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/utils@3.9.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/collections@3.3.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-types/button@3.4.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-aria/live-announcer@3.0.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-aria/live-announcer@3.0.1" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/searchfield@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-types/autocomplete@3.0.0-alpha.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/label@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/focus@3.5.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/interactions@3.6.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/textfield@3.4.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/combobox@3.0.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-types/combobox@3.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/list@3.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/autocomplete > @react-types/searchfield@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/listbox > @react-types/listbox@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/ssr@3.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/menu@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/selection@3.7.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/tree@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/menu > @react-types/menu@3.4.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/overlays@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/visually-hidden@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/overlays > @react-types/overlays@3.5.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/utils > @react-stately/utils@3.2.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/label > @react-types/label@3.5.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/select@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/numberfield > @react-types/textfield@3.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/combobox > @react-stately/layout@3.4.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/searchfield@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/select > @react-types/select@3.4.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/table > @react-types/grid@3.0.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/table > @react-stately/virtualizer@3.1.5" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/table > @react-types/table@3.0.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/breadcrumbs@3.1.5" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/link@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/breadcrumbs > @react-types/breadcrumbs@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/link > @react-types/link@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/button@3.3.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/toggle@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/checkbox > @react-types/checkbox@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/checkbox@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/checkbox@3.0.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/checkbox > @react-aria/toggle@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/switch > @react-types/switch@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/color@3.0.0-beta.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/color@3.0.0-beta.4" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/color > @react-aria/spinbutton@3.0.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/color > @react-aria/spinbutton@3.0.1" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/color > @react-types/slider@3.0.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/color > @react-types/color@3.0.0-beta.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/color@3.0.0-beta.4" has unmet peer dependency "react@^16.8.0".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/slider@3.0.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/radio > @react-types/radio@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/radio@3.3.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/slider@3.0.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/numberfield > @react-types/numberfield@3.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/dialog@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/dialog > @react-types/dialog@3.3.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/meter@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/meter > @react-types/meter@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/progress@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/progress > @react-types/progress@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/numberfield@3.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/numberfield@3.1.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/numberfield@3.0.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/radio@3.1.5" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/select@3.5.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/select@3.5.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/separator@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/switch@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/table@3.0.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/table@3.0.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/table@3.0.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/table > @react-aria/grid@3.0.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/table > @react-aria/grid@3.0.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/card > @react-stately/grid@3.0.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/tabs@3.0.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/tabs@3.0.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/tabs > @react-types/tabs@3.0.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-aria/tooltip@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-aria/tooltip > @react-types/tooltip@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/tooltip@3.0.5" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/actiongroup@3.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/actiongroup@3.3.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/form@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/menu@3.5.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/menu@3.5.1" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/button@3.6.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/text@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @react-types/actiongroup@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @react-aria/actiongroup@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/tooltip@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/tooltip@3.1.4" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @spectrum-icons/ui@3.2.1" has unmet peer dependency "@react-spectrum/provider@^3.0.0".
warning "@react-spectrum/actiongroup > @spectrum-icons/ui@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @spectrum-icons/ui > @adobe/react-spectrum-ui@1.0.1" has unmet peer dependency "react@^16.8.0".
warning "@react-spectrum/actiongroup > @spectrum-icons/ui > @adobe/react-spectrum-ui@1.0.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@react-spectrum/actiongroup > @react-spectrum/utils@3.6.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @spectrum-icons/workflow@3.2.1" has unmet peer dependency "@react-spectrum/provider@^3.0.0".
warning "@react-spectrum/actiongroup > @spectrum-icons/workflow@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @spectrum-icons/workflow > @adobe/react-spectrum-workflow@1.0.1" has unmet peer dependency "react@^16.8.0".
warning "@react-spectrum/actiongroup > @spectrum-icons/workflow > @adobe/react-spectrum-workflow@1.0.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@react-spectrum/form > @react-types/form@3.2.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/card > @react-aria/virtualizer@3.3.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/card > @react-aria/virtualizer@3.3.4" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/checkbox@3.2.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/combobox > @react-spectrum/overlays@3.4.4" has unmet peer dependency "@react-spectrum/provider@^3.0.0".
warning "@react-spectrum/combobox > @react-spectrum/overlays@3.4.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/combobox > @react-spectrum/overlays@3.4.4" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/actiongroup > @react-spectrum/menu > @react-spectrum/overlays > react-transition-group@2.9.0" has unmet peer dependency "react@>=15.0.0".
warning "@react-spectrum/actiongroup > @react-spectrum/menu > @react-spectrum/overlays > react-transition-group@2.9.0" has unmet peer dependency "react-dom@>=15.0.0".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/divider@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/icon@3.3.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/layout@3.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/checkbox > @react-spectrum/label@3.4.0" has unmet peer dependency "@react-spectrum/provider@^3.0.0".
warning "@react-spectrum/checkbox > @react-spectrum/label@3.4.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/divider > @react-types/divider@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/layout > @react-types/layout@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/text > @react-types/text@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/breadcrumbs@3.2.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/breadcrumbs@3.2.3" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/buttongroup@3.2.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/buttongroup > @react-types/buttongroup@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/card@3.0.0-alpha.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/progress@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/card > @react-types/card@3.0.0-alpha.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/color@3.0.0-beta.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/color@3.0.0-beta.4" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/textfield@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/combobox@3.1.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/combobox@3.1.1" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/listbox@3.5.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/listbox@3.5.3" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/dialog@3.3.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/dialog@3.3.4" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/view@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/view > @react-types/view@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/illustratedmessage@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/illustratedmessage > @react-types/illustratedmessage@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/image@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/image > @react-types/image@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/link@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/meter@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/numberfield@3.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/numberfield@3.1.0" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/picker@3.4.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/picker@3.4.1" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/provider@3.2.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/provider@3.2.2" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/provider > @react-types/provider@3.3.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/radio@3.1.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/searchfield@3.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/slider@3.0.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/statuslight@3.2.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/statuslight > @react-types/statuslight@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/switch@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/table@3.0.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/table@3.0.1" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/tabs@3.0.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/tabs@3.0.2" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-spectrum/well@3.1.3" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "@react-spectrum/well > @react-types/well@3.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
warning "workspace-aggregator-ce87d50c-b03e-4061-a562-e6719d1ee7d1 > @react-stately/data@3.4.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0-rc.1".
[4/4] Building fresh packages...
success Saved lockfile.
$ patch-package
patch-package 6.2.0
Applying patches...
@babel/types@7.10.4 ✔
@parcel/bundler-default@2.0.0-nightly.359 ✔
@parcel/transformer-typescript-types@2.0.0-nightly.359 ✔
Done in 137.85s.
yarn run v1.22.5
$ DOCS_ENV=production PARCEL_WORKER_BACKEND=process parcel build 'docs/*/*/docs/*.mdx' 'packages/dev/docs/pages/**/*.mdx' --no-scope-hoist
console: [BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
console: [BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
console: [BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
console: [BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
console: [BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
console: [BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
console: UNKNOWN TYPE ImportDefaultSpecifier
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
console: UNKNOWN TYPE NewExpression
console: UNKNOWN TYPE TSTypeOperator
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
console: UNKNOWN TYPE TSDeclareFunction
@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json) file whenever possible.
console: UNKNOWN TYPE TSIndexedAccessType
console: UNKNOWN TYPE TSIndexedAccessType
console: UNKNOWN TYPE TSIndexedAccessType
console: UNKNOWN TYPE ConditionalExpression
console: UNKNOWN TYPE TSConditionalType
console: UNKNOWN TYPE TSConditionalType
✨ Built in 527.64s

dist/react-aria/watchModals.html                                27.28 KB    164.05s
dist/ReactAria_976x445_2x.25a2e35e.png                         127.45 KB      2.24s
dist/ReactSpectrumHome_976x445_2x.d66cabe5.png                 251.28 KB      2.24s
dist/ReactSpectrum_976x445_2x.711c2311.png                     126.63 KB      2.24s
dist/ReactStately_976x445_2x.12e6d412.png                       92.13 KB      2.24s
dist/watchModals.25d813ca.js                                   388.65 KB    164.05s
dist/watchModals.40e544af.css                                  302.83 KB     39.96s
dist/react-aria/useBreadcrumbs.html                            195.96 KB    164.05s
dist/useBreadcrumbs.eebeea49.js                                393.09 KB    164.05s
dist/react-aria/useButton.html                                  98.86 KB    164.05s
dist/useButton.97da5c87.js                                     391.17 KB    219.21s
dist/react-aria/useToggleButton.html                           109.14 KB     23.43s
dist/useToggleButton.c55a4cea.js                               390.26 KB    219.21s
dist/react-aria/useCheckbox.html                               148.41 KB     23.43s
dist/useCheckbox.347b045a.js                                   394.06 KB    219.21s
dist/react-aria/useCheckboxGroup.html                           128.8 KB     28.87s
dist/useCheckboxGroup.7bb86380.js                              393.95 KB    230.71s
dist/react-aria/useColorField.html                             150.76 KB    178.08s
dist/useColorField.57f697a7.js                                 430.04 KB    181.17s
dist/react-aria/useColorSlider.html                            283.41 KB     28.87s
dist/useColorSlider.9b1a86af.js                                434.27 KB    226.91s
dist/react-aria/useColorWheel.html                             171.21 KB     24.90s
dist/useColorWheel.9c3d7e44.js                                 431.54 KB    276.44s
dist/react-aria/useDialog.html                                 150.61 KB     25.12s
dist/useDialog.01bdc246.js                                      391.1 KB    276.44s
dist/react-aria/FocusRing.html                                  39.49 KB    165.16s
dist/FocusRing.9d2fdc85.js                                     389.21 KB    166.44s
dist/react-aria/FocusScope.html                                  85.4 KB    165.16s
dist/FocusScope.32d1485a.js                                    390.18 KB    166.77s
dist/react-aria/useFocusRing.html                               51.41 KB    165.16s
dist/useFocusRing.bcef858b.js                                  389.64 KB    201.63s
dist/react-aria/I18nProvider.html                               30.82 KB    201.22s
dist/I18nProvider.34753ec8.js                                  388.98 KB    201.63s
dist/react-aria/internationalization.html                       41.14 KB     16.89s
dist/internationalization.829b1e69.js                          388.66 KB    201.63s
dist/react-aria/useCollator.html                                48.95 KB    163.98s
dist/useCollator.9715a8d1.js                                    389.7 KB    163.98s
dist/react-aria/useDateFormatter.html                           39.21 KB    163.98s
dist/useDateFormatter.97530b3b.js                              389.42 KB    163.98s
dist/react-aria/useFilter.html                                  64.57 KB    163.98s
dist/useFilter.1a68b689.js                                     389.82 KB    209.85s
dist/react-aria/useLocale.html                                  38.27 KB    208.87s
dist/useLocale.755b39ed.js                                     388.65 KB    209.85s
dist/react-aria/useMessageFormatter.html                        46.12 KB    208.87s
dist/useMessageFormatter.f2847f15.js                           389.55 KB    209.85s
dist/react-aria/useNumberFormatter.html                         43.32 KB    158.75s
dist/useNumberFormatter.543a4c18.js                            389.54 KB    163.98s
dist/react-aria/useField.html                                   72.19 KB    158.75s
dist/useField.429fb7f1.js                                      391.02 KB    163.98s
dist/react-aria/useLabel.html                                   51.01 KB    158.75s
dist/useLabel.9a855f00.js                                      390.31 KB    212.83s
dist/react-aria/useLink.html                                    98.71 KB    212.71s
dist/useLink.d2dbc244.js                                       391.16 KB    212.83s
dist/react-aria/useListBox.html                                358.79 KB    209.13s
dist/useListBox.7aee53de.js                                    400.31 KB    212.83s
dist/react-aria/useMenu.html                                   376.98 KB    164.10s
dist/useMenu.00a4e316.js                                       395.33 KB    166.63s
dist/react-aria/useMenuTrigger.html                            349.75 KB     31.77s
dist/useMenuTrigger.1260d09b.js                                392.42 KB    166.63s
dist/react-aria/useMeter.html                                    80.2 KB    165.70s
dist/useMeter.5905267d.js                                      391.93 KB    210.50s
dist/react-aria/useNumberField.html                            230.63 KB    210.12s
dist/useNumberField.ca0a460f.js                                412.55 KB    210.88s
dist/react-aria/DismissButton.html                              26.82 KB    209.30s
dist/DismissButton.c3addbc5.js                                 388.65 KB    210.88s
dist/react-aria/useModal.html                                   28.98 KB    163.98s
dist/useModal.7efa311d.js                                      388.64 KB    163.98s
dist/react-aria/useOverlay.html                                 33.92 KB    163.98s
dist/useOverlay.f91bdcf1.js                                    388.65 KB    163.98s
dist/react-aria/useOverlayPosition.html                         44.69 KB    163.98s
dist/useOverlayPosition.d39793d1.js                            388.65 KB    209.47s
dist/react-aria/useOverlayTrigger.html                         211.59 KB     19.95s
dist/useOverlayTrigger.a174c3bc.js                             391.95 KB    209.47s
dist/react-aria/usePreventScroll.html                           26.18 KB    205.70s
dist/usePreventScroll.41942998.js                              388.65 KB    209.47s
dist/react-aria/useComboBox.html                               633.11 KB    267.02s
dist/example.e1ccdc11.png                                       15.13 KB      2.23s
dist/search.84b7440c.png                                        29.43 KB      7.18s
dist/material.f6560211.png                                      18.35 KB      7.18s
dist/styled-components.f809eaac.png                             63.35 KB      7.17s
dist/chakra.19106c46.png                                        28.97 KB      7.17s
dist/useComboBox.4aa0fe02.js                                   441.66 KB    323.03s
dist/useComboBox.079d51e4.css                                    73.1 KB     39.96s
dist/react-aria/interactions.html                               31.42 KB     22.85s
dist/interactions.878e13b5.js                                  388.65 KB    323.03s
dist/react-aria/useFocus.html                                   63.61 KB     23.68s
dist/useFocus.263fce6e.js                                       389.8 KB    201.75s
dist/react-aria/useFocusVisible.html                            44.06 KB    201.06s
dist/useFocusVisible.14879076.js                               389.56 KB    201.75s
dist/react-aria/useFocusWithin.html                             75.42 KB    201.06s
dist/useFocusWithin.c01310e8.js                                390.13 KB    201.75s
dist/react-aria/useHover.html                                   74.98 KB    164.10s
dist/useHover.530e69bc.js                                      389.92 KB    164.10s
dist/react-aria/useKeyboard.html                                62.65 KB    164.10s
dist/useKeyboard.b4d963ed.js                                   389.82 KB    164.10s
dist/react-aria/useMove.html                                   113.65 KB    164.10s
dist/useMove.3617a865.js                                       390.41 KB    211.90s
dist/react-aria/usePress.html                                   92.97 KB    210.99s
dist/usePress.7ea7fbbd.js                                      389.98 KB    211.90s
dist/react-aria/useProgressBar.html                               108 KB    210.74s
dist/useProgressBar.37175109.js                                392.34 KB    211.90s
dist/react-aria/useRadioGroup.html                             188.81 KB     75.41s
dist/useRadioGroup.4f780ee5.js                                 394.99 KB    322.86s
dist/react-aria/useSearchField.html                            201.84 KB     75.33s
dist/useSearchField.f16ec3c0.js                                398.63 KB    308.98s
dist/react-aria/useSelect.html                                 429.32 KB    152.28s
dist/example.e28b44ec.png                                       20.03 KB      7.17s
dist/styled-components.43392079.png                             78.59 KB      7.17s
dist/useSelect.52fd0449.js                                     401.97 KB    219.06s
dist/react-aria/useSeparator.html                               60.78 KB    218.75s
dist/useSeparator.70cc3d66.js                                  389.96 KB    219.06s
dist/react-aria/useSlider.html                                 307.67 KB     21.19s
dist/useSlider.402417ff.js                                     402.36 KB    219.06s
dist/react-aria/SSRProvider.html                                29.75 KB     85.37s
dist/SSRProvider.dfe62c12.js                                   388.98 KB     85.87s
dist/react-aria/useIsSSR.html                                   31.64 KB     85.37s
dist/useIsSSR.baa9d475.js                                      388.64 KB     85.87s
dist/react-aria/useSwitch.html                                 127.17 KB     15.69s
dist/useSwitch.cb6fd4b3.js                                     391.61 KB    267.02s
dist/react-aria/useTable.html                                  809.31 KB    267.02s
dist/useTable.fa112e36.js                                         483 KB    267.03s
dist/react-aria/useTabList.html                                227.28 KB    177.48s
dist/useTabList.36203c05.js                                    397.71 KB    252.84s
dist/react-aria/useTextField.html                              120.88 KB     84.58s
dist/useTextField.acc99d3d.js                                  394.42 KB     86.31s
dist/react-aria/useTooltipTrigger.html                         121.92 KB     14.38s
dist/useTooltipTrigger.71b653f2.js                             392.88 KB     86.31s
dist/react-aria/mergeProps.html                                 43.88 KB     84.58s
dist/mergeProps.22d5232f.js                                    388.65 KB    301.76s
dist/react-aria/useId.html                                         28 KB    214.19s
dist/useId.1895a034.js                                         388.64 KB    301.76s
dist/react-aria/VisuallyHidden.html                                38 KB     86.60s
dist/VisuallyHidden.d67201de.js                                388.65 KB    265.50s
dist/react-spectrum/ActionGroup.html                           427.95 KB     15.80s
dist/ActionGroup.5f0cc311.js                                   470.77 KB     96.48s
dist/ActionGroup.db68d04b.css                                   72.58 KB     39.95s
dist/react-spectrum/Breadcrumbs.html                           197.61 KB     96.48s
dist/Breadcrumbs.86778bdd.js                                   392.78 KB     96.48s
dist/react-spectrum/ActionButton.html                          166.12 KB     96.48s
dist/ActionButton.4cdf9821.js                                  392.77 KB    206.14s
dist/react-spectrum/Button.html                                180.13 KB    205.65s
dist/Button.ab71a244.js                                        393.26 KB    206.14s
dist/react-spectrum/LogicButton.html                           150.32 KB    205.65s
dist/LogicButton.4fb0f1bf.js                                   389.98 KB    206.14s
dist/react-spectrum/ToggleButton.html                          173.21 KB    164.10s
dist/ToggleButton.b41ef7d8.js                                  393.01 KB    164.10s
dist/react-spectrum/ButtonGroup.html                           136.06 KB    164.10s
dist/ButtonGroup.cd03af89.js                                   390.92 KB    164.10s
dist/react-spectrum/Checkbox.html                              156.89 KB    164.10s
dist/Checkbox.87257b79.js                                      416.64 KB    238.47s
dist/Checkbox.f9dfa0f7.css                                      67.72 KB     39.95s
dist/react-spectrum/CheckboxGroup.html                         289.94 KB    238.44s
dist/CheckboxGroup.39590d1c.js                                  421.6 KB    238.47s
dist/react-spectrum/ColorField.html                            206.88 KB     21.74s
dist/ColorField.170d17d3.js                                     456.3 KB    238.47s
dist/ColorField.9f447547.css                                    31.83 KB     39.95s
dist/react-spectrum/ColorSlider.html                           238.93 KB    182.82s
dist/ColorSlider.94f270aa.js                                   458.17 KB    184.32s
dist/react-spectrum/ColorWheel.html                            165.81 KB    182.82s
dist/ColorWheel.838efb55.js                                    455.62 KB    184.32s
dist/react-spectrum/ComboBox.html                              823.83 KB    183.15s
dist/ComboBox.4d7133f8.js                                      557.95 KB    246.40s
dist/ComboBox.53bd29fa.css                                     122.72 KB     26.02s
dist/react-spectrum/AlertDialog.html                           185.04 KB    246.29s
dist/AlertDialog.97bad1c3.js                                   393.71 KB    246.40s
dist/react-spectrum/Dialog.html                                313.91 KB    246.29s
dist/Dialog.0ed16401.js                                        436.64 KB    246.40s
dist/Dialog.b44b7758.css                                         18.6 KB     26.02s
dist/react-spectrum/DialogContainer.html                       124.18 KB    169.47s
dist/DialogContainer.0150f2ad.js                               419.36 KB    178.90s
dist/react-spectrum/DialogTrigger.html                         237.16 KB    169.52s
dist/DialogTrigger.a413dec8.js                                 433.17 KB    178.90s
dist/react-spectrum/Divider.html                               120.52 KB    169.36s
dist/Divider.63d1d9f7.js                                       390.21 KB    235.93s
dist/react-spectrum/Form.html                                  251.17 KB    235.63s
dist/Form.3de71180.js                                             437 KB    235.93s
dist/Form.43a97318.css                                          14.43 KB     26.01s
dist/react-spectrum/workflow-icons.html                         52.37 KB    235.63s
dist/workflow-icons.d5bd188e.js                                397.51 KB    235.93s
dist/react-spectrum/IllustratedMessage.html                     144.6 KB     84.78s
dist/IllustratedMessage.55988aa6.js                            404.64 KB    128.35s
dist/IllustratedMessage.10472a0d.css                             1.93 KB     25.98s
dist/react-spectrum/Image.html                                 111.64 KB     96.48s
dist/Image.10e091ce.js                                         391.04 KB    267.77s
dist/react-spectrum/Flex.html                                  168.69 KB    209.77s
dist/Flex.88e4a52d.js                                          391.92 KB    259.08s
dist/react-spectrum/Grid.html                                  150.93 KB    238.46s
dist/Grid.3d0fe45f.js                                          390.13 KB    323.02s
dist/react-spectrum/Link.html                                  151.85 KB    219.20s
dist/Link.3fb9df0e.js                                          392.42 KB    263.33s
dist/react-spectrum/ListBox.html                               362.78 KB    254.88s
dist/ListBox.de00d1a0.js                                       472.24 KB    280.46s
dist/react-spectrum/Menu.html                                   300.1 KB    280.42s
dist/Menu.8420bf98.js                                          401.31 KB    227.22s
dist/react-spectrum/MenuTrigger.html                           134.84 KB    226.95s
dist/MenuTrigger.f2d92a8f.js                                   393.26 KB    227.22s
dist/react-spectrum/Meter.html                                  170.8 KB    226.95s
dist/Meter.209239c6.js                                         401.03 KB    227.22s
dist/Meter.f07e82dc.css                                          5.89 KB     25.98s
dist/react-spectrum/NumberField.html                           257.81 KB    231.88s
dist/NumberField.83c103f5.js                                   444.56 KB    232.46s
dist/NumberField.15adb654.css                                   33.79 KB     30.95s
dist/react-spectrum/Picker.html                                465.24 KB    205.33s
dist/Picker.69c643f4.js                                         508.5 KB    208.22s
dist/Picker.4953f382.css                                         8.04 KB     30.94s
dist/react-spectrum/ProgressBar.html                           163.09 KB    205.33s
dist/ProgressBar.342431e4.js                                   398.91 KB    208.22s
dist/react-spectrum/ProgressCircle.html                         132.6 KB    205.33s
dist/ProgressCircle.801d986b.js                                397.89 KB    312.87s
dist/react-spectrum/Provider.html                              179.64 KB    119.09s
dist/Provider.4114b3ce.js                                      508.87 KB    119.82s
dist/react-spectrum/RadioGroup.html                            299.71 KB    119.09s
dist/RadioGroup.b741e2fc.js                                    414.89 KB    119.75s
dist/react-spectrum/SearchField.html                            228.2 KB    119.08s
dist/SearchField.f795ac56.js                                    424.7 KB    265.42s
dist/SearchField.2746f755.css                                    5.27 KB     30.94s
dist/react-spectrum/RangeSlider.html                           189.92 KB     84.57s
dist/RangeSlider.77a58080.js                                   410.63 KB    265.24s
dist/RangeSlider.6763d98e.css                                   38.14 KB     30.94s
dist/react-spectrum/Slider.html                                187.73 KB     84.71s
dist/Slider.4dacb7ef.js                                        410.97 KB    308.80s
dist/react-spectrum/StatusLight.html                            132.6 KB    213.81s
dist/StatusLight.9d8ea4ed.js                                   393.09 KB    308.80s
dist/StatusLight.5152881b.css                                    3.15 KB     30.94s
dist/react-spectrum/Switch.html                                148.94 KB    111.33s
dist/Switch.899f86eb.js                                        394.01 KB    158.80s
dist/Switch.8af29d25.css                                        11.81 KB     37.46s
dist/react-spectrum/TableView.html                             673.59 KB    207.54s
dist/TableView.daaef45c.js                                      576.3 KB    163.96s
dist/TableView.b333c6ff.css                                     16.55 KB     37.46s
dist/react-spectrum/Tabs.html                                  540.16 KB    248.91s
dist/Tabs.cea7d0a0.js                                          532.47 KB    207.75s
dist/Tabs.a4214101.css                                          13.49 KB     37.46s
dist/react-spectrum/Heading.html                               101.56 KB    134.30s
dist/Heading.9bae67c9.js                                       389.14 KB    225.76s
dist/react-spectrum/Keyboard.html                               99.88 KB    120.21s
dist/Keyboard.298fa9ac.js                                      389.13 KB    225.76s
dist/react-spectrum/Text.html                                   99.55 KB    158.40s
dist/Text.5aa2126d.js                                          389.13 KB    225.76s
dist/react-spectrum/TextArea.html                              223.17 KB    141.10s
dist/TextArea.f6a7329c.js                                      414.72 KB    267.49s
dist/react-spectrum/TextField.html                             224.43 KB    141.10s
dist/TextField.76c3b5f1.js                                     414.75 KB    225.76s
dist/react-spectrum/Tooltip.html                               195.48 KB    264.89s
dist/Tooltip.98e1ccfa.js                                       416.61 KB    267.49s
dist/react-spectrum/Content.html                                99.31 KB    225.76s
dist/Content.9aa61a8f.js                                       389.14 KB    252.83s
dist/react-spectrum/Footer.html                                 99.02 KB    151.78s
dist/Footer.8e01e201.js                                        389.15 KB    252.83s
dist/react-spectrum/Header.html                                 98.96 KB    163.96s
dist/Header.5377c2d2.js                                        389.13 KB    252.84s
dist/react-spectrum/View.html                                  162.47 KB    267.49s
dist/View.a63d1290.js                                          489.49 KB    267.01s
dist/react-spectrum/Well.html                                  110.56 KB    267.49s
dist/Well.6e8643f9.js                                          390.67 KB    323.01s
dist/Well.c1e2a73f.css                                             544 B     37.46s
dist/react-stately/useCheckboxGroupState.html                    37.2 KB    260.93s
dist/useCheckboxGroupState.f5679664.js                         388.66 KB    208.14s
dist/react-stately/Collection.html                             276.66 KB    254.34s
dist/Collection.0583ff25.js                                    388.65 KB    254.94s
dist/react-stately/collections.html                            292.49 KB    196.57s
dist/collections.cb7f40d5.js                                   388.65 KB    307.46s
dist/react-stately/useColorFieldState.html                       65.5 KB    254.79s
dist/useColorFieldState.4930a6d0.js                            388.65 KB    307.46s
dist/react-stately/useColorSliderState.html                     89.09 KB    218.14s
dist/useColorSliderState.be9168c7.js                           388.66 KB    307.46s
dist/react-stately/useColorWheelState.html                      62.76 KB    218.14s
dist/useColorWheelState.ce145fb9.js                            388.65 KB    256.27s
dist/react-stately/useComboBoxState.html                       161.41 KB    207.74s
dist/useComboBoxState.81a74216.js                              388.65 KB    301.76s
dist/react-stately/useAsyncList.html                           210.35 KB    301.73s
dist/useAsyncList.cba73f73.js                                  388.65 KB    296.60s
dist/react-stately/useListData.html                            119.77 KB    177.37s
dist/useListData.5c3c376d.js                                   388.65 KB    296.60s
dist/react-stately/useTreeData.html                            131.34 KB    177.37s
dist/useTreeData.707defcb.js                                   388.65 KB    296.60s
dist/react-stately/useListState.html                              113 KB    177.37s
dist/useListState.1d33ae49.js                                  388.65 KB    264.69s
dist/react-stately/useSingleSelectListState.html                116.4 KB    177.37s
dist/useSingleSelectListState.29f10508.js                      388.66 KB    264.69s
dist/react-stately/useMenuTriggerState.html                      37.2 KB    177.37s
dist/useMenuTriggerState.0439a16d.js                           388.66 KB    307.44s
dist/react-stately/useNumberFieldState.html                     61.83 KB    216.61s
dist/useNumberFieldState.914bf8d5.js                           388.66 KB    307.44s
dist/react-stately/useOverlayTriggerState.html                  27.88 KB    216.71s
dist/useOverlayTriggerState.98f11ab6.js                        388.66 KB    307.44s
dist/react-stately/useRadioGroupState.html                      39.77 KB    177.47s
dist/useRadioGroupState.1547fc27.js                            388.65 KB    284.10s
dist/react-stately/useSearchFieldState.html                     41.27 KB    177.47s
dist/useSearchFieldState.fb547404.js                           388.66 KB    284.10s
dist/react-stately/useSelectState.html                         146.36 KB    177.47s
dist/useSelectState.719d88de.js                                388.65 KB    322.84s
dist/react-stately/useSliderState.html                          68.14 KB    312.82s
dist/useSliderState.832120a7.js                                388.65 KB    322.96s
dist/react-stately/useTableState.html                          182.55 KB    262.13s
dist/useTableState.32d393b9.js                                 388.65 KB    268.67s
dist/react-stately/useTabListState.html                        114.15 KB    179.10s
dist/useTabListState.5ffa04c4.js                               388.65 KB    287.96s
dist/react-stately/useToggleState.html                          40.44 KB    179.03s
dist/useToggleState.2961e42f.js                                388.65 KB    325.04s
dist/react-stately/useTooltipTriggerState.html                  31.54 KB    195.42s
dist/useTooltipTriggerState.a254c57b.js                        388.66 KB    325.04s
dist/react-stately/useTreeState.html                           118.22 KB    264.69s
dist/useTreeState.5614ac53.js                                  388.65 KB    325.04s
dist/react-stately/SelectionManager.html                       209.28 KB    300.21s
dist/SelectionManager.976b7621.js                              388.93 KB    300.21s
dist/react-stately/selection.html                              152.86 KB    321.32s
dist/selection.bee80745.js                                     388.65 KB    321.37s
dist/react-stately/useMultipleSelectionState.html              168.27 KB    309.63s
dist/useMultipleSelectionState.bd069864.js                     388.94 KB    309.68s
dist/Support.html                                               18.52 KB    284.10s
dist/Support.cb76462c.js                                       388.64 KB    326.01s
dist/architecture.html                                          27.37 KB    232.35s
dist/architecture.14b64cb0.js                                  388.65 KB    311.75s
dist/architecture.0631da22.css                                  89.15 KB     37.45s
dist/contribute.html                                            27.79 KB    248.73s
dist/contribute.c08f9635.js                                    292.97 KB    311.75s
dist/contribute.a2d077c6.js                                    582.69 KB    311.75s
dist/error.html                                                  8.32 KB    195.33s
dist/error.fb0ab0b9.js                                         292.97 KB    279.90s
dist/index.html                                                 10.47 KB    185.63s
dist/ReactSpectrumHome_Mobile_976x1025_1x.fa17c509.png          58.56 KB      7.16s
dist/ReactSpectrumHome_Mobile_976x1025_2x.d25b7574.png         152.49 KB      7.16s
dist/ReactSpectrumHome_Mobile_976x1025_1x.9ad5c6e2.webp         18.82 KB      7.16s
dist/ReactSpectrumHome_Mobile_976x1025_2x.05b235b3.webp         44.19 KB      7.16s
dist/ReactSpectrumHome_976x445_1x.c21af41c.png                  84.15 KB      7.16s
dist/ReactSpectrumHome_976x445_2x.d66cabe5.png                 251.28 KB      7.16s
dist/ReactSpectrumHome_976x445_1x.b26248e4.webp                 18.93 KB      7.16s
dist/ReactSpectrumHome_976x445_2x.c06559f3.webp                 51.31 KB      7.16s
dist/index.b27204a0.js                                         292.97 KB    302.35s
dist/blog/building-a-button-part-1.html                         28.34 KB    186.85s
dist/button-dragging.ec64fe11.mp4                              784.11 KB      7.16s
dist/button-mobile.f47d46ec.mp4                              ⚠️  2.12 MB      7.16s
dist/button-text-selection.fd7ccced.mp4                       ⚠️  1.4 MB      7.15s
dist/building-a-button-part-1.ea90c761.png                      75.98 KB      7.15s
dist/building-a-button-part-1.651cd903.js                      388.78 KB    302.95s
dist/blog/building-a-button-part-2.html                         24.63 KB    229.10s
dist/button-hover.247937f5.mp4                                 941.76 KB      7.15s
dist/button-hover-ipad.dc101d52.mp4                          ⚠️  1.76 MB      7.15s
dist/building-a-button-part-2.6a8fb6e8.js                      388.78 KB    302.97s
dist/blog/building-a-button-part-3.html                         22.85 KB    271.43s
dist/focus-ring.de125e92.mp4                                   130.63 KB      7.16s
dist/keyboard-settings.f6006f43.png                            509.55 KB      7.16s
dist/building-a-button-part-3.0367e054.js                      388.78 KB    325.06s
dist/blog/building-a-combobox.html                              32.09 KB    318.68s
dist/combobox-accessibility.775d281e.mp4                        988.1 KB      7.16s
dist/combobox-scrolling-safari.951a57b2.mp4                   ⚠️  6.1 MB      8.07s
dist/combobox-visual-viewport.160ad477.mp4                   ⚠️  6.48 MB      8.07s
dist/combobox-example.8728f0db.png                              19.75 KB      7.16s
dist/screenreader-spreadsheet-combobox.de5a0867.png            588.13 KB      7.16s
dist/combobox.bbee34bc.mp4                                   ⚠️  6.95 MB      8.07s
dist/building-a-combobox.9e07a2ad.js                           388.66 KB    268.73s
dist/blog/how-we-internationalized-our-numberfield.html         39.38 KB    206.69s
dist/NumberField-pinyin.2ec935b5.mp4                           153.22 KB      7.16s
dist/NumberField_Iphone_default.370cd465.png                   138.47 KB      7.16s
dist/NumberField_Iphone_positive.6f705f64.png                  146.08 KB      7.16s
dist/NumberField_Iphone_integer.bc19f772.png                   136.68 KB      7.16s
dist/NumberField_Android_positive.d0e2e400.jpg                  27.44 KB      7.16s
dist/NumberField_Android_integer.8639ce5f.jpg                   33.12 KB      7.16s
dist/how-we-internationalized-our-numberfield.4dee932b.js      440.32 KB    286.83s
dist/blog/index.html                                            13.28 KB    267.75s
dist/index.b3ac57da.js                                         292.97 KB    317.50s
dist/blog/introducing-react-spectrum.html                       77.15 KB    267.75s
dist/ReactAria_Mobile_976x1025_1x.c1b5a9e1.png                  49.95 KB      7.16s
dist/ReactAria_Mobile_976x1025_2x.0b6e251c.png                 136.56 KB      7.16s
dist/ReactAria_Mobile_976x1025_1x.6aab098a.webp                 14.71 KB      7.16s
dist/ReactAria_Mobile_976x1025_2x.4b018a69.webp                 39.24 KB      7.16s
dist/ReactAria_976x445_1x.4cecc67f.png                          47.74 KB      7.16s
dist/ReactAria_976x445_2x.25a2e35e.png                         127.45 KB      7.16s
dist/ReactAria_976x445_1x.9fb49e2c.webp                          9.42 KB      7.16s
dist/ReactAria_976x445_2x.d851b331.webp                         26.05 KB      7.16s
dist/introducing-react-spectrum.bfab6694.js                    489.18 KB    317.49s
dist/react-aria/accessibility.html                              30.56 KB    206.69s
dist/accessibility.d3a21f76.js                                 388.65 KB    306.39s
dist/react-aria/getting-started.html                             62.9 KB    206.69s
dist/getting-started.e213ea8b.js                               393.18 KB    313.71s
dist/react-aria/index.html                                      22.01 KB    208.20s
dist/index.5aaea328.js                                         292.97 KB    313.71s
dist/react-aria/ssr.html                                        48.58 KB    209.83s
dist/ssr.02c97ad0.js                                           388.64 KB    325.31s
dist/react-aria/why.html                                        27.73 KB    210.89s
dist/why.36fa38bb.js                                           388.64 KB    325.30s
dist/react-spectrum/getting-started.html                        34.45 KB    209.97s
dist/getting-started.097c2110.js                               389.46 KB    325.30s
dist/react-spectrum/index.html                                  20.64 KB    286.83s
dist/ReactSpectrum_Mobile_976x1025_1x.28e0999f.png               70.5 KB      7.16s
dist/ReactSpectrum_Mobile_976x1025_2x.7b1e9a4b.png             199.38 KB      7.16s
dist/ReactSpectrum_Mobile_976x1025_1x.207ead03.webp             21.45 KB      7.15s
dist/ReactSpectrum_Mobile_976x1025_2x.6bf4356f.webp             50.77 KB      7.15s
dist/ReactSpectrum_976x445_1x.9be173e7.png                      51.35 KB      7.15s
dist/ReactSpectrum_976x445_2x.711c2311.png                     126.63 KB      7.15s
dist/ReactSpectrum_976x445_1x.e7d2bdd0.webp                     11.73 KB      7.16s
dist/ReactSpectrum_976x445_2x.ff6d99c5.webp                     27.57 KB      7.16s
dist/index.43847482.js                                         292.97 KB    306.89s
dist/react-spectrum/layout.html                                111.21 KB    306.39s
dist/layout.80854c7a.js                                        488.85 KB    269.06s
dist/react-spectrum/ssr.html                                    49.23 KB    235.86s
dist/ssr.d5e804c7.js                                           388.64 KB    269.06s
dist/react-spectrum/styling.html                               174.25 KB    269.02s
dist/styling.4ed6dc6c.js                                        505.4 KB    323.59s
dist/react-spectrum/testing.html                                63.56 KB    286.98s
dist/testing.e04ba78a.js                                       388.64 KB    323.59s
dist/react-spectrum/theming.html                                45.96 KB    213.73s
dist/theming.beadd7f8.js                                       389.65 KB    303.86s
dist/react-spectrum/versioning.html                             31.89 KB    212.80s
dist/versioning.4b106929.js                                    388.65 KB    318.49s
dist/react-stately/getting-started.html                         45.62 KB    212.61s
dist/getting-started.f89a140e.js                               390.16 KB    312.35s
dist/react-stately/index.html                                   14.71 KB    212.73s
dist/ReactStately_Mobile_976x1025_1x.7d6cfb9e.png               53.27 KB      7.16s
dist/ReactStately_Mobile_976x1025_2x.9cf75e56.png              146.16 KB      7.16s
dist/ReactStately_Mobile_976x1025_1x.a974ed13.webp               14.6 KB      7.15s
dist/ReactStately_Mobile_976x1025_2x.6137e984.webp              38.86 KB      7.15s
dist/ReactStately_976x445_1x.76846264.png                       34.83 KB      7.15s
dist/ReactStately_976x445_2x.12e6d412.png                       92.13 KB      7.15s
dist/ReactStately_976x445_1x.37d28fb8.webp                       8.88 KB      7.15s
dist/ReactStately_976x445_2x.cc2b1c36.webp                      20.83 KB      7.15s
dist/index.85faf034.js                                         292.97 KB    321.87s
dist/releases/2020-07-23.html                                   21.38 KB    213.74s
dist/2020-07-23.83565977.js                                    388.65 KB    319.07s
dist/releases/2020-08-18.html                                   28.17 KB    253.18s
dist/2020-08-18.69a8d0bb.js                                    388.65 KB    325.32s
dist/releases/2020-09-02.html                                   19.53 KB    320.13s
dist/2020-09-02.2391ff8c.js                                    388.65 KB    318.50s
dist/releases/2020-10-01.html                                   26.53 KB    272.17s
dist/2020-10-01.dd653f9e.js                                    388.65 KB    317.68s
dist/releases/2020-10-29.html                                   16.48 KB    272.17s
dist/2020-10-29.c229f4af.js                                    388.65 KB    318.50s
dist/releases/2020-11-30.html                                   22.56 KB    258.56s
dist/2020-11-30.bdb69598.js                                    388.65 KB    317.68s
dist/releases/2020-12-22.html                                   13.38 KB    284.60s
dist/2020-12-22.93c9d25d.js                                    388.65 KB    317.71s
dist/releases/2021-02-17.html                                    30.4 KB    284.64s
dist/2021-02-17.19b98c66.js                                    388.65 KB    321.95s
dist/releases/2021-03-24.html                                   30.06 KB    216.14s
dist/2021-03-24.e5ec9489.js                                    388.65 KB    321.95s
dist/releases/2021-05-05.html                                   29.99 KB    216.14s
dist/2021-05-05.7d0e267c.js                                    388.65 KB    314.06s
dist/releases/2021-06-15.html                                   32.25 KB    216.14s
dist/2021-06-15.f62e317d.js                                    388.64 KB    314.06s
dist/releases/2021-07-12.html                                   12.16 KB    303.79s
dist/2021-07-12.44f0ed3e.js                                    388.65 KB    319.16s
dist/releases/2021-08-04.html                                   28.53 KB    265.43s
dist/2021-08-04.a95f6569.js                                    388.64 KB    301.08s
dist/releases/2021-09-13.html                                    26.1 KB    294.04s
dist/2021-09-13.39e63e33.js                                    388.65 KB    314.55s
dist/releases/index.html                                        16.88 KB    294.04s
dist/index.184f6902.js                                         292.97 KB    317.80s
Done in 539.75s.
cp packages/dev/docs/pages/robots.txt dist/production/docs/robots.txt
node scripts/brotli.js
```

</details>

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
N/A

## 🧢 Your Project:
Adobe/RSP