### PR TITLE
Fix import of icon

### DIFF
--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -17,7 +17,7 @@ import {Content} from '@react-spectrum/view';
 import type {DraggableItemResult} from '@react-aria/dnd';
 import {FocusRing, useFocusRing} from '@react-aria/focus';
 import {Grid} from '@react-spectrum/layout';
-import ListGripper from '@spectrum-icons/ui/src/ListGripper';
+import ListGripper from '@spectrum-icons/ui/ListGripper';
 import listStyles from './listview.css';
 import {ListViewContext} from './ListView';
 import {mergeProps} from '@react-aria/utils';


### PR DESCRIPTION
`src` is not published, so we need to use the top-level built icons.