### PR TITLE
fix(#3349): useTable: Passing down provided id to useTable and useGrid

### DIFF
--- a/packages/@react-aria/grid/src/useGrid.ts
+++ b/packages/@react-aria/grid/src/useGrid.ts
@@ -98,7 +98,7 @@ export function useGrid<T>(props: GridProps, state: GridState<T, GridCollection<
     scrollRef
   });
 
-  let id = useId();
+  let id = useId(props.id);
   gridMap.set(state, {keyboardDelegate: delegate, actions: {onRowAction, onCellAction}});
 
   let descriptionProps = useHighlightSelectionDescription({

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -56,8 +56,7 @@ export function useTable<T>(props: AriaTableProps<T>, state: TableState<T>, ref:
     collator,
     layout
   }), [keyboardDelegate, state.collection, state.disabledKeys, ref, direction, collator, layout]);
-
-  let id = useId();
+  let id = useId(props.id);
   gridIds.set(state, id);
 
   let {gridProps} = useGrid({

--- a/packages/@react-aria/table/test/useTable.test.tsx
+++ b/packages/@react-aria/table/test/useTable.test.tsx
@@ -142,4 +142,31 @@ describe('useTable', () => {
       expect(onAction).toHaveBeenCalledWith(2);
     });
   });
+  describe('setting DOM props', () => {
+    it('sets the passed id', () => {
+      let {getByTestId} = render(
+        <Table
+          aria-label="Table with id"
+          data-testid="test-id"
+          id="table-id"
+          >
+          <TableHeader columns={columns}>
+            {column => (
+              <Column key={column.uid}>
+                {column.name}
+              </Column>
+            )}
+          </TableHeader>
+          <TableBody items={rows}>
+            {item => (
+              <Row>
+                {columnKey => <Cell>{item[columnKey]}</Cell>}
+              </Row>
+            )}
+          </TableBody>
+        </Table>
+      );
+      expect(getByTestId("test-id").id).toEqual('table-id');
+    })
+  })
 });

--- a/packages/@react-aria/table/test/useTable.test.tsx
+++ b/packages/@react-aria/table/test/useTable.test.tsx
@@ -148,8 +148,7 @@ describe('useTable', () => {
         <Table
           aria-label="Table with id"
           data-testid="test-id"
-          id="table-id"
-          >
+          id="table-id">
           <TableHeader columns={columns}>
             {column => (
               <Column key={column.uid}>
@@ -166,7 +165,7 @@ describe('useTable', () => {
           </TableBody>
         </Table>
       );
-      expect(getByTestId("test-id").id).toEqual('table-id');
-    })
-  })
+      expect(getByTestId('test-id').id).toEqual('table-id');
+    });
+  });
 });


### PR DESCRIPTION
Closes #3349 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
1- Pass an id to useTable props 
2- the returning gridProps should have this id instead of a generated one
