### PR TITLE
Virtualizer: don't remove zero width items from _visibleViews

### DIFF
--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -1162,7 +1162,10 @@ export class Virtualizer<T extends object, V, W> {
 
     // Figure out which views were removed.
     for (let [key, view] of this._visibleViews) {
-      if (!finalMap.has(key)) {
+      // If an item has a width of 0, there is no need to remove it from the _visibleViews.
+      // Removing an item with  width of 0 can cause a loop where the item gets added, removed,
+      // added, removed... etc in a loop. The resize buffer ("spooky column") often has a width of 0.
+      if (!finalMap.has(key) && view.layoutInfo.rect.width > 0) {
         transaction.removed.set(key, view);
         this._visibleViews.delete(key);
 


### PR DESCRIPTION
A resize buffer column (spooky column) was added to the table collection if any columns are resizable. The purpose of the resize buffer is to grow and shrink when resizing to keep the width of the table constant if a user tries to shrink a column when the content width is greater than the virtualizer width.

Typically the resize buffer has a width of 0 since it only needs to take up space while actively resizing.

When `updateSubviews` gets called in `Virtualizer`, it determines everything that needs to be added/updated/removed. To determine what needs to be added, the `_visibleViews` is compared against the `visibleLayoutInfos`.  If the `_visibleViews` doesn't include the resizeBuffer, it will be added to the `toAdd` set.

`_postTransaction` calls `relayoutNow` with an `afterLayout` callback. This callback calls `_setupTransactionAnimations` which compares everything in the `_visibleViews` with the `finalMap`. The `finalMap` get's everything that is currently visible in the view. The purpose of this is to remove things from `_visibleViews` which aren't actually visible anymore (`finalMap`).

Since the resize buffer has a width of 0, it's possible for the resize buffer to not be included in `finalMap`. When this happens, the resize buffer gets removed from `_visibleViews` and then it gets re-added to `_visibleViews`  by `updateSubview` and then it gets removed again by `_setupTransactionAnimations` and so on...

One solution to this is to not remove zero width items from `_visibleViews`.
 
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
