### PR TITLE
issue-855: AlertDialog add support for allowsKeyboardConfirmation prop

### DIFF
--- a/packages/@react-spectrum/dialog/docs/AlertDialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/AlertDialog.mdx
@@ -239,3 +239,22 @@ Disables the secondary button.
   </AlertDialog>
 </DialogTrigger>
 ```
+
+### allowsKeyboardConfirmation enabled
+
+Pressing the `enter` key closes the AlertDialog as if primary action button was clicked, which would call `onPrimaryAction`.
+
+```tsx example
+<DialogTrigger>
+  <ActionButton>Upgrade</ActionButton>
+  <AlertDialog
+    allowsKeyboardConfirmation
+    variant="confirmation"
+    title="Upgrade subscription"
+    primaryActionLabel="Upgrade"
+    secondaryActionLabel="Apply Coupon"
+    cancelLabel="Cancel">
+    Upgrade subscription for an additional $14.99 a month? You can press Enter to confirm.
+  </AlertDialog>
+</DialogTrigger>
+```

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -13,7 +13,7 @@
 import {ActionButton} from '@react-spectrum/button';
 import {classNames, SlotProvider, unwrapDOMRef, useDOMRef, useHasChild, useStyleProps} from '@react-spectrum/utils';
 import CrossLarge from '@spectrum-icons/ui/CrossLarge';
-import {DialogContext, DialogContextValue} from './context';
+import {AlertDialogContext, AlertDialogContextValue, DialogContext, DialogContextValue} from './context';
 import {DismissButton} from '@react-aria/overlays';
 import {DOMRef} from '@react-types/shared';
 import {FocusScope} from '@react-aria/focus';
@@ -55,7 +55,9 @@ function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
   let domRef = useDOMRef(ref);
   let gridRef = useRef();
   let sizeVariant = sizeMap[type] || sizeMap[size];
+  let {onKeyDown} = useContext(AlertDialogContext) || {} as AlertDialogContextValue;
   let {dialogProps, titleProps} = useDialog(mergeProps(contextProps, props), domRef);
+  dialogProps = mergeProps(dialogProps, {onKeyDown});
 
   let hasHeader = useHasChild(`.${styles['spectrum-Dialog-header']}`, unwrapDOMRef(gridRef));
   let hasHeading = useHasChild(`.${styles['spectrum-Dialog-heading']}`, unwrapDOMRef(gridRef));

--- a/packages/@react-spectrum/dialog/src/context.ts
+++ b/packages/@react-spectrum/dialog/src/context.ts
@@ -19,3 +19,9 @@ export interface DialogContextValue extends HTMLAttributes<HTMLElement> {
 }
 
 export const DialogContext = React.createContext<DialogContextValue>(null);
+
+export interface AlertDialogContextValue extends HTMLAttributes<HTMLElement> {
+  onKeyDown: (e: any) => void
+}
+
+export const AlertDialogContext = React.createContext<AlertDialogContextValue>(null);

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -234,6 +234,21 @@ storiesOf('Dialog/Alert', module)
       onCancel: action('cancel'),
       autoFocusButton: 'cancel'
     })
+  )
+  .add(
+    'allowsKeyboardConfirmation',
+    () => renderAlert({
+      variant: 'error',
+      title: 'Error: Danger Will Robinson',
+      children: singleParagraph(),
+      primaryActionLabel: 'Accept',
+      cancelLabel: 'Cancel',
+      secondaryActionLabel: 'Secondary button',
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
+      onCancel: action('cancel'),
+      allowsKeyboardConfirmation: true
+    })
   );
 
 function render({width = 'auto', isDismissable = undefined, ...props}) {

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -13,7 +13,7 @@
 import {AlertDialog} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
-import {render, triggerPress} from '@react-spectrum/test-utils';
+import {fireEvent, render, triggerPress} from '@react-spectrum/test-utils';
 import {theme} from '@react-spectrum/theme-default';
 
 describe('AlertDialog', function () {
@@ -170,5 +170,22 @@ describe('AlertDialog', function () {
 
     let button = getByText('secondary').closest('button');
     expect(document.activeElement).toBe(button);
+  });
+
+  it('allowsKeyboardConfirmation enabled', function () {
+    let onPrimaryAction = jest.fn();
+    let {getByRole} = render(
+      <Provider theme={theme}>
+        <AlertDialog variant="confirmation" allowsKeyboardConfirmation title="the title" primaryActionLabel="confirm" onPrimaryAction={onPrimaryAction}>
+          Content body
+        </AlertDialog>
+      </Provider>
+    );
+
+    let dialog = getByRole('alertdialog');
+    expect(document.activeElement).toBe(dialog);
+
+    fireEvent.keyDown(document.activeElement, {key: 'Enter'});
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -98,5 +98,6 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   onSecondaryAction?: () => void,
   /** Button to focus by default when the dialog opens. */
   autoFocusButton?: 'cancel' | 'primary' | 'secondary'
-  // allowsKeyboardConfirmation?: boolean, // triggers primary action
+  /** Triggers primary action when the Enter key is pressed for AlertDialog */
+  allowsKeyboardConfirmation?: boolean
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->
https://github.com/adobe/react-spectrum/issues/855

<img width="926" alt="Screen Shot 2022-07-20 at 12 22 58 PM" src="https://user-images.githubusercontent.com/19467235/180100786-2e34e2fb-d932-4df0-86a2-bc3df90e9510.png">

![Screen Shot 2022-07-20 at 4 36 46 PM](https://user-images.githubusercontent.com/19467235/180100811-44800b54-8f78-4338-ba26-1a3b24f6ffa0.png)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
Open an AlertDialog, verify if pressing the "Enter" key closes it and triggers onPrimaryAction.

## 🧢 Your Project:

