### PR TITLE
Fix ListView css specificity

### DIFF
--- a/packages/@react-spectrum/list/src/listview.css
+++ b/packages/@react-spectrum/list/src/listview.css
@@ -68,6 +68,18 @@
     }
   }
 
+  .react-spectrum-ListView--compact & {
+    padding-top: var(--spectrum-listview-item-compact-padding-y);
+    padding-bottom: var(--spectrum-listview-item-compact-padding-y);
+    min-height: var(--spectrum-global-dimension-size-400);
+  }
+  
+  .react-spectrum-ListView--spacious & {
+    padding-top: var(--spectrum-listview-item-spacious-padding-y);
+    padding-bottom: var(--spectrum-listview-item-spacious-padding-y);
+    min-height: var(--spectrum-global-dimension-size-600);
+  }
+
   &.is-hovered,
   &.is-focused {
     background-color: var(--spectrum-table-row-background-color-hover);
@@ -97,6 +109,82 @@
     padding-top: 0px;
     padding-bottom: 0px;
   }
+
+  .react-spectrum-ListViewItem-grid {
+    display: grid;
+    grid-template-columns: auto auto auto 1fr auto auto;
+    grid-template-rows: 1fr auto;
+    grid-template-areas:
+      "checkbox icon image content actions actionmenu chevron"
+      "checkbox icon image description actions actionmenu chevron"
+    ;
+    align-items: center;
+  }
+  
+  .react-spectrum-ListViewItem-checkbox {
+    grid-area: checkbox;
+    align-items: center;
+    justify-items: center;
+    min-height: 0;
+    height: 100%;
+    > span {
+      margin: 0;
+    }
+  }
+
+  .react-spectrum-ListViewItem-icon,
+  .react-spectrum-ListViewItem-image {
+    grid-area: image;
+    align-items: center;
+    justify-items: center;
+
+    [dir="ltr"] & {
+      padding-right: var(--spectrum-global-dimension-size-100);
+    }
+    [dir="rtl"] & {
+      padding-left: var(--spectrum-global-dimension-size-100);
+    }
+  }
+
+  .react-spectrum-ListViewItem-image {
+    border-radius: var(--spectrum-global-dimension-size-25);
+    width: var(--spectrum-global-dimension-size-400);
+    height: var(--spectrum-global-dimension-size-400);
+  }
+
+  .react-spectrum-ListViewItem-content,
+  .react-spectrum-ListViewItem-description {
+    flex-grow: 1;
+  }
+
+  .react-spectrum-ListViewItem-content {
+    grid-area: content;
+  }
+
+  .react-spectrum-ListViewItem-description {
+    grid-area: description;
+  }
+
+  .react-spectrum-ListViewItem-actions {
+    grid-area: actions;
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
+
+  .react-spectrum-ListViewItem-actionmenu {
+    grid-area: actionmenu;
+  }
+
+  .react-spectrum-ListViewItem-parentIndicator {
+    grid-area: chevron;
+  
+    [dir="ltr"] & {
+      padding-left: var(--spectrum-global-dimension-size-75);
+    }
+    [dir="rtl"] & {
+      padding-right: var(--spectrum-global-dimension-size-75);
+    }
+  }
   
   /* give first and last items border-radius to match listview container */
   div:first-child > div[role="row"] > & {
@@ -109,83 +197,6 @@
   }
 }
 
-.react-spectrum-ListView--compact .react-spectrum-ListViewItem {
-  padding-top: var(--spectrum-listview-item-compact-padding-y);
-  padding-bottom: var(--spectrum-listview-item-compact-padding-y);
-  min-height: var(--spectrum-global-dimension-size-400);
-}
-
-.react-spectrum-ListView--spacious .react-spectrum-ListViewItem {
-  padding-top: var(--spectrum-listview-item-spacious-padding-y);
-  padding-bottom: var(--spectrum-listview-item-spacious-padding-y);
-  min-height: var(--spectrum-global-dimension-size-600);
-}
-
-.react-spectrum-ListViewItem-grid {
-  display: grid;
-  grid-template-columns: auto auto auto 1fr auto auto;
-  grid-template-rows: 1fr auto;
-  grid-template-areas:
-    "checkbox icon image content actions actionmenu chevron"
-    "checkbox icon image description actions actionmenu chevron"
-  ;
-  align-items: center;
-}
-
-.react-spectrum-ListViewItem-checkbox {
-  grid-area: checkbox;
-  align-items: center;
-  justify-items: center;
-  min-height: 0;
-  height: 100%;
-  > span {
-    margin: 0;
-  }
-}
-
-.react-spectrum-ListViewItem-icon,
-.react-spectrum-ListViewItem-image {
-  grid-area: image;
-  align-items: center;
-  justify-items: center;
-
-  [dir="ltr"] & {
-    padding-right: var(--spectrum-global-dimension-size-100);
-  }
-  [dir="rtl"] & {
-    padding-left: var(--spectrum-global-dimension-size-100);
-  }
-}
-
-.react-spectrum-ListViewItem-image {
-  border-radius: var(--spectrum-global-dimension-size-25);
-  width: var(--spectrum-global-dimension-size-400);
-  height: var(--spectrum-global-dimension-size-400);
-}
-
-.react-spectrum-ListViewItem-content,
-.react-spectrum-ListViewItem-description {
-  flex-grow: 1;
-}
-
-.react-spectrum-ListViewItem-content {
-  grid-area: content;
-}
-
-.react-spectrum-ListViewItem-description {
-  grid-area: description;
-}
-
-.react-spectrum-ListViewItem-actions {
-  grid-area: actions;
-  flex-grow: 0;
-  flex-shrink: 0;
-}
-
-.react-spectrum-ListViewItem-actionmenu {
-  grid-area: actionmenu;
-}
-
 .react-spectrum-ListView-centeredWrapper {
   display: flex;
   align-items: center;
@@ -194,13 +205,3 @@
   height: 100%;
 }
 
