### PR TITLE
Reverting ListView item padding back to 12px

### DIFF
--- a/packages/@react-spectrum/list/src/listview.css
+++ b/packages/@react-spectrum/list/src/listview.css
@@ -42,7 +42,7 @@
   font-size: var(--spectrum-table-cell-text-size, var(--spectrum-alias-font-size-default));
   font-weight: var(--spectrum-table-cell-text-font-weight, var(--spectrum-global-font-weight-regular));
   line-height: calc(var(--spectrum-table-cell-text-size, var(--spectrum-alias-font-size-default)) * var(--spectrum-table-cell-text-line-height, var(--spectrum-alias-body-text-line-height)) - 1px);
-  padding: var(--spectrum-listview-item-regular-padding-y) var(--spectrum-global-dimension-size-250);
+  padding: var(--spectrum-listview-item-regular-padding-y) var(--spectrum-global-dimension-size-150);
   transition: background-color var(--spectrum-global-animation-duration-100) ease-in-out;
   position: relative;
   /*background-color: var(--spectrum-table-background-color, var(--spectrum-global-color-gray-50));*/


### PR DESCRIPTION
Should be 12px padding like it was before, draggable rows override this themselves

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Run chromatic.
Padding between the row border and text/icon/checkbox for non draggable rows should be `spectrum-150` (aka 12px medium scale)
Padding between the row border and text/icon/checkbox for draggable rows should be `spectrum-250` (aka 20px medium scale)

## 🧢 Your Project:

RSP
