### PR TITLE
Fix SearchField to call onKeyDown

### DIFF
--- a/packages/@react-aria/searchfield/src/useSearchField.ts
+++ b/packages/@react-aria/searchfield/src/useSearchField.ts
@@ -12,6 +12,7 @@
 
 import {AriaButtonProps} from '@react-types/button';
 import {AriaSearchFieldProps} from '@react-types/searchfield';
+import {chain} from '@react-aria/utils';
 import {HTMLAttributes, InputHTMLAttributes, LabelHTMLAttributes, RefObject} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -92,7 +93,7 @@ export function useSearchField(
     ...props,
     value: state.value,
     onChange: state.setValue,
-    onKeyDown,
+    onKeyDown: chain(onKeyDown, props.onKeyDown),
     type
   }, inputRef);
 

--- a/packages/@react-aria/searchfield/test/useSearchField.test.js
+++ b/packages/@react-aria/searchfield/test/useSearchField.test.js
@@ -54,6 +54,7 @@ describe('useSearchField hook', () => {
       let preventDefault = jest.fn();
       let stopPropagation = jest.fn();
       let onSubmit = jest.fn();
+      let onKeyDown = jest.fn();
       let event = (key) => ({
         key,
         preventDefault,
@@ -96,6 +97,12 @@ describe('useSearchField hook', () => {
       it('does not return an defaultValue prop', () => {
         let {inputProps} = renderSearchHook({onClear, onSubmit, defaultValue: 'ABC'});
         expect(inputProps.defaultValue).not.toBeDefined();
+      });
+
+      it('onKeyDown prop is called', () => {
+        let {inputProps} = renderSearchHook({onKeyDown});
+        inputProps.onKeyDown(event('Enter'));
+        expect(onKeyDown).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
Closes #2253

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify new test for onKeyDown passes and user-provided onKeyDown even is called if provided as prop to SearchField.

## 🧢 Your Project:

RSP