### PR TITLE
Calendar final testing updates

### DIFF
--- a/packages/@react-aria/calendar/src/useCalendarBase.ts
+++ b/packages/@react-aria/calendar/src/useCalendarBase.ts
@@ -65,7 +65,8 @@ export function useCalendarBase(props: CalendarPropsBase & DOMProps, state: Cale
   hookData.set(state, {
     ariaLabel: props['aria-label'],
     ariaLabelledBy: props['aria-labelledby'],
-    errorMessageId
+    errorMessageId,
+    selectedDateDescription
   });
 
   // If the next or previous buttons become disabled while they are focused, move focus to the calendar body.

--- a/packages/@react-aria/calendar/src/useCalendarGrid.ts
+++ b/packages/@react-aria/calendar/src/useCalendarGrid.ts
@@ -12,9 +12,9 @@
 
 import {CalendarDate, startOfWeek} from '@internationalized/date';
 import {CalendarState, RangeCalendarState} from '@react-stately/calendar';
-import {hookData, useSelectedDateDescription, useVisibleRangeDescription} from './utils';
+import {hookData, useVisibleRangeDescription} from './utils';
 import {HTMLAttributes, KeyboardEvent, useMemo} from 'react';
-import {mergeProps, useDescription, useLabels} from '@react-aria/utils';
+import {mergeProps, useLabels} from '@react-aria/utils';
 import {useDateFormatter, useLocale} from '@react-aria/i18n';
 
 export interface AriaCalendarGridProps {
@@ -111,11 +111,9 @@ export function useCalendarGrid(props: AriaCalendarGridProps, state: CalendarSta
     }
   };
 
-  let selectedDateDescription = useSelectedDateDescription(state);
-  let descriptionProps = useDescription(selectedDateDescription);
   let visibleRangeDescription = useVisibleRangeDescription(startDate, endDate, state.timeZone, true);
 
-  let {ariaLabel, ariaLabelledBy, errorMessageId} = hookData.get(state);
+  let {ariaLabel, ariaLabelledBy} = hookData.get(state);
   let labelProps = useLabels({
     'aria-label': [ariaLabel, visibleRangeDescription].filter(Boolean).join(', '),
     'aria-labelledby': ariaLabelledBy
@@ -138,10 +136,6 @@ export function useCalendarGrid(props: AriaCalendarGridProps, state: CalendarSta
       'aria-readonly': state.isReadOnly || null,
       'aria-disabled': state.isDisabled || null,
       'aria-multiselectable': ('highlightedRange' in state) || undefined,
-      'aria-describedby': [
-        descriptionProps['aria-describedby'],
-        state.validationState === 'invalid' ? errorMessageId : null
-      ].filter(Boolean).join(' ') || undefined,
       onKeyDown,
       onFocus: () => state.setFocused(true),
       onBlur: () => state.setFocused(false)

--- a/packages/@react-aria/calendar/src/useRangeCalendar.ts
+++ b/packages/@react-aria/calendar/src/useRangeCalendar.ts
@@ -51,6 +51,7 @@ export function useRangeCalendar<T extends DateValue>(props: RangeCalendarProps<
     let target = e.target as HTMLElement;
     let body = document.getElementById(res.calendarProps.id);
     if (
+      body &&
       body.contains(document.activeElement) &&
       (!body.contains(target) || !target.closest('button, [role="button"]'))
     ) {

--- a/packages/@react-aria/calendar/src/utils.ts
+++ b/packages/@react-aria/calendar/src/utils.ts
@@ -17,7 +17,14 @@ import {FormatMessage, useDateFormatter, useMessageFormatter} from '@react-aria/
 import intlMessages from '../intl/*.json';
 import {useMemo} from 'react';
 
-export const hookData = new WeakMap<CalendarState | RangeCalendarState, {ariaLabel: string, ariaLabelledBy: string, errorMessageId: string}>();
+interface HookData {
+  ariaLabel: string,
+  ariaLabelledBy: string,
+  errorMessageId: string,
+  selectedDateDescription: string
+}
+
+export const hookData = new WeakMap<CalendarState | RangeCalendarState, HookData>();
 
 export function useSelectedDateDescription(state: CalendarState | RangeCalendarState) {
   let formatMessage = useMessageFormatter(intlMessages);

--- a/packages/@react-spectrum/calendar/test/Calendar.test.js
+++ b/packages/@react-spectrum/calendar/test/Calendar.test.js
@@ -328,10 +328,6 @@ describe('Calendar', () => {
 
       let description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Selected date unavailable.');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Date: Friday, March 11, 2022 Selected date unavailable.');
     });
 
     it('should support a custom errorMessage', () => {
@@ -349,10 +345,6 @@ describe('Calendar', () => {
 
       let description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Selection dates cannot include weekends.');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Date: Friday, March 11, 2022 Selection dates cannot include weekends.');
     });
 
     it('does not show error message without validationState="invalid"', () => {
@@ -366,10 +358,6 @@ describe('Calendar', () => {
       expect(cell).not.toHaveAttribute('aria-invalid', 'true');
       expect(cell.parentElement).toHaveAttribute('aria-selected', 'true');
       expect(cell.parentElement).not.toHaveAttribute('aria-invalid', 'true');
-
-      let grid = getByRole('grid');
-      let description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Date: Friday, March 11, 2022');
     });
 
     it('automatically marks selection as invalid using isDateUnavailable', () => {
@@ -392,10 +380,6 @@ describe('Calendar', () => {
 
       let description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Selected date unavailable.');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Date: Saturday, March 5, 2022 Selected date unavailable.');
     });
   });
 
@@ -430,20 +414,6 @@ describe('Calendar', () => {
 
       fireEvent.keyDown(grid, {key: 'ArrowRight'});
       expect(getByLabelText('Thursday, June 6, 2019', {exact: false})).toHaveFocus();
-    });
-
-    it('renders a description with the selected date', () => {
-      let {getByText, getByRole} = render(<Calendar defaultValue={new CalendarDate(2019, 6, 5)} />);
-
-      let grid = getByRole('grid');
-      let caption = document.getElementById(grid.getAttribute('aria-describedby'));
-      expect(caption).toHaveTextContent('Selected Date: Wednesday, June 5, 2019');
-
-      let newDate = getByText('17');
-      triggerPress(newDate);
-
-      caption = document.getElementById(grid.getAttribute('aria-describedby'));
-      expect(caption).toHaveTextContent('Selected Date: Monday, June 17, 2019');
     });
   });
 });

--- a/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
+++ b/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
@@ -53,12 +53,12 @@ describe('RangeCalendar', () => {
 
       let selectedDates = getAllByLabelText('Selected', {exact: false});
       let labels = [
-        'Wednesday, June 5, 2019 selected',
+        'Selected Range: Wednesday, June 5 to Monday, June 10, 2019, Wednesday, June 5, 2019 selected',
         'Thursday, June 6, 2019 selected',
         'Friday, June 7, 2019 selected',
         'Saturday, June 8, 2019 selected',
         'Sunday, June 9, 2019 selected',
-        'Monday, June 10, 2019 selected'
+        'Selected Range: Wednesday, June 5 to Monday, June 10, 2019, Monday, June 10, 2019 selected'
       ];
       expect(selectedDates.length).toBe(6);
 
@@ -84,12 +84,12 @@ describe('RangeCalendar', () => {
 
       let selectedDates = getAllByLabelText('Selected', {exact: false});
       let labels = [
-        'Wednesday, June 5, 2019 selected',
+        'Selected Range: Wednesday, June 5 to Monday, June 10, 2019, Wednesday, June 5, 2019 selected',
         'Thursday, June 6, 2019 selected',
         'Friday, June 7, 2019 selected',
         'Saturday, June 8, 2019 selected',
         'Sunday, June 9, 2019 selected',
-        'Monday, June 10, 2019 selected'
+        'Selected Range: Wednesday, June 5 to Monday, June 10, 2019, Monday, June 10, 2019 selected'
       ];
       expect(selectedDates.length).toBe(6);
 
@@ -129,7 +129,7 @@ describe('RangeCalendar', () => {
       let selected = getAllByLabelText('selected', {exact: false}).filter(cell => cell.getAttribute('aria-disabled') !== 'true');
       expect(selected.length).toBe(11);
       let juneLabels = [
-        'Thursday, June 20, 2019 selected',
+        'Selected Range: Thursday, June 20 to Wednesday, July 10, 2019, Thursday, June 20, 2019 selected',
         'Friday, June 21, 2019 selected',
         'Saturday, June 22, 2019 selected',
         'Sunday, June 23, 2019 selected',
@@ -163,7 +163,7 @@ describe('RangeCalendar', () => {
         'Sunday, July 7, 2019 selected',
         'Monday, July 8, 2019 selected',
         'Tuesday, July 9, 2019 selected',
-        'Wednesday, July 10, 2019 selected'
+        'Selected Range: Thursday, June 20 to Wednesday, July 10, 2019, Wednesday, July 10, 2019 selected'
       ];
 
       i = 0;
@@ -1060,7 +1060,7 @@ describe('RangeCalendar', () => {
       expect(nextButton).not.toHaveAttribute('disabled');
 
       // Clicking on one of the selected dates should also disable the dates outside the available range.
-      cell = getByRole('button', {name: 'Sunday, December 12, 2021 selected'});
+      cell = getByRole('button', {name: 'Selected Range: Sunday, December 12 to Tuesday, December 14, 2021, Sunday, December 12, 2021 selected'});
       act(() => userEvent.click(cell));
 
       expect(cellBefore).not.toHaveAttribute('tabIndex');
@@ -1249,10 +1249,6 @@ describe('RangeCalendar', () => {
 
       description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Selected dates unavailable. Click to start selecting date range');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Range: Thursday, March 10 to Saturday, March 12, 2022 Selected dates unavailable.');
     });
 
     it('should support a custom errorMessage', () => {
@@ -1275,10 +1271,6 @@ describe('RangeCalendar', () => {
 
       description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Selection dates cannot include weekends. Click to start selecting date range');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Range: Thursday, March 10 to Saturday, March 12, 2022 Selection dates cannot include weekends.');
     });
 
     it('does not show error message without validationState="invalid"', () => {
@@ -1298,10 +1290,6 @@ describe('RangeCalendar', () => {
 
       let description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Click to start selecting date range');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Range: Thursday, March 10 to Saturday, March 12, 2022');
     });
 
     it('automatically marks selection as invalid using isDateUnavailable', () => {
@@ -1329,10 +1317,6 @@ describe('RangeCalendar', () => {
 
       description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
       expect(description).toBe('Selected dates unavailable. Click to start selecting date range');
-
-      let grid = getByRole('grid');
-      description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected Range: Tuesday, March 1 to Saturday, March 5, 2022 Selected dates unavailable.');
     });
   });
 
@@ -1367,25 +1351,6 @@ describe('RangeCalendar', () => {
       type('ArrowRight');
 
       expect(selectedDates[1]).toHaveFocus();
-    });
-
-    it('renders a description with the selected date range', () => {
-      let {getByText, getByRole} = render(<RangeCalendar defaultValue={{start: new CalendarDate(2019, 6, 5), end: new CalendarDate(2019, 6, 10)}} />);
-
-      let grid = getByRole('grid');
-      let caption = document.getElementById(grid.getAttribute('aria-describedby'));
-      expect(caption).toHaveTextContent('Selected Range: Wednesday, June 5 to Monday, June 10, 2019');
-
-      act(() => userEvent.click(getByText('17')));
-
-      // in selection mode, the caption should be empty
-      expect(grid).not.toHaveAttribute('aria-describedby');
-
-      act(() => userEvent.click(getByText('10')));
-
-      caption = document.getElementById(grid.getAttribute('aria-describedby'));
-      expect(grid).toHaveAttribute('aria-describedby', caption.id);
-      expect(caption).toHaveTextContent('Selected Range: Monday, June 10 to Monday, June 17, 2019');
     });
   });
 });

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -184,7 +184,7 @@ describe('DatePickerBase', function () {
 
       let grid = getByRole('grid');
       expect(grid).toHaveAttribute('aria-label', 'July 2019');
-      expect(document.activeElement.getAttribute('aria-label').startsWith('Friday, July 5, 2019')).toBe(true);
+      expect(document.activeElement.getAttribute('aria-label').includes('Friday, July 5, 2019')).toBe(true);
     });
 
     it.each`

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -347,13 +347,13 @@ describe('DatePickerBase', function () {
     });
 
     it.each`
-      Name                   | Component
-      ${'DatePicker'}        | ${DatePicker}
-      ${'DateRangePicker'}   | ${DateRangePicker}
-    `('$Name should pass validationState and errorMessage to calendar', ({Component}) => {
+      Name                   | Component          | props
+      ${'DatePicker'}        | ${DatePicker}      | ${{defaultValue: new CalendarDate(2021, 10, 3)}}
+      ${'DateRangePicker'}   | ${DateRangePicker} | ${{defaultValue: {start: new CalendarDate(2021, 10, 3), end: new CalendarDate(2021, 10, 4)}}}
+    `('$Name should pass validationState and errorMessage to calendar', ({Component, props}) => {
       let {getAllByRole} = render(
         <Provider theme={theme}>
-          <Component label="Date" errorMessage="Selected dates cannot include weekends." validationState="invalid" />
+          <Component {...props} label="Date" errorMessage="Selected dates cannot include weekends." validationState="invalid" />
         </Provider>
       );
 
@@ -366,8 +366,9 @@ describe('DatePickerBase', function () {
 
       let dialog = getAllByRole('dialog')[0];
       let grid = within(dialog).getByRole('grid');
-      let description = grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
-      expect(description).toBe('Selected dates cannot include weekends.');
+      let cell = within(grid).getAllByLabelText('selected', {exact: false})[0];
+      let description = cell.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ');
+      expect(description.startsWith('Selected dates cannot include weekends.')).toBe(true);
     });
   });
 

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -287,7 +287,7 @@ describe('DateRangePicker', function () {
 
       let cells = getAllByRole('gridcell');
       let selected = cells.filter(cell => cell.getAttribute('aria-selected') === 'true');
-      expect(selected[0].children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
+      expect(selected[0].children[0]).toHaveAttribute('aria-label', 'Selected Range: Sunday, February 3 to Monday, May 6, 2019, Sunday, February 3, 2019 selected');
 
       triggerPress(getByLabelText('Sunday, February 10, 2019 selected'));
       triggerPress(getByLabelText('Sunday, February 17, 2019'));
@@ -320,7 +320,7 @@ describe('DateRangePicker', function () {
 
       let cells = getAllByRole('gridcell');
       let selected = cells.find(cell => cell.getAttribute('aria-selected') === 'true');
-      expect(selected.children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
+      expect(selected.children[0]).toHaveAttribute('aria-label', 'Selected Range: Sunday, February 3 to Monday, May 6, 2019, Sunday, February 3, 2019 selected');
 
       let startTimeField = getAllByLabelText('Start time')[0];
       expect(startTimeField).toHaveTextContent('8:45 AM');


### PR DESCRIPTION
Moved the full selected range description in RangeCalendar to the first and last selected cell rather than an `aria-describedby` on the grid, which it seems no screen reader actually announces. Considered moving it to the `aria-label` of the grid so that it is announced when entering any cell within the grid, but this is not announced on VO iOS. Putting it on cells and grid is too verbose, so just went for the cells.

Fixed crash in aria useDateRangePicker docs where dragging an already selected range but ending on the original value threw a "body is undefined" error.