### PR TITLE
Drag and drop bug fixes

### DIFF
--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -75,7 +75,8 @@ export function beginDragging(target: DragTarget, stringFormatter: LocalizedStri
       getDragModality() === 'keyboard' ||
       (getDragModality() === 'touch' && getInteractionModality() === 'virtual')
     ) {
-      dragSession.next();
+      let target = dragSession.findNearestDropTarget();
+      dragSession.setCurrentDropTarget(target);
     }
   });
 
@@ -409,6 +410,25 @@ class DragSession {
     } else {
       this.setCurrentDropTarget(this.validDropTargets[index - 1]);
     }
+  }
+
+  findNearestDropTarget(): DropTarget {
+    let dragTargetRect = this.dragTarget.element.getBoundingClientRect();
+
+    let minDistance = Infinity;
+    let nearest = null;
+    for (let dropTarget of this.validDropTargets) {
+      let rect = dropTarget.element.getBoundingClientRect();
+      let dx = rect.left - dragTargetRect.left;
+      let dy = rect.top - dragTargetRect.top;
+      let dist = (dx * dx) + (dy * dy);
+      if (dist < minDistance) {
+        minDistance = dist;
+        nearest = dropTarget;
+      }
+    }
+
+    return nearest;
   }
 
   setCurrentDropTarget(dropTarget: DropTarget, item?: DroppableItem) {

--- a/packages/@react-aria/dnd/src/ListDropTargetDelegate.ts
+++ b/packages/@react-aria/dnd/src/ListDropTargetDelegate.ts
@@ -1,0 +1,90 @@
+import {Collection, DropTarget, DropTargetDelegate, Node} from '@react-types/shared';
+import {RefObject} from 'react';
+
+export class ListDropTargetDelegate implements DropTargetDelegate {
+  private collection: Collection<Node<unknown>>;
+  private ref: RefObject<HTMLElement>;
+
+  constructor(collection: Collection<Node<unknown>>, ref: RefObject<HTMLElement>) {
+    this.collection = collection;
+    this.ref = ref;
+  }
+
+  getDropTargetFromPoint(x: number, y: number, isValidDropTarget: (target: DropTarget) => boolean): DropTarget {
+    if (this.collection.size === 0) {
+      return;
+    }
+
+    let rect = this.ref.current.getBoundingClientRect();
+    x += rect.x;
+    y += rect.y;
+
+    let elements = this.ref.current.querySelectorAll('[data-key]');
+    let elementMap = new Map<string, HTMLElement>();
+    for (let item of elements) {
+      if (item instanceof HTMLElement) {
+        elementMap.set(item.dataset.key, item);
+      }
+    }
+
+    let items = [...this.collection];
+    let low = 0;
+    let high = items.length;
+    while (low < high) {
+      let mid = Math.floor((low + high) / 2);
+      let item = items[mid];
+      let element = elementMap.get(String(item.key));
+      let rect = element.getBoundingClientRect();
+
+      if (y < rect.top) {
+        high = mid;
+      } else if (y > rect.bottom) {
+        low = mid + 1;
+      } else {
+        let target: DropTarget = {
+          type: 'item',
+          key: item.key,
+          dropPosition: 'on'
+        };
+
+        if (isValidDropTarget(target)) {
+          // Otherwise, if dropping on the item is accepted, try the before/after positions if within 5px
+          // of the top or bottom of the item.
+          if (y <= rect.top + 5 && isValidDropTarget({...target, dropPosition: 'before'})) {
+            target.dropPosition = 'before';
+          } else if (y >= rect.bottom - 5 && isValidDropTarget({...target, dropPosition: 'after'})) {
+            target.dropPosition = 'after';
+          }
+        } else {
+          // If dropping on the item isn't accepted, try the target before or after depending on the y position.
+          let midY = rect.top + rect.height / 2;
+          if (y <= midY && isValidDropTarget({...target, dropPosition: 'before'})) {
+            target.dropPosition = 'before';
+          } else if (y >= midY && isValidDropTarget({...target, dropPosition: 'after'})) {
+            target.dropPosition = 'after';
+          }
+        }
+
+        return target;
+      }
+    }
+
+    let item = items[Math.min(low, items.length - 1)];
+    let element = elementMap.get(String(item.key));
+    rect = element.getBoundingClientRect();
+
+    if (Math.abs(y - rect.top) < Math.abs(y - rect.bottom)) {
+      return {
+        type: 'item',
+        key: item.key,
+        dropPosition: 'before'
+      };
+    }
+
+    return {
+      type: 'item',
+      key: item.key,
+      dropPosition: 'after'
+    };
+  }
+}

--- a/packages/@react-aria/dnd/src/index.ts
+++ b/packages/@react-aria/dnd/src/index.ts
@@ -18,6 +18,7 @@ export type {DragPreviewProps} from './DragPreview';
 export type {DragOptions, DragResult} from './useDrag';
 export type {DropOptions, DropResult} from './useDrop';
 export type {ClipboardProps, ClipboardResult} from './useClipboard';
+export type {DropTargetDelegate} from '@react-types/shared';
 
 export {useDrag} from './useDrag';
 export {useDrop} from './useDrop';
@@ -27,3 +28,4 @@ export {useDropIndicator} from './useDropIndicator';
 export {useDraggableItem} from './useDraggableItem';
 export {useClipboard} from './useClipboard';
 export {DragPreview} from './DragPreview';
+export {ListDropTargetDelegate} from './ListDropTargetDelegate';

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -20,14 +20,24 @@ import {useVirtualDrop} from './useVirtualDrop';
 
 export interface DropOptions {
   ref: RefObject<HTMLElement>,
+  /**
+   * A function returning the drop operation to be performed when items matching the given types are dropped
+   * on the drop target.
+   */
   getDropOperation?: (types: IDragTypes, allowedOperations: DropOperation[]) => DropOperation,
   getDropOperationForPoint?: (types: IDragTypes, allowedOperations: DropOperation[], x: number, y: number) => DropOperation,
+  /** Handler that is called when a valid drag enters the drop target. */
   onDropEnter?: (e: DropEnterEvent) => void,
+  /** Handler that is called when a valid drag is moved within the drop target. */
   onDropMove?: (e: DropMoveEvent) => void,
-  // When the user hovers over the drop target for a period of time.
-  // typically opens that item. macOS/iOS call this "spring loading".
+  /**
+   * Handler that is called after a valid drag is held over the drop target for a period of time.
+   * This typically opens the item so that the user can drop within it.
+   */
   onDropActivate?: (e: DropActivateEvent) => void,
+  /** Handler that is called when a valid drag exits the drop target. */
   onDropExit?: (e: DropExitEvent) => void,
+  /** Handler that is called when a valid drag is dropped on the drop target. */
   onDrop?: (e: DropEvent) => void
 }
 
@@ -43,16 +53,43 @@ export function useDrop(options: DropOptions): DropResult {
   let state = useRef({
     x: 0,
     y: 0,
-    dragEnterCount: 0,
+    isDragWithin: false,
     dropEffect: 'none' as DataTransfer['dropEffect'],
+    effectAllowed: 'none' as DataTransfer['effectAllowed'],
     dropActivateTimer: null
   }).current;
+
+  let fireDropEnter = (e: DragEvent) => {
+    setDropTarget(true);
+
+    if (typeof options.onDropEnter === 'function') {
+      let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      options.onDropEnter({
+        type: 'dropenter',
+        x: e.clientX - rect.x,
+        y: e.clientY - rect.y
+      });
+    }
+  };
+
+  let fireDropExit = (e: DragEvent) => {
+    setDropTarget(false);
+
+    if (typeof options.onDropExit === 'function') {
+      let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      options.onDropExit({
+        type: 'dropexit',
+        x: e.clientX - rect.x,
+        y: e.clientY - rect.y
+      });
+    }
+  };
 
   let onDragOver = (e: DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
 
-    if (e.clientX === state.x && e.clientY === state.y) {
+    if (e.clientX === state.x && e.clientY === state.y && e.dataTransfer.effectAllowed === state.effectAllowed) {
       e.dataTransfer.dropEffect = state.dropEffect;
       return;
     }
@@ -60,17 +97,42 @@ export function useDrop(options: DropOptions): DropResult {
     state.x = e.clientX;
     state.y = e.clientY;
 
+    let prevDropEffect = state.dropEffect;
+
+    // Update drop effect if allowed drop operations changed (e.g. user pressed modifier key).
+    if (e.dataTransfer.effectAllowed !== state.effectAllowed) {
+      let allowedOperations = effectAllowedToOperations(e.dataTransfer.effectAllowed);
+      let dropOperation = allowedOperations[0];
+      if (typeof options.getDropOperation === 'function') {
+        let types = new DragTypes(e.dataTransfer);
+        dropOperation = getDropOperation(e.dataTransfer.effectAllowed, options.getDropOperation(types, allowedOperations));
+      }
+
+      state.dropEffect = DROP_OPERATION_TO_DROP_EFFECT[dropOperation] || 'none';
+    }
+
     if (typeof options.getDropOperationForPoint === 'function') {
       let allowedOperations = effectAllowedToOperations(e.dataTransfer.effectAllowed);
       let types = new DragTypes(e.dataTransfer);
       let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      let dropOperation = options.getDropOperationForPoint(types, allowedOperations, state.x - rect.x, state.y - rect.y);
+      let dropOperation = getDropOperation(
+        e.dataTransfer.effectAllowed,
+        options.getDropOperationForPoint(types, allowedOperations, state.x - rect.x, state.y - rect.y)
+      );
       state.dropEffect = DROP_OPERATION_TO_DROP_EFFECT[dropOperation] || 'none';
     }
 
+    state.effectAllowed = e.dataTransfer.effectAllowed;
     e.dataTransfer.dropEffect = state.dropEffect;
 
-    if (typeof options.onDropMove === 'function') {
+    // If the drop operation changes, update state and fire events appropriately.
+    if (state.dropEffect === 'none' && prevDropEffect !== 'none') {
+      fireDropExit(e);
+    } else if (state.dropEffect !== 'none' && prevDropEffect === 'none') {
+      fireDropEnter(e);
+    }
+
+    if (typeof options.onDropMove === 'function' && state.dropEffect !== 'none') {
       let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
       options.onDropMove({
         type: 'dropmove',
@@ -95,62 +157,51 @@ export function useDrop(options: DropOptions): DropResult {
 
   let onDragEnter = (e: DragEvent) => {
     e.stopPropagation();
-    state.dragEnterCount++;
-    if (state.dragEnterCount > 1) {
+    if (state.isDragWithin) {
       return;
     }
+
+    state.isDragWithin = true;
 
     let allowedOperations = effectAllowedToOperations(e.dataTransfer.effectAllowed);
     let dropOperation = allowedOperations[0];
 
     if (typeof options.getDropOperation === 'function') {
       let types = new DragTypes(e.dataTransfer);
-      dropOperation = options.getDropOperation(types, allowedOperations);
-    }
-
-    if (dropOperation !== 'cancel') {
-      setDropTarget(true);
+      dropOperation = getDropOperation(e.dataTransfer.effectAllowed, options.getDropOperation(types, allowedOperations));
     }
 
     if (typeof options.getDropOperationForPoint === 'function') {
       let types = new DragTypes(e.dataTransfer);
       let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      dropOperation = options.getDropOperationForPoint(types, allowedOperations, e.clientX - rect.x, e.clientY - rect.y);
-    }
-
-    state.dropEffect = DROP_OPERATION_TO_DROP_EFFECT[dropOperation] || 'none';
-    e.dataTransfer.dropEffect = state.dropEffect;
-
-    if (typeof options.onDropEnter === 'function' && dropOperation !== 'cancel') {
-      let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      options.onDropEnter({
-        type: 'dropenter',
-        x: e.clientX - rect.x,
-        y: e.clientY - rect.y
-      });
+      dropOperation = getDropOperation(
+        e.dataTransfer.effectAllowed,
+        options.getDropOperationForPoint(types, allowedOperations, e.clientX - rect.x, e.clientY - rect.y)
+      );
     }
 
     state.x = e.clientX;
     state.y = e.clientY;
+    state.effectAllowed = e.dataTransfer.effectAllowed;
+    state.dropEffect = DROP_OPERATION_TO_DROP_EFFECT[dropOperation] || 'none';
+    e.dataTransfer.dropEffect = state.dropEffect;
+
+    if (dropOperation !== 'cancel') {
+      fireDropEnter(e);
+    }
   };
 
   let onDragLeave = (e: DragEvent) => {
     e.stopPropagation();
-    state.dragEnterCount--;
-    if (state.dragEnterCount > 0) {
+    if (!state.isDragWithin || e.currentTarget.contains(e.relatedTarget as Element)) {
       return;
     }
 
-    if (typeof options.onDropExit === 'function' && state.dropEffect !== 'none') {
-      let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      options.onDropExit({
-        type: 'dropexit',
-        x: e.clientX - rect.x,
-        y: e.clientY - rect.y
-      });
+    state.isDragWithin = false;
+    if (state.dropEffect !== 'none') {
+      fireDropExit(e);
     }
 
-    setDropTarget(false);
     clearTimeout(state.dropActivateTimer);
   };
 
@@ -180,17 +231,8 @@ export function useDrop(options: DropOptions): DropResult {
       }, 0);
     }
 
-    if (typeof options.onDropExit === 'function') {
-      let rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      options.onDropExit({
-        type: 'dropexit',
-        x: e.clientX - rect.x,
-        y: e.clientY - rect.y
-      });
-    }
-
-    state.dragEnterCount = 0;
-    setDropTarget(false);
+    state.isDragWithin = false;
+    fireDropExit(e);
     clearTimeout(state.dropActivateTimer);
   };
 
@@ -254,4 +296,10 @@ function effectAllowedToOperations(effectAllowed: string) {
   }
 
   return allowedOperations;
+}
+
+function getDropOperation(effectAllowed: string, operation: DropOperation) {
+  let allowedOperationsBits = DROP_OPERATION_ALLOWED[effectAllowed];
+  let op = DROP_OPERATION[operation];
+  return allowedOperationsBits & op ? operation : 'cancel';
 }

--- a/packages/@react-aria/dnd/src/useDropIndicator.ts
+++ b/packages/@react-aria/dnd/src/useDropIndicator.ts
@@ -26,7 +26,9 @@ export interface DropIndicatorProps {
 }
 
 export interface DropIndicatorAria {
-  dropIndicatorProps: HTMLAttributes<HTMLElement>
+  dropIndicatorProps: HTMLAttributes<HTMLElement>,
+  isDropTarget: boolean,
+  isHidden: boolean
 }
 
 export function useDropIndicator(props: DropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement>): DropIndicatorAria {
@@ -72,6 +74,8 @@ export function useDropIndicator(props: DropIndicatorProps, state: DroppableColl
     }
   }
 
+  let isDropTarget = state.isDropTarget(target);
+  let ariaHidden = !dragSession ? 'true' : dropProps['aria-hidden'];
   return {
     dropIndicatorProps: {
       ...dropProps,
@@ -79,8 +83,13 @@ export function useDropIndicator(props: DropIndicatorProps, state: DroppableColl
       'aria-roledescription': stringFormatter.format('dropIndicator'),
       'aria-label': label,
       'aria-labelledby': labelledBy,
-      'aria-hidden': !dragSession ? 'true' : dropProps['aria-hidden'],
+      'aria-hidden': ariaHidden,
       tabIndex: -1
-    }
+    },
+    isDropTarget,
+    // If aria-hidden, we are either not in a drag session or the drop target is invalid.
+    // In that case, there's no need to render anything at all unless we need to show the indicator visually.
+    // This can happen when dragging using the native DnD API as opposed to keyboard dragging.
+    isHidden: !isDropTarget && !!ariaHidden
   };
 }

--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -111,7 +111,7 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
     // Focus the collection.
     state.selectionManager.setFocused(true);
 
-    // Save some state of the collection/selection before the drop occuers so we can compare later.
+    // Save some state of the collection/selection before the drop occurs so we can compare later.
     let focusedKey = state.selectionManager.focusedKey;
     droppingState.current = {
       timeout: null,

--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, DropEvent, DropOperation, DroppableCollectionProps, DropPosition, DropTarget, KeyboardDelegate, Node} from '@react-types/shared';
+import {Collection, DropEvent, DropOperation, DroppableCollectionProps, DropPosition, DropTarget, DropTargetDelegate, KeyboardDelegate, Node} from '@react-types/shared';
 import * as DragManager from './DragManager';
 import {DroppableCollectionState} from '@react-stately/dnd';
 import {getTypes} from './utils';
@@ -23,7 +23,7 @@ import {useDroppableCollectionId} from './utils';
 
 export interface DroppableCollectionOptions extends DroppableCollectionProps {
   keyboardDelegate: KeyboardDelegate,
-  getDropTargetFromPoint: (x: number, y: number) => DropTarget | null
+  dropTargetDelegate: DropTargetDelegate
 }
 
 export interface DroppableCollectionResult {
@@ -52,16 +52,16 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
   let autoScroll = useAutoScroll(ref);
   let {dropProps} = useDrop({
     ref,
-    onDropEnter(e) {
-      let target = props.getDropTargetFromPoint(e.x, e.y);
-      state.setTarget(target);
+    onDropEnter() {
+      state.setTarget(localState.nextTarget);
     },
     onDropMove(e) {
       state.setTarget(localState.nextTarget);
       autoScroll.move(e.x, e.y);
     },
     getDropOperationForPoint(types, allowedOperations, x, y) {
-      let target = props.getDropTargetFromPoint(x, y);
+      let isValidDropTarget = (target) => state.getDropOperation(target, types, allowedOperations) !== 'cancel';
+      let target = props.dropTargetDelegate.getDropTargetFromPoint(x, y, isValidDropTarget);
       if (!target) {
         localState.dropOperation = 'cancel';
         localState.nextTarget = null;
@@ -111,7 +111,7 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
     // Focus the collection.
     state.selectionManager.setFocused(true);
 
-    // Save some state of the collection/selection before the drop occurs so we can compare later.
+    // Save some state of the collection/selection before the drop occuers so we can compare later.
     let focusedKey = state.selectionManager.focusedKey;
     droppingState.current = {
       timeout: null,

--- a/packages/@react-aria/dnd/src/useDroppableItem.ts
+++ b/packages/@react-aria/dnd/src/useDroppableItem.ts
@@ -22,7 +22,8 @@ export interface DroppableItemOptions {
 }
 
 export interface DroppableItemResult {
-  dropProps: HTMLAttributes<HTMLElement>
+  dropProps: HTMLAttributes<HTMLElement>,
+  isDropTarget: boolean
 }
 
 export function useDroppableItem(options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>): DroppableItemResult {
@@ -62,6 +63,7 @@ export function useDroppableItem(options: DroppableItemOptions, state: Droppable
     dropProps: {
       ...dropProps,
       'aria-hidden': !dragSession || isValidDropTarget ? undefined : 'true'
-    }
+    },
+    isDropTarget
   };
 }

--- a/packages/@react-aria/dnd/stories/DroppableGrid.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableGrid.tsx
@@ -153,7 +153,7 @@ const DroppableGrid = React.forwardRef(function (props: any, ref) {
       return 'move';
     }
 
-    if (target.key === '2') {
+    if (target.key === '2' && target.dropPosition === 'on') {
       return 'cancel';
     }
 

--- a/packages/@react-aria/dnd/stories/DroppableGrid.tsx
+++ b/packages/@react-aria/dnd/stories/DroppableGrid.tsx
@@ -18,6 +18,7 @@ import {FocusRing} from '@react-aria/focus';
 import Folder from '@spectrum-icons/workflow/Folder';
 import {GridCollection, useGridState} from '@react-stately/grid';
 import {Item} from '@react-stately/collections';
+import {ListDropTargetDelegate} from '@react-aria/dnd';
 import {ListKeyboardDelegate} from '@react-aria/selection';
 import {mergeProps} from '@react-aria/utils';
 import React from 'react';
@@ -152,7 +153,7 @@ const DroppableGrid = React.forwardRef(function (props: any, ref) {
       return 'move';
     }
 
-    if (target.key === '2' && target.dropPosition === 'on') {
+    if (target.key === '2') {
       return 'cancel';
     }
 
@@ -171,57 +172,12 @@ const DroppableGrid = React.forwardRef(function (props: any, ref) {
 
   let {collectionProps} = useDroppableCollection({
     keyboardDelegate,
+    dropTargetDelegate: new ListDropTargetDelegate(gridState.collection, domRef),
     onDropEnter: props.onDropEnter,
     onDropMove: props.onDropMove,
     onDropExit: props.onDropExit,
     onDropActivate: props.onDropActivate,
-    onDrop: props.onDrop,
-    getDropTargetFromPoint(x, y) {
-      let rect = domRef.current.getBoundingClientRect();
-      x += rect.x;
-      y += rect.y;
-      let closest = null;
-      let closestDistance = Infinity;
-      let closestDir = null;
-
-      for (let child of domRef.current.children) {
-        if (!(child as HTMLElement).dataset.key) {
-          continue;
-        }
-
-        let r = child.getBoundingClientRect();
-        let points: [number, number, string][] = [
-          [r.left, r.top, 'before'],
-          [r.right, r.top, 'before'],
-          [r.left, r.bottom, 'after'],
-          [r.right, r.bottom, 'after']
-        ];
-
-        for (let [px, py, dir] of points) {
-          let dx = px - x;
-          let dy = py - y;
-          let d = dx * dx + dy * dy;
-          if (d < closestDistance) {
-            closestDistance = d;
-            closest = child;
-            closestDir = dir;
-          }
-        }
-
-        if (y >= r.top + 10 && y <= r.bottom - 10) {
-          closestDir = 'on';
-        }
-      }
-
-      let key = closest?.dataset.key;
-      if (key) {
-        return {
-          type: 'item',
-          key,
-          dropPosition: closestDir
-        };
-      }
-    }
+    onDrop: props.onDrop
   }, dropState, domRef);
 
   let {gridProps} = useGrid({
@@ -334,7 +290,7 @@ function InsertionIndicator(props) {
   }
 
   return (
-    <div role="row" aria-hidden={dropIndicatorProps['aria-hidden']}>
+    <div role="row" aria-hidden={dropIndicatorProps['aria-hidden']} style={{margin: '-5px 0'}}>
       <div
         role="gridcell"
         aria-selected="false"
@@ -346,7 +302,6 @@ function InsertionIndicator(props) {
           width: '100%',
           marginLeft: 0,
           height: 2,
-          marginBottom: -2,
           outline: 'none'
         }}>
         <div {...visuallyHiddenProps} role="button" {...dropIndicatorProps} ref={ref} />

--- a/packages/@react-aria/dnd/stories/Reorderable.tsx
+++ b/packages/@react-aria/dnd/stories/Reorderable.tsx
@@ -21,6 +21,7 @@ import Folder from '@spectrum-icons/workflow/Folder';
 import {GridCollection, useGridState} from '@react-stately/grid';
 import {Item} from '@react-stately/collections';
 import {ItemDropTarget} from '@react-types/shared';
+import {ListDropTargetDelegate} from '@react-aria/dnd';
 import {ListKeyboardDelegate} from '@react-aria/selection';
 import {mergeProps} from '@react-aria/utils';
 import React, {useRef} from 'react';
@@ -121,6 +122,7 @@ function ReorderableGrid(props) {
 
   let {collectionProps} = useDroppableCollection({
     keyboardDelegate,
+    dropTargetDelegate: new ListDropTargetDelegate(state.collection, ref),
     onDropEnter: chain(action('onDropEnter'), console.log),
     // onDropMove: action('onDropMove'),
     onDropExit: chain(action('onDropExit'), console.log),
@@ -136,52 +138,6 @@ function ReorderableGrid(props) {
         }
 
         props.onMove(keys, e.target);
-      }
-    },
-    getDropTargetFromPoint(x, y) {
-      let rect = ref.current.getBoundingClientRect();
-      x += rect.x;
-      y += rect.y;
-      let closest = null;
-      let closestDistance = Infinity;
-      let closestDir = null;
-
-      for (let child of ref.current.children) {
-        if (!(child as HTMLElement).dataset.key) {
-          continue;
-        }
-
-        let r = child.getBoundingClientRect();
-        let points: [number, number, string][] = [
-          [r.left, r.top, 'before'],
-          [r.right, r.top, 'before'],
-          [r.left, r.bottom, 'after'],
-          [r.right, r.bottom, 'after']
-        ];
-
-        for (let [px, py, dir] of points) {
-          let dx = px - x;
-          let dy = py - y;
-          let d = dx * dx + dy * dy;
-          if (d < closestDistance) {
-            closestDistance = d;
-            closest = child;
-            closestDir = dir;
-          }
-        }
-
-        if (y >= r.top + 10 && y <= r.bottom - 10) {
-          closestDir = 'on';
-        }
-      }
-
-      let key = closest?.dataset.key;
-      if (key) {
-        return {
-          type: 'item',
-          key,
-          dropPosition: closestDir
-        };
       }
     }
   }, dropState, ref);

--- a/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
+++ b/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
@@ -22,7 +22,6 @@ import {Item} from '@react-stately/collections';
 import {ListLayout} from '@react-stately/layout';
 import {mergeProps} from '@react-aria/utils';
 import React from 'react';
-import {Rect} from '@react-stately/virtualizer';
 import {useCollator} from '@react-aria/i18n';
 import {useDropIndicator, useDroppableCollection, useDroppableItem} from '..';
 import {useDroppableCollectionState} from '@react-stately/dnd';
@@ -150,6 +149,7 @@ export const VirtualizedListBox = React.forwardRef(function (props: any, ref) {
 
   let {collectionProps} = useDroppableCollection({
     keyboardDelegate: layout,
+    dropTargetDelegate: layout,
     onDropEnter: chain(action('onDropEnter'), console.log),
     // onDropMove: action('onDropMove'),
     onDropExit: chain(action('onDropExit'), console.log),
@@ -157,49 +157,6 @@ export const VirtualizedListBox = React.forwardRef(function (props: any, ref) {
     onDrop: async e => {
       onDrop(e);
       props.onDrop?.(e);
-    },
-    getDropTargetFromPoint(x, y) {
-      let closest = null;
-      let closestDistance = Infinity;
-      let closestDir = null;
-
-      x += domRef.current.scrollLeft;
-      y += domRef.current.scrollTop;
-      let visible = layout.getVisibleLayoutInfos(new Rect(x - 50, y - 50, x + 50, y + 50));
-
-      for (let layoutInfo of visible) {
-        let r = layoutInfo.rect;
-        let points: [number, number, string][] = [
-          [r.x, r.y + 4, 'before'],
-          [r.maxX, r.y + 4, 'before'],
-          [r.x, r.maxY - 8, 'after'],
-          [r.maxX, r.maxY - 8, 'after']
-        ];
-
-        for (let [px, py, dir] of points) {
-          let dx = px - x;
-          let dy = py - y;
-          let d = dx * dx + dy * dy;
-          if (d < closestDistance) {
-            closestDistance = d;
-            closest = layoutInfo;
-            closestDir = dir;
-          }
-        }
-
-        if (y >= r.y + 10 && y <= r.maxY - 10) {
-          closestDir = 'on';
-        }
-      }
-
-      let key = closest?.key;
-      if (key) {
-        return {
-          type: 'item',
-          key,
-          dropPosition: closestDir
-        };
-      }
     }
   }, dropState, domRef);
 

--- a/packages/@react-aria/dnd/stories/dnd.css
+++ b/packages/@react-aria/dnd/stories/dnd.css
@@ -134,6 +134,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  gap: 8px;
 
   &.is-drop-target {
     background-color: var(--spectrum-dropzone-background-color-selected-hover);
@@ -147,5 +148,9 @@
     > div > div {
       overflow: visible !important;
     }
+  }
+
+  .droppable {
+    margin: 0;
   }
 }

--- a/packages/@react-aria/dnd/test/useDroppableCollection.test.js
+++ b/packages/@react-aria/dnd/test/useDroppableCollection.test.js
@@ -143,7 +143,7 @@ describe('useDroppableCollection', () => {
         type: 'dropenter',
         x: 0,
         y: 0,
-        target: {type: 'item', key: '1', dropPosition: 'after'}
+        target: {type: 'item', key: '2', dropPosition: 'before'}
       });
 
       allCells = within(grid).getAllByRole('gridcell', {hidden: true});
@@ -157,31 +157,10 @@ describe('useDroppableCollection', () => {
         type: 'dropexit',
         x: 0,
         y: 0,
-        target: {type: 'item', key: '1', dropPosition: 'after'}
+        target: {type: 'item', key: '2', dropPosition: 'before'}
       });
 
       expect(onDropEnter).toHaveBeenCalledTimes(4);
-      expect(onDropEnter).toHaveBeenLastCalledWith({
-        type: 'dropenter',
-        x: 0,
-        y: 0,
-        target: {type: 'root'}
-      });
-
-      allCells = within(grid).getAllByRole('gridcell', {hidden: true});
-      expect(allCells).toHaveLength(3);
-      expect(grid).toHaveAttribute('data-droptarget', 'true');
-
-      fireEvent(cells[2], new DragEvent('dragover', {dataTransfer, clientX: 1, clientY: 100}));
-      expect(onDragExit).toHaveBeenCalledTimes(4);
-      expect(onDragExit).toHaveBeenLastCalledWith({
-        type: 'dropexit',
-        x: 0,
-        y: 0,
-        target: {type: 'root'}
-      });
-
-      expect(onDropEnter).toHaveBeenCalledTimes(5);
       expect(onDropEnter).toHaveBeenLastCalledWith({
         type: 'dropenter',
         x: 0,

--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -26,7 +26,6 @@ import {ListViewItem} from './ListViewItem';
 import {mergeProps} from '@react-aria/utils';
 import {ProgressCircle} from '@react-spectrum/progress';
 import React, {Key, ReactElement, useContext, useMemo, useRef, useState} from 'react';
-import {Rect} from '@react-stately/virtualizer';
 import RootDropIndicator from './RootDropIndicator';
 import {DragPreview as SpectrumDragPreview} from './DragPreview';
 import {SpectrumListViewProps} from '@react-types/list';
@@ -145,53 +144,7 @@ function ListView<T extends object>(props: SpectrumListViewProps<T>, ref: DOMRef
     });
     droppableCollection = dropHooks.useDroppableCollection({
       keyboardDelegate: layout,
-      getDropTargetFromPoint(x, y) {
-        let closest = null;
-        let closestDistance = Infinity;
-        let closestDir = null;
-
-        x += domRef.current.scrollLeft;
-        y += domRef.current.scrollTop;
-
-        let visible = layout.getVisibleLayoutInfos(new Rect(x - 50, y - 50, x + 50, y + 50));
-
-        for (let layoutInfo of visible) {
-          let r = layoutInfo.rect;
-          let points: [number, number, string][] = [
-            [r.x, r.y + 4, 'before'],
-            [r.maxX, r.y + 4, 'before'],
-            [r.x, r.maxY - 8, 'after'],
-            [r.maxX, r.maxY - 8, 'after']
-          ];
-
-          for (let [px, py, dir] of points) {
-            let dx = px - x;
-            let dy = py - y;
-            let d = dx * dx + dy * dy;
-            if (d < closestDistance) {
-              closestDistance = d;
-              closest = layoutInfo;
-              closestDir = dir;
-            }
-          }
-
-          // TODO: Best way to implement only for when closest can be dropped on
-          // TODO: Figure out the typescript for this
-          // @ts-ignore
-          if (y >= r.y + 10 && y <= r.maxY - 10 && collection.getItem(closest.key).value.type === 'folder') {
-            closestDir = 'on';
-          }
-        }
-
-        let key = closest?.key;
-        if (key) {
-          return {
-            type: 'item',
-            key,
-            dropPosition: closestDir
-          };
-        }
-      }
+      dropTargetDelegate: layout
     }, dropState, domRef);
 
     isRootDropTarget = dropState.isDropTarget({type: 'root'});

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -11,7 +11,7 @@
  */
 
 import {Collection, DropTarget, DropTargetDelegate, KeyboardDelegate, Node} from '@react-types/shared';
-import {InvalidationContext, Layout, LayoutInfo, Rect, Size} from '@react-stately/virtualizer';
+import {InvalidationContext, Layout, LayoutInfo, Point, Rect, Size} from '@react-stately/virtualizer';
 import {Key} from 'react';
 // import { DragTarget, DropTarget, DropPosition } from '@react-types/shared';
 
@@ -489,11 +489,12 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate, 
     x += this.virtualizer.visibleRect.x;
     y += this.virtualizer.visibleRect.y;
 
-    let layoutInfo = this.getVisibleLayoutInfos(new Rect(x, y, 1, 1))[0];
-    if (!layoutInfo) {
+    let key = this.virtualizer.keyAtPoint(new Point(x, y));
+    if (key == null) {
       return;
     }
 
+    let layoutInfo = this.getLayoutInfo(key);
     let rect = layoutInfo.rect;
     let target: DropTarget = {
       type: 'item',

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, KeyboardDelegate, Node} from '@react-types/shared';
+import {Collection, DropTarget, DropTargetDelegate, KeyboardDelegate, Node} from '@react-types/shared';
 import {InvalidationContext, Layout, LayoutInfo, Rect, Size} from '@react-stately/virtualizer';
 import {Key} from 'react';
 // import { DragTarget, DropTarget, DropPosition } from '@react-types/shared';
@@ -49,7 +49,7 @@ const DEFAULT_HEIGHT = 48;
  * delegate with an additional method to do this (it uses the same delegate object as
  * the collection view itself).
  */
-export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
+export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate, DropTargetDelegate {
   protected rowHeight: number;
   protected estimatedRowHeight: number;
   protected headingHeight: number;
@@ -473,32 +473,6 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     return null;
   }
 
-  // getDragTarget(point: Point): DragTarget {
-  //   let visible = this.getVisibleLayoutInfos(new Rect(point.x, point.y, 1, 1));
-  //   if (visible.length > 0) {
-  //     visible = visible.sort((a, b) => b.zIndex - a.zIndex);
-  //     return {
-  //       type: 'item',
-  //       key: visible[0].key
-  //     };
-  //   }
-
-  //   return null;
-  // }
-
-  // getDropTarget(point: Point): DropTarget {
-  //   let key = this.virtualizer.keyAtPoint(point);
-  //   if (key) {
-  //     return {
-  //       type: 'item',
-  //       key,
-  //       dropPosition: DropPosition.ON
-  //     };
-  //   }
-
-  //   return null;
-  // }
-
   getInitialLayoutInfo(layoutInfo: LayoutInfo) {
     layoutInfo.opacity = 0;
     layoutInfo.transform = 'scale3d(0.8, 0.8, 0.8)';
@@ -509,5 +483,39 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     layoutInfo.opacity = 0;
     layoutInfo.transform = 'scale3d(0.8, 0.8, 0.8)';
     return layoutInfo;
+  }
+
+  getDropTargetFromPoint(x: number, y: number, isValidDropTarget: (target: DropTarget) => boolean): DropTarget {
+    x += this.virtualizer.visibleRect.x;
+    y += this.virtualizer.visibleRect.y;
+
+    let layoutInfo = this.getVisibleLayoutInfos(new Rect(x, y, 1, 1))[0];
+    if (!layoutInfo) {
+      return;
+    }
+
+    let rect = layoutInfo.rect;
+    let target: DropTarget = {
+      type: 'item',
+      key: layoutInfo.key,
+      dropPosition: 'on'
+    };
+
+    // If dropping on the item isn't accepted, try the target before or after depending on the y position.
+    // Otherwise, if dropping on the item is accepted, still try the before/after positions if within 10px
+    // of the top or bottom of the item.
+    if (!isValidDropTarget(target)) {
+      if (y <= rect.y + rect.height / 2 && isValidDropTarget({...target, dropPosition: 'before'})) {
+        target.dropPosition = 'before';
+      } else if (isValidDropTarget({...target, dropPosition: 'after'})) {
+        target.dropPosition = 'after';
+      }
+    } else if (y <= rect.y + 10 && isValidDropTarget({...target, dropPosition: 'before'})) {
+      target.dropPosition = 'before';
+    } else if (y >= rect.maxY - 10 && isValidDropTarget({...target, dropPosition: 'after'})) {
+      target.dropPosition = 'after';
+    }
+
+    return target;
   }
 }

--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -410,12 +410,15 @@ export class Virtualizer<T extends object, V, W> {
     let rect = new Rect(point.x, point.y, 1, 1);
     let layoutInfos = this.layout.getVisibleLayoutInfos(rect);
 
-    let layoutInfo = layoutInfos[0];
-    if (!layoutInfo) {
-      return null;
+    // Layout may return multiple layout infos in the case of
+    // persisted keys, so find the first one that actualy intersects.
+    for (let layoutInfo of layoutInfos) {
+      if (layoutInfo.rect.intersects(rect)) {
+        return layoutInfo.key;
+      }
     }
 
-    return layoutInfo.key;
+    return null;
   }
 
   /**
@@ -666,7 +669,7 @@ export class Virtualizer<T extends object, V, W> {
     let keyFound = this._persistedKeys.has(node.layoutInfo.key);
 
     // for components like Table, where we have rows with cells as children,
-    // if the key isn't found at the top level (row in this example), check 
+    // if the key isn't found at the top level (row in this example), check
     // the children of this node to see if a child is persisted. If a child
     // of this node is a persisted key we consider this node as "persistable."
     if (!keyFound && node.children && node.node.type !== 'section') {

--- a/packages/@react-types/shared/src/dnd.d.ts
+++ b/packages/@react-types/shared/src/dnd.d.ts
@@ -118,21 +118,30 @@ export interface DragTypes {
   has(type: string): boolean
 }
 
+export interface DropTargetDelegate {
+  /**
+   * Returns a drop target within a collection for the given x and y coordinates.
+   * The point is provided relative to the top left corner of the collection container.
+   * A drop target can be checked to see if it is valid using the provided `isValidDropTarget` function.
+   */
+  getDropTargetFromPoint(x: number, y: number, isValidDropTarget: (target: DropTarget) => boolean): DropTarget | null
+}
+
 export interface DroppableCollectionProps {
   /**
    * A function returning the drop operation to be performed when items matching the given types are dropped
    * on the drop target.
    */
   getDropOperation?: (target: DropTarget, types: DragTypes, allowedOperations: DropOperation[]) => DropOperation,
-  /** Handler that is called when a valid drag element enters the drop target. */
+  /** Handler that is called when a valid drag enters the drop target. */
   onDropEnter?: (e: DroppableCollectionEnterEvent) => void,
-  /** Handler that is called when a valid drag element is moved within the drop target. */
+  /** Handler that is called when a valid drag is moved within the drop target. */
   onDropMove?: (e: DroppableCollectionMoveEvent) => void,
-  /** Handler that is called after a valid drag element is held over the drop target for a period of time. */
+  /** Handler that is called after a valid drag is held over the drop target for a period of time. */
   onDropActivate?: (e: DroppableCollectionActivateEvent) => void,
-  /** Handler that is called when a valid drag element exits the drop target. */
+  /** Handler that is called when a valid drag exits the drop target. */
   onDropExit?: (e: DroppableCollectionExitEvent) => void,
-  /** Handler that is called when a valid drag element is dropped on the drop target. */
+  /** Handler that is called when a valid drag is dropped on the drop target. */
   onDrop?: (e: DroppableCollectionDropEvent) => void
 }
 


### PR DESCRIPTION
This fixes a few bugs found while writing drag and drop docs:

* When starting a drag with the keyboard, the nearest drop target (positionally) is focused by default rather than the first one on the page.
* When pressing a modifier key while dragging to change the drop operation, the cursor sometimes did not update correctly. Also, if `getDropOperation` returns an operation that isn't allowed, the drag is now canceled.
* Drop target state would sometimes get stuck because of the logic with counting the number of times onDragEnter and onDragLeave are called. Instead, we now use `relatedTarget` to determine if we're in a nested target, similar to how `useFocusWithin` is implemented.
* Moved `getDropOperationForPoint` into a `DragTargetDelegate` interface to make it reusable, and implemented a `ListDragTargetDelegate`. This uses the DOM for layout. A separate implementation is also provided in `ListLayout` for virtualizer uses. Also removes a hard coded condition in ListView for specific folder dnd behavior, and behaves better when only certain drop positions are supported.
* Added some states to the return types of hooks.