### PR TITLE
Update ListView docs

### DIFF
--- a/packages/@react-spectrum/list/docs/ListView.mdx
+++ b/packages/@react-spectrum/list/docs/ListView.mdx
@@ -147,7 +147,7 @@ function AsyncList() {
 
 <Anatomy />
 
-Items within a ListView also allow for additional content used to add context or provide additional actions to items. Descriptions, icons, and thumbnails can be added to
+Items within a ListView also allow for additional content used to add context or provide additional actions to items. Descriptions, illustrations, and thumbnails can be added to
 the children of `<Item>` as shown in the example below. If a description is added, the prop `slot="description"` must be used to distinguish the different `<Text>` elements.
 Additionally, components such as `<ActionButton>`, `<ActionGroup>`, and `<ActionMenu>` will be styled appropriately if included within an item. Providing the `hasChildItems` prop
 to an `<Item>` will add a chevron icon to the end of the row to visually indicate that the row has children.


### PR DESCRIPTION
Closes <!-- Github issue # here -->[no-issue]

Update ListView docs to reflect that accepted content includes illustrations and not icons.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Look at website artifact

## 🧢 Your Project:

<!--- Company/project for pull request -->
