### PR TITLE
Restore reverted ReadOnly textfield/textarea work

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -35,11 +35,12 @@ governing permissions and limitations under the License.
   min-width: var(--spectrum-textfield-min-width);
   width: var(--spectrum-component-single-line-width);
 
-  &:not(.spectrum-Textfield--quiet).spectrum-Textfield--multiline .spectrum-Textfield-input:not(:disabled) {
+  &:not(.spectrum-Textfield--quiet, .spectrum-Textfield--readonly).spectrum-Textfield--multiline .spectrum-Textfield-input:not(:disabled){
     resize: vertical;
   }
 
-  &.spectrum-Textfield--quiet.spectrum-Textfield--multiline .spectrum-Textfield-input {
+  &.spectrum-Textfield--quiet.spectrum-Textfield--multiline .spectrum-Textfield-input,
+  &.spectrum-Textfield--readonly .spectrum-Textfield-input {
     height: var(--spectrum-textfield-height);
     min-height: var(--spectrum-textfield-height);
     overflow-x: hidden;
@@ -258,7 +259,6 @@ governing permissions and limitations under the License.
     min-height: var(--spectrum-textfield-height);
   }
 }
-
 
 /* same positioning as invalid icon */
 .spectrum-Textfield--loadable .spectrum-Textfield-circleLoader {

--- a/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
@@ -130,6 +130,10 @@ governing permissions and limitations under the License.
     }
   }
 
+  .spectrum-Textfield--readonly & {
+    border-color: var(--spectrum-textfield-quiet-background-color); 
+  }
+
   .spectrum-Textfield.spectrum-Textfield--invalid & {
     border-color: var(--spectrum-textfield-border-color-error);
 
@@ -148,7 +152,6 @@ governing permissions and limitations under the License.
       }
     }
   }
-
 }
 
 .spectrum-Textfield-icon {

--- a/packages/@react-spectrum/label/intl/ar-AE.json
+++ b/packages/@react-spectrum/label/intl/ar-AE.json
@@ -1,4 +1,5 @@
 {
   "(optional)": "(اختياري)",
-  "(required)": "(مطلوب)"
+  "(required)": "(مطلوب)",
+  "(None)": "(None)"
 }

--- a/packages/@react-spectrum/label/intl/en-US.json
+++ b/packages/@react-spectrum/label/intl/en-US.json
@@ -1,4 +1,5 @@
 {
   "(required)": "(required)",
-  "(optional)": "(optional)"
+  "(optional)": "(optional)",
+  "(None)": "(None)"
 }

--- a/packages/@react-spectrum/label/package.json
+++ b/packages/@react-spectrum/label/package.json
@@ -32,7 +32,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@react-aria/i18n": "^3.5.0",
+    "@react-aria/focus": "^3.6.1",
+    "@react-aria/i18n": "^3.5.1",
+    "@react-aria/interactions": "^3.10.0",
     "@react-aria/label": "^3.4.0",
     "@react-aria/utils": "^3.13.2",
     "@react-spectrum/form": "^3.4.0",

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -13,13 +13,17 @@
 import {classNames, useStyleProps} from '@react-spectrum/utils';
 import {Flex} from '@react-spectrum/layout';
 import {HelpText} from './HelpText';
+// @ts-ignore
+import intlMessages from '../intl/*.json';
 import {Label} from './Label';
 import {LabelPosition} from '@react-types/shared';
 import labelStyles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
 import {mergeProps, mergeRefs} from '@react-aria/utils';
 import React, {ForwardedRef, ReactElement, RefObject, useCallback} from 'react';
+import {ReadOnlyField} from './ReadOnlyField';
 import {SpectrumFieldProps} from '@react-types/label';
 import {useFormProps} from '@react-spectrum/form';
+import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
   props = useFormProps(props);
@@ -37,6 +41,10 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
     showErrorIcon,
     children,
     labelProps,
+    readOnlyText,
+    isReadOnly,
+    inputProps,
+    inputRef,
     // Not every component that uses <Field> supports help text.
     descriptionProps = {},
     errorMessageProps = {},
@@ -47,6 +55,8 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
   } = props;
   let {styleProps} = useStyleProps(otherProps);
   let hasHelpText = !!description || errorMessage && validationState === 'invalid';
