### PR TITLE
Fix entering dates with keyboard using VoiceOver on iOS

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -259,14 +259,9 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
     enteredKeys.current = '';
     scrollIntoView(getScrollParent(ref.current) as HTMLElement, ref.current);
 
-    // Safari requires that a selection is set or it won't fire input events.
-    // Since usePress disables text selection, this won't happen by default.
-    ref.current.style.webkitUserSelect = 'text';
-    ref.current.style.userSelect = 'text';
+    // Collapse selection to start or Chrome won't fire input events.
     let selection = window.getSelection();
     selection.collapse(ref.current);
-    ref.current.style.webkitUserSelect = 'none';
-    ref.current.style.userSelect = 'none';
   };
 
   let compositionRef = useRef('');
@@ -389,9 +384,7 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
       onKeyDown,
       onFocus,
       style: {
-        caretColor: 'transparent',
-        userSelect: 'none',
-        WebkitUserSelect: 'none'
+        caretColor: 'transparent'
       },
       // Prevent pointer events from reaching useDatePickerGroup, and allow native browser behavior to focus the segment.
       onPointerDown(e) {


### PR DESCRIPTION
This appears to have been a regression in the last release. Using the keyboard with VO on iOS, nothing happened when pressing a key. VO seems not to fire input events if `user-select: none` is present. This was changed here: https://github.com/adobe/react-spectrum/pull/3149/files#diff-91623cb4379cd8f4595bcf1861d171e23c8e3f161bed841f3d4a713471efc8f0. The original intent was to prevent the text selection menu (e.g. copy/paste) from coming up on long press, but I guess we can't really prevent that.