### PR TITLE
Fixing selection: single, disabled ListView story

### DIFF
--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -202,7 +202,7 @@ storiesOf('ListView', module)
     <Example selectionMode="single" />
   ))
   .add('selection: single, checkbox, disabled', () => (
-    <Example selectionMode="single" disabledKeys={['row1']} />
+    <Example selectionMode="single" disabledKeys={['Utilities']} />
   ))
   .add('selection: single, checkbox, isQuiet', () => (
     <Example selectionMode="single" isQuiet />

--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -201,7 +201,7 @@ storiesOf('ListView', module)
   .add('selection: single, checkbox', () => (
     <Example selectionMode="single" />
   ))
-  .add('selection: single, checkbox, disabled', () => (
+  .add('selection: single, checkbox, first row disabled', () => (
     <Example selectionMode="single" disabledKeys={['Utilities']} />
   ))
   .add('selection: single, checkbox, isQuiet', () => (


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

First row of the "/listview--selection-single-checkbox-disabled" story should be disabled now

## 🧢 Your Project:

RSP
