### PR TITLE
Remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-packages/@adobe/spectrum-css-temp/**    @lazd @garthdb
-packages/**                             @LFDanLu @ktabors @snowystinger @dannify @devongovett @reidbarber
-**                                      @snowystinger @dannify @devongovett


### PR DESCRIPTION
So we don't get assigned to every single PR