### PR TITLE
fix(#2449): ActionBar: add stopPropagation to useOverlay Esc key handler

### DIFF
--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -111,6 +111,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   // Handle the escape key
   let onKeyDown = (e) => {
     if (e.key === 'Escape' && !isKeyboardDismissDisabled) {
+      e.stopPropagation();
       e.preventDefault();
       onHide();
     }


### PR DESCRIPTION
Per: https://github.com/adobe/react-spectrum/pull/2451#discussion_r729421265 and https://github.com/adobe/react-spectrum/pull/2451/files#r825220630


Closes #2449 but does not resolve all issues with restoring focus to TableView when ActionBar closes, which are addressed in #2451.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding React Spectrum GitHub Issue #2449.
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/df4b5baa4f4be99ad54f624eaada3d689774c689/storybook/index.html?path=/story/actionbar--default
2. Tab and use Arrow keys to set focus to a row or cell within the TableView.
3. Press Space key to select the row.
4. Tab to move focus to the ActionGroup within the open ActionBar.
5. Use ArrowRight to focus the "..." dropdown menu button within the ActionGroup.
6. Press Space, Enter or ArrowDown to expand the dropdown menu.
7. Press Esc key to close the  dropdown menu.
8. Focus should restore to the "..." dropdown menu button without clearing the selection to closing the ActionBar.
9. Press Esc again to clear the selection and close the ActionBar.
10. Focus will be lost to the `document.body` due to other issues that should be resolved with PR #2451

Notes: 
The related PR #2451 attempts to resolve a several other issues with restoring focus to the collection view when the ActionBar closes.

With an item selected and the ActionBar expanded, it's possible to navigate and select additional elements within the collection view. It's also possible for the row or cell that had focus to be scrolled out of view, either by user interaction, or when the collection view resizes to make room for the ActionBar. This means the element to which the user expects focus to be restored may change after the ActionBar opens. We have to keep track of these focus changes within the collection view in order to restore focus to the appropriate element.

## 🧢 Your Project:

Adobe/Accessibility
