### PR TITLE
Fix typo in VisuallyHidden docs

### DIFF
--- a/packages/@react-aria/visually-hidden/docs/VisuallyHidden.mdx
+++ b/packages/@react-aria/visually-hidden/docs/VisuallyHidden.mdx
@@ -53,7 +53,7 @@ options as the component, and returns props to spread onto the element that shou
 <FunctionAPI links={docs.links} function={docs.exports.useVisuallyHidden} />
 
 ```tsx
-import {VisuallyHidden} from '@react-aria/visually-hidden';
+import {useVisuallyHidden} from '@react-aria/visually-hidden';
 
 let {visuallyHiddenProps} = useVisuallyHidden();
 


### PR DESCRIPTION
The `useVisuallyHidden` example was importing `VisuallyHidden` instead of `useVisuallyHidden`.