### PR TITLE
Fix ActionGroup static color

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -100,7 +100,7 @@ governing permissions and limitations under the License.
     .spectrum-ActionGroup-item {
       position: relative;
       border-radius: 0;
-      z-index: 2;
+      z-index: 1;
 
       &:first-child {
         border-start-start-radius: var(--spectrum-actionbutton-border-radius);
@@ -113,19 +113,19 @@ governing permissions and limitations under the License.
       }
 
       &.spectrum-ActionGroup-item--isDisabled {
-        z-index: 1;
+        z-index: 0;
       }
 
       &.is-selected {
-        z-index: 3;
+        z-index: 2;
       }
 
       &:hover {
-        z-index: 4;
+        z-index: 3;
       }
 
       &:focus {
-        z-index: 5;
+        z-index: 4;
       }
     }
 

--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -42,7 +42,6 @@ governing permissions and limitations under the License.
 
 
 .spectrum-ActionGroup {
-  isolation: isolate;
   display: flex;
   flex-wrap: wrap;
   --column-gap: var(--spectrum-actionbuttongroup-text-button-gap-x);
@@ -101,6 +100,7 @@ governing permissions and limitations under the License.
     .spectrum-ActionGroup-item {
       position: relative;
       border-radius: 0;
+      z-index: 2;
 
       &:first-child {
         border-start-start-radius: var(--spectrum-actionbutton-border-radius);
@@ -113,19 +113,19 @@ governing permissions and limitations under the License.
       }
 
       &.spectrum-ActionGroup-item--isDisabled {
-        z-index: -1;
-      }
-
-      &.is-selected {
         z-index: 1;
       }
 
+      &.is-selected {
+        z-index: 3;
+      }
+
       &:hover {
-        z-index: 2;
+        z-index: 4;
       }
 
       &:focus {
-        z-index: 3;
+        z-index: 5;
       }
     }
 


### PR DESCRIPTION
Fixes the following ActionGroup static color bug caught by chromatic: https://www.chromatic.com/test?appId=5f0dd5ad2b5fc10022a2e320&id=61de104b777900003aa56549

Uses the alternative method mentioned in https://github.com/adobe/react-spectrum/pull/2710.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Check the static color action group stories and make sure the text color/icon color matches the background div.
Also check that the borders between disabled and non disabled buttons in ActionGroup's "overflow mode: collapse, disabledKeys" story are clearly defined like shown below
![image](https://user-images.githubusercontent.com/9661127/149223892-06416c1f-6ee7-45a1-ad91-e57b2677674a.png)


## 🧢 Your Project:

RSP
