### PR TITLE
Have slider work like color area

### DIFF
--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -4,9 +4,9 @@ import {getSliderThumbId, sliderIds} from './utils';
 import React, {ChangeEvent, HTMLAttributes, InputHTMLAttributes, LabelHTMLAttributes, RefObject, useCallback, useEffect, useRef} from 'react';
 import {SliderState} from '@react-stately/slider';
 import {useFocusable} from '@react-aria/focus';
+import {useKeyboard, useMove} from '@react-aria/interactions';
 import {useLabel} from '@react-aria/label';
 import {useLocale} from '@react-aria/i18n';
-import {useKeyboard, useMove} from '@react-aria/interactions';
 
 interface SliderThumbAria {
   /** Props for the root thumb element; handles the dragging motion. */

--- a/packages/@react-aria/slider/test/useSliderThumb.test.js
+++ b/packages/@react-aria/slider/test/useSliderThumb.test.js
@@ -1,4 +1,4 @@
-import {act, fireEvent, render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {installMouseEvent, installPointerEvent} from '@react-spectrum/test-utils';
 import * as React from 'react';
 import {renderHook} from '@testing-library/react-hooks';
@@ -379,7 +379,7 @@ describe('useSliderThumb', () => {
       it('can be moved with keys', () => {
         let onChangeSpy = jest.fn();
         let onChangeEndSpy = jest.fn();
-        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]}/>);
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]} />);
 
         // Drag thumb
         let thumb0 = screen.getByTestId('thumb').firstChild;
@@ -443,8 +443,7 @@ describe('useSliderThumb', () => {
       it('can be moved with keys (vertical)', () => {
         let onChangeSpy = jest.fn();
         let onChangeEndSpy = jest.fn();
-        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]}
-                        orientation="vertical"/>);
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]} orientation="vertical" />);
 
         // Drag thumb
         let thumb0 = screen.getByTestId('thumb').firstChild;

