### PR TITLE
add try-catch to isRTL and fallback to en-US

### DIFF
--- a/packages/@react-aria/i18n/src/useDefaultLocale.ts
+++ b/packages/@react-aria/i18n/src/useDefaultLocale.ts
@@ -28,6 +28,12 @@ export interface Locale {
 export function getDefaultLocale(): Locale {
   // @ts-ignore
   let locale = (typeof navigator !== 'undefined' && (navigator.language || navigator.userLanguage)) || 'en-US';
+  try {
+    // @ts-ignore
+    Intl.DateTimeFormat.supportedLocalesOf([locale]);
+  } catch (_err) {
+    locale = 'en-US';
+  }
   return {
     locale,
     direction: isRTL(locale) ? 'rtl' : 'ltr'

--- a/packages/@react-aria/i18n/src/utils.ts
+++ b/packages/@react-aria/i18n/src/utils.ts
@@ -22,15 +22,9 @@ export function isRTL(locale: string) {
   // This is more accurate than guessing by language, since languages can be written in multiple scripts.
   // @ts-ignore
   if (Intl.Locale) {
-    let intlLocale;
-    try {
-      // @ts-ignore
-      intlLocale = new Intl.Locale(locale);
-    } catch (_err) {
-      // @ts-ignore
-      intlLocale = new Intl.Locale('en-US');
-    }
-    return RTL_SCRIPTS.has(intlLocale.maximize().script);
+    // @ts-ignore
+    let script = new Intl.Locale(locale).maximize().script;
+    return RTL_SCRIPTS.has(script);
   }
 
   // If not, just guess by the language (first part of the locale)

--- a/packages/@react-aria/i18n/src/utils.ts
+++ b/packages/@react-aria/i18n/src/utils.ts
@@ -22,9 +22,15 @@ export function isRTL(locale: string) {
   // This is more accurate than guessing by language, since languages can be written in multiple scripts.
   // @ts-ignore
   if (Intl.Locale) {
-    // @ts-ignore
-    let script = new Intl.Locale(locale).maximize().script;
-    return RTL_SCRIPTS.has(script);
+    let intlLocale;
+    try {
+      // @ts-ignore
+      intlLocale = new Intl.Locale(locale);
+    } catch (_err) {
+      // @ts-ignore
+      intlLocale = new Intl.Locale("en-US");
+    }
+    return RTL_SCRIPTS.has(intlLocale.maximize().script);
   }
 
   // If not, just guess by the language (first part of the locale)

--- a/packages/@react-aria/i18n/src/utils.ts
+++ b/packages/@react-aria/i18n/src/utils.ts
@@ -28,7 +28,7 @@ export function isRTL(locale: string) {
       intlLocale = new Intl.Locale(locale);
     } catch (_err) {
       // @ts-ignore
-      intlLocale = new Intl.Locale("en-US");
+      intlLocale = new Intl.Locale('en-US');
     }
     return RTL_SCRIPTS.has(intlLocale.maximize().script);
   }


### PR DESCRIPTION
Closes  #2436

Added try-catch to `isRTL` helper. Since `navigator.language` may return unpredictable outputs and it is not respecting the 
BCP 47 language tag standard the code may crash if we provide this value directly to `Intl.Locale()`

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Since we can't write to navigator.language, I'm afraid testing it is hardly possible 😄

## 🧢 Your Project:

<!--- Company/project for pull request -->

[LiveChat](https://www.livechat.com/)
