### PR TITLE
DnD: Re-focus dropped item after dropping

### DIFF
--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -463,11 +463,9 @@ class DragSession {
       });
     }
 
-    // Blur and re-focus the drop target so that the focus ring appears.
-    if (this.currentDropTarget) {
-      this.currentDropTarget.element.blur();
-      this.currentDropTarget.element.focus();
-    }
+    // Blur and re-focus the drag target so that the focus ring appears.
+    this.dragTarget.element.blur();
+    this.dragTarget.element.focus();
 
     this.setCurrentDropTarget(null);
     endDragging();

--- a/packages/@react-aria/dnd/test/dnd.test.js
+++ b/packages/@react-aria/dnd/test/dnd.test.js
@@ -1228,7 +1228,7 @@ describe('useDrag and useDrop', function () {
       fireEvent.keyDown(droppable2, {key: 'Enter'});
       fireEvent.keyUp(droppable2, {key: 'Enter'});
 
-      expect(document.activeElement).toBe(droppable2);
+      expect(document.activeElement).toBe(draggable);
       expect(droppable).not.toHaveAttribute('aria-describedby');
       expect(droppable2).not.toHaveAttribute('aria-describedby');
 
@@ -1538,7 +1538,7 @@ describe('useDrag and useDrop', function () {
         fireEvent.keyDown(droppable, {key: 'Escape'});
         fireEvent.keyUp(droppable, {key: 'Escape'});
         expect(droppable).toHaveAttribute('data-droptarget', 'false');
-        expect(document.activeElement).toBe(droppable);
+        expect(document.activeElement).toBe(draggable);
       });
     });
 
@@ -1961,7 +1961,7 @@ describe('useDrag and useDrop', function () {
 
       fireEvent.click(droppable2);
 
-      expect(document.activeElement).toBe(droppable2);
+      expect(document.activeElement).toBe(draggable);
       expect(droppable).not.toHaveAttribute('aria-describedby');
       expect(droppable2).not.toHaveAttribute('aria-describedby');
 

--- a/packages/@react-aria/dnd/test/useDroppableCollection.test.js
+++ b/packages/@react-aria/dnd/test/useDroppableCollection.test.js
@@ -402,8 +402,8 @@ describe('useDroppableCollection', () => {
       expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('hello world');
 
       act(() => jest.advanceTimersByTime(50));
-      expect(document.activeElement).toBe(cells[1]);
-      expect(cells[1].parentElement).toHaveAttribute('aria-selected', 'true');
+      expect(document.activeElement).toBe(draggable);
+      expect(cells[1].parentElement).toHaveAttribute('aria-selected', 'false');
     });
 
     it('should support arrow key navigation', () => {
@@ -1079,8 +1079,8 @@ describe('useDroppableCollection', () => {
       expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('hello world');
 
       act(() => jest.advanceTimersByTime(50));
-      expect(document.activeElement).toBe(cells[1]);
-      expect(cells[1].parentElement).toHaveAttribute('aria-selected', 'true');
+      expect(document.activeElement).toBe(draggable);
+      expect(cells[1].parentElement).toHaveAttribute('aria-selected', 'false');
     });
 
     it('should add descriptions to each item', () => {


### PR DESCRIPTION
Putting this in its own PR because I think it's still a bit up in there air if this is what we want.

The issue observed: 

>  Drag within list (Reorder) Focus appears to be lost when keyboard drag and dropping. Visual focus is not shown.

So currently, after dropping, focus goes to the drop target (the list itself), where there is no visual indicator of focus. This solution would instead re-focus the element that was dropped, after it is dropped.

The other option would be to leave it as is, and in the ListView case, we would get a visual focus indicator on the list after drop via https://github.com/adobe/react-spectrum/pull/3168

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
