### PR TITLE
useGridList docs refinements

### DIFF
--- a/packages/@react-aria/gridlist/docs/anatomy.svg
+++ b/packages/@react-aria/gridlist/docs/anatomy.svg
@@ -20,7 +20,7 @@
       </g>
     </g>
     <g id="Group_156664" data-name="Group 156664" transform="translate(0 -199)">
-      <g id="Rectangle_142243" data-name="Rectangle 142243" transform="translate(123 258)" fill="var(--anatomy-gray-50)" stroke="#c0cce7" stroke-width="1.5">
+      <g id="Rectangle_142243" data-name="Rectangle 142243" transform="translate(123 258)" fill="var(--anatomy-gray-50)" stroke="var(--anatomy-gray-400)" stroke-width="1.5">
         <rect width="364" height="232" rx="6" stroke="none"/>
         <rect x="0.75" y="0.75" width="362.5" height="230.5" rx="5.25" fill="none"/>
       </g>
@@ -32,11 +32,11 @@
       <text id="List_item-2" data-name="List item" transform="translate(174 351)" fill="var(--anatomy-gray-800)" font-size="21" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">List item</tspan></text>
       <text id="List_item-3" data-name="List item" transform="translate(174 409)" fill="var(--anatomy-gray-800)" font-size="21" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">List item</tspan></text>
       <text id="List_item-4" data-name="List item" transform="translate(174 467)" fill="var(--anatomy-gray-800)" font-size="21" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">List item</tspan></text>
-      <line id="Line_13" data-name="Line 13" x2="363.252" transform="translate(123.5 316.5)" fill="none" stroke="#c0cce7" stroke-width="1.5"/>
-      <line id="Line_14" data-name="Line 14" x2="363.252" transform="translate(123.5 374.522)" fill="none" stroke="#c0cce7" stroke-width="1.5"/>
-      <line id="Line_15" data-name="Line 15" x2="363.252" transform="translate(123.5 432.522)" fill="none" stroke="#c0cce7" stroke-width="1.5"/>
+      <line id="Line_13" data-name="Line 13" x2="363.252" transform="translate(123.5 316.5)" fill="none" stroke="var(--anatomy-gray-400)" stroke-width="1.5"/>
+      <line id="Line_14" data-name="Line 14" x2="363.252" transform="translate(123.5 374.522)" fill="none" stroke="var(--anatomy-gray-400)" stroke-width="1.5"/>
+      <line id="Line_15" data-name="Line 15" x2="363.252" transform="translate(123.5 432.522)" fill="none" stroke="var(--anatomy-gray-400)" stroke-width="1.5"/>
       <g id="Checkbox" transform="translate(142 264)">
-        <g id="Placement_Area" data-name="Placement Area" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+        <g id="Placement_Area" data-name="Placement Area" fill="red" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1" opacity="0">
           <rect width="21" height="48" stroke="none"/>
           <rect x="0.5" y="0.5" width="20" height="47" fill="none"/>
         </g>
@@ -46,7 +46,7 @@
         </g>
       </g>
       <g id="Checkbox-2" data-name="Checkbox" transform="translate(141 321)">
-        <g id="Placement_Area-2" data-name="Placement Area" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+        <g id="Placement_Area-2" data-name="Placement Area" fill="red" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1" opacity="0">
           <rect width="21" height="48" stroke="none"/>
           <rect x="0.5" y="0.5" width="20" height="47" fill="none"/>
         </g>
@@ -56,16 +56,16 @@
         </g>
       </g>
       <g id="Checkbox-3" data-name="Checkbox" transform="translate(141 379)">
-        <g id="Placement_Area-3" data-name="Placement Area" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+        <g id="Placement_Area-3" data-name="Placement Area" fill="red" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1" opacity="0">
           <rect width="21" height="48" stroke="none"/>
           <rect x="0.5" y="0.5" width="20" height="47" fill="none"/>
         </g>
