### PR TITLE
Workaround Parcel bug with re-exports

### DIFF
--- a/packages/@react-aria/grid/src/useGridRowGroup.ts
+++ b/packages/@react-aria/grid/src/useGridRowGroup.ts
@@ -12,7 +12,7 @@
 
 import {HTMLAttributes} from 'react';
 
-interface GridRowGroupAria {
+export interface GridRowGroupAria {
   /** Props for the row group element. */
   rowGroupProps: HTMLAttributes<HTMLElement>
 }

--- a/packages/@react-aria/table/src/index.ts
+++ b/packages/@react-aria/table/src/index.ts
@@ -17,4 +17,9 @@ export * from './useTableHeaderRow';
 export * from './useTableCell';
 export * from './useTableSelectionCheckbox';
 
-export {useGridRowGroup as useTableRowGroup} from '@react-aria/grid';
+// Workaround for a Parcel bug where re-exports don't work in the CommonJS output format...
+// export {useGridRowGroup as useTableRowGroup} from '@react-aria/grid';
+import {GridRowGroupAria, useGridRowGroup} from '@react-aria/grid';
+export function useTableRowGroup(): GridRowGroupAria {
+  return useGridRowGroup();
+}


### PR DESCRIPTION
Something must have broken in the Parcel upgrade. @jrgarciadev reported that the CommonJS build of `@react-aria/table` was broken in the nightly version. The ESM version is fine, but NextJS uses the CJS build for server rendering. For now, I've applied a workaround, and I will investigate the Parcel issue separately.