### PR TITLE
Allow entering era in date picker by typing

### DIFF
--- a/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
@@ -119,14 +119,14 @@ export class JapaneseCalendar extends GregorianCalendar {
           date.day = Math.min(endDay, date.day);
         }
       }
+    }
 
-      if (date.year === 1) {
-        let [, startMonth, startDay] = ERA_START_DATES[idx];
-        date.month = Math.max(startMonth, date.month);
+    if (date.year === 1 && idx >= 0) {
+      let [, startMonth, startDay] = ERA_START_DATES[idx];
+      date.month = Math.max(startMonth, date.month);
 
-        if (date.month === startMonth) {
-          date.day = Math.max(startDay, date.day);
-        }
+      if (date.month === startMonth) {
+        date.day = Math.max(startDay, date.day);
       }
     }
   }

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -474,6 +474,9 @@ describe('CalendarDate manipulation', function () {
 
         date = new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 30);
         expect(date.set({day: 5})).toEqual(new CalendarDate(new JapaneseCalendar(), 'showa', 1, 12, 25));
+
+        date = new CalendarDate(new JapaneseCalendar(), 'reiwa', 1, 12, 30);
+        expect(date.set({year: 1, month: 1, day: 1})).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 1, 5, 1));
       });
     });
 

--- a/packages/@react-aria/calendar/src/utils.ts
+++ b/packages/@react-aria/calendar/src/utils.ts
@@ -26,12 +26,8 @@ interface HookData {
 
 export const hookData = new WeakMap<CalendarState | RangeCalendarState, HookData>();
 
-export function getEraFormat(date: CalendarDate) {
-  if (date?.calendar.identifier !== 'gregory') {
-    return 'long';
-  } else if (date?.era === 'BC') {
-    return 'short';
-  }
+export function getEraFormat(date: CalendarDate): 'short' | undefined {
+  return date?.calendar.identifier === 'gregory' && date.era === 'BC' ? 'short' : undefined;
 }
 
 export function useSelectedDateDescription(state: CalendarState | RangeCalendarState) {

--- a/packages/@react-aria/datepicker/package.json
+++ b/packages/@react-aria/datepicker/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@internationalized/date": "3.0.0-rc.1",
     "@internationalized/message": "^3.0.7",
     "@internationalized/number": "^3.1.1",
     "@react-aria/focus": "^3.6.0",

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -145,8 +145,12 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
   }, [amPmFormatter]);
 
   // Get a list of formatted era names so users can type the first character to choose one.
-  let eraFormatter = useDateFormatter({era: 'narrow', timeZone: 'UTC'});
+  let eraFormatter = useDateFormatter({year: 'numeric', era: 'narrow', timeZone: 'UTC'});
   let eras = useMemo(() => {
+    if (segment.type !== 'era') {
+      return [];
+    }
+
     let date = toCalendar(new CalendarDate(1, 1, 1), state.calendar);
     let eras = state.calendar.getEras().map(era => {
       let eraDate = date.set({year: 1, month: 1, day: 1, era}).toDate('UTC');
@@ -166,7 +170,7 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
     }
 
     return eras;
-  }, [eraFormatter, state.calendar]);
+  }, [eraFormatter, state.calendar, segment.type]);
 
   let onInput = (key: string) => {
     if (state.isDisabled || state.isReadOnly) {

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {CalendarDate, toCalendar} from '@internationalized/date';
 import {DateFieldState, DateSegment} from '@react-stately/datepicker';
 import {getScrollParent, isIOS, isMac, mergeProps, scrollIntoView, useEvent, useId, useLabels} from '@react-aria/utils';
 import {hookData} from './useDateField';
@@ -143,6 +144,30 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
     return amPmFormatter.formatToParts(date).find(part => part.type === 'dayPeriod').value;
   }, [amPmFormatter]);
 
