### PR TITLE
Shift focus when era is removed while focused in DatePicker

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -11,7 +11,7 @@
  */
 
 import {DateFieldState, DateSegment} from '@react-stately/datepicker';
-import {getScrollParent, isIOS, isMac, mergeProps, scrollIntoView, useEvent, useId, useLabels} from '@react-aria/utils';
+import {getScrollParent, isIOS, isMac, mergeProps, scrollIntoView, useEvent, useId, useLabels, useLayoutEffect} from '@react-aria/utils';
 import {hookData} from './useDateField';
 import {NumberParser} from '@internationalized/number';
 import React, {HTMLAttributes, RefObject, useMemo, useRef} from 'react';
@@ -281,6 +281,19 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
   useEvent(ref, 'selectstart', e => {
     e.preventDefault();
   });
+
+  useLayoutEffect(() => {
+    let element = ref.current;
+    return () => {
+      // If the focused segment is removed, focus the previous one, or the next one if there was no previous one.
+      if (document.activeElement === element) {
+        let prev = focusManager.focusPrevious();
+        if (!prev) {
+          focusManager.focusNext();
+        }
+      }
+    };
+  }, [ref, focusManager]);
 
   // spinbuttons cannot be focused with VoiceOver on iOS.
   let touchPropOverrides = isIOS() || segment.type === 'timeZoneName' ? {

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -514,6 +514,9 @@ export function createFocusManager(ref: RefObject<HTMLElement>, defaultOptions: 
   return {
     focusNext(opts: FocusManagerOptions = {}) {
       let root = ref.current;
+      if (!root) {
+        return;
+      }
       let {from, tabbable = defaultOptions.tabbable, wrap = defaultOptions.wrap, accept = defaultOptions.accept} = opts;
       let node = from || document.activeElement;
       let walker = getFocusableTreeWalker(root, {tabbable, accept});
@@ -532,6 +535,9 @@ export function createFocusManager(ref: RefObject<HTMLElement>, defaultOptions: 
     },
     focusPrevious(opts: FocusManagerOptions = defaultOptions) {
       let root = ref.current;
+      if (!root) {
+        return;
+      }
       let {from, tabbable = defaultOptions.tabbable, wrap = defaultOptions.wrap, accept = defaultOptions.accept} = opts;
       let node = from || document.activeElement;
       let walker = getFocusableTreeWalker(root, {tabbable, accept});
@@ -556,6 +562,9 @@ export function createFocusManager(ref: RefObject<HTMLElement>, defaultOptions: 
     },
     focusFirst(opts = defaultOptions) {
       let root = ref.current;
+      if (!root) {
+        return;
+      }
       let {tabbable = defaultOptions.tabbable, accept = defaultOptions.accept} = opts;
       let walker = getFocusableTreeWalker(root, {tabbable, accept});
       let nextNode = walker.nextNode() as HTMLElement;
@@ -566,6 +575,9 @@ export function createFocusManager(ref: RefObject<HTMLElement>, defaultOptions: 
     },
     focusLast(opts = defaultOptions) {
       let root = ref.current;
+      if (!root) {
+        return;
+      }
       let {tabbable = defaultOptions.tabbable, accept = defaultOptions.accept} = opts;
       let walker = getFocusableTreeWalker(root, {tabbable, accept});
       let next = last(walker);

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -669,6 +669,49 @@ describe('DatePicker', function () {
       triggerPress(field);
       expect(segments[2]).toHaveFocus();
     });
+
+    it('should focus the previous segment when the era is removed', function () {
+      let {getByTestId, queryByTestId} = render(<DatePicker label="Date" defaultValue={new CalendarDate('BC', 2020, 2, 3)} />);
+      let field = getByTestId('date-field');
+      let era = getByTestId('era');
+      expect(era).toBe(field.lastChild);
+
+      act(() => era.focus());
+      fireEvent.keyDown(era, {key: 'ArrowUp'});
+      fireEvent.keyUp(era, {key: 'ArrowUp'});
+
+      expect(queryByTestId('era')).toBeNull();
+      expect(document.activeElement).toBe(field.lastChild);
+    });
+
+    it('should focus the next segment when the era is removed and is the first segment', function () {
+      let {getByTestId, queryByTestId} = render(
+        <Provider theme={theme} locale="lv-LV">
+          <DatePicker label="Date" defaultValue={new CalendarDate('BC', 2020, 2, 3)} />
+        </Provider>
+      );
+      let field = getByTestId('date-field');
+      let era = getByTestId('era');
+      expect(era).toBe(field.firstChild);
+
+      act(() => era.focus());
+      fireEvent.keyDown(era, {key: 'ArrowUp'});
+      fireEvent.keyUp(era, {key: 'ArrowUp'});
+
+      expect(queryByTestId('era')).toBeNull();
+      expect(document.activeElement).toBe(field.firstChild);
+    });
+
+    it('does not try to shift focus when the entire datepicker is unmounted while focused', function () {
+      let {rerender, getByTestId} = render(<DatePicker label="Date" defaultValue={new CalendarDate('BC', 2020, 2, 3)} />);
+      let era = getByTestId('era');
+
+      act(() => era.focus());
+
+      rerender(<div />);
+      expect(era).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(document.body);
+    });
   });
 
   describe('editing', function () {


### PR DESCRIPTION
Another small date picker bug found in testing: when pressing the up/down arrow on the BC era segment, it disappears and focus is lost. Now we shift focus to the previous or next segment (depending on the format). Try Latvian to have the era appear first.