### PR TITLE
missing semi-colon that parcel upgrade and docs-differ revealed

### DIFF
--- a/packages/@react-aria/ssr/docs/useIsSSR.mdx
+++ b/packages/@react-aria/ssr/docs/useIsSSR.mdx
@@ -50,5 +50,5 @@ import {useIsSSR} from '@react-aria/ssr';
 function MyComponent() {
   let isSSR = useIsSSR();
   return <span>{isSSR ? 'Server' : 'Client'}</span>;
-}
+};
 ```

--- a/packages/@react-aria/utils/docs/mergeProps.mdx
+++ b/packages/@react-aria/utils/docs/mergeProps.mdx
@@ -73,5 +73,5 @@ let merged = {
     a.onKeyDown(e);
     b.onKeyDown(e);
   }
-}
+};
 ```


### PR DESCRIPTION
Found when testing the parcel upgrade with docs-differ.

The previous configuration was adding missing semi-colons.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

goto react aria useIsSSR and mergeProps and all the code should have semicolons. 

## 🧢 Your Project:
RSP