### PR TITLE
Fixes missing 'props' from API sections of useFocus and useFocusWithin in aria-docs

### DIFF
--- a/packages/@react-aria/interactions/src/useFocus.ts
+++ b/packages/@react-aria/interactions/src/useFocus.ts
@@ -33,7 +33,14 @@ interface FocusResult {
  * Handles focus events for the immediate target.
  * Focus events on child elements will be ignored.
  */
-export function useFocus({isDisabled, onFocus: onFocusProp, onBlur: onBlurProp, onFocusChange}: FocusProps): FocusResult {
+export function useFocus(props: FocusProps): FocusResult {
+  let {
+    isDisabled,
+    onFocus: onFocusProp,
+    onBlur: onBlurProp,
+    onFocusChange
+  } = props;
+
   const onBlur: FocusProps['onBlur'] = useCallback((e: FocusEvent) => {
     if (e.target === e.currentTarget) {
       if (onBlurProp) {

--- a/packages/@react-aria/interactions/src/useFocusWithin.ts
+++ b/packages/@react-aria/interactions/src/useFocusWithin.ts
@@ -37,7 +37,13 @@ interface FocusWithinResult {
 /**
  * Handles focus events for the target and its descendants.
  */
-export function useFocusWithin({isDisabled, onBlurWithin, onFocusWithin, onFocusWithinChange}: FocusWithinProps): FocusWithinResult {
+export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
+  let {
+    isDisabled,
+    onBlurWithin,
+    onFocusWithin,
+    onFocusWithinChange
+  } = props;
   let state = useRef({
     isFocusWithin: false
   });


### PR DESCRIPTION
found during testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Goto the useFocus and useFocusWithin pages in the aria docs.
Confirm the "API" section's method signature has "props".

## 🧢 Your Project:
RSP