### PR TITLE
Improve handling when focused button becomes disabled

### DIFF
--- a/packages/@react-aria/interactions/src/useFocus.ts
+++ b/packages/@react-aria/interactions/src/useFocus.ts
@@ -16,7 +16,7 @@
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
 import {FocusEvents} from '@react-types/shared';
-import {HTMLAttributes, FocusEvent as ReactFocusEvent} from 'react';
+import {HTMLAttributes, FocusEvent as ReactFocusEvent, useRef} from 'react';
 
 interface FocusProps extends FocusEvents {
   /** Whether the focus events should be disabled. */
@@ -33,12 +33,9 @@ interface FocusResult {
  * Focus events on child elements will be ignored.
  */
 export function useFocus(props: FocusProps): FocusResult {
-  if (props.isDisabled) {
-    return {focusProps: {}};
-  }
-
+  let onBlur = useRef<FocusProps['onBlur']>(null);
   let onFocus: FocusProps['onFocus'];
-  if (props.onFocus || props.onFocusChange || props.onBlur) {
+  if (!props.isDisabled && (props.onFocus || props.onFocusChange || props.onBlur)) {
     onFocus = (e: ReactFocusEvent) => {
       if (e.target === e.currentTarget) {
         if (props.onFocus) {
@@ -51,60 +48,68 @@ export function useFocus(props: FocusProps): FocusResult {
 
         // Use native events to handle the onBlur. React does not fire onBlur when an element is disabled.
         // https://github.com/facebook/react/issues/9142
-        if (props.onBlur || props.onFocusChange) {
-          let isFocused = true;
-          let observer: MutationObserver;
-          let SyntheticEvent: any = e.constructor;
+        let isFocused = true;
+        let observer: MutationObserver;
+        let SyntheticEvent: any = e.constructor;
 
-          // Most browsers will fire a blur/focusout event when elements are disabled (except Firefox).
-          let onBlur = (e: FocusEvent) => {
-            if (e.target === e.currentTarget) {
-              isFocused = false;
+        // Most browsers will fire a blur/focusout event when elements are disabled (except Firefox).
+        let onBlurHandler = (e: FocusEvent) => {
+          if (e.target === e.currentTarget) {
+            isFocused = false;
 
-              // For backward compatibility, dispatch a React synthetic event.
-              let event: ReactFocusEvent = new SyntheticEvent('onBlur', 'blur', null, e, e.target);
-              event.currentTarget = e.currentTarget as Element;
+            // For backward compatibility, dispatch a React synthetic event.
+            let event: ReactFocusEvent = new SyntheticEvent('onBlur', 'blur', null, e, e.target);
+            event.currentTarget = e.currentTarget as Element;
 
-              if (props.onBlur) {
-                props.onBlur(event);
-              }
+            onBlur.current?.(event);
 
-              if (props.onFocusChange) {
-                props.onFocusChange(false);
-              }
-
-              if (event.isPropagationStopped()) {
-                e.stopPropagation();
-              }
-
-              e.target.removeEventListener('focusout', onBlur);
-              if (observer) {
-                observer.disconnect();
-                observer = null;
-              }
+            if (event.isPropagationStopped()) {
+              e.stopPropagation();
             }
-          };
 
-          e.target.addEventListener('focusout', onBlur);
-
-          // If this is a <button> or <input>, use a MutationObserver to watch for the disabled attribute.
-          // This is necessary because Firefox does not fire blur/focusout in this case. We dispatch these events ourselves instead.
-          // For browsers that do, focusout fires before the MutationObserver, so onBlur should not fire twice.
-          if (e.target instanceof HTMLButtonElement || e.target instanceof HTMLInputElement) {
-            let target = e.target;
-            observer = new MutationObserver(() => {
-              if (isFocused && target.disabled) {
-                observer.disconnect();
-                e.target.dispatchEvent(new FocusEvent('blur'));
-                e.target.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
-              }
-            });
-
-            observer.observe(e.target, {attributes: true, attributeFilter: ['disabled']});
+            e.target.removeEventListener('focusout', onBlurHandler);
+            if (observer) {
+              observer.disconnect();
+              observer = null;
+            }
           }
+        };
+
+        e.target.addEventListener('focusout', onBlurHandler);
+
+        // If this is a <button> or <input>, use a MutationObserver to watch for the disabled attribute.
+        // This is necessary because Firefox does not fire blur/focusout in this case. We dispatch these events ourselves instead.
+        // For browsers that do, focusout fires before the MutationObserver, so onBlur should not fire twice.
+        if (e.target instanceof HTMLButtonElement || e.target instanceof HTMLInputElement) {
+          let target = e.target;
+          observer = new MutationObserver(() => {
+            if (isFocused && target.disabled) {
+              observer.disconnect();
+              e.target.dispatchEvent(new FocusEvent('blur'));
+              e.target.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+            }
+          });
+
+          observer.observe(e.target, {attributes: true, attributeFilter: ['disabled']});
         }
       }
     };
+  }
+
+  if (!props.isDisabled && (props.onBlur || props.onFocusChange)) {
+    onBlur.current = (e: ReactFocusEvent) => {
+      if (e.target === e.currentTarget) {
+        if (props.onBlur) {
+          props.onBlur(e);
+        }
+
+        if (props.onFocusChange) {
+          props.onFocusChange(false);
+        }
+      }
+    };
+  } else {
+    onBlur.current = null;
   }
 
   return {

--- a/packages/@react-aria/interactions/src/useFocus.ts
+++ b/packages/@react-aria/interactions/src/useFocus.ts
@@ -15,8 +15,8 @@
 // NOTICE file in the root directory of this source tree.
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
-import {FocusEvent, HTMLAttributes} from 'react';
 import {FocusEvents} from '@react-types/shared';
+import {HTMLAttributes, FocusEvent as ReactFocusEvent} from 'react';
 
 interface FocusProps extends FocusEvents {
   /** Whether the focus events should be disabled. */
@@ -37,9 +37,9 @@ export function useFocus(props: FocusProps): FocusResult {
     return {focusProps: {}};
   }
 
-  let onFocus, onBlur;
-  if (props.onFocus || props.onFocusChange) {
-    onFocus = (e: FocusEvent) => {
+  let onFocus: FocusProps['onFocus'];
+  if (props.onFocus || props.onFocusChange || props.onBlur) {
+    onFocus = (e: ReactFocusEvent) => {
       if (e.target === e.currentTarget) {
         if (props.onFocus) {
           props.onFocus(e);
@@ -48,19 +48,60 @@ export function useFocus(props: FocusProps): FocusResult {
         if (props.onFocusChange) {
           props.onFocusChange(true);
         }
-      }
-    };
-  }
 
-  if (props.onBlur || props.onFocusChange) {
-    onBlur = (e: FocusEvent) => {
-      if (e.target === e.currentTarget) {
-        if (props.onBlur) {
-          props.onBlur(e);
-        }
+        // Use native events to handle the onBlur. React does not fire onBlur when an element is disabled.
+        // https://github.com/facebook/react/issues/9142
+        if (props.onBlur || props.onFocusChange) {
+          let isFocused = true;
+          let observer: MutationObserver;
+          let SyntheticEvent: any = e.constructor;
 
-        if (props.onFocusChange) {
-          props.onFocusChange(false);
+          // Most browsers will fire a blur/focusout event when elements are disabled (except Firefox).
+          let onBlur = (e: FocusEvent) => {
+            if (e.target === e.currentTarget) {
+              isFocused = false;
+
+              // For backward compatibility, dispatch a React synthetic event.
+              let event: ReactFocusEvent = new SyntheticEvent('onBlur', 'blur', null, e, e.target);
+              event.currentTarget = e.currentTarget as Element;
+
+              if (props.onBlur) {
+                props.onBlur(event);
+              }
+
+              if (props.onFocusChange) {
+                props.onFocusChange(false);
+              }
+
+              if (event.isPropagationStopped()) {
+                e.stopPropagation();
+              }
+
+              e.target.removeEventListener('focusout', onBlur);
+              if (observer) {
+                observer.disconnect();
+                observer = null;
+              }
+            }
+          };
+
+          e.target.addEventListener('focusout', onBlur);
+
+          // If this is a <button> or <input>, use a MutationObserver to watch for the disabled attribute.
+          // This is necessary because Firefox does not fire blur/focusout in this case. We dispatch these events ourselves instead.
+          // For browsers that do, focusout fires before the MutationObserver, so onBlur should not fire twice.
+          if (e.target instanceof HTMLButtonElement || e.target instanceof HTMLInputElement) {
+            let target = e.target;
+            observer = new MutationObserver(() => {
+              if (isFocused && target.disabled) {
+                observer.disconnect();
+                e.target.dispatchEvent(new FocusEvent('blur'));
+                e.target.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+              }
+            });
+
+            observer.observe(e.target, {attributes: true, attributeFilter: ['disabled']});
+          }
         }
       }
     };
@@ -68,8 +109,7 @@ export function useFocus(props: FocusProps): FocusResult {
 
   return {
     focusProps: {
-      onFocus,
-      onBlur
+      onFocus
     }
   };
 }

--- a/packages/@react-aria/interactions/src/useFocusWithin.ts
+++ b/packages/@react-aria/interactions/src/useFocusWithin.ts
@@ -15,15 +15,15 @@
 // NOTICE file in the root directory of this source tree.
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
-import {FocusEvent, HTMLAttributes, useRef} from 'react';
+import {HTMLAttributes, FocusEvent as ReactFocusEvent, useRef} from 'react';
 
 interface FocusWithinProps {
   /** Whether the focus within events should be disabled. */
   isDisabled?: boolean,
   /** Handler that is called when the target element or a descendant receives focus. */
-  onFocusWithin?: (e: FocusEvent) => void,
+  onFocusWithin?: (e: ReactFocusEvent) => void,
   /** Handler that is called when the target element and all descendants lose focus. */
-  onBlurWithin?: (e: FocusEvent) => void,
+  onBlurWithin?: (e: ReactFocusEvent) => void,
   /** Handler that is called when the the focus within state changes. */
   onFocusWithinChange?: (isFocusWithin: boolean) => void
 }
@@ -45,7 +45,7 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
     return {focusWithinProps: {}};
   }
 
-  let onFocus = (e: FocusEvent) => {
+  let onFocus = (e: ReactFocusEvent) => {
     if (!state.isFocusWithin) {
       if (props.onFocusWithin) {
         props.onFocusWithin(e);
@@ -56,30 +56,66 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
       }
 
       state.isFocusWithin = true;
-    }
-  };
 
-  let onBlur = (e: FocusEvent) => {
-    // We don't want to trigger onBlurWithin and then immediately onFocusWithin again
-    // when moving focus inside the element. Only trigger if the currentTarget doesn't
-    // include the relatedTarget (where focus is moving).
-    if (state.isFocusWithin && !e.currentTarget.contains(e.relatedTarget as HTMLElement)) {
-      if (props.onBlurWithin) {
-        props.onBlurWithin(e);
+      // Use native events to handle the onBlur. React does not fire onBlur when an element is disabled.
+      // https://github.com/facebook/react/issues/9142
+      let SyntheticEvent: any = e.constructor;
+      let observer: MutationObserver;
+      let onBlur = (e: FocusEvent) => {
+        // We don't want to trigger onBlurWithin and then immediately onFocusWithin again
+        // when moving focus inside the element. Only trigger if the currentTarget doesn't
+        // include the relatedTarget (where focus is moving).
+        if (state.isFocusWithin && !(e.currentTarget as Element).contains(e.relatedTarget as Element)) {
+          state.isFocusWithin = false;
+
+          // For backwards compatibility, construct a React synthetic event.
+          let event: ReactFocusEvent = new SyntheticEvent('onBlur', 'blur', null, e, e.target);
+          event.currentTarget = e.currentTarget as Element;
+
+          if (props.onBlurWithin) {
+            props.onBlurWithin(event);
+          }
+
+          if (props.onFocusWithinChange) {
+            props.onFocusWithinChange(false);
+          }
+
+          if (event.isPropagationStopped()) {
+            e.stopPropagation();
+          }
+
+          e.currentTarget.removeEventListener('focusout', onBlur);
+        }
+
+        if (observer) {
+          observer.disconnect();
+          observer = null;
+        }
+      };
+
+      e.currentTarget.addEventListener('focusout', onBlur);
+
+      // If this is a <button> or <input>, use a MutationObserver to watch for the disabled attribute.
+      // This is necessary because Firefox does not fire blur/focusout in this case. We dispatch these events ourselves instead.
+      // For browsers that do, focusout fires before the MutationObserver, so onBlur should not fire twice.
+      if (e.target instanceof HTMLButtonElement || e.target instanceof HTMLInputElement) {
+        let target = e.target;
+        observer = new MutationObserver(() => {
+          if (state.isFocusWithin && target.disabled) {
+            observer.disconnect();
+            target.dispatchEvent(new FocusEvent('blur'));
+            target.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+          }
+        });
+
+        observer.observe(e.target, {attributes: true, attributeFilter: ['disabled']});
       }
-
-      if (props.onFocusWithinChange) {
-        props.onFocusWithinChange(false);
-      }
-
-      state.isFocusWithin = false;
     }
   };
 
   return {
     focusWithinProps: {
-      onFocus: onFocus,
-      onBlur: onBlur
+      onFocus
     }
   };
 }

--- a/packages/@react-aria/interactions/src/useFocusWithin.ts
+++ b/packages/@react-aria/interactions/src/useFocusWithin.ts
@@ -41,6 +41,7 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
     isFocusWithin: false
   }).current;
 
+  let onBlurWithin = useRef<FocusWithinProps['onBlurWithin']>(null);
   if (props.isDisabled) {
     return {focusWithinProps: {}};
   }
@@ -72,13 +73,7 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
           let event: ReactFocusEvent = new SyntheticEvent('onBlur', 'blur', null, e, e.target);
           event.currentTarget = e.currentTarget as Element;
 
-          if (props.onBlurWithin) {
-            props.onBlurWithin(event);
-          }
-
-          if (props.onFocusWithinChange) {
-            props.onFocusWithinChange(false);
-          }
+          onBlurWithin.current?.(event);
 
           if (event.isPropagationStopped()) {
             e.stopPropagation();
@@ -112,6 +107,20 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
       }
     }
   };
+
+  if (props.onBlurWithin || props.onFocusWithinChange) {
+    onBlurWithin.current = (e: ReactFocusEvent) => {
+      if (props.onBlurWithin) {
+        props.onBlurWithin(e);
+      }
+
+      if (props.onFocusWithinChange) {
+        props.onFocusWithinChange(false);
+      }
+    };
+  } else {
+    onBlurWithin.current = null;
+  }
 
   return {
     focusWithinProps: {

--- a/packages/@react-aria/interactions/src/useFocusWithin.ts
+++ b/packages/@react-aria/interactions/src/useFocusWithin.ts
@@ -15,15 +15,16 @@
 // NOTICE file in the root directory of this source tree.
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
-import {HTMLAttributes, FocusEvent as ReactFocusEvent, useRef} from 'react';
+import {FocusEvent, HTMLAttributes, useRef} from 'react';
+import {useSyntheticBlurEvent} from './utils';
 
 interface FocusWithinProps {
   /** Whether the focus within events should be disabled. */
   isDisabled?: boolean,
   /** Handler that is called when the target element or a descendant receives focus. */
-  onFocusWithin?: (e: ReactFocusEvent) => void,
+  onFocusWithin?: (e: FocusEvent) => void,
   /** Handler that is called when the target element and all descendants lose focus. */
-  onBlurWithin?: (e: ReactFocusEvent) => void,
+  onBlurWithin?: (e: FocusEvent) => void,
   /** Handler that is called when the the focus within state changes. */
   onFocusWithinChange?: (isFocusWithin: boolean) => void
 }
@@ -41,12 +42,25 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
     isFocusWithin: false
   }).current;
 
-  let onBlurWithin = useRef<FocusWithinProps['onBlurWithin']>(null);
-  if (props.isDisabled) {
-    return {focusWithinProps: {}};
-  }
+  let onBlur = props.isDisabled ? null : (e: FocusEvent) => {
+    // We don't want to trigger onBlurWithin and then immediately onFocusWithin again
+    // when moving focus inside the element. Only trigger if the currentTarget doesn't
+    // include the relatedTarget (where focus is moving).
+    if (state.isFocusWithin && !(e.currentTarget as Element).contains(e.relatedTarget as Element)) {
+      state.isFocusWithin = false;
 
-  let onFocus = (e: ReactFocusEvent) => {
+      if (props.onBlurWithin) {
+        props.onBlurWithin(e);
+      }
+
+      if (props.onFocusWithinChange) {
+        props.onFocusWithinChange(false);
+      }
+    }
+  };
+
+  let onSyntheticFocus = useSyntheticBlurEvent(onBlur);
+  let onFocus = props.isDisabled ? null : (e: FocusEvent) => {
     if (!state.isFocusWithin) {
       if (props.onFocusWithin) {
         props.onFocusWithin(e);
@@ -57,74 +71,14 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
       }
 
       state.isFocusWithin = true;
-
-      // Use native events to handle the onBlur. React does not fire onBlur when an element is disabled.
-      // https://github.com/facebook/react/issues/9142
-      let SyntheticEvent: any = e.constructor;
-      let observer: MutationObserver;
-      let onBlur = (e: FocusEvent) => {
-        // We don't want to trigger onBlurWithin and then immediately onFocusWithin again
-        // when moving focus inside the element. Only trigger if the currentTarget doesn't
-        // include the relatedTarget (where focus is moving).
-        if (state.isFocusWithin && !(e.currentTarget as Element).contains(e.relatedTarget as Element)) {
-          state.isFocusWithin = false;
-
-          // For backwards compatibility, construct a React synthetic event.
-          let event: ReactFocusEvent = new SyntheticEvent('onBlur', 'blur', null, e, e.target);
-          event.currentTarget = e.currentTarget as Element;
-
-          onBlurWithin.current?.(event);
-
-          if (event.isPropagationStopped()) {
-            e.stopPropagation();
-          }
-
-          e.currentTarget.removeEventListener('focusout', onBlur);
-        }
-
-        if (observer) {
-          observer.disconnect();
-          observer = null;
-        }
-      };
-
-      e.currentTarget.addEventListener('focusout', onBlur);
-
-      // If this is a <button> or <input>, use a MutationObserver to watch for the disabled attribute.
-      // This is necessary because Firefox does not fire blur/focusout in this case. We dispatch these events ourselves instead.
-      // For browsers that do, focusout fires before the MutationObserver, so onBlur should not fire twice.
-      if (e.target instanceof HTMLButtonElement || e.target instanceof HTMLInputElement) {
-        let target = e.target;
-        observer = new MutationObserver(() => {
-          if (state.isFocusWithin && target.disabled) {
-            observer.disconnect();
-            target.dispatchEvent(new FocusEvent('blur'));
-            target.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
-          }
-        });
-
-        observer.observe(e.target, {attributes: true, attributeFilter: ['disabled']});
-      }
+      onSyntheticFocus(e);
     }
   };
 
-  if (props.onBlurWithin || props.onFocusWithinChange) {
-    onBlurWithin.current = (e: ReactFocusEvent) => {
-      if (props.onBlurWithin) {
-        props.onBlurWithin(e);
-      }
-
-      if (props.onFocusWithinChange) {
-        props.onFocusWithinChange(false);
-      }
-    };
-  } else {
-    onBlurWithin.current = null;
-  }
-
   return {
     focusWithinProps: {
-      onFocus
+      onFocus,
+      onBlur
     }
   };
 }

--- a/packages/@react-aria/interactions/src/utils.ts
+++ b/packages/@react-aria/interactions/src/utils.ts
@@ -91,11 +91,14 @@ export function useSyntheticBlurEvent(onBlur: (e: ReactFocusEvent) => void) {
   state.onBlur = onBlur;
 
   // Clean up MutationObserver on unmount. See below.
+  // eslint-disable-next-line arrow-body-style
   useLayoutEffect(() => {
-    if (state.observer) {
-      state.observer.disconnect();
-      state.observer = null;
-    }
+    return () => {
+      if (state.observer) {
+        state.observer.disconnect();
+        state.observer = null;
+      }
+    };
   }, [state]);
 
   // This function is called during a React onFocus event.

--- a/packages/@react-aria/interactions/src/utils.ts
+++ b/packages/@react-aria/interactions/src/utils.ts
@@ -10,6 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
+import {FocusEvent as ReactFocusEvent, useRef} from 'react';
+import {useLayoutEffect} from '@react-aria/utils';
+
 // Original licensing for the following method can be found in the
 // NOTICE file in the root directory of this source tree.
 // See https://github.com/facebook/react/blob/3c713d513195a53788b3f8bb4b70279d68b15bcc/packages/react-interactions/events/src/dom/shared/index.js#L74-L87
@@ -28,4 +31,115 @@ export function isVirtualClick(event: MouseEvent | PointerEvent): boolean {
   }
 
   return event.detail === 0 && !(event as PointerEvent).pointerType;
+}
+
+export class SyntheticFocusEvent implements ReactFocusEvent {
+  nativeEvent: FocusEvent;
+  target: Element;
+  currentTarget: Element;
+  relatedTarget: Element;
+  bubbles: boolean;
+  cancelable: boolean;
+  defaultPrevented: boolean;
+  eventPhase: number;
+  isTrusted: boolean;
+  timeStamp: number;
+  type: string;
+
+  constructor(type: string, nativeEvent: FocusEvent) {
+    this.nativeEvent = nativeEvent;
+    this.target = nativeEvent.target as Element;
+    this.currentTarget = nativeEvent.currentTarget as Element;
+    this.relatedTarget = nativeEvent.relatedTarget as Element;
+    this.bubbles = nativeEvent.bubbles;
+    this.cancelable = nativeEvent.cancelable;
+    this.defaultPrevented = nativeEvent.defaultPrevented;
+    this.eventPhase = nativeEvent.eventPhase;
+    this.isTrusted = nativeEvent.isTrusted;
+    this.timeStamp = nativeEvent.timeStamp;
+    this.type = type;
+  }
+
+  isDefaultPrevented(): boolean {
+    return this.nativeEvent.defaultPrevented;
+  }
+
+  preventDefault(): void {
+    this.defaultPrevented = true;
+    this.nativeEvent.preventDefault();
+  }
+
+  stopPropagation(): void {
+    this.nativeEvent.stopPropagation();
+    this.isPropagationStopped = () => true;
+  }
+
+  isPropagationStopped(): boolean {
+    return false;
+  }
+
+  persist() {}
+}
+
+export function useSyntheticBlurEvent(onBlur: (e: ReactFocusEvent) => void) {
+  let stateRef = useRef({
+    isFocused: false,
+    onBlur,
+    observer: null as MutationObserver
+  });
+  let state = stateRef.current;
+  state.onBlur = onBlur;
+
+  // Clean up MutationObserver on unmount. See below.
+  useLayoutEffect(() => {
+    if (state.observer) {
+      state.observer.disconnect();
+      state.observer = null;
+    }
+  }, [state]);
+
+  // This function is called during a React onFocus event.
+  return (e: ReactFocusEvent) => {
+    // React does not fire onBlur when an element is disabled. https://github.com/facebook/react/issues/9142
+    // Most browsers fire a native focusout event in this case, except for Firefox. In that case, we use a
+    // MutationObserver to watch for the disabled attribute, and dispatch these events ourselves.
+    // For browsers that do, focusout fires before the MutationObserver, so onBlur should not fire twice.
+    if (
+      e.target instanceof HTMLButtonElement ||
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement ||
+      e.target instanceof HTMLSelectElement
+    ) {
+      state.isFocused = true;
+
+      let target = e.target;
+      let onBlurHandler = (e: FocusEvent) => {
+        let state = stateRef.current;
+        state.isFocused = false;
+
+        if (target.disabled) {
+          // For backward compatibility, dispatch a (fake) React synthetic event.
+          state.onBlur?.(new SyntheticFocusEvent('blur', e));
+        }
+
+        // We no longer need the MutationObserver once the target is blurred.
+        if (state.observer) {
+          state.observer.disconnect();
+          state.observer = null;
+        }
+      };
+
+      target.addEventListener('focusout', onBlurHandler, {once: true});
+
+      state.observer = new MutationObserver(() => {
+        if (state.isFocused && target.disabled) {
+          state.observer.disconnect();
+          target.dispatchEvent(new FocusEvent('blur'));
+          target.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+        }
+      });
+
+      state.observer.observe(target, {attributes: true, attributeFilter: ['disabled']});
+    }
+  };
 }

--- a/packages/@react-aria/interactions/test/useFocus.test.js
+++ b/packages/@react-aria/interactions/test/useFocus.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, render} from '@testing-library/react';
+import {act, render, waitFor} from '@testing-library/react';
 import React from 'react';
 import {useFocus} from '../';
 
@@ -134,5 +134,23 @@ describe('useFocus', function () {
     expect(onInnerBlur).toHaveBeenCalledTimes(1);
     expect(onWrapperFocus).toHaveBeenCalledTimes(1);
     expect(onWrapperBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fire onBlur when a focused element is disabled', async function () {
+    function Example(props) {
+      let {focusProps} = useFocus(props);
+      return <button disabled={props.disabled} {...focusProps}>Button</button>;
+    }
+
+    let onFocus = jest.fn();
+    let onBlur = jest.fn();
+    let tree = render(<Example onFocus={onFocus} onBlur={onBlur} />);
+    let button = tree.getByRole('button');
+
+    act(() => {button.focus();});
+    expect(onFocus).toHaveBeenCalled();
+    tree.rerender(<Example disabled onFocus={onFocus} onBlur={onBlur} />);
+    // MutationObserver is async
+    await waitFor(() => expect(onBlur).toHaveBeenCalled());
   });
 });

--- a/packages/@react-aria/interactions/test/useFocusWithin.test.js
+++ b/packages/@react-aria/interactions/test/useFocusWithin.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, render} from '@testing-library/react';
+import {act, render, waitFor} from '@testing-library/react';
 import React from 'react';
 import {useFocusWithin} from '../';
 
@@ -137,5 +137,23 @@ describe('useFocusWithin', function () {
     expect(onInnerBlur).toHaveBeenCalledTimes(1);
     expect(onWrapperFocus).toHaveBeenCalledTimes(1);
     expect(onWrapperBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fire onBlur when a focused element is disabled', async function () {
+    function Example(props) {
+      let {focusWithinProps} = useFocusWithin(props);
+      return <div {...focusWithinProps}><button disabled={props.disabled}>Button</button></div>;
+    }
+
+    let onFocus = jest.fn();
+    let onBlur = jest.fn();
+    let tree = render(<Example onFocusWithin={onFocus} onBlurWithin={onBlur} />);
+    let button = tree.getByRole('button');
+
+    act(() => {button.focus();});
+    expect(onFocus).toHaveBeenCalled();
+    tree.rerender(<Example disabled onFocusWithin={onFocus} onBlurWithin={onBlur} />);
+    // MutationObserver is async
+    await waitFor(() => expect(onBlur).toHaveBeenCalled());
   });
 });

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -42,6 +42,7 @@
     "@react-spectrum/button": "^3.7.1",
     "@react-spectrum/utils": "^3.6.5",
     "@react-stately/calendar": "3.0.0-alpha.3",
+    "@react-types/button": "^3.4.3",
     "@react-types/calendar": "3.0.0-alpha.3",
     "@react-types/shared": "^3.11.1",
     "@spectrum-icons/ui": "^3.2.3",

--- a/packages/@react-spectrum/calendar/src/Calendar.tsx
+++ b/packages/@react-spectrum/calendar/src/Calendar.tsx
@@ -13,7 +13,7 @@
 import {CalendarBase} from './CalendarBase';
 import {createCalendar} from '@internationalized/date';
 import {DateValue, SpectrumCalendarProps} from '@react-types/calendar';
-import React, {useMemo} from 'react';
+import React, {useMemo, useRef} from 'react';
 import {useCalendar} from '@react-aria/calendar';
 import {useCalendarState} from '@react-stately/calendar';
 import {useLocale} from '@react-aria/i18n';
@@ -32,10 +32,16 @@ export function Calendar<T extends DateValue>(props: SpectrumCalendarProps<T>) {
     createCalendar
   });
 
+  let ref = useRef();
+  let {calendarProps, prevButtonProps, nextButtonProps} = useCalendar(props, state);
+
   return (
     <CalendarBase
       {...props}
       state={state}
-      useCalendar={useCalendar} />
+      calendarRef={ref}
+      calendarProps={calendarProps}
+      prevButtonProps={prevButtonProps}
+      nextButtonProps={nextButtonProps} />
   );
 }

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -11,7 +11,7 @@
  */
 
 import {ActionButton} from '@react-spectrum/button';
-import {CalendarAria} from '@react-aria/calendar';
+import {AriaButtonProps} from '@react-types/button';
 import {CalendarMonth} from './CalendarMonth';
 import {CalendarPropsBase} from '@react-types/calendar';
 import {CalendarState, RangeCalendarState} from '@react-stately/calendar';
@@ -19,22 +19,28 @@ import ChevronLeft from '@spectrum-icons/ui/ChevronLeftLarge';
 import ChevronRight from '@spectrum-icons/ui/ChevronRightLarge';
 import {classNames} from '@react-spectrum/utils';
 import {DOMProps, StyleProps} from '@react-types/shared';
-import React, {RefObject, useRef} from 'react';
+import React, {HTMLAttributes, RefObject} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/calendar/vars.css';
 import {useDateFormatter, useLocale} from '@react-aria/i18n';
 import {useProviderProps} from '@react-spectrum/provider';
 
 interface CalendarBaseProps<T extends CalendarState | RangeCalendarState> extends CalendarPropsBase, DOMProps, StyleProps {
   state: T,
-  useCalendar: (props: CalendarPropsBase, state: T, ref?: RefObject<HTMLElement>) => CalendarAria,
-  visibleMonths?: number
+  visibleMonths?: number,
+  calendarProps: HTMLAttributes<HTMLElement>,
+  nextButtonProps: AriaButtonProps,
+  prevButtonProps: AriaButtonProps,
+  calendarRef: RefObject<HTMLDivElement>
 }
 
 export function CalendarBase<T extends CalendarState | RangeCalendarState>(props: CalendarBaseProps<T>) {
   props = useProviderProps(props);
   let {
     state,
-    useCalendar,
+    calendarProps,
+    nextButtonProps,
+    prevButtonProps,
+    calendarRef: ref,
     visibleMonths = 1
   } = props;
   let {direction} = useLocale();
@@ -45,8 +51,6 @@ export function CalendarBase<T extends CalendarState | RangeCalendarState>(props
     era: currentMonth.calendar.identifier !== 'gregory' ? 'long' : undefined,
     calendar: currentMonth.calendar.identifier
   });
-  let ref = useRef(null);
-  let {calendarProps, prevButtonProps, nextButtonProps} = useCalendar(props, state, ref);
 
   let titles = [];
   let calendars = [];

--- a/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
+++ b/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
@@ -13,7 +13,7 @@
 import {CalendarBase} from './CalendarBase';
 import {createCalendar} from '@internationalized/date';
 import {DateValue, SpectrumRangeCalendarProps} from '@react-types/calendar';
-import React, {useMemo} from 'react';
+import React, {useMemo, useRef} from 'react';
 import {useLocale} from '@react-aria/i18n';
 import {useRangeCalendar} from '@react-aria/calendar';
 import {useRangeCalendarState} from '@react-stately/calendar';
@@ -32,10 +32,16 @@ export function RangeCalendar<T extends DateValue>(props: SpectrumRangeCalendarP
     createCalendar
   });
 
+  let ref = useRef();
+  let {calendarProps, prevButtonProps, nextButtonProps} = useRangeCalendar(props, state, ref);
+
   return (
     <CalendarBase
       {...props}
       state={state}
-      useCalendar={useRangeCalendar} />
+      calendarRef={ref}
+      calendarProps={calendarProps}
+      prevButtonProps={prevButtonProps}
+      nextButtonProps={nextButtonProps} />
   );
 }

--- a/packages/@react-spectrum/calendar/test/CalendarBase.test.js
+++ b/packages/@react-spectrum/calendar/test/CalendarBase.test.js
@@ -18,6 +18,7 @@ import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import {theme} from '@react-spectrum/theme-default';
 import {triggerPress} from '@react-spectrum/test-utils';
+import userEvent from '@testing-library/user-event';
 
 let cellFormatter = new Intl.DateTimeFormat('en-US', {weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'});
 let headingFormatter = new Intl.DateTimeFormat('en-US', {month: 'long', year: 'numeric'});
@@ -222,6 +223,36 @@ describe('CalendarBase', () => {
       expect(grids[0]).toHaveAttribute('aria-label', 'May 2019');
       expect(grids[1]).toHaveAttribute('aria-label', 'June 2019');
       expect(grids[2]).toHaveAttribute('aria-label', 'July 2019');
+    });
+
+    it.each`
+      Name                    | Calendar              | props
+      ${'v3 Calendar'}        | ${Calendar}           | ${{defaultValue: new CalendarDate(2019, 3, 10), minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 4, 20)}}
+      ${'v3 RangeCalendar'}   | ${RangeCalendar}      | ${{defaultValue: {start: new CalendarDate(2019, 3, 10), end: new CalendarDate(2019, 3, 15)}, minValue: new CalendarDate(2019, 2, 3), maxValue: new CalendarDate(2019, 4, 20)}}
+    `('$Name should move focus when the previous or next buttons become disabled', ({Calendar, props}) => {
+      let {getByLabelText} = render(<Calendar {...props} />);
+
+      let prevButton = getByLabelText('Previous');
+      let nextButton = getByLabelText('Next');
+
+      expect(prevButton).not.toHaveAttribute('disabled');
+      expect(nextButton).not.toHaveAttribute('disabled');
+
+      act(() => userEvent.click(prevButton));
+      expect(prevButton).toHaveAttribute('disabled');
+      expect(nextButton).not.toHaveAttribute('disabled');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Sunday, February 10, 2019')).toBe(true);
+
+      act(() => userEvent.click(nextButton));
+
+      expect(prevButton).not.toHaveAttribute('disabled');
+      expect(nextButton).not.toHaveAttribute('disabled');
+      expect(document.activeElement).toBe(nextButton);
+
+      act(() => userEvent.click(nextButton));
+      expect(prevButton).not.toHaveAttribute('disabled');
+      expect(nextButton).toHaveAttribute('disabled');
+      expect(document.activeElement.getAttribute('aria-label').startsWith('Wednesday, April 10, 2019')).toBe(true);
     });
 
     it.each`

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -11,7 +11,7 @@
  */
 
 import Checkmark from '@spectrum-icons/workflow/Checkmark';
-import {fireEvent, render, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, waitFor} from '@testing-library/react';
 import React from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
 import {TextArea, TextField} from '../';
@@ -126,9 +126,9 @@ describe('Shared TextField behavior', () => {
     ${'v3 TextArea'}    | ${TextArea}
     ${'v3 SearchField'} | ${SearchField}
   `('$Name calls onBlur when the input field loses focus', ({Name, Component}) => {
-    let tree = renderComponent(Component, {onBlur, 'aria-label': 'mandatory label'});
+    let tree = renderComponent(Component, {onBlur, autoFocus: true, 'aria-label': 'mandatory label'});
     let input = tree.getByTestId(testId);
-    fireEvent.blur(input);
+    act(() => input.blur());
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import Checkmark from '@spectrum-icons/workflow/Checkmark';
 import {act, fireEvent, render, waitFor} from '@testing-library/react';
+import Checkmark from '@spectrum-icons/workflow/Checkmark';
 import React from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
 import {TextArea, TextField} from '../';

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -154,13 +154,13 @@ export function useCalendarState<T extends DateValue>(props: CalendarStateOption
     },
     focusNextPage() {
       let start = startDate.add(visibleDuration);
-      setStartDate(constrainStart(focusedDate, start, visibleDuration, locale, minValue, maxValue));
       setFocusedDate(constrainValue(focusedDate.add(visibleDuration), minValue, maxValue));
+      setStartDate(constrainStart(focusedDate, start, visibleDuration, locale, minValue, maxValue));
     },
     focusPreviousPage() {
       let start = startDate.subtract(visibleDuration);
-      setStartDate(constrainStart(focusedDate, start, visibleDuration, locale, minValue, maxValue));
       setFocusedDate(constrainValue(focusedDate.subtract(visibleDuration), minValue, maxValue));
+      setStartDate(constrainStart(focusedDate, start, visibleDuration, locale, minValue, maxValue));
     },
     focusPageStart() {
       focusCell(startDate);


### PR DESCRIPTION
Closes #1935

This fixes two issues:

1. Focus ring not disappearing when a focused button becomes disabled. That is due to a combination of a React issue, where onBlur is not fired if a button becomes disabled, and the same issue natively in Firefox. This is solved by using native blur events, as well as a `MutationObserver` to simulate those for Firefox.
2. In calendar, when the previous and next buttons become disabled as a result of pressing them, focus is lost. Now we send it to the calendar body instead.