### PR TITLE
Making WaterFall cards have max height of 600px

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -224,9 +224,10 @@ user-provided
   }
 
   .spectrum-Card-grid {
+    max-height: 600px;
     display: grid;
     grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) 1fr var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) minmax(var(--spectrum-alias-single-line-height), 1fr) var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
@@ -563,10 +564,11 @@ user-provided
   min-inline-size: var(--spectrum-card-quiet-min-size);
 
   .spectrum-Card-grid {
+    max-height: 600px;
     block-size: 100%;
     display: grid;
     grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) 1fr;
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) minmax(var(--spectrum-alias-single-line-height), 1fr);
     grid-template-areas:
       "preview preview preview"
       ".       .       .      "

--- a/packages/@adobe/spectrum-css-temp/components/card/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/card/index.css
@@ -224,10 +224,10 @@ user-provided
   }
 
   .spectrum-Card-grid {
-    max-height: 600px;
+    max-height: 100%;
     display: grid;
     grid-template-columns: var(--spectrum-card-body-padding-left) minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto) var(--spectrum-card-body-padding-right);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) minmax(var(--spectrum-alias-single-line-height), 1fr) var(--spectrum-card-body-padding-bottom);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), 1fr) var(--spectrum-global-dimension-size-300) minmax(var(--spectrum-actionbutton-height), auto) auto var(--spectrum-card-body-padding-bottom);
     /* absolutely position avatar relative to the preview */
     grid-template-areas:
       "preview preview preview preview    preview"
@@ -564,11 +564,11 @@ user-provided
   min-inline-size: var(--spectrum-card-quiet-min-size);
 
   .spectrum-Card-grid {
-    max-height: 600px;
+    max-height: 100%;
     block-size: 100%;
     display: grid;
     grid-template-columns: minmax(0, auto) minmax(var(--spectrum-global-dimension-size-500), 1fr) minmax(0, auto);
-    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), auto) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) minmax(var(--spectrum-alias-single-line-height), 1fr);
+    grid-template-rows: minmax(var(--spectrum-card-coverphoto-height), 1fr) var(--spectrum-card-quiet-body-header-margin-top) minmax(var(--spectrum-actionbutton-height), auto) auto;
     grid-template-areas:
       "preview preview preview"
       ".       .       .      "

--- a/packages/@react-spectrum/card/src/WaterfallLayout.tsx
+++ b/packages/@react-spectrum/card/src/WaterfallLayout.tsx
@@ -172,7 +172,8 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
       // TODO: also not sure about copying layout info vs mutating it. Listlayout does the below
       // but I feel that is because it actually maintained a layoutNode map cache which this doesn't have
       let newLayoutInfo = layoutInfo.copy();
-      newLayoutInfo.rect.height = size.height;
+      newLayoutInfo.rect.height = size.height <= 600 ? size.height : 600;
+      newLayoutInfo.estimatedSize = false;
       this.layoutInfos.set(key, newLayoutInfo);
       // TODO: v2 had layoutInfo.estimatedSize = view.estimatedSize || false; but we can't do the same here?
       layoutInfo.estimatedSize = false;


### PR DESCRIPTION
Closes #2282

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Look at the CardView Waterfall stories and verify that the tall waterfall cards are less than 600px at all times

## 🧢 Your Project:

RSP
