### PR TITLE
Ensure all dependencies of published packages are public

### DIFF
--- a/packages/@internationalized/date/package.json
+++ b/packages/@internationalized/date/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.0-alpha.1",
   "description": "Internationalized calendar and date manipulation utilities",
   "license": "Apache-2.0",
-  "private": true,
   "main": "dist/main.js",
   "module": "dist/module.js",
   "types": "dist/types.d.ts",

--- a/scripts/checkPublishedDependencies.js
+++ b/scripts/checkPublishedDependencies.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').execSync;
+
+let output = exec('yarn workspaces info --json').toString().replace(/^(.|\n)*?\{/, '{').replace(/\}\nDone in .*\n?$/, '}');
+let workspacePackages = JSON.parse(output);
+
+let excludedPackages = new Set([
+  '@adobe/spectrum-css-temp',
+  '@react-spectrum/test-utils',
+  '@spectrum-icons/build-tools',
+  '@react-spectrum/docs'
+]);
+
+let missing = new Set();
+for (let pkg in workspacePackages) {
+  let json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', workspacePackages[pkg].location, 'package.json'), 'utf8'));
+  if (json.private) {
+    continue;
+  }
+
+  for (let dep of workspacePackages[pkg].workspaceDependencies) {
+    let json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', workspacePackages[dep].location, 'package.json'), 'utf8'));
+    if (json.private && !excludedPackages.has(json.name)) {
+      missing.add(dep);
+    }
+  }
+}
+
+if (missing.size) {
+  console.error('The following packages are marked private but are dependencies of published packages:');
+  console.error(missing);
+  process.exit(1);
+}

--- a/scripts/lint-packages.js
+++ b/scripts/lint-packages.js
@@ -136,3 +136,5 @@ for (let pkg of packages) {
 if (errors) {
   return process.exit(1);
 }
+
+require('./checkPublishedDependencies');


### PR DESCRIPTION
Nightlies currently cannot be installed due to a dependency on a private package. Fixed that and added a script to ensure it doesn't happen again.