### PR TITLE
Revert "removing transitionDuration prop (#3059)"

### DIFF
--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -95,6 +95,11 @@ interface ListViewProps<T> extends CollectionBase<T>, DOMProps, AriaLabelingProp
   /** Sets what the ListView should render when there is no content to display. */
   renderEmptyState?: () => JSX.Element,
   /**
+   * The duration of animated layout changes, in milliseconds. Used by the Virtualizer.
+   * @default 0
+   */
+  transitionDuration?: number,
+  /**
    * Handler that is called when a user performs an action on an item. The exact user event depends on
    * the collection's `selectionBehavior` prop and the interaction modality.
    */
@@ -112,6 +117,7 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
     onLoadMore,
     loadingState,
     isQuiet,
+    transitionDuration = 0,
     onAction,
     dragHooks
   } = props;
@@ -220,7 +226,7 @@ function ListView<T extends object>(props: ListViewProps<T>, ref: DOMRef<HTMLDiv
         }
         layout={layout}
         collection={gridCollection}
-        transitionDuration={isLoading ? 160 : 220}>
+        transitionDuration={transitionDuration}>
         {(type, item) => {
           if (type === 'item') {
             return (


### PR DESCRIPTION
This reverts commit 004180c9ea22ef71f2c3783eab735bf1481b73a7.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
