### PR TITLE
Adjust browserslist to compile optional chaining

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+chrome >= 79
+firefox >= 85
+safari >= 13
+edge >= 88

--- a/package.json
+++ b/package.json
@@ -7,12 +7,6 @@
     "type": "git",
     "url": "https://github.com/adobe/react-spectrum"
   },
-  "browserslist": [
-    "chrome >= 88",
-    "firefox >= 85",
-    "safari >= 13",
-    "edge >= 88"
-  ],
   "scripts": {
     "check-types": "tsc",
     "install-16": "yarn add -W react@^16.8.0 react-dom@^16.8.0",


### PR DESCRIPTION
#2857

Two issues:

1. Browserslist was not picked up by Parcel because it was not in the package.json of each package. The root package.json was not used. Instead, we can move the browserslist to a `.browserslistrc` file in the root so that we don't need to repeat it. This fixes private class fields being compiled.
2. We need to lower our browser targets to a browser version that doesn't support optional chaining and nullish coalescing because webpack 4 is still widely used and doesn't support them. At some point in the future we will raise this again, so we encourage all users to upgrade webpack soon if possible.