### PR TITLE
Make button attr type consistent with @types/react

### DIFF
--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -59,7 +59,7 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
    * The behavior of the button when used in an HTML form.
    * @default 'button'
    */
-  type?: 'button' | 'submit' | 'reset'
+  type?: string
 }
 
 export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}


### PR DESCRIPTION
Closes #2875

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Run the tests and typechecking with [the example from the @react-aria/button docs](https://react-spectrum.adobe.com/react-aria/useButton.html#example).

## 🧢 Your Project:

<!--- Company/project for pull request -->
-