+  let stringFormatter = useLocalizedStringFormatter(intlMessages);
+  let displayReadOnly = isReadOnly && (readOnlyText || readOnlyText === '');
   let mergedRefs = useMergeRefs((children as ReactElement & {ref: RefObject<HTMLElement>}).ref, ref);
 
   if (label || hasHelpText) {
@@ -79,10 +89,23 @@ function Field(props: SpectrumFieldProps, ref: RefObject<HTMLElement>) {
         showErrorIcon={showErrorIcon} />
     );
 
+    if (displayReadOnly) {
+      if (readOnlyText === '') {
+        readOnlyText = stringFormatter.format('(None)');
+      }
+      children = (
+        <ReadOnlyField
+          {...props}
+          readOnlyText={readOnlyText}
+          inputProps={inputProps}
+          ref={inputRef as RefObject<HTMLTextAreaElement>} />
+      );
+    }
+
     let renderChildren = () => (
       <Flex direction="column" UNSAFE_className={classNames(labelStyles, 'spectrum-Field-wrapper')}>
         {children}
-        {hasHelpText && renderHelpText()}
+        {hasHelpText && !displayReadOnly && renderHelpText()}
       </Flex>
     );
 

--- a/packages/@react-spectrum/label/src/ReadOnlyField.tsx
+++ b/packages/@react-spectrum/label/src/ReadOnlyField.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {classNames} from '@react-spectrum/utils';
+import {FocusRing} from '@react-aria/focus'; 
+import {mergeProps} from '@react-aria/utils';
+import React, {RefObject, useCallback} from 'react';
+import {SpectrumFieldProps} from '@react-types/label';
+import styles from '@adobe/spectrum-css-temp/components/textfield/vars.css';
+import {useFormProps} from '@react-spectrum/form';
+import {useHover} from '@react-aria/interactions';
+import {useLayoutEffect} from '@react-aria/utils';
+
+function ReadOnlyField(props: SpectrumFieldProps, ref: RefObject<HTMLTextAreaElement>) {
+  props = useFormProps(props);
+  let {
+    isDisabled,
+    readOnlyText,
+    inputProps,
+    autoFocus    
+  } = props;
+  delete inputProps.defaultValue;
+  let {hoverProps, isHovered} = useHover({isDisabled});
+
+  let onHeightChange = useCallback(() => {
+    let input = ref.current;
+    let prevAlignment = input.style.alignSelf;
+    input.style.alignSelf = 'start';
+    input.style.height = 'auto'; 
+    input.style.height = `${input.scrollHeight}px`;
+    input.style.alignSelf = prevAlignment;
+  }, [ref]);
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      onHeightChange();
+    }
+  }, [onHeightChange, readOnlyText, ref]);
+
+  return (
+    <div
+      className={
+        classNames(
+          styles,
+          'spectrum-Textfield',
+          {
+            'spectrum-Textfield--quiet': true,
+            'spectrum-Textfield--readonly': true
+          }
+        )
+      }>
+      <FocusRing focusRingClass={classNames(styles, 'focus-ring')} isTextInput autoFocus={autoFocus}>        
+        <textarea
+          {...mergeProps(inputProps, hoverProps)} 
+          rows={1}
+          ref={ref}
+          value={readOnlyText}
+          className={
+            classNames(
+              styles,
+              'spectrum-Textfield-input',
+              {
+                'is-hovered': isHovered
+              }
+            )
+        } />
+      </FocusRing> 
+    </div>
+  );
+}
+
+let _ReadOnlyField = React.forwardRef(ReadOnlyField);
+export {_ReadOnlyField as ReadOnlyField};

--- a/packages/@react-spectrum/textfield/src/TextArea.tsx
+++ b/packages/@react-spectrum/textfield/src/TextArea.tsx
@@ -28,14 +28,14 @@ function TextArea(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
     onChange,
     ...otherProps
   } = props;
-
   // not in stately because this is so we know when to re-measure, which is a spectrum design
   let [inputValue, setInputValue] = useControlledState(props.value, props.defaultValue, () => {});
 
