### PR TITLE
Refactor virtualizer persisted keys

### DIFF
--- a/packages/@react-aria/virtualizer/src/Virtualizer.tsx
+++ b/packages/@react-aria/virtualizer/src/Virtualizer.tsx
@@ -145,14 +145,8 @@ export function useVirtualizer<T extends object, V, W>(props: VirtualizerOptions
     lastFocusedKey.current = focusedKey;
   }, [focusedKey, virtualizer.visibleRect.height, virtualizer, lastFocusedKey, scrollToItem]);
 
-  // Tell the virtualizer to persist the focusedKey and prevent it from being reused.
-  // This is to prevent the FocusRing from setting focus to the ListView when a
-  // focused ListViewItem is scrolled out of the Virtualizer visible rectangle.
-  let focusedKeySet = useMemo((): Set<Key> => (
-    focusedKey ? new Set([focusedKey]) : new Set()
-  ), [focusedKey]);
-
-  virtualizer.persistedKeys = focusedKeySet;
+  // Persist the focusedKey and prevent it from being removed from the DOM when scrolled out of view.
+  virtualizer.persistedKeys = useMemo(() => focusedKey ? new Set([focusedKey]) : new Set(), [focusedKey]);
 
   let onFocus = useCallback((e: FocusEvent) => {
     // If the focused item is scrolled out of view and is not in the DOM, the collection

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -67,6 +67,11 @@ for (let i = 1; i <= 100; i++) {
   manyItems.push({id: i, foo: 'Foo ' + i, bar: 'Bar ' + i, baz: 'Baz ' + i});
 }
 
+let manyColumns = [];
+for (let i = 1; i <= 100; i++) {
+  manyColumns.push({id: i, name: 'Column ' + i});
+}
+
 function ExampleSortTable() {
   let [sortDescriptor, setSortDescriptor] = React.useState({column: 'bar', direction: 'ascending'});
 
@@ -816,6 +821,23 @@ describe('TableView', function () {
       </TableView>
     );
 
+    let renderManyColumns = () => render(
+      <TableView aria-label="Table" selectionMode="multiple">
+        <TableHeader columns={manyColumns}>
+          {column =>
+            <Column>{column.name}</Column>
+          }
+        </TableHeader>
+        <TableBody items={manyItems}>
+          {item =>
+            (<Row key={item.foo}>
+              {key => <Cell>{item.foo + ' ' + key}</Cell>}
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    );
+
     let focusCell = (tree, text) => act(() => getCell(tree, text).focus());
     let moveFocus = (key, opts = {}) => {fireEvent.keyDown(document.activeElement, {key, ...opts});};
 
@@ -1544,10 +1566,10 @@ describe('TableView', function () {
       });
 
       it('should scroll to a cell when it is focused off screen', function () {
-        let tree = renderMany();
+        let tree = renderManyColumns();
         let body = tree.getByRole('grid').childNodes[1];
 
-        let cell = getCell(tree, 'Baz 5');
+        let cell = getCell(tree, 'Foo 5 5');
         act(() => cell.focus());
         expect(document.activeElement).toBe(cell);
         expect(body.scrollTop).toBe(0);
@@ -1555,16 +1577,27 @@ describe('TableView', function () {
         // When scrolling the focused item out of view, focus should remaind on the item,
         // virtualizer keeps focused items from being reused
         body.scrollTop = 1000;
+        body.scrollLeft = 1000;
         fireEvent.scroll(body);
 
         expect(body.scrollTop).toBe(1000);
         expect(document.activeElement).toBe(cell);
-        expect(tree.queryByText('Baz 5')).toBe(cell.firstElementChild);
+        expect(tree.queryByText('Foo 5 5')).toBe(cell.firstElementChild);
+
+        // Ensure we have the correct sticky cells in the right order.
+        let row = cell.closest('[role=row]');
+        let cells = within(row).getAllByRole(role => role === 'gridcell' || role === 'rowheader');
+        expect(cells).toHaveLength(18);
+        expect(cells[0]).toHaveAttribute('aria-colindex', '1'); // checkbox
+        expect(cells[1]).toHaveAttribute('aria-colindex', '2'); // rowheader
+        expect(cells[2]).toHaveAttribute('aria-colindex', '6'); // persisted
+        expect(cells[2]).toBe(cell);
+        expect(cells[3]).toHaveAttribute('aria-colindex', '14'); // first visible
 
         // Moving focus should scroll the new focused item into view
         moveFocus('ArrowLeft');
         expect(body.scrollTop).toBe(164);
-        expect(document.activeElement).toBe(getCell(tree, 'Bar 5'));
+        expect(document.activeElement).toBe(getCell(tree, 'Foo 5 4'));
       });
 
       it('should not scroll when a column header receives focus', function () {

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -112,12 +112,6 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
           if (node.children) {
             addNodes(node.children);
           }
-        } else if (this.virtualizer.isPersistedKey(node)) {
-          res.push(node.layoutInfo);
-
-          if (node.children) {
-            addNodes(node.children);
-          }
         }
       }
     };
@@ -127,7 +121,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   }
 
   isVisible(node: LayoutNode, rect: Rect) {
-    return node.layoutInfo.rect.intersects(rect) || node.layoutInfo.isSticky;
+    return node.layoutInfo.rect.intersects(rect) || node.layoutInfo.isSticky || this.virtualizer.isPersistedKey(node.layoutInfo.key);
   }
 
   validate(invalidationContext: InvalidationContext<Node<T>, unknown>) {

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -24,6 +24,8 @@ export class TableLayout<T> extends ListLayout<T> {
   stickyColumnIndices: number[];
   wasLoading = false;
   isLoading = false;
+  lastPersistedKeys: Set<Key> = null;
+  persistedIndices: Map<Key, number[]> = new Map();
 
   constructor(options: ListLayoutOptions<T>) {
     super(options);
@@ -50,6 +52,7 @@ export class TableLayout<T> extends ListLayout<T> {
     let header = this.buildHeader();
     let body = this.buildBody(0);
     this.stickyColumnIndices = this.collection.columns.filter(c => c.props.isSelectionCell || this.collection.rowHeaderColumnKeys.has(c.key)).map(c => c.index);
+    this.lastPersistedKeys = null;
 
     body.layoutInfo.rect.width = Math.max(header.layoutInfo.rect.width, body.layoutInfo.rect.width);
     this.contentSize = new Size(body.layoutInfo.rect.width, body.layoutInfo.rect.maxY);
@@ -274,6 +277,7 @@ export class TableLayout<T> extends ListLayout<T> {
   getVisibleLayoutInfos(rect: Rect) {
     let res: LayoutInfo[] = [];
 
+    this.buildPersistedIndices();
     for (let node of this.rootNodes) {
       res.push(node.layoutInfo);
       this.addVisibleLayoutInfos(res, node, rect);
@@ -298,24 +302,35 @@ export class TableLayout<T> extends ListLayout<T> {
       case 'rowgroup': {
         let firstVisibleRow = this.binarySearch(node.children, rect.topLeft, 'y');
         let lastVisibleRow = this.binarySearch(node.children, rect.bottomRight, 'y');
-        // Check to see if a persisted key exists before the visible rows
-        // This is for keeping focus on a row that scrolls out of view
-        for (let h = 0; h < firstVisibleRow; h++) {
-          if (this.virtualizer.isPersistedKey(node.children[h])) {
-            res.push(node.children[h].layoutInfo);
-            this.addVisibleLayoutInfos(res, node.children[h], rect);
-          }
+
+        // Add persisted rows before the visible rows.
+        let persistedRowIndices = this.persistedIndices.get(node.layoutInfo.key);
+        let persistIndex = 0;
+        while (
+          persistedRowIndices &&
+          persistIndex < persistedRowIndices.length &&
+          persistedRowIndices[persistIndex] < firstVisibleRow
+        ) {
+          let idx = persistedRowIndices[persistIndex];
+          res.push(node.children[idx].layoutInfo);
+          this.addVisibleLayoutInfos(res, node.children[idx], rect);
+          persistIndex++;
         }
+
         for (let i = firstVisibleRow; i <= lastVisibleRow; i++) {
+          // Skip persisted rows that overlap with visible cells.
+          while (persistedRowIndices && persistIndex < persistedRowIndices.length && persistedRowIndices[persistIndex] < i) {
+            persistIndex++;
+          }
+
           res.push(node.children[i].layoutInfo);
           this.addVisibleLayoutInfos(res, node.children[i], rect);
         }
-        // Check to see if a persisted key exists after the visible rows
-        for (let j = lastVisibleRow + 1; j < node.children.length; j++) {
-          if (this.virtualizer.isPersistedKey(node.children[j])) {
-            res.push(node.children[j].layoutInfo);
-            this.addVisibleLayoutInfos(res, node.children[j], rect);
-          }
+
+        // Add persisted rows after the visible rows.
+        while (persistedRowIndices && persistIndex < persistedRowIndices.length) {
+          let idx = persistedRowIndices[persistIndex++];
+          res.push(node.children[idx].layoutInfo);
         }
         break;
       }
@@ -324,35 +339,27 @@ export class TableLayout<T> extends ListLayout<T> {
         let firstVisibleCell = this.binarySearch(node.children, rect.topLeft, 'x');
         let lastVisibleCell = this.binarySearch(node.children, rect.topRight, 'x');
         let stickyIndex = 0;
-        // Check to see if a persisted key exists before the visible cells
-        // This is for keeping focus on a cell that scrolls out of view
-        for (let h = 0; h < firstVisibleCell; h++) {
-          if (this.virtualizer.isPersistedKey(node.children[h])) {
-            res.push(node.children[h].layoutInfo);
-          }
+
+        // Add persisted/sticky cells before the visible cells.
+        let persistedCellIndices = this.persistedIndices.get(node.layoutInfo.key) || this.stickyColumnIndices;
+        while (stickyIndex < persistedCellIndices.length && persistedCellIndices[stickyIndex] < firstVisibleCell) {
+          let idx = persistedCellIndices[stickyIndex];
+          res.push(node.children[idx].layoutInfo);
+          stickyIndex++;
         }
+
         for (let i = firstVisibleCell; i <= lastVisibleCell; i++) {
-          // Sticky columns and row headers are always in the DOM. Interleave these
-          // with the visible range so that they are in the right order.
-          if (stickyIndex < this.stickyColumnIndices.length) {
-            let idx = this.stickyColumnIndices[stickyIndex];
-            while (idx < i) {
-              res.push(node.children[idx].layoutInfo);
-              idx = this.stickyColumnIndices[stickyIndex++];
-            }
+          // Skip sticky cells that overlap with visible cells.
+          while (stickyIndex < persistedCellIndices.length && persistedCellIndices[stickyIndex] < i) {
+            stickyIndex++;
           }
 
           res.push(node.children[i].layoutInfo);
         }
-        // Check to see if a persisted key exists after the visible cells
-        for (let j = lastVisibleCell; j < node.children.length; j++) {
-          if (this.virtualizer.isPersistedKey(node.children[j])) {
-            res.push(node.children[j].layoutInfo);
-          }
-        }
 
-        while (stickyIndex < this.stickyColumnIndices.length) {
-          let idx = this.stickyColumnIndices[stickyIndex++];
+        // Add any remaining sticky cells after the visible cells.
+        while (stickyIndex < persistedCellIndices.length) {
+          let idx = persistedCellIndices[stickyIndex++];
           res.push(node.children[idx].layoutInfo);
         }
         break;
@@ -379,6 +386,46 @@ export class TableLayout<T> extends ListLayout<T> {
     }
 
     return Math.max(0, Math.min(items.length - 1, low));
+  }
+
+  buildPersistedIndices() {
+    if (this.virtualizer.persistedKeys === this.lastPersistedKeys) {
+      return;
+    }
+
+    this.lastPersistedKeys = this.virtualizer.persistedKeys;
+    this.persistedIndices.clear();
+
+    // Build a map of parentKey => indices of children to persist.
+    for (let key of this.virtualizer.persistedKeys) {
+      let layoutInfo = this.layoutInfos.get(key);
+
+      // Walk up ancestors so parents are also persisted if children are.
+      while (layoutInfo && layoutInfo.parentKey) {
+        let collectionNode = this.collection.getItem(layoutInfo.key);
+        let indices = this.persistedIndices.get(layoutInfo.parentKey);
+        if (!indices) {
+          // stickyColumnIndices are always persisted along with any cells from persistedKeys.
+          indices = collectionNode.type === 'cell' ? [...this.stickyColumnIndices] : [];
+          this.persistedIndices.set(layoutInfo.parentKey, indices);
+        }
+
+        let index = collectionNode.index;
+        if (collectionNode.type === 'item') {
+          index -= this.collection.headerRows.length;
+        }
+
+        if (!indices.includes(index)) {
+          indices.push(index);
+        }
+
+        layoutInfo = this.layoutInfos.get(layoutInfo.parentKey);
+      }
+    }
+
+    for (let indices of this.persistedIndices.values()) {
+      indices.sort((a, b) => a - b);
+    }
   }
 
   getInitialLayoutInfo(layoutInfo: LayoutInfo) {

--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -12,7 +12,7 @@
 
 import {CancelablePromise, easeOut, tween} from './tween';
 import {Collection} from '@react-types/shared';
-import {concatIterators, difference} from './utils';
+import {concatIterators, difference, isSetEqual} from './utils';
 import {
   InvalidationContext,
   ScrollAnchor,
@@ -235,28 +235,43 @@ export class Virtualizer<T extends object, V, W> {
     return this._collection ? this._collection.getItem(key) : null;
   }
 
-  /**
-   * Set the keys of keys for layoutInfos persisted by the virtualizer.
-   * This is to prevent these views from being reused by the virtualizer.
-   */
-  set persistedKeys(persistedKeys: Set<Key>) {
-    let setsNotEqual = false;
+  /** The set of persisted keys are always present in the DOM, even if not currently in view. */
+  get persistedKeys(): Set<Key> {
+    return this._persistedKeys;
+  }
 
-    if (this._persistedKeys.size !== persistedKeys.size) {
-      setsNotEqual = true;
-    } else {
-      for (var existingKey of this._persistedKeys) {
-        if (!persistedKeys.has(existingKey)) {
-          setsNotEqual = true;
+  /** The set of persisted keys are always present in the DOM, even if not currently in view. */
+  set persistedKeys(persistedKeys: Set<Key>) {
+    if (!isSetEqual(persistedKeys, this._persistedKeys)) {
+      this._persistedKeys = persistedKeys;
+      this.updateSubviews();
+    }
+  }
+
+  /** Returns whether the given key, or an ancestor, is persisted. */
+  isPersistedKey(key: Key) {
+    // Quick check if the key is directly in the set of persisted keys.
+    if (this._persistedKeys.has(key)) {
+      return true;
+    }
+
+    // If not, check if the key is an ancestor of any of the persisted keys.
+    for (let k of this._persistedKeys) {
+      while (k != null) {
+        let layoutInfo = this.layout.getLayoutInfo(k);
+        if (!layoutInfo) {
           break;
+        }
+
+        k = layoutInfo.parentKey;
+
+        if (k === key) {
+          return true;
         }
       }
     }
 
-    if (setsNotEqual) {
-      this._persistedKeys = persistedKeys;
-      this.updateSubviews();
-    }
+    return false;
   }
 
   /**
@@ -660,24 +675,6 @@ export class Virtualizer<T extends object, V, W> {
     }
 
     return map;
-  }
-
-  isPersistedKey(node) {
-    let keyFound = this._persistedKeys.has(node.layoutInfo.key);
-
-    // for components like Table, where we have rows with cells as children,
-    // if the key isn't found at the top level (row in this example), check 
-    // the children of this node to see if a child is persisted. If a child
-    // of this node is a persisted key we consider this node as "persistable."
-    if (!keyFound && node.children && node.node.type !== 'section') {
-      for (let child of node.children) {
-        if (this._persistedKeys.has(child.layoutInfo.key)) {
-          keyFound = true;
-          break;
-        }
-      }
-    }
-    return keyFound;
   }
 
   updateSubviews(forceUpdate = false) {

--- a/packages/@react-stately/virtualizer/src/utils.ts
+++ b/packages/@react-stately/virtualizer/src/utils.ts
@@ -61,3 +61,22 @@ export function invert(object) {
 
   return res;
 }
+
+/** Returns whether two sets are equal. */
+export function isSetEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (a.size !== b.size) {
+    return false;
+  }
+
+  for (let key of a) {
+    if (!b.has(key)) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
This is a slight refactor of #3168 to fix a few issues:

* The Virtualizer `isPersistedKey` function accepted a full `LayoutNode` object, which is specific to `ListLayout`. It made some assumptions about the types of values, e.g. sections, as well. Additionally, the parameter was untyped so TS couldn't catch this. Now it accepts a `key` and uses the `LayoutInfo` to walk up the `parentKey` hierarchy to see if a key should be persisted.
* Simplified ListLayout logic.
* In TableView, the persisted keys could get out of order with sticky columns. They were always added at the start or end of a row, but the sticky columns might really need to be before them. In addition, a linear search through all rows and cells prior and after the visible range was needed. Now, a mapping of keys to indices of children to persist is generated whenever `persistedKeys` changes, and used to interleave the persisted rows/cells with the visible ones in the correct order. Added a test case for this. Since the persisted keys will usually consist of a single item, this should be much faster than linearly scanning through all rows/cells as well.