### PR TITLE
Add support for controlling focused date in calendar

### DIFF
--- a/packages/@react-aria/calendar/docs/useCalendar.mdx
+++ b/packages/@react-aria/calendar/docs/useCalendar.mdx
@@ -382,6 +382,28 @@ import {today} from '@internationalized/date';
 <Calendar aria-label="Appointment date" minValue={today(getLocalTimeZone())} />
 ```
 
+### Controlling the focused date
+
+By default, the selected date is focused when a `Calendar` first mounts. If no `value` or `defaultValue` prop is provided, then the current date is focused.  However, `useCalendar` supports controlling which date is focused using the `focusedValue` and `onFocusChange` props. This also determines which month is visible. The `defaultFocusedValue` prop allows setting the initial focused date when the `Calendar` first mounts, without controlling it.
+
+This example focuses July 1, 2021 by default. The user may change the focused date, and the `onFocusChange` event updates the state. Clicking the button resets the focused date back to the initial value.
+
+```tsx example
+import {CalendarDate} from '@internationalized/date';
+
+function Example() {
+  let defaultDate = new CalendarDate(2021, 7, 1);
+  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+
+  return (
+    <div style={{flexDirection: 'column', alignItems: 'start', gap: 20}}>
+      <button onClick={() => setFocusedDate(defaultDate)}>Reset focused date</button>
+      <Calendar focusedValue={focusedDate} onFocusChange={setFocusedDate} />
+    </div>
+  );
+}
+```
+
 ### Disabled
 
 The `isDisabled` boolean prop makes the Calendar disabled. Cells cannot be focused or selected.

--- a/packages/@react-aria/calendar/docs/useRangeCalendar.mdx
+++ b/packages/@react-aria/calendar/docs/useRangeCalendar.mdx
@@ -392,6 +392,28 @@ import {today} from '@internationalized/date';
 <RangeCalendar aria-label="Trip dates" minValue={today(getLocalTimeZone())} />
 ```
 
+### Controlling the focused date
+
+By default, the first selected date is focused when a `RangeCalendar` first mounts. If no `value` or `defaultValue` prop is provided, then the current date is focused.  However, `useRangeCalendar` supports controlling which date is focused using the `focusedValue` and `onFocusChange` props. This also determines which month is visible. The `defaultFocusedValue` prop allows setting the initial focused date when the `Calendar` first mounts, without controlling it.
+
+This example focuses July 1, 2021 by default. The user may change the focused date, and the `onFocusChange` event updates the state. Clicking the button resets the focused date back to the initial value.
+
+```tsx example
+import {CalendarDate} from '@internationalized/date';
+
+function Example() {
+  let defaultDate = new CalendarDate(2021, 7, 1);
+  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+
+  return (
+    <div style={{flexDirection: 'column', alignItems: 'start', gap: 20}}>
+      <button onClick={() => setFocusedDate(defaultDate)}>Reset focused date</button>
+      <RangeCalendar focusedValue={focusedDate} onFocusChange={setFocusedDate} />
+    </div>
+  );
+}
+```
+
 ### Disabled
 
 The `isDisabled` boolean prop makes the RangeCalendar disabled. Cells cannot be focused or selected.

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -119,7 +119,8 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       maxValue: props.maxValue,
       isDisabled: props.isDisabled,
       isReadOnly: props.isReadOnly,
-      isDateDisabled: props.isDateDisabled
+      isDateDisabled: props.isDateDisabled,
+      defaultFocusedValue: state.dateValue ? undefined : props.placeholderValue
     }
   };
 }

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -155,7 +155,8 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
       maxValue: props.maxValue,
       isDisabled: props.isDisabled,
       isReadOnly: props.isReadOnly,
-      isDateDisabled: props.isDateDisabled
+      isDateDisabled: props.isDateDisabled,
+      defaultFocusedValue: state.dateRange ? undefined : props.placeholderValue
     }
   };
 }

--- a/packages/@react-spectrum/calendar/docs/Calendar.mdx
+++ b/packages/@react-spectrum/calendar/docs/Calendar.mdx
@@ -18,6 +18,7 @@ import packageData from '@react-spectrum/calendar/package.json';
 ```jsx import
 import {Calendar} from '@react-spectrum/calendar';
 import {Flex} from '@react-spectrum/layout';
+import {ActionButton} from '@adobe/react-spectrum';
 ```
 
 ---
