### PR TITLE
Fixing CardView Gallery layout card overlap and container resizing

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -717,7 +717,7 @@ user-provided
   .spectrum-Card-grid:after {
     z-index: 2;
   }
-  min-inline-size: var(--spectrum-card-quiet-min-size);
+  min-inline-size: 0;
 
   .spectrum-Card-grid {
     block-size: 100%;


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2465

Unable to reproduce the following from the issue:
- Very difficult to scroll the default story gallery layout in iPhone, it requires multiple swipe gestures to get it going, i think the card view container is too tall? 
- in gallery layout dynamic cards, low variance in aspect ratios on iPhone, i get flashes as i'm scrolling of layout redoing something

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Check the CardView gallery stories in large scale and verify that none of the cards overlap
2. Go to the "static card" story in Gallery Layout and try resizing the CardView container so it has 0 width. Resize it back to its original width and the cards should reappear.

## 🧢 Your Project:

RSP
