### PR TITLE
Making listview items select on pressUp if list is draggable

### DIFF
--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -53,7 +53,7 @@ export function ListViewItem(props) {
     node: item,
     isVirtualized: true,
     onAction: onAction ? () => onAction(item.key) : undefined,
-    shouldSelectOnPressUp: isDraggable
+    shouldSelectOnPressUp: isListDraggable
   }, state, rowRef);
   let {gridCellProps} = useGridCell({
     node: cellNode,

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1016,6 +1016,39 @@ describe('ListView', function () {
       });
     });
 
+    it('should make row selection happen on pressUp if list is draggable', function () {
+      let allowsDraggingItem = (key) => {
+        if (key === 'b') {
+          return false;
+        }
+        return true;
+      };
+
+      let {getAllByRole} = render(
+        <DraggableListView dragHookOptions={{allowsDraggingItem}} />
+      );
+
+      let rows = getAllByRole('row');
+      let draggableRow = rows[0];
+      let nonDraggableRow = rows[1];
+      expect(draggableRow).toHaveAttribute('aria-selected', 'false');
+      fireEvent.mouseDown(draggableRow);
+      expect(draggableRow).toHaveAttribute('aria-selected', 'false');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
+      fireEvent.mouseUp(draggableRow);
+      expect(draggableRow).toHaveAttribute('aria-selected', 'true');
+      checkSelection(onSelectionChange, ['a']);
+
+      onSelectionChange.mockReset();
+      expect(nonDraggableRow).toHaveAttribute('aria-selected', 'false');
+      fireEvent.mouseDown(nonDraggableRow);
+      expect(nonDraggableRow).toHaveAttribute('aria-selected', 'false');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
+      fireEvent.mouseUp(nonDraggableRow);
+      expect(nonDraggableRow).toHaveAttribute('aria-selected', 'true');
+      checkSelection(onSelectionChange, ['a', 'b']);
+    });
+
     it('should toggle selection upon clicking the row checkbox', function () {
       let {getAllByRole} = render(
         <DraggableListView />


### PR DESCRIPTION
Testing followup

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the draggable story for ListView and make sure all selectable rows are selected on pressUp

## 🧢 Your Project:
RSP
