### PR TITLE
Support customizing the tab order of an uncontained FocusScope

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -58,16 +58,16 @@ interface FocusManager {
   focusLast(opts?: FocusManagerOptions): HTMLElement
 }
 
-type ScopeRef = RefObject<HTMLElement[]>;
+type Scope = HTMLElement[];
 interface IFocusContext {
-  scopeRef: ScopeRef,
+  scope: Scope,
   focusManager: FocusManager
 }
 
 const FocusContext = React.createContext<IFocusContext>(null);
 
-let activeScope: ScopeRef = null;
-let scopes: Map<ScopeRef, ScopeRef | null> = new Map();
+let activeScope: Scope = null;
+let scopes: Map<Scope, Scope | null> = new Map();
 
 // This is a hacky DOM-based implementation of a FocusScope until this RFC lands in React:
 // https://github.com/reactjs/rfcs/pull/109
@@ -85,9 +85,10 @@ export function FocusScope(props: FocusScopeProps) {
   let {children, contain, restoreFocus, autoFocus} = props;
   let startRef = useRef<HTMLSpanElement>();
   let endRef = useRef<HTMLSpanElement>();
-  let scopeRef = useRef<HTMLElement[]>([]);
+  // enforce immutability of the scope object as this component's hooks should not change
+  let scopeRef: RefObject<Scope> = useRef([]);
   let ctx = useContext(FocusContext);
-  let parentScope = ctx?.scopeRef;
+  let parentScope = ctx?.scope;
 
   useLayoutEffect(() => {
     // Find all rendered nodes between the sentinels and add them to the scope.
@@ -98,33 +99,34 @@ export function FocusScope(props: FocusScopeProps) {
       node = node.nextSibling;
     }
 
-    scopeRef.current = nodes;
+    scopeRef.current.splice(0, undefined, ...nodes);
   }, [children, parentScope]);
 
   useLayoutEffect(() => {
-    scopes.set(scopeRef, parentScope);
+    let scope = scopeRef.current;
+    scopes.set(scope, parentScope);
     return () => {
       // Restore the active scope on unmount if this scope or a descendant scope is active.
       // Parent effect cleanups run before children, so we need to check if the
       // parent scope actually still exists before restoring the active scope to it.
       if (
-        (scopeRef === activeScope || isAncestorScope(scopeRef, activeScope)) &&
+        (scope === activeScope || isAncestorScope(scope, activeScope)) &&
         (!parentScope || scopes.has(parentScope))
       ) {
         activeScope = parentScope;
       }
-      scopes.delete(scopeRef);
+      scopes.delete(scope);
     };
-  }, [scopeRef, parentScope]);
+  }, [parentScope]);
 
-  useFocusContainment(scopeRef, contain);
-  useRestoreFocus(scopeRef, restoreFocus, contain);
-  useAutoFocus(scopeRef, autoFocus);
+  useFocusContainment(scopeRef.current, contain);
+  useRestoreFocus(scopeRef.current, restoreFocus, contain);
+  useAutoFocus(scopeRef.current, autoFocus);
 
