### PR TITLE
Fix text truncation in mobile SearchAutocomplete

### DIFF
--- a/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
@@ -279,6 +279,10 @@ const SearchAutocompleteButton = React.forwardRef(function SearchAutocompleteBut
               classNames(
                 searchStyles,
                 'spectrum-Search-input'
+              ),
+              classNames(
+                searchAutocompleteStyles,
+                'mobile-input'
               )
             )
           }>

--- a/packages/@react-spectrum/autocomplete/src/searchautocomplete.css
+++ b/packages/@react-spectrum/autocomplete/src/searchautocomplete.css
@@ -28,13 +28,14 @@
 }
 
 .mobile-input {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
 }
 
 .mobile-value {
-  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tray-dialog {

--- a/packages/@react-spectrum/combobox/src/combobox.css
+++ b/packages/@react-spectrum/combobox/src/combobox.css
@@ -28,13 +28,14 @@
 }
 
 .mobile-input {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
 }
 
 .mobile-value {
-  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tray-dialog {


### PR DESCRIPTION
Found while testing #3383.

This adds a missing class to SearchAutocomplete so the text truncates with an ellipsis rather than wrapping on mobile.

Also noticed that the ellipsis was not quite aligned with the vertically centered text, so fixed that too (also in combobox).