### PR TITLE
Expose focusPage from useCalendarState

### DIFF
--- a/packages/@react-stately/calendar/src/types.ts
+++ b/packages/@react-stately/calendar/src/types.ts
@@ -25,6 +25,7 @@ export interface CalendarStateBase {
   focusPreviousDay(): void,
   focusNextRow(): void,
   focusPreviousRow(): void,
+  focusPage(date: CalendarDate): void,
   focusNextPage(): void,
   focusPreviousPage(): void,
   focusPageStart(): void,

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -144,6 +144,9 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
         focusCell(focusedDate.subtract({weeks: 1}));
       }
     },
+    focusPage(date: CalendarDate) {
+      focusCell(date.set({day: 1}));
+    },
     focusNextPage() {
       let start = startDate.add(visibleDuration);
       setStartDate(constrainStart(focusedDate, start, visibleDuration, locale, minValue, maxValue));


### PR DESCRIPTION
Closes #2627

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

1. Attempt to use state.focusPage from a component, to focus on a particular date (different month, year).
2. Verify that the focused date changes.
## 🧢 Your Project:

<!--- Company/project for pull request -->
