### PR TITLE
DnD: announce first drop target after drag start announcement

### DIFF
--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -157,6 +157,7 @@ class DragSession {
   private restoreAriaHidden: () => void;
   private formatMessage: (key: string) => string;
   private isVirtualClick: boolean;
+  private initialFocused: boolean;
 
   constructor(target: DragTarget, formatMessage: (key: string) => string) {
     this.dragTarget = target;
@@ -168,6 +169,7 @@ class DragSession {
     this.onClick = this.onClick.bind(this);
     this.onPointerDown = this.onPointerDown.bind(this);
     this.cancelEvent = this.cancelEvent.bind(this);
+    this.initialFocused = false;
   }
 
   setup() {
@@ -446,6 +448,13 @@ class DragSession {
 
       item?.element.focus();
       this.currentDropItem = item;
+
+      // Annouce first drop target after drag start announcement finishes.
+      // Otherwise, it will never get announced because drag start announcement is assertive.
+      if (!this.initialFocused) {
+        announce(item?.element.getAttribute('aria-label'), 'polite');
+        this.initialFocused = true;
+      }
     }
   }
 


### PR DESCRIPTION
Because there is an assertive live announcement made when a drag session starts, the first drop target never gets announced.

This is a method for announcing the first drop target after the drag session start announcement finishes.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

In the ListView -> Drag and Drop -> Reorder story, initiate a drag session via keyboard. After VO reads `Started dragging. Press Tab to navigate to a drop target, then press Enter to drop, or press Escape to cancel.`, it should then read `Insert Item X between Item X and Item X`, if focus is kept on that initial drop target.

## 🧢 Your Project:

<!--- Company/project for pull request -->
