### PR TITLE
Fix Next.js SSR Docs

### DIFF
--- a/packages/dev/docs/pages/react-spectrum/ssr.mdx
+++ b/packages/dev/docs/pages/react-spectrum/ssr.mdx
@@ -91,6 +91,7 @@ const withTM = require("next-transpile-modules")([
   "@react-spectrum/searchfield",
   "@react-spectrum/statuslight",
   "@react-spectrum/switch",
+  "@react-spectrum/table",
   "@react-spectrum/tabs",
   "@react-spectrum/text",
   "@react-spectrum/textfield",


### PR DESCRIPTION
Without this change, Next.js latest fails to compile and complains with:

```
./node_modules/@react-spectrum/table/dist/main.css
Global CSS cannot be imported from within node_modules.
Read more: https://nextjs.org/docs/messages/css-npm
Location: node_modules/@react-spectrum/table/dist/module.js
```

NB: In the future, it might be nice to template this section in the doc
to automatically include the requisite imports, but I'm not familiar
enough with this project, nor Next, nor MDX to make that change at the
moment.


Closes #2639 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Create a boiler plate Next.js project and attempt to use a `Button` from `@adobe/react-spectrum`.

## 🧢 Your Project:

N/A
