### PR TITLE
updating AlertDialog spectrum doc links

### DIFF
--- a/packages/@react-spectrum/dialog/docs/AlertDialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/AlertDialog.mdx
@@ -32,7 +32,7 @@ keywords: [alert dialog]
   packageData={packageData}
   componentNames={['AlertDialog', 'DialogTrigger']}
   sourceData={[
-    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/dialog/#Options'}
+    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/alert-dialog/'}
   ]} />
 
 ## Example
@@ -134,7 +134,7 @@ function Example() {
 ## Visual options
 
 ### Variant
-[View guidelines](https://spectrum.adobe.com/page/dialog/#Options)
+[View guidelines](https://spectrum.adobe.com/page/alert-dialog/#Options)
 
 **Confirmation**
 ```tsx example

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -74,7 +74,7 @@ export interface SpectrumDialogProps extends AriaDialogProps, StyleProps {
 }
 
 export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
-  /** The [visual style](https://spectrum.adobe.com/page/dialog/#Options) of the AlertDialog.  */
+  /** The [visual style](https://spectrum.adobe.com/page/alert-dialog/#Options) of the AlertDialog.  */
   variant?: 'confirmation' | 'information' | 'destructive' | 'error' | 'warning',
   /** The title of the AlertDialog. */
   title: string,


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Fixes broken links to spectrum docs in https://react-spectrum.adobe.com/react-spectrum/AlertDialog.html 
