### PR TITLE
Changed justify-content: end to flex-end & start to flex-start for better Browser Support

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -97,7 +97,7 @@ svg.spectrum-Table-sortedIcon {
 
 .spectrum-Table-columnResizer {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   box-sizing: border-box;
   position: absolute;
   inset-block-start: 0px;

--- a/packages/@react-spectrum/table/src/table.css
+++ b/packages/@react-spectrum/table/src/table.css
@@ -29,7 +29,7 @@
 
 .react-spectrum-Table-cell--alignStart {
   text-align: start;
-  justify-content: start;
+  justify-content: flex-start;
 }
 
 .react-spectrum-Table-cell--alignCenter {


### PR DESCRIPTION
Same fix like #2695 for Table Component for better Browser Support and to eliminate eslint errors.

https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
>### flex-start
>The items are packed flush to each other toward the edge of the alignment container depending on the flex container's main-start side. This only applies to flex layout items. **For items that are not children of a flex container, this value is treated like start.**

>### flex-end
>The items are packed flush to each other toward the edge of the alignment container depending on the flex container's main-end side. This only applies to flex layout items. **For items that are not children of a flex container, this value is treated like end.**

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
