### PR TITLE
Fix bug where sort info doesnt exist because a sort is applied on a column that is not passed into useTable

### DIFF
--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -106,7 +106,7 @@ export function useTable<T>(props: TableProps<T>, state: TableState<T>, ref: Ref
   let formatMessage = useMessageFormatter(intlMessages);
   let sortDescription = useMemo(() => {
     let columnName = state.collection.columns.find(c => c.key === column)?.textValue;
-    return sortDirection && column ? formatMessage(`${sortDirection}Sort`, {columnName}) : undefined;
+    return sortDirection && column && columnName ? formatMessage(`${sortDirection}Sort`, {columnName}) : undefined;
   }, [sortDirection, column, state.collection.columns]);
 
   let descriptionProps = useDescription(sortDescription);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

- Create a TableView where the sortDescription relies on a column that does not exist (in this case it is a hidden column, so it is not passed in from @quarry/inventory)

## 🧢 Your Project:

Adobe/Quarry/Inventory/Analytics (hidden columns)
