### PR TITLE
chore: suggested improvements for useDialog types

### DIFF
--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -15,19 +15,22 @@ import {filterDOMProps, useSlotId} from '@react-aria/utils';
 import {focusSafely} from '@react-aria/focus';
 import {HTMLAttributes, RefObject, useEffect} from 'react';
 
-interface DialogAria {
+interface DialogAria<D, T> {
   /** Props for the dialog container element. */
-  dialogProps: HTMLAttributes<HTMLElement>,
+  dialogProps: HTMLAttributes<D>,
 
   /** Props for the dialog title element. */
-  titleProps: HTMLAttributes<HTMLElement>
+  titleProps: HTMLAttributes<T>,
 }
 
 /**
  * Provides the behavior and accessibility implementation for a dialog component.
  * A dialog is an overlay shown above other content in an application.
  */
-export function useDialog(props: AriaDialogProps, ref: RefObject<HTMLElement>): DialogAria {
+export function useDialog<D extends HTMLElement, T extends HTMLElement>(
+  props: AriaDialogProps,
+  ref: RefObject<HTMLElement>
+): DialogAria<D, T> {
   let {role = 'dialog'} = props;
   let titleId = useSlotId();
   titleId = props['aria-label'] ? undefined : titleId;


### PR DESCRIPTION
Suggestion for https://github.com/adobe/react-spectrum/discussions/1618#discussioncomment-396010
Would this be a possibiliy to keep the wide types, while still offering a possibility to make them narrower? It also "solves" the issue when `HTMLElement` being incompatible when `react-aria` has different `@types/react` than the application.

## 📝 Test Instructions:

```
const Test = (props: { onClose: () => void, isDismissable: boolean, id: string }) => {
  const ref = useRef()
  const { dialogProps, titleProps } = useDialog<HTMLDivElement, HTMLHeadElement>(props, ref);
  // sets it as a more specific element
  // however useDialog(props, ref) also keeps working
  return (
    <div { ...dialogProps } > <h4>Keker < /h4>{props.children}</div >
    )
}
```

## 🧢 Your Project:

Private repository
