### PR TITLE
(Approach #1) Update keyboard navigation in CardView

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -88,10 +88,7 @@ user-provided
 .spectrum-Card-avatar
 .spectrum-Card-heading
 .spectrum-Card-detail
-.spectrum-Card-actions
 .spectrum-Card-content
-.spectrum-Card-divider
-.spectrum-Card-footer
  */
 
 
@@ -182,20 +179,10 @@ user-provided
   grid-area: detail;
   word-break: break-word;
 }
-.spectrum-Card-actions {
-  grid-area: actionmenu;
-  align-self: start;
-}
 .spectrum-Card-content {
   grid-area: content;
   word-break: break-word;
   overflow: hidden;
-}
-.spectrum-Card-divider {
-  grid-area: divider;
-}
-.spectrum-Card-footer {
-  grid-area: footer;
 }
 .spectrum-Card-decoration {
   display: none;
@@ -238,13 +225,13 @@ user-provided
 
   .spectrum-Card-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
       ".       .       .       .          ."
-      ".       title   detail  actionmenu ."
+      ".       title   detail  .          ."
       ".       content content content    ."
       ".       .       .       .          .";
 
@@ -265,7 +252,7 @@ user-provided
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       ".       .       .       .          ."
-      ".       title   detail  actionmenu ."
+      ".       title   detail  .          ."
       ".       content content content    ."
       ".       .       .       .          .";
 
@@ -313,8 +300,6 @@ user-provided
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
   }
@@ -357,13 +342,13 @@ user-provided
   &:not(.spectrum-Card--noPreview) .spectrum-Card-grid {
     display: grid;
     block-size: 100%;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), 1fr) var(--spectrum-global-dimension-size-200) minmax(var(--spectrum-actionbutton-height), auto) auto var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
       ".       .       .       .          ."
-      ".       title   detail  actionmenu ."
+      ".       title   detail  .          ."
       ".       content content content    ."
       ".       .       .       .          .";
 
@@ -380,12 +365,12 @@ user-provided
   &.spectrum-Card--noPreview .spectrum-Card-grid {
     display: grid;
     block-size: 100%;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       ".       .       .       .          ."
-      ".       title   detail  actionmenu ."
+      ".       title   detail  .          ."
       ".       content content content    ."
       ".       .       .       .          .";
 
@@ -433,8 +418,6 @@ user-provided
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
     white-space: nowrap;
@@ -478,16 +461,14 @@ user-provided
 
   &:not(.spectrum-Card--noPreview) .spectrum-Card-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr auto auto var(--spectrum-card-body-padding-bottom);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
       ".       .       .       .          ."
-      ".       title   detail  actionmenu ."
+      ".       title   detail  .          ."
       ".       content content content    ."
-      ".       divider divider divider    ."
-      ".       footer  footer  footer     ."
       ".       .       .       .          .";
 
     &:before {
@@ -502,15 +483,13 @@ user-provided
 
   &.spectrum-Card--noPreview .spectrum-Card-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr auto auto var(--spectrum-card-body-padding-bottom);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       ".       .       .       .          ."
-      ".       title   detail  actionmenu ."
+      ".       title   detail  .          ."
       ".       content content content    ."
-      ".       divider divider divider    ."
-      ".       footer  footer  footer     ."
       ".       .       .       .          .";
 
     /* TODO: is this accurate? if we don't want to enforce it, then we can
@@ -562,19 +541,8 @@ user-provided
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
-  }
-  .spectrum-Card-divider {
-    margin-block-start: 5px;
-    margin-block-end: 5px;
-  }
-  .spectrum-Card-footer {
-    margin-block-start: 5px;
-    display: flex;
-    justify-content: flex-end;
   }
 }
 /** END Standard Vertical **/
@@ -597,12 +565,12 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(30px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     grid-template-areas:
       "preview preview preview"
-      ".       .       ."
-      "title   detail  actionmenu"
+      ".       .       .      "
+      "title   detail  .      "
       "content content content"
       ".       .       .      ";
 
@@ -666,8 +634,6 @@ user-provided
     text-overflow: ellipsis;
     margin-inline-end: var(--spectrum-card-title-padding-right);
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
   }
@@ -690,12 +656,12 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(30px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
     grid-template-rows: 1fr var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) minmax(auto, var(--spectrum-global-dimension-size-600)) var(--spectrum-card-body-padding-bottom);
     grid-template-areas:
       "preview preview preview"
-      ".       .       ."
-      "title   detail  actionmenu"
+      ".       .       .      "
+      "title   detail  .      "
       "content content content"
       ".       .       .      ";
 
@@ -764,8 +730,6 @@ user-provided
     text-overflow: ellipsis;
     margin-inline-end: var(--spectrum-card-title-padding-right);
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
     white-space: nowrap;
@@ -789,12 +753,12 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(30px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
     grid-template-rows: auto var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) var(--spectrum-alias-single-line-height) 1fr;
     grid-template-areas:
       "preview preview preview"
-      ".       .       ."
-      "title   detail  actionmenu"
+      ".       .       .      "
+      "title   detail  .      "
       "content content content"
       ".       .       .      ";
 
@@ -881,8 +845,6 @@ user-provided
     text-overflow: ellipsis;
     margin-inline-end: var(--spectrum-card-title-padding-right);
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
     white-space: nowrap;
@@ -906,12 +868,12 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(30px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
     grid-template-rows: auto var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) auto var(--spectrum-card-body-padding-bottom);
     grid-template-areas:
       "preview preview preview"
-      ".       .       ."
-      "title   detail  actionmenu"
+      ".       .       .      "
+      "title   detail  .      "
       "content content content"
       ".       .       .      ";
 
@@ -977,16 +939,8 @@ user-provided
     text-overflow: ellipsis;
     margin-inline-end: var(--spectrum-card-title-padding-right);
   }
-  .spectrum-Card-actions {
-  }
   .spectrum-Card-content {
     margin-block-end: 5px;
-  }
-  .spectrum-Card-divider {
-    display: none;
-  }
-  .spectrum-Card-footer {
-    display: none;
   }
 }
 /** END Quiet Vertical **/
@@ -1020,9 +974,9 @@ For now working around it with a useLayoutEffect in CardBase.
     display: grid;
     block-size: 100%;
     grid-template-columns: auto var(--spectrum-global-dimension-size-200) 1fr auto var(--spectrum-global-dimension-size-200);
-    grid-template-rows: auto 1fr var(--spectrum-global-dimension-size-200);
+    grid-template-rows: var(--spectrum-global-dimension-size-400) 1fr var(--spectrum-global-dimension-size-200);
     grid-template-areas:
-      "preview . title   actionmenu ."
+      "preview . title   .       ."
       "preview . content content ."
       "preview . .       .       .";
 
@@ -1072,8 +1026,6 @@ For now working around it with a useLayoutEffect in CardBase.
   .spectrum-Card-detail {
     display: none;
   }
-  .spectrum-Card-actions {
-  }
   /* how to handle long description?? */
   .spectrum-Card-content {
     width: 100%;
@@ -1112,9 +1064,9 @@ For now working around it with a useLayoutEffect in CardBase.
     block-size: 100%;
     max-block-size: 100%;
     grid-template-columns: auto var(--spectrum-global-dimension-size-200) 1fr auto var(--spectrum-global-dimension-size-200);
-    grid-template-rows: auto 1fr var(--spectrum-global-dimension-size-200);
+    grid-template-rows: var(--spectrum-global-dimension-size-400) 1fr var(--spectrum-global-dimension-size-200);
     grid-template-areas:
-      "preview . title   actionmenu ."
+      "preview . title   .       ."
       "preview . content content ."
       "preview . .       .       .";
 
@@ -1171,8 +1123,6 @@ For now working around it with a useLayoutEffect in CardBase.
   .spectrum-Card-detail {
     display: none;
   }
-  .spectrum-Card-actions {
-  }
   /* how to handle long description?? */
   .spectrum-Card-content {
     width: 100%;
@@ -1182,12 +1132,6 @@ For now working around it with a useLayoutEffect in CardBase.
     /* not working because this line is removed in css preprocessing */
     -webkit-box-orient: vertical;
     visibility: visible;
-  }
-  .spectrum-Card-divider {
-    display: none;
-  }
-  .spectrum-Card-footer {
-    display: none;
   }
 }
 /** END Standard Horizontal **/

