### PR TITLE
Making selected, keyboard focused, emphasized ListView rows a darker blue

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/skin.css
@@ -153,7 +153,9 @@ tbody.spectrum-Table-body {
    * the bottom border curved corners were cut off when using borders.
    */
 
-  /* Box shadow for bottom border for non-selected rows that aren't immediatly above a selected row. */
+  /* Box shadow for bottom border for non-selected rows that aren't immediatly above a selected row. Can't omit the bottom border for last row unlike listview
+   * due to how table rows always reserve 1px for the bottom border (results in a white gap on hover otherwise).
+   */
   &:after {
     box-shadow: inset 0 -1px 0 0 var(--spectrum-table-cell-border-color);
     content: '';

--- a/packages/@react-spectrum/list/src/listview.css
+++ b/packages/@react-spectrum/list/src/listview.css
@@ -59,6 +59,10 @@
           background-color: var(--spectrum-table-row-background-color-selected-hover);
         }
 
+        &:focus-ring {
+          background-color: var(--spectrum-table-row-background-color-selected-key-focus);
+        }
+
         /* Box shadow for left, right, and bottom border for selected rows. */
         &:after {
           box-shadow: inset 1px 0 0 0 var(--spectrum-global-color-blue-500), inset -1px 0 0 0 var(--spectrum-global-color-blue-500), inset 0 -1px 0 0 var(--spectrum-global-color-blue-500);


### PR DESCRIPTION
Testing followups

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to any ListView story and verify that selected + keyboard focused rows are a darker blue compared to just selected rows

## 🧢 Your Project:

RSP
