### PR TITLE
Fix onRemove typescript definition for RSP 3 Tag (Taggroup)

### DIFF
--- a/packages/@react-types/tag/src/index.d.ts
+++ b/packages/@react-types/tag/src/index.d.ts
@@ -18,7 +18,7 @@ export interface TagGroupProps<T> extends CollectionBase<T>, MultipleSelection {
   disabledKeys?: Iterable<Key>,
   isDisabled?: boolean,
   isRemovable?: boolean,
-  onRemove?: (items: any[]) => void
+  onRemove?: (item: any) => void
 }
 
 export interface SpectrumTagGroupProps<T> extends TagGroupProps<T>, DOMProps, StyleProps {}


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
