### PR TITLE
fix: allow input pasting on iOS Safari inside of Modals

### DIFF
--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -126,7 +126,9 @@ function preventScrollMobileSafari() {
 
   let onTouchEnd = (e: TouchEvent) => {
     let target = e.target as HTMLElement;
-    if (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type)) {
+
+    // Apply this change if we're not already focused on the target element
+    if (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type) && target !== document.activeElement) {
       e.preventDefault();
 
       // Apply a transform to trick Safari into thinking the input is at the top of the page


### PR DESCRIPTION
Closes #2030

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

See reproducible example: https://sosbp.csb.app/ from Issue [#2030](https://github.com/adobe/react-spectrum/issues/2030)

## 🧢 Your Project:

<!--- Company/project for pull request -->

Private repository w/ [@contra](https://github.com/contra)
