### PR TITLE
Fix issues converting and comparing Gregorian dates in BC

### DIFF
--- a/packages/@internationalized/date/src/CalendarDate.ts
+++ b/packages/@internationalized/date/src/CalendarDate.ts
@@ -59,6 +59,7 @@ export class CalendarDate {
   public readonly day: number;
 
   constructor(year: number, month: number, day: number);
+  constructor(era: string, year: number, month: number, day: number);
   constructor(calendar: Calendar, year: number, month: number, day: number);
   constructor(calendar: Calendar, era: string, year: number, month: number, day: number);
   constructor(...args: any[]) {
@@ -213,6 +214,7 @@ export class CalendarDateTime {
   public readonly millisecond: number;
 
   constructor(year: number, month: number, day: number, hour?: number, minute?: number, second?: number, millisecond?: number);
+  constructor(era: string, year: number, month: number, day: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(calendar: Calendar, year: number, month: number, day: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(calendar: Calendar, era: string, year: number, month: number, day: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(...args: any[]) {
@@ -323,6 +325,7 @@ export class ZonedDateTime {
   public readonly offset: number;
 
   constructor(year: number, month: number, day: number, timeZone: string, offset: number, hour?: number, minute?: number, second?: number, millisecond?: number);
+  constructor(era: string, year: number, month: number, day: number, timeZone: string, offset: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(calendar: Calendar, year: number, month: number, day: number, timeZone: string, offset: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(calendar: Calendar, era: string, year: number, month: number, day: number, timeZone: string, offset: number, hour?: number, minute?: number, second?: number, millisecond?: number);
   constructor(...args: any[]) {

--- a/packages/@internationalized/date/src/calendars/BuddhistCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/BuddhistCalendar.ts
@@ -15,8 +15,7 @@
 
 import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
-import {GregorianCalendar} from './GregorianCalendar';
-import {Mutable} from '../utils';
+import {fromExtendedYear, getExtendedYear, GregorianCalendar} from './GregorianCalendar';
 
 const BUDDHIST_ERA_START = -543;
 
@@ -29,9 +28,14 @@ export class BuddhistCalendar extends GregorianCalendar {
   identifier = 'buddhist';
 
   fromJulianDay(jd: number): CalendarDate {
-    let date = super.fromJulianDay(jd) as Mutable<CalendarDate>;
-    date.year -= BUDDHIST_ERA_START;
-    return date as CalendarDate;
+    let gregorianDate = super.fromJulianDay(jd);
+    let year = getExtendedYear(gregorianDate.era, gregorianDate.year);
+    return new CalendarDate(
+      this,
+      year - BUDDHIST_ERA_START,
+      gregorianDate.month,
+      gregorianDate.day
+    );
   }
 
   toJulianDay(date: AnyCalendarDate) {
@@ -48,8 +52,10 @@ export class BuddhistCalendar extends GregorianCalendar {
 }
 
 function toGregorian(date: AnyCalendarDate) {
+  let [era, year] = fromExtendedYear(date.year + BUDDHIST_ERA_START);
   return new CalendarDate(
-    date.year + BUDDHIST_ERA_START,
+    era,
+    year,
     date.month,
     date.day
   );

--- a/packages/@internationalized/date/src/calendars/GregorianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/GregorianCalendar.ts
@@ -18,7 +18,9 @@ import {CalendarDate} from '../CalendarDate';
 import {mod, Mutable} from '../utils';
 
 const EPOCH = 1721426; // 001/01/03 Julian C.E.
-export function gregorianToJulianDay(year: number, month: number, day: number): number {
+export function gregorianToJulianDay(era: string, year: number, month: number, day: number): number {
+  year = getExtendedYear(era, year);
+
   let y1 = year - 1;
   let monthOffset = -2;
   if (month <= 2) {
@@ -40,6 +42,20 @@ export function gregorianToJulianDay(year: number, month: number, day: number): 
 
 export function isLeapYear(year: number): boolean {
   return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+export function getExtendedYear(era: string, year: number): number {
+  return era === 'BC' ? 1 - year : year;
+}
+
+export function fromExtendedYear(year: number): [string, number] {
+  let era = 'AD';
+  if (year <= 0) {
+    era = 'BC';
+    year = 1 - year;
+  }
+
+  return [era, year];
 }
 
 const daysInMonth = {
@@ -65,22 +81,23 @@ export class GregorianCalendar implements Calendar {
     let dquad = mod(dcent, 1461);
     let yindex = Math.floor(dquad / 365);
 
-    let year = quadricent * 400 + cent * 100 + quad * 4 + yindex + (cent !== 4 && yindex !== 4 ? 1 : 0);
-    let yearDay = jd0 - gregorianToJulianDay(year, 1, 1);
+    let extendedYear = quadricent * 400 + cent * 100 + quad * 4 + yindex + (cent !== 4 && yindex !== 4 ? 1 : 0);
+    let [era, year] = fromExtendedYear(extendedYear);
+    let yearDay = jd0 - gregorianToJulianDay(era, year, 1, 1);
     let leapAdj = 2;
-    if (jd0 < gregorianToJulianDay(year, 3, 1)) {
+    if (jd0 < gregorianToJulianDay(era, year, 3, 1)) {
       leapAdj = 0;
     } else if (isLeapYear(year)) {
       leapAdj = 1;
     }
     let month = Math.floor(((yearDay + leapAdj) * 12 + 373) / 367);
-    let day = jd0 - gregorianToJulianDay(year, month, 1) + 1;
+    let day = jd0 - gregorianToJulianDay(era, year, month, 1) + 1;
 
-    return new CalendarDate(this, year, month, day);
+    return new CalendarDate(era, year, month, day);
   }
 
   toJulianDay(date: AnyCalendarDate): number {
-    return gregorianToJulianDay(date.year, date.month, date.day);
+    return gregorianToJulianDay(date.era, date.year, date.month, date.day);
   }
 
   getDaysInMonth(date: AnyCalendarDate): number {

--- a/packages/@internationalized/date/src/calendars/IndianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/IndianCalendar.ts
@@ -2,7 +2,6 @@
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
@@ -15,8 +14,7 @@
 
 import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
-import {GregorianCalendar, gregorianToJulianDay, isLeapYear} from './GregorianCalendar';
-import {Mutable} from '../utils';
+import {fromExtendedYear, GregorianCalendar, gregorianToJulianDay, isLeapYear} from './GregorianCalendar';
 
 // Starts in 78 AD,
 const INDIAN_ERA_START = 78;
@@ -34,13 +32,13 @@ export class IndianCalendar extends GregorianCalendar {
 
   fromJulianDay(jd: number): CalendarDate {
     // Gregorian date for Julian day
-    let date = super.fromJulianDay(jd) as Mutable<CalendarDate>;
+    let date = super.fromJulianDay(jd);
 
     // Year in Saka era
     let indianYear = date.year - INDIAN_ERA_START;
 
     // Day number in Gregorian year (starting from 0)
-    let yDay = jd - gregorianToJulianDay(date.year, 1, 1);
+    let yDay = jd - gregorianToJulianDay(date.era, date.year, 1, 1);
 
     let leapMonth: number;
     if (yDay < INDIAN_YEAR_START) {
@@ -77,16 +75,17 @@ export class IndianCalendar extends GregorianCalendar {
   }
 
   toJulianDay(date: AnyCalendarDate) {
-    let year = date.year + INDIAN_ERA_START;
+    let extendedYear = date.year + INDIAN_ERA_START;
+    let [era, year] = fromExtendedYear(extendedYear);
 
     let leapMonth: number;
     let jd: number;
     if (isLeapYear(year)) {
       leapMonth = 31;
-      jd = gregorianToJulianDay(year, 3, 21);
+      jd = gregorianToJulianDay(era, year, 3, 21);
     } else {
       leapMonth = 30;
-      jd = gregorianToJulianDay(year, 3, 22);
+      jd = gregorianToJulianDay(era, year, 3, 22);
     }
 
     if (date.month === 1) {

--- a/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
@@ -73,13 +73,16 @@ export class JapaneseCalendar extends GregorianCalendar {
   identifier = 'japanese';
 
   fromJulianDay(jd: number): CalendarDate {
-    let date = super.fromJulianDay(jd) as Mutable<CalendarDate>;
-
+    let date = super.fromJulianDay(jd);
     let era = findEraFromGregorianDate(date);
-    date.era = ERA_NAMES[era];
-    date.year -= ERA_ADDENDS[era];
-    this.constrainDate(date);
-    return date as CalendarDate;
+
+    return new CalendarDate(
+      this,
+      ERA_NAMES[era],
+      date.year - ERA_ADDENDS[era],
+      date.month,
+      date.day
+    );
   }
 
   toJulianDay(date: AnyCalendarDate) {

--- a/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
@@ -15,7 +15,7 @@
 
 import {AnyCalendarDate} from '../types';
 import {CalendarDate} from '../CalendarDate';
-import {GregorianCalendar} from './GregorianCalendar';
+import {fromExtendedYear, getExtendedYear, GregorianCalendar} from './GregorianCalendar';
 import {Mutable} from '../utils';
 
 const TAIWAN_ERA_START = 1911;
@@ -26,14 +26,12 @@ function gregorianYear(date: AnyCalendarDate) {
     : 1 - date.year + TAIWAN_ERA_START;
 }
 
-function gregorianToTaiwan(year: number, date: Mutable<AnyCalendarDate>) {
+function gregorianToTaiwan(year: number): [string, number] {
   let y = year - TAIWAN_ERA_START;
   if (y > 0) {
-    date.era = 'minguo';
-    date.year = y;
+    return ['minguo', y];
   } else {
-    date.era = 'before_minguo';
-    date.year = 1 - y;
+    return ['before_minguo', 1 - y];
   }
 }
 
@@ -46,9 +44,10 @@ export class TaiwanCalendar extends GregorianCalendar {
   identifier = 'roc'; // Republic of China
 
   fromJulianDay(jd: number): CalendarDate {
-    let date: Mutable<CalendarDate> = super.fromJulianDay(jd);
-    gregorianToTaiwan(date.year, date);
-    return date as CalendarDate;
+    let date = super.fromJulianDay(jd);
+    let extendedYear = getExtendedYear(date.era, date.year);
+    let [era, year] = gregorianToTaiwan(extendedYear);
+    return new CalendarDate(this, era, year, date.month, date.day);
   }
 
   toJulianDay(date: AnyCalendarDate) {
@@ -60,7 +59,9 @@ export class TaiwanCalendar extends GregorianCalendar {
   }
 
   balanceDate(date: Mutable<AnyCalendarDate>) {
-    gregorianToTaiwan(gregorianYear(date), date);
+    let [era, year] = gregorianToTaiwan(gregorianYear(date));
+    date.era = era;
+    date.year = year;
   }
 
   getYearsToAdd(date: Mutable<AnyCalendarDate>, years: number) {
@@ -73,8 +74,10 @@ export class TaiwanCalendar extends GregorianCalendar {
 }
 
 function toGregorian(date: AnyCalendarDate) {
+  let [era, year] = fromExtendedYear(gregorianYear(date));
   return new CalendarDate(
-    gregorianYear(date),
+    era,
+    year,
     date.month,
     date.day
   );

--- a/packages/@internationalized/date/tests/conversion.test.js
+++ b/packages/@internationalized/date/tests/conversion.test.js
@@ -206,6 +206,14 @@ describe('CalendarDate conversion', function () {
         date = new CalendarDate(1911, 1, 1);
         expect(toCalendar(date, new TaiwanCalendar())).toEqual(new CalendarDate(new TaiwanCalendar(), 'before_minguo', 1, 1, 1));
       });
+
+      it('handles BC dates', function () {
+        let date = new CalendarDate('BC', 2, 1, 1);
+        expect(toCalendar(date, new TaiwanCalendar())).toEqual(new CalendarDate(new TaiwanCalendar(), 'before_minguo', 1913, 1, 1));
+
+        date = new CalendarDate(new TaiwanCalendar(), 'before_minguo', 1913, 1, 1);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate('BC', 2, 1, 1));
+      });
     });
 
     describe('buddhist', function () {
@@ -217,6 +225,14 @@ describe('CalendarDate conversion', function () {
       it('gregorian to buddhist', function () {
         let date = new CalendarDate(2020, 4, 30);
         expect(toCalendar(date, new BuddhistCalendar())).toEqual(new CalendarDate(new BuddhistCalendar(), 2563, 4, 30));
+      });
+
+      it('handles BC dates', function () {
+        let date = new CalendarDate('BC', 2, 1, 1);
+        expect(toCalendar(date, new BuddhistCalendar())).toEqual(new CalendarDate(new BuddhistCalendar(), 542, 1, 1));
+
+        date = new CalendarDate(new BuddhistCalendar(), 542, 1, 1);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate('BC', 2, 1, 1));
       });
     });
 

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -43,6 +43,7 @@ describe('queries', function () {
       expect(isSameDay(new CalendarDate(2019, 2, 3), new CalendarDate(2020, 2, 3))).toBe(false);
       expect(isSameDay(new CalendarDate(2020, 3, 3), new CalendarDate(2020, 2, 3))).toBe(false);
       expect(isSameDay(new CalendarDate(2020, 2, 4), new CalendarDate(2020, 2, 3))).toBe(false);
+      expect(isSameDay(new CalendarDate('AD', 1, 1, 1), new CalendarDate('BC', 1, 1, 1))).toBe(false);
     });
 
     it('works with two dates in different calendars', function () {
@@ -296,6 +297,15 @@ describe('queries', function () {
     it('should return the maximum date', function () {
       expect(maxDate(new CalendarDate(2020, 2, 3), new CalendarDate(2020, 5, 3))).toEqual(new CalendarDate(2020, 5, 3));
       expect(maxDate(new CalendarDate(2020, 5, 3), new CalendarDate(2020, 2, 3))).toEqual(new CalendarDate(2020, 5, 3));
+    });
+  });
+
+  describe('compare', function () {
+    it('works with dates in different eras', function () {
+      let a = new CalendarDate('BC', 1, 1, 1);
+      let b = new CalendarDate('AD', 1, 1, 1);
+      expect(a.compare(b)).toBeLessThan(0);
+      expect(b.compare(a)).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
Fixes issues identified by @majornista in https://github.com/adobe/react-spectrum/pull/3046#issuecomment-1106757623. The underlying cause was in code that converts Gregorian dates to and from a Julian day number, which is used for comparison and conversion between calendars. For this, we need to compute the "extended year", which flips the sign for dates in the BC era. This also needs to be handled in all calendars that extend from GregorianCalendar.