### PR TITLE
Prevent resize error when DatePicker input ref is undefined

### DIFF
--- a/packages/@react-spectrum/datepicker/src/Input.tsx
+++ b/packages/@react-spectrum/datepicker/src/Input.tsx
@@ -37,29 +37,32 @@ function Input(props, ref) {
   // not cause a layout shift.
   let [reservePadding, setReservePadding] = useValueEffect(false);
   let onResize = useCallback(() => setReservePadding(function *(reservePadding) {
-    if (reservePadding) {
-      // Try to collapse padding if the content is clipped.
-      if (inputRef.current.scrollWidth > inputRef.current.offsetWidth) {
-        let width = inputRef.current.parentElement.offsetWidth;
-        yield false;
-
-        // If removing padding causes a layout shift, add it back.
-        if (inputRef.current.parentElement.offsetWidth !== width) {
-          yield true;
-        }
-      }
-    } else {
-      // Try to add padding if the content is not clipped.
-      if (inputRef.current.offsetWidth >= inputRef.current.scrollWidth) {
-        let width = inputRef.current.parentElement.offsetWidth;
-        yield true;
-
-        // If adding padding does not change the width (i.e. width is constrained), remove it again.
-        if (inputRef.current.parentElement.offsetWidth === width) {
+    if (inputRef.current) {
+      if (reservePadding) {
+        // Try to collapse padding if the content is clipped.
+        if (inputRef.current.scrollWidth > inputRef.current.offsetWidth) {
+          let width = inputRef.current.parentElement.offsetWidth;
           yield false;
+
+          // If removing padding causes a layout shift, add it back.
+          if (inputRef.current.parentElement.offsetWidth !== width) {
+            yield true;
+          }
+        }
+      } else {
+        // Try to add padding if the content is not clipped.
+        if (inputRef.current.offsetWidth >= inputRef.current.scrollWidth) {
+          let width = inputRef.current.parentElement.offsetWidth;
+          yield true;
+
+          // If adding padding does not change the width (i.e. width is constrained), remove it again.
+          if (inputRef.current.parentElement.offsetWidth === width) {
+            yield false;
+          }
         }
       }
     }
+
   }), [inputRef, setReservePadding]);
 
   useLayoutEffect(onResize, [onResize]);


### PR DESCRIPTION
Closes #3357
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test that DatePicker and other Date components that use Input still work. Original issue couldn't be reproduced on our end but issue submitter confirmed applying a similar fix resolved the issue on their end

## 🧢 Your Project:

RSP
