### PR TITLE
Fixing stuck FireFox ListView root drop indicator 

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -259,14 +259,9 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
     enteredKeys.current = '';
     scrollIntoView(getScrollParent(ref.current) as HTMLElement, ref.current);
 
-    // Safari requires that a selection is set or it won't fire input events.
-    // Since usePress disables text selection, this won't happen by default.
-    ref.current.style.webkitUserSelect = 'text';
-    ref.current.style.userSelect = 'text';
+    // Collapse selection to start or Chrome won't fire input events.
     let selection = window.getSelection();
     selection.collapse(ref.current);
-    ref.current.style.webkitUserSelect = 'none';
-    ref.current.style.userSelect = 'none';
   };
 
   let compositionRef = useRef('');
@@ -389,9 +384,7 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
       onKeyDown,
       onFocus,
       style: {
-        caretColor: 'transparent',
-        userSelect: 'none',
-        WebkitUserSelect: 'none'
+        caretColor: 'transparent'
       },
       // Prevent pointer events from reaching useDatePickerGroup, and allow native browser behavior to focus the segment.
       onPointerDown(e) {

--- a/packages/@react-spectrum/list/src/styles.css
+++ b/packages/@react-spectrum/list/src/styles.css
@@ -513,19 +513,6 @@
   border-color: var(--spectrum-global-color-blue-500);
   background-color: var(--spectrum-alias-highlight-selected);
   box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
-  &::after {
-    border-radius: inherit;
-    border-color: var(--spectrum-global-color-blue-500);
-    background-color: var(--spectrum-alias-highlight-selected);
-    box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    inset-inline-start: 0;
-    width: 100%;
-    height: 100%;
-  }
 }
 
 .react-spectrum-ListView-centeredWrapper {

--- a/packages/@react-spectrum/list/src/styles.css
+++ b/packages/@react-spectrum/list/src/styles.css
@@ -47,6 +47,15 @@
   }
 
   &.react-spectrum-ListView--emphasized {
+    &.react-spectrum-ListView--dropTarget {
+      .react-spectrum-ListViewItem:not(.is-selected) {
+        /* shift bottom border inwards so it doesn't overlap the root drop target */
+        &:after {
+          inset-inline-start: 1px;
+          inset-inline-end: 1px;
+        }
+      }
+    }
     .react-spectrum-ListViewItem {
       /* common pseudoelement for box shadows */
       &:after {
@@ -509,10 +518,15 @@
     inset 0 2px 0 0 var(--spectrum-table-cell-border-color-key-focus);
 }
 
-.react-spectrum-ListView--dropTarget {
+.react-spectrum-ListView.react-spectrum-ListView--dropTarget {
   border-color: var(--spectrum-global-color-blue-500);
   background-color: var(--spectrum-alias-highlight-selected);
   box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
+
+  /* Add border to quiet ListView only when it is a drop target */
+  &.react-spectrum-ListView--quiet {
+    box-shadow: inset 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus), 0 0 0 1px var(--spectrum-table-cell-border-color-key-focus);
+  }
 }
 
 .react-spectrum-ListView-centeredWrapper {

--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -369,7 +369,7 @@ storiesOf('ListView/Drag and Drop', module)
     'Drag into folder',
     args => (
       <Flex direction="row" wrap alignItems="center">
-        <DragIntoItemExample {...args} />
+        <DragIntoItemExample listViewProps={args} />
       </Flex>
     )
   )
@@ -385,7 +385,7 @@ storiesOf('ListView/Drag and Drop', module)
     'Drag between lists (Root only)',
     args => (
       <Flex direction="row" wrap alignItems="center">
-        <DragBetweenListsRootOnlyExample {...args} />
+        <DragBetweenListsRootOnlyExample listViewProps={args} />
       </Flex>
     ), {description: {data: 'Folders are non-draggable.'}}
   )


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. In FF, go to the root drop ListView story and try dragging an item from list1 to list 2 via mouse. The root drop indicator for the lists should not persist upon leaving the list
2. Make the list quiet via controls and perform a root drop. The list should have a ring around it when it is the drop target

## 🧢 Your Project:

RSP
