### PR TITLE
ColorArea: add HSB and HSL support

### DIFF
--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -298,11 +298,29 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
 
   let colorAriaLabellingProps = useLabels(props);
 
-  let getValueTitle = () =>  [
-    formatMessage('colorNameAndValue', {name: state.value.getChannelName('red', locale), value: state.value.formatChannelValue('red', locale)}),
-    formatMessage('colorNameAndValue', {name: state.value.getChannelName('green', locale), value: state.value.formatChannelValue('green', locale)}),
-    formatMessage('colorNameAndValue', {name: state.value.getChannelName('blue', locale), value: state.value.formatChannelValue('blue', locale)})
-  ].join(', ');
+  let getValueTitle = () => {
+    switch (state.value.getColorSpace()) {
+      case 'hsb':
+        return [
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('hue', locale), value: state.value.formatChannelValue('hue', locale)}),
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('saturation', locale), value: state.value.formatChannelValue('saturation', locale)}),
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('brightness', locale), value: state.value.formatChannelValue('brightness', locale)})
+        ].join(', ');
+      case 'hsl':
+        return [
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('hue', locale), value: state.value.formatChannelValue('hue', locale)}),
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('saturation', locale), value: state.value.formatChannelValue('saturation', locale)}),
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('lightness', locale), value: state.value.formatChannelValue('lightness', locale)})
+        ].join(', ');
+      case 'rgb':
+        return [
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('red', locale), value: state.value.formatChannelValue('red', locale)}),
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('green', locale), value: state.value.formatChannelValue('green', locale)}),
+          formatMessage('colorNameAndValue', {name: state.value.getChannelName('blue', locale), value: state.value.formatChannelValue('blue', locale)})
+        ].join(', ');
+    }
+    return null;
+  };
 
   let ariaRoleDescription = isMobile ? null : formatMessage('twoDimensionalSlider');
 

--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaColorAreaProps} from '@react-types/color';
+import {AriaColorAreaProps, ColorChannel} from '@react-types/color';
 import {ColorAreaState} from '@react-stately/color';
 import {focusWithoutScrolling, isAndroid, isIOS, mergeProps, useGlobalListeners, useLabels} from '@react-aria/utils';
 // @ts-ignore
@@ -299,27 +299,14 @@ export function useColorArea(props: AriaColorAreaProps, state: ColorAreaState, i
   let colorAriaLabellingProps = useLabels(props);
 
   let getValueTitle = () => {
-    switch (state.value.getColorSpace()) {
-      case 'hsb':
-        return [
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('hue', locale), value: state.value.formatChannelValue('hue', locale)}),
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('saturation', locale), value: state.value.formatChannelValue('saturation', locale)}),
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('brightness', locale), value: state.value.formatChannelValue('brightness', locale)})
-        ].join(', ');
-      case 'hsl':
-        return [
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('hue', locale), value: state.value.formatChannelValue('hue', locale)}),
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('saturation', locale), value: state.value.formatChannelValue('saturation', locale)}),
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('lightness', locale), value: state.value.formatChannelValue('lightness', locale)})
-        ].join(', ');
-      case 'rgb':
-        return [
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('red', locale), value: state.value.formatChannelValue('red', locale)}),
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('green', locale), value: state.value.formatChannelValue('green', locale)}),
-          formatMessage('colorNameAndValue', {name: state.value.getChannelName('blue', locale), value: state.value.formatChannelValue('blue', locale)})
-        ].join(', ');
-    }
-    return null;
+    const channels: Set<ColorChannel> = state.value.getColorChannels();
+    const colorNamesAndValues = [];
+    channels.forEach(channel => 
+      colorNamesAndValues.push(
+        formatMessage('colorNameAndValue', {name: state.value.getChannelName(channel, locale), value: state.value.formatChannelValue(channel, locale)})
+      )
+    );
+    return colorNamesAndValues.length ? colorNamesAndValues.join(', ') : null;
   };
 
   let ariaRoleDescription = isMobile ? null : formatMessage('twoDimensionalSlider');

