### PR TITLE
ColorArea: remove aria-roledescription on iOS/Android

### DIFF
--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -12,7 +12,7 @@
 
 import {AriaColorAreaProps} from '@react-types/color';
 import {ColorAreaState} from '@react-stately/color';
-import {focusWithoutScrolling, mergeProps, useGlobalListeners, useLabels} from '@react-aria/utils';
+import {focusWithoutScrolling, isAndroid, isIOS, mergeProps, useGlobalListeners, useLabels} from '@react-aria/utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {MessageDictionary} from '@internationalized/message';
@@ -272,15 +272,16 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
       })
   }, keyboardProps, movePropsThumb);
 
+  let isMobile = isIOS() || isAndroid();
 
   let xInputLabellingProps = useLabels({
     ...props,
-    'aria-label': `${state.value.getChannelName(xChannel, locale)} / ${state.value.getChannelName(yChannel, locale)}`
+    'aria-label': isMobile  ? state.value.getChannelName(xChannel, locale) : `${state.value.getChannelName(xChannel, locale)} / ${state.value.getChannelName(yChannel, locale)}`
   });
 
   let yInputLabellingProps = useLabels({
     ...props,
-    'aria-label': `${state.value.getChannelName(xChannel, locale)} / ${state.value.getChannelName(yChannel, locale)}`
+    'aria-label': isMobile ? state.value.getChannelName(yChannel, locale) : `${state.value.getChannelName(xChannel, locale)} / ${state.value.getChannelName(yChannel, locale)}`
   });
 
   let colorAriaLabellingProps = useLabels(props);
@@ -291,7 +292,7 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
     `${state.value.getChannelName('blue', locale)}: ${state.value.formatChannelValue('blue', locale)}`
   ].join(', ');
 
-  let ariaRoleDescription = messages.getStringForLocale('twoDimensionalSlider', locale);
+  let ariaRoleDescription = isMobile ? null : messages.getStringForLocale('twoDimensionalSlider', locale);
 
   let {visuallyHiddenProps} = useVisuallyHidden({style: {
     opacity: '0.0001',

--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -319,7 +319,7 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
       max: state.value.getChannelRange(xChannel).maxValue,
       step: xChannelStep,
       'aria-roledescription': ariaRoleDescription,
-      'aria-valuetext': (isMobile ? state.value.formatChannelValue(xChannel, locale) : [
+      'aria-valuetext': (isMobile ? `${state.value.getChannelName(xChannel, locale)}: ${state.value.formatChannelValue(xChannel, locale)}` : [
         `${state.value.getChannelName(xChannel, locale)}: ${state.value.formatChannelValue(xChannel, locale)}`,
         `${state.value.getChannelName(yChannel, locale)}: ${state.value.formatChannelValue(yChannel, locale)}`
       ].join(', ')),
@@ -339,7 +339,7 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
       max: state.value.getChannelRange(yChannel).maxValue,
       step: yChannelStep,
       'aria-roledescription': ariaRoleDescription,
-      'aria-valuetext': (isMobile ? state.value.formatChannelValue(yChannel, locale) : [
+      'aria-valuetext': (isMobile ? `${state.value.getChannelName(yChannel, locale)}: ${state.value.formatChannelValue(yChannel, locale)}` : [
         `${state.value.getChannelName(yChannel, locale)}: ${state.value.formatChannelValue(yChannel, locale)}`,
         `${state.value.getChannelName(xChannel, locale)}: ${state.value.formatChannelValue(xChannel, locale)}`
       ].join(', ')),

--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -319,10 +319,10 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
       max: state.value.getChannelRange(xChannel).maxValue,
       step: xChannelStep,
       'aria-roledescription': ariaRoleDescription,
-      'aria-valuetext': [
+      'aria-valuetext': (isMobile ? state.value.formatChannelValue(xChannel, locale) : [
         `${state.value.getChannelName(xChannel, locale)}: ${state.value.formatChannelValue(xChannel, locale)}`,
         `${state.value.getChannelName(yChannel, locale)}: ${state.value.formatChannelValue(yChannel, locale)}`
-      ].join(', '),
+      ].join(', ')),
       title: getValueTitle(),
       disabled: isDisabled,
       value: state.value.getChannelValue(xChannel),
@@ -339,10 +339,10 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
       max: state.value.getChannelRange(yChannel).maxValue,
       step: yChannelStep,
       'aria-roledescription': ariaRoleDescription,
-      'aria-valuetext': [
+      'aria-valuetext': (isMobile ? state.value.formatChannelValue(yChannel, locale) : [
         `${state.value.getChannelName(yChannel, locale)}: ${state.value.formatChannelValue(yChannel, locale)}`,
         `${state.value.getChannelName(xChannel, locale)}: ${state.value.formatChannelValue(xChannel, locale)}`
-      ].join(', '),
+      ].join(', ')),
       'aria-orientation': 'vertical',
       title: getValueTitle(),
       disabled: isDisabled,


### PR DESCRIPTION
To better reflect behavior of slider inputs with mobile screen readers on iOS and Android, each input should be labeled by its individual channel name and we should remove aria-roledescription so the input is identified simply as a slider control.


Relates to: #2483, #1732 and #1118 in particular: https://github.com/adobe/react-spectrum/pull/2483#discussion_r746975895

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/pull/2483).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open [a ColorArea story](https://reactspectrum.blob.core.windows.net/reactspectrum/967edb1559fff010f4ce6873e54ae2b3b5db7150/storybook/iframe.html?id=colorarea--x-blue-y-green&providerSwitcher-locale=&providerSwitcher-theme=&providerSwitcher-scale=&providerSwitcher-toastPosition=bottom&viewMode=story) in Safari on an iOS device.
2. Turn on VoiceOver for iOS.
3. Use right swipe VoiceOver gesture to navigate to the first of the `input[type=range]` elements within the ColorArea component. 
4. It should announce simply as a slider, labelled by the color channel name for the horizontal channel and with the value text for just that channel.
5. Swipe down/up to decrease/increase the value of the horizontal channel.
6. Use right swipe VoiceOver gesture to navigate to the second of the `input[type=range]` elements within the ColorArea component. 
7. It should announce simply as a slider, labelled by the color channel name for the vertical channel and with the value text for just that channel.
8. Swipe down/up to decrease/increase the value of the vertical channel.

Since each slider within the ColorArea control adjusts independently on mobile, it doesn't make sense to describe them as a "2D slider".

## 🧢 Your Project:

Adobe/Accessibility
