### PR TITLE
Add `getModules` function to make transpiling easier with Next.js.

### DIFF
--- a/lib/getModules.js
+++ b/lib/getModules.js
@@ -1,0 +1,50 @@
+// This defines a function called `getModules` that can get an array of all
+// React Spectrum modules.
+//
+// One use case for this function is it can be used to wrap the Next.js
+// configuration in `next.config.js` so that React Spectrum works in Next.js
+// without any errors.
+//
+// You can do something like this in your `next.config.js`:
+//
+// <next.config.js>
+//
+// const nextTranspileModules = require("next-transpile-modules");
+// const getReactSpectrumModules = require("react-spectrum-monorepo/lib/getModules");
+//
+// // This wraps the Next.js configuration to do some transpilations so that React
+// // Spectrum works in Next.js without any errors.
+// //
+// // Inspired by https://react-spectrum.adobe.com/react-spectrum/ssr.html#nextjs
+// //
+// const withTM = nextTranspileModules(getReactSpectrumModules());
+//
+// module.exports = withTM({
+//   // Your Next.js configuration
+// });
+//
+// </next.config.js>
+
+const fs = require("fs");
+
+const flatten = (arr) => arr.reduce((acc, val) => acc.concat(val));
+
+const getModules = () =>
+  flatten(
+    // Returns something like [
+    //   '@adobe/react-spectrum',
+    //   '@adobe/react-spectrum-ui',
+    //   '@adobe/react-spectrum-workflow',
+    //   '@react-spectrum/actiongroup',
+    //   '@react-spectrum/breadcrumbs',
+    //   '@react-spectrum/button',
+    //    ...
+    //   '@spectrum-icons/ui',
+    //   '@spectrum-icons/workflow'
+    // ]
+    ["@adobe", "@react-spectrum", "@spectrum-icons"].map((ns) =>
+      fs.readdirSync(`./node_modules/${ns}`).map((dir) => `${ns}/${dir}`)
+    )
+  );
+
+module.exports = getModules;

--- a/packages/dev/docs/pages/react-spectrum/ssr.mdx
+++ b/packages/dev/docs/pages/react-spectrum/ssr.mdx
@@ -58,52 +58,17 @@ First, you’ll need to install an additional Next.js plugin:
 yarn add next-transpile-modules
 ```
 
-With this installed, add the following to your `next.config.js` file. This will ensure that React Spectrum’s CSS is loaded properly by Next.js. Note that packages may need to be removed or added to the config below if using an older or newer version of React Spectrum.
+With this installed, add the following to your `next.config.js` file. This will ensure that React Spectrum’s CSS is loaded properly by Next.js.
 
 ```tsx
