### PR TITLE
Fix useDragModality to not cause re-render on modality change

### DIFF
--- a/packages/@react-aria/dnd/src/utils.ts
+++ b/packages/@react-aria/dnd/src/utils.ts
@@ -13,8 +13,9 @@
 import {CUSTOM_DRAG_TYPE, GENERIC_TYPE, NATIVE_DRAG_TYPES} from './constants';
 import {DirectoryItem, DragItem, DropItem, FileItem, DragTypes as IDragTypes} from '@react-types/shared';
 import {DroppableCollectionState} from '@react-stately/dnd';
-import {getInteractionModality, useInteractionModality} from '@react-aria/interactions';
+import {getInteractionModality, useInteractionModalityListener} from '@react-aria/interactions';
 import {useId} from '@react-aria/utils';
+import {useRef} from 'react';
 
 const droppableCollectionIds = new WeakMap<DroppableCollectionState, string>();
 
@@ -61,7 +62,13 @@ function mapModality(modality: string) {
 }
 
 export function useDragModality() {
-  return mapModality(useInteractionModality());
+  let modalityRef = useRef(getInteractionModality());
+  
+  useInteractionModalityListener((modality) => {
+    modalityRef.current = modality;
+  });
+  
+  return mapModality(modalityRef.current);
 }
 
 export function getDragModality() {

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -23,6 +23,7 @@ type Modality = 'keyboard' | 'pointer' | 'virtual';
 type HandlerEvent = PointerEvent | MouseEvent | KeyboardEvent | FocusEvent;
 type Handler = (modality: Modality, e: HandlerEvent) => void;
 type FocusVisibleHandler = (isFocusVisible: boolean) => void;
+type ModalityHandler = (modality: Modality) => void;
 interface FocusVisibleProps {
   /** Whether the element is a text input. */
   isTextInput?: boolean,
@@ -181,19 +182,29 @@ export function setInteractionModality(modality: Modality) {
 export function useInteractionModality(): Modality {
   setupGlobalFocusEvents();
 
-  let [modality, setModality] = useState(currentModality);
+  let [modalityState, setModality] = useState(currentModality);
+
+  useInteractionModalityListener((modality) => {
+    setModality(modality);
+  });
+
+  return modalityState;
+}
+
+/**
+ * Listens for changes in current modality.
+ */
+export function useInteractionModalityListener(fn: ModalityHandler) {
+  setupGlobalFocusEvents();
+
   useEffect(() => {
     let handler = () => {
-      setModality(currentModality);
+      fn(currentModality);
     };
 
     changeHandlers.add(handler);
-    return () => {
-      changeHandlers.delete(handler);
-    };
-  }, []);
-
-  return modality;
+    return () => changeHandlers.delete(handler);
+  }, [fn]);
 }
 
 /**


### PR DESCRIPTION
Closes #2403 

Added `useInteractionModalityListener`:
- `useDragModality` updated to use this. Since `useInteractionModality` was using `useState`, all draggable items were re-rendering on modality change.
- behaves similar to `useFocusVisibleListener`
- `useInteractionModality` updated to use this

Some additional re-renders that might need to be handled separately are with focus change (https://github.com/adobe/react-spectrum/pull/2059) and with `useDescription` use.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