--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -225,7 +225,7 @@ user-provided
 
   .spectrum-Card-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
@@ -342,7 +342,7 @@ user-provided
   &:not(.spectrum-Card--noPreview) .spectrum-Card-grid {
     display: grid;
     block-size: 100%;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), 1fr) var(--spectrum-global-dimension-size-200) minmax(var(--spectrum-actionbutton-height), auto) auto var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
@@ -365,7 +365,7 @@ user-provided
   &.spectrum-Card--noPreview .spectrum-Card-grid {
     display: grid;
     block-size: 100%;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
@@ -461,7 +461,7 @@ user-provided
 
   &:not(.spectrum-Card--noPreview) .spectrum-Card-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
@@ -483,7 +483,7 @@ user-provided
 
   &.spectrum-Card--noPreview .spectrum-Card-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(40px, 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
+    grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
     grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
@@ -565,7 +565,7 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
     grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     grid-template-areas:
       "preview preview preview"
@@ -656,7 +656,7 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
     grid-template-rows: 1fr var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) minmax(auto, var(--spectrum-global-dimension-size-600)) var(--spectrum-card-body-padding-bottom);
     grid-template-areas:
       "preview preview preview"
@@ -753,7 +753,7 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
     grid-template-rows: auto var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) var(--spectrum-alias-single-line-height) 1fr;
     grid-template-areas:
       "preview preview preview"
@@ -868,7 +868,7 @@ user-provided
   .spectrum-Card-grid {
     block-size: 100%;
     display: grid;
-    grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
+    grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
     grid-template-rows: auto var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) auto var(--spectrum-card-body-padding-bottom);
     grid-template-areas:
       "preview preview preview"

--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -239,15 +239,13 @@ user-provided
   .spectrum-Card-grid {
     display: grid;
     grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr auto auto var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
       ".       .       .       .          ."
       ".       title   detail  actionmenu ."
       ".       content content content    ."
-      ".       divider divider divider    ."
-      ".       footer  footer  footer     ."
       ".       .       .       .          .";
 
     &:before {
@@ -263,14 +261,12 @@ user-provided
   &.spectrum-Card--noPreview .spectrum-Card-grid {
     display: grid;
     grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr auto auto var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       ".       .       .       .          ."
       ".       title   detail  actionmenu ."
       ".       content content content    ."
-      ".       divider divider divider    ."
-      ".       footer  footer  footer     ."
       ".       .       .       .          .";
 
     .spectrum-Card-avatar {
@@ -322,15 +318,6 @@ user-provided
   .spectrum-Card-content {
     margin-block-end: 5px;
   }
-  .spectrum-Card-divider {
-    margin-block-start: 5px;
-    margin-block-end: 5px;
-  }
-  .spectrum-Card-footer {
-    margin-block-start: 5px;
-    display: flex;
-    justify-content: flex-end;
-  }
 }
 
 /** Tile **/
@@ -371,15 +358,13 @@ user-provided
     display: grid;
     block-size: 100%;
     grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), 1fr) var(--spectrum-global-dimension-size-200) minmax(var(--spectrum-actionbutton-height), auto) auto auto auto var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), 1fr) var(--spectrum-global-dimension-size-200) minmax(var(--spectrum-actionbutton-height), auto) auto var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
       ".       .       .       .          ."
       ".       title   detail  actionmenu ."
       ".       content content content    ."
-      ".       divider divider divider    ."
-      ".       footer  footer  footer     ."
       ".       .       .       .          .";
 
     &:before {
@@ -396,14 +381,12 @@ user-provided
     display: grid;
     block-size: 100%;
     grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) 1fr minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr auto auto var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: var(--spectrum-global-dimension-size-300) auto 1fr var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       ".       .       .       .          ."
       ".       title   detail  actionmenu ."
       ".       content content content    ."
-      ".       divider divider divider    ."
-      ".       footer  footer  footer     ."
       ".       .       .       .          .";
 
     .spectrum-Card-avatar {
@@ -456,15 +439,6 @@ user-provided
     margin-block-end: 5px;
     white-space: nowrap;
     text-overflow: ellipsis;
-  }
-  .spectrum-Card-divider {
-    margin-block-start: 5px;
-    margin-block-end: 5px;
-  }
-  .spectrum-Card-footer {
-    margin-block-start: 5px;
-    display: flex;
-    justify-content: flex-end;
   }
 }
 
@@ -697,12 +671,6 @@ user-provided
   .spectrum-Card-content {
     margin-block-end: 5px;
   }
-  .spectrum-Card-divider {
-    display: none;
-  }
-  .spectrum-Card-footer {
-    display: none;
-  }
 }
 
 /** Gallery **/
@@ -802,12 +770,6 @@ user-provided
     margin-block-end: 5px;
     white-space: nowrap;
     text-overflow: ellipsis;
-  }
-  .spectrum-Card-divider {
-    display: none;
-  }
-  .spectrum-Card-footer {
-    display: none;
   }
 }
 
@@ -925,12 +887,6 @@ user-provided
     margin-block-end: 5px;
     white-space: nowrap;
     text-overflow: ellipsis;
-  }
-  .spectrum-Card-divider {
-    display: none;
-  }
-  .spectrum-Card-footer {
-    display: none;
   }
 }
 
@@ -1127,12 +1083,6 @@ For now working around it with a useLayoutEffect in CardBase.
     /* not working because this line is removed in css preprocessing */
     -webkit-box-orient: vertical;
     visibility: visible;
-  }
-  .spectrum-Card-divider {
-    display: none;
-  }
-  .spectrum-Card-footer {
-    display: none;
   }
 }
 

--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -1149,6 +1149,15 @@ For now working around it with a useLayoutEffect in CardBase.
   }
   .spectrum-CardView-row {
     outline: none;
-    height: 100%
+    height: 100%;
+
+    /* Card "row" div is focused instead of the grid cell when in a CardView so handling that case here */
+    &.focus-ring {
+      .spectrum-Card-checkboxWrapper {
+        visibility: visible;
+        opacity: 1;
+        pointer-events: all;
+      }
+    }
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/card/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/skin.css
@@ -348,3 +348,56 @@ governing permissions and limitations under the License.
   .spectrum-Card-footer {
   }
 }
