### PR TITLE
Fixing ListView drag preview badge

### DIFF
--- a/packages/@react-spectrum/list/src/DragPreview.tsx
+++ b/packages/@react-spectrum/list/src/DragPreview.tsx
@@ -36,11 +36,10 @@ export function DragPreview(props: DragPreviewProps) {
       <Grid UNSAFE_className={listStyles['react-spectrum-ListViewItem-grid']}>
         <SlotProvider
           slots={{
-            content: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-content']},
             text: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-content']},
             description: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-description']},
-            illustration: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-illustration']},
-            image: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-image']},
+            illustration: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-thumbnail']},
+            image: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-thumbnail']},
             actionButton: {UNSAFE_className: listStyles['react-spectrum-ListViewItem-actions'], isQuiet: true},
             actionGroup: {
               UNSAFE_className: listStyles['react-spectrum-ListViewItem-actions'],

--- a/packages/@react-spectrum/list/src/styles.css
+++ b/packages/@react-spectrum/list/src/styles.css
@@ -403,7 +403,7 @@
       grid-template-areas:
         "thumbnail content     . badge"
         "thumbnail description . badge";
-      grid-template-columns: auto auto auto 1fr;
+      grid-template-columns: auto auto 1fr auto;
     }
 
     .react-spectrum-ListViewItem-badge {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Try dragging multiple ListView rows in the ListView drag stories. The badge shouldn't stretch to fill remaining space in the grid

## 🧢 Your Project:

RSP