### PR TITLE
DnD: Focus initial drop target when using iOS VO

### DIFF
--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -14,6 +14,7 @@ import {announce} from '@react-aria/live-announcer';
 import {ariaHideOutside} from '@react-aria/overlays';
 import {DragEndEvent, DragItem, DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropItem, DropOperation, DropTarget as DroppableCollectionTarget} from '@react-types/shared';
 import {getDragModality, getTypes} from './utils';
+import {getInteractionModality} from '@react-aria/interactions';
 import {useEffect, useState} from 'react';
 
 let dropTargets = new Map<Element, DropTarget>();
@@ -69,8 +70,10 @@ export function beginDragging(target: DragTarget, formatMessage: (key: string) =
   dragSession = new DragSession(target, formatMessage);
   requestAnimationFrame(() => {
     dragSession.setup();
-
-    if (getDragModality() === 'keyboard') {
+    if (
+      getDragModality() === 'keyboard' ||
+      (getDragModality() === 'touch' && getInteractionModality() === 'virtual')
+    ) {
       dragSession.next();
     }
   });

--- a/packages/@react-aria/dnd/test/dnd.test.js
+++ b/packages/@react-aria/dnd/test/dnd.test.js
@@ -2355,7 +2355,7 @@ describe('useDrag and useDrop', function () {
 
       fireEvent.click(draggable);
       act(() => jest.runAllTimers());
-      expect(document.activeElement).toBe(draggable);
+      expect(document.activeElement).toBe(droppable);
       expect(draggable).toHaveAttribute('aria-describedby');
       expect(document.getElementById(draggable.getAttribute('aria-describedby'))).toHaveTextContent('Dragging. Double tap to cancel drag.');
       expect(announce).toHaveBeenCalledWith('Started dragging. Navigate to a drop target, then double tap to drop.');


### PR DESCRIPTION
Previously when using VO on touch, no drop target was set when initiating a drag session. Now, the first drop target is set, so the user can immediately navigate drop targets when the drag session starts.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

On iOS Safari with VoiceOver enabled:
1. Go to ListView -> Drag and Drop -> Drag within list (Reorder)
2. Start dragging an item
3. A drop indicator should appear, and you should be able to swipe left/right to navigate between drop items. (Previously there was no initial drop target).

## 🧢 Your Project:

<!--- Company/project for pull request -->
