### PR TITLE
Fix dialog flicker on close for "three buttons, footer" story for React 18

### DIFF
--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -19,9 +19,9 @@ import {
   useStyleProps
 } from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
-import {filterDOMProps, useValueEffect} from '@react-aria/utils';
+import {filterDOMProps, useLayoutEffect, useValueEffect} from '@react-aria/utils';
 import {Provider, useProvider, useProviderProps} from '@react-spectrum/provider';
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useCallback, useRef} from 'react';
 import {SpectrumButtonGroupProps} from '@react-types/buttongroup';
 import styles from '@adobe/spectrum-css-temp/components/buttongroup/vars.css';
 
@@ -68,13 +68,13 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
 
   // There are two main reasons we need to remeasure:
   // 1. Internal changes: Check for initial overflow or when orientation/scale/children change (from checkForOverflow dep array)
-  useEffect(() => {
+  useLayoutEffect(() => {
     checkForOverflow();
   }, [checkForOverflow]);
 
   // 2. External changes: buttongroup won't change size due to any parents changing size, so listen to its container for size changes to figure out if we should remeasure
   let parent = useRef<HTMLElement>();
-  useEffect(() => {
+  useLayoutEffect(() => {
     parent.current = domRef.current.parentElement;
   }, [domRef.current]);
   useResizeObserver({ref: parent, onResize: checkForOverflow});


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the "three buttons, footer" story and resize your window in such a way that the buttongroup in the dialog is vertically oriented. Close the dialog and note that there isn't a brief flicker of the dialog layout changing

Sample storybook where this issue happens for comparison: https://reactspectrum.blob.core.windows.net/reactspectrum/b5db74d40c139192c709193ee976dfc945d505b6/storybook/index.html?path=/story/dialog--three-buttons-footer&providerSwitcher-toastPosition=bottom

## 🧢 Your Project:

RSP