-  let focusManager = createFocusManagerForScope(scopeRef);
+  let focusManager = createFocusManagerForScope(scopeRef.current);
 
   return (
-    <FocusContext.Provider value={{scopeRef, focusManager}}>
+    <FocusContext.Provider value={{scope: scopeRef.current, focusManager}}>
       <span data-focus-scope-start hidden ref={startRef} />
       {children}
       <span data-focus-scope-end hidden ref={endRef} />
@@ -141,10 +143,9 @@ export function useFocusManager(): FocusManager {
   return useContext(FocusContext)?.focusManager;
 }
 
-function createFocusManagerForScope(scopeRef: React.RefObject<HTMLElement[]>): FocusManager {
+function createFocusManagerForScope(scope: Scope): FocusManager {
   return {
     focusNext(opts: FocusManagerOptions = {}) {
-      let scope = scopeRef.current;
       let {from, tabbable, wrap} = opts;
       let node = from || document.activeElement;
       let sentinel = scope[0].previousElementSibling;
@@ -161,7 +162,6 @@ function createFocusManagerForScope(scopeRef: React.RefObject<HTMLElement[]>): F
       return nextNode;
     },
     focusPrevious(opts: FocusManagerOptions = {}) {
-      let scope = scopeRef.current;
       let {from, tabbable, wrap} = opts;
       let node = from || document.activeElement;
       let sentinel = scope[scope.length - 1].nextElementSibling;
@@ -178,7 +178,6 @@ function createFocusManagerForScope(scopeRef: React.RefObject<HTMLElement[]>): F
       return previousNode;
     },
     focusFirst(opts = {}) {
-      let scope = scopeRef.current;
       let {tabbable} = opts;
       let walker = getFocusableTreeWalker(getScopeRoot(scope), {tabbable}, scope);
       walker.currentNode = scope[0].previousElementSibling;
@@ -189,7 +188,6 @@ function createFocusManagerForScope(scopeRef: React.RefObject<HTMLElement[]>): F
       return nextNode;
     },
     focusLast(opts = {}) {
-      let scope = scopeRef.current;
       let {tabbable} = opts;
       let walker = getFocusableTreeWalker(getScopeRoot(scope), {tabbable}, scope);
       walker.currentNode = scope[scope.length - 1].nextElementSibling;
@@ -223,28 +221,26 @@ const FOCUSABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]),') + '
 focusableElements.push('[tabindex]:not([tabindex="-1"]):not([disabled])');
 const TABBABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]):not([tabindex="-1"]),');
 
-function getScopeRoot(scope: HTMLElement[]) {
+function getScopeRoot(scope: Scope) {
   return scope[0].parentElement;
 }
 
-function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolean) {
+function useFocusContainment(scope: Scope, contain: boolean) {
   let focusedNode = useRef<HTMLElement>();
 
   let raf = useRef(null);
   useLayoutEffect(() => {
-    let scope = scopeRef.current;
     if (!contain) {
       return;
     }
 
     // Handle the Tab key to contain focus within the scope
     let onKeyDown = (e) => {
-      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || scopeRef !== activeScope) {
+      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || scope !== activeScope) {
         return;
       }
 
       let focusedElement = document.activeElement as HTMLElement;
-      let scope = scopeRef.current;
       if (!isElementInScope(focusedElement, scope)) {
         return;
       }
@@ -266,18 +262,18 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
     let onFocus = (e) => {
       // If focusing an element in a child scope of the currently active scope, the child becomes active.
       // Moving out of the active scope to an ancestor is not allowed.
-      if (!activeScope || isAncestorScope(activeScope, scopeRef)) {
-        activeScope = scopeRef;
+      if (!activeScope || isAncestorScope(activeScope, scope)) {
+        activeScope = scope;
         focusedNode.current = e.target;
-      } else if (scopeRef === activeScope && !isElementInChildScope(e.target, scopeRef)) {
+      } else if (scope === activeScope && !isElementInChildScope(e.target, scope)) {
         // If a focus event occurs outside the active scope (e.g. user tabs from browser location bar),
         // restore focus to the previously focused node or the first tabbable element in the active scope.
         if (focusedNode.current) {
           focusedNode.current.focus();
         } else if (activeScope) {
-          focusFirstInScope(activeScope.current);
+          focusFirstInScope(activeScope);
         }
-      } else if (scopeRef === activeScope) {
+      } else if (scope === activeScope) {
         focusedNode.current = e.target;
       }
     };
@@ -286,8 +282,8 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
       // Firefox doesn't shift focus back to the Dialog properly without this
       raf.current = requestAnimationFrame(() => {
         // Use document.activeElement instead of e.relatedTarget so we can tell if user clicked into iframe
-        if (scopeRef === activeScope && !isElementInChildScope(document.activeElement, scopeRef)) {
-          activeScope = scopeRef;
+        if (scope === activeScope && !isElementInChildScope(document.activeElement, scope)) {
+          activeScope = scope;
           focusedNode.current = e.target;
           focusedNode.current.focus();
         }
@@ -304,7 +300,7 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
       scope.forEach(element => element.removeEventListener('focusin', onFocus, false));
       scope.forEach(element => element.removeEventListener('focusout', onBlur, false));
     };
-  }, [scopeRef, contain]);
+  }, [scope, contain]);
 
   // eslint-disable-next-line arrow-body-style
   useEffect(() => {
@@ -314,22 +310,22 @@ function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolea
 
 function isElementInAnyScope(element: Element) {
   for (let scope of scopes.keys()) {
-    if (isElementInScope(element, scope.current)) {
+    if (isElementInScope(element, scope)) {
       return true;
     }
   }
   return false;
 }
 
-function isElementInScope(element: Element, scope: HTMLElement[]) {
+function isElementInScope(element: Element, scope: Scope) {
   return scope.some(node => node.contains(element));
 }
 
-function isElementInChildScope(element: Element, scope: ScopeRef) {
+function isElementInChildScope(element: Element, scope: Scope) {
   // node.contains in isElementInScope covers child scopes that are also DOM children,
   // but does not cover child scopes in portals.
   for (let s of scopes.keys()) {
-    if ((s === scope || isAncestorScope(scope, s)) && isElementInScope(element, s.current)) {
+    if ((s === scope || isAncestorScope(scope, s)) && isElementInScope(element, s)) {
       return true;
     }
   }
@@ -337,7 +333,7 @@ function isElementInChildScope(element: Element, scope: ScopeRef) {
   return false;
 }
 
-function isAncestorScope(ancestor: ScopeRef, scope: ScopeRef) {
+function isAncestorScope(ancestor: Scope, scope: Scope) {
   let parent = scopes.get(scope);
   if (!parent) {
     return false;
@@ -366,35 +362,33 @@ function focusElement(element: HTMLElement | null, scroll = false) {
   }
 }
 
-function focusFirstInScope(scope: HTMLElement[]) {
+function focusFirstInScope(scope: Scope) {
   let sentinel = scope[0].previousElementSibling;
   let walker = getFocusableTreeWalker(getScopeRoot(scope), {tabbable: true}, scope);
   walker.currentNode = sentinel;
   focusElement(walker.nextNode() as HTMLElement);
 }
 
-function useAutoFocus(scopeRef: RefObject<HTMLElement[]>, autoFocus: boolean) {
+function useAutoFocus(scope: Scope, autoFocus: boolean) {
   const autoFocusRef = React.useRef(autoFocus);
   useEffect(() => {
     if (autoFocusRef.current) {
-      activeScope = scopeRef;
-      if (!isElementInScope(document.activeElement, activeScope.current)) {
-        focusFirstInScope(scopeRef.current);
+      activeScope = scope;
+      if (!isElementInScope(document.activeElement, activeScope)) {
+        focusFirstInScope(scope);
       }
     }
     autoFocusRef.current = false;
-  }, []);
+  }, [scope]);
 }
 
-function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boolean, contain: boolean) {
+function useRestoreFocus(scope: Scope, restoreFocus: boolean, contain: boolean) {
   // create a ref during render instead of useLayoutEffect so the active element is saved before a child with autoFocus=true mounts.
   const nodeToRestore = useRef(typeof document !== 'undefined' ? document.activeElement as HTMLElement : null);
   useLayoutEffect(() => {
     if (!restoreFocus) {
       return;
     }
-
-    let scope = scopeRef.current;
 
     // Handle the Tab key so that tabbing out of the scope goes to the next element
     // after the node that had focus when the scope mounted. This is important when
@@ -465,14 +459,14 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
         });
       }
     };
-  }, [scopeRef, restoreFocus, contain]);
+  }, [scope, restoreFocus, contain]);
 }
 
 /**
  * Create a [TreeWalker]{@link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker}
  * that matches all focusable/tabbable elements.
  */
-export function getFocusableTreeWalker(root: HTMLElement, opts?: FocusManagerOptions, scope?: HTMLElement[]) {
+export function getFocusableTreeWalker(root: HTMLElement, opts?: FocusManagerOptions, scope?: Scope) {
   let selector = opts?.tabbable ? TABBABLE_ELEMENT_SELECTOR : FOCUSABLE_ELEMENT_SELECTOR;
   let walker = document.createTreeWalker(
     root,

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -331,6 +331,37 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(outside);
     });
 
+    it('should restore focus to the previously focused node after a child with autoFocus unmounts', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="outside" />
+            {show &&
+              <FocusScope restoreFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" autoFocus />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+
+      let input2 = getByTestId('input2');
+      expect(document.activeElement).toBe(input2);
+
+      rerender(<Test />);
+
+      expect(document.activeElement).toBe(outside);
+    });
+
     it('should move focus to the next element after the previously focused node on Tab', function () {
       function Test({show}) {
         return (

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -362,6 +362,37 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(outside);
     });
 
+    it('should restore focus to the previously focused node when tabbing away from a child with autoFocus', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="outside" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" autoFocus />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+
+      let input3 = getByTestId('input3');
+      expect(document.activeElement).toBe(input3);
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
+
     it('should restore focus to the previously focused node after children change', function () {
       function Test({show, showChild}) {
         return (

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -362,6 +362,38 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(outside);
     });
 
+    it('should restore focus to the previously focused node after children change', function () {
+      function Test({show, showChild}) {
+        return (
+          <div>
+            <input data-testid="outside" />
+            {show &&
+              <FocusScope restoreFocus autoFocus>
+                <input data-testid="input1" />
+                {showChild && <input data-testid="dynamic" />}
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+      rerender(<Test show showChild />);
+
+      let dynamic = getByTestId('dynamic');
+      act(() => {dynamic.focus();});
+      expect(document.activeElement).toBe(dynamic);
+
+      rerender(<Test />);
+
+      expect(document.activeElement).toBe(outside);
+    });
+
     it('should move focus to the next element after the previously focused node on Tab', function () {
       function Test({show}) {
         return (

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -12,7 +12,7 @@
 
 import {act, fireEvent, render} from '@testing-library/react';
 import {FocusScope, useFocusManager} from '../';
-import React from 'react';
+import React, {useRef} from 'react';
 import ReactDOM from 'react-dom';
 import userEvent from '@testing-library/user-event';
 
@@ -492,6 +492,73 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(getByTestId('before'));
     });
 
+    it('should move focus to the trigger element on Shift+Tab with tabOrder="after-trigger"', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <button data-testid="trigger" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus autoFocus tabOrder="after-trigger">
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      act(() => {trigger.focus();});
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      userEvent.tab({shift: true});
+      expect(document.activeElement).toBe(getByTestId('trigger'));
+    });
+
+    it('should move focus to the next element on Tab with tabOrder="after-trigger"', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <button data-testid="trigger" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus autoFocus tabOrder="after-trigger">
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      act(() => {trigger.focus();});
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      let input3 = getByTestId('input3');
+      act(() => {input3.focus();});
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
+
     it('should skip over elements within the scope when moving focus to the next element', function () {
       function Test({show}) {
         return (
@@ -561,6 +628,89 @@ describe('FocusScope', function () {
 
       userEvent.tab();
       expect(document.activeElement).toBe(getByTestId('after'));
+    });
+
+    it('should move focus to the element after a reference location on Tab', function () {
+      function Test({show}) {
+        const tabRef = useRef();
+        return (
+          <>
+            <div>
+              <button data-testid="trigger" />
+              <input data-testid="before" />
+              <div ref={tabRef} tabIndex={-1} />
+              <input data-testid="after" />
+            </div>
+            {show &&
+              <div>
+                <FocusScope restoreFocus autoFocus tabOrder={tabRef}>
+                  <input data-testid="input1" />
+                  <input data-testid="input2" />
+                  <input data-testid="input3" />
+                </FocusScope>
+              </div>
+            }
+          </>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      act(() => {trigger.focus();});
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      let input3 = getByTestId('input3');
+      act(() => {input3.focus();});
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
+
+    it('should move focus to the element before a reference location on Shift+Tab', function () {
+      function Test({show}) {
+        let tabRef = useRef();
+        return (
+          <>
+            <div>
+              <button data-testid="trigger" />
+              <input data-testid="before" />
+              <div ref={tabRef} tabIndex={-1} />
+              <input data-testid="after" />
+            </div>
+            {show &&
+            <div>
+              <FocusScope restoreFocus autoFocus tabOrder={tabRef}>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+
+            </div>
+            }
+          </>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      act(() => {trigger.focus();});
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      let input3 = getByTestId('input3');
+      act(() => {input3.focus();});
+
+      userEvent.tab({shift: true});
+      expect(document.activeElement).toBe(getByTestId('before'));
     });
   });
 


### PR DESCRIPTION
Closes #2421.

This PR implements the feature proposed in the linked issue by adding a new prop to `FocusScope` named `tabOrder`. `tabOrder` can take on the following values:

* `'replace-trigger'` (default)
* `'after-trigger'`
* `RefObject<HTMLElement>`

The string options `'replace-trigger'` and `'after-trigger'` values only function when `restoreFocus` is enabled.

`'replace-trigger'` captures the existing behavior of `FocusScope` where tabbing backwards out of the scope moves focus to the element before the trigger, and tabbing forwards moves it to the node after.

`'after-trigger'` behaves the same as `'replace-trigger'` but covers the frequent use case I encounter where I want the trigger element to remain as part of the tab order. Here, tabbing backwards moves focus to the trigger rather than the element before it.

Finally, passing a ref allows for full control over how focus moves out of the scope. This is useful when the scope has no trigger element or if its position in the virtual DOM is far away from the trigger's position.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
