### PR TITLE
Fix Tabs with every key disabled

### DIFF
--- a/packages/@react-stately/tabs/package.json
+++ b/packages/@react-stately/tabs/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-stately/list": "^3.4.5",
+    "@react-stately/selection": "^3.9.4",
     "@react-stately/utils": "^3.4.1",
     "@react-types/tabs": "^3.0.5"
   },

--- a/packages/@react-stately/tabs/package.json
+++ b/packages/@react-stately/tabs/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-stately/list": "^3.4.5",
-    "@react-stately/selection": "^3.9.4",
     "@react-stately/utils": "^3.4.1",
     "@react-types/tabs": "^3.0.5"
   },

--- a/packages/@react-stately/tabs/src/useTabListState.ts
+++ b/packages/@react-stately/tabs/src/useTabListState.ts
@@ -13,6 +13,7 @@
 import {SingleSelectListState, useSingleSelectListState} from '@react-stately/list';
 import {TabListProps} from '@react-types/tabs';
 import {useRef} from 'react';
+import {Selection} from '@react-stately/selection/src/Selection';
 
 
 export interface TabListState<T> extends SingleSelectListState<T> {}
@@ -38,7 +39,16 @@ export function useTabListState<T extends object>(props: TabListProps<T>): TabLi
   let selectedKey = currentSelectedKey;
   if (selectionManager.isEmpty || !collection.getItem(selectedKey)) {
     selectedKey = collection.getFirstKey();
-    selectionManager.replaceSelection(selectedKey);
+    // loop over tabs until we find one that isn't disabled and select that
+    while (state.disabledKeys.has(selectedKey) && selectedKey !== collection.getLastKey()) {
+      selectedKey = collection.getKeyAfter(selectedKey);
+    }
+    // if this check is true, then every item is disabled, it makes more sense to default to the first key than the last
+    if (state.disabledKeys.has(selectedKey) && selectedKey === collection.getLastKey()) {
+      selectedKey = collection.getFirstKey();
+    }
+    // directly set selection because replace/toggle selection won't consider disabled keys
+    selectionManager.setSelectedKeys(new Selection([selectedKey], selectedKey, selectedKey));
   }
 
   // If the tablist doesn't have focus and the selected key changes or if there isn't a focused key yet, change focused key to the selected key if it exists.

--- a/packages/@react-stately/tabs/src/useTabListState.ts
+++ b/packages/@react-stately/tabs/src/useTabListState.ts
@@ -13,7 +13,6 @@
 import {SingleSelectListState, useSingleSelectListState} from '@react-stately/list';
 import {TabListProps} from '@react-types/tabs';
 import {useRef} from 'react';
-import {Selection} from '@react-stately/selection/src/Selection';
 
 
 export interface TabListState<T> extends SingleSelectListState<T> {}
@@ -48,7 +47,7 @@ export function useTabListState<T extends object>(props: TabListProps<T>): TabLi
       selectedKey = collection.getFirstKey();
     }
     // directly set selection because replace/toggle selection won't consider disabled keys
-    selectionManager.setSelectedKeys(new Selection([selectedKey], selectedKey, selectedKey));
+    selectionManager.setSelectedKeys([selectedKey]);
   }
 
   // If the tablist doesn't have focus and the selected key changes or if there isn't a focused key yet, change focused key to the selected key if it exists.


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Found in testing session
One outstanding question, should we select anything if all tabs are disabled? should it display anything in the tab panel? This PR gets us back to the state we had before which was yes to both of those questions, but I don't feel like we adequately considered this back when we implemented it.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Load up the story `/story/tabs--all-disabled`
it should render, the first tab should be selected, focus should go immediately to the tab panel

unit tests should cover the cases

## 🧢 Your Project:

<!--- Company/project for pull request -->
