### PR TITLE
fix(#2468): Combobox: Added onCustomValueEnterPressed event for allowsCustomValue

### DIFF
--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -110,12 +110,14 @@ export function useComboBox<T>(props: AriaComboBoxProps<T>, state: ComboBoxState
   let onKeyDown = (e: KeyboardEvent) => {
     switch (e.key) {
       case 'Enter':
-      case 'Tab':
         // Prevent form submission if menu is open since we may be selecting a option
         if (state.isOpen && e.key === 'Enter') {
           e.preventDefault();
         }
-
+        !state.isOpen && props.allowsCustomValue && props.onCustomValueEnterPressed(state.inputValue);
+        state.commit();
+        break;
+      case 'Tab':
         state.commit();
         break;
       case 'Escape':

--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -64,7 +64,8 @@ let actions = {
   onInputChange: action('onInputChange'),
   onSelectionChange: action('onSelectionChange'),
   onBlur: action('onBlur'),
-  onFocus: action('onFocus')
+  onFocus: action('onFocus'),
+  onCustomValueEnterPressed: action('onCustomValueEnterPressed')
 };
 
 storiesOf('ComboBox', module)
@@ -251,7 +252,7 @@ storiesOf('ComboBox', module)
   )
   .add(
     'validationState: invalid',
-    () => render({validationState: 'invalid', defaultSelectedKey: 'two'})
+    () => render({allowsCustomValue: true, validationState: 'invalid', defaultSelectedKey: 'two'})
   )
   .add(
     'validationState: valid',

--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -252,7 +252,7 @@ storiesOf('ComboBox', module)
   )
   .add(
     'validationState: invalid',
-    () => render({allowsCustomValue: true, validationState: 'invalid', defaultSelectedKey: 'two'})
+    () => render({validationState: 'invalid', defaultSelectedKey: 'two'})
   )
   .add(
     'validationState: valid',

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -32,6 +32,7 @@ let theme = {
   medium: scaleMedium
 };
 
+let onCustomValueEnterPressed = jest.fn();
 let onSelectionChange = jest.fn();
 let onOpenChange = jest.fn();
 let onInputChange = jest.fn();
@@ -1535,6 +1536,94 @@ describe('ComboBox', function () {
       expect(onSelectionChange).toHaveBeenCalledWith(null);
 
       expect(queryByRole('listbox')).toBeNull();
+    });
+
+    it('commits custom value and calls onCustomValueEnterPressed on Enter pressed', function () {
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <ComboBox label="Test" allowsCustomValue onCustomValueEnterPressed={onCustomValueEnterPressed} onInputChange={onInputChange} >
+            <Item key="1">Bulbasaur</Item>
+            <Item key="2">Squirtle</Item>
+            <Item key="3">Charmander</Item>
+          </ComboBox>
+        </Provider>
+      );
+
+      let combobox = getByRole('combobox');
+      act(() => {
+        userEvent.click(combobox);
+        jest.runAllTimers();
+      });
+      act(() => {
+        fireEvent.change(combobox, {target: {value: 'Bulba'}});
+        jest.runAllTimers();
+        combobox.blur();
+        jest.runAllTimers();
+        fireEvent.keyDown(combobox, {key: 'Enter', code: 13, charCode: 13});
+        fireEvent.keyUp(combobox, {key: 'Enter', code: 13, charCode: 13});
+        jest.runAllTimers();
+      });
+
+      expect(onInputChange).toHaveBeenCalledWith('Bulba');
+      expect(onCustomValueEnterPressed).toHaveBeenCalledWith('Bulba');
+    });
+
+    it('onCustomValueEnterPressed should not be called upon Enter press if menu is open', function () {
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <ComboBox label="Test" allowsCustomValue onCustomValueEnterPressed={onCustomValueEnterPressed} onOpenChange={onOpenChange}>
+            <Item key="1">Bulbasaur</Item>
+            <Item key="2">Squirtle</Item>
+            <Item key="3">Charmander</Item>
+          </ComboBox>
+        </Provider>
+      );
+
+      let combobox = getByRole('combobox');
+      act(() => {
+        userEvent.click(combobox);
+        jest.runAllTimers();
+      });
+      act(() => {
+        fireEvent.keyDown(combobox, {key: 'ArrowDown', code: 40, charCode: 40});
+        fireEvent.keyUp(combobox, {key: 'ArrowDown', code: 40, charCode: 40});
+        jest.runAllTimers();
+        fireEvent.keyDown(combobox, {key: 'Enter', code: 13, charCode: 13});
+        fireEvent.keyUp(combobox, {key: 'Enter', code: 13, charCode: 13});
+        jest.runAllTimers();
+      });
+
+      expect(onOpenChange).toHaveBeenCalled();
+      expect(onCustomValueEnterPressed).not.toHaveBeenCalled();
+    });
+
+    it('onCustomValueEnterPressed should not be called upon Enter press if allowsCustomValue is false', function () {
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <ComboBox label="Test" onCustomValueEnterPressed={onCustomValueEnterPressed} onInputChange={onInputChange} >
+            <Item key="1">Bulbasaur</Item>
+            <Item key="2">Squirtle</Item>
+            <Item key="3">Charmander</Item>
+          </ComboBox>
+        </Provider>
+      );
+
+      let combobox = getByRole('combobox');
+      act(() => {
+        userEvent.click(combobox);
+        jest.runAllTimers();
+      });
+      act(() => {
+        fireEvent.change(combobox, {target: {value: 'Bulba'}});
+        jest.runAllTimers();
+        combobox.blur();
+        jest.runAllTimers();
+        fireEvent.keyDown(combobox, {key: 'Enter', code: 13, charCode: 13});
+        fireEvent.keyUp(combobox, {key: 'Enter', code: 13, charCode: 13});
+        jest.runAllTimers();
+      });
+
+      expect(onCustomValueEnterPressed).not.toHaveBeenCalled();
     });
 
     it('retains selected key on blur if input value matches', function () {

--- a/packages/@react-types/combobox/src/index.d.ts
+++ b/packages/@react-types/combobox/src/index.d.ts
@@ -29,6 +29,8 @@ export interface ComboBoxProps<T> extends CollectionBase<T>, SingleSelection, In
   onInputChange?: (value: string) => void,
   /** Whether the ComboBox allows a non-item matching input value to be set. */
   allowsCustomValue?: boolean,
+  /** Handler that is called when allowsCustomValue is true and Enter was pressed. */
+  onCustomValueEnterPressed?: (value: string) => void,
   // /**
   //  * Whether the Combobox should only suggest matching options or autocomplete the field with the nearest matching option.
   //  * @default 'suggest'


### PR DESCRIPTION
Closes [2468](https://github.com/adobe/react-spectrum/issues/2468)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1) Use _allowsCustomValue: true_ storybook example
2) Type a "_pepe le pew_" in comboBox
3) Press Enter

Expected
----------
onCustomValueEnterPressed event is fired and _pepe le pew_ is passed to function

## 🧢 Your Project:

Adobe
