### PR TITLE
Removing the prevent scroll behavior on virtualizer item focus

### DIFF
--- a/packages/@react-aria/virtualizer/src/Virtualizer.tsx
+++ b/packages/@react-aria/virtualizer/src/Virtualizer.tsx
@@ -12,7 +12,6 @@
 
 import {Collection} from '@react-types/shared';
 import {focusWithoutScrolling, mergeProps, useLayoutEffect} from '@react-aria/utils';
-import {getInteractionModality} from '@react-aria/interactions';
 import {Layout, Rect, ReusableView, useVirtualizerState, VirtualizerState} from '@react-stately/virtualizer';
 import React, {FocusEvent, HTMLAttributes, Key, ReactElement, RefObject, useCallback, useEffect, useRef} from 'react';
 import {ScrollView} from './ScrollView';
@@ -129,8 +128,8 @@ export function useVirtualizer<T extends object, V, W>(props: VirtualizerOptions
     if (virtualizer.visibleRect.height === 0) {
       return;
     }
-    let modality = getInteractionModality();
-    if (focusedKey !== lastFocusedKey.current && modality !== 'pointer') {
+
+    if (focusedKey !== lastFocusedKey.current) {
       if (scrollToItem) {
         scrollToItem(focusedKey);
       } else {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to Picker story: "picker async-loading"
2. Open the Picker and scroll down so it loads a couple more sets of results. Select one of those pokemon
3. Close the dropdown and reopen it. The selected item should be brought into view
## 🧢 Your Project:

<!--- Company/project for pull request -->
