### PR TITLE
Restore aria labeling props for Spectrum Calendar/RangeCalendar props

### DIFF
--- a/packages/@react-types/calendar/src/index.d.ts
+++ b/packages/@react-types/calendar/src/index.d.ts
@@ -69,7 +69,7 @@ export interface AriaCalendarProps<T extends DateValue> extends CalendarProps<T>
 
 export interface AriaRangeCalendarProps<T extends DateValue> extends RangeCalendarProps<T>, DOMProps, AriaLabelingProps {}
 
-export interface SpectrumCalendarProps<T extends DateValue> extends CalendarProps<T>, StyleProps {
+export interface SpectrumCalendarProps<T extends DateValue> extends AriaCalendarProps<T>, StyleProps {
   /**
    * The number of months to display at once. Up to 3 months are supported.
    * @default 1
@@ -77,7 +77,7 @@ export interface SpectrumCalendarProps<T extends DateValue> extends CalendarProp
   visibleMonths?: number
 }
 
-export interface SpectrumRangeCalendarProps<T extends DateValue> extends RangeCalendarProps<T>, StyleProps {
+export interface SpectrumRangeCalendarProps<T extends DateValue> extends AriaRangeCalendarProps<T>, StyleProps {
   /**
    * The number of months to display at once. Up to 3 months are supported.
    * @default 1


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
