### PR TITLE
Update browserslist config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "browserslist": [
-    "chrome >= 80",
-    "firefox >= 76",
+    "chrome >= 88",
+    "firefox >= 85",
     "safari >= 13",
-    "edge >= 80"
+    "edge >= 88"
   ],
   "scripts": {
     "check-types": "tsc",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "browserslist": [
-    "chrome >= 61",
-    "firefox >= 60",
-    "safari >= 11",
-    "edge >= 16"
+    "chrome >= 80",
+    "firefox >= 76",
+    "safari >= 13",
+    "edge >= 80"
   ],
   "scripts": {
     "check-types": "tsc",

--- a/packages/@react-aria/interactions/docs/interactions.mdx
+++ b/packages/@react-aria/interactions/docs/interactions.mdx
@@ -109,9 +109,9 @@ so that components receive a consistent stream of events regardless of the inter
 All React Aria components are tested across a wide variety of browsers and devices. We test across devices with
 mouse input, touchscreens, and also hybrid devices.
 
-* Chrome 80+ on macOS and Windows
-* Firefox 76+ on macOS and Windows
+* Chrome 88+ on macOS and Windows
+* Firefox 85+ on macOS and Windows
 * Safari 13+ on macOS
-* Edge 80+ on Windows
+* Edge 88+ on Windows
 * Safari 13+ on iOS and iPadOS
-* Chrome 80+ on Android
+* Chrome 88+ on Android


### PR DESCRIPTION
Followup to #2776. This bumps the versions we have defined in our browserslist to match our documented browser support matrix. Due to this, our CSS gets smaller due to needing fewer prefixes (11 KB smaller than main, 15 KB smaller than cssnano).