### PR TITLE
Fix controlled numberfield blur shows old value quickly

### DIFF
--- a/packages/@react-stately/numberfield/package.json
+++ b/packages/@react-stately/numberfield/package.json
@@ -18,10 +18,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@internationalized/number": "^3.0.5",
+    "@react-aria/utils": "^3.11.2",
     "@react-stately/utils": "^3.4.1",
     "@react-types/numberfield": "^3.1.2",
-    "@react-types/shared": "^3.11.1",
-    "@internationalized/number": "^3.0.5"
+    "@react-types/shared": "^3.11.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1"

--- a/packages/@react-stately/numberfield/src/useNumberFieldState.ts
+++ b/packages/@react-stately/numberfield/src/useNumberFieldState.ts
@@ -13,7 +13,8 @@
 import {clamp, snapValueToStep, useControlledState} from '@react-stately/utils';
 import {NumberFieldProps} from '@react-types/numberfield';
 import {NumberFormatter, NumberParser} from '@internationalized/number';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {useLayoutEffect} from '@react-aria/utils';
 
 export interface NumberFieldState {
   /**
@@ -104,7 +105,7 @@ export function useNumberFieldState(
   // Update the input value when the number value or format options change. This is done
   // in a useEffect so that the controlled behavior is correct and we only update the
   // textfield after prop changes.
-  useEffect(() => {
+  useLayoutEffect(() => {
     setInputValue(format(numberValue));
   }, [numberValue, locale, formatOptions]);
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2870

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Go to NumberField `controlled` story
Select all the text in the input
Type '1'
Blur
Should no longer see a blur showing the original value before the formatting takes hold

## 🧢 Your Project:

<!--- Company/project for pull request -->