+  let inputText = props.value ?? props.defaultValue ?? ''; 
   let inputRef = useRef<HTMLTextAreaElement>();
 
   let onHeightChange = useCallback(() => {
-    if (isQuiet) {
+    if (isQuiet && !isReadOnly) {
       let input = inputRef.current;
       let prevAlignment = input.style.alignSelf;
       input.style.alignSelf = 'start';
@@ -43,7 +43,7 @@ function TextArea(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
       input.style.height = `${input.scrollHeight}px`;
       input.style.alignSelf = prevAlignment;
     }
-  }, [isQuiet, inputRef]);
+  }, [isQuiet, isReadOnly, inputRef]);
 
   useLayoutEffect(() => {
     if (inputRef.current) {
@@ -74,7 +74,8 @@ function TextArea(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
       isDisabled={isDisabled}
       isQuiet={isQuiet}
       isReadOnly={isReadOnly}
-      isRequired={isRequired} />
+      isRequired={isRequired} 
+      readOnlyText={inputText} />
   );
 }
 

--- a/packages/@react-spectrum/textfield/src/TextField.tsx
+++ b/packages/@react-spectrum/textfield/src/TextField.tsx
@@ -18,14 +18,14 @@ import {useTextField} from '@react-aria/textfield';
 
 function TextField(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) {
   props = useProviderProps(props);
-
+  let inputText = props.value ?? props.defaultValue ?? ''; 
   let inputRef = useRef<HTMLInputElement>();
   let {labelProps, inputProps, descriptionProps, errorMessageProps} = useTextField(props, inputRef);
 
   if (props.placeholder) {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead. See the docs for details: https://react-spectrum.adobe.com/react-spectrum/TextField.html#help-text');
   }
-
+  
   return (
     <TextFieldBase
       {...props}
@@ -34,7 +34,8 @@ function TextField(props: SpectrumTextFieldProps, ref: RefObject<TextFieldRef>) 
       descriptionProps={descriptionProps}
       errorMessageProps={errorMessageProps}
       ref={ref}
-      inputRef={inputRef} />
+      inputRef={inputRef} 
+      readOnlyText={inputText} />
   );
 }
 

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -33,7 +33,8 @@ interface TextFieldBaseProps extends Omit<SpectrumTextFieldProps, 'onChange'>, P
   errorMessageProps?: HTMLAttributes<HTMLElement>,
   inputRef?: RefObject<HTMLInputElement | HTMLTextAreaElement>,
   loadingIndicator?: ReactElement,
-  isLoading?: boolean
+  isLoading?: boolean,
+  readOnlyText?: string
 }
 
 function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
@@ -54,13 +55,14 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
     inputRef,
     isLoading,
     loadingIndicator,
-    validationIconClassName
+    validationIconClassName,
+    readOnlyText
   } = props;
   let {hoverProps, isHovered} = useHover({isDisabled});
   let domRef = useRef<HTMLDivElement>(null);
   let defaultInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   inputRef = inputRef || defaultInputRef;
-
+  
   // Expose imperative interface for ref
   useImperativeHandle(ref, () => ({
     ...createFocusableRef(domRef, inputRef),
@@ -143,7 +145,7 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
       className: multiLine ? 'spectrum-Field-field--multiline' : ''
     }));
   }
-
+  
   return (
     <Field
       {...props}
@@ -151,7 +153,9 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
       descriptionProps={descriptionProps}
       errorMessageProps={errorMessageProps}
       showErrorIcon={false}
-      ref={domRef}>
+      ref={domRef}
+      readOnlyText={readOnlyText}
+      inputProps={inputProps}>
       {textField}
     </Field>
   );

--- a/packages/@react-spectrum/textfield/stories/TextArea.stories.js
+++ b/packages/@react-spectrum/textfield/stories/TextArea.stories.js
@@ -19,6 +19,58 @@ import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {TextArea} from '../';
 