--- a/packages/@react-aria/color/src/useColorSlider.ts
+++ b/packages/@react-aria/color/src/useColorSlider.ts
@@ -13,7 +13,8 @@
 import {AriaColorSliderProps} from '@react-types/color';
 import {ColorSliderState} from '@react-stately/color';
 import {HTMLAttributes, RefObject} from 'react';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, snapValueToStep} from '@react-aria/utils';
+import {useKeyboard} from '@react-aria/interactions';
 import {useLocale} from '@react-aria/i18n';
 import {useSlider, useSliderThumb} from '@react-aria/slider';
 
@@ -60,6 +61,43 @@ export function useColorSlider(props: ColorSliderAriaOptions, state: ColorSlider
     trackRef,
     inputRef
   }, state);
+
+  let {minValue, maxValue, step, pageSize} = state.value.getChannelRange(channel);
+  let {keyboardProps} = useKeyboard({
+    onKeyDown(e) {
+      // these are the cases that useMove or useSlider don't handle
+      if (!/^(PageUp|PageDown|Home|End)$/.test(e.key)) {
+        e.continuePropagation();
+        return;
+      }
+      // same handling as useMove, stopPropagation to prevent useSlider from handling the event as well.
+      e.preventDefault();
+      let channelValue = state.value.getChannelValue(channel);
+      let pageStep = Math.max(pageSize, step);
+      let newValue = channelValue;
+      switch (e.key) {
+        case 'PageUp':
+          newValue = channelValue + pageStep > maxValue ? maxValue : snapValueToStep(channelValue + pageStep, minValue, maxValue, pageStep);
+          break;
+        case 'PageDown':
+          newValue = snapValueToStep(channelValue - pageStep, minValue, maxValue, pageStep);
+          break;
+        case 'Home':
+          newValue = minValue;
+          break;
+        case 'End':
+          newValue = maxValue;
+          break;
+      }
+      // remember to set this so that onChangeEnd is fired
+      state.setThumbDragging(0, true);
+      if (newValue !== channelValue) {
+        state.setValue(state.value.withChannelValue(channel, newValue));
+      }
+      // wait a frame to ensure value has changed then unset this so that onChangeEnd is fired
+      requestAnimationFrame(() => state.setThumbDragging(0, false));
+    }
+  });
 
   let generateBackground = () => {
     let value = state.getDisplayColor();
@@ -113,7 +151,7 @@ export function useColorSlider(props: ColorSliderAriaOptions, state: ColorSlider
         background: generateBackground()
       }
     },
