### PR TITLE
Hide dragging ListView row from Talkback during virtual drag

### DIFF
--- a/packages/@react-spectrum/dnd/src/useDragHooks.ts
+++ b/packages/@react-spectrum/dnd/src/useDragHooks.ts
@@ -1,12 +1,13 @@
 import {DraggableCollectionOptions, DraggableCollectionState, useDraggableCollectionState} from '@react-stately/dnd';
 import {DraggableCollectionProps} from '@react-types/shared';
-import {DraggableItemProps, DraggableItemResult, DragPreview, useDraggableItem} from '@react-aria/dnd';
+import {DraggableItemProps, DraggableItemResult, DragPreview, isVirtualDragging, useDraggableItem} from '@react-aria/dnd';
 import {useMemo} from 'react';
 
 export interface DragHooks {
   useDraggableCollectionState(props: Omit<DraggableCollectionOptions, 'getItems'>): DraggableCollectionState,
   useDraggableItem(props: DraggableItemProps, state: DraggableCollectionState): DraggableItemResult,
-  DragPreview: typeof DragPreview
+  DragPreview: typeof DragPreview,
+  isVirtualDragging(): boolean
 }
 
 export interface DragHookOptions extends Omit<DraggableCollectionProps, 'preview'> {}
@@ -17,6 +18,7 @@ export function useDragHooks(options: DragHookOptions): DragHooks {
       return useDraggableCollectionState({...props, ...options});
     },
     useDraggableItem,
-    DragPreview
+    DragPreview,
+    isVirtualDragging
   }), [options]);
 }

--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -129,6 +129,7 @@ export function ListViewItem<T>(props: ListViewItemProps<T>) {
   let {visuallyHiddenProps} = useVisuallyHidden();
 
   let dropProps = isDroppable ? droppableItem?.dropProps : {'aria-hidden': droppableItem?.dropProps['aria-hidden']};
+  let isVirtualDragging = dropHooks?.isVirtualDragging() || dragHooks?.isVirtualDragging();
   const mergedProps = mergeProps(
     rowProps,
     draggableItem?.dragProps,
@@ -138,7 +139,7 @@ export function ListViewItem<T>(props: ListViewItemProps<T>) {
     focusProps,
     // Remove tab index from list row if performing a screenreader drag. This prevents TalkBack from focusing the row,
     // allowing for single swipe navigation between row drop indicator
-    dropHooks?.isVirtualDragging() && {tabIndex: null}
+    isVirtualDragging && {tabIndex: null}
   );
 
   let isFirstRow = item.prevKey == null;


### PR DESCRIPTION
If a listview was only draggable, the dragged row element and drag handle was focusable via TalkBack since we only removed the tabindexes from the rows if the list was droppable. Now we do the same if the list is draggable

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to the "drag out of list" story in ListView drag and drop.
2. Begin a drag via TalkBack and ensure that the row containing the dragged row can't be focused during the drag operation

## 🧢 Your Project:

RSP
