### PR TITLE
Bug fixes for DatePicker and Calendar

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/calendar/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/calendar/index.css
@@ -90,7 +90,7 @@ governing permissions and limitations under the License.
   justify-content: flex-end;
   height: 100%;
 
-  width: var(--spectrum-calendar-day-width);
+  width: 100%;
 
   border-bottom: none !important; /* override abbr styling from normalize.css */
 

--- a/packages/@adobe/spectrum-css-temp/components/calendar/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/calendar/index.css
@@ -207,6 +207,7 @@ governing permissions and limitations under the License.
         height: 2px;
         transform: rotate(-16deg);
         border-radius: 1px;
+        background: currentColor;
       }
     }
   }

--- a/packages/@adobe/spectrum-css-temp/components/calendar/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/calendar/skin.css
@@ -120,9 +120,5 @@ governing permissions and limitations under the License.
     &.is-today {
       --background: transparent;
     }
-
-    & .spectrum-Calendar-dateText span:after {
-      background: var(--spectrum-global-color-gray-600);
-    }
   }
 }

--- a/packages/@internationalized/date/src/calendars/BuddhistCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/BuddhistCalendar.ts
@@ -35,16 +35,22 @@ export class BuddhistCalendar extends GregorianCalendar {
   }
 
   toJulianDay(date: AnyCalendarDate) {
-    return super.toJulianDay(
-      new CalendarDate(
-        date.year + BUDDHIST_ERA_START,
-        date.month,
-        date.day
-      )
-    );
+    return super.toJulianDay(toGregorian(date));
   }
 
   getEras() {
     return ['BE'];
   }
+
+  getDaysInMonth(date: AnyCalendarDate): number {
+    return super.getDaysInMonth(toGregorian(date));
+  }
+}
+
+function toGregorian(date: AnyCalendarDate) {
+  return new CalendarDate(
+    date.year + BUDDHIST_ERA_START,
+    date.month,
+    date.day
+  );
 }

--- a/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
@@ -146,6 +146,10 @@ export class JapaneseCalendar extends GregorianCalendar {
     return years;
   }
 
+  getDaysInMonth(date: AnyCalendarDate): number {
+    return super.getDaysInMonth(toGregorian(date));
+  }
+
   getMinimumMonthInYear(date: AnyCalendarDate): number {
     let start = getMinimums(date);
     return start ? start[1] : 1;

--- a/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
@@ -52,13 +52,7 @@ export class TaiwanCalendar extends GregorianCalendar {
   }
 
   toJulianDay(date: AnyCalendarDate) {
-    return super.toJulianDay(
-      new CalendarDate(
-        gregorianYear(date),
-        date.month,
-        date.day
-      )
-    );
+    return super.toJulianDay(toGregorian(date));
   }
 
   getEras() {
@@ -72,4 +66,16 @@ export class TaiwanCalendar extends GregorianCalendar {
   getYearsToAdd(date: Mutable<AnyCalendarDate>, years: number) {
     return date.era === 'before_minguo' ? -years : years;
   }
+
+  getDaysInMonth(date: AnyCalendarDate): number {
+    return super.getDaysInMonth(toGregorian(date));
+  }
+}
+
+function toGregorian(date: AnyCalendarDate) {
+  return new CalendarDate(
+    gregorianYear(date),
+    date.month,
+    date.day
+  );
 }

--- a/packages/@internationalized/date/tests/conversion.test.js
+++ b/packages/@internationalized/date/tests/conversion.test.js
@@ -165,6 +165,14 @@ describe('CalendarDate conversion', function () {
         date = new CalendarDate(2020, 4, 30);
         expect(toCalendar(date, new JapaneseCalendar())).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 2, 4, 30));
       });
