### PR TITLE
Make useObjectRef use useLayoutEffect

### DIFF
--- a/packages/@react-aria/utils/src/useObjectRef.ts
+++ b/packages/@react-aria/utils/src/useObjectRef.ts
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {MutableRefObject, useEffect, useRef} from 'react';
+import {MutableRefObject, useRef} from 'react';
+import {useLayoutEffect} from './';
 
 /**
  * Offers an object ref for a given callback ref or an object ref. Especially
@@ -24,7 +25,12 @@ import {MutableRefObject, useEffect, useRef} from 'react';
 export function useObjectRef<T>(forwardedRef?: ((instance: T | null) => void) | MutableRefObject<T | null> | null): MutableRefObject<T> {
   const objRef = useRef<T>();
 
-  useEffect(() => {
+  /**
+   * We're using `useLayoutEffect` here instead of `useEffect` because we want
+   * to make sure that the `ref` value is up to date before other places in the
+   * the execution cycle try to read it.
+   */
+  useLayoutEffect(() => {
     if (!forwardedRef) {
       return;
     }


### PR DESCRIPTION
Relates to https://github.com/adobe/react-spectrum/pull/2293#issuecomment-944657735

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
```
yarn test
```

## 🧢 Your Project:
Adobe/RSP