### PR TITLE
Fix isDisabled in tabs

### DIFF
--- a/packages/@react-aria/tabs/src/useTab.ts
+++ b/packages/@react-aria/tabs/src/useTab.ts
@@ -40,7 +40,7 @@ export function useTab<T>(
 
   let isSelected = key === selectedKey;
 
-  let isDisabled = propsDisabled || state.disabledKeys.has(key);
+  let isDisabled = propsDisabled || state.isDisabled || state.disabledKeys.has(key);
   let {itemProps} = useSelectableItem({
     selectionManager: manager,
     key,

--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -15,7 +15,7 @@ import {DOMProps, DOMRef, Node, Orientation} from '@react-types/shared';
 import {filterDOMProps} from '@react-aria/utils';
 import {FocusRing} from '@react-aria/focus';
 import {Item, Picker} from '@react-spectrum/picker';
-import {ListCollection, SingleSelectListState} from '@react-stately/list';
+import {ListCollection} from '@react-stately/list';
 import {mergeProps, useId, useLayoutEffect} from '@react-aria/utils';
 import React, {Key, MutableRefObject, ReactElement, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
@@ -134,24 +134,22 @@ function Tabs<T extends object>(props: SpectrumTabsProps<T>, ref: DOMRef<HTMLDiv
 
 interface TabProps<T> extends DOMProps {
   item: Node<T>,
-  state: SingleSelectListState<T>,
+  state: TabListState<T>,
   isDisabled?: boolean,
   orientation?: Orientation
 }
 
 // @private
 function Tab<T>(props: TabProps<T>) {
-  let {item, state, isDisabled: propsDisabled} = props;
+  let {item, state} = props;
   let {key, rendered} = item;
-  let isDisabled = propsDisabled || state.disabledKeys.has(key);
 
   let ref = useRef<HTMLDivElement>();
-  let {tabProps} = useTab({key, isDisabled}, state, ref);
+  let {tabProps, isSelected, isDisabled} = useTab({key}, state, ref);
 
   let {hoverProps, isHovered} = useHover({
     ...props
   });
-  let isSelected = state.selectedKey === key;
   let domProps = filterDOMProps(item.props);
   delete domProps.id;
 
@@ -241,7 +239,7 @@ function TabLine(props: TabLineProps) {
 export function TabList<T>(props: SpectrumTabListProps<T>) {
   const tabContext = useContext(TabContext);
   const {refs, tabState, tabProps, tabPanelProps} = tabContext;
-  const {isQuiet, density, isDisabled, isEmphasized, orientation} = tabProps;
+  const {isQuiet, density, isEmphasized, orientation} = tabProps;
   const {selectedTab, collapsed, setTabListState} = tabState;
   const {tablistRef, wrapperRef} = refs;
   // Pass original Tab props but override children to create the collection.
@@ -283,7 +281,7 @@ export function TabList<T>(props: SpectrumTabListProps<T>) {
       )
       }>
       {[...state.collection].map((item) => (
-        <Tab key={item.key} item={item} state={state} isDisabled={isDisabled} orientation={orientation} />
+        <Tab key={item.key} item={item} state={state} orientation={orientation} />
       ))}
       <TabLine orientation={orientation} selectedTab={selectedTab} />
     </div>
@@ -352,7 +350,7 @@ function TabPanel<T>(props: SpectrumTabPanelsProps<T>) {
 interface TabPickerProps<T> extends Omit<SpectrumPickerProps<T>, 'children'> {
   density?: 'compact' | 'regular',
   isEmphasized?: boolean,
-  state: SingleSelectListState<T>,
+  state: TabListState<T>,
   className?: string,
   visible: boolean
 }

--- a/packages/@react-stately/tabs/src/useTabListState.ts
+++ b/packages/@react-stately/tabs/src/useTabListState.ts
@@ -15,7 +15,10 @@ import {TabListProps} from '@react-types/tabs';
 import {useRef} from 'react';
 
 
-export interface TabListState<T> extends SingleSelectListState<T> {}
+export interface TabListState<T> extends SingleSelectListState<T> {
+  /** Whether the tab list is disabled. */
+  isDisabled: boolean
+}
 
 /**
  * Provides state management for a Tabs component. Tabs include a TabList which tracks
@@ -56,5 +59,8 @@ export function useTabListState<T extends object>(props: TabListProps<T>): TabLi
   }
   lastSelectedKey.current = selectedKey;
 
-  return state;
+  return {
+    ...state,
+    isDisabled: props.isDisabled || false
+  };
 }

--- a/packages/@react-types/tabs/src/index.d.ts
+++ b/packages/@react-types/tabs/src/index.d.ts
@@ -28,7 +28,13 @@ export interface AriaTabProps {
   isDisabled?: boolean
 }
 
-export interface TabListProps<T> extends CollectionBase<T>, Omit<SingleSelection, 'disallowEmptySelection'> {}
+export interface TabListProps<T> extends CollectionBase<T>, Omit<SingleSelection, 'disallowEmptySelection'> {
+  /**
+   * Whether the Tabs are disabled.
+   * Shows that a selection exists, but is not available in that circumstance.
+   */
+  isDisabled?: boolean
+}
 
 interface AriaTabListBase {
   /**
@@ -40,12 +46,7 @@ interface AriaTabListBase {
    * The orientation of the tabs.
    * @default 'horizontal'
    */
-  orientation?: Orientation,
-  /**
-   * Whether the Tabs are disabled.
-   * Shows that a selection exists, but is not available in that circumstance.
-   */
-  isDisabled?: boolean
+  orientation?: Orientation
 }
 
 export interface AriaTabListProps<T> extends TabListProps<T>, AriaTabListBase, DOMProps, AriaLabelingProps {}


### PR DESCRIPTION
Fixes the aria docs example for isDisabled to disable all tabs (this PR will need to be merged into that one). This is done by attaching isDisabled to the state object. Also updates Spectrum Tabs to use the new Aria API.