### PR TITLE
Fix focus scope with changing children

### DIFF
--- a/packages/@react-aria/focus/stories/FocusScope.stories.tsx
+++ b/packages/@react-aria/focus/stories/FocusScope.stories.tsx
@@ -18,7 +18,8 @@ import ReactDOM from 'react-dom';
 const dialogsRoot = 'dialogsRoot';
 
 interface StoryProps {
-  usePortal: boolean
+  usePortal: boolean,
+  contain: boolean
 }
 
 const meta: Meta<StoryProps> = {
@@ -33,7 +34,7 @@ const meta: Meta<StoryProps> = {
 
 export default meta;
 
-const Template = (): Story<StoryProps> => ({usePortal}) => <Example usePortal={usePortal} />;
+const Template = (): Story<StoryProps> => ({usePortal, contain = true}) => <Example usePortal={usePortal} contain={contain} />;
 
 function MaybePortal({children, usePortal}: { children: ReactNode, usePortal: boolean}) {
   if (!usePortal) {
@@ -46,35 +47,47 @@ function MaybePortal({children, usePortal}: { children: ReactNode, usePortal: bo
   );
 }
 
-function NestedDialog({onClose, usePortal}: {onClose: VoidFunction, usePortal: boolean}) {
+function NestedDialog({onClose, usePortal, contain}: {onClose: VoidFunction, usePortal: boolean, contain: boolean}) {
   let [open, setOpen] = useState(false);
+  let [showNew, setShowNew] = useState(false);
+  let onKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      onClose();
+    }
+  };
 
   return (
     <MaybePortal usePortal={usePortal}>
-      <FocusScope contain restoreFocus autoFocus>
-        <div>
-          <input />
-
-          <input />
-
-          <input />
-
-          <button type="button" onClick={() => setOpen(true)}>
-            Open dialog
-          </button>
-
-          <button type="button" onClick={onClose}>
-            close
-          </button>
-
-          {open && <NestedDialog onClose={() => setOpen(false)} usePortal={usePortal} />}
-        </div>
+      <FocusScope contain={contain} restoreFocus autoFocus>
+        {!showNew && (
+          <div role="dialog" onKeyDown={onKeyDown}>
+            <input autoFocus />
+            <input />
+            <input />
+            <button onClick={() => setShowNew(true)}>replace focusscope children</button>
+            <button type="button" onClick={() => setOpen(true)}>
+              Open dialog
+            </button>
+            <button type="button" onClick={onClose}>
+              close
+            </button>
+            {open && <NestedDialog contain={contain} onClose={() => setOpen(false)} usePortal={usePortal} />}
+          </div>
+        )}
+        {showNew && (
+          <div role="dialog" onKeyDown={onKeyDown}>
+            <input />
+            <input autoFocus />
+            <input />
+          </div>
+        )}
       </FocusScope>
     </MaybePortal>
   );
 }
 
-function Example({usePortal}: StoryProps) {
+function Example({usePortal, contain}: StoryProps) {
   let [open, setOpen] = useState(false);
 
   return (
@@ -84,8 +97,8 @@ function Example({usePortal}: StoryProps) {
       <button type="button" onClick={() => setOpen(true)}>
         Open dialog
       </button>
-
-      {open && <NestedDialog onClose={() => setOpen(false)} usePortal={usePortal} />}
+      <input />
+      {open && <NestedDialog onClose={() => setOpen(false)} usePortal={usePortal} contain={contain} />}
 
       <div id={dialogsRoot} />
     </div>
@@ -97,3 +110,9 @@ KeyboardNavigation.args = {usePortal: false};
 
 export const KeyboardNavigationInsidePortal = Template().bind({});
 KeyboardNavigationInsidePortal.args = {usePortal: true};
+
+export const KeyboardNavigationNoContain = Template().bind({});
+KeyboardNavigationNoContain.args = {usePortal: false, contain: false};
+
+export const KeyboardNavigationInsidePortalNoContain = Template().bind({});
+KeyboardNavigationInsidePortalNoContain.args = {usePortal: true, contain: false};

--- a/packages/@react-aria/focus/stories/FocusScope.stories.tsx
+++ b/packages/@react-aria/focus/stories/FocusScope.stories.tsx
@@ -62,7 +62,7 @@ function NestedDialog({onClose, usePortal, contain}: {onClose: VoidFunction, use
       <FocusScope contain={contain} restoreFocus autoFocus>
         {!showNew && (
           <div role="dialog" onKeyDown={onKeyDown}>
-            <input autoFocus />
+            <input />
             <input />
             <input />
             <button onClick={() => setShowNew(true)}>replace focusscope children</button>

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -331,7 +331,134 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(outside);
     });
 
-    it('should move focus to the next element after the previously focused node on Tab', function () {
+    it('should restore focus to the previously focused node after a child with autoFocus unmounts', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="outside" />
+            {show &&
+              <FocusScope restoreFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" autoFocus />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+
+      let input2 = getByTestId('input2');
+      expect(document.activeElement).toBe(input2);
+
+      rerender(<Test />);
+
+      expect(document.activeElement).toBe(outside);
+    });
+
+    it('should move focus after the previously focused node when tabbing away from a scope with autoFocus', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <input data-testid="outside" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" autoFocus />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+
+      let input3 = getByTestId('input3');
+      expect(document.activeElement).toBe(input3);
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
+
+    it('should move focus before the previously focused node when tabbing away from a scope with Shift+Tab', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <input data-testid="outside" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus>
+                <input data-testid="input1" autoFocus />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      userEvent.tab({shift: true});
+      expect(document.activeElement).toBe(getByTestId('before'));
+    });
+
+    it('should restore focus to the previously focused node after children change', function () {
+      function Test({show, showChild}) {
+        return (
+          <div>
+            <input data-testid="outside" />
+            {show &&
+              <FocusScope restoreFocus autoFocus>
+                <input data-testid="input1" />
+                {showChild && <input data-testid="dynamic" />}
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let outside = getByTestId('outside');
+      act(() => {outside.focus();});
+
+      rerender(<Test show />);
+      rerender(<Test show showChild />);
+
+      let dynamic = getByTestId('dynamic');
+      act(() => {dynamic.focus();});
+      expect(document.activeElement).toBe(dynamic);
+
+      rerender(<Test />);
+
+      expect(document.activeElement).toBe(outside);
+    });
+
+    it('should move focus to the element after the previously focused node on Tab', function () {
       function Test({show}) {
         return (
           <div>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2415

Keep focus scope up to date with changing children and auto focus children.
The two cases observed are:
1) Open a dialog, change the children in the dialog, hit esc, focus is lost.
This was fixed by using scopeRef.current as pointed out in the issue description because the scope was out of date.
2) Open a dialog where a child has autofocus, hit esc, focus is lost.
This was fixed by changing when nodeToRestore is set so that it runs before autoFocus takes place.

We are preferring this PR over https://github.com/adobe/react-spectrum/pull/2416 right now because it's difficult to review due to the refactor. Not that the refactor is bad, but by breaking this up, we can make sure we know what the fix is, and we can refactor it separately such that no changes to behavior occur.

Thank you @kherock for your hard work on this!

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test steps (case 1):
1. Go to https://reactspectrum.blob.core.windows.net/reactspectrum/f976e1d87682ba3a61027506d360b91d8976e267/storybook/index.html?path=/story/focusscope--keyboard-navigation-no-contain
2. Tab to "Open dialog" and hit enter. A new FocusScope row should appear and focus should be moved to the first input element. 
3. Tab to "replace focusscope children" and hit Enter. The children in the 2nd row should be replaced by 3 inputs and focus should move to the middle input element
4. Hit Escape key. The 2nd "dialog" row should close and focus should be moved to the trigger child

Case 2 is covered by the unit test

## 🧢 Your Project:

RSP
