### PR TITLE
fix useTableColumnResize imports and exports

### DIFF
--- a/packages/@react-aria/table/src/index.ts
+++ b/packages/@react-aria/table/src/index.ts
@@ -16,6 +16,7 @@ export * from './useTableRow';
 export * from './useTableHeaderRow';
 export * from './useTableCell';
 export * from './useTableSelectionCheckbox';
+export * from './useTableColumnResize';
 
 // Workaround for a Parcel bug where re-exports don't work in the CommonJS output format...
 // export {useGridRowGroup as useTableRowGroup} from '@react-aria/grid';

--- a/packages/@react-spectrum/table/src/Resizer.tsx
+++ b/packages/@react-spectrum/table/src/Resizer.tsx
@@ -3,7 +3,7 @@ import {classNames} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/table/vars.css';
-import {useTableColumnResize} from '@react-aria/table/src/useTableColumnResize';
+import {useTableColumnResize} from '@react-aria/table';
 import {useTableContext} from './TableView';
 
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
