### PR TITLE
Comment out column resizing code for release

### DIFF
--- a/packages/@react-aria/table/src/index.ts
+++ b/packages/@react-aria/table/src/index.ts
@@ -16,7 +16,7 @@ export * from './useTableRow';
 export * from './useTableHeaderRow';
 export * from './useTableCell';
 export * from './useTableSelectionCheckbox';
-export * from './useTableColumnResize';
+// export * from './useTableColumnResize';
 
 // Workaround for a Parcel bug where re-exports don't work in the CommonJS output format...
 // export {useGridRowGroup as useTableRowGroup} from '@react-aria/grid';

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -42,14 +42,14 @@ interface ColumnHeaderAria {
  */
 export function useTableColumnHeader<T>(props: ColumnHeaderProps, state: TableState<T>, ref: RefObject<HTMLElement>): ColumnHeaderAria {
   let {node} = props;
-  let allowsResizing = node.props.allowsResizing;
+  // let allowsResizing = node.props.allowsResizing;
   let allowsSorting = node.props.allowsSorting;
   let {gridCellProps} = useGridCell(props, state, ref);
 
   let isSelectionCellDisabled = node.props.isSelectionCell && state.selectionManager.selectionMode === 'single';
   let {pressProps} = usePress({
     // Disabled for allowsResizing because if resizing is allowed, a menu trigger is added to the column header.
-    isDisabled: !allowsSorting || isSelectionCellDisabled || allowsResizing,
+    isDisabled: !allowsSorting || isSelectionCellDisabled, // || allowsResizing,
     onPress() {
       state.sort(node.key);
     }

--- a/packages/@react-spectrum/table/src/Resizer.tsx
+++ b/packages/@react-spectrum/table/src/Resizer.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable jsx-a11y/role-supports-aria-props */
+// @ts-nocheck
 import {classNames} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';

--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+// @ts-nocheck
+
 import ArrowDownSmall from '@spectrum-icons/ui/ArrowDownSmall';
 import {chain, mergeProps, useLayoutEffect} from '@react-aria/utils';
 import {Checkbox} from '@react-spectrum/checkbox';
@@ -470,7 +472,7 @@ function TableColumnHeader(props) {
 
   let {buttonProps} = useButton({...props, elementType: 'div'}, ref);
 
-  let columnProps = column.props as SpectrumColumnProps<unknown>;
+  let columnProps = column.props;
 
   if (columnProps.width && columnProps.allowsResizing) {
     throw new Error('Controlled state is not yet supported with column resizing. Please use defaultWidth for uncontrolled column resizing or remove the allowsResizing prop.');

--- a/packages/@react-spectrum/table/src/TableView_DEPRECATED.tsx
+++ b/packages/@react-spectrum/table/src/TableView_DEPRECATED.tsx
@@ -26,7 +26,7 @@ import {Rect, ReusableView, useVirtualizerState} from '@react-stately/virtualize
 import {SpectrumColumnProps, SpectrumTableProps} from '@react-types/table';
 import styles from '@adobe/spectrum-css-temp/components/table/vars.css';
 import stylesOverrides from './table.css';
-import {TableLayout_DEPRECATED} from '@react-stately/layout';
+import {TableLayout} from '@react-stately/layout';
 import {TableState, useTableState} from '@react-stately/table';
 import {Tooltip, TooltipTrigger} from '@react-spectrum/tooltip';
 import {useHover} from '@react-aria/interactions';
@@ -77,7 +77,7 @@ const SELECTION_CELL_DEFAULT_WIDTH = {
 
 interface TableContextValue<T> {
   state: TableState<T>,
-  layout: TableLayout_DEPRECATED<T>
+  layout: TableLayout<T>
 }
 
 const TableContext = React.createContext<TableContextValue<unknown>>(null);
@@ -109,7 +109,7 @@ function TableView_DEPRECATED<T extends object>(props: SpectrumTableProps<T>, re
 
   let {scale} = useProvider();
   let density = props.density || 'regular';
-  let layout = useMemo(() => new TableLayout_DEPRECATED({
+  let layout = useMemo(() => new TableLayout({
     // If props.rowHeight is auto, then use estimated heights based on scale, otherwise use fixed heights.
     rowHeight: props.overflowMode === 'wrap'
       ? null

--- a/packages/@react-spectrum/table/src/index.ts
+++ b/packages/@react-spectrum/table/src/index.ts
@@ -12,7 +12,7 @@
 
 /// <reference types="css-module-types" />
 
-export {TableView} from './TableView';
+export {TableView_DEPRECATED as TableView} from './TableView_DEPRECATED';
 import {Column} from '@react-stately/table';
 import {SpectrumColumnProps} from '@react-types/table';
 

--- a/packages/@react-spectrum/table/stories/HidingColumnsAllowsResizing.tsx
+++ b/packages/@react-spectrum/table/stories/HidingColumnsAllowsResizing.tsx
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+// @ts-nocheck
+
 import {Cell, Column, Row, TableBody, TableHeader, TableView} from '../';
 import {Checkbox} from '@react-spectrum/checkbox';
 import {Flex} from '@react-spectrum/layout';

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -24,7 +24,7 @@ import {Divider} from '@react-spectrum/divider';
 import {Flex} from '@react-spectrum/layout';
 import {Heading} from '@react-spectrum/text';
 import {HidingColumns} from './HidingColumns';
-import {HidingColumnsAllowsResizing} from './HidingColumnsAllowsResizing';
+// import {HidingColumnsAllowsResizing} from './HidingColumnsAllowsResizing';
 import {IllustratedMessage} from '@react-spectrum/illustratedmessage';
 import {Link} from '@react-spectrum/link';
 import {LoadingState, SelectionMode} from '@react-types/shared';
@@ -1118,253 +1118,252 @@ storiesOf('TableView', module)
       </TableView>
     )
   )
-  .add('table with breadcrumb navigation', () => <TableWithBreadcrumbs />)
-  .add(
-    'allowsResizing, uncontrolled, dynamic widths',
-    () => (
-      <>
-        <label htmlFor="focusable-before">Focusable before</label>
-        <input id="focusable-before" />
-        <TableView aria-label="TableView with resizable columns" width={800} height={200}>
-          <TableHeader>
-            <Column allowsResizing defaultWidth="1fr">File Name</Column>
-            <Column allowsResizing defaultWidth="2fr">Type</Column>
-            <Column allowsResizing defaultWidth="2fr">Size</Column>
-            <Column allowsResizing defaultWidth="1fr">Weight</Column>
-          </TableHeader>
-          <TableBody>
-            <Row>
-              <Cell>2018 Proposal</Cell>
-              <Cell>PDF</Cell>
-              <Cell>214 KB</Cell>
-              <Cell>1 LB</Cell>
-            </Row>
-            <Row>
-              <Cell>Budget</Cell>
-              <Cell>XLS</Cell>
-              <Cell>120 KB</Cell>
-              <Cell>20 LB</Cell>
-            </Row>
-          </TableBody>
-        </TableView>
-        <label htmlFor="focusable-after">Focusable after</label>
-        <input id="focusable-after" />
-      </>
-    )
-  )
-  .add(
-    'allowsResizing, uncontrolled, static widths', () => (
-      <TableView aria-label="TableView with resizable columns" width={800} height={200}>
-        <TableHeader>
-          <Column allowsResizing defaultWidth="50%">File Name</Column>
-          <Column allowsResizing defaultWidth="20%">Type</Column>
-          <Column allowsResizing defaultWidth={239}>Size</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-    )
-  )
-  .add(
-    'allowsResizing, uncontrolled, column divider', () => (
-      <TableView aria-label="TableView with resizable columns and divider" width={800} height={200}>
-        <TableHeader>
-          <Column allowsResizing showDivider>File Name</Column>
-          <Column allowsResizing defaultWidth="3fr">Type</Column>
-          <Column allowsResizing>Size</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-    )
-  )
-  .add(
-    'allowsResizing, uncontrolled, min/max widths', () => (
-      <TableView aria-label="TableView with resizable columns" width={800} height={200}>
-        <TableHeader>
-          <Column allowsResizing defaultWidth={200} minWidth={175} maxWidth={300}>File Name</Column>
-          <Column allowsResizing defaultWidth="1fr" minWidth={175} maxWidth={500}>Size</Column>
-          <Column allowsResizing defaultWidth={200} minWidth={175} maxWidth={300}>Type</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-    )
-  )
-  .add(
-    'allowsResizing, uncontrolled, some columns not allowed resizing', () => (
-      <TableView aria-label="TableView with resizable columns" width={800} height={200}>
-        <TableHeader>
-          <Column allowsResizing >File Name</Column>
-          <Column defaultWidth="1fr">Type</Column>
-          <Column defaultWidth="2fr">Size</Column>
-          <Column allowsResizing defaultWidth="2fr">Weight</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-            <Cell>1 LB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-            <Cell>20 LB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-    )
-  )
-  .add(
-    'allowsResizing, uncontrolled, undefined table width and height', () => (
-      <TableView aria-label="TableView with resizable columns and no width or height set">
-        <TableHeader>
-          <Column allowsResizing defaultWidth={150}>File Name</Column>
-          <Column allowsResizing defaultWidth={100}>Type</Column>
-          <Column allowsResizing defaultWidth={100}>Size</Column>
-          <Column allowsResizing defaultWidth={100}>Weight</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-            <Cell>1 LB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-            <Cell>20 LB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-    )
-  )
-  .add(
-    'allowsResizing, uncontrolled, sortable columns',
-    () => <AsyncLoadingExample isResizable />,
-    {chromatic: {disable: true}}
-  )
-  .add(
-    'allowsResizing, many columns and rows',
-    () => (
-      <>
-        <label htmlFor="focusable-before">Focusable before</label>
-        <input id="focusable-before" />
-        <TableView aria-label="TableView with many columns and rows" selectionMode="multiple" width={700} height={500} onSelectionChange={s => onSelectionChange([...s])}>
-          <TableHeader columns={manyColunns}>
-            {column =>
-              <Column allowsResizing minWidth={100}>{column.name}</Column>
-            }
-          </TableHeader>
-          <TableBody items={manyRows}>
-            {item =>
-              (<Row key={item.foo}>
-                {key => <Cell>{item[key]}</Cell>}
-              </Row>)
-            }
-          </TableBody>
-        </TableView>
-        <label htmlFor="focusable-after">Focusable after</label>
-        <input id="focusable-after" />
-      </>
-    ),
-    {chromatic: {disable: true}}
-  )
-  .add(
-    'allowsResizing, onColumnResize action',
-    () => (
-      <TableView aria-label="TableView with resizable columns" width={800} height={200} onColumnResize={action('onColumnResize')}>
-        <TableHeader>
-          <Column allowsResizing defaultWidth="1fr">File Name</Column>
-          <Column allowsResizing defaultWidth="2fr">Type</Column>
-          <Column allowsResizing defaultWidth="2fr">Size</Column>
-          <Column allowsResizing defaultWidth="1fr">Weight</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-            <Cell>1 LB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-            <Cell>20 LB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-  ))
-  .add(
-    'allowsResizing, onColumnResizeEnd action',
-    () => (
-      <TableView aria-label="TableView with resizable columns" width={800} height={200} onColumnResizeEnd={action('onColumnResizeEnd')}>
-        <TableHeader>
-          <Column allowsResizing defaultWidth="1fr">File Name</Column>
-          <Column allowsResizing defaultWidth="2fr">Type</Column>
-          <Column allowsResizing defaultWidth="2fr">Size</Column>
-          <Column allowsResizing defaultWidth="1fr">Weight</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell>2018 Proposal</Cell>
-            <Cell>PDF</Cell>
-            <Cell>214 KB</Cell>
-            <Cell>1 LB</Cell>
-          </Row>
-          <Row>
-            <Cell>Budget</Cell>
-            <Cell>XLS</Cell>
-            <Cell>120 KB</Cell>
-            <Cell>20 LB</Cell>
-          </Row>
-        </TableBody>
-      </TableView>
-  ))
-  .add(
-    'allowsResizing, hiding columns',
-    () => (
-      <HidingColumnsAllowsResizing />
-    )
-  );
+  .add('table with breadcrumb navigation', () => <TableWithBreadcrumbs />);
+  // .add(
+  //   'allowsResizing, uncontrolled, dynamic widths',
+  //   () => (
+  //     <>
+  //       <label htmlFor="focusable-before">Focusable before</label>
+  //       <input id="focusable-before" />
+  //       <TableView aria-label="TableView with resizable columns" width={800} height={200}>
+  //         <TableHeader>
+  //           <Column allowsResizing defaultWidth="1fr">File Name</Column>
+  //           <Column allowsResizing defaultWidth="2fr">Type</Column>
+  //           <Column allowsResizing defaultWidth="2fr">Size</Column>
+  //           <Column allowsResizing defaultWidth="1fr">Weight</Column>
+  //         </TableHeader>
+  //         <TableBody>
+  //           <Row>
+  //             <Cell>2018 Proposal</Cell>
+  //             <Cell>PDF</Cell>
+  //             <Cell>214 KB</Cell>
+  //             <Cell>1 LB</Cell>
+  //           </Row>
+  //           <Row>
+  //             <Cell>Budget</Cell>
+  //             <Cell>XLS</Cell>
+  //             <Cell>120 KB</Cell>
+  //             <Cell>20 LB</Cell>
+  //           </Row>
+  //         </TableBody>
+  //       </TableView>
+  //       <label htmlFor="focusable-after">Focusable after</label>
+  //       <input id="focusable-after" />
+  //     </>
+  //   )
+  // )
+  // .add(
+  //   'allowsResizing, uncontrolled, static widths', () => (
+  //     <TableView aria-label="TableView with resizable columns" width={800} height={200}>
+  //       <TableHeader>
+  //         <Column allowsResizing defaultWidth="50%">File Name</Column>
+  //         <Column allowsResizing defaultWidth="20%">Type</Column>
+  //         <Column allowsResizing defaultWidth={239}>Size</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  //   )
+  // )
+  // .add(
+  //   'allowsResizing, uncontrolled, column divider', () => (
+  //     <TableView aria-label="TableView with resizable columns and divider" width={800} height={200}>
+  //       <TableHeader>
+  //         <Column allowsResizing showDivider>File Name</Column>
+  //         <Column allowsResizing defaultWidth="3fr">Type</Column>
+  //         <Column allowsResizing>Size</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  //   )
+  // )
+  // .add(
+  //   'allowsResizing, uncontrolled, min/max widths', () => (
+  //     <TableView aria-label="TableView with resizable columns" width={800} height={200}>
+  //       <TableHeader>
+  //         <Column allowsResizing defaultWidth={200} minWidth={175} maxWidth={300}>File Name</Column>
+  //         <Column allowsResizing defaultWidth="1fr" minWidth={175} maxWidth={500}>Size</Column>
+  //         <Column allowsResizing defaultWidth={200} minWidth={175} maxWidth={300}>Type</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  //   )
+  // )
+  // .add(
+  //   'allowsResizing, uncontrolled, some columns not allowed resizing', () => (
+  //     <TableView aria-label="TableView with resizable columns" width={800} height={200}>
+  //       <TableHeader>
+  //         <Column allowsResizing >File Name</Column>
+  //         <Column defaultWidth="1fr">Type</Column>
+  //         <Column defaultWidth="2fr">Size</Column>
+  //         <Column allowsResizing defaultWidth="2fr">Weight</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //           <Cell>1 LB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //           <Cell>20 LB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  //   )
+  // )
+  // .add(
+  //   'allowsResizing, uncontrolled, undefined table width and height', () => (
+  //     <TableView aria-label="TableView with resizable columns and no width or height set">
+  //       <TableHeader>
+  //         <Column allowsResizing defaultWidth={150}>File Name</Column>
+  //         <Column allowsResizing defaultWidth={100}>Type</Column>
+  //         <Column allowsResizing defaultWidth={100}>Size</Column>
+  //         <Column allowsResizing defaultWidth={100}>Weight</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //           <Cell>1 LB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //           <Cell>20 LB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  //   )
+  // )
+  // .add(
+  //   'allowsResizing, uncontrolled, sortable columns',
+  //   () => <AsyncLoadingExample isResizable />,
+  //   {chromatic: {disable: true}}
+  // )
+  // .add(
+  //   'allowsResizing, many columns and rows',
+  //   () => (
+  //     <>
+  //       <label htmlFor="focusable-before">Focusable before</label>
+  //       <input id="focusable-before" />
+  //       <TableView aria-label="TableView with many columns and rows" selectionMode="multiple" width={700} height={500} onSelectionChange={s => onSelectionChange([...s])}>
+  //         <TableHeader columns={manyColunns}>
+  //           {column =>
+  //             <Column allowsResizing minWidth={100}>{column.name}</Column>
+  //           }
+  //         </TableHeader>
+  //         <TableBody items={manyRows}>
+  //           {item =>
+  //             (<Row key={item.foo}>
+  //               {key => <Cell>{item[key]}</Cell>}
+  //             </Row>)
+  //           }
+  //         </TableBody>
+  //       </TableView>
+  //       <label htmlFor="focusable-after">Focusable after</label>
+  //       <input id="focusable-after" />
+  //     </>
+  //   ),
+  //   {chromatic: {disable: true}}
+  // )
+  // .add(
+  //   'allowsResizing, onColumnResize action',
+  //   () => (
+  //     <TableView aria-label="TableView with resizable columns" width={800} height={200} onColumnResize={action('onColumnResize')}>
+  //       <TableHeader>
+  //         <Column allowsResizing defaultWidth="1fr">File Name</Column>
+  //         <Column allowsResizing defaultWidth="2fr">Type</Column>
+  //         <Column allowsResizing defaultWidth="2fr">Size</Column>
+  //         <Column allowsResizing defaultWidth="1fr">Weight</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //           <Cell>1 LB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //           <Cell>20 LB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  // ))
+  // .add(
+  //   'allowsResizing, onColumnResizeEnd action',
+  //   () => (
+  //     <TableView aria-label="TableView with resizable columns" width={800} height={200} onColumnResizeEnd={action('onColumnResizeEnd')}>
+  //       <TableHeader>
+  //         <Column allowsResizing defaultWidth="1fr">File Name</Column>
+  //         <Column allowsResizing defaultWidth="2fr">Type</Column>
+  //         <Column allowsResizing defaultWidth="2fr">Size</Column>
+  //         <Column allowsResizing defaultWidth="1fr">Weight</Column>
+  //       </TableHeader>
+  //       <TableBody>
+  //         <Row>
+  //           <Cell>2018 Proposal</Cell>
+  //           <Cell>PDF</Cell>
+  //           <Cell>214 KB</Cell>
+  //           <Cell>1 LB</Cell>
+  //         </Row>
+  //         <Row>
+  //           <Cell>Budget</Cell>
+  //           <Cell>XLS</Cell>
+  //           <Cell>120 KB</Cell>
+  //           <Cell>20 LB</Cell>
+  //         </Row>
+  //       </TableBody>
+  //     </TableView>
+  // ))
+  // .add(
+  //   'allowsResizing, hiding columns',
+  //   () => (
+  //     <HidingColumnsAllowsResizing />
+  //   )
+  // );
 
-function AsyncLoadingExample(props) {
-  const {isResizable} = props;
+function AsyncLoadingExample() {
   interface Item {
     data: {
       id: string,
@@ -1403,10 +1402,10 @@ function AsyncLoadingExample(props) {
       <ActionButton marginBottom={10} onPress={() => list.remove(list.items[0].data.id)}>Remove first item</ActionButton>
       <TableView aria-label="Top news from Reddit" selectionMode="multiple" width={1000} height={400} isQuiet sortDescriptor={list.sortDescriptor} onSortChange={list.sort} selectedKeys={list.selectedKeys} onSelectionChange={list.setSelectedKeys}>
         <TableHeader>
-          <Column key="score" defaultWidth={100} allowsResizing={isResizable} allowsSorting>Score</Column>
-          <Column key="title" isRowHeader allowsResizing={isResizable} allowsSorting>Title</Column>
-          <Column key="author" defaultWidth={200} allowsResizing={isResizable} allowsSorting>Author</Column>
-          <Column key="num_comments" defaultWidth={100} allowsResizing={isResizable} allowsSorting>Comments</Column>
+          <Column key="score" defaultWidth={100} allowsSorting>Score</Column>
+          <Column key="title" isRowHeader allowsSorting>Title</Column>
+          <Column key="author" defaultWidth={200} allowsSorting>Author</Column>
+          <Column key="num_comments" defaultWidth={100} allowsSorting>Comments</Column>
         </TableHeader>
         <TableBody items={list.items} loadingState={list.loadingState} onLoadMore={list.loadMore}>
           {item =>

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -1402,10 +1402,10 @@ function AsyncLoadingExample() {
       <ActionButton marginBottom={10} onPress={() => list.remove(list.items[0].data.id)}>Remove first item</ActionButton>
       <TableView aria-label="Top news from Reddit" selectionMode="multiple" width={1000} height={400} isQuiet sortDescriptor={list.sortDescriptor} onSortChange={list.sort} selectedKeys={list.selectedKeys} onSelectionChange={list.setSelectedKeys}>
         <TableHeader>
-          <Column key="score" defaultWidth={100} allowsSorting>Score</Column>
+          <Column key="score" width={100} allowsSorting>Score</Column>
           <Column key="title" isRowHeader allowsSorting>Title</Column>
-          <Column key="author" defaultWidth={200} allowsSorting>Author</Column>
-          <Column key="num_comments" defaultWidth={100} allowsSorting>Comments</Column>
+          <Column key="author" width={200} allowsSorting>Author</Column>
+          <Column key="num_comments" width={100} allowsSorting>Comments</Column>
         </TableHeader>
         <TableBody items={list.items} loadingState={list.loadingState} onLoadMore={list.loadMore}>
           {item =>

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -4536,7 +4536,7 @@ describe('TableView', function () {
         }
       });
 
-      describe('bounded constraint on columns where dynamic columns exist before the bounded columns', () => {
+      describe.skip('bounded constraint on columns where dynamic columns exist before the bounded columns', () => {
         it('should fulfill the constraints of the static columns and give remaining width to previously defined dynamic columns', () => {
           let tree = render(
             <TableView aria-label="Table">
@@ -4565,7 +4565,7 @@ describe('TableView', function () {
         });
       });
 
-      describe("mutiple columns are bounded but earlier columns are 'less bounded' than future columns", () => {
+      describe.skip("mutiple columns are bounded but earlier columns are 'less bounded' than future columns", () => {
         it("should satisfy the conditions of all columns but also allocate remaining space to the 'less bounded' previous columns", () => {
           let tree = render(
             <TableView aria-label="Table">

--- a/packages/@react-stately/layout/src/index.ts
+++ b/packages/@react-stately/layout/src/index.ts
@@ -11,5 +11,5 @@
  */
 
 export * from './ListLayout';
-export * from './TableLayout';
-export * from './TableLayout_DEPRECATED';
+// export * from './TableLayout';
+export {TableLayout_DEPRECATED as TableLayout} from './TableLayout_DEPRECATED';

--- a/packages/@react-stately/table/src/TableCollection.ts
+++ b/packages/@react-stately/table/src/TableCollection.ts
@@ -18,7 +18,7 @@ interface GridCollectionOptions {
 }
 
 const ROW_HEADER_COLUMN_KEY = 'row-header-column-' + Math.random().toString(36).slice(2);
-const RESIZE_BUFFER_COLUMN_KEY = 'resize-buffer-column' + Math.random().toString(36).slice(2);
+// const RESIZE_BUFFER_COLUMN_KEY = 'resize-buffer-column' + Math.random().toString(36).slice(2);
 
 function buildHeaderRows<T>(keyMap: Map<Key, GridNode<T>>, columnNodes: GridNode<T>[]): GridNode<T>[] {
   let columns = [];
@@ -218,36 +218,36 @@ export class TableCollection<T> extends GridCollection<T> {
       visit(node);
     }
 
-    if (Array.from(nodes).some(node => node.props?.allowsResizing)) {
-      /* 
-      If the table content width > table width, a horizontal scroll bar is present.
-      If a user tries to resize a column, making it smaller while they are scrolled to the
-      end of the content horizontally, it shrinks the total table content width, causing
-      things to snap around and breaks the resize behavior.
-      
-      To fix this, we add a resize buffer column (aka "spooky column") to the end of the table.
-      The width of this column defaults to 0. If you try and shrink a column and the width of the
-      table contents > table width, then the "spooky column" will grow to take up the difference
-      so that the total table content width remains constant while you are resizing. Once you
-      finish resizing, the "spooky column" snaps back to 0.
-      */
-      let resizeBufferColumn: GridNode<T> = {
-        type: 'column',
-        key: RESIZE_BUFFER_COLUMN_KEY,
-        value: null,
-        textValue: '',
-        level: 0,
-        index: columns.length,
-        hasChildNodes: false,
-        rendered: null,
-        childNodes: [],
-        props: {
-          isResizeBuffer: true,
-          defaultWidth: 0
-        }
-      };
-      columns.push(resizeBufferColumn);
-    }
+    // if (Array.from(nodes).some(node => node.props?.allowsResizing)) {
+    //   /*
+    //   If the table content width > table width, a horizontal scroll bar is present.
+    //   If a user tries to resize a column, making it smaller while they are scrolled to the
+    //   end of the content horizontally, it shrinks the total table content width, causing
+    //   things to snap around and breaks the resize behavior.
+
+    //   To fix this, we add a resize buffer column (aka "spooky column") to the end of the table.
+    //   The width of this column defaults to 0. If you try and shrink a column and the width of the
+    //   table contents > table width, then the "spooky column" will grow to take up the difference
+    //   so that the total table content width remains constant while you are resizing. Once you
+    //   finish resizing, the "spooky column" snaps back to 0.
+    //   */
+    //   let resizeBufferColumn: GridNode<T> = {
+    //     type: 'column',
+    //     key: RESIZE_BUFFER_COLUMN_KEY,
+    //     value: null,
+    //     textValue: '',
+    //     level: 0,
+    //     index: columns.length,
+    //     hasChildNodes: false,
+    //     rendered: null,
+    //     childNodes: [],
+    //     props: {
+    //       isResizeBuffer: true,
+    //       defaultWidth: 0
+    //     }
+    //   };
+    //   columns.push(resizeBufferColumn);
+    // }
 
     let headerRows = buildHeaderRows(columnKeyMap, columns) as GridNode<T>[];
     headerRows.forEach((row, i) => rows.splice(i, 0, row));

--- a/packages/@react-stately/table/src/index.ts
+++ b/packages/@react-stately/table/src/index.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './useTableColumnResizeState';
-export * from './utils';
+// export * from './useTableColumnResizeState';
+// export * from './utils';
 export * from './useTableState';
 export * from './TableHeader';
 export * from './TableBody';

--- a/packages/@react-stately/table/src/useTableColumnResizeState.ts
+++ b/packages/@react-stately/table/src/useTableColumnResizeState.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import {ColumnProps} from '@react-types/table';
 import {getContentWidth, getDynamicColumnWidths, getMaxWidth, getMinWidth, isStatic, parseStaticWidth} from './utils';
@@ -65,7 +66,7 @@ export function useTableColumnResizeState<T>(props: ColumnResizeStateProps<T>): 
     setColumnWidths(newWidths);
   }
   /*
-    returns the resolved column width in this order: 
+    returns the resolved column width in this order:
     previously calculated width -> controlled width prop -> uncontrolled defaultWidth prop -> dev assigned width -> default dynamic width
   */
   let getResolvedColumnWidth = useCallback((column: GridNode<T>): (number | string) => {
@@ -75,7 +76,7 @@ export function useTableColumnResizeState<T>(props: ColumnResizeStateProps<T>): 
 
   let getStaticAndDynamicColumns = useCallback((columns: GridNode<T>[]) : { staticColumns: GridNode<T>[], dynamicColumns: GridNode<T>[] } => columns.reduce((acc, column) => {
     let width = getResolvedColumnWidth(column);
-    return isStatic(width) ? {...acc, staticColumns: [...acc.staticColumns, column]} : {...acc, dynamicColumns: [...acc.dynamicColumns, column]}; 
+    return isStatic(width) ? {...acc, staticColumns: [...acc.staticColumns, column]} : {...acc, dynamicColumns: [...acc.dynamicColumns, column]};
   }, {staticColumns: [], dynamicColumns: []}), [getResolvedColumnWidth]);
 
   let buildColumnWidths = useCallback((affectedColumns: GridNode<T>[], availableSpace: number): Map<Key, number> => {
@@ -173,7 +174,7 @@ export function useTableColumnResizeState<T>(props: ColumnResizeStateProps<T>): 
       }
       return acc;
     }, tableWidth.current);
-    
+
     // merge the unaffected column widths and the recalculated column widths
     let recalculatedColumnWidths = buildColumnWidths(dynamicColumns, availableSpace);
     widths = new Map<Key, number>([...widths, ...recalculatedColumnWidths]);

--- a/packages/@react-stately/table/src/useTableState.ts
+++ b/packages/@react-stately/table/src/useTableState.ts
@@ -10,12 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import {AffectedColumnWidths, useTableColumnResizeState} from './useTableColumnResizeState';
+import {AffectedColumnWidths} from './useTableColumnResizeState';
 import {CollectionBase, Node, SelectionMode, Sortable, SortDescriptor, SortDirection} from '@react-types/shared';
-import {GridNode} from '@react-types/grid';
+// import {GridNode} from '@react-types/grid';
 import {GridState, useGridState} from '@react-stately/grid';
 import {TableCollection as ITableCollection} from '@react-types/table';
-import {Key, MutableRefObject, useMemo} from 'react';
+import {Key, useMemo} from 'react';
 import {MultipleSelectionStateProps} from '@react-stately/selection';
 import {TableCollection} from './TableCollection';
 import {useCollection} from '@react-stately/collections';
@@ -28,25 +28,25 @@ export interface TableState<T> extends GridState<T, ITableCollection<T>> {
   /** The current sorted column and direction. */
   sortDescriptor: SortDescriptor,
   /** Calls the provided onSortChange handler with the provided column key and sort direction. */
-  sort(columnKey: Key, direction?: 'ascending' | 'descending'): void,
-  /** A map of all the column widths by key. */
-  columnWidths: MutableRefObject<Map<Key, number>>,
-  /** Boolean for if a column is being resized. */
-  isResizingColumn: boolean,
-  /** Getter for column width. */
-  getColumnWidth(key: Key): number,
-    /** Getter for column min width. */
-  getColumnMinWidth(key: Key): number,
-    /** Getter for column max widths. */
-  getColumnMaxWidth(key: Key): number,
-  /** Trigger a resize and recalc. */
-  onColumnResize: (column: GridNode<T>, width: number) => void,
-  /** Runs at the start of resizing. */
-  onColumnResizeStart: () => void,
-  /** Triggers the onColumnResizeEnd prop. */
-  onColumnResizeEnd: () => void,
-  /** Need to be able to set the table width so that it can be used to calculate the column widths, this will trigger a recalc. */
-  setTableWidth: (width: number) => void
+  sort(columnKey: Key, direction?: 'ascending' | 'descending'): void
+  // /** A map of all the column widths by key. */
+  // columnWidths: MutableRefObject<Map<Key, number>>,
+  // /** Boolean for if a column is being resized. */
+  // isResizingColumn: boolean,
+  // /** Getter for column width. */
+  // getColumnWidth(key: Key): number,
+  //   /** Getter for column min width. */
+  // getColumnMinWidth(key: Key): number,
+  //   /** Getter for column max widths. */
+  // getColumnMaxWidth(key: Key): number,
+  // /** Trigger a resize and recalc. */
+  // onColumnResize: (column: GridNode<T>, width: number) => void,
+  // /** Runs at the start of resizing. */
+  // onColumnResizeStart: () => void,
+  // /** Triggers the onColumnResizeEnd prop. */
+  // onColumnResizeEnd: () => void,
+  // /** Need to be able to set the table width so that it can be used to calculate the column widths, this will trigger a recalc. */
+  // setTableWidth: (width: number) => void
 }
 
 export interface CollectionBuilderContext<T> {
@@ -90,8 +90,8 @@ export function useTableState<T extends object>(props: TableStateProps<T>): Tabl
     context
   );
   let {disabledKeys, selectionManager} = useGridState({...props, collection});
-    
-  const tableColumnResizeState = useTableColumnResizeState({columns: collection.columns, getDefaultWidth: props.getDefaultWidth, onColumnResize: props.onColumnResize, onColumnResizeEnd: props.onColumnResizeEnd});
+
+  // const tableColumnResizeState = useTableColumnResizeState({columns: collection.columns, getDefaultWidth: props.getDefaultWidth, onColumnResize: props.onColumnResize, onColumnResizeEnd: props.onColumnResizeEnd});
 
 
   return {
@@ -107,7 +107,7 @@ export function useTableState<T extends object>(props: TableStateProps<T>): Tabl
           ? OPPOSITE_SORT_DIRECTION[props.sortDescriptor.direction]
           : 'ascending')
       });
-    },
-    ...tableColumnResizeState
+    }
+    // ...tableColumnResizeState
   };
 }

--- a/packages/@react-stately/table/test/useTableColumnResizeState.test.ts
+++ b/packages/@react-stately/table/test/useTableColumnResizeState.test.ts
@@ -10,8 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {getContentWidth, useTableColumnResizeState} from '../';
+import {getContentWidth} from '../src/utils';
 import {renderHook} from '@react-spectrum/test-utils';
+import {useTableColumnResizeState} from '../src/useTableColumnResizeState';
 
 const createColumn = (key, columnProps) => ({
   type: 'column',
@@ -25,7 +26,7 @@ const createColumn = (key, columnProps) => ({
   textValue: key
 });
 
-describe('useTableColumnResizeState', () => {
+describe.skip('useTableColumnResizeState', () => {
   describe('static defaultWidth', () => {
     it('should handle pixel widths', () => {
       const columns = [

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -37,11 +37,11 @@ export interface SpectrumTableProps<T> extends TableProps<T>, SpectrumSelectionP
   /** Sets what the TableView should render when there is no content to display. */
   renderEmptyState?: () => JSX.Element,
   /** Handler that is called when a user performs an action on a row. */
-  onAction?: (key: Key) => void,
-  /** Handler that is called when a user performs a column resize. */
-  onColumnResize?: (affectedColumns: {key: Key, width: number}[]) => void,
-  /** Handler that is called when a column resize ends. */
-  onColumnResizeEnd?: (affectedColumns: {key: Key, width: number}[]) => void
+  onAction?: (key: Key) => void
+  // /** Handler that is called when a user performs a column resize. */
+  // onColumnResize?: (affectedColumns: {key: Key, width: number}[]) => void,
+  // /** Handler that is called when a column resize ends. */
+  // onColumnResizeEnd?: (affectedColumns: {key: Key, width: number}[]) => void
 }
 
 export interface TableHeaderProps<T> {
@@ -69,7 +69,7 @@ export interface ColumnProps<T> {
   /** The default width of the column. */
   defaultWidth?: number | string,
   /** Whether the column allows resizing. */
-  allowsResizing?: boolean,
+  // allowsResizing?: boolean,
   /** Whether the column allows sorting. */
   allowsSorting?: boolean,
   /** Whether a column is a [row header](https://www.w3.org/TR/wai-aria-1.1/#rowheader) and should be announced by assistive technology during row navigation. */

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -66,9 +66,9 @@ export interface ColumnProps<T> {
   minWidth?: number | string,
   /** The maximum width of the column. */
   maxWidth?: number | string,
-  /** The default width of the column. */
-  defaultWidth?: number | string,
-  /** Whether the column allows resizing. */
+  // /** The default width of the column. */
+  // defaultWidth?: number | string,
+  // /** Whether the column allows resizing. */
   // allowsResizing?: boolean,
   /** Whether the column allows sorting. */
   allowsSorting?: boolean,


### PR DESCRIPTION
We have to release Table for React 18 support, but column resizing isn't ready for a full release yet. Commenting it out for now, revert this PR after release.