### PR TITLE
Reduce vertical item spacing in CardView and remove item padding option from Waterfall layout

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -566,13 +566,12 @@ user-provided
     block-size: 100%;
     display: grid;
     grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) 1fr;
     grid-template-areas:
       "preview preview preview"
       ".       .       .      "
       "title   detail  .      "
-      "content content content"
-      ".       .       .      ";
+      "content content content";
 
     &:before {
       content: ' ';
@@ -657,13 +656,12 @@ user-provided
     block-size: 100%;
     display: grid;
     grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
-    grid-template-rows: 1fr var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) minmax(auto, var(--spectrum-global-dimension-size-600)) var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: 1fr var(--spectrum-card-quiet-body-header-margin-top) var(--spectrum-actionbutton-height) var(--spectrum-alias-single-line-height);
     grid-template-areas:
       "preview preview preview"
       ".       .       .      "
       "title   detail  .      "
-      "content content content"
-      ".       .       .      ";
+      "content content content";
 
     &:before {
       content: ' ';

--- a/packages/@react-spectrum/card/src/GalleryLayout.tsx
+++ b/packages/@react-spectrum/card/src/GalleryLayout.tsx
@@ -30,7 +30,7 @@ export interface GalleryLayoutOptions extends BaseLayoutOptions {
   itemSpacing?: Size,
   /**
    * The vertical padding for an item.
-   * @default 114
+   * @default 78
    */
   itemPadding?: number,
   /**
@@ -60,8 +60,8 @@ const DEFAULT_OPTIONS = {
     minItemSize: new Size(136, 136),
     itemSpacing: new Size(18, 18),
     itemPadding: {
-      'medium': 114,
-      'large': 143
+      'medium': 78,
+      'large': 99
     },
     dropSpacing: 100,
     margin: 24

--- a/packages/@react-spectrum/card/src/WaterfallLayout.tsx
+++ b/packages/@react-spectrum/card/src/WaterfallLayout.tsx
@@ -105,7 +105,7 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
       } else if (node.props.width && node.props.height) {
         let nodeWidth = node.props.width;
         let nodeHeight = node.props.height;
-        let scaledHeight = Math.round(nodeWidth * ((itemWidth) / nodeHeight));
+        let scaledHeight = Math.round(nodeHeight * ((itemWidth) / nodeWidth));
         height = Math.max(this.minItemSize.height, Math.min(this.maxItemSize.height, scaledHeight));
       } else {
         height = itemWidth;

--- a/packages/@react-spectrum/card/src/WaterfallLayout.tsx
+++ b/packages/@react-spectrum/card/src/WaterfallLayout.tsx
@@ -35,12 +35,7 @@ export interface WaterfallLayoutOptions extends BaseLayoutOptions {
    * The maximum number of columns.
    * @default Infinity
    */
-  maxColumns?: number,
-  /**
-   * The vertical padding for an item.
-   * @default 56
-   */
-  itemPadding?: number
+  maxColumns?: number
 }
 
 // TODO: this didn't have any options that varied with card size, should it have?
@@ -49,7 +44,6 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
   protected maxItemSize: Size;
   protected minSpace: Size;
   protected maxColumns: number;
-  itemPadding: number;
   protected numColumns: number;
   protected itemWidth: number;
   protected horizontalSpacing: number;
@@ -63,8 +57,6 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
     this.margin = options.margin != null ? options.margin : 24;
     this.minSpace = options.minSpace || new Size(18, 18);
     this.maxColumns = options.maxColumns || Infinity;
-    // TODO: not entirely sure what this is for since the layout will automatically shift itself to the correct vertical space for the card
-    this.itemPadding = options.itemPadding != null ? options.itemPadding : 56;
 
     this.itemWidth = 0;
     this.numColumns = 0;
@@ -114,7 +106,7 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
         let nodeWidth = node.props.width;
         let nodeHeight = node.props.height;
         let scaledHeight = Math.round(nodeWidth * ((itemWidth) / nodeHeight));
-        height = Math.max(this.minItemSize.height, Math.min(this.maxItemSize.height, scaledHeight)) + this.itemPadding;
+        height = Math.max(this.minItemSize.height, Math.min(this.maxItemSize.height, scaledHeight));
       } else {
         height = itemWidth;
       }

--- a/packages/@react-spectrum/card/stories/GalleryCardView.stories.tsx
+++ b/packages/@react-spectrum/card/stories/GalleryCardView.stories.tsx
@@ -130,7 +130,7 @@ CustomLayoutOptions.args = {
   'aria-label': 'Test CardView',
   selectionMode: 'multiple',
   items: itemsLowVariance,
-  layoutOptions: {idealRowHeight: 400, itemSpacing: new Size(10, 10), itemPadding: 114, minItemSize: new Size(150, 400)}
+  layoutOptions: {idealRowHeight: 400, itemSpacing: new Size(10, 10), itemPadding: 78, minItemSize: new Size(150, 400)}
 };
 CustomLayoutOptions.storyName = 'Custom layout options';
 

--- a/packages/@react-spectrum/card/stories/WaterfallCardView.stories.tsx
+++ b/packages/@react-spectrum/card/stories/WaterfallCardView.stories.tsx
@@ -117,7 +117,7 @@ CustomLayoutOptions.args = {
   'aria-label': 'Test CardView',
   selectionMode: 'multiple',
   items: itemsNoSize,
-  layoutOptions: {minSpace: new Size(50, 50), maxColumns: 2, itemPadding: 400, margin: 10}
+  layoutOptions: {minSpace: new Size(50, 50), maxColumns: 2, margin: 10}
 };
 CustomLayoutOptions.storyName = 'Custom layout options';
 


### PR DESCRIPTION
Just some things I felt were a bit off:
- item padding didn't really do anything in WaterfallLayout so I removed it 
- reduced the vertical item spacing between cards in quiet Waterfall and Gallery

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test the Gallery layout and Waterfall layout stories for CardView. Ignore the overlapping issue in Gallery large scale, solved by different PR

## 🧢 Your Project:

RSP
