### PR TITLE
Fix Icons docs build

### DIFF
--- a/packages/@react-spectrum/icon/docs/workflow-icons.mdx
+++ b/packages/@react-spectrum/icon/docs/workflow-icons.mdx
@@ -5,7 +5,7 @@ of the License at http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License. -->
+governing permissions and limitations under the License. */}
 
 import {Layout} from '@react-spectrum/docs';
 export default Layout;


### PR DESCRIPTION
Fixes Workflow Icons page being missing from docs build

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify Workflow Icons page is present in docs build

## 🧢 Your Project:

RSP
