### PR TITLE
Improving Modal unmounting trigger story for mobile

### DIFF
--- a/packages/@react-spectrum/overlays/stories/Modal.stories.tsx
+++ b/packages/@react-spectrum/overlays/stories/Modal.stories.tsx
@@ -15,6 +15,7 @@ import {ButtonGroup} from '@react-spectrum/buttongroup';
 import {Content} from '@react-spectrum/view';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Divider} from '@react-spectrum/divider';
+import {Flex} from '@react-spectrum/layout';
 import {Heading, Text} from '@react-spectrum/text';
 import {Modal} from '../';
 import React, {Fragment, useState} from 'react';
@@ -66,8 +67,12 @@ function UnmountingTrigger() {
         <Dialog>
           <Heading>Title</Heading>
           <Divider />
-          <Content><Text>I am a dialog</Text></Content>
-          <ButtonGroup><ActionButton onPress={openModal}>Open modal</ActionButton></ButtonGroup>
+          <Content>
+            <Flex direction="column" gap="size-100">
+              <Text>I am a dialog</Text>
+              <ActionButton onPress={openModal}>Open modal</ActionButton>
+            </Flex>
+          </Content>
         </Dialog>
       </DialogTrigger>
       <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>


### PR DESCRIPTION
Closes

Found during testing of focus PR #3385. The "open modal" button didn't work on mobile because the button was in a button group that is replaced by the dismiss button in a popover on mobile.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Goto to the Modal -> unmountingTrigger story and confirm that the popover has the "Open modal" button on both Desktop and Mobile.

Should tests how focus is managed on mobile with Voiceover.

## 🧢 Your Project:
RSP