@@ -132,6 +133,28 @@ import {today} from '@internationalized/date';
 <Calendar aria-label="Appointment date" minValue={today(getLocalTimeZone())} />
 ```
 
+## Controlling the focused date
+
+By default, the selected date is focused when a `Calendar` first mounts. If no `value` or `defaultValue` prop is provided, then the current date is focused.  However, `Calendar` supports controlling which date is focused using the `focusedValue` and `onFocusChange` props. This also determines which month is visible. The `defaultFocusedValue` prop allows setting the initial focused date when the `Calendar` first mounts, without controlling it.
+
+This example focuses July 1, 2021 by default. The user may change the focused date, and the `onFocusChange` event updates the state. Clicking the button resets the focused date back to the initial value.
+
+```tsx example
+import {CalendarDate} from '@internationalized/date';
+
+function Example() {
+  let defaultDate = new CalendarDate(2021, 7, 1);
+  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+
+  return (
+    <Flex direction="column" alignItems="start" gap="size-200">
+      <ActionButton onPress={() => setFocusedDate(defaultDate)}>Reset focused date</ActionButton>
+      <Calendar focusedValue={focusedDate} onFocusChange={setFocusedDate} />
+    </Flex>
+  );
+}
+```
+
 ## Props
 
 <PropTable component={docs.exports.Calendar} links={docs.links} />
@@ -170,5 +193,7 @@ The `isReadOnly` boolean prop makes the Calendar's value immutable. Unlike `isDi
 By default, the `Calendar` displays a single month. The `visibleMonths` prop allows displaying up to 3 months at a time.
 
 ```tsx example
-<Calendar aria-label="Event date" visibleMonths={3} />
+<div style={{maxWidth: '100%', overflow: 'auto'}}>
+  <Calendar aria-label="Event date" visibleMonths={3} />
+</div>
 ```

--- a/packages/@react-spectrum/calendar/docs/RangeCalendar.mdx
+++ b/packages/@react-spectrum/calendar/docs/RangeCalendar.mdx
@@ -18,6 +18,7 @@ import packageData from '@react-spectrum/calendar/package.json';
 ```jsx import
 import {RangeCalendar} from '@react-spectrum/calendar';
 import {Flex} from '@react-spectrum/layout';
+import {ActionButton} from '@adobe/react-spectrum';
 ```
 
 ---
@@ -148,6 +149,28 @@ import {today} from '@internationalized/date';
 <RangeCalendar aria-label="Trip dates" minValue={today(getLocalTimeZone())} />
 ```
 
+## Controlling the focused date
+
+By default, the first selected date is focused when a `RangeCalendar` first mounts. If no `value` or `defaultValue` prop is provided, then the current date is focused.  However, `RangeCalendar` supports controlling which date is focused using the `focusedValue` and `onFocusChange` props. This also determines which month is visible. The `defaultFocusedValue` prop allows setting the initial focused date when the `Calendar` first mounts, without controlling it.
+
+This example focuses July 1, 2021 by default. The user may change the focused date, and the `onFocusChange` event updates the state. Clicking the button resets the focused date back to the initial value.
+
+```tsx example
+import {CalendarDate} from '@internationalized/date';
+
+function Example() {
+  let defaultDate = new CalendarDate(2021, 7, 1);
+  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+
+  return (
+    <Flex direction="column" alignItems="start" gap="size-200">
+      <ActionButton onPress={() => setFocusedDate(defaultDate)}>Reset focused date</ActionButton>
+      <RangeCalendar focusedValue={focusedDate} onFocusChange={setFocusedDate} />
+    </Flex>
+  );
+}
+```
+
 ## Props
 
 <PropTable component={docs.exports.RangeCalendar} links={docs.links} />
@@ -186,5 +209,7 @@ The `isReadOnly` boolean prop makes the RangeCalendar's value immutable. Unlike 
 By default, a `RangeCalendar` displays a single month. The `visibleMonths` prop allows displaying up to 3 months at a time.
 
 ```tsx example
