### PR TITLE
Stop propagation when pressing Enter on a native link

### DIFF
--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -1822,6 +1822,54 @@ describe('TableView', function () {
         let checkbox = tree.getByLabelText('Select All');
         expect(checkbox.checked).toBeFalsy();
       });
+
+      describe('Space key with focus on a link within a cell', () => {
+        it('should toggle selection and prevent scrolling of the table', () => {
+          let tree = render(
+            <TableView aria-label="Table" selectionMode="multiple">
+              <TableHeader columns={columns}>
+                {column => <Column>{column.name}</Column>}
+              </TableHeader>
+              <TableBody items={items}>
+                {item =>
+                  (<Row key={item.foo}>
+                    {key => <Cell><Link><a href={`https://example.com/?id=${item.id}`} target="_blank">{item[key]}</a></Link></Cell>}
+                  </Row>)
+                }
+              </TableBody>
+            </TableView>
+          );
+
+          let row = tree.getAllByRole('row')[1];
+          expect(row).toHaveAttribute('aria-selected', 'false');
+
+          let link = within(row).getAllByRole('link')[0];
+          expect(link.textContent).toBe('Foo 1');
+
+          act(() => {
+            link.focus();
+            fireEvent.keyDown(link, {key: ' '});
+            fireEvent.keyUp(link, {key: ' '});
+            jest.runAllTimers();
+          });
+
+          row = tree.getAllByRole('row')[1];
+          expect(row).toHaveAttribute('aria-selected', 'true');
+
+          act(() => {
+            link.focus();
+            fireEvent.keyDown(link, {key: ' '});
+            fireEvent.keyUp(link, {key: ' '});
+            jest.runAllTimers();
+          });
+
+          row = tree.getAllByRole('row')[1];
+          link = within(row).getAllByRole('link')[0];
+
+          expect(row).toHaveAttribute('aria-selected', 'false');
+          expect(link.textContent).toBe('Foo 1');
+        });
+      });
     });
 
     describe('range selection', function () {


### PR DESCRIPTION
Closes #2599. Closes #2619.

Slightly different version of the fix in #2619 (test and partial fix reused). This fixes scrolling and selection when pressing Space when focused on a link in a TableView, while letting Enter trigger the link natively. Two fixes:

1. Use `currentTarget` rather than `target` to check whether to handle a keyboard event. This ensures the check for link handling doesn't apply when the table row is handling an event that propagated up from a link (e.g. Space key). This is the same as in #2619.
2. Stop propagation on native HTML links during keydown, even when we don't otherwise handle the event, because the browser will handle it natively and we don't want TableView to also handle it. This is different from #2619 in that the link handles it rather than the table. I think we should stop propagation here because the event is handled (by the browser), so elements above it should not handle it as well.

## 📝 Test Instructions:
1. Open TableView async loading story.
2. Move focus to a link in the table.
3. Press Space key. Selection of the table row should be toggled, and it should not scroll.
4. Press Enter on the link. It should open in a new tab.