+  // Get a list of formatted era names so users can type the first character to choose one.
+  let eraFormatter = useDateFormatter({era: 'narrow', timeZone: 'UTC'});
+  let eras = useMemo(() => {
+    let date = toCalendar(new CalendarDate(1, 1, 1), state.calendar);
+    let eras = state.calendar.getEras().map(era => {
+      let eraDate = date.set({year: 1, month: 1, day: 1, era}).toDate('UTC');
+      let parts = eraFormatter.formatToParts(eraDate);
+      let formatted = parts.find(p => p.type === 'era').value;
+      return {era, formatted};
+    });
+
+    // Remove the common prefix from formatted values. This is so that in calendars with eras like
+    // ERA0 and ERA1 (e.g. Ethiopic), users can press "0" and "1" to select an era. In other cases,
+    // the first letter is used.
+    let prefixLength = commonPrefixLength(eras.map(era => era.formatted));
+    if (prefixLength) {
+      for (let era of eras) {
+        era.formatted = era.formatted.slice(prefixLength);
+      }
+    }
+
+    return eras;
+  }, [eraFormatter, state.calendar]);
+
   let onInput = (key: string) => {
     if (state.isDisabled || state.isReadOnly) {
       return;
@@ -161,6 +186,14 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
         }
         focusManager.focusNext();
         break;
+      case 'era': {
+        let matched = eras.find(e => startsWith(e.formatted, key));
+        if (matched) {
+          state.setSegment('era', matched.era);
+          focusManager.focusNext();
+        }
+        break;
+      }
       case 'day':
       case 'hour':
       case 'minute':
@@ -334,7 +367,7 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
       autoCorrect: isEditable ? 'off' : undefined,
       // Capitalization was changed in React 17...
       [parseInt(React.version, 10) >= 17 ? 'enterKeyHint' : 'enterkeyhint']: isEditable ? 'next' : undefined,
-      inputMode: state.isDisabled || segment.type === 'dayPeriod' || !isEditable ? undefined : 'numeric',
+      inputMode: state.isDisabled || segment.type === 'dayPeriod' || segment.type === 'era' || !isEditable ? undefined : 'numeric',
       tabIndex: state.isDisabled ? undefined : 0,
       onKeyDown,
       onFocus,
@@ -352,4 +385,17 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
       }
     })
   };