-        <g id="Box-3" data-name="Box" transform="translate(0 13.5)" fill="var(--anatomy-gray-700)" stroke="rgba(0,0,0,0)" stroke-width="1">
+        <g id="Box-3" data-name="Box" transform="translate(0 13.5)" fill="var(--anatomy-gray-700)" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1">
           <rect width="21" height="21" rx="2" stroke="none"/>
           <rect x="0.5" y="0.5" width="20" height="20" rx="1.5" fill="none"/>
         </g>
         <g id="Checkmark" transform="translate(3 16.5)">
-          <g id="Frame" fill="#f0f" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+          <g id="Frame" fill="var(--anatomy-gray-600)" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1" opacity="0">
             <rect width="15" height="15" stroke="none"/>
             <rect x="0.5" y="0.5" width="14" height="14" fill="none"/>
           </g>
@@ -73,7 +73,7 @@
         </g>
       </g>
       <g id="Checkbox-4" data-name="Checkbox" transform="translate(141 437)">
-        <g id="Placement_Area-4" data-name="Placement Area" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+        <g id="Placement_Area-4" data-name="Placement Area" fill="red" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1" opacity="0">
           <rect width="21" height="48" stroke="none"/>
           <rect x="0.5" y="0.5" width="20" height="47" fill="none"/>
         </g>
@@ -87,14 +87,14 @@
       <text id="List_item_row" data-name="List item row" transform="translate(336 -343)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">List item row</tspan></text>
       <g id="Group_152108" data-name="Group 152108" transform="translate(752.999 -692) rotate(180)">
         <rect id="Rectangle_3659" data-name="Rectangle 3659" width="20" height="48" transform="translate(421 -336) rotate(-90)" fill="red" opacity="0"/>
-        <path id="Union_56" data-name="Union 56" d="M-9134-324.5a2.5,2.5,0,0,1,2-2.449V-370h1v43.052a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9134-324.5Z" transform="translate(791 -9477.5) rotate(-90)" fill="#a2b6e1"/>
+        <path id="Union_56" data-name="Union 56" d="M-9134-324.5a2.5,2.5,0,0,1,2-2.449V-370h1v43.052a2.5,2.5,0,0,1,2,2.449,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9134-324.5Z" transform="translate(791 -9477.5) rotate(-90)" fill="var(--anatomy-gray-500)"/>
       </g>
     </g>
     <g id="Group_156663" data-name="Group 156663" transform="translate(200.005 447)">
       <text id="List_item_grid_cell" data-name="List item grid cell" transform="translate(336 -343)" fill="var(--anatomy-gray-700)" font-size="13" font-family="Adobe-Clean" font-style="italic"><tspan x="0" y="0">List item grid cell</tspan></text>
       <g id="Group_152108-2" data-name="Group 152108" transform="translate(752.999 -692) rotate(180)">
         <rect id="Rectangle_3659-2" data-name="Rectangle 3659" width="20" height="48" transform="translate(421 -336) rotate(-90)" fill="red" opacity="0"/>
-        <path id="Union_56-2" data-name="Union 56" d="M-9134-304.5a2.5,2.5,0,0,1,2-2.451V-370h1v63.05a2.5,2.5,0,0,1,2,2.451,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9134-304.5Z" transform="translate(791 -9477.5) rotate(-90)" fill="#a2b6e1"/>
+        <path id="Union_56-2" data-name="Union 56" d="M-9134-304.5a2.5,2.5,0,0,1,2-2.451V-370h1v63.05a2.5,2.5,0,0,1,2,2.451,2.5,2.5,0,0,1-2.5,2.5A2.5,2.5,0,0,1-9134-304.5Z" transform="translate(791 -9477.5) rotate(-90)" fill="var(--anatomy-gray-500)"/>
       </g>
     </g>
     <text id="Selection_checkbox_optional_" data-name="Selection