-.react-spectrum-ListViewItem-parentIndicator {
-  grid-area: chevron;
-
-  [dir="ltr"] & {
-    padding-left: var(--spectrum-global-dimension-size-75);
-  }
-  [dir="rtl"] & {
-    padding-right: var(--spectrum-global-dimension-size-75);
-  }
-}

--- a/packages/@react-spectrum/list/src/listview.css
+++ b/packages/@react-spectrum/list/src/listview.css
@@ -125,13 +125,7 @@
     grid-area: image;
     align-items: center;
     justify-items: center;
-
-    [dir="ltr"] & {
-      padding-right: var(--spectrum-global-dimension-size-100);
-    }
-    [dir="rtl"] & {
-      padding-left: var(--spectrum-global-dimension-size-100);
-    }
+    padding-inline-end: var(--spectrum-global-dimension-size-100);
   }
 
   .react-spectrum-ListViewItem-image {
@@ -165,13 +159,7 @@
 
   .react-spectrum-ListViewItem-parentIndicator {
     grid-area: chevron;
-  
-    [dir="ltr"] & {
-      padding-left: var(--spectrum-global-dimension-size-75);
-    }
-    [dir="rtl"] & {
-      padding-right: var(--spectrum-global-dimension-size-75);
-    }
+    padding-inline-start: var(--spectrum-global-dimension-size-75);
   }
   
   /* give first and last items border-radius to match listview container */

--- a/packages/@react-spectrum/list/src/listview.css
+++ b/packages/@react-spectrum/list/src/listview.css
@@ -68,18 +68,6 @@
     }
   }
 
-  .react-spectrum-ListView--compact & {
-    padding-top: var(--spectrum-listview-item-compact-padding-y);
-    padding-bottom: var(--spectrum-listview-item-compact-padding-y);
-    min-height: var(--spectrum-global-dimension-size-400);
-  }
-  
-  .react-spectrum-ListView--spacious & {
-    padding-top: var(--spectrum-listview-item-spacious-padding-y);
-    padding-bottom: var(--spectrum-listview-item-spacious-padding-y);
-    min-height: var(--spectrum-global-dimension-size-600);
-  }
-
   &.is-hovered,
   &.is-focused {
     background-color: var(--spectrum-table-row-background-color-hover);
@@ -195,6 +183,18 @@
     border-end-start-radius: var(--spectrum-listview-item-start-end-border-radius);
     border-end-end-radius: var(--spectrum-listview-item-start-end-border-radius);
   }
+}
+
+.react-spectrum-ListView--compact .react-spectrum-ListViewItem {
+  padding-top: var(--spectrum-listview-item-compact-padding-y);
+  padding-bottom: var(--spectrum-listview-item-compact-padding-y);
+  min-height: var(--spectrum-global-dimension-size-400);
+}
+
+.react-spectrum-ListView--spacious .react-spectrum-ListViewItem {
+  padding-top: var(--spectrum-listview-item-spacious-padding-y);
+  padding-bottom: var(--spectrum-listview-item-spacious-padding-y);
+  min-height: var(--spectrum-global-dimension-size-600);
 }
 
 .react-spectrum-ListView-centeredWrapper {


### PR DESCRIPTION
When working on ListView's docs, I noticed some css specificity issues that weren't apparent in storybook. This PR essentially moves some selectors to be explicit descendants:

```scss
.react-spectrum-ListViewItem {
  ....
}

.react-spectrum-ListViewItem-checkbox {
  ...
}
```
to
```scss
.react-spectrum-ListViewItem {
  ....
  .react-spectrum-ListViewItem-checkbox {
    ...
  }
}
```

Generic checkbox styles were getting precedence over ListViewItem's checkbox styles in the docs, so this fixes that.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify that there are no style changes in storybook

## 🧢 Your Project:

RSP