-<RangeCalendar aria-label="Trip dates" visibleMonths={3} />
+<div style={{maxWidth: '100%', overflow: 'auto'}}>
+  <RangeCalendar aria-label="Trip dates" visibleMonths={3} />
+</div>
 ```

--- a/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
+++ b/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
@@ -11,6 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
+import {ActionButton} from '@react-spectrum/button';
 import {Calendar} from '../';
 import {CalendarDate, CalendarDateTime, getLocalTimeZone, parseZonedDateTime, today, ZonedDateTime} from '@internationalized/date';
 import {DateValue} from '@react-types/calendar';
@@ -86,6 +87,14 @@ storiesOf('Date and Time/Calendar', module)
   .add(
     'minValue, visibleMonths: 3, defaultValue',
     () => render({minValue: new CalendarDate(2019, 6, 1), defaultValue: new CalendarDate(2019, 6, 5), visibleMonths: 3})
+  )
+  .add(
+    'defaultFocusedValue',
+    () => render({defaultFocusedValue: new CalendarDate(2019, 6, 5)})
+  )
+  .add(
+    'focusedValue',
+    () => <ControlledFocus />
   );
 
 function render(props = {}) {
@@ -191,6 +200,16 @@ function CalendarWithZonedTime() {
     <Flex direction="column">
       <Calendar value={value} onChange={onChange} />
       <TimeField label="Time" value={value} onChange={onChange} />
+    </Flex>
+  );
+}
+
+function ControlledFocus() {
+  let [focusedDate, setFocusedDate] = useState(new CalendarDate(2019, 6, 5));
+  return (
+    <Flex direction="column" alignItems="start" gap="size-200">
+      <ActionButton onPress={() => setFocusedDate(new CalendarDate(2019, 6, 5))}>Reset focused date</ActionButton>
+      <Calendar focusedValue={focusedDate} onFocusChange={setFocusedDate} />
     </Flex>
   );
 }

--- a/packages/@react-spectrum/calendar/test/CalendarBase.test.js
+++ b/packages/@react-spectrum/calendar/test/CalendarBase.test.js
@@ -281,6 +281,66 @@ describe('CalendarBase', () => {
       let gridCells = getAllByRole('gridcell').filter(cell => cell.getAttribute('aria-disabled') !== 'true');
       expect(gridCells.length).toBe(21);
     });
+
+    it.each`
+      Name                   | Calendar
+      ${'v3 Calendar'}       | ${Calendar}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar}
+    `('$Name should support defaultFocusedValue', ({Calendar}) => {
+      let onFocusChange = jest.fn();
+      let {getByRole} = render(<Calendar defaultFocusedValue={new CalendarDate(2019, 6, 5)} autoFocus onFocusChange={onFocusChange} />);
+
+      let grid = getByRole('grid');
+      expect(grid).toHaveAttribute('aria-label', 'June 2019');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Wednesday, June 5, 2019')).toBe(true);
+
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowRight'});
+      fireEvent.keyUp(document.activeElement, {key: 'ArrowRight'});
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Thursday, June 6, 2019')).toBe(true);
+      expect(onFocusChange).toHaveBeenCalledWith(new CalendarDate(2019, 6, 6));
+    });
+
+    it.each`
+      Name                   | Calendar
+      ${'v3 Calendar'}       | ${Calendar}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar}
+    `('$Name should support controlled focusedValue', ({Calendar}) => {
+      let onFocusChange = jest.fn();
+      let {getByRole} = render(<Calendar focusedValue={new CalendarDate(2019, 6, 5)} autoFocus onFocusChange={onFocusChange} />);
+
+      let grid = getByRole('grid');
+      expect(grid).toHaveAttribute('aria-label', 'June 2019');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Wednesday, June 5, 2019')).toBe(true);
+
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowRight'});
+      fireEvent.keyUp(document.activeElement, {key: 'ArrowRight'});
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Wednesday, June 5, 2019')).toBe(true);
+      expect(onFocusChange).toHaveBeenCalledWith(new CalendarDate(2019, 6, 6));
+    });
+
+    it.each`
+      Name                   | Calendar
+      ${'v3 Calendar'}       | ${Calendar}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar}
+    `('$Name should constrain defaultFocusedValue', ({Calendar}) => {
+      let {getByRole} = render(<Calendar defaultFocusedValue={new CalendarDate(2019, 6, 5)} minValue={new CalendarDate(2019, 7, 5)} autoFocus />);
+
+      let grid = getByRole('grid');
+      expect(grid).toHaveAttribute('aria-label', 'July 2019');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Friday, July 5, 2019')).toBe(true);
+    });
+
+    it.each`
+      Name                   | Calendar
+      ${'v3 Calendar'}       | ${Calendar}
+      ${'v3 RangeCalendar'}  | ${RangeCalendar}
+    `('$Name should constrain focusedValue', ({Calendar}) => {
+      let {getByRole} = render(<Calendar focusedValue={new CalendarDate(2019, 6, 5)} minValue={new CalendarDate(2019, 7, 5)} autoFocus />);
+
+      let grid = getByRole('grid');
+      expect(grid).toHaveAttribute('aria-label', 'July 2019');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Friday, July 5, 2019')).toBe(true);
+    });
   });
 
   describe('labeling', () => {

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -156,6 +156,36 @@ describe('DatePickerBase', function () {
         expect(tz).not.toHaveAttribute('contenteditable');
       }
     });
+
+    it.each`
+      Name                   | Component
+      ${'DatePicker'}        | ${DatePicker}
+      ${'DateRangePicker'}   | ${DateRangePicker}
+    `('$Name should focus placeholderValue in calendar', ({Component}) => {
+      let {getByRole} = render(<Component label="Date" placeholderValue={new CalendarDate(2019, 6, 5)} />);
+
+      let button = getByRole('button');
+      triggerPress(button);
+
+      let grid = getByRole('grid');
+      expect(grid).toHaveAttribute('aria-label', 'June 2019');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Wednesday, June 5, 2019')).toBe(true);
+    });
+
+    it.each`
+      Name                   | Component          | props
+      ${'DatePicker'}        | ${DatePicker}      | ${{defaultValue: new CalendarDate(2019, 7, 5)}}
+      ${'DateRangePicker'}   | ${DateRangePicker} | ${{defaultValue: {start: new CalendarDate(2019, 7, 5), end: new CalendarDate(2019, 7, 10)}}}
+    `('$Name should focus selected date over placeholderValue', ({Component, props}) => {
+      let {getByRole} = render(<Component label="Date" {...props} placeholderValue={new CalendarDate(2019, 6, 5)} />);
+
+      let button = getByRole('button');
+      triggerPress(button);
+
+      let grid = getByRole('grid');
+      expect(grid).toHaveAttribute('aria-label', 'July 2019');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Friday, July 5, 2019')).toBe(true);
+    });
   });
 
   describe('calendar popover', function () {

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -25,7 +25,7 @@ import {CalendarProps, DateValue} from '@react-types/calendar';
 import {CalendarState} from './types';
 import {useControlledState} from '@react-stately/utils';
 import {useDateFormatter} from '@react-aria/i18n';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 
 interface CalendarStateOptions<T extends DateValue> extends CalendarProps<T> {
   locale: string,

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -51,46 +51,54 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
   let [value, setControlledValue] = useControlledState<DateValue>(props.value, props.defaultValue, props.onChange);
   let calendarDateValue = useMemo(() => value ? toCalendar(toCalendarDate(value), calendar) : null, [value, calendar]);
   let timeZone = useMemo(() => value && 'timeZone' in value ? value.timeZone : resolvedOptions.timeZone, [value, resolvedOptions.timeZone]);
-  let defaultDate = useMemo(() => calendarDateValue || constrainValue(toCalendar(today(timeZone), calendar), minValue, maxValue), [calendarDateValue, timeZone, calendar, minValue, maxValue]);
+  let focusedCalendarDate = useMemo(() => (
+    props.focusedValue
+      ? constrainValue(toCalendar(toCalendarDate(props.focusedValue), calendar), minValue, maxValue)
+      : undefined
+  ), [props.focusedValue, calendar, minValue, maxValue]);
+  let defaultFocusedCalendarDate = useMemo(() => (
+    constrainValue(
+      props.defaultFocusedValue
+        ? toCalendar(toCalendarDate(props.defaultFocusedValue), calendar)
+        : calendarDateValue || toCalendar(today(timeZone), calendar),
+      minValue,
+      maxValue
+    )
+  ), [props.defaultFocusedValue, calendarDateValue, timeZone, calendar, minValue, maxValue]);
+  let [focusedDate, setFocusedDate] = useControlledState(focusedCalendarDate, defaultFocusedCalendarDate, props.onFocusChange);
   let [startDate, setStartDate] = useState(() => {
     switch (selectionAlignment) {
       case 'start':
-        return alignStart(defaultDate, visibleDuration, locale, minValue, maxValue);
+        return alignStart(focusedDate, visibleDuration, locale, minValue, maxValue);
       case 'end':
-        return alignEnd(defaultDate, visibleDuration, locale, minValue, maxValue);
+        return alignEnd(focusedDate, visibleDuration, locale, minValue, maxValue);
       case 'center':
       default:
-        return alignCenter(defaultDate, visibleDuration, locale, minValue, maxValue);
+        return alignCenter(focusedDate, visibleDuration, locale, minValue, maxValue);
     }
   });
-  let [focusedDate, setFocusedDate] = useState(defaultDate);
   let [isFocused, setFocused] = useState(props.autoFocus || false);
 
   let endDate = useMemo(() => startDate.add(visibleDuration).subtract({days: 1}), [startDate, visibleDuration]);
 
   // Reset focused date and visible range when calendar changes.
   let lastCalendarIdentifier = useRef(calendar.identifier);
-  useEffect(() => {
-    if (calendar.identifier !== lastCalendarIdentifier.current) {
-      let newFocusedDate = toCalendar(focusedDate, calendar);
-      setStartDate(alignCenter(newFocusedDate, visibleDuration, locale, minValue, maxValue));
-      setFocusedDate(newFocusedDate);
-      lastCalendarIdentifier.current = calendar.identifier;
-    }
-  }, [calendar, focusedDate, visibleDuration, locale, minValue, maxValue]);
+  if (calendar.identifier !== lastCalendarIdentifier.current) {
+    let newFocusedDate = toCalendar(focusedDate, calendar);
+    setStartDate(alignCenter(newFocusedDate, visibleDuration, locale, minValue, maxValue));
+    setFocusedDate(newFocusedDate);
+    lastCalendarIdentifier.current = calendar.identifier;
+  }
+
+  if (focusedDate.compare(startDate) < 0) {
+    setStartDate(alignEnd(focusedDate, visibleDuration, locale, minValue, maxValue));
+  } else if (focusedDate.compare(startDate.add(visibleDuration)) >= 0) {
+    setStartDate(alignStart(focusedDate, visibleDuration, locale, minValue, maxValue));
+  }
 
   // Sets focus to a specific cell date
   function focusCell(date: CalendarDate) {
-    // date = constrain(focusedDate, date, visibleDuration, locale, minValue, maxValue);
     date = constrainValue(date, minValue, maxValue);
-
-    let next = startDate.add(visibleDuration);
-    if (date.compare(startDate) < 0) {
-      setStartDate(alignEnd(date, visibleDuration, locale, minValue, maxValue));
-    } else if (date.compare(next) >= 0) {
-      setStartDate(alignStart(date, visibleDuration, locale, minValue, maxValue));
-    }
-
     setFocusedDate(date);
   }
 
@@ -121,7 +129,7 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
     focusedDate,
     timeZone,
     setFocusedDate(date) {
-      setFocusedDate(date);
+      focusCell(date);
       setFocused(true);
     },
     focusNextDay() {

--- a/packages/@react-types/calendar/src/index.d.ts
+++ b/packages/@react-types/calendar/src/index.d.ts
@@ -41,7 +41,13 @@ export interface CalendarPropsBase {
    * Whether to automatically focus the calendar when it mounts.
    * @default false
    */
-  autoFocus?: boolean
+  autoFocus?: boolean,
+  /** Controls the currently focused date within the calendar. */
+  focusedValue?: DateValue,
+  /** The date that is focused when the calendar first mounts (uncountrolled). */
+  defaultFocusedValue?: DateValue,
+  /** Handler that is called when the focused date changes. */
+  onFocusChange?: (date: CalendarDate) => void
 }
 
 export type DateRange = RangeValue<DateValue>;


### PR DESCRIPTION
Depends on #2772 and #2873.

Closes #2627. Closes #2628.

This adds `focusedValue` and `defaultFocusedValue` props that allow setting or controlling the focused date in a calendar from the outside. Setting either one of these does not move DOM focus immediately, but just sets which date will get focus when the user tabs there. It also controls what month is visible in the calendar, if set to a value outside the currently visible range. There is also an `onFocusChange` event that is triggered whenever the user moves focus within the calendar.

This enables the `placeholderValue` prop on date picker to control where the calendar is opened up to, rather than always going to today's date if nothing is selected. You can also use it to control what month is showing from the outside, e.g. in the case of a year picker.