### PR TITLE
Removing broken DnD links from ListView types

### DIFF
--- a/packages/@react-types/list/src/index.d.ts
+++ b/packages/@react-types/list/src/index.d.ts
@@ -58,13 +58,11 @@ export interface SpectrumListProps<T> extends AriaListProps<T>, StyleProps, Spec
   /** Whether `disabledKeys` applies to all interactions, or only selection. */
   disabledBehavior?: DisabledBehavior,
   /**
-   * The drag hooks returned by `useDragHooks` used to enable drag and drop behavior for the ListView. See the
-   * [docs](https://react-spectrum.adobe.com/react-spectrum/dragAndDrop.html) for more info.
+   * The drag hooks returned by `useDragHooks` used to enable drag and drop behavior for the ListView.
    */
   dragHooks?: DragHooks,
   /**
-   * The drag hooks returned by `useDragHooks` used to enable drag and drop behavior for the ListView. See the
-   * [docs](https://react-spectrum.adobe.com/react-spectrum/dragAndDrop.html) for more info.
+   * The drag hooks returned by `useDragHooks` used to enable drag and drop behavior for the ListView.
    */
   dropHooks?: DropHooks
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Dnd docs won't be live for some time so the types shouldn't link to them until they are ready

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
