### PR TITLE
Fix ActionGroup 'More' icon not rendering

### DIFF
--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -462,7 +462,7 @@ function ActionGroupMenu<T>({state, isDisabled, isEmphasized, staticColor, items
             }
             isDisabled={isDisabled}
             staticColor={staticColor}>
-            {summaryIcon ? <More /> : null}
+            {summaryIcon || <More />}
           </ActionButton>
         </PressResponder>
       </SlotProvider>


### PR DESCRIPTION
Broke in https://github.com/adobe/react-spectrum/pull/3416. Should still pass `tsc-strict`. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
