### PR TITLE
Fix SearchWithin input focus/hover state style issue

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -57,11 +57,6 @@ governing permissions and limitations under the License.
     flex: 1;
     box-sizing: border-box;
     min-inline-size: inherit;
-
-    &:hover,
-    &:focus {
-      position: relative; /* shows right border */
-    }
   }
 }
 


### PR DESCRIPTION
In Chrome v95, focusing the SearchWithin input messes up the style:

<img width="255" alt="Screen Shot 2021-11-19 at 12 53 10 PM" src="https://user-images.githubusercontent.com/8961049/142676643-473930e2-0980-4371-9e3f-682359aa324d.png">

Removed style that set `position: relative`, looks like a Spectrum CSS style that isn't necessary anymore.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the default SearchWithin story and focus the input. Verify the styles are correct and above screenshot doesn't happen. Verify chromatic looks good.

## 🧢 Your Project:

RSP
