### PR TITLE
Add aria-describedby to date field segments so help text and value is read

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -32,7 +32,7 @@ interface DateFieldAria {
   errorMessageProps: HTMLAttributes<HTMLElement>
 }
 
-export const labelIds = new WeakMap<DatePickerFieldState, string>();
+export const labelIds = new WeakMap<DatePickerFieldState, {ariaLabelledBy: string, ariaDescribedBy: string}>();
 
 export function useDateField<T extends DateValue>(props: DateFieldProps<T>, state: DatePickerFieldState, ref: RefObject<HTMLElement>): DateFieldAria {
   let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useField({
@@ -51,7 +51,13 @@ export function useDateField<T extends DateValue>(props: DateFieldProps<T>, stat
   let formatter = useDateFormatter(state.getFormatOptions({month: 'long'}));
   let descProps = useDescription(state.value ? formatter.format(state.dateValue) : null);
 
-  labelIds.set(state, fieldProps['aria-labelledby'] || fieldProps.id);
+  let segmentLabelledBy = fieldProps['aria-labelledby'] || fieldProps.id;
+  let describedBy = [descProps['aria-describedby'], fieldProps['aria-describedby']].filter(Boolean).join(' ') || undefined;
+
+  labelIds.set(state, {
+    ariaLabelledBy: segmentLabelledBy,
+    ariaDescribedBy: describedBy
+  });
 
   return {
     labelProps: {
@@ -64,7 +70,7 @@ export function useDateField<T extends DateValue>(props: DateFieldProps<T>, stat
     fieldProps: mergeProps(fieldProps, descProps, groupProps, focusWithinProps, {
       role: 'group',
       'aria-disabled': props.isDisabled || undefined,
-      'aria-describedby': [descProps['aria-describedby'], fieldProps['aria-describedby']].filter(Boolean).join(' ') || undefined
+      'aria-describedby': describedBy
     }),
     descriptionProps,
     errorMessageProps

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -44,7 +44,7 @@ export function useDateSegment<T extends DateValue>(props: DatePickerProps<T> & 
 
   if (segment.type === 'month') {
     let monthTextValue = monthDateFormatter.format(state.dateValue);
-    textValue = monthTextValue !== textValue ? `${textValue} - ${monthTextValue}` : monthTextValue;
+    textValue = monthTextValue !== textValue ? `${textValue} – ${monthTextValue}` : monthTextValue;
   } else if (segment.type === 'hour' || segment.type === 'dayPeriod') {
     textValue = hourDateFormatter.format(state.dateValue);
   }
@@ -330,7 +330,14 @@ export function useDateSegment<T extends DateValue>(props: DatePickerProps<T> & 
     'aria-valuenow': null
   } : {};
 
-  let fieldLabelId = labelIds.get(state);
+  let {ariaLabelledBy, ariaDescribedBy} = labelIds.get(state);
+
+  // Only apply aria-describedby to the first segment, unless the field is invalid. This avoids it being
+  // read every time the user navigates to a new segment.
+  let firstSegment = useMemo(() => state.segments.find(s => s.isEditable), [state.segments]);
+  if (segment !== firstSegment && state.validationState !== 'invalid') {
+    ariaDescribedBy = undefined;
+  }
 
   let id = useId(props.id);
   let isEditable = !props.isDisabled && !props.isReadOnly && segment.isEditable;
@@ -342,7 +349,8 @@ export function useDateSegment<T extends DateValue>(props: DatePickerProps<T> & 
       // 'aria-haspopup': props['aria-haspopup'], // deprecated in ARIA 1.2
       'aria-invalid': state.validationState === 'invalid' ? 'true' : undefined,
       'aria-label': segment.type !== 'literal' ? displayNames.of(segment.type) : undefined,
-      'aria-labelledby': `${fieldLabelId} ${id}`,
+      'aria-labelledby': `${ariaLabelledBy} ${id}`,
+      'aria-describedby': ariaDescribedBy,
       'aria-placeholder': segment.isPlaceholder ? segment.text : undefined,
       'aria-readonly': props.isReadOnly || !segment.isEditable ? 'true' : undefined,
       contentEditable: isEditable,

--- a/packages/@react-spectrum/datepicker/test/DateField.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateField.test.js
@@ -84,60 +84,94 @@ describe('DateField', function () {
     });
 
     it('should support help text description', function () {
-      let {getByRole} = render(<DateField label="Date" description="Help text" />);
+      let {getByRole, getAllByRole} = render(<DateField label="Date" description="Help text" />);
 
       let group = getByRole('group');
       expect(group).toHaveAttribute('aria-describedby');
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Help text');
+
+      let segments = getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support error message', function () {
-      let {getByRole} = render(<DateField label="Date" errorMessage="Error message" validationState="invalid" />);
+      let {getByRole, getAllByRole} = render(<DateField label="Date" errorMessage="Error message" validationState="invalid" />);
 
       let group = getByRole('group');
       expect(group).toHaveAttribute('aria-describedby');
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Error message');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      }
     });
 
     it('should not display error message if not invalid', function () {
-      let {getByRole} = render(<DateField label="Date" errorMessage="Error message" />);
+      let {getByRole, getAllByRole} = render(<DateField label="Date" errorMessage="Error message" />);
 
       let group = getByRole('group');
       expect(group).not.toHaveAttribute('aria-describedby');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support help text with a value', function () {
-      let {getByRole} = render(<DateField label="Date" description="Help text" value={new CalendarDate(2020, 2, 3)} />);
+      let {getByRole, getAllByRole} = render(<DateField label="Date" description="Help text" value={new CalendarDate(2020, 2, 3)} />);
 
       let group = getByRole('group');
       expect(group).toHaveAttribute('aria-describedby');
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Help text');
+
+      let segments = getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support error message with a value', function () {
-      let {getByRole} = render(<DateField label="Date" errorMessage="Error message" validationState="invalid" value={new CalendarDate(2020, 2, 3)} />);
+      let {getByRole, getAllByRole} = render(<DateField label="Date" errorMessage="Error message" validationState="invalid" value={new CalendarDate(2020, 2, 3)} />);
 
       let group = getByRole('group');
       expect(group).toHaveAttribute('aria-describedby');
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Error message');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      }
     });
 
     it('should support format help text', function () {
-      let {getByRole, getByText} = render(<DateField label="Date" showFormatHelpText />);
+      let {getByRole, getByText, getAllByRole} = render(<DateField label="Date" showFormatHelpText />);
 
       // Not needed in aria-described by because each segment has a label already, so this would be duplicative.
       let group = getByRole('group');
       expect(group).not.toHaveAttribute('aria-describedby');
 
       expect(getByText('month / day / year')).toBeVisible();
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
   });
 });

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -80,7 +80,7 @@ describe('DatePicker', function () {
       expect(segments[0].textContent).toBe('2');
       expect(segments[0].getAttribute('aria-label')).toBe('month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
-      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 − February');
+      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 – February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
@@ -113,7 +113,7 @@ describe('DatePicker', function () {
       expect(segments[0].textContent).toBe('2');
       expect(segments[0].getAttribute('aria-label')).toBe('month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
-      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 − February');
+      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 – February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
@@ -504,6 +504,13 @@ describe('DatePicker', function () {
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Help text');
+
+      let segments = getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', description.id);
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support error message', function () {
@@ -515,6 +522,11 @@ describe('DatePicker', function () {
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Error message');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      }
     });
 
     it('should not display error message if not invalid', function () {
@@ -523,6 +535,11 @@ describe('DatePicker', function () {
       let [group, field] = getAllByRole('group');
       expect(group).not.toHaveAttribute('aria-describedby');
       expect(field).not.toHaveAttribute('aria-describedby');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support help text with a value', function () {
@@ -534,6 +551,13 @@ describe('DatePicker', function () {
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Help text');
+
+      let segments = getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support error message with a value', function () {
@@ -545,6 +569,11 @@ describe('DatePicker', function () {
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Error message');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      }
     });
 
     it('should support format help text', function () {
@@ -556,6 +585,11 @@ describe('DatePicker', function () {
       expect(field).not.toHaveAttribute('aria-describedby');
 
       expect(getByText('month / day / year')).toBeVisible();
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
   });
 

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -91,7 +91,7 @@ describe('DateRangePicker', function () {
       expect(segments[0].textContent).toBe('2');
       expect(segments[0].getAttribute('aria-label')).toBe('month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
-      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 − February');
+      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 – February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
@@ -112,7 +112,7 @@ describe('DateRangePicker', function () {
       expect(segments[3].textContent).toBe('5');
       expect(segments[3].getAttribute('aria-label')).toBe('month');
       expect(segments[3].getAttribute('aria-valuenow')).toBe('5');
-      expect(segments[3].getAttribute('aria-valuetext')).toBe('5 − May');
+      expect(segments[3].getAttribute('aria-valuetext')).toBe('5 – May');
       expect(segments[3].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[3].getAttribute('aria-valuemax')).toBe('12');
 
@@ -145,7 +145,7 @@ describe('DateRangePicker', function () {
       expect(segments[0].textContent).toBe('2');
       expect(segments[0].getAttribute('aria-label')).toBe('month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
-      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 − February');
+      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 – February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
@@ -191,7 +191,7 @@ describe('DateRangePicker', function () {
       expect(segments[7].textContent).toBe('5');
       expect(segments[7].getAttribute('aria-label')).toBe('month');
       expect(segments[7].getAttribute('aria-valuenow')).toBe('5');
-      expect(segments[7].getAttribute('aria-valuetext')).toBe('5 − May');
+      expect(segments[7].getAttribute('aria-valuetext')).toBe('5 – May');
       expect(segments[7].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[7].getAttribute('aria-valuemax')).toBe('12');
 
@@ -619,6 +619,20 @@ describe('DateRangePicker', function () {
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Help text');
+
+      let segments = within(startField).getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
+
+      segments = within(endField).getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support error message', function () {
@@ -631,6 +645,11 @@ describe('DateRangePicker', function () {
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Error message');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      }
     });
 
     it('should not display error message if not invalid', function () {
@@ -640,6 +659,11 @@ describe('DateRangePicker', function () {
       expect(group).not.toHaveAttribute('aria-describedby');
       expect(startField).not.toHaveAttribute('aria-describedby');
       expect(endField).not.toHaveAttribute('aria-describedby');
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support help text with a value', function () {
@@ -656,8 +680,22 @@ describe('DateRangePicker', function () {
       description = startField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Help text');
 
+      let segments = within(startField).getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', startField.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
+
       description = endField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 10, 2020 Help text');
+
+      segments = within(endField).getAllByRole('spinbutton');
+      expect(segments[0]).toHaveAttribute('aria-describedby', endField.getAttribute('aria-describedby'));
+
+      for (let segment of segments.slice(1)) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
 
     it('should support error message with a value', function () {
@@ -674,8 +712,18 @@ describe('DateRangePicker', function () {
       description = startField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Error message');
 
+      let segments = within(startField).getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', startField.getAttribute('aria-describedby'));
+      }
+
       description = endField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 10, 2020 Error message');
+
+      segments = within(endField).getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-describedby', endField.getAttribute('aria-describedby'));
+      }
     });
 
     it('should support format help text', function () {
@@ -688,6 +736,11 @@ describe('DateRangePicker', function () {
       expect(endField).not.toHaveAttribute('aria-describedby');
 
       expect(getByText('month / day / year')).toBeVisible();
+
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).not.toHaveAttribute('aria-describedby');
+      }
     });
   });
 


### PR DESCRIPTION
This fixes two issues identified during previous testing sessions:

1. The currently selected date is not read until you change one of the segments and the live announcer picks up the change.
2. The help text and error message is not read unless you manually navigate to the group wrapper with the SR cursor (impossible with touch screen readers).

This is solved by applying the `aria-describedby` attribute to the individual date segments rather than only the group. However, reading the help text and currently selected date every single time you navigate to a segment is very repetitive and verbose. So, I only applied it to the first segment of a field (within a date range picker there are two fields). Assuming users navigate linearly, this should be ok and much less verbose. When there is an error message, however, I applied it to all segments so a user can tell if the date is still invalid as they fix it.

@majornista I'm curious what you think of this experience.