### PR TITLE
Fix ComboBox left/right arrows so they move the input cursor when the menu is open

### DIFF
--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -377,14 +377,6 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate, 
     }
   }
 
-  getKeyLeftOf(key: Key): Key {
-    return key;
-  }
-
-  getKeyRightOf(key: Key): Key {
-    return key;
-  }
-
   getKeyPageAbove(key: Key) {
     let layoutInfo = this.getLayoutInfo(key);
 


### PR DESCRIPTION
Closes #3400

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to any combobox story and do the following:
1. Type in something that will open the menu
2. Attempt to move the cursor left/right via the arrow keys. You should be able to now

## 🧢 Your Project:

RSP
