### PR TITLE
Updating minimum supported version for iOS

### DIFF
--- a/packages/@react-aria/interactions/docs/interactions.mdx
+++ b/packages/@react-aria/interactions/docs/interactions.mdx
@@ -110,7 +110,7 @@ mouse input, touchscreens, and also hybrid devices.
 
 * Chrome 80+ on macOS and Windows
 * Firefox 76+ on macOS and Windows
-* Safari 12+ on macOS
-* Edge 44+ on Windows
+* Safari 13+ on macOS
+* Edge 80+ on Windows
 * Safari 13+ on iOS and iPadOS
 * Chrome 80+ on Android

--- a/packages/@react-aria/interactions/docs/interactions.mdx
+++ b/packages/@react-aria/interactions/docs/interactions.mdx
@@ -112,5 +112,5 @@ mouse input, touchscreens, and also hybrid devices.
 * Firefox 76+ on macOS and Windows
 * Safari 12+ on macOS
 * Edge 44+ on Windows
-* Safari 12+ on iOS and iPadOS
+* Safari 13+ on iOS and iPadOS
 * Chrome 80+ on Android


### PR DESCRIPTION
Closes <!-- Github issue # here -->
We don't test on 12 anymore, so we cannot verify its support. We follow along with roughly the last two major versions of any given browser. iOS is now on 15.
We also aren't going to prioritize fixing anything for iOS 12, though we still welcome contributions to provide wider support if the PR isn't overly complicated.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
