### PR TITLE
fix(#2912): BreakpointProvider: recalculate breakpoint handler and matched breakpoints if breakpoints are updated

### DIFF
--- a/packages/@react-spectrum/provider/stories/Provider.stories.tsx
+++ b/packages/@react-spectrum/provider/stories/Provider.stories.tsx
@@ -10,17 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
+import {Breakpoints} from '@react-types/provider';
 import {Button} from '@react-spectrum/button';
 import {Checkbox, CheckboxGroup} from '@react-spectrum/checkbox';
 import {ComboBox} from '@react-spectrum/combobox';
 import customTheme from './custom-theme.css';
 import {Flex} from '@react-spectrum/layout';
 import {Form} from '@react-spectrum/form';
+import {Heading, Text} from '@react-spectrum/text';
 import {Item, Picker} from '@react-spectrum/picker';
 import {NumberField} from '@react-spectrum/numberfield';
 import {Provider} from '../';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
-import React from 'react';
+import React, {useState} from 'react';
+import {Responsive} from '@react-types/shared';
 import scaleLarge from '@adobe/spectrum-css-temp/vars/spectrum-large.css';
 import scaleMedium from '@adobe/spectrum-css-temp/vars/spectrum-medium.css';
 import {SearchField} from '@react-spectrum/searchfield';
@@ -29,6 +32,7 @@ import {storiesOf} from '@storybook/react';
 import {Switch} from '@react-spectrum/switch';
 import {TextField} from '@react-spectrum/textfield';
 import {useBreakpoint} from '@react-spectrum/utils';
+import {View} from '@react-spectrum/view';
 
 const THEME = {
   light: customTheme,
@@ -164,7 +168,103 @@ storiesOf('Provider', module)
             <Breakpoint />
           </Provider>
         );
-      });
+      })
+      .add(
+        'breakpoints updated',
+        () => (
+          <ProviderWithBreakpointsEditor />
+          ));
+
+function ProviderWithBreakpointsEditor() {
+  const DEFAULT_BREAKPOINTS: Breakpoints = {S: 640, M: 768, L: 1024, XL: 1280, XXL: 1536};
+  const DEFAULT_STEP_SIZE = 148; // 148px is the least distance between breakpoints
+  const RESET_BUTTON_HIDE: Responsive<boolean> = {S: true, M: true, L: true, XL: true, XXL: true};
+  const RESET_BUTTON_SHOW: Responsive<boolean> = {S: false, M: false, L: false, XL: false, XXL: false};
+
+  const [breakpoints, setBreakpoints] = useState(DEFAULT_BREAKPOINTS);
+  const [resetButtonIsHiddenSettings, setResetButtonIsHiddenSettings] = useState(RESET_BUTTON_HIDE);
+
+  let onPress = (stepSize: number) => {
+    let updatedBreakpoints: Breakpoints = {};
+    if (stepSize === 0) {
+      updatedBreakpoints = DEFAULT_BREAKPOINTS;
+    } else {
+      for (const [key, value] of Object.entries(breakpoints)) {
+        updatedBreakpoints[key] = value + stepSize;
+      }
+    }
+    if (updatedBreakpoints.M === DEFAULT_BREAKPOINTS.M) {
+      setResetButtonIsHiddenSettings(RESET_BUTTON_HIDE);
+    } else {
+      setResetButtonIsHiddenSettings(RESET_BUTTON_SHOW);
+    }
+    setBreakpoints(updatedBreakpoints);
+  };
+  let onDecrement = () => {
+    onPress(-DEFAULT_STEP_SIZE);
+  };
+  let onIncrement = () => {
+    onPress(DEFAULT_STEP_SIZE);
+  };
+  let onReset = () => {
+    onPress(0);
+  };
+
+
+  return (
+    <Provider breakpoints={breakpoints}>
+      <Flex alignItems="center" direction="column" gap="size-100" minWidth="single-line-width">
+        <Text>Buttons to increment or decrement breakpoints will hide to prevent values beyond current XXL or base</Text>
+        <Text>A reset button will show when the current breakpoints are different than the default breakpoints</Text>
+        <AppliedBreakpointsTracker />
+        <Flex gap="size-100">
+          <Button
+            isHidden={{base: false, S: false, M: false, L: false, XL: false, XXL: true}}
+            onPress={onDecrement}
+            variant="primary">
+            <Text>Decrement breakpoints by {DEFAULT_STEP_SIZE}px</Text>
+          </Button>
+          <Button
+            isHidden={resetButtonIsHiddenSettings}
+            onPress={onReset}
+            variant="secondary">
+            <Text>Reset breakpoints</Text>
+          </Button>
+          <Button
+            isHidden={{base: true, S: false, M: false, L: false, XL: false, XXL: false}}
+            onPress={onIncrement}
+            variant="primary">
+            <Text>Increment breakpoints by {DEFAULT_STEP_SIZE}px</Text>
+          </Button>
+        </Flex>
+        <Text>Breakpoints are currently set to: {JSON.stringify(breakpoints)}</Text>
+      </Flex>
+    </Provider>
+  );
+
+  function AppliedBreakpointsTracker() {
+    return (
+      <Flex gap="size-100" marginY="single-line-height">
+        <AppliedBreakpointsTrackerCube isHidden={{base: false, S: false, M: false, L: false, XL: false, XXL: false}} heading="BASE" />
+        <AppliedBreakpointsTrackerCube isHidden={{base: true, S: false, M: false, L: false, XL: false, XXL: false}} heading="S" />
+        <AppliedBreakpointsTrackerCube isHidden={{base: true, S: true, M: false, L: false, XL: false, XXL: false}} heading="M" />
+        <AppliedBreakpointsTrackerCube isHidden={{base: true, S: true, M: true, L: false, XL: false, XXL: false}} heading="L" />
+        <AppliedBreakpointsTrackerCube isHidden={{base: true, S: true, M: true, L: true, XL: false, XXL: false}} heading="XL" />
+        <AppliedBreakpointsTrackerCube isHidden={{base: true, S: true, M: true, L: true, XL: true, XXL: false}} heading="XXL" />
+      </Flex>
+    );
+
+    function AppliedBreakpointsTrackerCube({heading, isHidden}: {heading: string, isHidden: Responsive<boolean>}): JSX.Element {
+      return (
+        <View backgroundColor="gray-50" borderColor={{base: 'gray-900'}} borderRadius={{base: 'regular'}} borderWidth={{base: 'thick'}} isHidden={isHidden} width="size-800">
+          <Flex alignItems="center" justifyContent="center">
+            <Heading level={2}>{heading}</Heading>
+          </Flex>
+        </View>
+      );
+    }
+  }
+}
 
 function render(props = {}) {
   return (

--- a/packages/@react-spectrum/provider/test/Provider.test.js
+++ b/packages/@react-spectrum/provider/test/Provider.test.js
@@ -292,18 +292,8 @@ describe('Provider', () => {
       [testWidths.S]: {S: 1024, M: 1168, L: 1440},
       [testWidths.base]: {S: 1168, M: 1440, L: 1680}
     };
+    const testId = 'responsive-breakpoints-test-container';
 
-    // render once to get a reference to the rerender method
-    let {container, rerender} = render(
-      <Provider breakpoints={testBreakpoints[testWidths.L]} theme={theme}>
-        <TextField
-          label="foo"
-          width={testWidths} />
-      </Provider>
-    );
-    let provider, textField;
-
-    // only rerender, updating the breakpoints prop (all others constant)
     it.each`
       name                                 | breakpoints                         | expected
       ${'(L) ' + testWidths.L + ':'}       | ${testBreakpoints[testWidths.L]}    | ${testWidths.L}
@@ -313,16 +303,27 @@ describe('Provider', () => {
     `('$name $breakpoints', function ({breakpoints, expected}) {
       matchMedia.useMediaQuery('(min-width: 1024px)');
 
-      rerender(
-        <Provider breakpoints={breakpoints} theme={theme}>
+      let {getByTestId, rerender} = render(
+        <Provider breakpoints={testBreakpoints[testWidths.L]} data-testid={testId} theme={theme}>
           <TextField
             label="foo"
             width={testWidths} />
         </Provider>
       );
 
-      provider = container.firstChild;
-      textField = provider.firstChild;
+      rerender(
+        <Provider breakpoints={breakpoints} data-testid={testId} theme={theme}>
+          <TextField
+            label="foo"
+            width={testWidths} />
+        </Provider>
+      );
+
+      // text field ends up being wrapped in a div that gets the width styles
+      // applied to it, so you must access via the provider's first child to
+      // compare the width in a headless environment (jsdom)
+      let provider = getByTestId(testId);
+      let textField = provider.firstChild;
       expect(textField).toHaveStyle({width: expected});
     });
   });

--- a/packages/@react-spectrum/provider/test/Provider.test.js
+++ b/packages/@react-spectrum/provider/test/Provider.test.js
@@ -283,4 +283,47 @@ describe('Provider', () => {
       expect(onRender).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('responsive breakpoints', function () {
+    const testWidths = {base: '100px', S: '200px', M: '300px', L: '400px'};
+    const testBreakpoints = {
+      [testWidths.L]: {S: 480, M: 640, L: 1024},
+      [testWidths.M]: {S: 640, M: 1024, L: 1168},
+      [testWidths.S]: {S: 1024, M: 1168, L: 1440},
+      [testWidths.base]: {S: 1168, M: 1440, L: 1680}
+    };
+
+    // render once to get a reference to the rerender method
+    let {container, rerender} = render(
+      <Provider breakpoints={testBreakpoints[testWidths.L]} theme={theme}>
+        <TextField
+          label="foo"
+          width={testWidths} />
+      </Provider>
+    );
+    let provider, textField;
+
+    // only rerender, updating the breakpoints prop (all others constant)
+    it.each`
+      name                                 | breakpoints                         | expected
+      ${'(L) ' + testWidths.L + ':'}       | ${testBreakpoints[testWidths.L]}    | ${testWidths.L}
+      ${'(M) ' + testWidths.M + ':'}       | ${testBreakpoints[testWidths.M]}    | ${testWidths.M}
+      ${'(S) ' + testWidths.S + ':'}       | ${testBreakpoints[testWidths.S]}    | ${testWidths.S}
+      ${'(base) ' + testWidths.base + ':'} | ${testBreakpoints[testWidths.base]} | ${testWidths.base}
+    `('$name $breakpoints', function ({breakpoints, expected}) {
+      matchMedia.useMediaQuery('(min-width: 1024px)');
+
+      rerender(
+        <Provider breakpoints={breakpoints} theme={theme}>
+          <TextField
+            label="foo"
+            width={testWidths} />
+        </Provider>
+      );
+
+      provider = container.firstChild;
+      textField = provider.firstChild;
+      expect(textField).toHaveStyle({width: expected});
+    });
+  });
 });

--- a/packages/@react-spectrum/utils/src/BreakpointProvider.tsx
+++ b/packages/@react-spectrum/utils/src/BreakpointProvider.tsx
@@ -1,5 +1,6 @@
-import React, {ReactNode, useCallback, useContext, useEffect, useState} from 'react';
+import React, {ReactNode, useCallback, useContext, useState} from 'react';
 import {useIsSSR} from '@react-aria/ssr';
+import {useLayoutEffect} from '@react-aria/utils';
 
 interface Breakpoints {
   S?: number,
@@ -61,7 +62,7 @@ export function useMatchedBreakpoints(breakpoints: Breakpoints): string[] {
       : ['base']
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!supportsMatchMedia) {
       return;
     }


### PR DESCRIPTION
Closes: https://github.com/adobe/react-spectrum/issues/2912

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/2912).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Sync branch (build, start storybook, etc)
2. Open http://localhost:9003/?path=/story/provider--breakpoints-updated in a new browser
3. You will see increment and decrement buttons that allow you to adjust the current Provider breakpoints
4. You will see the corresponding boxes appear/disappear as their respective responsive styles change

## 🧢 Your Project:

Adobe | Admin Console
