### PR TITLE
TableView overlay auto tab stop Firefox fix

### DIFF
--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -449,6 +449,7 @@ function TableVirtualizer({layout, collection, focusedKey, renderView, renderWra
               }
             )
           }
+          tabIndex={-1}
           style={{flex: 1}}
           innerStyle={{overflow: 'visible', transition: state.isAnimating ? `none ${state.virtualizer.transitionDuration}ms` : undefined}}
           ref={bodyRef}


### PR DESCRIPTION
Closes

Found during testing, but pre-existing issue. In Firefox, an element with overflow auto or scroll is a tab stop. This caused an empty table to be tabbed too twice.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

In FireFox, go to any TableView story with no content (renderEmptyState, isLoading, etc.) and tab into the TableView. It should only stop once on the table body during keyboard tab navigation.

## 🧢 Your Project:
RSP