### PR TITLE
Fix menu trigger longpress

### DIFF
--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -118,6 +118,9 @@ export function useMenuTrigger<T>(props: MenuTriggerAriaProps, state: MenuTrigge
     }
   };
 
+  // omit onPress from triggerProps since we override it above.
+  delete triggerProps.onPress;
+
   return {
     menuTriggerProps: {
       ...triggerProps,


### PR DESCRIPTION
Fixes a regression found in #3264. MenuTrigger with menuTrigger=longpress would open both when long pressing and pressing normally. This was due to onPress being added in useOverlayTrigger. So now we override that at the useMenuTrigger level.