+
+      it('returns the correct number of days for leap and non-leap years', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'reiwa', 4, 2, 5);
+        expect(date.calendar.getDaysInMonth(date)).toBe(28);
+
+        date = new CalendarDate(new JapaneseCalendar(), 'reiwa', 2, 2, 5);
+        expect(date.calendar.getDaysInMonth(date)).toBe(29);
+      });
     });
 
     describe('taiwan', function () {

--- a/packages/@react-aria/calendar/src/useCalendarGrid.ts
+++ b/packages/@react-aria/calendar/src/useCalendarGrid.ts
@@ -120,8 +120,8 @@ export function useCalendarGrid(props: CalendarGridProps, state: CalendarState |
     'aria-labelledby': calendarIds.get(state)
   });
 
-  let dayFormatter = useDateFormatter({weekday: 'narrow'});
-  let dayFormatterLong = useDateFormatter({weekday: 'long'});
+  let dayFormatter = useDateFormatter({weekday: 'narrow', timeZone: state.timeZone});
+  let dayFormatterLong = useDateFormatter({weekday: 'long', timeZone: state.timeZone});
   let {locale} = useLocale();
   let weekStart = startOfWeek(state.visibleRange.start, locale);
   let weekDays = [...new Array(7).keys()].map((index) => {

--- a/packages/@react-aria/calendar/src/useRangeCalendar.ts
+++ b/packages/@react-aria/calendar/src/useRangeCalendar.ts
@@ -53,7 +53,7 @@ export function useRangeCalendar<T extends DateValue>(props: RangeCalendarProps<
     let target = e.target as HTMLElement;
     let body = document.getElementById(res.calendarProps.id);
     if (
-      (!body.contains(target) || target.getAttribute('role') !== 'button') &&
+      (!body.contains(target) && target.getAttribute('role') !== 'button') &&
       !document.getElementById(res.nextButtonProps.id)?.contains(target) &&
       !document.getElementById(res.prevButtonProps.id)?.contains(target)
     ) {

--- a/packages/@react-aria/calendar/src/useRangeCalendar.ts
+++ b/packages/@react-aria/calendar/src/useRangeCalendar.ts
@@ -53,7 +53,7 @@ export function useRangeCalendar<T extends DateValue>(props: RangeCalendarProps<
     let target = e.target as HTMLElement;
     let body = document.getElementById(res.calendarProps.id);
     if (
-      (!body.contains(target) && target.getAttribute('role') !== 'button') &&
+      (!body.contains(target) || !target.closest('[role="button"]')) &&
       !document.getElementById(res.nextButtonProps.id)?.contains(target) &&
       !document.getElementById(res.prevButtonProps.id)?.contains(target)
     ) {

--- a/packages/@react-aria/calendar/src/utils.ts
+++ b/packages/@react-aria/calendar/src/utils.ts
@@ -50,12 +50,14 @@ export function useVisibleRangeDescription(startDate: CalendarDate, endDate: Cal
     month: 'long',
     year: 'numeric',
     era: startDate.calendar.identifier !== 'gregory' ? 'long' : undefined,
-    calendar: startDate.calendar.identifier
+    calendar: startDate.calendar.identifier,
+    timeZone
   });
 
   let dateFormatter = useDateFormatter({
     dateStyle: 'long',
-    calendar: startDate.calendar.identifier
+    calendar: startDate.calendar.identifier,
+    timeZone
   });
 
   return useMemo(() => {

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -13,7 +13,6 @@
 import {AriaDatePickerProps, AriaTimeFieldProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {createFocusManager, FocusManager} from '@react-aria/focus';
 import {DateFieldState} from '@react-stately/datepicker';
-import {focusManagerSymbol} from './useDateRangePicker';
 import {HTMLAttributes, RefObject, useEffect, useMemo, useRef} from 'react';
 import {mergeProps, useDescription} from '@react-aria/utils';
 import {useDatePickerGroup} from './useDatePickerGroup';

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -13,7 +13,6 @@
 import {AriaDatePickerProps, AriaTimeFieldProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {createFocusManager, FocusManager} from '@react-aria/focus';
 import {DatePickerFieldState} from '@react-stately/datepicker';
-import {focusManagerSymbol} from './useDateRangePicker';
 import {HTMLAttributes, RefObject, useEffect, useMemo, useRef} from 'react';
 import {mergeProps, useDescription} from '@react-aria/utils';
 import {useDateFormatter} from '@react-aria/i18n';
@@ -37,12 +36,18 @@ interface DateFieldAria {
 
 // Data that is passed between useDateField and useDateSegment.
 interface HookData {
+  ariaLabel: string,
   ariaLabelledBy: string,
   ariaDescribedBy: string,
   focusManager: FocusManager
 }
 
 export const hookData = new WeakMap<DatePickerFieldState, HookData>();
+
+// Private props that we pass from useDatePicker/useDateRangePicker.
+// Ideally we'd use a Symbol for this, but React doesn't support them: https://github.com/facebook/react/issues/7552
+export const roleSymbol = '__role_' + Date.now();
+export const focusManagerSymbol = '__focusManager_' + Date.now();
 
 /**
  * Provides the behavior and accessibility implementation for a date field component.
@@ -66,18 +71,40 @@ export function useDateField<T extends DateValue>(props: DateFieldProps<T>, stat
   let formatter = useDateFormatter(state.getFormatOptions({month: 'long'}));
   let descProps = useDescription(state.value ? formatter.format(state.dateValue) : null);
 
-  let segmentLabelledBy = fieldProps['aria-labelledby'] || fieldProps.id;
-  let describedBy = [descProps['aria-describedby'], fieldProps['aria-describedby']].filter(Boolean).join(' ') || undefined;
+  // If within a date picker or date range picker, the date field will have role="presentation" and an aria-describedby
+  // will be passed in that references the value (e.g. entire range). Otherwise, add the field's value description.
+  let describedBy = props[roleSymbol] === 'presentation'
+    ? fieldProps['aria-describedby']
+    : [descProps['aria-describedby'], fieldProps['aria-describedby']].filter(Boolean).join(' ') || undefined;
   let propsFocusManager = props[focusManagerSymbol];
   let focusManager = useMemo(() => propsFocusManager || createFocusManager(ref), [propsFocusManager, ref]);
 
+  // Pass labels and other information to segments.
   hookData.set(state, {
-    ariaLabelledBy: segmentLabelledBy,
+    ariaLabel: props['aria-label'],
+    ariaLabelledBy: [props['aria-labelledby'], labelProps.id].filter(Boolean).join(' ') || undefined,
     ariaDescribedBy: describedBy,
     focusManager
   });
 
   let autoFocusRef = useRef(props.autoFocus);
+
+  // When used within a date picker or date range picker, the field gets role="presentation"
+  // rather than role="group". Since the date picker/date range picker already has a role="group"
+  // with a label and description, and the segments are already labeled by this as well, this
+  // avoids very verbose duplicate announcements.
+  let fieldDOMProps: HTMLAttributes<HTMLElement>;
+  if (props[roleSymbol] === 'presentation') {
+    fieldDOMProps = {
+      role: 'presentation'
+    };
+  } else {
+    fieldDOMProps = mergeProps(fieldProps, {
+      role: 'group',
+      'aria-disabled': props.isDisabled || undefined,
+      'aria-describedby': describedBy
+    });
+  }
 
   useEffect(() => {
     if (autoFocusRef.current) {
@@ -93,11 +120,7 @@ export function useDateField<T extends DateValue>(props: DateFieldProps<T>, stat
         focusManager.focusFirst();
       }
     },
-    fieldProps: mergeProps(fieldProps, descProps, groupProps, focusWithinProps, {
-      role: 'group',
-      'aria-disabled': props.isDisabled || undefined,
-      'aria-describedby': describedBy
-    }),
+    fieldProps: mergeProps(fieldDOMProps, groupProps, focusWithinProps),
     descriptionProps,
     errorMessageProps
   };

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -20,6 +20,7 @@ import {HTMLAttributes, RefObject} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {mergeProps, useDescription, useId} from '@react-aria/utils';
+import {roleSymbol} from './useDateField';
 import {useDatePickerGroup} from './useDatePickerGroup';
 import {useField} from '@react-aria/label';
 import {useLocale, useMessageFormatter} from '@react-aria/i18n';
@@ -66,7 +67,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
   let ariaDescribedBy = [descProps['aria-describedby'], fieldProps['aria-describedby']].filter(Boolean).join(' ') || undefined;
 
   return {
-    groupProps: mergeProps(groupProps, descProps, {
+    groupProps: mergeProps(groupProps, fieldProps, descProps, {
       role: 'group',
       'aria-disabled': props.isDisabled || null,
       'aria-labelledby': labelledBy,
@@ -81,6 +82,8 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
     },
     fieldProps: {
       ...fieldProps,
+      [roleSymbol]: 'presentation',
+      'aria-describedby': ariaDescribedBy,
       value: state.value,
       onChange: state.setValue,
       minValue: props.minValue,

--- a/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
+++ b/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
@@ -8,7 +8,7 @@ import {usePress} from '@react-aria/interactions';
 export function useDatePickerGroup(state: DatePickerState | DateRangePickerState | DatePickerFieldState, ref: RefObject<HTMLElement>) {
   // Open the popover on alt + arrow down
   let onKeyDown = (e: KeyboardEvent) => {
-    if (e.altKey && e.key === 'ArrowDown' && 'setOpen' in state) {
+    if (e.altKey && (e.key === 'ArrowDown' || e.key === 'ArrowUp') && 'setOpen' in state) {
       e.preventDefault();
       e.stopPropagation();
       state.setOpen(true);

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -15,10 +15,11 @@ import {AriaDatePickerProps, AriaDateRangePickerProps, DateValue} from '@react-t
 import {AriaDialogProps} from '@react-types/dialog';
 import {createFocusManager} from '@react-aria/focus';
 import {DateRangePickerState} from '@react-stately/datepicker';
+import {focusManagerSymbol, roleSymbol} from './useDateField';
 import {HTMLAttributes, RefObject, useMemo} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {mergeProps, useDescription, useId, useLabels} from '@react-aria/utils';
+import {mergeProps, useDescription, useId} from '@react-aria/utils';
 import {RangeCalendarProps} from '@react-types/calendar';
 import {useDatePickerGroup} from './useDatePickerGroup';
 import {useField} from '@react-aria/label';
@@ -46,10 +47,6 @@ interface DateRangePickerAria {
   calendarProps: RangeCalendarProps<DateValue>
 }
 
-// Used to pass the focus manager to the date fields.
-// Ideally we'd use a Symbol for this, but React doesn't support them: https://github.com/facebook/react/issues/7552
-export const focusManagerSymbol = '__focusManager_' + Date.now();
-
 /**
  * Provides the behavior and accessibility implementation for a date picker component.
  * A date range picker combines two DateFields and a RangeCalendar popover to allow
@@ -68,15 +65,15 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
   let description = state.formatValue(locale, {month: 'long'});
   let descProps = useDescription(description);
 
-  let startFieldProps = useLabels({
+  let startFieldProps = {
     'aria-label': formatMessage('startDate'),
     'aria-labelledby': labelledBy
-  });
+  };
 
-  let endFieldProps = useLabels({
+  let endFieldProps = {
     'aria-label': formatMessage('endDate'),
     'aria-labelledby': labelledBy
-  });
+  };
 
   let buttonId = useId();
   let dialogId = useId();
@@ -92,6 +89,8 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
   let focusManager = useMemo(() => createFocusManager(ref), [ref]);
   let commonFieldProps = {
     [focusManagerSymbol]: focusManager,
+    [roleSymbol]: 'presentation',
+    'aria-describedby': ariaDescribedBy,
     minValue: props.minValue,
     maxValue: props.maxValue,
     placeholderValue: props.placeholderValue,
@@ -133,7 +132,6 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
     startFieldProps: {
       ...startFieldProps,
       ...commonFieldProps,
-      'aria-describedby': fieldProps['aria-describedby'],
       value: state.value?.start,
       onChange: start => state.setDateTime('start', start),
       autoFocus: props.autoFocus
@@ -141,7 +139,6 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
     endFieldProps: {
       ...endFieldProps,
       ...commonFieldProps,
-      'aria-describedby': fieldProps['aria-describedby'],
       value: state.value?.end,
       onChange: end => state.setDateTime('end', end)
     },

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -11,7 +11,7 @@
  */
 
 import {DatePickerFieldState, DateSegment} from '@react-stately/datepicker';
-import {getScrollParent, isIOS, isMac, mergeProps, scrollIntoView, useEvent, useId} from '@react-aria/utils';
+import {getScrollParent, isIOS, isMac, mergeProps, scrollIntoView, useEvent, useId, useLabels} from '@react-aria/utils';
 import {hookData} from './useDateField';
 import {NumberParser} from '@internationalized/number';
 import React, {HTMLAttributes, RefObject, useMemo, useRef} from 'react';
@@ -34,7 +34,7 @@ export function useDateSegment(segment: DateSegment, state: DatePickerFieldState
   let enteredKeys = useRef('');
   let {locale, direction} = useLocale();
   let displayNames = useDisplayNames();
-  let {ariaLabelledBy, ariaDescribedBy, focusManager} = hookData.get(state);
+  let {ariaLabel, ariaLabelledBy, ariaDescribedBy, focusManager} = hookData.get(state);
 
   let textValue = segment.text;
   let options = useMemo(() => state.dateFormatter.resolvedOptions(), [state.dateFormatter]);
@@ -341,6 +341,14 @@ export function useDateSegment(segment: DateSegment, state: DatePickerFieldState
   let id = useId();
   let isEditable = !state.isDisabled && !state.isReadOnly && segment.isEditable;
 
+  // Prepend the label passed from the field to each segment name.
+  // This is needed because VoiceOver on iOS does not announce groups.
+  let name = segment.type === 'literal' ? '' : displayNames.of(segment.type);
+  let labelProps = useLabels({
+    'aria-label': (ariaLabel ? ariaLabel + ' ' : '') + name,
+    'aria-labelledby': ariaLabelledBy
+  });
+
   // Literal segments should not be visible to screen readers. We don't really need any of the above,
   // but the rules of hooks mean hooks cannot be conditional so we have to put this condition here.
   if (segment.type === 'literal') {
@@ -352,12 +360,10 @@ export function useDateSegment(segment: DateSegment, state: DatePickerFieldState
   }
 
   return {
-    segmentProps: mergeProps(spinButtonProps, pressProps, {
+    segmentProps: mergeProps(spinButtonProps, pressProps, labelProps, {
       id,
       ...touchPropOverrides,
       'aria-invalid': state.validationState === 'invalid' ? 'true' : undefined,
-      'aria-label': displayNames.of(segment.type),
-      'aria-labelledby': `${ariaLabelledBy} ${id}`,
       'aria-describedby': ariaDescribedBy,
       'aria-placeholder': segment.isPlaceholder ? segment.text : undefined,
       'aria-readonly': state.isReadOnly || !segment.isEditable ? 'true' : undefined,

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -48,7 +48,7 @@ export function useDateSegment(segment: DateSegment, state: DatePickerFieldState
   if (segment.type === 'month') {
     let monthTextValue = monthDateFormatter.format(state.dateValue);
     textValue = monthTextValue !== textValue ? `${textValue} – ${monthTextValue}` : monthTextValue;
-  } else if (segment.type === 'hour' || segment.type === 'dayPeriod') {
+  } else if (segment.type === 'hour') {
     textValue = hourDateFormatter.format(state.dateValue);
   }
 

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -49,7 +49,8 @@ export function CalendarBase<T extends CalendarState | RangeCalendarState>(props
     month: 'long',
     year: 'numeric',
     era: currentMonth.calendar.identifier !== 'gregory' ? 'long' : undefined,
-    calendar: currentMonth.calendar.identifier
+    calendar: currentMonth.calendar.identifier,
+    timeZone: state.timeZone
   });
 
   let titles = [];

--- a/packages/@react-spectrum/calendar/src/CalendarCell.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarCell.tsx
@@ -51,7 +51,7 @@ export function CalendarCell({state, currentMonth, ...props}: CalendarCellProps)
   let isRangeStart = isSelected && (isFirstSelectedAfterDisabled || dayOfWeek === 0 || props.date.day === 1);
   let isRangeEnd = isSelected && (isLastSelectedBeforeDisabled || dayOfWeek === 6 || props.date.day === currentMonth.calendar.getDaysInMonth(currentMonth));
   let {focusProps, isFocusVisible} = useFocusRing();
-  let {hoverProps, isHovered} = useHover({isDisabled: isDisabled || isUnavailable});
+  let {hoverProps, isHovered} = useHover({isDisabled: isDisabled || isUnavailable || state.isReadOnly});
 
   return (
     <td
@@ -73,7 +73,7 @@ export function CalendarCell({state, currentMonth, ...props}: CalendarCellProps)
           'is-selection-start': isSelectionStart,
           'is-selection-end': isSelectionEnd,
           'is-hovered': isHovered,
-          'is-pressed': isPressed
+          'is-pressed': isPressed && !state.isReadOnly
         })}>
         <span className={classNames(styles, 'spectrum-Calendar-dateText')}>
           <span>{formattedDate}</span>

--- a/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
+++ b/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
@@ -166,7 +166,7 @@ function Example(props) {
         </Picker>
       </Flex>
       <Provider locale={(locale || defaultLocale) + (calendar && calendar !== preferredCalendars[0].key ? '-u-ca-' + calendar : '')}>
-        <View maxWidth="100vw" overflow="auto">
+        <View maxWidth="100vw" padding="size-10" overflow="auto">
           <Calendar {...props} />
         </View>
       </Provider>

--- a/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
+++ b/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
@@ -14,6 +14,7 @@ jest.mock('@react-aria/live-announcer');
 import {act, fireEvent, render} from '@testing-library/react';
 import {announce} from '@react-aria/live-announcer';
 import {CalendarDate, isWeekend} from '@internationalized/date';
+import {installPointerEvent} from '@react-spectrum/test-utils';
 import {RangeCalendar} from '../';
 import React from 'react';
 import {useLocale} from '@react-aria/i18n';
@@ -580,49 +581,51 @@ describe('RangeCalendar', () => {
       expect(end).toEqual(new CalendarDate(2019, 6, 25));
     });
 
-    it('selects by dragging with touch', () => {
-      let onChange = jest.fn();
-      let {getAllByLabelText, getByText} = render(<RangeCalendar onChange={onChange} defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} />);
+    describe('touch', () => {
+      installPointerEvent();
 
-      fireEvent.pointerDown(getByText('17'), {pointerType: 'touch'});
-      fireEvent.touchStart(getByText('17'), {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      it('selects by dragging with touch', () => {
+        let onChange = jest.fn();
+        let {getAllByLabelText, getByText} = render(<RangeCalendar onChange={onChange} defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} />);
 
-      // There is a delay to distinguish between dragging and scrolling
-      let selectedDates = getAllByLabelText('selected', {exact: false});
-      expect(selectedDates).toHaveLength(6);
+        fireEvent.pointerDown(getByText('17'), {pointerType: 'touch'});
 
-      act(() => jest.advanceTimersByTime(300));
+        // There is a delay to distinguish between dragging and scrolling
+        let selectedDates = getAllByLabelText('selected', {exact: false});
+        expect(selectedDates).toHaveLength(6);
 
-      selectedDates = getAllByLabelText('selected', {exact: false});
-      expect(selectedDates).toHaveLength(1);
-      expect(selectedDates[0].textContent).toBe('17');
-      expect(selectedDates[selectedDates.length - 1].textContent).toBe('17');
-      expect(onChange).toHaveBeenCalledTimes(0);
+        act(() => jest.advanceTimersByTime(300));
 
-      // dragging updates the highlighted dates
-      fireEvent.pointerEnter(getByText('18'));
-      selectedDates = getAllByLabelText('selected', {exact: false});
-      expect(selectedDates[0].textContent).toBe('17');
-      expect(selectedDates[selectedDates.length - 1].textContent).toBe('18');
-      expect(onChange).toHaveBeenCalledTimes(0);
+        selectedDates = getAllByLabelText('selected', {exact: false});
+        expect(selectedDates).toHaveLength(1);
+        expect(selectedDates[0].textContent).toBe('17');
+        expect(selectedDates[selectedDates.length - 1].textContent).toBe('17');
+        expect(onChange).toHaveBeenCalledTimes(0);
 
-      fireEvent.pointerEnter(getByText('23'));
-      selectedDates = getAllByLabelText('selected', {exact: false});
-      expect(selectedDates[0].textContent).toBe('17');
-      expect(selectedDates[selectedDates.length - 1].textContent).toBe('23');
-      expect(onChange).toHaveBeenCalledTimes(0);
+        // dragging updates the highlighted dates
+        fireEvent.pointerEnter(getByText('18'));
+        selectedDates = getAllByLabelText('selected', {exact: false});
+        expect(selectedDates[0].textContent).toBe('17');
+        expect(selectedDates[selectedDates.length - 1].textContent).toBe('18');
+        expect(onChange).toHaveBeenCalledTimes(0);
 
-      fireEvent.touchEnd(getByText('23'), {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
-      fireEvent.pointerUp(getByText('17'), {pointerType: 'touch'});
+        fireEvent.pointerEnter(getByText('23'));
+        selectedDates = getAllByLabelText('selected', {exact: false});
+        expect(selectedDates[0].textContent).toBe('17');
+        expect(selectedDates[selectedDates.length - 1].textContent).toBe('23');
+        expect(onChange).toHaveBeenCalledTimes(0);
 
-      selectedDates = getAllByLabelText('selected', {exact: false});
-      expect(selectedDates[0].textContent).toBe('17');
-      expect(selectedDates[selectedDates.length - 1].textContent).toBe('23');
-      expect(onChange).toHaveBeenCalledTimes(1);
+        fireEvent.pointerUp(getByText('23'), {pointerType: 'touch'});
 
-      let {start, end} = onChange.mock.calls[0][0];
-      expect(start).toEqual(new CalendarDate(2019, 6, 17));
-      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+        selectedDates = getAllByLabelText('selected', {exact: false});
+        expect(selectedDates[0].textContent).toBe('17');
+        expect(selectedDates[selectedDates.length - 1].textContent).toBe('23');
+        expect(onChange).toHaveBeenCalledTimes(1);
+
+        let {start, end} = onChange.mock.calls[0][0];
+        expect(start).toEqual(new CalendarDate(2019, 6, 17));
+        expect(end).toEqual(new CalendarDate(2019, 6, 23));
+      });
     });
 
     it('clicking outside calendar commits selection', () => {

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -44,7 +44,7 @@ export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps
   let {fieldProps} = useDateField(props, state, ref);
 
   return (
-    <div {...fieldProps} className={classNames(datepickerStyles, 'react-spectrum-Datepicker-segments', inputClassName)} ref={ref}>
+    <div {...fieldProps} data-testid={props['data-testid']} className={classNames(datepickerStyles, 'react-spectrum-Datepicker-segments', inputClassName)} ref={ref}>
       {state.segments.map((segment, i) =>
         (<DatePickerSegment
           key={i}

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -128,11 +128,13 @@ export function DateRangePicker<T extends DateValue>(props: SpectrumDateRangePic
           inputClassName={fieldClassName}>
           <DatePickerField
             {...startFieldProps}
+            data-testid="start-date"
             isQuiet={props.isQuiet}
             inputClassName={classNames(datepickerStyles, 'react-spectrum-Datepicker-startField')} />
           <DateRangeDash />
           <DatePickerField
             {...endFieldProps}
+            data-testid="end-date"
             isQuiet={props.isQuiet}
             inputClassName={classNames(
               styles,

--- a/packages/@react-spectrum/datepicker/src/Input.tsx
+++ b/packages/@react-spectrum/datepicker/src/Input.tsx
@@ -15,9 +15,9 @@ import Checkmark from '@spectrum-icons/ui/CheckmarkMedium';
 import {classNames, useValueEffect} from '@react-spectrum/utils';
 import datepickerStyles from './index.css';
 import {FocusRing} from '@react-aria/focus';
-import {mergeProps, useEvent, useLayoutEffect, useResizeObserver} from '@react-aria/utils';
 import React, {useCallback, useRef} from 'react';
 import textfieldStyles from '@adobe/spectrum-css-temp/components/textfield/vars.css';
+import {useEvent, useLayoutEffect, useResizeObserver} from '@react-aria/utils';
 
 export function Input(props) {
   let defaultRef = useRef();
@@ -112,7 +112,7 @@ export function Input(props) {
   }
 
   return (
-    <div {...mergeProps(fieldProps)} className={textfieldClass} style={style}>
+    <div role="presentation" {...fieldProps} className={textfieldClass} style={style}>
       <FocusRing focusClass={classNames(textfieldStyles, 'is-focused')} focusRingClass={classNames(textfieldStyles, 'focus-ring')} isTextInput within>
         <div role="presentation" className={inputClass}>
           <div role="presentation" className={classNames(datepickerStyles, 'react-spectrum-Datepicker-inputContents')} ref={inputRef}>

--- a/packages/@react-spectrum/datepicker/test/DateField.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateField.test.js
@@ -58,13 +58,12 @@ describe('DateField', function () {
       let field = getByRole('group');
       expect(field).toHaveAttribute('aria-label', 'Birth date');
       expect(field).toHaveAttribute('id');
-      let comboboxId = field.getAttribute('id');
 
       let segments = getAllByRole('spinbutton');
       for (let segment of segments) {
         expect(segment).toHaveAttribute('id');
-        let segmentId = segment.getAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `${comboboxId} ${segmentId}`);
+        expect(segment.getAttribute('aria-label').startsWith('Birth date ')).toBe(true);
+        expect(segment).not.toHaveAttribute('aria-labelledby');
       }
     });
 

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -446,15 +446,16 @@ describe('DatePicker', function () {
     });
 
     it('should support labeling with aria-label', function () {
-      let {getByRole, getAllByRole} = render(<DatePicker aria-label="Birth date" />);
+      let {getByRole, getAllByRole, getByTestId} = render(<DatePicker aria-label="Birth date" />);
 
-      let field = getAllByRole('group')[1];
-      expect(field).toHaveAttribute('aria-label', 'Birth date');
-      expect(field).toHaveAttribute('id');
-      let comboboxId = field.getAttribute('id');
+      let group = getByRole('group');
+      expect(group).toHaveAttribute('id');
+      expect(group).toHaveAttribute('aria-label', 'Birth date');
+      let comboboxId = group.getAttribute('id');
 
-      let combobox = getAllByRole('group')[0];
-      expect(combobox).toHaveAttribute('aria-labelledby', comboboxId);
+      let field = getByTestId('date-field');
+      expect(field).toHaveAttribute('role', 'presentation');
+      expect(field).not.toHaveAttribute('aria-label');
 
       let button = getByRole('button');
       expect(button).toHaveAttribute('aria-label', 'Calendar');
@@ -465,20 +466,21 @@ describe('DatePicker', function () {
       let segments = getAllByRole('spinbutton');
       for (let segment of segments) {
         expect(segment).toHaveAttribute('id');
-        let segmentId = segment.getAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `${comboboxId} ${segmentId}`);
+        expect(segment.getAttribute('aria-label').startsWith('Birth date ')).toBe(true);
+        expect(segment).not.toHaveAttribute('aria-labelledby');
       }
     });
 
     it('should support labeling with aria-labelledby', function () {
-      let {getByRole, getAllByRole} = render(<DatePicker aria-labelledby="foo" />);
+      let {getByRole, getAllByRole, getByTestId} = render(<DatePicker aria-labelledby="foo" />);
 
-      let combobox = getAllByRole('group')[0];
+      let combobox = getByRole('group');
       expect(combobox).not.toHaveAttribute('aria-label');
       expect(combobox).toHaveAttribute('aria-labelledby', 'foo');
 
-      let field = getAllByRole('group')[1];
-      expect(field).toHaveAttribute('aria-labelledby', 'foo');
+      let field = getByTestId('date-field');
+      expect(field).toHaveAttribute('role', 'presentation');
+      expect(field).not.toHaveAttribute('aria-labelledby');
 
       let button = getByRole('button');
       expect(button).toHaveAttribute('aria-label', 'Calendar');
@@ -495,11 +497,12 @@ describe('DatePicker', function () {
     });
 
     it('should support help text description', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" description="Help text" />);
+      let {getAllByRole, getByRole, getByTestId} = render(<DatePicker label="Date" description="Help text" />);
 
-      let [group, field] = getAllByRole('group');
+      let group = getByRole('group');
+      let field = getByTestId('date-field');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(field).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      expect(field).not.toHaveAttribute('aria-describedby');
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Help text');
@@ -513,11 +516,12 @@ describe('DatePicker', function () {
     });
 
     it('should support error message', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" errorMessage="Error message" validationState="invalid" />);
+      let {getAllByRole, getByRole, getByTestId} = render(<DatePicker label="Date" errorMessage="Error message" validationState="invalid" />);
 
-      let [group, field] = getAllByRole('group');
+      let group = getByRole('group');
+      let field = getByTestId('date-field');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(field).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      expect(field).not.toHaveAttribute('aria-describedby');
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Error message');
@@ -529,9 +533,10 @@ describe('DatePicker', function () {
     });
 
     it('should not display error message if not invalid', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" errorMessage="Error message" />);
+      let {getAllByRole, getByRole, getByTestId} = render(<DatePicker label="Date" errorMessage="Error message" />);
 
-      let [group, field] = getAllByRole('group');
+      let group = getByRole('group');
+      let field = getByTestId('date-field');
       expect(group).not.toHaveAttribute('aria-describedby');
       expect(field).not.toHaveAttribute('aria-describedby');
 
@@ -542,11 +547,12 @@ describe('DatePicker', function () {
     });
 
     it('should support help text with a value', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" description="Help text" value={new CalendarDate(2020, 2, 3)} />);
+      let {getAllByRole, getByRole, getByTestId} = render(<DatePicker label="Date" description="Help text" value={new CalendarDate(2020, 2, 3)} />);
 
-      let [group, field] = getAllByRole('group');
+      let group = getByRole('group');
+      let field = getByTestId('date-field');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(field).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      expect(field).not.toHaveAttribute('aria-describedby');
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Help text');
@@ -560,11 +566,12 @@ describe('DatePicker', function () {
     });
 
     it('should support error message with a value', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" errorMessage="Error message" validationState="invalid" value={new CalendarDate(2020, 2, 3)} />);
+      let {getAllByRole, getByRole, getByTestId} = render(<DatePicker label="Date" errorMessage="Error message" validationState="invalid" value={new CalendarDate(2020, 2, 3)} />);
 
-      let [group, field] = getAllByRole('group');
+      let group = getByRole('group');
+      let field = getByTestId('date-field');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(field).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
+      expect(field).not.toHaveAttribute('aria-describedby');
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3, 2020 Error message');
@@ -576,10 +583,11 @@ describe('DatePicker', function () {
     });
 
     it('should support format help text', function () {
-      let {getAllByRole, getByText} = render(<DatePicker label="Date" showFormatHelpText />);
+      let {getAllByRole, getByText, getByRole, getByTestId} = render(<DatePicker label="Date" showFormatHelpText />);
 
       // Not needed in aria-described by because each segment has a label already, so this would be duplicative.
-      let [group, field] = getAllByRole('group');
+      let group = getByRole('group');
+      let field = getByTestId('date-field');
       expect(group).not.toHaveAttribute('aria-describedby');
       expect(field).not.toHaveAttribute('aria-describedby');
 
@@ -594,8 +602,8 @@ describe('DatePicker', function () {
 
   describe('focus management', function () {
     it('should focus the first segment on mouse down in the field', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" />);
-      let field = getAllByRole('group')[1];
+      let {getAllByRole, getByTestId} = render(<DatePicker label="Date" />);
+      let field = getByTestId('date-field');
       let segments = getAllByRole('spinbutton');
 
       triggerPress(field);
@@ -603,8 +611,8 @@ describe('DatePicker', function () {
     });
 
     it('should focus the first unfilled segment on mouse down in the field', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" />);
-      let field = getAllByRole('group')[1];
+      let {getAllByRole, getByTestId} = render(<DatePicker label="Date" />);
+      let field = getByTestId('date-field');
       let segments = getAllByRole('spinbutton');
 
       act(() => segments[0].focus());
@@ -617,8 +625,8 @@ describe('DatePicker', function () {
     });
 
     it('should focus the last segment on mouse down in the field with a value', function () {
-      let {getAllByRole} = render(<DatePicker label="Date" value={new CalendarDate(2020, 2, 3)} />);
-      let field = getAllByRole('group')[1];
+      let {getAllByRole, getByTestId} = render(<DatePicker label="Date" value={new CalendarDate(2020, 2, 3)} />);
+      let field = getByTestId('date-field');
       let segments = getAllByRole('spinbutton');
 
       triggerPress(field);

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -153,7 +153,7 @@ describe('DatePicker', function () {
 
       expect(segments[6].textContent).toBe('AM');
       expect(segments[6].getAttribute('aria-label')).toBe('AM/PM');
-      expect(segments[6].getAttribute('aria-valuetext')).toBe('12 AM');
+      expect(segments[6].getAttribute('aria-valuetext')).toBe('AM');
     });
   });
 
@@ -332,7 +332,7 @@ describe('DatePicker', function () {
       fireEvent.keyUp(hour, {key: 'ArrowRight'});
 
       expect(document.activeElement).toHaveAttribute('aria-label', 'AM/PM');
-      expect(document.activeElement).toHaveAttribute('aria-valuetext', '1 AM');
+      expect(document.activeElement).toHaveAttribute('aria-valuetext', 'AM');
 
       fireEvent.keyDown(document.activeElement, {key: 'Enter'});
       fireEvent.keyUp(document.activeElement, {key: 'Enter'});

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -88,42 +88,42 @@ describe('DateRangePicker', function () {
       expect(segments.length).toBe(6);
 
       expect(segments[0].textContent).toBe('2');
-      expect(segments[0].getAttribute('aria-label')).toBe('month');
+      expect(segments[0].getAttribute('aria-label')).toBe('Start Date month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
       expect(segments[0].getAttribute('aria-valuetext')).toBe('2 – February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
       expect(segments[1].textContent).toBe('3');
-      expect(segments[1].getAttribute('aria-label')).toBe('day');
+      expect(segments[1].getAttribute('aria-label')).toBe('Start Date day');
       expect(segments[1].getAttribute('aria-valuenow')).toBe('3');
       expect(segments[1].getAttribute('aria-valuetext')).toBe('3');
       expect(segments[1].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[1].getAttribute('aria-valuemax')).toBe('28');
 
       expect(segments[2].textContent).toBe('2019');
-      expect(segments[2].getAttribute('aria-label')).toBe('year');
+      expect(segments[2].getAttribute('aria-label')).toBe('Start Date year');
       expect(segments[2].getAttribute('aria-valuenow')).toBe('2019');
       expect(segments[2].getAttribute('aria-valuetext')).toBe('2019');
       expect(segments[2].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[2].getAttribute('aria-valuemax')).toBe('9999');
 
       expect(segments[3].textContent).toBe('5');
-      expect(segments[3].getAttribute('aria-label')).toBe('month');
+      expect(segments[3].getAttribute('aria-label')).toBe('End Date month');
       expect(segments[3].getAttribute('aria-valuenow')).toBe('5');
       expect(segments[3].getAttribute('aria-valuetext')).toBe('5 – May');
       expect(segments[3].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[3].getAttribute('aria-valuemax')).toBe('12');
 
       expect(segments[4].textContent).toBe('6');
-      expect(segments[4].getAttribute('aria-label')).toBe('day');
+      expect(segments[4].getAttribute('aria-label')).toBe('End Date day');
       expect(segments[4].getAttribute('aria-valuenow')).toBe('6');
       expect(segments[4].getAttribute('aria-valuetext')).toBe('6');
       expect(segments[4].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[4].getAttribute('aria-valuemax')).toBe('31');
 
       expect(segments[5].textContent).toBe('2019');
-      expect(segments[5].getAttribute('aria-label')).toBe('year');
+      expect(segments[5].getAttribute('aria-label')).toBe('End Date year');
       expect(segments[5].getAttribute('aria-valuenow')).toBe('2019');
       expect(segments[5].getAttribute('aria-valuetext')).toBe('2019');
       expect(segments[5].getAttribute('aria-valuemin')).toBe('1');
@@ -142,95 +142,95 @@ describe('DateRangePicker', function () {
       expect(segments.length).toBe(14);
 
       expect(segments[0].textContent).toBe('2');
-      expect(segments[0].getAttribute('aria-label')).toBe('month');
+      expect(segments[0].getAttribute('aria-label')).toBe('Start Date month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
       expect(segments[0].getAttribute('aria-valuetext')).toBe('2 – February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
       expect(segments[1].textContent).toBe('3');
-      expect(segments[1].getAttribute('aria-label')).toBe('day');
+      expect(segments[1].getAttribute('aria-label')).toBe('Start Date day');
       expect(segments[1].getAttribute('aria-valuenow')).toBe('3');
       expect(segments[1].getAttribute('aria-valuetext')).toBe('3');
       expect(segments[1].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[1].getAttribute('aria-valuemax')).toBe('28');
 
       expect(segments[2].textContent).toBe('2019');
-      expect(segments[2].getAttribute('aria-label')).toBe('year');
+      expect(segments[2].getAttribute('aria-label')).toBe('Start Date year');
       expect(segments[2].getAttribute('aria-valuenow')).toBe('2019');
       expect(segments[2].getAttribute('aria-valuetext')).toBe('2019');
       expect(segments[2].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[2].getAttribute('aria-valuemax')).toBe('9999');
 
       expect(segments[3].textContent).toBe('12');
-      expect(segments[3].getAttribute('aria-label')).toBe('hour');
+      expect(segments[3].getAttribute('aria-label')).toBe('Start Date hour');
       expect(segments[3].getAttribute('aria-valuenow')).toBe('0');
       expect(segments[3].getAttribute('aria-valuetext')).toBe('12 AM');
       expect(segments[3].getAttribute('aria-valuemin')).toBe('0');
       expect(segments[3].getAttribute('aria-valuemax')).toBe('11');
 
       expect(segments[4].textContent).toBe('00');
-      expect(segments[4].getAttribute('aria-label')).toBe('minute');
+      expect(segments[4].getAttribute('aria-label')).toBe('Start Date minute');
       expect(segments[4].getAttribute('aria-valuenow')).toBe('0');
       expect(segments[4].getAttribute('aria-valuetext')).toBe('00');
       expect(segments[4].getAttribute('aria-valuemin')).toBe('0');
       expect(segments[4].getAttribute('aria-valuemax')).toBe('59');
 
       expect(segments[5].textContent).toBe('00');
-      expect(segments[5].getAttribute('aria-label')).toBe('second');
+      expect(segments[5].getAttribute('aria-label')).toBe('Start Date second');
       expect(segments[5].getAttribute('aria-valuenow')).toBe('0');
       expect(segments[5].getAttribute('aria-valuetext')).toBe('00');
       expect(segments[5].getAttribute('aria-valuemin')).toBe('0');
       expect(segments[5].getAttribute('aria-valuemax')).toBe('59');
 
       expect(segments[6].textContent).toBe('AM');
-      expect(segments[6].getAttribute('aria-label')).toBe('AM/PM');
+      expect(segments[6].getAttribute('aria-label')).toBe('Start Date AM/PM');
       expect(segments[6].getAttribute('aria-valuetext')).toBe('12 AM');
 
       expect(segments[7].textContent).toBe('5');
-      expect(segments[7].getAttribute('aria-label')).toBe('month');
+      expect(segments[7].getAttribute('aria-label')).toBe('End Date month');
       expect(segments[7].getAttribute('aria-valuenow')).toBe('5');
       expect(segments[7].getAttribute('aria-valuetext')).toBe('5 – May');
       expect(segments[7].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[7].getAttribute('aria-valuemax')).toBe('12');
 
       expect(segments[8].textContent).toBe('6');
-      expect(segments[8].getAttribute('aria-label')).toBe('day');
+      expect(segments[8].getAttribute('aria-label')).toBe('End Date day');
       expect(segments[8].getAttribute('aria-valuenow')).toBe('6');
       expect(segments[8].getAttribute('aria-valuetext')).toBe('6');
       expect(segments[8].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[8].getAttribute('aria-valuemax')).toBe('31');
 
       expect(segments[9].textContent).toBe('2019');
-      expect(segments[9].getAttribute('aria-label')).toBe('year');
+      expect(segments[9].getAttribute('aria-label')).toBe('End Date year');
       expect(segments[9].getAttribute('aria-valuenow')).toBe('2019');
       expect(segments[9].getAttribute('aria-valuetext')).toBe('2019');
       expect(segments[9].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[9].getAttribute('aria-valuemax')).toBe('9999');
 
       expect(segments[10].textContent).toBe('12');
-      expect(segments[10].getAttribute('aria-label')).toBe('hour');
+      expect(segments[10].getAttribute('aria-label')).toBe('End Date hour');
       expect(segments[10].getAttribute('aria-valuenow')).toBe('0');
       expect(segments[10].getAttribute('aria-valuetext')).toBe('12 AM');
       expect(segments[10].getAttribute('aria-valuemin')).toBe('0');
       expect(segments[10].getAttribute('aria-valuemax')).toBe('11');
 
       expect(segments[11].textContent).toBe('00');
-      expect(segments[11].getAttribute('aria-label')).toBe('minute');
+      expect(segments[11].getAttribute('aria-label')).toBe('End Date minute');
       expect(segments[11].getAttribute('aria-valuenow')).toBe('0');
       expect(segments[11].getAttribute('aria-valuetext')).toBe('00');
       expect(segments[11].getAttribute('aria-valuemin')).toBe('0');
       expect(segments[11].getAttribute('aria-valuemax')).toBe('59');
 
       expect(segments[12].textContent).toBe('00');
-      expect(segments[12].getAttribute('aria-label')).toBe('second');
+      expect(segments[12].getAttribute('aria-label')).toBe('End Date second');
       expect(segments[12].getAttribute('aria-valuenow')).toBe('0');
       expect(segments[12].getAttribute('aria-valuetext')).toBe('00');
       expect(segments[12].getAttribute('aria-valuemin')).toBe('0');
       expect(segments[12].getAttribute('aria-valuemax')).toBe('59');
 
       expect(segments[13].textContent).toBe('AM');
-      expect(segments[13].getAttribute('aria-label')).toBe('AM/PM');
+      expect(segments[13].getAttribute('aria-label')).toBe('End Date AM/PM');
       expect(segments[13].getAttribute('aria-valuetext')).toBe('12 AM');
     });
   });
@@ -238,14 +238,14 @@ describe('DateRangePicker', function () {
   describe('calendar popover', function () {
     it('should emit onChange when selecting a date range in the calendar in uncontrolled mode', function () {
       let onChange = jest.fn();
-      let {getByRole, getAllByRole, getByLabelText} = render(
+      let {getByRole, getByTestId, getAllByRole, getByLabelText} = render(
         <Provider theme={theme}>
           <DateRangePicker label="Date range" defaultValue={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}} onChange={onChange} />
         </Provider>
       );
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       expect(startDate).toHaveTextContent('2/3/2019');
       expect(endDate).toHaveTextContent('5/6/2019');
 
@@ -271,14 +271,14 @@ describe('DateRangePicker', function () {
 
     it('should display time fields when a CalendarDateTime value is used', function () {
       let onChange = jest.fn();
-      let {getByRole, getAllByRole, getByLabelText, getAllByLabelText} = render(
+      let {getByRole, getByTestId, getAllByRole, getByLabelText, getAllByLabelText} = render(
         <Provider theme={theme}>
           <DateRangePicker label="Date" defaultValue={{start: new CalendarDateTime(2019, 2, 3, 8, 45), end: new CalendarDateTime(2019, 5, 6, 10, 45)}} onChange={onChange} />
         </Provider>
       );
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       expect(startDate).toHaveTextContent('2/3/2019, 8:45 AM');
       expect(endDate).toHaveTextContent('5/6/2019, 10:45 AM');
 
@@ -343,7 +343,7 @@ describe('DateRangePicker', function () {
 
     it('should not fire onChange until both date range and time range are selected', function () {
       let onChange = jest.fn();
-      let {getByRole, getAllByRole, getByLabelText, getAllByLabelText} = render(
+      let {getByRole, getAllByRole, getByTestId, getAllByLabelText} = render(
         <Provider theme={theme}>
           <DateRangePicker label="Date" granularity="minute" onChange={onChange} />
         </Provider>
@@ -351,8 +351,8 @@ describe('DateRangePicker', function () {
 
       let formatter = new Intl.DateTimeFormat('en-US', {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric'});
       let placeholder = formatter.format(toCalendarDateTime(today(getLocalTimeZone())).toDate(getLocalTimeZone()));
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       expectPlaceholder(startDate, placeholder);
       expectPlaceholder(endDate, placeholder);
 
@@ -432,7 +432,7 @@ describe('DateRangePicker', function () {
 
     it('should confirm time placeholders on blur if date range is selected', function () {
       let onChange = jest.fn();
-      let {getByRole, getAllByRole, getByLabelText} = render(
+      let {getByRole, getAllByRole, getByTestId} = render(
         <Provider theme={theme}>
           <DateRangePicker label="Date" granularity="minute" onChange={onChange} />
         </Provider>
@@ -440,8 +440,8 @@ describe('DateRangePicker', function () {
 
       let formatter = new Intl.DateTimeFormat('en-US', {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric'});
       let placeholder = formatter.format(toCalendarDateTime(today(getLocalTimeZone())).toDate(getLocalTimeZone()));
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       expectPlaceholder(startDate, placeholder);
       expectPlaceholder(endDate, placeholder);
 
@@ -473,7 +473,7 @@ describe('DateRangePicker', function () {
 
     it('should not confirm on blur if date range is not selected', function () {
       let onChange = jest.fn();
-      let {getByRole, getAllByLabelText, getByLabelText} = render(
+      let {getByRole, getAllByLabelText, getByTestId} = render(
         <Provider theme={theme}>
           <DateRangePicker label="Date" granularity="minute" onChange={onChange} />
         </Provider>
@@ -481,8 +481,8 @@ describe('DateRangePicker', function () {
 
       let formatter = new Intl.DateTimeFormat('en-US', {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric'});
       let placeholder = formatter.format(toCalendarDateTime(today(getLocalTimeZone())).toDate(getLocalTimeZone()));
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       expectPlaceholder(startDate, placeholder);
       expectPlaceholder(endDate, placeholder);
 
@@ -516,18 +516,20 @@ describe('DateRangePicker', function () {
 
   describe('labeling', function () {
     it('should support labeling', function () {
-      let {getAllByRole, getByLabelText, getByText} = render(<DateRangePicker label="Date range" />);
+      let {getAllByRole, getByTestId, getByText} = render(<DateRangePicker label="Date range" />);
 
       let label = getByText('Date range');
 
       let combobox = getAllByRole('group')[0];
       expect(combobox).toHaveAttribute('aria-labelledby', label.id);
 
-      let startDate = getByLabelText('Start Date');
-      expect(startDate).toHaveAttribute('aria-labelledby', `${label.id} ${startDate.id}`);
+      let startDate = getByTestId('start-date');
+      expect(startDate).toHaveAttribute('role', 'presentation');
+      expect(startDate).not.toHaveAttribute('aria-labelledby');
 
-      let endDate = getByLabelText('End Date');
-      expect(endDate).toHaveAttribute('aria-labelledby', `${label.id} ${endDate.id}`);
+      let endDate = getByTestId('end-date');
+      expect(endDate).toHaveAttribute('role', 'presentation');
+      expect(endDate).not.toHaveAttribute('aria-labelledby');
 
       let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-label', 'Calendar');
@@ -537,28 +539,32 @@ describe('DateRangePicker', function () {
       let startSegments = getAllByRoleInContainer(startDate, 'spinbutton');
       for (let segment of startSegments) {
         expect(segment).toHaveAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `${label.id} ${startDate.id} ${segment.id}`);
+        expect(segment.getAttribute('aria-label').startsWith('Start Date ')).toBe(true);
+        expect(segment).toHaveAttribute('aria-labelledby', `${label.id} ${segment.id}`);
       }
 
       let endSegments = getAllByRoleInContainer(endDate, 'spinbutton');
       for (let segment of endSegments) {
         expect(segment).toHaveAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `${label.id} ${endDate.id} ${segment.id}`);
+        expect(segment.getAttribute('aria-label').startsWith('End Date ')).toBe(true);
+        expect(segment).toHaveAttribute('aria-labelledby', `${label.id} ${segment.id}`);
       }
     });
 
     it('should support labeling with aria-label', function () {
-      let {getAllByRole, getByLabelText} = render(<DateRangePicker aria-label="Birth date" />);
+      let {getAllByRole, getByTestId} = render(<DateRangePicker aria-label="Birth date" />);
 
       let field = getAllByRole('group')[0];
       expect(field).toHaveAttribute('aria-label', 'Birth date');
       expect(field).toHaveAttribute('id');
 
-      let startDate = getByLabelText('Start Date');
-      expect(startDate).toHaveAttribute('aria-labelledby', `${field.id} ${startDate.id}`);
+      let startDate = getByTestId('start-date');
+      expect(startDate).toHaveAttribute('role', 'presentation');
+      expect(startDate).not.toHaveAttribute('aria-labelledby');
 
-      let endDate = getByLabelText('End Date');
-      expect(endDate).toHaveAttribute('aria-labelledby', `${field.id} ${endDate.id}`);
+      let endDate = getByTestId('end-date');
+      expect(endDate).toHaveAttribute('role', 'presentation');
+      expect(endDate).not.toHaveAttribute('aria-labelledby');
 
       let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-label', 'Calendar');
@@ -568,27 +574,31 @@ describe('DateRangePicker', function () {
       let startSegments = getAllByRoleInContainer(startDate, 'spinbutton');
       for (let segment of startSegments) {
         expect(segment).toHaveAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `${field.id} ${startDate.id} ${segment.id}`);
+        expect(segment.getAttribute('aria-label').startsWith('Start Date ')).toBe(true);
+        expect(segment).toHaveAttribute('aria-labelledby', `${field.id} ${segment.id}`);
       }
 
       let endSegments = getAllByRoleInContainer(endDate, 'spinbutton');
       for (let segment of endSegments) {
         expect(segment).toHaveAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `${field.id} ${endDate.id} ${segment.id}`);
+        expect(segment.getAttribute('aria-label').startsWith('End Date ')).toBe(true);
+        expect(segment).toHaveAttribute('aria-labelledby', `${field.id} ${segment.id}`);
       }
     });
 
     it('should support labeling with aria-labelledby', function () {
-      let {getAllByRole, getByLabelText} = render(<DateRangePicker aria-labelledby="foo" />);
+      let {getAllByRole, getByTestId} = render(<DateRangePicker aria-labelledby="foo" />);
 
       let field = getAllByRole('group')[0];
       expect(field).toHaveAttribute('aria-labelledby', 'foo');
 
-      let startDate = getByLabelText('Start Date');
-      expect(startDate).toHaveAttribute('aria-labelledby', `foo ${startDate.id}`);
+      let startDate = getByTestId('start-date');
+      expect(startDate).toHaveAttribute('role', 'presentation');
+      expect(startDate).not.toHaveAttribute('aria-labelledby');
 
-      let endDate = getByLabelText('End Date');
-      expect(endDate).toHaveAttribute('aria-labelledby', `foo ${endDate.id}`);
+      let endDate = getByTestId('end-date');
+      expect(endDate).toHaveAttribute('role', 'presentation');
+      expect(endDate).not.toHaveAttribute('aria-labelledby');
 
       let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-label', 'Calendar');
@@ -598,23 +608,25 @@ describe('DateRangePicker', function () {
       let startSegments = getAllByRoleInContainer(startDate, 'spinbutton');
       for (let segment of startSegments) {
         expect(segment).toHaveAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `foo ${startDate.id} ${segment.id}`);
+        expect(segment.getAttribute('aria-label').startsWith('Start Date ')).toBe(true);
+        expect(segment).toHaveAttribute('aria-labelledby', `foo ${segment.id}`);
       }
 
       let endSegments = getAllByRoleInContainer(endDate, 'spinbutton');
       for (let segment of endSegments) {
         expect(segment).toHaveAttribute('id');
-        expect(segment).toHaveAttribute('aria-labelledby', `foo ${endDate.id} ${segment.id}`);
+        expect(segment.getAttribute('aria-label').startsWith('End Date ')).toBe(true);
+        expect(segment).toHaveAttribute('aria-labelledby', `foo ${segment.id}`);
       }
     });
 
     it('should support help text description', function () {
-      let {getAllByRole} = render(<DateRangePicker label="Date" description="Help text" />);
+      let {getByRole, getByTestId} = render(<DateRangePicker label="Date" description="Help text" />);
 
-      let [group, startField, endField] = getAllByRole('group');
+      let group = getByRole('group');
+      let startField = getByTestId('start-date');
+      let endField = getByTestId('end-date');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(startField).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
-      expect(endField).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Help text');
@@ -635,12 +647,10 @@ describe('DateRangePicker', function () {
     });
 
     it('should support error message', function () {
-      let {getAllByRole} = render(<DateRangePicker label="Date" errorMessage="Error message" validationState="invalid" />);
+      let {getByRole, getAllByRole} = render(<DateRangePicker label="Date" errorMessage="Error message" validationState="invalid" />);
 
-      let [group, startField, endField] = getAllByRole('group');
+      let group = getByRole('group');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(startField).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
-      expect(endField).toHaveAttribute('aria-describedby', group.getAttribute('aria-describedby'));
 
       let description = document.getElementById(group.getAttribute('aria-describedby'));
       expect(description).toHaveTextContent('Error message');
@@ -652,9 +662,11 @@ describe('DateRangePicker', function () {
     });
 
     it('should not display error message if not invalid', function () {
-      let {getAllByRole} = render(<DateRangePicker label="Date" errorMessage="Error message" />);
+      let {getByRole, getAllByRole, getByTestId} = render(<DateRangePicker label="Date" errorMessage="Error message" />);
 
-      let [group, startField, endField] = getAllByRole('group');
+      let group = getByRole('group');
+      let startField = getByTestId('start-date');
+      let endField = getByTestId('end-date');
       expect(group).not.toHaveAttribute('aria-describedby');
       expect(startField).not.toHaveAttribute('aria-describedby');
       expect(endField).not.toHaveAttribute('aria-describedby');
@@ -666,31 +678,29 @@ describe('DateRangePicker', function () {
     });
 
     it('should support help text with a value', function () {
-      let {getAllByRole} = render(<DateRangePicker label="Date" description="Help text" value={{start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2020, 2, 10)}} />);
+      let {getByRole, getByTestId} = render(<DateRangePicker label="Date" description="Help text" value={{start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2020, 2, 10)}} />);
 
-      let [group, startField, endField] = getAllByRole('group');
+      let group = getByRole('group');
+      let startField = getByTestId('start-date');
+      let endField = getByTestId('end-date');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(startField).toHaveAttribute('aria-describedby');
-      expect(endField).toHaveAttribute('aria-describedby');
+      expect(startField).not.toHaveAttribute('aria-describedby');
+      expect(endField).not.toHaveAttribute('aria-describedby');
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3 – 10, 2020 Help text');
 
-      description = startField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
-      expect(description).toBe('February 3, 2020 Help text');
-
       let segments = within(startField).getAllByRole('spinbutton');
-      expect(segments[0]).toHaveAttribute('aria-describedby', startField.getAttribute('aria-describedby'));
+      description = segments[0].getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
+      expect(description).toBe('February 3 – 10, 2020 Help text');
 
       for (let segment of segments.slice(1)) {
         expect(segment).not.toHaveAttribute('aria-describedby');
       }
 
-      description = endField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
-      expect(description).toBe('February 10, 2020 Help text');
-
       segments = within(endField).getAllByRole('spinbutton');
-      expect(segments[0]).toHaveAttribute('aria-describedby', endField.getAttribute('aria-describedby'));
+      description = segments[0].getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
+      expect(description).toBe('February 3 – 10, 2020 Help text');
 
       for (let segment of segments.slice(1)) {
         expect(segment).not.toHaveAttribute('aria-describedby');
@@ -698,38 +708,38 @@ describe('DateRangePicker', function () {
     });
 
     it('should support error message with a value', function () {
-      let {getAllByRole} = render(<DateRangePicker label="Date" errorMessage="Error message" validationState="invalid" value={{start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2020, 2, 10)}} />);
+      let {getByRole, getByTestId} = render(<DateRangePicker label="Date" errorMessage="Error message" validationState="invalid" value={{start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2020, 2, 10)}} />);
 
-      let [group, startField, endField] = getAllByRole('group');
+      let group = getByRole('group');
+      let startField = getByTestId('start-date');
+      let endField = getByTestId('end-date');
       expect(group).toHaveAttribute('aria-describedby');
-      expect(startField).toHaveAttribute('aria-describedby');
-      expect(endField).toHaveAttribute('aria-describedby');
+      expect(startField).not.toHaveAttribute('aria-describedby');
+      expect(endField).not.toHaveAttribute('aria-describedby');
 
       let description = group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
       expect(description).toBe('February 3 – 10, 2020 Error message');
 
-      description = startField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
-      expect(description).toBe('February 3, 2020 Error message');
-
       let segments = within(startField).getAllByRole('spinbutton');
       for (let segment of segments) {
-        expect(segment).toHaveAttribute('aria-describedby', startField.getAttribute('aria-describedby'));
+        description = segment.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
+        expect(description).toBe('February 3 – 10, 2020 Error message');
       }
-
-      description = endField.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
-      expect(description).toBe('February 10, 2020 Error message');
 
       segments = within(endField).getAllByRole('spinbutton');
       for (let segment of segments) {
-        expect(segment).toHaveAttribute('aria-describedby', endField.getAttribute('aria-describedby'));
+        description = segment.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
+        expect(description).toBe('February 3 – 10, 2020 Error message');
       }
     });
 
     it('should support format help text', function () {
-      let {getAllByRole, getByText} = render(<DateRangePicker label="Date" showFormatHelpText />);
+      let {getAllByRole, getByText, getByRole, getByTestId} = render(<DateRangePicker label="Date" showFormatHelpText />);
 
       // Not needed in aria-described by because each segment has a label already, so this would be duplicative.
-      let [group, startField, endField] = getAllByRole('group');
+      let group = getByRole('group');
+      let startField = getByTestId('start-date');
+      let endField = getByTestId('end-date');
       expect(group).not.toHaveAttribute('aria-describedby');
       expect(startField).not.toHaveAttribute('aria-describedby');
       expect(endField).not.toHaveAttribute('aria-describedby');
@@ -745,9 +755,9 @@ describe('DateRangePicker', function () {
 
   describe('focus management', function () {
     it('should focus the first segment of each field on mouse down', function () {
-      let {getByLabelText} = render(<DateRangePicker label="Date range" />);
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let {getByTestId} = render(<DateRangePicker label="Date range" />);
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       let startSegments = getAllByRoleInContainer(startDate, 'spinbutton');
       let endSegments = getAllByRoleInContainer(endDate, 'spinbutton');
 
@@ -761,9 +771,9 @@ describe('DateRangePicker', function () {
     });
 
     it('should focus the first segment of the end date on mouse down on the dash', function () {
-      let {getByTestId, getByLabelText} = render(<DateRangePicker label="Date range" />);
+      let {getByTestId} = render(<DateRangePicker label="Date range" />);
       let rangeDash = getByTestId('date-range-dash');
-      let startDate = getByLabelText('Start Date');
+      let startDate = getByTestId('start-date');
       let startSegments = getAllByRoleInContainer(startDate, 'spinbutton');
 
       fireEvent(rangeDash, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
@@ -778,14 +788,14 @@ describe('DateRangePicker', function () {
 
     it('should edit a date range with the arrow keys (uncontrolled)', function () {
       let onChange = jest.fn();
-      let {getAllByLabelText} = render(
+      let {getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}}
           onChange={onChange} />
       );
 
-      let startMonth = getAllByLabelText('month')[0];
+      let startMonth = getByLabelText('Start Date month');
       expect(startMonth).toHaveTextContent('2');
       act(() => {startMonth.focus();});
       fireEvent.keyDown(startMonth, {key: 'ArrowDown'});
@@ -794,7 +804,7 @@ describe('DateRangePicker', function () {
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDate(2019, 1, 3), end: new CalendarDate(2019, 5, 6)});
 
-      let endYear = getAllByLabelText('year')[1];
+      let endYear = getByLabelText('End Date year');
       expect(endYear).toHaveTextContent('2019');
       act(() => {endYear.focus();});
       fireEvent.keyDown(endYear, {key: 'ArrowUp'});
@@ -806,14 +816,14 @@ describe('DateRangePicker', function () {
 
     it('should edit a date range with the arrow keys (controlled)', function () {
       let onChange = jest.fn();
-      let {getAllByLabelText} = render(
+      let {getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           value={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}}
           onChange={onChange} />
       );
 
-      let startMonth = getAllByLabelText('month')[0];
+      let startMonth = getByLabelText('Start Date month');
       expect(startMonth).toHaveTextContent('2');
       act(() => {startMonth.focus();});
       fireEvent.keyDown(startMonth, {key: 'ArrowDown'});
@@ -822,7 +832,7 @@ describe('DateRangePicker', function () {
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDate(2019, 1, 3), end: new CalendarDate(2019, 5, 6)});
 
-      let endYear = getAllByLabelText('year')[1];
+      let endYear = getByLabelText('End Date year');
       expect(endYear).toHaveTextContent('2019');
       act(() => {endYear.focus();});
       fireEvent.keyDown(endYear, {key: 'ArrowUp'});
@@ -834,14 +844,14 @@ describe('DateRangePicker', function () {
 
     it('should edit a date range by entering text (uncontrolled)', function () {
       let onChange = jest.fn();
-      let {getAllByLabelText} = render(
+      let {getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}}
           onChange={onChange} />
       );
 
-      let startMonth = getAllByLabelText('month')[0];
+      let startMonth = getByLabelText('Start Date month');
       act(() => {startMonth.focus();});
       beforeInput(startMonth, '8');
 
@@ -849,9 +859,9 @@ describe('DateRangePicker', function () {
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDate(2019, 8, 3), end: new CalendarDate(2019, 5, 6)});
 
-      expect(getAllByLabelText('day')[0]).toHaveFocus();
+      expect(getByLabelText('Start Date day')).toHaveFocus();
 
-      let endYear = getAllByLabelText('year')[1];
+      let endYear = getByLabelText('End Date year');
       expect(endYear).toHaveTextContent('2019');
       act(() => {endYear.focus();});
       beforeInput(endYear, '2');
@@ -866,14 +876,14 @@ describe('DateRangePicker', function () {
 
     it('should edit a date range by entering text (controlled)', function () {
       let onChange = jest.fn();
-      let {getAllByLabelText} = render(
+      let {getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           value={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}}
           onChange={onChange} />
       );
 
-      let startMonth = getAllByLabelText('month')[0];
+      let startMonth = getByLabelText('Start Date month');
       act(() => {startMonth.focus();});
       beforeInput(startMonth, '8');
 
@@ -881,9 +891,9 @@ describe('DateRangePicker', function () {
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDate(2019, 8, 3), end: new CalendarDate(2019, 5, 6)});
 
-      expect(getAllByLabelText('day')[0]).toHaveFocus();
+      expect(getByLabelText('Start Date day')).toHaveFocus();
 
-      let endDay = getAllByLabelText('day')[1];
+      let endDay = getByLabelText('End Date day');
       expect(endDay).toHaveTextContent('6');
       act(() => {endDay.focus();});
       beforeInput(endDay, '4');
@@ -895,14 +905,14 @@ describe('DateRangePicker', function () {
 
     it('should support backspace (uncontrolled)', function () {
       let onChange = jest.fn();
-      let {getAllByLabelText} = render(
+      let {getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}}
           onChange={onChange} />
       );
 
-      let endYear = getAllByLabelText('year')[1];
+      let endYear = getByLabelText('End Date year');
       expect(endYear).toHaveTextContent('2019');
       act(() => {endYear.focus();});
       fireEvent.keyDown(endYear, {key: 'Backspace'});
@@ -914,14 +924,14 @@ describe('DateRangePicker', function () {
 
     it('should support backspace (controlled)', function () {
       let onChange = jest.fn();
-      let {getAllByLabelText} = render(
+      let {getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           value={{start: new CalendarDate(2019, 2, 3), end: new CalendarDate(2019, 5, 6)}}
           onChange={onChange} />
       );
 
-      let endYear = getAllByLabelText('year')[1];
+      let endYear = getByLabelText('End Date year');
       expect(endYear).toHaveTextContent('2019');
       act(() => {endYear.focus();});
       fireEvent.keyDown(endYear, {key: 'Backspace'});
@@ -944,7 +954,7 @@ describe('DateRangePicker', function () {
     });
 
     it('should display an error icon when the start date is less than the minimum (uncontrolled)', function () {
-      let {getByTestId, getAllByLabelText} = render(
+      let {getByTestId, getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(1985, 1, 1), end: new CalendarDate(1999, 2, 3)}}
@@ -952,7 +962,7 @@ describe('DateRangePicker', function () {
       );
       expect(() => getByTestId('invalid-icon')).toThrow();
 
-      let year = getAllByLabelText('year')[0];
+      let year = getByLabelText('Start Date year');
       fireEvent.keyDown(year, {key: 'ArrowDown'});
 
       expect(getByTestId('invalid-icon')).toBeVisible();
@@ -972,7 +982,7 @@ describe('DateRangePicker', function () {
     });
 
     it('should display an error icon when the start date is greater than the maximum (uncontrolled)', function () {
-      let {getByTestId, getAllByLabelText} = render(
+      let {getByTestId, getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(1984, 2, 1), end: new CalendarDate(1984, 2, 3)}}
@@ -980,7 +990,7 @@ describe('DateRangePicker', function () {
       );
       expect(() => getByTestId('invalid-icon')).toThrow();
 
-      let year = getAllByLabelText('year')[0];
+      let year = getByLabelText('Start Date year');
       fireEvent.keyDown(year, {key: 'ArrowUp'});
 
       expect(getByTestId('invalid-icon')).toBeVisible();
@@ -1000,7 +1010,7 @@ describe('DateRangePicker', function () {
     });
 
     it('should display an error icon when the end date is greater than the maximum (uncontrolled)', function () {
-      let {getByTestId, getAllByLabelText} = render(
+      let {getByTestId, getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(1980, 2, 1), end: new CalendarDate(1984, 2, 3)}}
@@ -1008,7 +1018,7 @@ describe('DateRangePicker', function () {
       );
       expect(() => getByTestId('invalid-icon')).toThrow();
 
-      let year = getAllByLabelText('year')[1];
+      let year = getByLabelText('End Date year');
       fireEvent.keyDown(year, {key: 'ArrowUp'});
 
       expect(getByTestId('invalid-icon')).toBeVisible();
@@ -1027,14 +1037,14 @@ describe('DateRangePicker', function () {
     });
 
     it('should display an error icon when the end date is less than the start date (uncontrolled)', function () {
-      let {getByTestId, getAllByLabelText} = render(
+      let {getByTestId, getByLabelText} = render(
         <DateRangePicker
           label="Date range"
           defaultValue={{start: new CalendarDate(1980, 2, 1), end: new CalendarDate(1980, 2, 3)}} />
       );
       expect(() => getByTestId('invalid-icon')).toThrow();
 
-      let year = getAllByLabelText('year')[1];
+      let year = getByLabelText('End Date year');
       fireEvent.keyDown(year, {key: 'ArrowDown'});
 
       expect(getByTestId('invalid-icon')).toBeVisible();
@@ -1047,10 +1057,10 @@ describe('DateRangePicker', function () {
   describe('placeholder', function () {
     it('should display a placeholder date if no value is provided', function () {
       let onChange = jest.fn();
-      let {getByLabelText} = render(<DateRangePicker label="Date range" onChange={onChange} />);
+      let {getByTestId} = render(<DateRangePicker label="Date range" onChange={onChange} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       let today = new Intl.DateTimeFormat('en-US').format(new Date());
       expectPlaceholder(startDate, today);
       expectPlaceholder(endDate, today);
@@ -1058,10 +1068,10 @@ describe('DateRangePicker', function () {
 
     it('should display a placeholder date if the value prop is null', function () {
       let onChange = jest.fn();
-      let {getByLabelText} = render(<DateRangePicker label="Date range" onChange={onChange} value={null} />);
+      let {getByTestId} = render(<DateRangePicker label="Date range" onChange={onChange} value={null} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       let today = new Intl.DateTimeFormat('en-US').format(new Date());
       expectPlaceholder(startDate, today);
       expectPlaceholder(endDate, today);
@@ -1069,20 +1079,20 @@ describe('DateRangePicker', function () {
 
     it('should use the placeholderValue prop if provided', function () {
       let onChange = jest.fn();
-      let {getByLabelText} = render(<DateRangePicker label="Date range" onChange={onChange} placeholderValue={new CalendarDate(1980, 1, 1)} />);
+      let {getByTestId} = render(<DateRangePicker label="Date range" onChange={onChange} placeholderValue={new CalendarDate(1980, 1, 1)} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
       expectPlaceholder(startDate, '1/1/1980');
       expectPlaceholder(endDate, '1/1/1980');
     });
 
     it('should not fire onChange until both start and end dates have been entered', function () {
       let onChange = jest.fn();
-      let {getByLabelText, getAllByRole} = render(<DateRangePicker label="Date range" onChange={onChange} />);
+      let {getByTestId, getAllByRole} = render(<DateRangePicker label="Date range" onChange={onChange} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
 
       let formatter = new Intl.DateTimeFormat('en-US');
       expectPlaceholder(startDate, formatter.format(new Date()));
@@ -1137,10 +1147,10 @@ describe('DateRangePicker', function () {
 
     it('should confirm the placeholder on blur', function () {
       let onChange = jest.fn();
-      let {getAllByRole, getByLabelText} = render(<DateRangePicker label="Date" onChange={onChange} />);
+      let {getAllByRole, getByTestId} = render(<DateRangePicker label="Date" onChange={onChange} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
 
       let formatter = new Intl.DateTimeFormat('en-US');
       expectPlaceholder(startDate, formatter.format(new Date()));
@@ -1167,10 +1177,10 @@ describe('DateRangePicker', function () {
 
     it('should confirm the placeholder on blur when controlled', function () {
       let onChange = jest.fn();
-      let {getAllByRole, getByLabelText} = render(<DateRangePicker label="Date" onChange={onChange} value={null} />);
+      let {getAllByRole, getByTestId} = render(<DateRangePicker label="Date" onChange={onChange} value={null} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
 
       let formatter = new Intl.DateTimeFormat('en-US');
       expectPlaceholder(startDate, formatter.format(new Date()));
@@ -1199,10 +1209,10 @@ describe('DateRangePicker', function () {
 
     it('should reset to the placeholder if controlled value is set to null', function () {
       let onChange = jest.fn();
-      let {getByLabelText, rerender} = render(<DateRangePicker label="Date" onChange={onChange} value={{start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2022, 4, 8)}} />);
+      let {getByTestId, rerender} = render(<DateRangePicker label="Date" onChange={onChange} value={{start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2022, 4, 8)}} />);
 
-      let startDate = getByLabelText('Start Date');
-      let endDate = getByLabelText('End Date');
+      let startDate = getByTestId('start-date');
+      let endDate = getByTestId('end-date');
 
       let formatter = new Intl.DateTimeFormat('en-US');
       expectPlaceholder(startDate, formatter.format(new Date(2020, 1, 3)));

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -185,7 +185,7 @@ describe('DateRangePicker', function () {
 
       expect(segments[6].textContent).toBe('AM');
       expect(segments[6].getAttribute('aria-label')).toBe('Start Date AM/PM');
-      expect(segments[6].getAttribute('aria-valuetext')).toBe('12 AM');
+      expect(segments[6].getAttribute('aria-valuetext')).toBe('AM');
 
       expect(segments[7].textContent).toBe('5');
       expect(segments[7].getAttribute('aria-label')).toBe('End Date month');
@@ -231,7 +231,7 @@ describe('DateRangePicker', function () {
 
       expect(segments[13].textContent).toBe('AM');
       expect(segments[13].getAttribute('aria-label')).toBe('End Date AM/PM');
-      expect(segments[13].getAttribute('aria-valuetext')).toBe('12 AM');
+      expect(segments[13].getAttribute('aria-valuetext')).toBe('AM');
     });
   });
 
@@ -415,7 +415,7 @@ describe('DateRangePicker', function () {
         fireEvent.keyUp(hour, {key: 'ArrowRight'});
 
         expect(document.activeElement).toHaveAttribute('aria-label', 'AM/PM');
-        expect(document.activeElement).toHaveAttribute('aria-valuetext', '1 AM');
+        expect(document.activeElement).toHaveAttribute('aria-valuetext', 'AM');
 
         fireEvent.keyDown(document.activeElement, {key: 'Enter'});
         fireEvent.keyUp(document.activeElement, {key: 'Enter'});

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -15,6 +15,7 @@ import {
   Calendar,
   CalendarDate,
   DateDuration,
+  DateFormatter,
   GregorianCalendar,
   isSameDay,
   toCalendar,
@@ -24,7 +25,6 @@ import {
 import {CalendarProps, DateValue} from '@react-types/calendar';
 import {CalendarState} from './types';
 import {useControlledState} from '@react-stately/utils';
-import {useDateFormatter} from '@react-aria/i18n';
 import {useMemo, useRef, useState} from 'react';
 
 interface CalendarStateOptions<T extends DateValue> extends CalendarProps<T> {
@@ -35,7 +35,7 @@ interface CalendarStateOptions<T extends DateValue> extends CalendarProps<T> {
 }
 
 export function useCalendarState<T extends DateValue>(props: CalendarStateOptions<T>): CalendarState {
-  let defaultFormatter = useDateFormatter();
+  let defaultFormatter = useMemo(() => new DateFormatter(props.locale), [props.locale]);
   let resolvedOptions = useMemo(() => defaultFormatter.resolvedOptions(), [defaultFormatter]);
   let {
     locale,

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -431,6 +431,7 @@ footer li:last-child:after {
   display: inline !important;
   background: none !important;
   font-family: inherit !important;
+  isolation: initial !important;
 }
 
 .article pre {


### PR DESCRIPTION
The individual commits may be easier to review. This fixes many bugs found during testing:

* Day names are not centered (DG)
* If you switch to Japanese calendar it repeats monday twice (DG)
* Dark mode strike outs on unavailable dates are hard to see (RS)
* Remove hover and active state in read only (DG)
* If I click outside the circle but inside the cell, it will start and end my new range immediately, making it feel broken (RS)
* Option+Up arrow doesn't open the popover, only Option+Down arrow. Given that menus, pickers, etc open for both, I feel like this should too (RS)
* For the zoned time story it announces the range as march and not february. Devon says it should be march and is display february. Screenshot row 11 (KT)
* Minor issue with the "ZonedDateTime" text appearing above the popover in the "Events" section of the useDateRangePicker docs. See screenshots row 12 (DL)
* field and datepicker each have their own group, and both of them are announced on focus. (DG)
* VO iphone default TimeField story, change time to 12:20 AM, leave field, come back, tap on AM and change to PM. VO only reads "12 PM" instead of "12:20 PM" (RS)