--- a/packages/@react-aria/gridlist/docs/useGridList.mdx
+++ b/packages/@react-aria/gridlist/docs/useGridList.mdx
@@ -52,20 +52,15 @@ A list can be built using [&lt;ul&gt;](https://developer.mozilla.org/en-US/docs/
 HTML lists are meant for static content, rather than lists with rich interactions like focusable elements within rows, keyboard navigation, row selection, etc.
 `useGridList` helps achieve accessible and interactive list components that can be styled as needed.
 
-* Exposed to assistive technology as a `grid` using ARIA
-* Keyboard navigation between rows and in-rows focusable elements via the arrow keys
-* Single, multiple, or no row selection via mouse, touch, or keyboard interactions
-* Support for disabled rows, which cannot be selected
-* Optional support for checkboxes in each row for selection
-* Support for both `toggle` and `replace` selection behaviors
-* Support for row actions via double click, <Keyboard>Enter</Keyboard> key, or tapping
-* Long press to enter selection mode on touch when there is both selection and row actions
-* Async loading and infinite scrolling
-* Typeahead to allow focusing rows by typing text
-* Automatic scrolling support during keyboard navigation
-* Labeling support for accessibility
-* Ensures that selections are announced using an ARIA live region
-* Virtualized scrolling support for performance with large lists
+* **Item selection** – Single or multiple selection, with optional checkboxes, disabled rows, and both `toggle` and `replace` selection behaviors.
+* **Interactive children** – List items may include interactive elements such as buttons, checkboxes, menus, etc.
+* **Actions** – Items support optional row actions such as navigation via click, tap, double click, or <Keyboard>Enter</Keyboard> key.
+* **Async loading** – Support for loading items asynchronously, with infinite and virtualized scrolling.
+* **Keyboard navigation** – List items and focusable children can be navigated using the arrow keys, along with page up/down, home/end, etc. Typeahead, auto scrolling, and selection modifier keys are supported as well.
+* **Touch friendly** – Selection and actions adapt their behavior depending on the device. For example, selection is activated via long press on touch when item actions are present.
+* **Accessible** – Follows the [ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/), with additional selection announcements via an ARIA live region. Extensively tested across many devices and [assistive technologies](accessibility.html#testing) to ensure announcements and behaviors are consistent.
+
+**Note**: Use `useGridList` when your list items may contain interactive elements such as buttons, checkboxes, menus, etc. within them. If your list items contain only static content such as text and images, then consider using [useListBox](useListBox.html) instead for a slightly better screen reader experience (especially on mobile).
 
 ## Anatomy
 
@@ -76,7 +71,19 @@ If the list supports row selection, each row can optionally include a selection 
 
 The <TypeLink links={docs.links} type={docs.exports.useGridList} /> and <TypeLink links={docs.links} type={docs.exports.useGridListItem} /> hooks handle keyboard, mouse, and other interactions to support
 row selection, in list navigation, and overall focus behavior. Those hooks handle exposing the list and its contents to assistive technology using ARIA. <TypeLink links={docs.links} type={docs.exports.useGridListSelectionCheckbox} /> handles row selection and associating each checkbox with its respective rows
-for assistive technology. Each of these hooks returns props to be spread onto the appropriate HTML element.
+for assistive technology.
+
+`useGridList` returns props that you should spread onto the list container element:
+
+<TypeContext.Provider value={docs.links}>
+  <InterfaceType properties={docs.links[docs.exports.useGridList.return.id].properties} />
+</TypeContext.Provider>
+
+`useGridListItem` returns props for an individual option and its children, along with states you can use for styling:
+
+<TypeContext.Provider value={docs.links}>
+  <InterfaceType properties={docs.links[docs.exports.useGridListItem.return.id].properties} />
+</TypeContext.Provider>
 
 State is managed by the <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useListState} />
 hook from `@react-stately/list`. The state object should be passed as an option to each of the above hooks where applicable.
@@ -94,8 +101,6 @@ but <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useListState} 
 `@react-stately/list` implements a JSX based interface for building collections instead.
 See [Collection Components](/react-stately/collections.html) for more information,
 and [Collection Interface](/react-stately/Collection.html) for internal details.
-
-See the examples in the [usage](#usage) section below for details on how to use these components.
 
 In addition, <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useListState} />
 manages the state necessary for multiple selection and exposes
@@ -117,38 +122,21 @@ the rows of the List and render the relevant components, which we'll define belo
 
 You may notice the extra `<div>` with `gridCellProps` in our example. This is needed because we are following the [ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/), which does not allow rows without any child `gridcell` elements.
 