--- a/packages/@react-aria/slider/test/useSliderThumb.test.js
+++ b/packages/@react-aria/slider/test/useSliderThumb.test.js
@@ -379,11 +379,12 @@ describe('useSliderThumb', () => {
       it('can be moved with keys', () => {
         let onChangeSpy = jest.fn();
         let onChangeEndSpy = jest.fn();
-        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]} />);
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]}/>);
 
         // Drag thumb
         let thumb0 = screen.getByTestId('thumb').firstChild;
         fireEvent.keyDown(thumb0, {key: 'ArrowRight'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowRight'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([11]);
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
         expect(onChangeEndSpy).toHaveBeenLastCalledWith([11]);
@@ -391,105 +392,119 @@ describe('useSliderThumb', () => {
         expect(stateRef.current.values).toEqual([11]);
 
         fireEvent.keyDown(thumb0, {key: 'ArrowLeft'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowLeft'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([10]);
         expect(onChangeSpy).toHaveBeenCalledTimes(2);
         expect(onChangeEndSpy).toHaveBeenLastCalledWith([10]);
         expect(onChangeEndSpy).toHaveBeenCalledTimes(2);
         expect(stateRef.current.values).toEqual([10]);
+      });
 
-        // Note: Unlike ArrowLeft/ArrowRight/ArrowUp/ArrowDown added by the useMove hook, 
-        // Home/End/PageUp/PageDown events are executed natively by the HTML input[type="range"], 
-        // without the need for an additional keyboard event handlers in React Aria.
-        // This make it harder to test using the testing-library.
+      it('can be moved with keys at the beginning of the slider', () => {
+        let onChangeSpy = jest.fn();
+        let onChangeEndSpy = jest.fn();
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[0]} />);
 
-        act(() => stateRef.current.setThumbPercent(0, 0));
-
-        onChangeSpy.mockClear();
-        onChangeEndSpy.mockClear();
-
+        let thumb0 = screen.getByTestId('thumb').firstChild;
         fireEvent.keyDown(thumb0, {key: 'ArrowLeft'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowLeft'});
         expect(onChangeSpy).not.toHaveBeenCalled();
-        expect(onChangeEndSpy).not.toHaveBeenCalled();
+        expect(onChangeEndSpy).toHaveBeenCalledWith([0]);
 
         fireEvent.keyDown(thumb0, {key: 'ArrowRight'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowRight'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([1]);
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
         expect(onChangeEndSpy).toHaveBeenLastCalledWith([1]);
-        expect(onChangeEndSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeEndSpy).toHaveBeenCalledTimes(2);
         expect(stateRef.current.values).toEqual([1]);
+      });
 
-        act(() => stateRef.current.setThumbPercent(0, 1));
+      it('can be moved with keys at the end of the slider', () => {
+        let onChangeSpy = jest.fn();
+        let onChangeEndSpy = jest.fn();
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[100]} />);
 
-        onChangeSpy.mockClear();
-        onChangeEndSpy.mockClear();
-
+        let thumb0 = screen.getByTestId('thumb').firstChild;
         fireEvent.keyDown(thumb0, {key: 'ArrowRight'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowRight'});
         expect(onChangeSpy).not.toHaveBeenCalled();
-        expect(onChangeEndSpy).not.toHaveBeenCalled();
+        expect(onChangeEndSpy).toHaveBeenCalledWith([100]);
 
         fireEvent.keyDown(thumb0, {key: 'ArrowLeft'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowLeft'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([99]);
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
         expect(onChangeEndSpy).toHaveBeenLastCalledWith([99]);
-        expect(onChangeEndSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeEndSpy).toHaveBeenCalledTimes(2);
         expect(stateRef.current.values).toEqual([99]);
       });
 
       it('can be moved with keys (vertical)', () => {
         let onChangeSpy = jest.fn();
         let onChangeEndSpy = jest.fn();
-        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]} orientation="vertical" />);
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[10]}
+                        orientation="vertical"/>);
 
         // Drag thumb
         let thumb0 = screen.getByTestId('thumb').firstChild;
         fireEvent.keyDown(thumb0, {key: 'ArrowRight'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowRight'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([11]);
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
         fireEvent.keyDown(thumb0, {key: 'ArrowUp'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowUp'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([12]);
         expect(onChangeSpy).toHaveBeenCalledTimes(2);
         fireEvent.keyDown(thumb0, {key: 'ArrowDown'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowDown'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([11]);
         expect(onChangeSpy).toHaveBeenCalledTimes(3);
         fireEvent.keyDown(thumb0, {key: 'ArrowLeft'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowLeft'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([10]);
         expect(onChangeSpy).toHaveBeenCalledTimes(4);
+      });
 
-        // Note: Unlike ArrowLeft/ArrowRight/ArrowUp/ArrowDown added by the useMove hook, 
-        // Home/End/PageUp/PageDown events are executed natively by the HTML input[type="range"], 
-        // without the need for an additional keyboard event handlers in React Aria.
-        // This make it harder to test using the testing-library.
+      it('can be moved with keys (vertical) at the bottom of the slider', () => {
+        let onChangeSpy = jest.fn();
+        let onChangeEndSpy = jest.fn();
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[0]} orientation="vertical" />);
 
-        act(() => stateRef.current.setThumbPercent(0, 0));
-
-        onChangeSpy.mockClear();
-        onChangeEndSpy.mockClear();
-
+        // Drag thumb
+        let thumb0 = screen.getByTestId('thumb').firstChild;
         fireEvent.keyDown(thumb0, {key: 'ArrowDown'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowDown'});
         expect(onChangeSpy).not.toHaveBeenCalled();
-        expect(onChangeEndSpy).not.toHaveBeenCalled();
+        expect(onChangeEndSpy).toHaveBeenCalledWith([0]);
 
         fireEvent.keyDown(thumb0, {key: 'ArrowUp'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowUp'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([1]);
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
         expect(onChangeEndSpy).toHaveBeenLastCalledWith([1]);
-        expect(onChangeEndSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeEndSpy).toHaveBeenCalledTimes(2);
         expect(stateRef.current.values).toEqual([1]);
+      });
 
-        act(() => stateRef.current.setThumbPercent(0, 1));
+      it('can be moved with keys (vertical) at the top of the slider', () => {
+        let onChangeSpy = jest.fn();
+        let onChangeEndSpy = jest.fn();
+        render(<Example onChange={onChangeSpy} onChangeEnd={onChangeEndSpy} aria-label="Slider" defaultValue={[100]} orientation="vertical" />);
 
-        onChangeSpy.mockClear();
-        onChangeEndSpy.mockClear();
-
+        // Drag thumb
+        let thumb0 = screen.getByTestId('thumb').firstChild;
         fireEvent.keyDown(thumb0, {key: 'ArrowUp'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowUp'});
         expect(onChangeSpy).not.toHaveBeenCalled();
-        expect(onChangeEndSpy).not.toHaveBeenCalled();
+        expect(onChangeEndSpy).toHaveBeenCalledWith([100]);
 
         fireEvent.keyDown(thumb0, {key: 'ArrowDown'});
+        fireEvent.keyUp(thumb0, {key: 'ArrowDown'});
         expect(onChangeSpy).toHaveBeenLastCalledWith([99]);
         expect(onChangeSpy).toHaveBeenCalledTimes(1);
         expect(onChangeEndSpy).toHaveBeenLastCalledWith([99]);
-        expect(onChangeEndSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeEndSpy).toHaveBeenCalledTimes(2);
         expect(stateRef.current.values).toEqual([99]);
       });
     });

--- a/packages/@react-spectrum/slider/test/Slider.test.tsx
+++ b/packages/@react-spectrum/slider/test/Slider.test.tsx
@@ -207,13 +207,17 @@ describe('Slider', function () {
   });
 
   describe('keyboard interactions', () => {
-    // Can't test arrow/page up/down, home/end arrows because they are handled by the browser and JSDOM doesn't feel like it.
-
     it.each`
       Name                                 | props                                 | commands
       ${'(left/right arrows, ltr)'}        | ${{locale: 'de-DE'}}                  | ${[{left: press.ArrowRight, result: +1}, {left: press.ArrowLeft, result: -1}]}
       ${'(left/right arrows, rtl)'}        | ${{locale: 'ar-AE'}}                  | ${[{left: press.ArrowRight, result: -1}, {left: press.ArrowLeft, result: +1}]}
       ${'(left/right arrows, isDisabled)'} | ${{locale: 'de-DE', isDisabled: true}}| ${[{left: press.ArrowRight, result: 0}, {left: press.ArrowLeft, result: 0}]}
+      ${'(up/down arrows, ltr)'}           | ${{locale: 'de-DE'}}                  | ${[{left: press.ArrowUp, result: +1}, {left: press.ArrowDown, result: -1}]}
+      ${'(up/down arrows, rtl)'}           | ${{locale: 'ar-AE'}}                  | ${[{left: press.ArrowUp, result: +1}, {left: press.ArrowDown, result: -1}]}
+      ${'(page up/down, ltr)'}             | ${{locale: 'de-DE'}}                  | ${[{left: press.PageUp, result: +1}, {left: press.PageDown, result: -1}]}
+      ${'(page up/down, rtl)'}             | ${{locale: 'ar-AE'}}                  | ${[{left: press.PageUp, result: +1}, {left: press.PageDown, result: -1}]}
+      ${'(home/end, ltr)'}                 | ${{locale: 'de-DE'}}                  | ${[{left: press.Home, result: -50}, {left: press.End, result: +100}]}
+      ${'(home/end, rtl)'}                 | ${{locale: 'ar-AE'}}                  | ${[{left: press.Home, result: -50}, {left: press.End, result: +100}]}
     `('$Name moves the slider in the correct direction', function ({props, commands}) {
       let tree = render(
         <Provider theme={theme} {...props}>
@@ -225,9 +229,32 @@ describe('Slider', function () {
     });
 
     it.each`
+      Name                                 | props                                 | commands
+      ${'(left/right arrows, ltr)'}        | ${{locale: 'de-DE'}}                  | ${[{left: press.ArrowRight, result: +1}, {left: press.ArrowLeft, result: -1}]}
+      ${'(left/right arrows, rtl)'}        | ${{locale: 'ar-AE'}}                  | ${[{left: press.ArrowRight, result: -1}, {left: press.ArrowLeft, result: +1}]}
+      ${'(left/right arrows, isDisabled)'} | ${{locale: 'de-DE', isDisabled: true}}| ${[{left: press.ArrowRight, result: 0}, {left: press.ArrowLeft, result: 0}]}
+      ${'(up/down arrows, ltr)'}           | ${{locale: 'de-DE'}}                  | ${[{left: press.ArrowUp, result: +1}, {left: press.ArrowDown, result: -1}]}
+      ${'(up/down arrows, rtl)'}           | ${{locale: 'ar-AE'}}                  | ${[{left: press.ArrowUp, result: +1}, {left: press.ArrowDown, result: -1}]}
+      ${'(page up/down, ltr)'}             | ${{locale: 'de-DE'}}                  | ${[{left: press.PageUp, result: +1}, {left: press.PageDown, result: -1}]}
+      ${'(page up/down, rtl)'}             | ${{locale: 'ar-AE'}}                  | ${[{left: press.PageUp, result: +1}, {left: press.PageDown, result: -1}]}
+      ${'(home/end, ltr)'}                 | ${{locale: 'de-DE'}}                  | ${[{left: press.Home, result: -50}, {left: press.End, result: +100}]}
+      ${'(home/end, rtl)'}                 | ${{locale: 'ar-AE'}}                  | ${[{left: press.Home, result: -50}, {left: press.End, result: +100}]}
+    `('$Name moves the slider in the correct direction orientation vertical', function ({props, commands}) {
+      let tree = render(
+        <Provider theme={theme} {...props}>
+          <Slider label="Label" defaultValue={50} minValue={0} maxValue={100} orientation="vertical" />
+        </Provider>
+      );
+      let slider = tree.getByRole('slider');
+      testKeypresses([slider, slider], commands);
+    });
+
+    it.each`
       Name                          | props                 | commands
       ${'(left/right arrows, ltr)'} | ${{locale: 'de-DE'}}  | ${[{left: press.ArrowRight, result: +10}, {left: press.ArrowLeft, result: -10}]}
       ${'(left/right arrows, rtl)'} | ${{locale: 'ar-AE'}}  | ${[{left: press.ArrowRight, result: -10}, {left: press.ArrowLeft, result: +10}]}
+      ${'(page up/down, ltr)'}      | ${{locale: 'de-DE'}}  | ${[{left: press.PageUp, result: +10}, {left: press.PageDown, result: -10}]}
+      ${'(page up/down, rtl)'}      | ${{locale: 'ar-AE'}}  | ${[{left: press.PageUp, result: +10}, {left: press.PageDown, result: -10}]}
     `('$Name respects the step size', function ({props, commands}) {
       let tree = render(
         <Provider theme={theme} {...props}>

--- a/packages/@react-spectrum/slider/test/utils.ts
+++ b/packages/@react-spectrum/slider/test/utils.ts
@@ -14,12 +14,17 @@ import {act, fireEvent} from '@testing-library/react';
 
 function pressKeyOnButton(key, button) {
   fireEvent.keyDown(button, {key});
+  fireEvent.keyUp(button, {key});
 }
 export const press = {
   ArrowRight: (button: HTMLElement) => pressKeyOnButton('ArrowRight', button),
   ArrowLeft: (button: HTMLElement) => pressKeyOnButton('ArrowLeft', button),
+  ArrowUp: (button: HTMLElement) => pressKeyOnButton('ArrowUp', button),
+  ArrowDown: (button: HTMLElement) => pressKeyOnButton('ArrowDown', button),
   Home: (button: HTMLElement) => pressKeyOnButton('Home', button),
-  End: (button: HTMLElement) => pressKeyOnButton('End', button)
+  End: (button: HTMLElement) => pressKeyOnButton('End', button),
+  PageUp: (button: HTMLElement) => pressKeyOnButton('PageUp', button),
+  PageDown: (button: HTMLElement) => pressKeyOnButton('PageDown', button)
 };
 
 export function testKeypresses([sliderLeft, sliderRight], commands: any[]) {

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -229,11 +229,11 @@ export function useSliderState(props: SliderStateOptions): SliderState {
     return clamp(getRoundedValue(val), minValue, maxValue);
   }
 
-  function incrementThumb(index: number, stepSize: number) {
+  function incrementThumb(index: number, stepSize: number = 1) {
     updateValue(index, snapValueToStep(values[index] + stepSize, minValue, maxValue, stepSize));
   }
 
-  function decrementThumb(index: number, stepSize: number) {
+  function decrementThumb(index: number, stepSize: number = 1) {
     updateValue(index, snapValueToStep(values[index] - stepSize, minValue, maxValue, stepSize));
   }
 

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -120,6 +120,15 @@ export interface SliderState {
   setThumbEditable(index: number, editable: boolean): void,
 
   /**
+   * Increments the value of the thumb by the step or page amount.
+   */
+  incrementThumb(index: number, stepSize?: number): void,
+  /**
+   * Decrements the value of the thumb by the step or page amount.
+   */
+  decrementThumb(index: number, stepSize?: number): void,
+
+  /**
    * The step amount for the slider.
    */
   readonly step: number
@@ -220,6 +229,14 @@ export function useSliderState(props: SliderStateOptions): SliderState {
     return clamp(getRoundedValue(val), minValue, maxValue);
   }
 
+  function incrementThumb(index: number, stepSize: number) {
+    updateValue(index, snapValueToStep(values[index] + stepSize, minValue, maxValue, stepSize));
+  }
+
+  function decrementThumb(index: number, stepSize: number) {
+    updateValue(index, snapValueToStep(values[index] - stepSize, minValue, maxValue, stepSize));
+  }
+
   return {
     values: values,
     getThumbValue: (index: number) => values[index],
@@ -238,6 +255,8 @@ export function useSliderState(props: SliderStateOptions): SliderState {
     getPercentValue,
     isThumbEditable,
     setThumbEditable,
+    incrementThumb,
+    decrementThumb,
     step
   };
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

This matches our work in color area and color slider.
Yes, we could rely on native behavior, but it causes the code to be fairly different and would make it harder in the future to support custom page size steps.
It also allows us to run some tests we couldn't run before.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
