### PR TITLE
Replace "start" with "flex-start" in CSS

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Breadcrumbs {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   list-style-type: none;
   flex-wrap: nowrap;
   flex-grow: 1;
@@ -46,7 +46,7 @@ governing permissions and limitations under the License.
 .spectrum-Breadcrumbs-item {
   display: inline-flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
 
   box-sizing: border-box;
   height: var(--spectrum-breadcrumb-list-height);

--- a/packages/@adobe/spectrum-css-temp/components/coachmark/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/coachmark/index.css
@@ -59,7 +59,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-CoachMarkPopover-step {
-  align-self: start;
+  align-self: flex-start;
 
   font-size: var(--spectrum-coachmark-step-text-size);
   font-weight: var(--spectrum-coachmark-step-text-font-weight);

--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -239,7 +239,7 @@ governing permissions and limitations under the License.
 .spectrum-Dialog.spectrum-Dialog--dismissable .spectrum-Dialog-closeButton {
   grid-area: closeButton;
   /* align and justify so it doesn't do the default 'stretch' and end up with forced height/width */
-  align-self: start;
+  align-self: flex-start;
   justify-self: end;
 
   margin-inline-end: var(--spectrum-dialog-close-button-padding);

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -121,7 +121,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu-checkmark {
   display: none;
-  align-self: start;
+  align-self: flex-start;
   justify-self: end;
   grid-area: checkmark;
 }
@@ -185,7 +185,7 @@ governing permissions and limitations under the License.
 .spectrum-Menu .spectrum-Menu-end {
   grid-area: end;
   justify-self: end;
-  align-self: start;
+  align-self: flex-start;
   padding-inline-start: var(--spectrum-global-dimension-size-125);
 }
 .spectrum-Menu-icon {
@@ -201,7 +201,7 @@ governing permissions and limitations under the License.
 }
 .spectrum-Menu-keyboard {
   grid-area: keyboard;
-  align-self: start;
+  align-self: flex-start;
   padding-inline-start: var(--spectrum-global-dimension-size-125);
   /* override default browser styling. */
   /* keyboard shortcuts are always ASCII, so use base font */

--- a/packages/@adobe/spectrum-css-temp/components/sidenav/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/sidenav/index.css
@@ -35,7 +35,7 @@ governing permissions and limitations under the License.
   position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   box-sizing: border-box;
 
   inline-size: 100%;


### PR DESCRIPTION
Currently when using react-spectrum eslint will show a warning about `start` having mixed support:

```
./node_modules/@react-spectrum/breadcrumbs/dist/main.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-4-1!./node_modules/postcss-loader/src??postcss!./node_modules/@rea
Warning

(1:745) start value has mixed support, consider using flex-start instead

./node_modules/@react-spectrum/breadcrumbs/dist/main.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-4-1!./node_modules/postcss-loader/src??postcss!./node_modules/@rea
Warning

(1:83) start value has mixed support, consider using flex-start instead
```

This was reported in #956, #844 and #768.

This fixes those warnings.

This takes over from https://github.com/adobe/react-spectrum/pull/1793 (from @MarkRedeman), which has been inactive since April 2021 and also borrows some changes from https://github.com/adobe/react-spectrum/pull/686 that never got applied.

A total of 5 files are modified:

```
$ git diff --stat main...HEAD
 packages/@adobe/spectrum-css-temp/components/breadcrumb/index.css | 4 ++--
 packages/@adobe/spectrum-css-temp/components/coachmark/index.css  | 2 +-
 packages/@adobe/spectrum-css-temp/components/dialog/index.css     | 2 +-
 packages/@adobe/spectrum-css-temp/components/menu/index.css       | 6 +++---
 packages/@adobe/spectrum-css-temp/components/sidenav/index.css    | 2 +-
 5 files changed, 8 insertions(+), 8 deletions(-)
```


Closes #768

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
