### PR TITLE
Fix TableKeyboardDelegate `key` null checks and rendering of rows with falsy ids

### DIFF
--- a/packages/@react-aria/table/src/TableKeyboardDelegate.ts
+++ b/packages/@react-aria/table/src/TableKeyboardDelegate.ts
@@ -36,7 +36,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
       }
 
       let firstKey = this.getFirstKey();
-      if (!firstKey) {
+      if (firstKey == null) {
         return;
       }
 
@@ -65,7 +65,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
 
     // only return above row key if not header row
     let superKey = super.getKeyAbove(key);
-    if (superKey && this.collection.getItem(superKey).type !== 'headerrow') {
+    if (superKey != null && this.collection.getItem(superKey).type !== 'headerrow') {
       return superKey;
     }
 
@@ -152,7 +152,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
 
     let collection = this.collection;
     let key = fromKey ?? this.getFirstKey();
-    if (!key) {
+    if (key == null) {
       return null;
     }
 

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -68,6 +68,12 @@ let items = [
   {test: 'Test 2', foo: 'Foo 8', bar: 'Bar 2', yay: 'Yay 2', baz: 'Baz 2'}
 ];
 
+let itemsWithFalsyId = [
+  {test: 'Test 1', foo: 'Foo 1', bar: 'Bar 1', yay: 'Yay 1', baz: 'Baz 1', id: 0},
+  {test: 'Test 2', foo: 'Foo 2', bar: 'Bar 2', yay: 'Yay 2', baz: 'Baz 2', id: ''},
+  {test: 'Test 1', foo: 'Foo 3', bar: 'Bar 1', yay: 'Yay 1', baz: 'Baz 1', id: 2}
+];
+
 let manyColunns = [];
 for (let i = 0; i < 100; i++) {
   manyColunns.push({name: 'Column ' + i, key: 'C' + i});
@@ -155,6 +161,23 @@ storiesOf('TableView', module)
         <TableBody items={items}>
           {item =>
             (<Row key={item.foo}>
+              {key => <Cell>{item[key]}</Cell>}
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    )
+  )
+  .add(
+    'dynamic, falsy row keys',
+    () => (
+      <TableView aria-label="TableView with dynamic contents and falsy keys" width={300} height={200}>
+        <TableHeader columns={columns}>
+          {column => <Column>{column.name}</Column>}
+        </TableHeader>
+        <TableBody items={itemsWithFalsyId}>
+          {item =>
+            (<Row>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -187,7 +187,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     let layoutNode = this.buildNode(node, x, y);
     layoutNode.node = node;
 
-    layoutNode.layoutInfo.parentKey = node.parentKey || null;
+    layoutNode.layoutInfo.parentKey = node.parentKey ?? null;
     this.layoutInfos.set(layoutNode.layoutInfo.key, layoutNode.layoutInfo);
     if (layoutNode.header) {
       this.layoutInfos.set(layoutNode.header.key, layoutNode.header);

--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -555,7 +555,7 @@ export class Virtualizer<T extends object, V, W> {
     // Ask the delegate to provide a scroll anchor, if possible
     if (this.delegate.getScrollAnchor) {
       let key = this.delegate.getScrollAnchor(visibleRect);
-      if (key) {
+      if (key != null) {
         let layoutInfo = this.layout.getLayoutInfo(key);
         let corner = layoutInfo.rect.getCornerInRect(visibleRect);
         if (corner) {


### PR DESCRIPTION
Closes #2835

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
