### PR TITLE
Fix programmatically focusing datepicker segments on iOS

### DIFF
--- a/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
+++ b/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
@@ -81,6 +81,8 @@ export function useDatePickerGroup(state: DatePickerState | DateRangePickerState
   };
 
   let {pressProps} = usePress({
+    preventFocusOnPress: true,
+    allowTextSelectionOnPress: true,
     onPressStart(e) {
       if (e.pointerType === 'mouse') {
         focusLast();


### PR DESCRIPTION
@gaearon reported an issue where sometimes tapping a date segment would focus it but typing wouldn't do anything on iOS. This seemed to be caused by tapping slightly outside the segment, or in the whitespace of the date field. In this case, we programmatically focus the date segment. The date segments are contenteditable divs, and programmatic focusing seemed to cause there to be no cursor set (even though it's invisible, it's still there).

Turns out, `usePress` was preventing text selection, so when focusing no cursor was set by the browser. And since there was no cursor, no input events would be fired when typing. Preventing `usePress` from stopping text selection in this case is ok, and solves this issue in my testing.