### PR TITLE
fixes the picker label on docs/react-spectrum/layout.html

### DIFF
--- a/packages/dev/docs/pages/react-spectrum/layout.mdx
+++ b/packages/dev/docs/pages/react-spectrum/layout.mdx
@@ -18,6 +18,7 @@ import Book from '@spectrum-icons/workflow/Book';
 import BulkEditUsers from '@spectrum-icons/workflow/BulkEditUsers';
 import Draw from '@spectrum-icons/workflow/Draw';
 import {Text} from '@react-spectrum/text';
+import {TextField} from '@react-spectrum/textfield';
 ```
 
 ---


### PR DESCRIPTION
no issue

This is a temp fix until we upgrade parcel. We need to discuss if there is a cleaner way to do this. Applying what was done for text-area onto picker didn't work.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

build the docs site using verdaccio or a production release
goto react-spectrum/layout.html
the label on the picker at the bottom should be positioned correctly (above instead of to the left side)

## 🧢 Your Project:
RSP