### PR TITLE
Update year limits for all calendars to match 9999 gregorian

### DIFF
--- a/packages/@internationalized/date/src/calendars/EthiopicCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/EthiopicCalendar.ts
@@ -38,7 +38,6 @@ function julianDayToCE(calendar: Calendar, epoch: number, jd: number): Mutable<C
   let year = Math.floor((4 * (jd - epoch)) / 1461);
   let month = 1 + Math.floor((jd - ceToJulianDay(epoch, year, 1, 1)) / 30);
   let day = jd + 1 - ceToJulianDay(epoch, year, month, 1);
-
   return new CalendarDate(calendar, year, month, day);
 }
 
@@ -91,12 +90,7 @@ export class EthiopicCalendar implements Calendar {
   }
 
   getDaysInMonth(date: AnyCalendarDate): number {
-    let year = date.year;
-    if (date.era === 'AA') {
-      year -= AMETE_MIHRET_DELTA;
-    }
-
-    return getDaysInMonth(year, date.month);
+    return getDaysInMonth(date.year, date.month);
   }
 
   getMonthsInYear(): number {
@@ -107,8 +101,11 @@ export class EthiopicCalendar implements Calendar {
     return 365 + getLeapDay(date.year);
   }
 
-  getYearsInEra(): number {
-    return 9999;
+  getYearsInEra(date: AnyCalendarDate): number {
+    // 9999-12-31 gregorian is 9992-20-02 ethiopic.
+    // Round down to 9991 for the last full year.
+    // AA 9999-01-01 ethiopic is 4506-09-30 gregorian.
+    return date.era === 'AA' ? 9999 : 9991;
   }
 
   getEras() {
@@ -132,6 +129,11 @@ export class EthiopicAmeteAlemCalendar extends EthiopicCalendar {
 
   getEras() {
     return ['AA'];
+  }
+
+  getYearsInEra(): number {
+    // 9999-13-04 ethioaa is the maximum date, which is equivalent to 4506-09-29 gregorian.
+    return 9999;
   }
 }
 
@@ -186,5 +188,12 @@ export class CopticCalendar extends EthiopicCalendar {
 
   getEras() {
     return ['BCE', 'CE'];
+  }
+
+  getYearsInEra(date: AnyCalendarDate): number {
+    // 9999-12-30 gregorian is 9716-02-20 coptic.
+    // Round down to 9715 for the last full year.
+    // BCE 9999-01-01 coptic is BC 9716-06-15 gregorian.
+    return date.era === 'BCE' ? 9999 : 9715;
   }
 }

--- a/packages/@internationalized/date/src/calendars/HebrewCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/HebrewCalendar.ts
@@ -181,6 +181,7 @@ export class HebrewCalendar implements Calendar {
   }
 
   getYearsInEra(): number {
+    // 6239 gregorian
     return 9999;
   }
 

--- a/packages/@internationalized/date/src/calendars/IndianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/IndianCalendar.ts
@@ -116,7 +116,9 @@ export class IndianCalendar extends GregorianCalendar {
   }
 
   getYearsInEra(): number {
-    return 9999;
+    // 9999-12-31 gregorian is 9920-10-10 indian.
+    // Round down to 9919 for the last full year.
+    return 9919;
   }
 
   getEras() {

--- a/packages/@internationalized/date/src/calendars/IslamicCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/IslamicCalendar.ts
@@ -78,7 +78,8 @@ export class IslamicCivilCalendar implements Calendar {
   }
 
   getYearsInEra(): number {
-    return 9999;
+    // 9999 gregorian
+    return 9665;
   }
 
   getEras() {

--- a/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/JapaneseCalendar.ts
@@ -138,12 +138,13 @@ export class JapaneseCalendar extends GregorianCalendar {
   getYearsInEra(date: AnyCalendarDate): number {
     // Get the number of years in the era, taking into account the date's month and day fields.
     let era = ERA_NAMES.indexOf(date.era);
+    let cur = ERA_START_DATES[era];
     let next = ERA_START_DATES[era + 1];
     if (next == null) {
-      return 9999;
+      // 9999 gregorian is the maximum year allowed.
+      return 9999 - cur[0] + 1;
     }
 
-    let cur = ERA_START_DATES[era];
     let years = next[0] - cur[0];
 
     if (date.month < next[1] || (date.month === next[1] && date.day < next[2])) {

--- a/packages/@internationalized/date/src/calendars/PersianCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/PersianCalendar.ts
@@ -93,6 +93,8 @@ export class PersianCalendar implements Calendar {
   }
 
   getYearsInEra(): number {
-    return 9999;
+    // 9378-10-10 persian is 9999-12-31 gregorian.
+    // Round down to 9377 to set the maximum full year.
+    return 9377;
   }
 }

--- a/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/TaiwanCalendar.ts
@@ -71,6 +71,10 @@ export class TaiwanCalendar extends GregorianCalendar {
   getDaysInMonth(date: AnyCalendarDate): number {
     return super.getDaysInMonth(toGregorian(date));
   }
+
+  getYearsInEra(date: AnyCalendarDate): number {
+    return date.era === 'before_minguo' ? 9999 : 9999 - TAIWAN_ERA_START;
+  }
 }
 
 function toGregorian(date: AnyCalendarDate) {

--- a/packages/@internationalized/date/src/conversion.ts
+++ b/packages/@internationalized/date/src/conversion.ts
@@ -15,6 +15,7 @@
 
 import {AnyCalendarDate, AnyDateTime, AnyTime, Calendar, DateFields, Disambiguation, TimeFields} from './types';
 import {CalendarDate, CalendarDateTime, Time, ZonedDateTime} from './CalendarDate';
+import {constrain} from './manipulation';
 import {getExtendedYear, GregorianCalendar} from './calendars/GregorianCalendar';
 import {getLocalTimeZone} from './queries';
 import {Mutable} from './utils';
@@ -264,6 +265,7 @@ export function toCalendar<T extends AnyCalendarDate>(date: T, calendar: Calenda
   copy.year = calendarDate.year;
   copy.month = calendarDate.month;
   copy.day = calendarDate.day;
+  constrain(copy);
   return copy;
 }
 

--- a/packages/@internationalized/date/tests/conversion.test.js
+++ b/packages/@internationalized/date/tests/conversion.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {BuddhistCalendar, CalendarDate, CalendarDateTime, GregorianCalendar, HebrewCalendar, IndianCalendar, IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar, Time, toCalendar, toCalendarDate, toCalendarDateTime, toTime, ZonedDateTime} from '..';
+import {BuddhistCalendar, CalendarDate, CalendarDateTime, EthiopicAmeteAlemCalendar, GregorianCalendar, HebrewCalendar, IndianCalendar, IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar, Time, toCalendar, toCalendarDate, toCalendarDateTime, toTime, ZonedDateTime} from '..';
 import {fromAbsolute, possibleAbsolutes, toAbsolute, toDate} from '../src/conversion';
 
 describe('CalendarDate conversion', function () {
@@ -373,6 +373,18 @@ describe('CalendarDate conversion', function () {
       it('gregorian to hebrew in a leap year', function () {
         let date = new CalendarDate(2022, 2, 2);
         expect(toCalendar(date, new HebrewCalendar())).toEqual(new CalendarDate(new HebrewCalendar(), 5782, 6, 1));
+      });
+    });
+
+    describe('ethioaa', function () {
+      it('ethioaa to gregorian', function () {
+        let date = new CalendarDate(new EthiopicAmeteAlemCalendar(), 9999, 13, 5);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate(4507, 9, 29));
+      });
+
+      it('gregorian to ethioaa', function () {
+        let date = new CalendarDate(4507, 9, 29);
+        expect(toCalendar(date, new EthiopicAmeteAlemCalendar())).toEqual(new CalendarDate(new EthiopicAmeteAlemCalendar(), 9999, 13, 5));
       });
     });
   });

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {BuddhistCalendar, CalendarDate, CopticCalendar, HebrewCalendar, IndianCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar} from '..';
+import {BuddhistCalendar, CalendarDate, CopticCalendar, EthiopicAmeteAlemCalendar, EthiopicCalendar, HebrewCalendar, IndianCalendar, IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar} from '..';
 
 describe('CalendarDate manipulation', function () {
   describe('add', function () {
@@ -137,9 +137,9 @@ describe('CalendarDate manipulation', function () {
         expect(date.subtract({months: 1})).toEqual(new CalendarDate(new JapaneseCalendar(), 'meiji', 1, 9, 8));
       });
 
-      it('should contstrain when reaching 9999 reiwa', function () {
-        let date = new CalendarDate(new JapaneseCalendar(), 'reiwa', 9999, 12, 5);
-        expect(date.add({months: 1})).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 9999, 12, 31));
+      it('should constrain when reaching 7981 reiwa', function () {
+        let date = new CalendarDate(new JapaneseCalendar(), 'reiwa', 7981, 12, 5);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new JapaneseCalendar(), 'reiwa', 7981, 12, 31));
       });
     });
 
@@ -164,12 +164,12 @@ describe('CalendarDate manipulation', function () {
         expect(date.add({days: 1})).toEqual(new CalendarDate(new TaiwanCalendar(), 'minguo', 1, 1, 1));
       });
 
-      it('should constrain when reaching year 9999', function () {
-        let date = new CalendarDate(new TaiwanCalendar(), 9999, 12, 10);
-        expect(date.add({months: 1})).toEqual(new CalendarDate(new TaiwanCalendar(), 9999, 12, 31));
+      it('should constrain when reaching year 8088', function () {
+        let date = new CalendarDate(new TaiwanCalendar(), 8088, 12, 10);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new TaiwanCalendar(), 8088, 12, 31));
       });
 
-      it('should constrain when reaching year 9999 before minguo', function () {
+      it('should constrain when reaching year 8088 before minguo', function () {
         let date = new CalendarDate(new TaiwanCalendar(), 'before_minguo', 9999, 1, 10);
         expect(date.subtract({months: 1})).toEqual(new CalendarDate(new TaiwanCalendar(), 'before_minguo', 9999, 1, 1));
       });
@@ -214,9 +214,9 @@ describe('CalendarDate manipulation', function () {
         expect(date.subtract({months: 1})).toEqual(new CalendarDate(new IndianCalendar(), 1, 1, 1));
       });
 
-      it('should constrain when reaching year 9999', function () {
-        let date = new CalendarDate(new PersianCalendar(), 9999, 12, 10);
-        expect(date.add({months: 1})).toEqual(new CalendarDate(new PersianCalendar(), 9999, 12, 31));
+      it('should constrain when reaching year 9919', function () {
+        let date = new CalendarDate(new IndianCalendar(), 9919, 12, 10);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new IndianCalendar(), 9919, 12, 31));
       });
     });
 
@@ -226,9 +226,9 @@ describe('CalendarDate manipulation', function () {
         expect(date.subtract({months: 1})).toEqual(new CalendarDate(new PersianCalendar(), 1, 1, 1));
       });
 
-      it('should constrain when reaching year 9999', function () {
-        let date = new CalendarDate(new PersianCalendar(), 9999, 12, 10);
-        expect(date.add({months: 1})).toEqual(new CalendarDate(new PersianCalendar(), 9999, 12, 31));
+      it('should constrain when reaching year 9377', function () {
+        let date = new CalendarDate(new PersianCalendar(), 9377, 12, 10);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new PersianCalendar(), 9377, 12, 31));
       });
     });
 
@@ -253,6 +253,56 @@ describe('CalendarDate manipulation', function () {
       it('should rebalance era when adding', function () {
         let date = new CalendarDate(new CopticCalendar(), 'BCE', 1, 13, 5);
         expect(date.add({months: 1})).toEqual(new CalendarDate(new CopticCalendar(), 1, 1, 5));
+      });
+
+      it('should constrain when reaching year 9715 CE', function () {
+        let date = new CalendarDate(new CopticCalendar(), 9715, 13, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new CopticCalendar(), 9715, 13, 6));
+      });
+
+      it('should constrain when reaching year 9999 BCE', function () {
+        let date = new CalendarDate(new CopticCalendar(), 'BCE', 9999, 1, 5);
+        expect(date.subtract({months: 1})).toEqual(new CalendarDate(new CopticCalendar(), 'BCE', 9999, 1, 1));
+      });
+    });
+
+    describe('EthiopicCalendar', function () {
+      it('should constrain when reaching year 9991 AM', function () {
+        let date = new CalendarDate(new EthiopicCalendar(), 9991, 13, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new EthiopicCalendar(), 9991, 13, 6));
+      });
+
+      it('should constrain when reaching year 9999 AA', function () {
+        let date = new CalendarDate(new EthiopicCalendar(), 'AA', 9999, 13, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new EthiopicCalendar(), 'AA', 9999, 13, 6));
+      });
+    });
+
+    describe('EthiopicAmeteAlemCalendar', function () {
+      it('should constrain when reaching year 9999 AA', function () {
+        let date = new CalendarDate(new EthiopicAmeteAlemCalendar(), 'AA', 9999, 13, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new EthiopicAmeteAlemCalendar(), 'AA', 9999, 13, 6));
+      });
+    });
+
+    describe('IslamicCivilCalendar', function () {
+      it('should constrain when reaching year 9995', function () {
+        let date = new CalendarDate(new IslamicCivilCalendar(), 9995, 12, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new IslamicCivilCalendar(), 9995, 12, 30));
+      });
+    });
+
+    describe('IslamicTabularCalendar', function () {
+      it('should constrain when reaching year 9995', function () {
+        let date = new CalendarDate(new IslamicTabularCalendar(), 9995, 12, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new IslamicTabularCalendar(), 9995, 12, 30));
+      });
+    });
+
+    describe('IslamicUmalquraCalendar', function () {
+      it('should constrain when reaching year 9995', function () {
+        let date = new CalendarDate(new IslamicUmalquraCalendar(), 9995, 12, 2);
+        expect(date.add({months: 1})).toEqual(new CalendarDate(new IslamicUmalquraCalendar(), 9995, 12, 30));
       });
     });
   });


### PR DESCRIPTION
This fixes a bug found in testing related to #3149.

> default story - enter year 9999, change to japanese calendar
> it'll go to year 7981
> open the calendar and keyboard navigate to the cells
> press and hold down, it should eventually stop with the "next" button disabled, but this does not happen, instead it infinitely loops through the year 7981 (RS)

This was because we limit to 9999 in the Japanese calendar, but when calling onChange we convert to the Gregorian calendar and it gets clamped, thus making the effective maximum 7981 rather than 9999 Japanese.

I tried to remove the limits entirely, but this causes other issues, especially when hitting the actual maximum of the JS Date object. Instead, I've just changed the limits of each calendar so the maximum year is always 9999 _Gregorian_ regardless of the actual calendar.