+}
+
+function commonPrefixLength(strings: string[]): number {
+  // Sort the strings, and compare the characters in the first and last to find the common prefix.
+  strings.sort();
+  let first = strings[0];
+  let last = strings[strings.length - 1];
+  for (let i = 0; i < first.length; i++) {
+    if (first[i] !== last[i]) {
+      return i;
+    }
+  }
+  return 0;
 }

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -51,16 +51,10 @@ export function CalendarBase<T extends CalendarState | RangeCalendarState>(props
   let formatMessage = useMessageFormatter(intlMessages);
   let {direction} = useLocale();
   let currentMonth = state.visibleRange.start;
-  let era = undefined;
-  if (currentMonth.calendar.identifier !== 'gregory') {
-    era = 'long';
-  } else if (currentMonth.era === 'BC') {
-    era = 'short';
-  }
   let monthDateFormatter = useDateFormatter({
     month: 'long',
     year: 'numeric',
-    era,
+    era: currentMonth.calendar.identifier === 'gregory' && currentMonth.era === 'BC' ? 'short' : undefined,
     calendar: currentMonth.calendar.identifier,
     timeZone: state.timeZone
   });

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -11,7 +11,7 @@
  */
 
 import {act, fireEvent, render as render_, within} from '@testing-library/react';
-import {CalendarDate, CalendarDateTime, getLocalTimeZone, toCalendarDateTime, today} from '@internationalized/date';
+import {CalendarDate, CalendarDateTime, EthiopicCalendar, getLocalTimeZone, JapaneseCalendar, toCalendarDateTime, today} from '@internationalized/date';
 import {DatePicker} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -880,7 +880,12 @@ describe('DatePicker', function () {
       function testInput(label, value, keys, newValue, moved, props) {
         let onChange = jest.fn();
         // Test controlled mode
-        let {getByLabelText, getAllByRole, unmount} = render(<DatePicker label="Date" value={value} onChange={onChange} {...props} />);
+        let {getByLabelText, getAllByRole, unmount} = render(
+          <Provider theme={theme} locale={props?.locale}>
+            <DatePicker label="Date" value={value} onChange={onChange} {...props} />
+          </Provider>
+        );
+
         let segment = getByLabelText(label);
         let textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -914,7 +919,11 @@ describe('DatePicker', function () {
 
         // Test uncontrolled mode
         onChange = jest.fn();
-        ({getByLabelText, getAllByRole, unmount} = render(<DatePicker label="Date" defaultValue={value} onChange={onChange} {...props} />));
+        ({getByLabelText, getAllByRole, unmount} = render(
+          <Provider theme={theme} locale={props?.locale}>
+            <DatePicker label="Date" defaultValue={value} onChange={onChange} {...props} />
+          </Provider>
+        ));
         segment = getByLabelText(label);
         textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -947,7 +956,11 @@ describe('DatePicker', function () {
 
         // Test read only mode
         onChange = jest.fn();
-        ({getByLabelText, getAllByRole, unmount} = render(<DatePicker label="Date" defaultValue={value} isReadOnly onChange={onChange} {...props} />));
+        ({getByLabelText, getAllByRole, unmount} = render(
+          <Provider theme={theme} locale={props?.locale}>
+            <DatePicker label="Date" defaultValue={value} isReadOnly onChange={onChange} {...props} />
+          </Provider>
+        ));
         segment = getByLabelText(label);
         textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -1064,6 +1077,14 @@ describe('DatePicker', function () {
 
       it('should support entering arabic digits', function () {
         testInput('year', new CalendarDate(2019, 2, 3), '٢٠٢٤', new CalendarDate(2024, 2, 3), false);
+      });
+
+      it('should support typing into the era segment', function () {
+        testInput('era', new CalendarDate(new JapaneseCalendar(), 'reiwa', 5, 2, 3), 'h', new CalendarDate(new JapaneseCalendar(), 'heisei', 5, 2, 3), false, {locale: 'en-US-u-ca-japanese'});
+        testInput('era', new CalendarDate(new JapaneseCalendar(), 'reiwa', 5, 2, 3), 's', new CalendarDate(new JapaneseCalendar(), 'showa', 5, 2, 3), false, {locale: 'en-US-u-ca-japanese'});
+        testInput('era', new CalendarDate(new JapaneseCalendar(), 'showa', 5, 2, 3), 'r', new CalendarDate(new JapaneseCalendar(), 'reiwa', 5, 2, 3), false, {locale: 'en-US-u-ca-japanese'});
+        testInput('era', new CalendarDate(new EthiopicCalendar(), 'AM', 2012, 2, 3), '0', new CalendarDate(new EthiopicCalendar(), 'AA', 2012, 2, 3), false, {locale: 'en-US-u-ca-ethiopic'});
+        testInput('era', new CalendarDate(new EthiopicCalendar(), 'AA', 2012, 2, 3), '1', new CalendarDate(new EthiopicCalendar(), 'AM', 2012, 2, 3), false, {locale: 'en-US-u-ca-ethiopic'});
       });
     });
 

--- a/packages/@react-stately/datepicker/src/useDateFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDateFieldState.ts
@@ -43,6 +43,8 @@ export interface DateFieldState {
   value: DateValue,
   /** The current value, converted to a native JavaScript `Date` object.  */
   dateValue: Date,
+  /** The calendar system currently in use. */
+  calendar: Calendar,
   /** Sets the field's value. */
   setValue(value: DateValue): void,
   /** A list of segments for the current value. */
@@ -78,6 +80,7 @@ export interface DateFieldState {
    */
   decrementPage(type: SegmentType): void,
   /** Sets the value of the given segment. */
+  setSegment(type: 'era', value: string): void,
   setSegment(type: SegmentType, value: number): void,
   /** Updates the remaining unfilled segments with the placeholder value. */
   confirmPlaceholder(): void,
@@ -291,6 +294,7 @@ export function useDateFieldState(props: DateFieldStateOptions): DateFieldState 
   return {
     value: calendarValue,
     dateValue,
+    calendar,
     setValue,
     segments,
     dateFormatter,
@@ -468,6 +472,7 @@ function setSegment(value: DateValue, part: string, segmentValue: number, option
     case 'day':
     case 'month':
     case 'year':
+    case 'era':
       return value.set({[part]: segmentValue});
   }
 

--- a/packages/dev/parcel-transformer-docs/DocsTransformer.js
+++ b/packages/dev/parcel-transformer-docs/DocsTransformer.js
@@ -293,6 +293,10 @@ module.exports = new Transformer({
         for (let propertyPath of path.get('body.body')) {
           let property = processExport(propertyPath);
           if (property) {
+            let prev = properties[property.name];
+            if (!property.description && prev?.description) {
+              property.description = prev.description;
+            }
             properties[property.name] = property;
           } else {
             console.log('UNKNOWN PROPERTY interface declaration', propertyPath.node);


### PR DESCRIPTION
Depends on #3167.

This adds support for entering an era in DatePicker by typing the first letter. This enables users of mobile devices to select an era when up and down arrow keys are not available.