### PR TITLE
Update OverlayContainer to work in SSR

### DIFF
--- a/packages/@react-aria/overlays/src/useModal.tsx
+++ b/packages/@react-aria/overlays/src/useModal.tsx
@@ -122,16 +122,25 @@ interface OverlayContainerProps extends ModalProviderProps {
  * be accessible at once.
  */
 export function OverlayContainer(props: OverlayContainerProps): React.ReactPortal {
-  let {portalContainer = document.body, ...rest} = props;
-
+  let {portalContainer, ...rest} = props;
+  let [container, setContainer] = useState(portalContainer);
+ 
   React.useEffect(() => {
-    if (portalContainer.closest('[data-overlay-container]')) {
+    let currentContainer = portalContainer || document.body
+    
+    if (currentContainer.closest('[data-overlay-container]')) {
       throw new Error('An OverlayContainer must not be inside another container. Please change the portalContainer prop.');
     }
+    
+    setContainer(currentContainer)
   }, [portalContainer]);
 
-  let contents = <OverlayProvider {...rest} />;
-  return ReactDOM.createPortal(contents, portalContainer);
+  if (container) {
+    let contents = <OverlayProvider {...rest} />;
+    return ReactDOM.createPortal(contents, container);
+  }
+  
+  return null
 }
 
 interface ModalAriaProps extends HTMLAttributes<HTMLElement> {

--- a/packages/@react-aria/overlays/test/useModal.test.js
+++ b/packages/@react-aria/overlays/test/useModal.test.js
@@ -91,9 +91,7 @@ describe('useModal', function () {
 
   it('will render when document.body is not available and is open by default', () => {
     let res = render(
-      <div id="defaultContainer" data-testid="default-container">
-        <Example isOpen={true} />
-      </div>
+      <Example isOpen={true} />
     )
     let rootProvider = res.getByTestId('root-provider')
 

--- a/packages/@react-aria/overlays/test/useModal.test.js
+++ b/packages/@react-aria/overlays/test/useModal.test.js
@@ -21,7 +21,7 @@ function ModalDOM(props) {
 
 function Modal(props) {
   return (
-    <OverlayContainer portalContainer={props.container} data-testid={props.providerId || 'modal-provider'}>
+    <OverlayContainer portalContainer={props.container} data-testid={props.providerId || 'modal-provider'} isOpen={props.isOpen}>
       <ModalDOM modalId={props.modalId}>{props.children}</ModalDOM>
     </OverlayContainer>
   );
@@ -32,7 +32,7 @@ function Example(props) {
     <OverlayProvider data-testid="root-provider">
       This is the root provider.
       {props.showModal &&
-        <Modal container={props.container}>{props.children}</Modal>
+        <Modal container={props.container} isOpen={props.isOpen}>{props.children}</Modal>
       }
     </OverlayProvider>
   );
@@ -88,6 +88,17 @@ describe('useModal', function () {
     res.rerender(<Example />);
     expect(rootProvider).not.toHaveAttribute('aria-hidden');
   });
+
+  it('will render when document.body is not available and is open by default', () => {
+    let res = render(
+      <div id="defaultContainer" data-testid="default-container">
+        <Example isOpen={true} />
+      </div>
+    )
+    let rootProvider = res.getByTestId('root-provider')
+
+    expect(rootProvider).to.haveAttribute('aria-hidden')
+  })
 
   it('can specify a different container from the default document.body', function () {
     let res = render(


### PR DESCRIPTION
Currently if OverlayContainer is rendered during SSR it would fail because of trying to access document.body. This ensures that the window APIs are only called on the browser during useEffect, and only attempts to render the portal when it has a container


Closes https://github.com/adobe/react-spectrum/issues/1055

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

1. Make sure SSR works when `OverlayContainer` is present.
2. Confirm that aria-hidden displays as expected with useModal

## 🧢 Your Project:

<!--- Company/project for pull request -->
On behalf of chrisdmacrae.com