### PR TITLE
Fix ListView rows above focus ring

### DIFF
--- a/packages/@react-spectrum/list/src/styles.css
+++ b/packages/@react-spectrum/list/src/styles.css
@@ -489,14 +489,18 @@
   border-color: var(--spectrum-global-color-blue-500);
   background-color: var(--spectrum-alias-highlight-selected);
   box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
-
-  &.react-spectrum-ListView--emphasized {
-    .react-spectrum-ListViewItem::after {
-        inset-inline-start: 1px;
-        inset-inline-end: 1px;
-        inset-block-end: 1px;
-        inset-block-start: 1px;
-    }
+  &::after {
+    border-radius: inherit;
+    border-color: var(--spectrum-global-color-blue-500);
+    background-color: var(--spectrum-alias-highlight-selected);
+    box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    width: 100%;
+    height: 100%;
   }
 }
 

--- a/packages/@react-spectrum/list/src/styles.css
+++ b/packages/@react-spectrum/list/src/styles.css
@@ -489,6 +489,15 @@
   border-color: var(--spectrum-global-color-blue-500);
   background-color: var(--spectrum-alias-highlight-selected);
   box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
+
+  &.react-spectrum-ListView--emphasized {
+    .react-spectrum-ListViewItem::after {
+        inset-inline-start: 1px;
+        inset-inline-end: 1px;
+        inset-block-end: 1px;
+        inset-block-start: 1px;
+    }
+  }
 }
 
 .react-spectrum-ListView-centeredWrapper {


### PR DESCRIPTION
Before:
<img width="113" alt="Before" src="https://user-images.githubusercontent.com/8961049/168925362-5aa54f2a-9325-4c76-88a6-672ef320480c.png">
After:
<img width="113" alt="After" src="https://user-images.githubusercontent.com/8961049/168925367-cf6f90f5-3fe8-4902-ad20-d13d41789c01.png">

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to ListView -> Drag and Drop -> Drag Between Lists (Root only) story

When performing a drag, verify that row dividers are not above the root drop indicator focus ring as shown above.

## 🧢 Your Project:

<!--- Company/project for pull request -->
