### PR TITLE
Make link tooltip testing story obvious

### DIFF
--- a/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
+++ b/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
@@ -332,10 +332,10 @@ function LinkWithTooltip(props = {}) {
           href="https://react-spectrum.adobe.com/"
           target="_blank"
           rel="noreferrer">
-          Link with tooltip
+          Why did dinosaurs have feathers?
         </a>
       </Link>
-      <Tooltip>This is a link</Tooltip>
+      <Tooltip>Dinosaurs had feathers, find out more.</Tooltip>
     </TooltipTrigger>
   );
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Great news, chrome was reading it, it was just hard to detect because it sounded like such a normal thing to VO to say. So I made the text much more obvious

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