-    inputProps,
+    inputProps: mergeProps(inputProps, keyboardProps),
     thumbProps: {
       ...thumbProps,
       style: {

--- a/packages/@react-spectrum/color/stories/ColorArea.stories.tsx
+++ b/packages/@react-spectrum/color/stories/ColorArea.stories.tsx
@@ -11,14 +11,12 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ColorArea, ColorSlider, ColorWheel} from '../';
+import {ColorArea, ColorField, ColorSlider, ColorWheel} from '../';
 import {ColorChannel, SpectrumColorAreaProps} from '@react-types/color';
 import {Flex} from '@adobe/react-spectrum';
 import {Meta, Story} from '@storybook/react';
-import {parseColor} from '@react-stately/color';
+import {normalizeColor, parseColor} from '@react-stately/color';
 import React, {useState} from 'react';
-import {Text} from '@react-spectrum/text';
-
 
 const meta: Meta<SpectrumColorAreaProps> = {
   title: 'ColorArea',
@@ -53,29 +51,33 @@ function ColorAreaExample(props: SpectrumColorAreaProps) {
   } 
   let zChannel: ColorChannel = difference(colorSpaceSet, channels).keys().next().value;
   let isHue = zChannel === 'hue';
+  function onChange(e) {
+    try {
+      e = normalizeColor(e);
+    // eslint-disable-next-line no-empty
+    } catch (error) {
+      e = undefined;
+      return;
+    }
+    const newColor = (e || color).toFormat(colorSpace);
+    if (props.onChange) {
+      props.onChange(newColor);
+    }
+    setColor(newColor);
+  }
   return (<div role="group" aria-label={`${colorSpace.toUpperCase()} Color Picker`}>
-    <Flex gap="size-500" alignItems="center">
+    <Flex gap="size-500" alignItems="start">
       <Flex direction="column" gap={isHue ? 0 : 'size-50'} alignItems="center">
         <ColorArea
           size={isHue ? 'size-1200' : null}
           {...props}
           value={color}
-          onChange={(e) => {
-            if (props.onChange) {
-              props.onChange(e);
-            }
-            setColor(e);
-          }}
+          onChange={onChange}
           onChangeEnd={props.onChangeEnd} />
         {isHue ? (
           <ColorWheel
             value={color}
-            onChange={(e) => {
-              if (props.onChange) {
-                props.onChange(e);
-              }
-              setColor(e);
-            }}
+            onChange={onChange}
             onChangeEnd={props.onChangeEnd}
             isDisabled={isDisabled}
             size={'size-2400'}
@@ -85,20 +87,24 @@ function ColorAreaExample(props: SpectrumColorAreaProps) {
         ) : (
           <ColorSlider
             value={color}
-            onChange={(e) => {
-              if (props.onChange) {
-                props.onChange(e);
-              }
-              setColor(e);
-            }}
+            onChange={onChange}
             onChangeEnd={props.onChangeEnd}
             channel={zChannel}
             isDisabled={isDisabled} />
         )}
       </Flex>
-      <Flex direction="column" alignItems="center" gap="size-200" minWidth={'size-2000'}>
-        <div role="img" aria-label={`color swatch: ${color.toString('rgb')}`} title={`${color.toString('hex')}`} style={{width: '100px', height: '100px', background: color.toString('css')}} />
-        <Text>{color.toString('hex')}</Text>
+      <Flex direction="column" alignItems="center" gap="size-100" minWidth="size-1200">
+        <div role="img" aria-label={`color swatch: ${color.toString('rgb')}`} title={`${color.toString('hex')}`} style={{width: '96px', height: '96px', background: color.toString('css')}} />
+        <ColorField
+          label="HEX Color"
+          value={color}
+          onChange={onChange}
+          onKeyDown={event => 
+            event.key === 'Enter' &&
+            onChange((event.target as HTMLInputElement).value)
+          }
+          isDisabled={isDisabled}
+          width="size-1200" />
       </Flex>
     </Flex>
   </div>);

--- a/packages/@react-spectrum/color/stories/ColorArea.stories.tsx
+++ b/packages/@react-spectrum/color/stories/ColorArea.stories.tsx
@@ -29,27 +29,15 @@ const Template: Story<SpectrumColorAreaProps> = (args) => (
   <ColorAreaExample {...args} />
 );
 
-let RGB: Set<ColorChannel> = new Set(['red', 'green', 'blue']);
-let HSL: Set<ColorChannel> = new Set(['hue', 'saturation', 'lightness']);
-let HSB: Set<ColorChannel> = new Set(['hue', 'saturation', 'brightness']);
 let difference = (a, b): Set<ColorChannel> => new Set([...a].filter(x => !b.has(x)));
 
 function ColorAreaExample(props: SpectrumColorAreaProps) {
   let {xChannel, yChannel, isDisabled} = props;
   let defaultValue = typeof props.defaultValue === 'string' ? parseColor(props.defaultValue) : props.defaultValue;
   let [color, setColor] = useState(defaultValue || parseColor('#ff00ff'));
-  let channels = new Set([xChannel, yChannel]);
-  let colorSpace = color.getColorSpace();
-  let colorSpaceSet = RGB;
-  switch (colorSpace) {
-    case 'hsl':
-      colorSpaceSet = HSL;
-      break;
-    case 'hsb':
-      colorSpaceSet = HSB;
-      break;
-  } 
-  let zChannel: ColorChannel = difference(colorSpaceSet, channels).keys().next().value;
+  let xyChannels = new Set([xChannel, yChannel]);
+  let colorSpace = color.getColorSpace(); 
+  let zChannel: ColorChannel = difference(color.getColorChannels(), xyChannels).keys().next().value;
   let isHue = zChannel === 'hue';
   function onChange(e) {
     try {

--- a/packages/@react-spectrum/color/stories/ColorArea.stories.tsx
+++ b/packages/@react-spectrum/color/stories/ColorArea.stories.tsx
@@ -65,7 +65,8 @@ function ColorAreaExample(props: SpectrumColorAreaProps) {
               props.onChange(e);
             }
             setColor(e);
-          }} />
+          }}
+          onChangeEnd={props.onChangeEnd} />
         {isHue ? (
           <ColorWheel
             value={color}
@@ -95,7 +96,7 @@ function ColorAreaExample(props: SpectrumColorAreaProps) {
             isDisabled={isDisabled} />
         )}
       </Flex>
-      <Flex direction="column" alignItems="center" gap="size-100" minWidth={'size-2000'}>
+      <Flex direction="column" alignItems="center" gap="size-200" minWidth={'size-2000'}>
         <div role="img" aria-label={`color swatch: ${color.toString('rgb')}`} title={`${color.toString('hex')}`} style={{width: '100px', height: '100px', background: color.toString('css')}} />
         <Text>{color.toString('hex')}</Text>
       </Flex>
@@ -155,11 +156,11 @@ XBlueYGreenSize600.args = {...XBlueYGreen.args, size: 'size-600'};
 
 export let XSaturationYLightness = Template.bind({});
 XSaturationYLightness.storyName = 'HSL xChannel="saturation", yChannel="lightness"';
-XSaturationYLightness.args = {xChannel: 'saturation', yChannel: 'lightness', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange')};
+XSaturationYLightness.args = {xChannel: 'saturation', yChannel: 'lightness', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 export let XLightnessYSaturation = Template.bind({});
 XLightnessYSaturation.storyName = 'HSL xChannel="lightness", yChannel="saturation"';
-XLightnessYSaturation.args = {xChannel: 'lightness', yChannel: 'saturation', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange')};
+XLightnessYSaturation.args = {xChannel: 'lightness', yChannel: 'saturation', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 /* TODO: what does a disabled color area look like? */
 export let XSaturationYLightnessisDisabled = Template.bind({});
@@ -168,11 +169,11 @@ XSaturationYLightnessisDisabled.args = {...XSaturationYLightness.args, isDisable
 
 export let XHueYSaturationHSL = Template.bind({});
 XHueYSaturationHSL.storyName = 'HSL xChannel="hue", yChannel="saturation"';
-XHueYSaturationHSL.args = {xChannel: 'hue', yChannel: 'saturation', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange')};
+XHueYSaturationHSL.args = {xChannel: 'hue', yChannel: 'saturation', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 export let XSaturationYHueHSL = Template.bind({});
 XSaturationYHueHSL.storyName = 'HSL xChannel="saturation", yChannel="hue"';
-XSaturationYHueHSL.args = {xChannel: 'saturation', yChannel: 'hue', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange')};
+XSaturationYHueHSL.args = {xChannel: 'saturation', yChannel: 'hue', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 /* TODO: what does a disabled color area look like? */
 export let XHueYSaturationHSLisDisabled = Template.bind({});
@@ -181,11 +182,11 @@ XHueYSaturationHSLisDisabled.args = {...XHueYSaturationHSL.args, isDisabled: tru
 
 export let XHueYLightnessHSL = Template.bind({});
 XHueYLightnessHSL.storyName = 'HSL xChannel="hue", yChannel="lightness"';
-XHueYLightnessHSL.args = {xChannel: 'hue', yChannel: 'lightness', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange')};
+XHueYLightnessHSL.args = {xChannel: 'hue', yChannel: 'lightness', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 export let XLightnessYHueHSL = Template.bind({});
 XLightnessYHueHSL.storyName = 'HSL xChannel="lightness", yChannel="hue"';
-XLightnessYHueHSL.args = {xChannel: 'lightness', yChannel: 'hue', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange')};
+XLightnessYHueHSL.args = {xChannel: 'lightness', yChannel: 'hue', defaultValue: 'hsl(0, 100%, 50%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 /* TODO: what does a disabled color area look like? */
 export let XHueYLightnessHSLisDisabled = Template.bind({});
@@ -194,11 +195,11 @@ XHueYLightnessHSLisDisabled.args = {...XHueYLightnessHSL.args, isDisabled: true}
 
 export let XSaturationYBrightness = Template.bind({});
 XSaturationYBrightness.storyName = 'HSB xChannel="saturation", yChannel="brightness"';
-XSaturationYBrightness.args = {xChannel: 'saturation', yChannel: 'brightness', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange')};
+XSaturationYBrightness.args = {xChannel: 'saturation', yChannel: 'brightness', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 export let XBrightnessYSaturation = Template.bind({});
 XBrightnessYSaturation.storyName = 'HSB xChannel="brightness", yChannel="saturation"';
-XBrightnessYSaturation.args = {xChannel: 'brightness', yChannel: 'saturation', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange')};
+XBrightnessYSaturation.args = {xChannel: 'brightness', yChannel: 'saturation', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 /* TODO: what does a disabled color area look like? */
 export let XSaturationYBrightnessisDisabled = Template.bind({});
@@ -207,11 +208,11 @@ XSaturationYBrightnessisDisabled.args = {...XSaturationYBrightness.args, isDisab
 
 export let XHueYSaturationHSB = Template.bind({});
 XHueYSaturationHSB.storyName = 'HSB xChannel="hue", yChannel="saturation"';
-XHueYSaturationHSB.args = {xChannel: 'hue', yChannel: 'saturation', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange')};
+XHueYSaturationHSB.args = {xChannel: 'hue', yChannel: 'saturation', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 export let XSaturationYHueHSB = Template.bind({});
 XSaturationYHueHSB.storyName = 'HSB xChannel="saturation", yChannel="hue"';
-XSaturationYHueHSB.args = {xChannel: 'saturation', yChannel: 'hue', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange')};
+XSaturationYHueHSB.args = {xChannel: 'saturation', yChannel: 'hue', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 /* TODO: what does a disabled color area look like? */
 export let XHueYSaturationHSBisDisabled = Template.bind({});
@@ -220,11 +221,11 @@ XHueYSaturationHSBisDisabled.args = {...XHueYSaturationHSB.args, isDisabled: tru
 
 export let XHueYBrightnessHSB = Template.bind({});
 XHueYBrightnessHSB.storyName = 'HSB xChannel="hue", yChannel="brightness"';
-XHueYBrightnessHSB.args = {xChannel: 'hue', yChannel: 'brightness', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange')};
+XHueYBrightnessHSB.args = {xChannel: 'hue', yChannel: 'brightness', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 export let XBrightnessYHueHSB = Template.bind({});
 XBrightnessYHueHSB.storyName = 'HSB xChannel="brightness", yChannel="hue"';
-XBrightnessYHueHSB.args = {xChannel: 'brightness', yChannel: 'hue', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange')};
+XBrightnessYHueHSB.args = {xChannel: 'brightness', yChannel: 'hue', defaultValue: 'hsb(0, 100%, 100%)', onChange: action('onChange'), onChangeEnd: action('onChangeEnd')};
 
 /* TODO: what does a disabled color area look like? */
 export let XBrightnessYHueHSBisDisabled = Template.bind({});

--- a/packages/@react-spectrum/color/test/ColorArea.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorArea.test.tsx
@@ -540,12 +540,13 @@ describe('ColorArea', () => {
     });
 
     it('the slider is focusable', () => {
-      let {getAllByRole} = render(<div>
+      let {getAllByRole, getByRole} = render(<div>
         <button>A</button>
         <DefaultColorArea defaultValue={'#ff00ff'} />
         <button>B</button>
       </div>);
       let sliders = getAllByRole('slider');
+      let colorField = getByRole('textbox');
       let [buttonA, buttonB] = getAllByRole('button');
 
       userEvent.tab();
@@ -555,7 +556,10 @@ describe('ColorArea', () => {
       userEvent.tab();
       expect(document.activeElement).toBe(sliders[2]);
       userEvent.tab();
+      expect(document.activeElement).toBe(colorField);
+      userEvent.tab();
       expect(document.activeElement).toBe(buttonB);
+      userEvent.tab({shift: true});
       userEvent.tab({shift: true});
       expect(document.activeElement).toBe(sliders[2]);
     });

--- a/packages/@react-spectrum/color/test/ColorSlider.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorSlider.test.tsx
@@ -19,18 +19,20 @@ import userEvent from '@testing-library/user-event';
 
 describe('ColorSlider', () => {
   let onChangeSpy = jest.fn();
+  let onChangeEndSpy = jest.fn();
 
   beforeAll(() => {
     jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 100);
     jest.spyOn(window.HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(() => 100);
     // @ts-ignore
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => setTimeout(cb, 0));
     // @ts-ignore
     jest.useFakeTimers('legacy');
   });
 
   afterEach(() => {
     onChangeSpy.mockClear();
+    onChangeEndSpy.mockClear();
     // for restoreTextSelection
     act(() => {jest.runAllTimers();});
   });
@@ -264,16 +266,65 @@ describe('ColorSlider', () => {
   describe('keyboard events', () => {
     it('works', () => {
       let defaultColor = parseColor('#000000');
-      let {getByRole} = render(<ColorSlider defaultValue={defaultColor} onChange={onChangeSpy} channel="red" />);
+      let {getByRole} = render(<ColorSlider defaultValue={defaultColor} onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} channel="red" />);
       let slider = getByRole('slider');
       act(() => {slider.focus();});
 
       fireEvent.keyDown(slider, {key: 'Right'});
+      act(() => {jest.runAllTimers();});
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy.mock.calls[0][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 1).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(1);
+      expect(onChangeEndSpy.mock.calls[0][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 1).toString('hexa'));
+      
       fireEvent.keyDown(slider, {key: 'Left'});
+      act(() => {jest.runAllTimers();});
       expect(onChangeSpy).toHaveBeenCalledTimes(2);
       expect(onChangeSpy.mock.calls[1][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 0).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(2);
+      expect(onChangeEndSpy.mock.calls[1][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 0).toString('hexa'));
+
+      fireEvent.keyDown(slider, {key: 'PageUp'});
+      act(() => {jest.runAllTimers();});
+      expect(onChangeSpy).toHaveBeenCalledTimes(3);
+      expect(onChangeSpy.mock.calls[2][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 16).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(3);
+      expect(onChangeEndSpy.mock.calls[2][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 16).toString('hexa'));
+
+      fireEvent.keyDown(slider, {key: 'Right'});
+      act(() => {jest.runAllTimers();});
+      expect(onChangeSpy).toHaveBeenCalledTimes(4);
+      expect(onChangeSpy.mock.calls[3][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 17).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(4);
+      expect(onChangeEndSpy.mock.calls[3][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 17).toString('hexa'));
+       
+      fireEvent.keyDown(slider, {key: 'PageDown'});
+      act(() => {jest.runAllTimers();});
+      expect(onChangeSpy).toHaveBeenCalledTimes(5);
+      expect(onChangeSpy.mock.calls[4][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 0).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(5);
+      expect(onChangeEndSpy.mock.calls[4][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 0).toString('hexa'));
+
+      fireEvent.keyDown(slider, {key: 'End'});
+      act(() => {jest.runAllTimers();});
+      expect(onChangeSpy).toHaveBeenCalledTimes(6);
+      expect(onChangeSpy.mock.calls[5][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 255).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(6);
+      expect(onChangeEndSpy.mock.calls[5][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 255).toString('hexa'));
+
+      fireEvent.keyDown(slider, {key: 'PageDown'});
+      act(() => {jest.runAllTimers();});
+      expect(onChangeSpy).toHaveBeenCalledTimes(7);
+      expect(onChangeSpy.mock.calls[6][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 240).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(7);
+      expect(onChangeEndSpy.mock.calls[6][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 240).toString('hexa'));
+
+      fireEvent.keyDown(slider, {key: 'Home'});
+      act(() => {jest.runAllTimers();});
+      expect(onChangeSpy).toHaveBeenCalledTimes(8);
+      expect(onChangeSpy.mock.calls[7][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 0).toString('hexa'));
+      expect(onChangeEndSpy).toHaveBeenCalledTimes(8);
+      expect(onChangeEndSpy.mock.calls[7][0].toString('hexa')).toBe(defaultColor.withChannelValue('red', 0).toString('hexa'));
     });
 
     it('doesn\'t work when disabled', () => {

--- a/packages/@react-stately/color/src/Color.ts
+++ b/packages/@react-stately/color/src/Color.ts
@@ -71,6 +71,7 @@ abstract class Color implements IColor {
   }
 
   abstract getColorSpace(): ColorFormat
+  abstract getColorChannels(): Set<ColorChannel>
 }
 
 const HEX_REGEX = /^#(?:([0-9a-f]{3})|([0-9a-f]{6}))$/i;
@@ -266,6 +267,11 @@ class RGBColor extends Color {
   getColorSpace(): ColorFormat {
     return 'rgb';
   }
+
+  private static colorChannels: Set<ColorChannel> = new Set(['red', 'green', 'blue']);
+  getColorChannels(): Set<ColorChannel> {
+    return RGBColor.colorChannels;
+  }
 }
 
 // X = <negative/positive number with/without decimal places>
@@ -398,6 +404,11 @@ class HSBColor extends Color {
 
   getColorSpace(): ColorFormat {
     return 'hsb';
+  }
+
+  private static colorChannels: Set<ColorChannel> = new Set(['hue', 'saturation', 'brightness']);
+  getColorChannels(): Set<ColorChannel> {
+    return HSBColor.colorChannels;
   }
 }
 
@@ -533,5 +544,10 @@ class HSLColor extends Color {
 
   getColorSpace(): ColorFormat {
     return 'hsl';
+  }
+
+  private static colorChannels: Set<ColorChannel> = new Set(['hue', 'saturation', 'lightness']);
+  getColorChannels(): Set<ColorChannel> {
+    return HSLColor.colorChannels;
   }
 }

--- a/packages/@react-stately/color/src/useColorAreaState.ts
+++ b/packages/@react-stately/color/src/useColorAreaState.ts
@@ -237,8 +237,6 @@ export function useColorAreaState(props: ColorAreaProps): ColorAreaState {
     yValue,
     setYValue,
     setColorFromPoint(x: number, y: number) {
-      let {minValue: minValueX, maxValue: maxValueX} = color.getChannelRange(channels.xChannel);
-      let {minValue: minValueY, maxValue: maxValueY} = color.getChannelRange(channels.yChannel);
       let newXValue = minValueX + clamp(x, 0, 1) * (maxValueX - minValueX);
       let newYValue = minValueY + (1 - clamp(y, 0, 1)) * (maxValueY - minValueY);
       let newColor:Color;
@@ -262,10 +260,10 @@ export function useColorAreaState(props: ColorAreaProps): ColorAreaState {
       return {x, y};
     },
     incrementX(stepSize) {
-      setXValue(snapValueToStep(xValue + stepSize, minValueX, maxValueX, stepSize));
+      setXValue(xValue + stepSize > maxValueX ? maxValueX : snapValueToStep(xValue + stepSize, minValueX, maxValueX, stepSize));
     },
     incrementY(stepSize) {
-      setYValue(snapValueToStep(yValue + stepSize, minValueY, maxValueY, stepSize));
+      setYValue(yValue + stepSize > maxValueY ? maxValueY : snapValueToStep(yValue + stepSize, minValueY, maxValueY, stepSize));
     },
     decrementX(stepSize) {
       setXValue(snapValueToStep(xValue - stepSize, minValueX, maxValueX, stepSize));

--- a/packages/@react-stately/color/src/useColorWheelState.ts
+++ b/packages/@react-stately/color/src/useColorWheelState.ts
@@ -167,7 +167,7 @@ export function useColorWheelState(props: ColorWheelProps): ColorWheelState {
     },
     isDragging,
     getDisplayColor() {
-      return value.withChannelValue('saturation', 100).withChannelValue('lightness', 50);
+      return value.toFormat('hsl').withChannelValue('saturation', 100).withChannelValue('lightness', 50);
     }
   };
 }

--- a/packages/@react-types/color/src/index.d.ts
+++ b/packages/@react-types/color/src/index.d.ts
@@ -51,6 +51,8 @@ export interface Color {
   toFormat(format: ColorFormat): Color,
   /** Converts the color to a string in the given format. */
   toString(format: ColorFormat | 'css'): string,
+  /** Returns a duplicate of the color value. */
+  clone(): Color,
   /** Converts the color to hex, and returns an integer representation. */
   toHexInt(): number,
   /**
@@ -75,7 +77,11 @@ export interface Color {
   /**
    * Formats the numeric value for a given channel for display according to the provided locale.
    */
-  formatChannelValue(channel: ColorChannel, locale: string): string
+  formatChannelValue(channel: ColorChannel, locale: string): string,
+  /**
+   * Returns the color space, 'rgb', 'hsb' or 'hsl', for the current color.
+   */
+  getColorSpace(): ColorFormat
 }
 
 export interface ColorFieldProps extends Omit<ValueBase<string | Color>, 'onChange'>, InputBase, Validation, FocusableProps, TextInputBase, LabelableProps {

--- a/packages/@react-types/color/src/index.d.ts
+++ b/packages/@react-types/color/src/index.d.ts
@@ -81,7 +81,11 @@ export interface Color {
   /**
    * Returns the color space, 'rgb', 'hsb' or 'hsl', for the current color.
    */
-  getColorSpace(): ColorFormat
+  getColorSpace(): ColorFormat,
+  /**
+   * Returns an array of the color channels within the current color space space.
+   */
+  getColorChannels(): Set<ColorChannel>
 }
 
 export interface ColorFieldProps extends Omit<ValueBase<string | Color>, 'onChange'>, InputBase, Validation, FocusableProps, TextInputBase, LabelableProps {


### PR DESCRIPTION
Closes #1732 Closes #1118

Opening this PR mainly so I don't lose track of this work.

Storybook examples: 
- https://reactspectrum.blob.core.windows.net/reactspectrum/76922ca3aba738561d789f783319d4be62d79e7b/storybook/index.html?path=/story/colorarea--x-blue-y-green
- https://reactspectrum.blob.core.windows.net/reactspectrum/76922ca3aba738561d789f783319d4be62d79e7b/storybook/index.html?path=/story/colorarea--x-saturation-y-lightness
- https://reactspectrum.blob.core.windows.net/reactspectrum/76922ca3aba738561d789f783319d4be62d79e7b/storybook/index.html?path=/story/colorarea--x-saturation-y-brightness

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

Adobe/Accessibility
