### PR TITLE
Add a script to detect circular dependencies

### DIFF
--- a/packages/@react-aria/ssr/package.json
+++ b/packages/@react-aria/ssr/package.json
@@ -17,8 +17,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2",
-    "@react-aria/utils": "^3.10.0"
+    "@babel/runtime": "^7.6.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/packages/@react-aria/ssr/src/SSRProvider.tsx
+++ b/packages/@react-aria/ssr/src/SSRProvider.tsx
@@ -10,8 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import React, {ReactNode, useContext, useMemo, useState} from 'react';
-import {useLayoutEffect} from '@react-aria/utils';
+// We must avoid a circular dependency with @react-aria/utils, and this useLayoutEffect is
+// guarded by a check that it only runs on the client side.
+// eslint-disable-next-line rulesdir/useLayoutEffectRule
+import React, {ReactNode, useContext, useLayoutEffect, useMemo, useState} from 'react';
 
 // To support SSR, the auto incrementing id counter is stored in a context. This allows
 // it to be reset on every request to ensure the client and server are consistent.

--- a/scripts/findCircularDeps.js
+++ b/scripts/findCircularDeps.js
@@ -1,6 +1,7 @@
 const exec = require('child_process').execSync;
 
-let workspaces = JSON.parse(exec('yarn workspaces info --json').toString().split('\n').slice(1, -2).join('\n'));
+let output = exec('yarn workspaces info --json').toString().replace(/^(.|\n)*?\{/, '{').replace(/\}\nDone in .*\n?$/, '}');
+let workspaces = JSON.parse(output);
 
 for (let pkg in workspaces) {
   addDep(pkg);

--- a/scripts/findCircularDeps.js
+++ b/scripts/findCircularDeps.js
@@ -1,0 +1,24 @@
+const exec = require('child_process').execSync;
+
+let workspaces = JSON.parse(exec('yarn workspaces info --json').toString().split('\n').slice(1, -2).join('\n'));
+
+for (let pkg in workspaces) {
+  addDep(pkg);
+}
+
+function addDep(dep, seen = new Set()) {
+  if (seen.has(dep)) {
+    let arr = [...seen];
+    let index = arr.indexOf(dep);
+    console.log(`Circular dependency detected: ${arr.slice(index).join(' -> ')} -> ${dep}`);
+    process.exit(1);
+  }
+
+  seen.add(dep);
+
+  for (let d of workspaces[dep].workspaceDependencies) {
+    addDep(d, seen);
+  }
+
+  seen.delete(dep);
+}

--- a/scripts/lint-packages.js
+++ b/scripts/lint-packages.js
@@ -138,3 +138,4 @@ if (errors) {
 }
 
 require('./checkPublishedDependencies');
+require('./findCircularDeps');


### PR DESCRIPTION
We had one from `@react-aria/ssr` -> `@react-aria/utils` -> `@react-aria/ssr`. Fixed it and added a lint script to check this so it doesn't happen again.