### PR TITLE
fix(checkbox): removes + selector to solve grey flicker

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/checkbox/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/checkbox/skin.css
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
 
 /* Indeterminate is basically a checked state, so handle colors for checked state here */
 .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-box,
-.spectrum-Checkbox-input:checked + .spectrum-Checkbox-box {
+.spectrum-Checkbox.is-checked .spectrum-Checkbox-box {
   &:before {
     border-color: var(--spectrum-checkbox-emphasized-box-border-color-selected);
   }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Check out this branch and run storybook
2. Navigate to the [TableView / dynamic with selection](http://localhost:9003/?path=/story/tableview--dynamic-with-selection) story.
3. Select all checkboxes.
4. Click any of the rows repeatedly to toggle its checkbox on and off.
5. Notice how the Select All checkbox will no longer flicker grey.

## 🧢 Your Project:

Issue: [Checkbox flickers gray when switching from indeterminate to selected in Chrome #1834](https://github.com/adobe/react-spectrum/issues/1834)

If you navigate to the hosted [TableView / dynamic with selection](https://reactspectrum.blob.core.windows.net/reactspectrum/21f32255590d88597e73618614e83a3a6a8cc73e/storybook-17/index.html?path=/story/tableview--dynamic-with-selection) story, you will see that after selecting all the checkboxes  and clicking on a row repeatedly (not the actual checkbox) you will see the grey checkbox. If you hover over it, it will immediately turn the correct blue color.

It looks like this is an issue with how Chrome is interpreting the `+` adjacent sibling selector (I tried it with the `~` general sibling selector as well, but it was doing the same thing). So I reworked the CSS to rely on class names instead of the sibling selector.

I did not update the Stories or documentation as this was a small CSS change, and the functionality works as expected.