### PR TITLE
Add chromatic story with all icons

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -407,7 +407,8 @@ governing permissions and limitations under the License.
          ".    .            .";
     }
     .spectrum-Dialog-heading {
-      &.spectrum-Dialog-heading--noHeader {
+      &.spectrum-Dialog-heading--noHeader,
+      &.spectrum-Dialog-heading--noTypeIcon {
         grid-area: heading;
       }
 

--- a/packages/@spectrum-icons/build-tools/generateIcons.js
+++ b/packages/@spectrum-icons/build-tools/generateIcons.js
@@ -47,7 +47,7 @@ export function generateIcons(iconDir, outputDir, nameRegex, template) {
     // generate index barrel
     let indexFile = iconFiles.map(icon => {
       let iconName = icon.substring(0, icon.length - 3);
-      return `export * from './${iconName}';\n`;
+      return `export * as ${isNaN(Number(iconName[0])) ? iconName : `_${iconName}`} from './${iconName}';\n`;
     }).join('');
     let indexFilepath = `${outputDir}/index.ts`;
     writeToFile(indexFilepath, indexFile);

--- a/packages/@spectrum-icons/workflow/chromatic/Workflow.chromatic.tsx
+++ b/packages/@spectrum-icons/workflow/chromatic/Workflow.chromatic.tsx
@@ -15,6 +15,17 @@ import Alert from '@spectrum-icons/workflow/Alert';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Flex} from "@react-spectrum/layout";
+import * as AllIcons from '../src';
+
+let allIcons = Object.keys(AllIcons);
+let alphabet = [...Array(26)]
+  .map((val, i) => String.fromCharCode(i + 65));
+alphabet = ['_', ...alphabet];
+let alphabetizedIcons = alphabet
+  .reduce((acc, char) => {
+    acc[char] = allIcons.filter(iconName => iconName[0] === char);
+    return acc;
+  }, {});
 
 storiesOf('Icons/Workflow', module)
   .add(
@@ -31,6 +42,28 @@ storiesOf('Icons/Workflow', module)
         <Alert color="notice" aria-label="notice alert" />
       </Flex>
     )
+  )
+  .add('All Workflow',
+    () => (
+      <Flex direction="column">
+        {
+          Object.keys(alphabetizedIcons).map(char => (
+            <div style={{height: "calc(12 * var(--spectrum-global-dimension-size-300))"}}>
+              <div>{char}</div>
+              <Flex direction="row" gap="size-50" wrap>
+                {
+                  alphabetizedIcons[char].map(iconName => {
+                    let Icon = AllIcons[iconName].default;
+                    return <Icon key={iconName}/>;
+                  })
+                }
+              </Flex>
+            </div>
+          ))
+        }
+      </Flex>
+    ),
+  {chromaticProvider: {colorSchemes: ['light'], locales: ['en-US'], scales: ['medium', 'large'], disableAnimations: true}}
   );
 
 function renderIconSizes(Component, props) {


### PR DESCRIPTION
Closes <!-- Github issue # here -->
In preparation to being able to upgrade icon packages again in the future. Since we'll always pin our version now, we can rely on chromatic tests so we know if any particular update breaks anything.

It's broken up alphabetically with large heights so that if a single icon is added/removed we'll know without it affected every single other icon in the chromatic. Instead, it'll only affect icons after it in it's section of the alphabet.

Also contains a dialog style fix that was broken in chromatic

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
