### PR TITLE
Fix bugs with eras in DatePicker

### DIFF
--- a/packages/@internationalized/date/src/calendars/EthiopicCalendar.ts
+++ b/packages/@internationalized/date/src/calendars/EthiopicCalendar.ts
@@ -34,11 +34,11 @@ function ceToJulianDay(epoch: number, year: number, month: number, day: number):
   );
 }
 
-function julianDayToCE(calendar: Calendar, epoch: number, jd: number): Mutable<CalendarDate> {
+function julianDayToCE(epoch: number, jd: number) {
   let year = Math.floor((4 * (jd - epoch)) / 1461);
   let month = 1 + Math.floor((jd - ceToJulianDay(epoch, year, 1, 1)) / 30);
   let day = jd + 1 - ceToJulianDay(epoch, year, month, 1);
-  return new CalendarDate(calendar, year, month, day);
+  return [year, month, day];
 }
 
 function getLeapDay(year: number) {
@@ -69,15 +69,14 @@ export class EthiopicCalendar implements Calendar {
   identifier = 'ethiopic';
 
   fromJulianDay(jd: number): CalendarDate {
-    let date = julianDayToCE(this, ETHIOPIC_EPOCH, jd);
-    if (date.year > 0) {
-      date.era = 'AM';
-    } else {
-      date.era = 'AA';
-      date.year += AMETE_MIHRET_DELTA;
+    let [year, month, day] = julianDayToCE(ETHIOPIC_EPOCH, jd);
+    let era = 'AM';
+    if (year <= 0) {
+      era = 'AA';
+      year += AMETE_MIHRET_DELTA;
     }
 
-    return date as CalendarDate;
+    return new CalendarDate(this, era, year, month, day);
   }
 
   toJulianDay(date: AnyCalendarDate) {
@@ -121,10 +120,9 @@ export class EthiopicAmeteAlemCalendar extends EthiopicCalendar {
   identifier = 'ethioaa'; // also known as 'ethiopic-amete-alem' in ICU
 
   fromJulianDay(jd: number): CalendarDate {
-    let date = julianDayToCE(this, ETHIOPIC_EPOCH, jd);
-    date.era = 'AA';
-    date.year += AMETE_MIHRET_DELTA;
-    return date as CalendarDate;
+    let [year, month, day] = julianDayToCE(ETHIOPIC_EPOCH, jd);
+    year += AMETE_MIHRET_DELTA;
+    return new CalendarDate(this, 'AA', year, month, day);
   }
 
   getEras() {
@@ -146,15 +144,14 @@ export class CopticCalendar extends EthiopicCalendar {
   identifier = 'coptic';
 
   fromJulianDay(jd: number): CalendarDate {
-    let date = julianDayToCE(this, COPTIC_EPOCH, jd);
-    if (date.year <= 0) {
-      date.era = 'BCE';
-      date.year = 1 - date.year;
-    } else {
-      date.era = 'CE';
+    let [year, month, day] = julianDayToCE(COPTIC_EPOCH, jd);
+    let era = 'CE';
+    if (year <= 0) {
+      era = 'BCE';
+      year = 1 - year;
     }
 
-    return date as CalendarDate;
+    return new CalendarDate(this, era, year, month, day);
   }
 
   toJulianDay(date: AnyCalendarDate) {

--- a/packages/@internationalized/date/tests/conversion.test.js
+++ b/packages/@internationalized/date/tests/conversion.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {BuddhistCalendar, CalendarDate, CalendarDateTime, EthiopicAmeteAlemCalendar, GregorianCalendar, HebrewCalendar, IndianCalendar, IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar, Time, toCalendar, toCalendarDate, toCalendarDateTime, toTime, ZonedDateTime} from '..';
+import {BuddhistCalendar, CalendarDate, CalendarDateTime, EthiopicAmeteAlemCalendar, EthiopicCalendar, GregorianCalendar, HebrewCalendar, IndianCalendar, IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar, Time, toCalendar, toCalendarDate, toCalendarDateTime, toTime, ZonedDateTime} from '..';
 import {fromAbsolute, possibleAbsolutes, toAbsolute, toDate} from '../src/conversion';
 
 describe('CalendarDate conversion', function () {
@@ -373,6 +373,27 @@ describe('CalendarDate conversion', function () {
       it('gregorian to hebrew in a leap year', function () {
         let date = new CalendarDate(2022, 2, 2);
         expect(toCalendar(date, new HebrewCalendar())).toEqual(new CalendarDate(new HebrewCalendar(), 5782, 6, 1));
+      });
+    });
+
+    describe('ethiopic', function () {
+      it('ethiopic to gregorian', function () {
+        let date = new CalendarDate(new EthiopicCalendar(), 'AA', 9999, 13, 5);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate(4507, 9, 29));
+
+        date = new CalendarDate(new EthiopicCalendar(), 'AM', 9991, 13, 5);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate(9999, 11, 9));
+      });
+
+      it('gregorian to ethioaa', function () {
+        let date = new CalendarDate(4507, 9, 29);
+        expect(toCalendar(date, new EthiopicCalendar())).toEqual(new CalendarDate(new EthiopicCalendar(), 'AM', 4499, 13, 5));
+
+        date = new CalendarDate(1, 9, 29);
+        expect(toCalendar(date, new EthiopicCalendar())).toEqual(new CalendarDate(new EthiopicCalendar(), 'AA', 5494, 2, 4));
+
+        date = new CalendarDate('BC', 1200, 9, 29);
+        expect(toCalendar(date, new EthiopicCalendar())).toEqual(new CalendarDate(new EthiopicCalendar(), 'AA', 4294, 2, 13));
       });
     });
 

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -720,7 +720,11 @@ describe('DatePicker', function () {
         let onChange = jest.fn();
 
         // Test controlled mode
-        let {getByLabelText, unmount} = render(<DatePicker label="Date" value={value} onChange={onChange} {...options.props} />);
+        let {getByLabelText, unmount} = render(
+          <Provider theme={theme} locale={options?.locale}>
+            <DatePicker label="Date" value={value} onChange={onChange} {...options.props} />
+          </Provider>
+        );
         let segment = getByLabelText(label);
         let textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -738,7 +742,11 @@ describe('DatePicker', function () {
 
         // Test uncontrolled mode (increment)
         onChange = jest.fn();
-        ({getByLabelText, unmount} = render(<DatePicker label="Date" defaultValue={value} onChange={onChange} {...options.props} />));
+        ({getByLabelText, unmount} = render(
+          <Provider theme={theme} locale={options?.locale}>
+            <DatePicker label="Date" defaultValue={value} onChange={onChange} {...options.props} />
+          </Provider>
+        ));
         segment = getByLabelText(label);
         textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -751,7 +759,11 @@ describe('DatePicker', function () {
 
         // Test uncontrolled mode (decrement)
         onChange = jest.fn();
-        ({getByLabelText, unmount} = render(<DatePicker label="Date" defaultValue={value} onChange={onChange} {...options.props} />));
+        ({getByLabelText, unmount} = render(
+          <Provider theme={theme} locale={options?.locale}>
+            <DatePicker label="Date" defaultValue={value} onChange={onChange} {...options.props} />
+          </Provider>
+          ));
         segment = getByLabelText(label);
         textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -764,7 +776,11 @@ describe('DatePicker', function () {
 
         // Test read only mode (increment)
         onChange = jest.fn();
-        ({getByLabelText, unmount} = render(<DatePicker label="Date" defaultValue={value} isReadOnly onChange={onChange} {...options.props} />));
+        ({getByLabelText, unmount} = render(
+          <Provider theme={theme} locale={options?.locale}>
+            <DatePicker label="Date" defaultValue={value} isReadOnly onChange={onChange} {...options.props} />
+          </Provider>
+        ));
         segment = getByLabelText(label);
         textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -776,7 +792,11 @@ describe('DatePicker', function () {
 
         // Test read only mode (decrement)
         onChange = jest.fn();
-        ({getByLabelText, unmount} = render(<DatePicker label="Date" defaultValue={value} isReadOnly onChange={onChange} {...options.props} />));
+        ({getByLabelText, unmount} = render(
+          <Provider theme={theme} locale={options?.locale}>
+            <DatePicker label="Date" defaultValue={value} isReadOnly onChange={onChange} {...options.props} />
+          </Provider>
+        ));
         segment = getByLabelText(label);
         textContent = segment.textContent;
         act(() => {segment.focus();});
@@ -915,6 +935,30 @@ describe('DatePicker', function () {
         it('should support using the arrow keys to increment and decrement the day period', function () {
           testArrows('AM/PM', new CalendarDateTime(2019, 2, 3, 8), new CalendarDateTime(2019, 2, 3, 20), new CalendarDateTime(2019, 2, 3, 20));
           testArrows('AM/PM', new CalendarDateTime(2019, 2, 3, 20), new CalendarDateTime(2019, 2, 3, 8), new CalendarDateTime(2019, 2, 3, 8));
+        });
+      });
+
+      describe('era', function () {
+        it('should support using the arrow keys to increment and decrement the era', function () {
+          testArrows('era', new CalendarDate(new JapaneseCalendar(), 'heisei', 5, 2, 3), new CalendarDate(new JapaneseCalendar(), 'reiwa', 5, 2, 3), new CalendarDate(new JapaneseCalendar(), 'showa', 5, 2, 3), {locale: 'en-US-u-ca-japanese'});
+        });
+
+        it('should show and hide the era field as needed', function () {
+          let {queryByTestId} = render(<DatePicker label="Date" />);
+          let year = queryByTestId('year');
+          expect(queryByTestId('era')).toBeNull();
+
+          beforeInput(year, '1');
+          fireEvent.keyDown(year, {key: 'ArrowDown'});
+          fireEvent.keyUp(year, {key: 'ArrowDown'});
+
+          let era = queryByTestId('era');
+          expect(era).not.toBeNull();
+
+          fireEvent.keyDown(era, {key: 'ArrowDown'});
+          fireEvent.keyUp(era, {key: 'ArrowDown'});
+
+          expect(queryByTestId('era')).toBeNull();
         });
       });
     });

--- a/packages/@react-stately/datepicker/src/useDateFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDateFieldState.ts
@@ -267,11 +267,19 @@ export function useDateFieldState(props: DateFieldStateOptions): DateFieldState 
       })
   , [dateValue, validSegments, dateFormatter, resolvedOptions, displayValue, calendar, locale]);
 
-  let hasEra = useMemo(() => segments.some(s => s.type === 'era'), [segments]);
+  // When the era field appears, mark it valid if the year field is already valid.
+  // If the era field disappears, remove it from the valid segments.
+  if (allSegments.era && validSegments.year && !validSegments.era) {
+    validSegments.era = true;
+    setValidSegments({...validSegments});
+  } else if (!allSegments.era && validSegments.era) {
+    delete validSegments.era;
+    setValidSegments({...validSegments});
+  }
 
   let markValid = (part: Intl.DateTimeFormatPartTypes) => {
     validSegments[part] = true;
-    if (part === 'year' && hasEra) {
+    if (part === 'year' && allSegments.era) {
       validSegments.era = true;
     }
     setValidSegments({...validSegments});


### PR DESCRIPTION
Bugs found in #3208 and #3213.

* Fix changing the era in Ethiopic dates. This was due to year being clamped to >= 1 when constructing CalendarDate.
* When the era field appears (e.g. due to changing the year field), we should mark it valid when the year is already valid.