+
+ /* Card "row" div is focused instead of the grid cell when in a CardView so handle focus ring cases here */
+.spectrum-CardView {
+  .spectrum-CardView-row:focus-ring {
+    .spectrum-Card--default {
+      border-color: var(--spectrum-card-border-color-key-focus);
+      &:before {
+        box-shadow: 0 0 0 2px var(--spectrum-card-border-color-key-focus);
+      }
+
+      &:hover.is-selected {
+        border-color: var(--spectrum-card-border-color-key-focus);
+        &:before {
+          box-shadow: 0 0 0 2px var(--spectrum-card-border-color-key-focus);
+        }
+      }
+    }
+
+    .spectrum-Card--isQuiet {
+      .spectrum-Card-grid {
+        &:after {
+          box-shadow: 0 0 0 2px var(--spectrum-card-border-color-key-focus);
+        }
+      }
+
+      &:hover.is-selected {
+        .spectrum-Card-grid {
+          &:after {
+            box-shadow: 0 0 0 2px var(--spectrum-card-border-color-key-focus);
+          }
+        }
+      }
+    }
+
+    .spectrum-Card--horizontal {
+      border-color: var(--spectrum-card-border-color-key-focus);
+      .spectrum-Card-grid {
+        &:before {
+          box-shadow: 0 0 0 2px var(--spectrum-card-border-color-key-focus);
+        }
+      }
+
+      &:hover.is-selected {
+        border-color: var(--spectrum-card-border-color-key-focus);
+        .spectrum-Card-grid {
+          &:before {
+            box-shadow: 0 0 0 2px var(--spectrum-card-border-color-key-focus);
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/@react-aria/grid/src/useGridCell.ts
+++ b/packages/@react-aria/grid/src/useGridCell.ts
@@ -96,8 +96,6 @@ export function useGridCell<T, C extends GridCollection<T>>(props: GridCellProps
       return;
     }
 
-    // TODO: Can't do {tabbable: true} because that would stop focus from reaching the roving tabindex -1 buttons in a action group
-    // within a grid cell
     let walker = getFocusableTreeWalker(ref.current);
     walker.currentNode = document.activeElement;
 

--- a/packages/@react-aria/grid/src/useGridCell.ts
+++ b/packages/@react-aria/grid/src/useGridCell.ts
@@ -96,6 +96,8 @@ export function useGridCell<T, C extends GridCollection<T>>(props: GridCellProps
       return;
     }
 
+    // TODO: Can't do {tabbable: true} because that would stop focus from reaching the roving tabindex -1 buttons in a action group
+    // within a grid cell
     let walker = getFocusableTreeWalker(ref.current);
     walker.currentNode = document.activeElement;
 
@@ -150,7 +152,7 @@ export function useGridCell<T, C extends GridCollection<T>>(props: GridCellProps
         if (focusMode === 'child' && focusable === ref.current) {
           focusable = null;
         }
-
+        console.log('focusable', focusable);
         if (focusable) {
           e.preventDefault();
           e.stopPropagation();

--- a/packages/@react-spectrum/card/src/CardBase.tsx
+++ b/packages/@react-spectrum/card/src/CardBase.tsx
@@ -174,7 +174,6 @@ function CardBase<T extends object>(props: CardBaseProps<T>, ref: DOMRef<HTMLDiv
           {manager && manager.selectionMode !== 'none' && (
             <div className={classNames(styles, 'spectrum-Card-checkboxWrapper')}>
               <Checkbox
-                preventFocus
                 isDisabled={isDisabled}
                 excludeFromTabOrder
                 isSelected={isSelected}

--- a/packages/@react-spectrum/card/src/CardBase.tsx
+++ b/packages/@react-spectrum/card/src/CardBase.tsx
@@ -174,6 +174,7 @@ function CardBase<T extends object>(props: CardBaseProps<T>, ref: DOMRef<HTMLDiv
           {manager && manager.selectionMode !== 'none' && (
             <div className={classNames(styles, 'spectrum-Card-checkboxWrapper')}>
               <Checkbox
+                preventFocus
                 isDisabled={isDisabled}
                 excludeFromTabOrder
                 isSelected={isSelected}

--- a/packages/@react-spectrum/card/src/CardView.tsx
+++ b/packages/@react-spectrum/card/src/CardView.tsx
@@ -14,6 +14,7 @@ import {CardBase} from './CardBase';
 import {CardViewContext, useCardViewContext} from './CardViewContext';
 import {classNames, useDOMRef, useStyleProps, useUnwrapDOMRef} from '@react-spectrum/utils';
 import {DOMRef, DOMRefValue, Node} from '@react-types/shared';
+import {FocusRing} from '@react-aria/focus';
 import {GridCollection, useGridState} from '@react-stately/grid';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -73,7 +74,7 @@ function CardView<T extends object>(props: SpectrumCardViewProps<T>, ref: DOMRef
     ...props,
     selectionMode: cardOrientation === 'horizontal' && layoutType === 'grid' ? 'none' : props.selectionMode,
     collection: gridCollection,
-    focusMode: 'cell'
+    focusMode: 'row'
   });
 
   cardViewLayout.collection = gridCollection;
@@ -84,7 +85,8 @@ function CardView<T extends object>(props: SpectrumCardViewProps<T>, ref: DOMRef
   let {gridProps} = useGrid({
     ...props,
     isVirtualized: true,
-    keyboardDelegate: cardViewLayout
+    keyboardDelegate: cardViewLayout,
+    focusMode: 'row'
   }, state, domRef);
 
   type View = ReusableView<Node<T>, unknown>;
@@ -96,10 +98,6 @@ function CardView<T extends object>(props: SpectrumCardViewProps<T>, ref: DOMRef
   );
 
   let focusedKey = state.selectionManager.focusedKey;
-  let focusedItem = gridCollection.getItem(state.selectionManager.focusedKey);
-  if (focusedItem?.parentKey != null) {
-    focusedKey = focusedItem.parentKey;
-  }
 
   let margin = cardViewLayout.margin || 0;
   let virtualizer = cardViewLayout.virtualizer;
@@ -205,17 +203,19 @@ function InternalCard(props) {
   }
 
   return (
-    <div {...rowProps} ref={rowRef} className={classNames(styles, 'spectrum-CardView-row')}>
-      <CardBase
-        ref={cellRef}
-        articleProps={gridCellProps}
-        isQuiet={isQuiet}
-        orientation={cardOrientation}
-        item={item}
-        layout={layoutType}>
-        {item.rendered}
-      </CardBase>
-    </div>
+    <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+      <div {...rowProps} ref={rowRef} className={classNames(styles, 'spectrum-CardView-row')}>
+        <CardBase
+          ref={cellRef}
+          articleProps={gridCellProps}
+          isQuiet={isQuiet}
+          orientation={cardOrientation}
+          item={item}
+          layout={layoutType}>
+          {item.rendered}
+        </CardBase>
+      </div>
+    </FocusRing>
   );
 }
 

--- a/packages/@react-spectrum/card/src/CardView.tsx
+++ b/packages/@react-spectrum/card/src/CardView.tsx
@@ -74,7 +74,8 @@ function CardView<T extends object>(props: SpectrumCardViewProps<T>, ref: DOMRef
     ...props,
     selectionMode: cardOrientation === 'horizontal' && layoutType === 'grid' ? 'none' : props.selectionMode,
     collection: gridCollection,
-    focusMode: 'row'
+    focusMode: 'row',
+    preventCellFocus: true
   });
 
   cardViewLayout.collection = gridCollection;

--- a/packages/@react-spectrum/card/src/GridLayout.tsx
+++ b/packages/@react-spectrum/card/src/GridLayout.tsx
@@ -245,30 +245,26 @@ export class GridLayout<T> extends BaseLayout<T> {
   // then return the key that occupies the row + column below. This can be done by figuring out how many cards exist per column then dividing the
   // collection contents by that number (which will give us the row distribution)
   getKeyBelow(key: Key) {
-    // Expected key is the currently focused cell so we need the parent row key
-    let parentRowKey = this.collection.getItem(key).parentKey;
     let indexRowBelow;
-    let index = this.collection.rows.findIndex(card => card.key === parentRowKey);
+    let index = this.collection.rows.findIndex(card => card.key === key);
     if (index !== -1) {
       indexRowBelow = index + this.numColumns;
     } else {
       return null;
     }
 
-    return this.collection.rows[indexRowBelow]?.childNodes[0].key || null;
+    return this.collection.rows[indexRowBelow]?.key || null;
   }
 
   getKeyAbove(key: Key) {
-    // Expected key is the currently focused cell so we need the parent row key
-    let parentRowKey = this.collection.getItem(key).parentKey;
     let indexRowAbove;
-    let index = this.collection.rows.findIndex(card => card.key === parentRowKey);
+    let index = this.collection.rows.findIndex(card => card.key === key);
     if (index !== -1) {
       indexRowAbove = index - this.numColumns;
     } else {
       return null;
     }
 
-    return this.collection.rows[indexRowAbove]?.childNodes[0].key || null;
+    return this.collection.rows[indexRowAbove]?.key || null;
   }
 }

--- a/packages/@react-spectrum/card/src/WaterfallLayout.tsx
+++ b/packages/@react-spectrum/card/src/WaterfallLayout.tsx
@@ -216,7 +216,7 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
       key = this._findClosest(layoutInfo.rect, rect)?.key;
     }
 
-    return this.collection.getItem(key)?.childNodes[0]?.key;
+    return key;
   }
 
   getClosestLeft(key: Key) {
@@ -230,18 +230,14 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
       key = this._findClosest(layoutInfo.rect, rect)?.key;
     }
 
-    return this.collection.getItem(key)?.childNodes[0]?.key;
+    return key;
   }
 
   getKeyRightOf(key: Key) {
-    // Expected key is the currently focused cell so we need the parent row key
-    let parentRowKey = this.collection.getItem(key).parentKey;
-    return this.direction === 'rtl' ?  this.getClosestLeft(parentRowKey) : this.getClosestRight(parentRowKey);
+    return this.direction === 'rtl' ?  this.getClosestLeft(key) : this.getClosestRight(key);
   }
 
   getKeyLeftOf(key: Key) {
-    // Expected key is the currently focused cell so we need the parent row key
-    let parentRowKey = this.collection.getItem(key).parentKey;
-    return this.direction === 'rtl' ?  this.getClosestRight(parentRowKey) : this.getClosestLeft(parentRowKey);
+    return this.direction === 'rtl' ?  this.getClosestRight(key) : this.getClosestLeft(key);
   }
 }

--- a/packages/@react-spectrum/card/stories/Card.stories.tsx
+++ b/packages/@react-spectrum/card/stories/Card.stories.tsx
@@ -10,15 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionMenu, Item} from '@react-spectrum/menu';
 import assetStyles from '@adobe/spectrum-css-temp/components/asset/vars.css';
 import {Avatar} from '@react-spectrum/avatar';
-import {Button} from '@react-spectrum/button';
 import {Card} from '..';
 import {CardBase} from '../src/CardBase';
 import {CardViewContext} from '../src/CardViewContext';
 import {classNames, useSlotProps, useStyleProps} from '@react-spectrum/utils';
-import {Content, Footer} from '@react-spectrum/view';
+import {Content} from '@react-spectrum/view';
 import {getDescription, getImage} from './utils';
 import {Heading, Text} from '@react-spectrum/text';
 import {IllustratedMessage} from '@react-spectrum/illustratedmessage';
@@ -100,13 +98,6 @@ Default.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -117,13 +108,6 @@ DefaultSquare.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -134,13 +118,6 @@ DefaultTall.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -151,13 +128,6 @@ DefaultPreviewAlt.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -168,13 +138,6 @@ LongContent.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>This is the description that never ends, it goes on and on my friends. Someone started typing without knowing what it was.</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -185,13 +148,6 @@ LongContentSquare.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>This is the description that never ends, it goes on and on my friends. Someone started typing without knowing what it was.</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -202,13 +158,6 @@ LongContentPoorWordSize.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -218,13 +167,6 @@ NoDescription.args = {children: (
     <Image src="https://i.imgur.com/Z7AzH2c.png" />
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -234,53 +176,6 @@ NoDescriptionSquare.args = {children: (
     <Image src="https://i.imgur.com/DhygPot.jpg" />
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
-  </>
-)};
-
-export const NoFooter = Template().bind({});
-NoFooter.args = {children: (
-  <>
-    <Image src="https://i.imgur.com/Z7AzH2c.png" />
-    <Heading>Title</Heading>
-    <Text slot="detail">PNG</Text>
-    <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-  </>
-)};
-
-export const NoActionMenu = Template().bind({});
-NoActionMenu.args = {children: (
-  <>
-    <Image src="https://i.imgur.com/Z7AzH2c.png" />
-    <Heading>Title</Heading>
-    <Text slot="detail">PNG</Text>
-    <Content>Description</Content>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
-  </>
-)};
-
-export const NoFooterOrDescription = Template().bind({});
-NoFooterOrDescription.args = {children: (
-  <>
-    <Image src="https://i.imgur.com/Z7AzH2c.png" />
-    <Heading>Title</Heading>
-    <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
   </>
 )};
 
@@ -289,10 +184,6 @@ NoImage.args = {children: (
   <>
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
   </>
 )};
 
@@ -322,13 +213,6 @@ export const CardGrid = (props: SpectrumCardProps) => {
                 <Heading>Title {index}</Heading>
                 <Text slot="detail">PNG</Text>
                 <Content>Description</Content>
-                <ActionMenu>
-                  <Item>Action 1</Item>
-                  <Item>Action 2</Item>
-                </ActionMenu>
-                <Footer>
-                  <Button variant="secondary">Button</Button>
-                </Footer>
               </Card>
             </div>
           );
@@ -359,13 +243,6 @@ export const CardWaterfall = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>{getDescription(index)}</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="secondary">Button</Button>
-              </Footer>
             </Card>
           </div>
         );
@@ -390,13 +267,6 @@ export const CardFloat = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="secondary">Button</Button>
-              </Footer>
             </Card>
           </div>
         );
@@ -431,13 +301,6 @@ export const CardGridMessyText = (props: SpectrumCardProps) => {
                 <Heading>{index} Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Heading>
                 <Text slot="detail">Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Text>
                 <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-                <ActionMenu>
-                  <Item>Action 1</Item>
-                  <Item>Action 2</Item>
-                </ActionMenu>
-                <Footer>
-                  <Button variant="primary">Something</Button>
-                </Footer>
               </Card>
             </div>
           );
@@ -468,13 +331,6 @@ export const CardWaterfallMessyText = (props: SpectrumCardProps) => (
               <Heading>{index} Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Heading>
               <Text slot="detail">Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Text>
               <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="primary">Something</Button>
-              </Footer>
             </Card>
           </div>
         );
@@ -508,13 +364,6 @@ export const CardGridNoPreview = (props: SpectrumCardProps) => {
                 <Heading>Title {index}</Heading>
                 <Text slot="detail">PNG</Text>
                 <Content>Description</Content>
-                <ActionMenu>
-                  <Item>Action 1</Item>
-                  <Item>Action 2</Item>
-                </ActionMenu>
-                <Footer>
-                  <Button variant="secondary">Button</Button>
-                </Footer>
               </Card>
             </div>
           );
@@ -544,13 +393,6 @@ export const CardWaterfallNoPreview = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>{getDescription(index)}</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="secondary">Button</Button>
-              </Footer>
             </Card>
           </div>
         );
@@ -565,10 +407,6 @@ WithIllustration.args = {children: (
     <File alt="file" slot="illustration" width={50} height={50} />
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
   </>
 )};
 
@@ -578,10 +416,6 @@ WithColorfulIllustration.args = {children: (
     <IllustrationContainer><ColorfulIllustration /></IllustrationContainer>
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
   </>
 )};
 WithColorfulIllustration.decorators = [(Story) => (
@@ -598,10 +432,6 @@ WithColorfulIllustratedMessage.args = {children: (
     <IllustratedMessage><ColorfulIllustration /></IllustratedMessage>
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
   </>
 )};
 WithColorfulIllustratedMessage.decorators = [(Story) => (
@@ -618,13 +448,6 @@ LongTitle.args = {children: (
     <Heading>This is a long title about how dinosaurs used to rule the earth before a meteor came and wiped them all out</Heading>
     <Text slot="detail">PNG</Text>
     <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -636,13 +459,6 @@ LongDescription.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">PNG</Text>
     <Content>This is a long description about the Pterodactyl, a pterosaur of the late Jurassic period, with a long slender head and neck and a very short tail.</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -653,13 +469,6 @@ LongDetail.args = {children: (
     <Heading>Title</Heading>
     <Text slot="detail">Stats: Genus: Pterodactylus; Rafinesque, 1815 Order: Pterosauria Kingdom: Animalia Phylum: Chordata</Text>
     <Content>Description</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 
@@ -670,13 +479,6 @@ LongEverything.args = {children: (
     <Heading>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Heading>
     <Text slot="detail">Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Text>
     <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-    <ActionMenu>
-      <Item>Action 1</Item>
-      <Item>Action 2</Item>
-    </ActionMenu>
-    <Footer>
-      <Button variant="primary">Something</Button>
-    </Footer>
   </>
 )};
 

--- a/packages/@react-spectrum/card/stories/GalleryCardView.stories.tsx
+++ b/packages/@react-spectrum/card/stories/GalleryCardView.stories.tsx
@@ -36,7 +36,7 @@ import {useMemo} from 'react';
 
 let itemsLowVariance = [
   {width: 1001, height: 381, src: 'https://i.imgur.com/Z7AzH2c.jpg', id: 1, title: 'Bob 1'},
-  {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', id: 2, title: 'Joe 1'},
+  {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', id: 2, title: 'Joe 1 really really really really long'},
   {width: 314, height: 1009, src: 'https://i.imgur.com/3lzeoK7.jpg', id: 3, title: 'Jane 1'},
   {width: 1516, height: 1009, src: 'https://i.imgur.com/1nScMIH.jpg', id: 4, title: 'Bob 2'},
   {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', id: 5, title: 'Joe 2'},
@@ -61,7 +61,7 @@ let itemsLowVariance = [
 
 let itemsNoThinImages = [
   {width: 1001, height: 381, src: 'https://i.imgur.com/Z7AzH2c.jpg', id: 1, title: 'Bob 1'},
-  {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', id: 2, title: 'Joe 1'},
+  {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', id: 2, title: 'Joe 1 really really really really long'},
   {width: 1516, height: 1009, src: 'https://i.imgur.com/1nScMIH.jpg', id: 4, title: 'Jane 1'},
   {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', id: 5, title: 'Bob 2'},
   {width: 1516, height: 1009, src: 'https://i.imgur.com/1nScMIH.jpg', id: 6, title: 'Joe 2'},

--- a/packages/@react-spectrum/card/stories/GridCardView.stories.tsx
+++ b/packages/@react-spectrum/card/stories/GridCardView.stories.tsx
@@ -31,7 +31,7 @@ import {useProvider} from '@react-spectrum/provider';
 
 let items = [
   {width: 1001, height: 381, src: 'https://i.imgur.com/Z7AzH2c.jpg', title: 'Bob 1'},
-  {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', title: 'Joe 1'},
+  {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', title: 'Joe 1 really really really really really really really really really really really really long'},
   {width: 182, height: 1009, src: 'https://i.imgur.com/L7RTlvI.png', title: 'Jane 1'},
   {width: 1516, height: 1009, src: 'https://i.imgur.com/1nScMIH.jpg', title: 'Bob 2'},
   {width: 640, height: 640, src: 'https://i.imgur.com/DhygPot.jpg', title: 'Joe 2'},

--- a/packages/@react-spectrum/card/stories/GridCardView.stories.tsx
+++ b/packages/@react-spectrum/card/stories/GridCardView.stories.tsx
@@ -11,10 +11,9 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionButton, Button} from '@react-spectrum/button';
-import {ActionMenu, Item} from '@react-spectrum/menu';
+import {ActionButton} from '@react-spectrum/button';
 import {Card, CardView, GridLayout} from '../';
-import {Content, Footer} from '@react-spectrum/view';
+import {Content} from '@react-spectrum/view';
 import {Flex} from '@react-spectrum/layout';
 import {getImageFullData} from './utils';
 import {GridLayoutOptions} from '../src/GridLayout';
@@ -214,13 +213,6 @@ function DynamicCardView(props: SpectrumCardViewProps<object>) {
               <Heading>{item.title}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Very very very very very very very very very very very very very long description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="primary">Something</Button>
-              </Footer>
             </Card>
           )}
         </CardView>
@@ -269,13 +261,6 @@ function ControlledCardView(props: SpectrumCardViewProps<object>) {
               <Heading>{item.title}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Very very very very very very very very very very very very very long description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="primary">Something</Button>
-              </Footer>
             </Card>
           )}
         </CardView>
@@ -310,13 +295,6 @@ function NoItemCardView(props: SpectrumCardViewProps<object>) {
             <Heading>{item.title}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Very very very very very very very very very very very very very long description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
-            <Footer>
-              <Button variant="primary">Something</Button>
-            </Footer>
           </Card>
         )}
       </CardView>
@@ -348,54 +326,29 @@ function StaticCardView(props: SpectrumCardViewProps<object>) {
           <Heading>Bob 1</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Very very very very very very very very very very very very very long description</Content>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
-          <Footer>
-            <Button variant="primary">Something</Button>
-          </Footer>
         </Card>
         <Card key="Joe 1" width={640} height={640} textValue="Joe 1">
           <Image src="https://i.imgur.com/DhygPot.jpg" />
           <Heading>Joe 1</Heading>
           <Text slot="detail">PNG</Text>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
         </Card>
         <Card key="Jane 1" width={182} height={1009} textValue="Jane 1">
           <Image src="https://i.imgur.com/L7RTlvI.png" />
           <Heading>Jane 1</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Description</Content>
-          <Footer>
-            <Button variant="primary">Something</Button>
-          </Footer>
         </Card>
         <Card key="Bob 2" width={1516} height={1009} textValue="Bob 2">
           <Image src="https://i.imgur.com/1nScMIH.jpg" />
           <Heading>Bob 2</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Very very very very very very very very very very very very very long description</Content>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
         </Card>
         <Card key="Joe 2" width={640} height={640} textValue="Joe 2">
           <Image src="https://i.imgur.com/DhygPot.jpg" />
           <Heading>Joe 2</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Description</Content>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
-          <Footer>
-            <Button variant="primary">Something</Button>
-          </Footer>
         </Card>
       </CardView>
     </div>
@@ -449,13 +402,6 @@ function AsyncLoadingCardView(props: SpectrumCardViewProps<object>) {
             <Heading>{item.title}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Very very very very very very very very very very very very very long description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
-            <Footer>
-              <Button variant="primary">Something</Button>
-            </Footer>
           </Card>
         )}
       </CardView>
@@ -507,13 +453,6 @@ export function CustomLayout(props: SpectrumCardViewProps<object> & LayoutOption
               <Heading>{item.title}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Very very very very very very very very very very very very very long description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
-              <Footer>
-                <Button variant="primary">Something</Button>
-              </Footer>
             </Card>
           )}
         </CardView>

--- a/packages/@react-spectrum/card/stories/HorizontalCard.stories.tsx
+++ b/packages/@react-spectrum/card/stories/HorizontalCard.stories.tsx
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionMenu, Item} from '@react-spectrum/menu';
 import {Card} from '..';
 import {Content} from '@react-spectrum/view';
 import {
@@ -20,7 +19,6 @@ import {
   LongContent,
   LongDetail,
   LongTitle,
-  NoActionMenu,
   NoDescription,
   NoDescriptionSquare,
   WithIllustration
@@ -65,9 +63,6 @@ HorizontalNoDescription.args = {...Horizontal.args, ...NoDescription.args};
 export const HorizontalNoDescriptionSquare = Template().bind({});
 HorizontalNoDescriptionSquare.args = {...Horizontal.args, ...NoDescriptionSquare.args};
 
-export const HorizontalNoActionMenu = Template().bind({});
-HorizontalNoActionMenu.args = {...Horizontal.args, ...NoActionMenu.args};
-
 export const HorizontalWithIllustration = Template().bind({});
 HorizontalWithIllustration.args = {...Horizontal.args, ...WithIllustration.args};
 
@@ -99,10 +94,6 @@ export const CardGrid = (props: SpectrumCardProps) => (
             <Heading>Title {index}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -127,10 +118,6 @@ export const CardFloat = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
             </Card>
           </div>
         );
@@ -158,10 +145,6 @@ export const CardGridTall = (props: SpectrumCardProps) => (
             <Heading>Title {index}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })

--- a/packages/@react-spectrum/card/stories/QuietCard.stories.tsx
+++ b/packages/@react-spectrum/card/stories/QuietCard.stories.tsx
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionMenu, Item} from '@react-spectrum/menu';
 import assetStyles from '@adobe/spectrum-css-temp/components/asset/vars.css';
 import {Card} from '..';
 import {CardBase} from '../src/CardBase';
@@ -26,7 +25,6 @@ import {
   LongDetail,
   LongEverything,
   LongTitle,
-  NoActionMenu,
   NoDescription,
   NoDescriptionSquare,
   WithIllustration
@@ -116,9 +114,6 @@ QuietNoDescription.args = {...Quiet.args, ...NoDescription.args};
 export const QuietNoDescriptionSquare = Template().bind({});
 QuietNoDescriptionSquare.args = {...Quiet.args, ...NoDescriptionSquare.args};
 
-export const QuietNoActionMenu = Template().bind({});
-QuietNoActionMenu.args = {...Quiet.args, ...NoActionMenu.args};
-
 export const QuietWithIllustration = Template().bind({});
 QuietWithIllustration.args = {...Quiet.args, ...WithIllustration.args};
 
@@ -156,10 +151,6 @@ export const CardGrid = (props: SpectrumCardProps) => (
             <Heading>Title {index}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -188,10 +179,6 @@ export const CardWaterfall = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>{getDescription(index)}</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
             </Card>
           </div>
         );
@@ -219,10 +206,6 @@ export const CardGallery = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
             </Card>
           </div>
         );
@@ -248,10 +231,6 @@ export const CardFloat = (props: SpectrumCardProps) => (
               <Heading>Title {index}</Heading>
               <Text slot="detail">PNG</Text>
               <Content>Description</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
             </Card>
           </div>
         );
@@ -279,10 +258,6 @@ export const CardGridNoDescription = (props: SpectrumCardProps) => (
             <Image src={url} />
             <Heading>Title {index}</Heading>
             <Text slot="detail">PNG</Text>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -309,10 +284,6 @@ export const CardGridIllustrations = (props: SpectrumCardProps) => (
             <File slot="illustration" />
             <Heading>Title {index}</Heading>
             <Text slot="detail">PNG</Text>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -340,10 +311,6 @@ export const CardGridLongTitle = (props: SpectrumCardProps) => (
             <Heading>This is a long title about how dinosaurs used to rule the earth before a meteor came and wiped them all out {index}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -372,10 +339,6 @@ export const CardGridTallRows = (props: SpectrumCardProps) => (
             <Heading>Title {index}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -402,10 +365,6 @@ export const CardGridMessyText = (props: SpectrumCardProps) => (
             <Heading>{index} Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Heading>
             <Text slot="detail">Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Text>
             <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
           </Card>
         );
       })
@@ -434,10 +393,6 @@ export const CardWaterfallMessyText = (props: SpectrumCardProps) => (
               <Heading>{index} Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Heading>
               <Text slot="detail">Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Text>
               <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
             </Card>
           </div>
         );
@@ -465,10 +420,6 @@ export const CardGalleryMessyText = (props: SpectrumCardProps) => (
               <Heading>{index} Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Heading>
               <Text slot="detail">Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Text>
               <Content>Rechtsschutzversicherungsgesellschaften Nahrungsmittelunverträglichkeit Unabhängigkeitserklärungen Freundschaftsbeziehungen</Content>
-              <ActionMenu>
-                <Item>Action 1</Item>
-                <Item>Action 2</Item>
-              </ActionMenu>
             </Card>
           </div>
         );

--- a/packages/@react-spectrum/card/stories/WaterfallCardView.stories.tsx
+++ b/packages/@react-spectrum/card/stories/WaterfallCardView.stories.tsx
@@ -36,7 +36,7 @@ import {WaterfallLayoutOptions} from '../src/WaterfallLayout';
 
 let itemsNoSize = [
   {src: 'https://i.imgur.com/Z7AzH2c.jpg', title: 'Bob 1'},
-  {src: 'https://i.imgur.com/DhygPot.jpg', title: 'Joe 1'},
+  {src: 'https://i.imgur.com/DhygPot.jpg', title: 'Joe 1 really really really really really really really really really really really really long'},
   {src: 'https://i.imgur.com/L7RTlvI.png', title: 'Jane 1'},
   {src: 'https://i.imgur.com/1nScMIH.jpg', title: 'Bob 2'},
   {src: 'https://i.imgur.com/DhygPot.jpg', title: 'Joe 2'},

--- a/packages/@react-spectrum/card/test/Card.test.js
+++ b/packages/@react-spectrum/card/test/Card.test.js
@@ -31,17 +31,6 @@ describe('Card', function () {
     userEvent.tab();
     expect(card).toBe(document.activeElement);
 
-    let buttons = getAllByRole('button');
-    expect(buttons.length).toBe(2);
-
-    userEvent.tab();
-    expect(buttons[0]).toBe(document.activeElement);
-    expect(buttons[0]).toHaveAttribute('aria-label', 'More actions');
-
-    // this is the footer button
-    userEvent.tab();
-    expect(buttons[1]).toBe(document.activeElement);
-
     userEvent.tab();
     expect(document.body).toBe(document.activeElement);
   });
@@ -74,11 +63,5 @@ describe('Card', function () {
 
     userEvent.tab();
     expect(card).toBe(document.activeElement);
-
-    let button = getByRole('button');
-
-    userEvent.tab();
-    expect(button).toBe(document.activeElement);
-    expect(button).toHaveAttribute('aria-label', 'More actions');
   });
 });

--- a/packages/@react-spectrum/card/test/CardView.test.js
+++ b/packages/@react-spectrum/card/test/CardView.test.js
@@ -61,7 +61,7 @@ let itemsNoSize = [
 let mockHeight = 800;
 let mockWidth = 800;
 let onSelectionChange = jest.fn();
-let getCardStyles = (card) => card.parentNode.parentNode.style;
+let getCardStyles = (card) => card.parentNode.style;
 
 function StaticCardView(props) {
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
@@ -280,7 +280,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[1]);
         expect(document.activeElement).toBe(cards[1]);
         let cardStyles = getCardStyles(cards[1]);
@@ -304,7 +304,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[5]);
         expect(document.activeElement).toBe(cards[5]);
         let cardStyles = getCardStyles(cards[5]);
@@ -332,7 +332,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
 
         triggerPress(cards[1]);
         expect(document.activeElement).toBe(cards[1]);
@@ -376,7 +376,7 @@ describe('CardView', function () {
 
         let expectedRight;
         let expectedTop;
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
 
         triggerPress(cards[1]);
         expect(document.activeElement).toBe(cards[1]);
@@ -405,7 +405,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[5]);
 
         act(() => {
@@ -414,7 +414,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        cards = tree.getAllByRole('gridcell');
+        cards = tree.getAllByRole('row');
         expect(document.activeElement).toBe(cards[cards.length - 1]);
         let cardStyles = getCardStyles(document.activeElement);
         let expectedLeft = cardStyles.left;
@@ -439,7 +439,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[1]);
 
         expect(document.activeElement).toBe(cards[1]);
@@ -508,7 +508,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[0]);
         expect(document.activeElement).toBe(cards[0]);
         expect(within(document.activeElement).getByText('Title 1')).toBeTruthy();
@@ -533,7 +533,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[3]);
         expect(document.activeElement).toBe(cards[3]);
         expect(within(document.activeElement).getByText('Title 4')).toBeTruthy();
@@ -689,7 +689,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[0]);
         expect(document.activeElement).toBe(cards[0]);
         expect(within(document.activeElement).getByText('Title 1')).toBeTruthy();
@@ -716,7 +716,7 @@ describe('CardView', function () {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
         triggerPress(cards[2]);
         expect(document.activeElement).toBe(cards[2]);
         expect(within(document.activeElement).getByText('Title 3')).toBeTruthy();
@@ -738,7 +738,6 @@ describe('CardView', function () {
         expect(within(document.activeElement).getByText('Title 1')).toBeTruthy();
       });
 
-      // TODO: figure out why the spacing is only 16px between each item
       it.skip('should move focus via Arrow Left', function () {
         let tree = render(<DynamicCardView layout={WaterfallLayout} />);
         act(() => {
@@ -769,19 +768,6 @@ describe('CardView', function () {
         expect(cardStyles.left).toEqual(expectedLeft);
       });
 
-      // TODO: update the below two tests when we decide on exact keyboard behavior for entering the card
-      // it('should move focus via Arrow Left (RTL)', function () {
-
-      // });
-
-      // it('should move focus via Arrow Right', function () {
-
-      // });
-
-      // it('should move focus via Arrow Right (RTL)', function () {
-
-      // });
-
       // TODO: Can't test PageUp/Down of WaterfallLayout because it is setting the heights of the items to 0. Figure out why
       // seems to be the updateItemSize
     });
@@ -799,7 +785,7 @@ describe('CardView', function () {
         jest.runAllTimers();
       });
 
-      let cards = tree.getAllByRole('gridcell');
+      let cards = tree.getAllByRole('row');
       triggerPress(cards[2]);
       expect(document.activeElement).toBe(cards[2]);
 
@@ -823,7 +809,7 @@ describe('CardView', function () {
         jest.runAllTimers();
       });
 
-      let cards = tree.getAllByRole('gridcell');
+      let cards = tree.getAllByRole('row');
       triggerPress(cards[2]);
       expect(document.activeElement).toBe(cards[2]);
 
@@ -833,7 +819,7 @@ describe('CardView', function () {
         jest.runAllTimers();
       });
 
-      cards = tree.getAllByRole('gridcell');
+      cards = tree.getAllByRole('row');
       expect(document.activeElement).toBe(cards[cards.length - 1]);
     });
 
@@ -848,7 +834,7 @@ describe('CardView', function () {
         jest.runAllTimers();
       });
 
-      let cards = tree.getAllByRole('gridcell');
+      let cards = tree.getAllByRole('row');
       triggerPress(cards[1]);
       expect(document.activeElement).toBe(cards[1]);
 
@@ -1030,7 +1016,7 @@ describe('CardView', function () {
 
       let spinner = within(grid).getByRole('progressbar');
       expect(spinner).toHaveAttribute('aria-label', 'Loading more…');
-      expect(getCardStyles(spinner.parentNode).height).toBe('60px');
+      expect(getCardStyles(spinner.parentNode.parentNode).height).toBe('60px');
     });
 
     it.each`

--- a/packages/@react-spectrum/card/test/CardView.test.js
+++ b/packages/@react-spectrum/card/test/CardView.test.js
@@ -11,10 +11,8 @@
  */
 
 import {act, fireEvent, render, within} from '@testing-library/react';
-import {ActionMenu, Item} from '@react-spectrum/menu';
-import {Button} from '@react-spectrum/button';
 import {Card, CardView, GalleryLayout, GridLayout, WaterfallLayout} from '../';
-import {Content, Footer} from '@react-spectrum/view';
+import {Content} from '@react-spectrum/view';
 import {Heading, Text} from '@react-spectrum/text';
 import {Image} from '@react-spectrum/image';
 import {Provider} from '@react-spectrum/provider';
@@ -83,39 +81,18 @@ function StaticCardView(props) {
           <Heading>Title  1</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Description</Content>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
-          <Footer>
-            <Button variant="primary">Something</Button>
-          </Footer>
         </Card>
         <Card width={640} height={640} textValue="Title  1">
           <Image src="https://i.imgur.com/DhygPot.jpg" />
           <Heading>Title  1</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Description</Content>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
-          <Footer>
-            <Button variant="primary">Something</Button>
-          </Footer>
         </Card>
         <Card width={182} height={1009} textValue="Title  1">
           <Image src="https://i.imgur.com/L7RTlvI.png" />
           <Heading>Title  1</Heading>
           <Text slot="detail">PNG</Text>
           <Content>Description</Content>
-          <ActionMenu>
-            <Item>Action 1</Item>
-            <Item>Action 2</Item>
-          </ActionMenu>
-          <Footer>
-            <Button variant="primary">Something</Button>
-          </Footer>
         </Card>
       </CardView>
     </Provider>
@@ -143,13 +120,6 @@ function DynamicCardView(props) {
             <Heading>{item.title}</Heading>
             <Text slot="detail">PNG</Text>
             <Content>Description</Content>
-            <ActionMenu>
-              <Item>Action 1</Item>
-              <Item>Action 2</Item>
-            </ActionMenu>
-            <Footer>
-              <Button variant="primary">Something</Button>
-            </Footer>
           </Card>
         )}
       </CardView>
@@ -205,18 +175,6 @@ describe('CardView', function () {
       expect(within(cell).getByText('Description')).toBeTruthy();
       expect(within(cell).getByText('PNG')).toBeTruthy();
       expect(within(cell).getByText('Title', {exact: false})).toBeTruthy();
-
-      if (Name === 'Waterfall layout') {
-        let buttons = within(cell).getAllByRole('button');
-        expect(buttons.length).toEqual(2);
-        expect(buttons[0]).toHaveAttribute('aria-label', 'More actions');
-        expect(buttons[1]).toHaveTextContent('Something');
-      } else {
-        // Grid and Gallery only support quiet cards for now.
-        let actionMenuButton = within(cell).getByRole('button');
-        expect(actionMenuButton).toBeTruthy();
-        expect(actionMenuButton).toHaveAttribute('aria-label', 'More actions');
-      }
     }
   });
 
@@ -248,18 +206,6 @@ describe('CardView', function () {
       expect(within(cell).getByText('Description')).toBeTruthy();
       expect(within(cell).getByText('PNG')).toBeTruthy();
       expect(within(cell).getByText('Title', {exact: false})).toBeTruthy();
-
-      if (Name === 'Waterfall layout') {
-        let buttons = within(cell).getAllByRole('button');
-        expect(buttons.length).toEqual(2);
-        expect(buttons[0]).toHaveAttribute('aria-label', 'More actions');
-        expect(buttons[1]).toHaveTextContent('Something');
-      } else {
-        // Grid and Gallery only support quiet cards for now.
-        let actionMenuButton = within(cell).getByRole('button');
-        expect(actionMenuButton).toBeTruthy();
-        expect(actionMenuButton).toHaveAttribute('aria-label', 'More actions');
-      }
     }
   });
 

--- a/packages/@react-spectrum/card/test/CardView.test.js
+++ b/packages/@react-spectrum/card/test/CardView.test.js
@@ -355,14 +355,73 @@ describe('CardView', function () {
         expect(cardStyles.left).toEqual(expectedLeft);
       });
 
-      // TODO: update the below two tests when we decide on exact keyboard behavior for entering the card
-      // it('should move focus via Arrow Left (RTL)', function () {
+      it.each`
+        Name                  | layout
+        ${'Grid layout'}      | ${GridLayout}
+        ${'Gallery layout'}   | ${GalleryLayout}
+      `('$Name CardView should move focus via Arrow Left (RTL)', function ({Name, layout}) {
+        let tree = render(<DynamicCardView locale="ar-AE" layout={layout} />);
+        act(() => {
+          jest.runAllTimers();
+        });
 
-      // });
+        let expectedRight;
+        let expectedTop;
+        let cards = tree.getAllByRole('row');
 
-      // it('should move focus via Arrow Right', function () {
+        triggerPress(cards[0]);
+        expect(document.activeElement).toBe(cards[0]);
+        let cardStyles = getCardStyles(cards[0]);
+        expectedRight = cardStyles.right;
+        expectedTop = cardStyles.top;
 
-      // });
+        act(() => {
+          fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', code: 37, charCode: 37});
+          fireEvent.keyUp(document.activeElement, {key: 'ArrowLeft', code: 37, charCode: 37});
+          jest.runAllTimers();
+        });
+
+        expect(document.activeElement).toBe(cards[1]);
+        // horizontal spacing in grid is minimum 18px, but in this specific setup the calculated horizontal spacing is 19px due to margins
+        let horizontalSpacing = Name === 'Grid layout' ? 19 : 18;
+        expectedRight = `${parseInt(expectedRight, 10) + parseInt(cardStyles.width, 10) + horizontalSpacing}px`;
+        cardStyles = getCardStyles(document.activeElement);
+        expect(cardStyles.top).toEqual(expectedTop);
+        expect(cardStyles.right).toEqual(expectedRight);
+      });
+
+      it.each`
+        Name                  | layout
+        ${'Grid layout'}      | ${GridLayout}
+        ${'Gallery layout'}   | ${GalleryLayout}
+      `('$Name CardView should move focus via Arrow Right', function ({Name, layout}) {
+        let tree = render(<DynamicCardView layout={layout} />);
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        let cards = tree.getAllByRole('row');
+
+        triggerPress(cards[0]);
+        expect(document.activeElement).toBe(cards[0]);
+        let cardStyles = getCardStyles(cards[0]);
+        let expectedLeft = cardStyles.left;
+        let expectedTop = cardStyles.top;
+
+        act(() => {
+          fireEvent.keyDown(document.activeElement, {key: 'ArrowRight', code: 39, charCode: 39});
+          fireEvent.keyUp(document.activeElement, {key: 'ArrowRight', code: 39, charCode: 39});
+          jest.runAllTimers();
+        });
+
+        expect(document.activeElement).toBe(cards[1]);
+        // horizontal spacing in grid is minimum 18px, but in this specific setup the calculated horizontal spacing is 19px due to margins
+        let horizontalSpacing = Name === 'Grid layout' ? 19 : 18;
+        expectedLeft = `${parseInt(expectedLeft, 10) + parseInt(cardStyles.width, 10) + horizontalSpacing}px`;
+        cardStyles = getCardStyles(document.activeElement);
+        expect(cardStyles.top).toEqual(expectedTop);
+        expect(cardStyles.left).toEqual(expectedLeft);
+      });
 
       it.each`
         Name                  | layout
@@ -738,13 +797,13 @@ describe('CardView', function () {
         expect(within(document.activeElement).getByText('Title 1')).toBeTruthy();
       });
 
-      it.skip('should move focus via Arrow Left', function () {
+      it('should move focus via Arrow Left', function () {
         let tree = render(<DynamicCardView layout={WaterfallLayout} />);
         act(() => {
           jest.runAllTimers();
         });
 
-        let cards = tree.getAllByRole('gridcell');
+        let cards = tree.getAllByRole('row');
 
         triggerPress(cards[1]);
         act(() => {
@@ -766,6 +825,95 @@ describe('CardView', function () {
         expectedLeft = `${parseInt(expectedLeft, 10) - parseInt(cardStyles.width, 10) - 18}px`;
         expect(cardStyles.top).toEqual(expectedTop);
         expect(cardStyles.left).toEqual(expectedLeft);
+      });
+
+      it('should move focus via Arrow Left (RTL)', function () {
+        let tree = render(<DynamicCardView locale="ar-AE" layout={WaterfallLayout} />);
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        let cards = tree.getAllByRole('row');
+        triggerPress(cards[0]);
+        act(() => {
+          jest.runAllTimers();
+        });
+        expect(document.activeElement).toBe(cards[0]);
+        let cardStyles = getCardStyles(cards[0]);
+        let expectedRight = cardStyles.right;
+        let expectedTop = cardStyles.top;
+
+        act(() => {
+          fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', code: 37, charCode: 37});
+          fireEvent.keyUp(document.activeElement, {key: 'ArrowLeft', code: 37, charCode: 37});
+          jest.runAllTimers();
+        });
+
+        expect(document.activeElement).toBe(cards[1]);
+        cardStyles = getCardStyles(document.activeElement);
+        expectedRight = `${parseInt(expectedRight, 10) + parseInt(cardStyles.width, 10) + 18}px`;
+        expect(cardStyles.top).toEqual(expectedTop);
+        expect(cardStyles.right).toEqual(expectedRight);
+      });
+
+      it('should move focus via Arrow Right', function () {
+        let tree = render(<DynamicCardView layout={WaterfallLayout} />);
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        let cards = tree.getAllByRole('row');
+
+        triggerPress(cards[0]);
+        act(() => {
+          jest.runAllTimers();
+        });
+        expect(document.activeElement).toBe(cards[0]);
+        let cardStyles = getCardStyles(cards[0]);
+        let expectedLeft = cardStyles.left;
+        let expectedTop = cardStyles.top;
+
+        act(() => {
+          fireEvent.keyDown(document.activeElement, {key: 'ArrowRight', code: 39, charCode: 39});
+          fireEvent.keyUp(document.activeElement, {key: 'ArrowRight', code: 39, charCode: 39});
+          jest.runAllTimers();
+        });
+
+        expect(document.activeElement).toBe(cards[1]);
+        cardStyles = getCardStyles(document.activeElement);
+        expectedLeft = `${parseInt(expectedLeft, 10) + parseInt(cardStyles.width, 10) + 18}px`;
+        expect(cardStyles.top).toEqual(expectedTop);
+        expect(cardStyles.left).toEqual(expectedLeft);
+      });
+
+      it('should move focus via Arrow Right (RTL)', function () {
+        let tree = render(<DynamicCardView locale="ar-AE" layout={WaterfallLayout} />);
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        let cards = tree.getAllByRole('row');
+
+        triggerPress(cards[1]);
+        act(() => {
+          jest.runAllTimers();
+        });
+        expect(document.activeElement).toBe(cards[1]);
+        let cardStyles = getCardStyles(cards[1]);
+        let expectedRight = cardStyles.right;
+        let expectedTop = cardStyles.top;
+
+        act(() => {
+          fireEvent.keyDown(document.activeElement, {key: 'ArrowRight', code: 39, charCode: 39});
+          fireEvent.keyUp(document.activeElement, {key: 'ArrowRight', code: 39, charCode: 39});
+          jest.runAllTimers();
+        });
+
+        expect(document.activeElement).toBe(cards[0]);
+        cardStyles = getCardStyles(document.activeElement);
+        expectedRight = `${parseInt(expectedRight, 10) - parseInt(cardStyles.width, 10) - 18}px`;
+        expect(cardStyles.top).toEqual(expectedTop);
+        expect(cardStyles.right).toEqual(expectedRight);
       });
 
       // TODO: Can't test PageUp/Down of WaterfallLayout because it is setting the heights of the items to 0. Figure out why

--- a/packages/@react-stately/grid/src/useGridState.ts
+++ b/packages/@react-stately/grid/src/useGridState.ts
@@ -13,14 +13,15 @@ export interface GridState<T, C extends GridCollection<T>> {
 interface GridStateOptions<T, C extends GridCollection<T>> extends MultipleSelectionStateProps {
   collection: C,
   disabledKeys?: Iterable<Key>,
-  focusMode?: 'row' | 'cell'
+  focusMode?: 'row' | 'cell',
+  preventCellFocus?: boolean
 }
 
 /**
  * Provides state management for a grid component. Handles row selection and focusing a grid cell's focusable child if applicable.
  */
 export function useGridState<T extends object, C extends GridCollection<T>>(props: GridStateOptions<T, C>): GridState<T, C> {
-  let {collection, focusMode} = props;
+  let {collection, focusMode, preventCellFocus} = props;
   let selectionState = useMultipleSelectionState(props);
   let disabledKeys = useMemo(() =>
       props.disabledKeys ? new Set(props.disabledKeys) : new Set<Key>()
@@ -38,6 +39,15 @@ export function useGridState<T extends object, C extends GridCollection<T>>(prop
         } else {
           key = children[0]?.key;
         }
+      }
+    } else if (preventCellFocus && key != null) {
+      // If preventCellFocus is true, set focus to the row containing the cell
+      let item = collection.getItem(key);
+      if (item?.type === 'cell') {
+        while (item && item?.type === 'cell') {
+          item = collection.getItem(item.parentKey);
+        }
+        key = item.key;
       }
     }
 


### PR DESCRIPTION
Closes #2605 

This approach changes CardView behavior so that the Card row is what receives focus instead of the GridCell. This allows me to then modify the keyboard behavior to shift focus from row to row instead of moving into the grid cell (dodges the checkbox on ArrowRight). 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP