### PR TITLE
ListView dnd testing followups

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -135,8 +135,8 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
   };
 
   // Focus the associated DOM node when this item becomes the focusedKey
-  let isFocused = key === manager.focusedKey;
   useEffect(() => {
+    let isFocused = key === manager.focusedKey;
     if (isFocused && manager.isFocused && !shouldUseVirtualFocus && document.activeElement !== ref.current) {
       if (focus) {
         focus();
@@ -144,7 +144,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
         focusSafely(ref.current);
       }
     }
-  }, [ref, isFocused, manager.focusedKey, manager.childFocusStrategy, manager.isFocused, shouldUseVirtualFocus]);
+  }, [ref, key, manager.focusedKey, manager.childFocusStrategy, manager.isFocused, shouldUseVirtualFocus]);
 
   // Set tabIndex to 0 if the element is focused, or -1 otherwise so that only the last focused
   // item is tabbable.  If using virtual focus, don't set a tabIndex at all so that VoiceOver
@@ -152,7 +152,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
   let itemProps: SelectableItemAria['itemProps'] = {};
   if (!shouldUseVirtualFocus) {
     itemProps = {
-      tabIndex: isFocused ? 0 : -1,
+      tabIndex: key === manager.focusedKey ? 0 : -1,
       onFocus(e) {
         if (e.target === ref.current) {
           manager.setFocusedKey(key);

--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -126,10 +126,11 @@ export function ListViewItem<T>(props: ListViewItemProps<T>) {
   let showCheckbox = state.selectionManager.selectionMode !== 'none' && state.selectionManager.selectionBehavior === 'toggle';
   let {visuallyHiddenProps} = useVisuallyHidden();
 
+  let dropProps = isDroppable ? droppableItem?.dropProps : {'aria-hidden': droppableItem?.dropProps['aria-hidden']};
   const mergedProps = mergeProps(
     rowProps,
     draggableItem?.dragProps,
-    isDroppable && droppableItem?.dropProps,
+    dropProps,
     hoverProps,
     focusWithinProps,
     focusProps

--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -948,7 +948,14 @@ export function DragBetweenListsExample(props) {
 }
 
 export function DragBetweenListsRootOnlyExample(props) {
-  let onDropAction = action('onDrop');
+  let {
+    listViewProps = {},
+    dragHookOptions = {},
+    dropHookOptions = {}
+  } = props;
+  let {onDragStart, onDragEnd} = dragHookOptions;
+  let {onDrop} = dropHookOptions;
+  let onDropAction = chain(action('onDrop'), onDrop);
 
   let list1 = useListData({
     initialItems: props.items1 || itemList1
@@ -976,8 +983,8 @@ export function DragBetweenListsRootOnlyExample(props) {
         };
       });
     },
-    onDragStart: action('dragStart'),
-    onDragEnd: action('dragEnd')
+    onDragStart: chain(action('dragStart'), onDragStart),
+    onDragEnd: chain(action('dragEnd'), onDragEnd)
   });
 
   let dragHooksSecond = useDragHooks({
@@ -990,8 +997,8 @@ export function DragBetweenListsRootOnlyExample(props) {
         };
       });
     },
-    onDragStart: action('dragStart'),
-    onDragEnd: action('dragEnd')
+    onDragStart: chain(action('dragStart'), onDragStart),
+    onDragEnd: chain(action('dragEnd'), onDragEnd)
   });
 
   let dropHooksFirst = useDropHooks({
@@ -1069,7 +1076,7 @@ export function DragBetweenListsRootOnlyExample(props) {
           disabledKeys={['2']}
           dragHooks={dragHooksFirst}
           dropHooks={dropHooksFirst}
-          {...props}>
+          {...listViewProps}>
           {(item: any) => (
             <Item>
               {item.textValue}
@@ -1087,7 +1094,7 @@ export function DragBetweenListsRootOnlyExample(props) {
           disabledKeys={['2']}
           dragHooks={dragHooksSecond}
           dropHooks={dropHooksSecond}
-          {...props}>
+          {...listViewProps}>
           {(item: any) => (
             <Item>
               {item.textValue}

--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -721,7 +721,14 @@ export function ReorderExample(props) {
 }
 
 export function DragIntoItemExample(props) {
-  let onDropAction = action('onDrop');
+  let {
+    listViewProps = {},
+    dragHookOptions = {},
+    dropHookOptions = {}
+  } = props;
+  let {onDragStart, onDragEnd} = dragHookOptions;
+  let {onDrop} = dropHookOptions;
+  let onDropAction = chain(action('onDrop'), onDrop);
 
   let list = useListData({
     initialItems: [
@@ -755,8 +762,8 @@ export function DragIntoItemExample(props) {
         };
       });
     },
-    onDragStart: action('dragStart'),
-    onDragEnd: action('dragEnd')
+    onDragStart: chain(action('dragStart'), onDragStart),
+    onDragEnd: chain(action('dragEnd'), onDragEnd)
   });
 
   let dropHooks = useDropHooks({
@@ -801,7 +808,7 @@ export function DragIntoItemExample(props) {
       disabledKeys={['2']}
       dragHooks={dragHooks}
       dropHooks={dropHooks}
-      {...props}>
+      {...listViewProps}>
       {(item: any) => (
         <Item textValue={item.textValue} hasChildItems={item.type === 'folder'}>
           <Text>{item.type === 'folder' ? 'Drop items here' : `Item ${item.textValue}`}</Text>

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1871,7 +1871,7 @@ describe('ListView', function () {
       expect(document.activeElement).toBe(droppable);
       fireEvent.keyDown(droppable, {key: 'Enter'});
       fireEvent.keyUp(droppable, {key: 'Enter'});
-      await act(async () => jest.runAllTimers());
+      await act(async () => Promise.resolve());
       act(() => jest.runAllTimers());
 
       expect(onDrop).toHaveBeenCalledTimes(1);

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1922,7 +1922,7 @@ describe('ListView', function () {
     });
 
     describe('accessibility', function () {
-      it('drag handle should reflect the correct number of draggable rows', async function () {
+      it('drag handle should reflect the correct number of draggable rows', function () {
 
         let {getAllByRole} = render(
           <DraggableListView listViewProps={{defaultSelectedKeys: ['a', 'b', 'c']}} />

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1957,6 +1957,14 @@ describe('ListView', function () {
       expect(secondListRows[6]).toBe(document.activeElement);
       expect(secondListRows[6]).toHaveTextContent('Item One');
 
+      for (let [index, row] of secondListRows.entries()) {
+        if (index !== 6) {
+          expect(row).toHaveAttribute('tabIndex', '-1');
+        } else {
+          expect(row).toHaveAttribute('tabIndex', '0');
+        }
+      }
+
       draggedCell = firstListRows[3];
       dataTransfer = new DataTransfer();
       fireEvent.pointerDown(draggedCell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -1984,6 +1992,14 @@ describe('ListView', function () {
       // The 2nd newly added row in the second list should still be the active element
       expect(secondListRows[7]).toBe(document.activeElement);
       expect(secondListRows[7]).toHaveTextContent('Item Five');
+
+      for (let [index, row] of secondListRows.entries()) {
+        if (index !== 7) {
+          expect(row).toHaveAttribute('tabIndex', '-1');
+        } else {
+          expect(row).toHaveAttribute('tabIndex', '0');
+        }
+      }
     });
 
     describe('accessibility', function () {

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1872,7 +1872,7 @@ describe('ListView', function () {
       fireEvent.keyDown(droppable, {key: 'Enter'});
       fireEvent.keyUp(droppable, {key: 'Enter'});
       await act(async () => jest.runAllTimers());
-      await act(async () => jest.runAllTimers());
+      act(() => jest.runAllTimers());
 
       expect(onDrop).toHaveBeenCalledTimes(1);
       expect(await onDrop.mock.calls[0][0].items).toHaveLength(3);
@@ -1903,8 +1903,7 @@ describe('ListView', function () {
       moveFocus('ArrowRight');
       fireEvent.keyDown(draghandle, {key: 'Enter'});
       fireEvent.keyUp(draghandle, {key: 'Enter'});
-      await act(async () => jest.runAllTimers());
-      await act(async () => jest.runAllTimers());
+      act(() => jest.runAllTimers());
 
       expect(onDragStart).toHaveBeenCalledTimes(1);
       expect(onDragStart).toHaveBeenCalledWith({

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1831,7 +1831,7 @@ describe('ListView', function () {
       expect(onSelectionChange).toHaveBeenCalledTimes(0);
     });
 
-    it.skip('should only count the selected keys that exist in the collection when dragging and dropping', async function () {
+    it('should only count the selected keys that exist in the collection when dragging and dropping', async function () {
       let {getAllByRole} = render(
         <DragIntoItemExample dragHookOptions={{onDragStart, onDragEnd}} listViewProps={{onSelectionChange, disabledKeys: []}} dropHookOptions={{onDrop}} />
       );
@@ -1867,13 +1867,12 @@ describe('ListView', function () {
         y: 25
       });
 
-      await act(() => jest.runAllTimers());
+      act(() => jest.runAllTimers());
       expect(document.activeElement).toBe(droppable);
-      await act(async () => {
-        fireEvent.keyDown(droppable, {key: 'Enter'});
-        fireEvent.keyUp(droppable, {key: 'Enter'});
-      });
-      await act(() => jest.runAllTimers());
+      fireEvent.keyDown(droppable, {key: 'Enter'});
+      fireEvent.keyUp(droppable, {key: 'Enter'});
+      await act(async () => jest.runAllTimers());
+      await act(async () => jest.runAllTimers());
 
       expect(onDrop).toHaveBeenCalledTimes(1);
       expect(await onDrop.mock.calls[0][0].items).toHaveLength(3);
@@ -1887,6 +1886,7 @@ describe('ListView', function () {
       });
       onSelectionChange.mockClear();
       onDragStart.mockClear();
+
       rows = getAllByRole('row');
       expect(rows).toHaveLength(4);
 
@@ -1901,11 +1901,10 @@ describe('ListView', function () {
       expect(draghandle).toBeTruthy();
       expect(draghandle).toHaveAttribute('draggable', 'true');
       moveFocus('ArrowRight');
-      await act(async () => {
-        fireEvent.keyDown(draghandle, {key: 'Enter'});
-        fireEvent.keyUp(draghandle, {key: 'Enter'});
-      });
-      await act(() => jest.runAllTimers());
+      fireEvent.keyDown(draghandle, {key: 'Enter'});
+      fireEvent.keyUp(draghandle, {key: 'Enter'});
+      await act(async () => jest.runAllTimers());
+      await act(async () => jest.runAllTimers());
 
       expect(onDragStart).toHaveBeenCalledTimes(1);
       expect(onDragStart).toHaveBeenCalledWith({
@@ -1957,7 +1956,7 @@ describe('ListView', function () {
 
       // The newly added row in the second list should be the active element
       expect(secondListRows[6]).toBe(document.activeElement);
-      // expect(secondListRows[6]).toHaveTextContent('Item One');
+      expect(secondListRows[6]).toHaveTextContent('Item One');
 
       draggedCell = firstListRows[3];
       dataTransfer = new DataTransfer();
@@ -1985,7 +1984,7 @@ describe('ListView', function () {
 
       // The 2nd newly added row in the second list should still be the active element
       expect(secondListRows[7]).toBe(document.activeElement);
-      // expect(secondListRows[7]).toHaveTextContent('Item Five');
+      expect(secondListRows[7]).toHaveTextContent('Item Five');
     });
 
     describe('accessibility', function () {

--- a/packages/@react-stately/dnd/src/useDraggableCollectionState.ts
+++ b/packages/@react-stately/dnd/src/useDraggableCollectionState.ts
@@ -52,7 +52,7 @@ export function useDraggableCollectionState(props: DraggableCollectionOptions): 
     // item is dragged. This matches native macOS behavior.
     let keys = new Set(
       selectionManager.isSelected(key)
-        ? new Set([...selectionManager.selectedKeys])
+        ? new Set([...selectionManager.selectedKeys].filter(key => !!collection.getItem(key)))
         : []
     );
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Fixes the following bugs:
- disabled rows are focusable when swiping left/right during a drag session
- drag into folder story: dropping items into the folder and then dragging the folder itself reflects the incorrect number of dragged items

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

In https://reactspectrum.blob.core.windows.net/reactspectrum/f8982cb86e88a39851a081bca7ba4f1767fb105f/storybook/index.html?path=/story/listview-drag-and-drop--drag-between-lists&providerSwitcher-toastPosition=bottom:
1. Focus an item in the second list
2. Drag a item from the first list to the second list via your mouse/touch
3. After the insert, focus should be on the newly inserted item

In https://reactspectrum.blob.core.windows.net/reactspectrum/f8982cb86e88a39851a081bca7ba4f1767fb105f/storybook/index.html?path=/story/listview-drag-and-drop--drag-into-folder&providerSwitcher-toastPosition=bottom
1. Select and drag two items into the folder
2. Select the folder and drag it. The drag indicator shouldn't say 3 items are dragged

In https://reactspectrum.blob.core.windows.net/reactspectrum/f8982cb86e88a39851a081bca7ba4f1767fb105f/storybook/index.html?path=/story/listview-drag-and-drop--drag-between-lists&providerSwitcher-toastPosition=bottom
1. Using a mobile device, activate the screen reader and begin a drag operation via the drag handle on a row
2. Go to the first list and swipe through the drop targets. The disabled row shouldn't be a droppable target and should be skipped entirely when swiping 
## 🧢 Your Project:

RSP