### PR TITLE
Fix issue with page scrolling when opening calendar popover

### DIFF
--- a/packages/@react-aria/calendar/src/useCalendarCell.ts
+++ b/packages/@react-aria/calendar/src/useCalendarCell.ts
@@ -12,7 +12,7 @@
 
 import {CalendarDate, isEqualDay, isSameDay, isToday} from '@internationalized/date';
 import {CalendarState, RangeCalendarState} from '@react-stately/calendar';
-import {focusWithoutScrolling, useDescription} from '@react-aria/utils';
+import {focusWithoutScrolling, getScrollParent, scrollIntoView, useDescription} from '@react-aria/utils';
 import {getEraFormat, hookData} from './utils';
 import {getInteractionModality, usePress} from '@react-aria/interactions';
 import {HTMLAttributes, RefObject, useEffect, useMemo, useRef} from 'react';
@@ -283,12 +283,14 @@ export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarSta
   // Focus the button in the DOM when the state updates.
   useEffect(() => {
     if (isFocused && ref.current) {
+      focusWithoutScrolling(ref.current);
+
       // Scroll into view if navigating with a keyboard, otherwise
       // try not to shift the view under the user's mouse/finger.
-      if (getInteractionModality() === 'pointer') {
-        focusWithoutScrolling(ref.current);
-      } else {
-        ref.current.focus();
+      // Only scroll the direct scroll parent, not the whole page, so
+      // we don't scroll to the bottom when opening date picker popover.
+      if (getInteractionModality() !== 'pointer') {
+        scrollIntoView(getScrollParent(ref.current) as HTMLElement, ref.current);
       }
     }
   }, [isFocused, ref]);


### PR DESCRIPTION
Fixes an issue seen in the docs, and in apps with page scrolling.

Reproduction steps:

1. Open https://react-spectrum.adobe.com/react-spectrum/DatePicker.html
2. Tab to the calendar button in the first date picker example, and press Enter.
3. See that it scrolls the whole page to the bottom.

This seems to be due to positioning code running after focusing of the cell. Workaround is to prevent default browser scrolling, but scroll into view manually so we only adjust the immediate scroll parent rather than the whole page.

This does break another case, where if you focus a cell and scroll the calendar off screen, then press an arrow key it doesn't scroll back into view. However, we have this issue in other components already and it's a less visible problem than scrolling the whole page to the bottom when opening the date picker, so I think we can tackle that separately.