### PR TITLE
Remove useIsSSR and replace with native check

### DIFF
--- a/packages/@react-aria/overlays/package.json
+++ b/packages/@react-aria/overlays/package.json
@@ -20,7 +20,6 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/i18n": "^3.4.1",
     "@react-aria/interactions": "^3.9.1",
-    "@react-aria/ssr": "^3.2.0",
     "@react-aria/utils": "^3.13.1",
     "@react-aria/visually-hidden": "^3.3.1",
     "@react-stately/overlays": "^3.3.1",

--- a/packages/@react-aria/overlays/src/useModal.tsx
+++ b/packages/@react-aria/overlays/src/useModal.tsx
@@ -12,7 +12,6 @@
 
 import React, {AriaAttributes, HTMLAttributes, ReactNode, useContext, useEffect, useMemo, useState} from 'react';
 import ReactDOM from 'react-dom';
-import {useIsSSR} from '@react-aria/ssr';
 
 interface ModalProviderProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode
@@ -123,8 +122,7 @@ interface OverlayContainerProps extends ModalProviderProps {
  * be accessible at once.
  */
 export function OverlayContainer(props: OverlayContainerProps): React.ReactPortal {
-  let isSSR = useIsSSR();
-  let {portalContainer = isSSR ? null : document.body, ...rest} = props;
+  let {portalContainer = typeof document !== 'undefined' ? document.body : null, ...rest} = props;
 
   React.useEffect(() => {
     if (portalContainer?.closest('[data-overlay-container]')) {


### PR DESCRIPTION
Closes #1055

`useIsSSR` is not working correctly in Remix. This fix removes the hook and replaces it with a native type check.

See also: [https://github.com/adobe/react-spectrum/pull/3186#discussion_r894075490](https://github.com/adobe/react-spectrum/pull/3186#discussion_r894075490)

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

- `useModal.ssr.test.js` still passes
- `useModal` story behaves the same before and after the change

