### PR TITLE
fix(#2598): ColorField input should disable spellcheck

### DIFF
--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -112,6 +112,7 @@ export function useColorField(
       'aria-valuenow': null,
       'aria-valuetext': null,
       autoCorrect: 'off',
+      spellCheck: 'false',
       onBlur: commit
     })
   };

--- a/packages/@react-aria/color/test/useColorField.test.js
+++ b/packages/@react-aria/color/test/useColorField.test.js
@@ -50,6 +50,7 @@ describe('useColorField', function () {
     expect(inputProps['aria-invalid']).toBeUndefined();
     expect(inputProps.disabled).toBe(false);
     expect(inputProps.readOnly).toBe(false);
+    expect(inputProps.spellCheck).toBe('false');
   });
 
   it('should return props for colorValue provided', function () {

--- a/packages/@react-spectrum/color/test/ColorField.test.js
+++ b/packages/@react-spectrum/color/test/ColorField.test.js
@@ -44,6 +44,7 @@ describe('ColorField', function () {
     expect(colorField).toHaveAttribute('type', 'text');
     expect(colorField).toHaveAttribute('autocomplete', 'off');
     expect(colorField).toHaveAttribute('autocorrect', 'off');
+    expect(colorField).toHaveAttribute('spellcheck', 'false');
     expect(colorField).not.toHaveAttribute('readonly');
     expect(colorField).not.toBeInvalid();
     expect(colorField).not.toBeDisabled();


### PR DESCRIPTION
Closes #2598 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 2598](https://github.com/adobe/react-spectrum/issues/2598).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
1. Open any of the [ColorField examples in storybook](https://reactspectrum.blob.core.windows.net/reactspectrum/d0c3b850da21761efc49e6ea1cf1ce74fea1d5d7/storybook/index.html?path=/story/colorfield--default).
2. Focus the ColorField and enter a HEX value for a color.
3. Browser should not add red dotted underling for spellchecking the value entered.

## 🧢 Your Project:

Adobe/Accessibility