-You may also notice that we included an info button in the rows in our example. This is to highlight `useGridList`'s ability to handle interactive elements inside a row.
-This differs from [useListBox](useListBox.html), which is a selectable list with no support for interactive elements. If your list will not contain interactive elements,
-[useListBox](useListBox.html) may be a better choice due to better screen reader experience, especially on mobile devices.
-
-```tsx example export=true
+```tsx example export=true render=false
 import {useListState} from '@react-stately/list';
 import {mergeProps} from '@react-aria/utils';
 import {useRef} from 'react';
 import {useFocusRing} from '@react-aria/focus';
-import {useButton} from '@react-aria/button';
 import {useGridList, useGridListItem} from '@react-aria/gridlist';
-import { Item } from "@react-stately/collections";
 
 function List(props) {
   let state = useListState(props);
   let ref = useRef();
-  let { collection } = state;
   let { gridProps } = useGridList(props, state, ref);
 
   return (
-    <ul
-      {...gridProps}
-      ref={ref}
-      style={{
-        padding: 0,
-        margin: '5px 0',
-        listStyle: 'none',
-        border: '1px solid gray',
-        maxWidth: 400
-      }}
-    >
-      {[...collection].map((item) => (
+    <ul {...gridProps} ref={ref} className="list">
+      {[...state.collection].map((item) => (
         <ListItem key={item.key} item={item} state={state} />
       ))}
     </ul>
@@ -157,54 +145,20 @@ function List(props) {
 
 function ListItem({ item, state }) {
   let ref = React.useRef();
-
-  let {
-    rowProps,
-    gridCellProps,
-    isPressed,
-    isSelected,
-    isFocused,
-    isDisabled
-  } = useGridListItem(
-    {
-      node: item
-    },
+  let {rowProps, gridCellProps, isPressed} = useGridListItem(
+    {node: item},
     state,
     ref
   );
+
   let {isFocusVisible, focusProps} = useFocusRing();
   let showCheckbox = state.selectionManager.selectionMode !== 'none' && state.selectionManager.selectionBehavior === 'toggle';
-
-  let backgroundColor;
-  let color = "black";
-
-  if (isSelected) {
-    backgroundColor = "blueviolet";
-    color = "white";
-  } else if (isFocused) {
-    backgroundColor = "gray";
-  } else if (isDisabled) {
-    backgroundColor = "transparent";
-    color = "gray";
-  }
 
   return (
     <li
       {...mergeProps(rowProps, focusProps)}
       ref={ref}
-      style={{
-        background: isSelected
-          ? 'blueviolet'
-          : isPressed
-            ? 'var(--spectrum-global-color-gray-400)'
-            : item.index % 2
-              ? 'var(--spectrum-alias-highlight-hover)'
-              : 'none',
-        color: isSelected ? 'white' : null,
-        padding: '2px 5px',
-        outline: isFocusVisible ? '2px solid orange' : 'none'
-      }}
-    >
+      className={`${isPressed ? 'pressed' : ''} ${isFocusVisible ? 'focus-visible' : ''}`}>
       <div {...gridCellProps}>
         {showCheckbox && <ListCheckbox item={item} state={state} />}
         {item.rendered}
@@ -212,28 +166,109 @@ function ListItem({ item, state }) {
     </li>
   );
 }
+```
+
+Now we can render a basic example list, with multiple selection and interactive children in each item.
+
+```tsx example
+import {Item} from "@react-stately/collections";
+
+// Reuse the Button from your component library. See below.
+import {Button} from 'your-component-library';
 
 <List aria-label="Example List" selectionMode="multiple" selectionBehavior="replace">
-  <Item key="1" textValue="Charizard">
+  <Item textValue="Charizard">
     Charizard
     <Button onPress={() => alert(`Info for Charizard...`)}>Info</Button>
   </Item>
-  <Item key="2">Blastoise</Item>
-  <Item key="3">Venusaur</Item>
-  <Item key="4">Pikachu</Item>
+  <Item textValue="Blastoise">
+    Blastoise
+    <Button onPress={() => alert(`Info for Blastoise...`)}>Info</Button>
+  </Item>
+  <Item textValue="Venusaur">
+    Venusaur
+    <Button onPress={() => alert(`Info for Venusaur...`)}>Info</Button>
+  </Item>
+  <Item textValue="Pikachu">
+    Pikachu
+    <Button onPress={() => alert(`Info for Pikachu...`)}>Info</Button>
+  </Item>
 </List>
 ```
 
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
+
+```css
+.list {
+  padding: 0;
+  list-style: none;
+  background: var(--page-background);
+  border: 1px solid var(--spectrum-global-color-gray-400);
+  max-width: 400px;
+  min-width: 200px;
+  max-height: 250px;
+  overflow: auto;
+}
+
+.list li {
+  padding: 8px;
+  outline: none;
+  cursor: default;
+}
+
+.list li:nth-child(2n) {
+  background: var(--spectrum-alias-highlight-hover);
+}
+
+.list li.pressed {
+  background: var(--spectrum-global-color-gray-200);
+}
+
+.list li[aria-selected=true] {
+  background: slateblue;
+  color: white;
+}
+
+.list li.focus-visible {
+  outline: 2px solid slateblue;
+  outline-offset: -3px;
+}
+
+.list li.focus-visible[aria-selected=true] {
+  outline-color: white;
+}
+
+.list li[aria-disabled] {
+  opacity: 0.4;
+}
+
+.list [role=gridcell] {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.list li button {
+  margin-left: auto;
+}
+
+.list li input[type=checkbox] {
+  accent-color: white;
+}
+```
+
+</details>
+
 ### Adding selection checkboxes
 
-Next, let's add support for selection checkboxes. For multiple selection, we'll want to add a checkbox to the row to allow the user to select rows.
+Next, let's add support for selection checkboxes to allow the user to select items explicitly.
 This is done using the <TypeLink links={docs.links} type={docs.exports.useGridListSelectionCheckbox} />
 hook. It is passed the `key` of the item it is contained within. When the user
 checks or unchecks the checkbox, the row will be added or removed from the List's selection.
 
-In this example, we pass the result of the `checkboxProps` into our checkbox defined below.
-It's likely you'll have a `Checkbox` component in your component library that uses these hooks already.
-See below for an example.
+The `Checkbox` component used in this example is independent and can be used separately from `useGridList`. The code is available below.
+
 ```tsx example export=true render=false
 import {useGridListSelectionCheckbox} from '@react-aria/gridlist';
 
@@ -242,23 +277,30 @@ import {Checkbox} from 'your-component-library';
 
 function ListCheckbox({ item, state }) {
   let { checkboxProps } = useGridListSelectionCheckbox({ key: item.key }, state);
-
   return <Checkbox {...checkboxProps} />;
 }
 ```
 
-The following example shows how to enable multiple selection support using the List component we built above.
-It's as simple as setting the `selectionMode` prop to `"multiple"`.
+The following example shows an example list with multiple selection using checkboxes and the default `toggle` [selection behavior](#selection-behavior).
 
 ```tsx example
 <List aria-label="List with selection" selectionMode="multiple">
-  <Item key="1" textValue="Charizard">
+  <Item textValue="Charizard">
     Charizard
     <Button onPress={() => alert(`Info for Charizard...`)}>Info</Button>
   </Item>
-  <Item key="2">Blastoise</Item>
-  <Item key="3">Venusaur</Item>
-  <Item key="4">Pikachu</Item>
+  <Item textValue="Blastoise">
+    Blastoise
+    <Button onPress={() => alert(`Info for Blastoise...`)}>Info</Button>
+  </Item>
+  <Item textValue="Venusaur">
+    Venusaur
+    <Button onPress={() => alert(`Info for Venusaur...`)}>Info</Button>
+  </Item>
+  <Item textValue="Pikachu">
+    Pikachu
+    <Button onPress={() => alert(`Info for Pikachu...`)}>Info</Button>
+  </Item>
 </List>
 ```
 
@@ -303,7 +345,7 @@ import {useButton} from '@react-aria/button';
 function Button(props) {
   let ref = React.useRef();
   let {buttonProps} = useButton(props, ref);
-  return <button {...buttonProps} ref={ref} style={{margin: '0 5px'}}>{props.children}</button>;
+  return <button {...buttonProps} ref={ref}>{props.children}</button>;
 }
 ```
 
@@ -314,7 +356,7 @@ function Button(props) {
 ### Dynamic collections
 
 So far, our examples have shown static collections, where the data is hard coded.
-Dynamic collections, as shown below, can be used when the List data comes from an external data source such as an API, or updates over time.
+Dynamic collections, as shown below, can be used when the data comes from an external data source such as an API, or updates over time.
 In the example below, the rows are provided to the List via a render function.
 
 ```tsx example export=true
@@ -328,7 +370,14 @@ function ExampleList(props) {
 
   return (
     <List aria-label="Example dynamic collection List" selectionMode="multiple" items={rows} {...props}>
-      {item => <Item>{item.name}</Item>}
+      {item => (
+        <Item>
+          {item.name}
+          <Button onPress={() => alert(`Info for ${item.name}...`)}>
+            Info
+          </Button>
+        </Item>
+      )}
     </List>
   );
 }
@@ -352,17 +401,15 @@ A user can click on a different row to change the selection, or click on the sam
 Multiple selection can be enabled by setting `selectionMode` to `multiple`.
 
 ```tsx example
-// Using the example above
 <ExampleList aria-label="List with multiple selection" selectionMode="multiple" defaultSelectedKeys={[2, 4]} />
 ```
 
 ### Disallow empty selection
 
-List also supports a `disallowEmptySelection` prop which forces the user to have at least one row in the List selected at all times.
+`useGridList` also supports a `disallowEmptySelection` prop which forces the user to have at least one row in the List selected at all times.
 In this mode, if a single row is selected and the user presses it, it will not be deselected.
 
 ```tsx example
-// Using the example above
 <ExampleList aria-label="List with disallowed empty selection" selectionMode="multiple" defaultSelectedKeys={[2]} disallowEmptySelection />
 ```
 
@@ -392,12 +439,19 @@ function PokemonList(props) {
 
 ### Disabled rows
 
-You can disable specific rows by providing an array of keys to `useListState` via the `disabledKeys` prop. This will prevent rows from being selectable as shown in the example below.
+You can disable specific rows by providing an array of keys to `useListState` via the `disabledKeys` prop. This will disable all interactions on disabled rows,
+unless the `disabledBehavior` prop is used to change this behavior.
 Note that you are responsible for the styling of disabled rows, however, the selection checkbox will be automatically disabled.
 
 ```tsx example
-// Using the same List as above
+// Using the example above
 <PokemonList aria-label="List with disabled rows" selectionMode="multiple" disabledKeys={[3]} />
+```
+
+When `disabledBehavior` is set to `selection`, interactions such as focus, dragging, or actions can still be performed on disabled rows.
+
+```tsx example
+<PokemonList aria-label="List with selection disabled for disabled rows" selectionMode="multiple" disabledKeys={[3]} disabledBehavior="selection" />
 ```
 
 ### Selection behavior
@@ -421,8 +475,48 @@ be triggered via the <Keyboard>Enter</Keyboard> key, and selection using the <Ke
 This behavior is slightly different when `selectionBehavior="replace"`, where single clicking selects the row and actions are performed via double click. Touch and keyboard behaviors are unaffected.
 
 ```tsx example
-<PokemonList aria-label="Checkbox selection list with row actions" selectionMode="multiple" selectionBehavior="toggle" onAction={key => alert(`Opening item ${key}...`)} />
-<PokemonList aria-label="Highlight selection list with row actions" selectionMode="multiple" selectionBehavior="replace" onAction={key => alert(`Opening item ${key}...`)} />
+<div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: 24 }}>
+  <ExampleList aria-label="Checkbox selection list with row actions" selectionMode="multiple" selectionBehavior="toggle" onAction={key => alert(`Opening item ${key}...`)} />
+  <ExampleList aria-label="Highlight selection list with row actions" selectionMode="multiple" selectionBehavior="replace" onAction={key => alert(`Opening item ${key}...`)} />
+</div>
+```
+
+### Asynchronous loading
+
+This example uses the [useAsyncList](../react-stately/useAsyncList.html) hook to handle loadiasynchronous loading of data from a server. You may additionally want to display a spinner to indicate the loading state to the user, or support features like infinite scroll to load more data.
+
+```tsx example
+import {useAsyncList} from '@react-stately/data';
+
+function AsyncList() {
+
+  let list = useAsyncList({
+    async load({signal, cursor}) {
+      if (cursor) {
+        cursor = cursor.replace(/^http:\/\//i, 'https://');
+      }
+
+      let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search=`, {signal});
+      let json = await res.json();
+
+      return {
+        items: json.results,
+        cursor: json.next
+      };
+    }
+  });
+
+  return (
+    <List
+      selectionMode="multiple"
+      aria-label="Async loading ListView example"
+      items={list.items}>
+      {(item) => (
+        <Item key={item.name}>{item.name}</Item>
+      )}
+    </List>
+  );
+}
 ```
 
 ## Internationalization

--- a/packages/@react-aria/gridlist/docs/useGridList.mdx
+++ b/packages/@react-aria/gridlist/docs/useGridList.mdx
@@ -253,8 +253,11 @@ import {Button} from 'your-component-library';
   margin-left: auto;
 }
 
-.list li input[type=checkbox] {
-  accent-color: white;
+/* iOS Safari has a bug that prevents accent-color: white from working. */
+@supports not (-webkit-touch-callout: none) {
+  .list li input[type=checkbox] {
+    accent-color: white;
+  }
 }
 ```
 

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -78,7 +78,7 @@ export interface SelectableItemStates {
   allowsSelection: boolean,
   /**
    * Whether the item has an action, dependent on `onAction`, `disabledKeys`,
-   * and `disabledBehavior. It may also change depending on the current selection state
+   * and `disabledBehavior`. It may also change depending on the current selection state
    * of the list (e.g. when selection is primary). This can be used to enable or disable hover
    * styles or other visual indications of interactivity.
    */

--- a/packages/@react-aria/selection/src/useSelectableList.ts
+++ b/packages/@react-aria/selection/src/useSelectableList.ts
@@ -107,7 +107,10 @@ export function useSelectableList(props: AriaSelectableListOptions): SelectableL
   // By default, a KeyboardDelegate is provided which uses the DOM to query layout information (e.g. for page up/page down).
   // When virtualized, the layout object will be passed in as a prop and override this.
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
-  let delegate = useMemo(() => keyboardDelegate || new ListKeyboardDelegate(collection, disabledKeys, ref, collator), [keyboardDelegate, collection, disabledKeys, ref, collator]);
+  let disabledBehavior = selectionManager.disabledBehavior;
+  let delegate = useMemo(() => (
+    keyboardDelegate || new ListKeyboardDelegate(collection, disabledBehavior === 'selection' ? new Set() : disabledKeys, ref, collator)
+  ), [keyboardDelegate, collection, disabledKeys, ref, collator, disabledBehavior]);
 
   let {collectionProps} = useSelectableCollection({
     ref,

--- a/packages/@react-spectrum/list/docs/anatomy.svg
+++ b/packages/@react-spectrum/list/docs/anatomy.svg
@@ -11,11 +11,11 @@
   </defs>
   <g id="listview_anatomy" clip-path="url(#clip-listview_anatomy)" transform="translate(-55 -55)">
     <rect id="Rectangle_142147" data-name="Rectangle 142147" width="436" height="58" transform="translate(123 96)" fill="var(--anatomy-gray-50)"/>
-    <g id="Rectangle_142150" data-name="Rectangle 142150" transform="translate(177.5 104)" fill="var(--anatomy-gray-100)" stroke="#a5b6dd" stroke-width="1" stroke-dasharray="3">
+    <g id="Rectangle_142150" data-name="Rectangle 142150" transform="translate(177.5 104)" fill="var(--anatomy-gray-100)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="3">
       <rect width="42" height="42" stroke="none"/>
       <rect x="0.5" y="0.5" width="41" height="41" fill="none"/>
     </g>
-    <g id="Rectangle_142152" data-name="Rectangle 142152" transform="translate(416 104)" fill="var(--anatomy-gray-100)" stroke="#a5b6dd" stroke-width="1" stroke-dasharray="3">
+    <g id="Rectangle_142152" data-name="Rectangle 142152" transform="translate(416 104)" fill="var(--anatomy-gray-100)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="3">
       <rect width="101.504" height="42" stroke="none"/>
       <rect x="0.5" y="0.5" width="100.504" height="41" fill="none"/>
     </g>
@@ -65,18 +65,18 @@
         <rect id="Rectangle_11-6" data-name="Rectangle 11" width="4" height="4" rx="1" transform="translate(287 281)" fill="var(--anatomy-gray-700)"/>
       </g>
     </g>
-    <g id="Rectangle_142153" data-name="Rectangle 142153" transform="translate(227.5 127)" fill="var(--anatomy-gray-100)" stroke="#a5b6dd" stroke-width="1" stroke-dasharray="3">
+    <g id="Rectangle_142153" data-name="Rectangle 142153" transform="translate(227.5 127)" fill="var(--anatomy-gray-100)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="3">
       <rect width="181" height="19" stroke="none"/>
       <rect x="0.5" y="0.5" width="180" height="18" fill="none"/>
     </g>
-    <g id="Rectangle_142154" data-name="Rectangle 142154" transform="translate(227.5 104)" fill="var(--anatomy-gray-100)" stroke="#a5b6dd" stroke-width="1" stroke-dasharray="3">
+    <g id="Rectangle_142154" data-name="Rectangle 142154" transform="translate(227.5 104)" fill="var(--anatomy-gray-100)" stroke="var(--anatomy-gray-500)" stroke-width="1" stroke-dasharray="3">
       <rect width="181" height="19" stroke="none"/>
       <rect x="0.5" y="0.5" width="180" height="18" fill="none"/>
     </g>
     <text id="Label_area" data-name="Label area" transform="translate(318.5 118)" fill="var(--anatomy-gray-900)" font-size="12" font-family="Adobe-Clean" font-style="italic"><tspan x="-24.678" y="0">Label area</tspan></text>
     <text id="Description_area_optional_" data-name="Description area (optional)" transform="translate(318.5 141)" fill="var(--anatomy-gray-900)" font-size="12" font-family="Adobe-Clean" font-style="italic"><tspan x="-62.94" y="0">Description area (optional)</tspan></text>
     <g id="Checkbox" transform="translate(149 101)">
-      <g id="Placement_Area" data-name="Placement Area" fill="red" stroke="rgba(0,0,0,0)" stroke-width="1" opacity="0">
+      <g id="Placement_Area" data-name="Placement Area" fill="red" stroke="var(--anatomy-gray-900)" stroke-opacity="0" stroke-width="1" opacity="0">
         <rect width="21" height="48" stroke="none"/>
         <rect x="0.5" y="0.5" width="20" height="47" fill="none"/>
       </g>
@@ -88,7 +88,7 @@
     <g id="Group_156660" data-name="Group 156660" transform="translate(515 101)">
       <rect id="Rectangle_139996" data-name="Rectangle 139996" width="15" height="48" transform="translate(11)" fill="red" opacity="0"/>
       <g id="ChevronSize100" transform="translate(11 16.5)">
-        <rect id="Frame" width="15" height="15" fill="rgba(255,0,0,0)"/>
+        <rect id="Frame" width="15" height="15" fill="var(--anatomy-gray-800)" fill-opacity="0"/>
         <path id="Path_35561" data-name="Path 35561" d="M3.437,14.9a1.312,1.312,0,0,1-.922-2.246L7.757,7.475,2.515,2.3A1.312,1.312,0,1,1,4.36.428l6.188,6.113a1.314,1.314,0,0,1,0,1.868L4.36,14.522A1.307,1.307,0,0,1,3.437,14.9Z" transform="translate(1.063 0.025)" fill="var(--anatomy-gray-700)"/>
       </g>
     </g>


### PR DESCRIPTION
A few small updates to the `useGridList` docs:

* Restructure the "Features" section into categories that can be more easily scanned.
* Make examples a little prettier, and move to using collapsed CSS in the example to reduce styling noise.
* Add interactive elements to most examples to highlight this as the main feature. Also move the note about using listbox to the top of the page.
* More examples.
* Fix `disabledBehavior` in `useSelectableList`.
* Fix dark mode in anatomy diagrams.