-const withTM = require("next-transpile-modules")([
-  "@adobe/react-spectrum",
-  "@react-spectrum/actiongroup",
-  "@react-spectrum/breadcrumbs",
-  "@react-spectrum/button",
-  "@react-spectrum/buttongroup",
-  "@react-spectrum/checkbox",
-  "@react-spectrum/combobox",
-  "@react-spectrum/dialog",
-  "@react-spectrum/divider",
-  "@react-spectrum/form",
-  "@react-spectrum/icon",
-  "@react-spectrum/illustratedmessage",
-  "@react-spectrum/image",
-  "@react-spectrum/label",
-  "@react-spectrum/layout",
-  "@react-spectrum/link",
-  "@react-spectrum/listbox",
-  "@react-spectrum/menu",
-  "@react-spectrum/meter",
-  "@react-spectrum/numberfield",
-  "@react-spectrum/overlays",
-  "@react-spectrum/picker",
-  "@react-spectrum/progress",
-  "@react-spectrum/provider",
-  "@react-spectrum/radio",
-  "@react-spectrum/slider",
-  "@react-spectrum/searchfield",
-  "@react-spectrum/statuslight",
-  "@react-spectrum/switch",
-  "@react-spectrum/table",
-  "@react-spectrum/tabs",
-  "@react-spectrum/text",
-  "@react-spectrum/textfield",
-  "@react-spectrum/theme-dark",
-  "@react-spectrum/theme-default",
-  "@react-spectrum/theme-light",
-  "@react-spectrum/tooltip",
-  "@react-spectrum/view",
-  "@react-spectrum/well",
-  "@spectrum-icons/ui",
-  "@spectrum-icons/workflow"
-]);
+const nextTranspileModules = require("next-transpile-modules");
+const getReactSpectrumModules = require("react-spectrum-monorepo/lib/getModules");
+
+// This wraps the Next.js configuration to do some transpilations so that React
+// Spectrum works in Next.js without any errors.
+//
+// Inspired by https://react-spectrum.adobe.com/react-spectrum/ssr.html#nextjs
+const withTM = nextTranspileModules(getReactSpectrumModules());
 
 module.exports = withTM({
   // Your Next.js configuration


### PR DESCRIPTION
Add `getModules` function to make transpiling for Next.js easier and less likely to break when new versions of React Spectrum are released.

```js
const withTM = nextTranspileModules(getReactSpectrumModules());

module.exports = withTM({
  // Your Next.js configuration
});
```

This can help prevent issues like #2638 in the future.

Closes #2638 #1156 ?

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
    #1156
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
    [`ssr.mdx`](https://github.com/adobe/react-spectrum/pull/2696/files#diff-12b20ae498a7f8c662dc426db28088a78035d8119c46a4cde7001536ecde5cb5)
- [X] **(N/A)** ~~Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)~~

## 📝 Test Instructions:

- Create a new Next app and `cd` into it
```sh
npx create-next-app next-with-react-spectrum-test
cd next-with-react-spectrum-test
```

- Modify `pages/index.js` to have:
```tsx
import {
  Button, Heading, Provider, SSRProvider, View,
  defaultTheme,
} from "@adobe/react-spectrum";

export default function Home() {
  return (
    <SSRProvider>
      <Provider theme={defaultTheme}>
        <View margin="size-150">
          <Heading level={1}>React Spectrum in Next.js</Heading>
          <Button>React Spectrum Button</Button>
        </View>
      </Provider>
    </SSRProvider>
  );
}
```

- Install necessary packages
```sh
npm install @adobe/react-spectrum
```

- Run the app
```sh
npm run dev
```

- Visit the app in the browser (e.g.: http://localhost:3000) and see the following error:

![Screen Shot 2021-12-17 at 8 54 10 AM](https://user-images.githubusercontent.com/305268/146580152-d54d00fe-1b95-4b0a-aa5a-f95b296fb428.png)

```
Failed to compile
./node_modules/@react-spectrum/actiongroup/dist/main.css
Global CSS cannot be imported from within node_modules.
Read more: https://nextjs.org/docs/messages/css-npm
Location: node_modules/@react-spectrum/actiongroup/dist/module.js
```

- Hit Ctrl-c to kill the dev server

Now do:

```sh
npm install --save-dev next-transpile-modules
```

Link to my package

```
$ pushd /path/to/clone/of/my/branch/of/this/monorepo
$ npm link
$ popd
$ npm link react-spectrum-monorepo
```

- Change `next.config.js` to:
```js
const nextTranspileModules = require("next-transpile-modules");
const getReactSpectrumModules = require("react-spectrum-monorepo/lib/getModules");

// This wraps the Next.js configuration to do some transpilations so that React
// Spectrum works in Next.js without any errors.
//
// Inspired by https://react-spectrum.adobe.com/react-spectrum/ssr.html#nextjs
const withReactSpectrum = nextTranspileModules(getReactSpectrumModules());

module.exports = withReactSpectrum({ reactStrictMode: true });
```

- Relaunch the dev server:
```
$ npm run dev
```

- Note that app (at http://localhost:3000/) now works!

![Screen Shot 2021-12-17 at 10 43 03 AM](https://user-images.githubusercontent.com/305268/146592822-cb69ae35-b76e-4c5c-8633-b0cf9baa4cff.png)

## 🧢 Your Project:

<!--- Company/project for pull request -->
https://github.com/msabramo/next-with-react-spectrum-test