+const parameters = {
+  args: {
+    isReadOnly: true,
+    isQuiet: false,
+    isRequired: false,
+    isDisabled: false,
+    autoFocus: true,
+    validationState: '',
+    description: '',
+    errorMessage: '',
+    value: ''
+  },
+  argTypes: {
+    isQuiet: {
+      control: {type: 'boolean'}
+    },
+    isRequired: {
+      control: {type: 'boolean'}
+    },
+    isDisabled: {
+      control: {type: 'boolean'}
+    },
+    autoFocus: {
+      control: {type: 'boolean'}
+    },
+    validationState: {
+      control: {
+        type: 'radio',
+        options: ['', 'invalid', 'valid', '']
+      }
+    },
+    description: {
+      control: {
+        type: 'radio',
+        options: ['', 'Please enter a street address']
+      }
+    },
+    errorMessage: {
+      control: {
+        type: 'radio',
+        options: ['', 'please enter a valid street address']
+      }
+    },
+    value: {
+      control: {
+        type: 'radio',
+        options: ['', 'foo  '.repeat(20)]
+      }
+    }
+  }
+};
+
 storiesOf('TextArea', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
   .add(
@@ -147,7 +199,24 @@ storiesOf('TextArea', module)
     () => <ControlledTextArea />
   )
   .add('in flex', () => renderInFlexRowAndBlock())
-  .add('in flex validation state', () => renderInFlexRowAndBlock({validationState: 'invalid'}));
+  .add('in flex validation state', () => renderInFlexRowAndBlock({validationState: 'invalid'}))
+  .add('test: isReadOnly, with controls',
+    (args) => (   
+      <TextArea
+        label="Comments"
+        onChange={action('change')}
+        onFocus={action('focus')}
+        onBlur={action('blur')}
+        UNSAFE_className="custom_classname"
+        {...args} />
+    ), parameters
+  )
+  .add('test: isReadOnly, defaultValue',
+    () => render({isReadOnly: true, defaultValue: 'foo  '.repeat(10)})
+  )
+  .add('test: isReadOnly, with icon, value = icon',
+    () => render({isReadOnly: true, icon: <Info />,  value: 'icon'})
+  );
 
 function render(props = {}) {
   return (
@@ -166,6 +235,7 @@ function ControlledTextArea(props) {
   return (
     <>
       <TextArea label="megatron" value={value} onChange={setValue} {...props} isQuiet />
+      <TextArea label="megatron" value={value} onChange={setValue} {...props} isReadOnly />
       <Button variant="primary" onPress={() => setValue('decepticons are evil transformers and should be kicked out of earth')}>Set Text</Button>
     </>
   );

--- a/packages/@react-spectrum/textfield/stories/Textfield.stories.js
+++ b/packages/@react-spectrum/textfield/stories/Textfield.stories.js
@@ -16,6 +16,58 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {TextField} from '../';
 
+const parameters = {
+  args: {
+    isReadOnly: true,
+    isQuiet: false,
+    isRequired: false,
+    isDisabled: false,
+    autofocus: false,
+    validationState: '',
+    description: '',
+    errorMessage: '',
+    value: ''
+  },
+  argTypes: {
+    isQuiet: {
+      control: {type: 'boolean'}
+    },
+    isRequired: {
+      control: {type: 'boolean'}
+    },
+    isDisabled: {
+      control: {type: 'boolean'}
+    },
+    autofocus: {
+      control: {type: 'boolean'}
+    },
+    validationState: {
+      control: {
+        type: 'radio',
+        options: ['', 'invalid', 'valid']
+      }
+    },
+    description: {
+      control: {
+        type: 'radio',
+        options: ['', 'Please enter a street address']
+      }
+    },
+    errorMessage: {
+      control: {
+        type: 'radio',
+        options: ['', 'please enter a valid street address']
+      }
+    },
+    value: {
+      control: {
+        type: 'radio',
+        options: ['', 'foo  '.repeat(10)]
+      }
+    }
+  }
+};
+
 storiesOf('TextField', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
   .add(
@@ -140,6 +192,23 @@ storiesOf('TextField', module)
   )
   .add('custom width small, labelPosition: side',
     () => render({icon: <Info />, validationState: 'invalid', width: '30px', labelPosition: 'side'})
+  )
+  .add('test: isReadOnly, with controls', 
+    (args) => (   
+      <TextField
+        label="Street address"
+        onChange={action('change')}
+        onFocus={action('focus')}
+        onBlur={action('blur')}
+        UNSAFE_className="custom_classname"
+        {...args} />
+    ), parameters
+  )
+  .add('test: isReadOnly, defaultValue',
+    () => render({isReadOnly: true, defaultValue: 'foo  '.repeat(10)})
+  )
+  .add('test: isReadOnly, with icon, value = icon',
+    () => render({isReadOnly: true, icon: <Info />,  value: 'icon'})
   );
 
 function render(props = {}) {

--- a/packages/@react-types/label/src/index.d.ts
+++ b/packages/@react-types/label/src/index.d.ts
@@ -12,6 +12,7 @@
 
 import {Alignment, DOMProps, LabelPosition, NecessityIndicator, SpectrumHelpTextProps, StyleProps} from '@react-types/shared';
 import {ElementType, HTMLAttributes, ReactElement, ReactNode} from 'react';
+import {InputHTMLAttributes, RefObject, TextareaHTMLAttributes} from 'react';
 
 export interface LabelProps {
   children?: ReactNode,
@@ -36,5 +37,10 @@ export interface SpectrumFieldProps extends SpectrumLabelPropsBase, SpectrumHelp
   labelProps: HTMLAttributes<HTMLElement>,
   descriptionProps?: HTMLAttributes<HTMLElement>,
   errorMessageProps?: HTMLAttributes<HTMLElement>,
-  wrapperClassName?: string
+  wrapperClassName?: string,
+  readOnlyText?: string,
+  isReadOnly?: boolean,
+  inputProps?: InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>,
+  inputRef?: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  autoFocus?: boolean
 }


### PR DESCRIPTION
This reverts commit 94b3845182bb0df861febcc8dea395f5d0c92e76. Now that the release is done, we want this stuff back

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
