### PR TITLE
Fix plop docs template after MDX upgrade

### DIFF
--- a/plop-templates/@react-spectrum/docs/{{ componentName }}.mdx.hbs
+++ b/plop-templates/@react-spectrum/docs/{{ componentName }}.mdx.hbs
@@ -1,11 +1,11 @@
-<!-- Copyright {{currentYear}} Adobe. All rights reserved.
+{/* Copyright {{currentYear}} Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License. -->
+governing permissions and limitations under the License. */}
 
 import {Layout} from '@react-spectrum/docs';
 export default Layout;


### PR DESCRIPTION

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify new plop template for React Spectrum components is compatible with MDX v2

## 🧢 Your Project:

RSP
