### PR TITLE
Fix FF date segment typing

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -309,11 +309,6 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
     }
   });
 
-  // For Android: prevent selection on long press.
-  useEvent(ref, 'selectstart', e => {
-    e.preventDefault();
-  });
-
   useLayoutEffect(() => {
     let element = ref.current;
     return () => {

--- a/packages/@react-spectrum/datepicker/src/styles.css
+++ b/packages/@react-spectrum/datepicker/src/styles.css
@@ -114,6 +114,7 @@
   font-style: italic;
   visibility: hidden;
   height: 0;
+  pointer-events: none;
 }
 
 .react-spectrum-DatePicker-cell.is-placeholder {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Remove a prevent default that wasn't working to prevent Android text selection of segment and context menu.
Also fixes iOS because pointer-events none is necessary (DatePicker with TimeField in a tray)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
