### PR TITLE
fix(#2921): Changing locale on ColorArea doesn't change direction thumb moves with home/end key

### DIFF
--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -97,11 +97,11 @@ export function useColorArea(props: ColorAreaAriaProps, state: ColorAreaState): 
           focusedInputRef.current = inputYRef.current;
           break;
         case 'Home':
-          direction === 'rtl' ? stateRef.current.incrementX(stateRef.current.xChannelPageStep) : stateRef.current.decrementX(stateRef.current.xChannelPageStep);
+          stateRef.current.decrementX(stateRef.current.xChannelPageStep);
           focusedInputRef.current = inputXRef.current;
           break;
         case 'End':
-          direction === 'rtl' ? stateRef.current.decrementX(stateRef.current.xChannelPageStep) : stateRef.current.incrementX(stateRef.current.xChannelPageStep);
+          stateRef.current.incrementX(stateRef.current.xChannelPageStep);
           focusedInputRef.current = inputXRef.current;
           break;
       }
@@ -377,6 +377,7 @@ export function useColorArea(props: ColorAreaAriaProps, state: ColorAreaState): 
             formatMessage('colorNameAndValue', {name: state.value.getChannelName(yChannel, locale), value: state.value.formatChannelValue(yChannel, locale)})
           ].join(', ')
       ),
+      'aria-orientation': 'horizontal',
       title: getValueTitle(),
       disabled: isDisabled,
       value: state.value.getChannelValue(xChannel),

--- a/packages/@react-spectrum/color/test/ColorArea.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorArea.test.tsx
@@ -165,7 +165,7 @@ describe('ColorArea', () => {
           ${'shiftleft/shiftright'} | ${{defaultValue: parseColor('#f000f0')}} | ${{forward: (elem) => pressKey(elem, {key: 'ArrowRight', shiftKey: true}), backward: (elem) => pressKey(elem, {key: 'ArrowLeft', shiftKey: true})}} | ${parseColor('#df00f0')}
           ${'shiftup/shiftdown'}    | ${{defaultValue: parseColor('#f000f0')}} | ${{forward: (elem) => pressKey(elem, {key: 'ArrowUp', shiftKey: true}), backward: (elem) => pressKey(elem, {key: 'ArrowDown', shiftKey: true})}}    | ${parseColor('#f011f0')}
           ${'pageup/pagedown'}      | ${{defaultValue: parseColor('#f000f0')}} | ${{forward: (elem) => pressKey(elem, {key: 'PageUp'}), backward: (elem) => pressKey(elem, {key: 'PageDown'})}}                                      | ${parseColor('#f011f0')}
-          ${'home/end'}             | ${{defaultValue: parseColor('#f000f0')}} | ${{forward: (elem) => pressKey(elem, {key: 'End'}), backward: (elem) => pressKey(elem, {key: 'Home'})}}                                             | ${parseColor('#df00f0')}
+          ${'home/end'}             | ${{defaultValue: parseColor('#f000f0')}} | ${{forward: (elem) => pressKey(elem, {key: 'Home'}), backward: (elem) => pressKey(elem, {key: 'End'})}}                                             | ${parseColor('#df00f0')}
         `('$Name RTL', ({props, actions: {forward, backward}, result}) => {
           let {getAllByRole} = render(
             <Provider locale="ar-AE" theme={defaultTheme}>


### PR DESCRIPTION
Removes the special RTL behavior so that reversing the direction of the gradient actually reverses the direction in which Home or End keys adjust the value.


Closes #2921

## ✅ Pull Request Checklist:

- [x] Included link to corresponding React Spectrum GitHub Issue: #2921 
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open [HSB xChannel="saturation", yChannel="brightness"](https://reactspectrum.blob.core.windows.net/reactspectrum/adbfff9729d347ee89934771e56b81094919be79/storybook/index.html?path=/story/colorarea--x-saturation-y-brightness)
2. Set the Locale to a RTL language, either Arabic or Hebrew.
3. Tab to move keyboard focus to the ColorThumb within the ColorArea in the Storybook example.
4. Press Home (fn + ArrowLeft on a Mac) key to decrease the horizontal channel value, in this case "saturation", by 10%. The thumb should move to the right.
5. Press End (fn + ArrowRight on a Mac) key to increase the horizontal channel value, in this case "brightness", by 10%. The thumb should move to the left.
6. Press Shift + ArrowRight keys to decrease the horizontal channel value, in this case "saturation", by 10%. The thumb should move to the right.
7. Press Shift + ArrowLeft keys to increase the horizontal channel value, in this case "saturation", by 10%. The thumb should move to the right.

Does this seem like the correct behavior, where Home decreases value and End increases value, or should the Arrow keys used to trigger Home or End match the orientation of the ColorArea?

## 🧢 Your Project:

Adobe/Accessibility
