### PR TITLE
Retry docs job on OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,18 @@ jobs:
 
       - run:
           name: build docs
-          command: make website
+          command: make website &> results.txt
+
+      - run:
+          name: Rerun once on out of memory
+          command: |
+              if grep -q "error: ENOMEM: not enough memory, read" results.txt; then
+                rm -rf dist/*/docs
+                make website
+              else
+                exit 1
+              fi
+          when: on_fail
 
       - persist_to_workspace:
           root: dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
 
       - run:
           name: build docs
-          command: make website &> results.txt
+          command: make website | tee results.txt
 
       - run:
           name: Rerun once on out of memory


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Out of memory, not out of mana. Though both frustrate me. So here's a PR to try and address our docs build failing frequently by retrying.

I'll try to get a case where it fails and this runs to happen, but it's intermittent

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
