### PR TITLE
Ensure useRadioGroup arrow keys select only radio inputs

### DIFF
--- a/packages/@react-aria/radio/src/useRadioGroup.ts
+++ b/packages/@react-aria/radio/src/useRadioGroup.ts
@@ -94,7 +94,7 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
     let walker = getFocusableTreeWalker(e.currentTarget, {
       from: e.target,
       accept: node =>  node instanceof HTMLInputElement && node.type === 'radio'
-    })
+    });
     let nextElem;
     if (nextDir === 'next') {
       nextElem = walker.nextNode();

--- a/packages/@react-aria/radio/src/useRadioGroup.ts
+++ b/packages/@react-aria/radio/src/useRadioGroup.ts
@@ -91,7 +91,10 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
         return;
     }
     e.preventDefault();
-    let walker = getFocusableTreeWalker(e.currentTarget, {from: e.target});
+    let walker = getFocusableTreeWalker(e.currentTarget, {
+      from: e.target,
+      accept: node =>  node instanceof HTMLInputElement && node.type === 'radio'
+    })
     let nextElem;
     if (nextDir === 'next') {
       nextElem = walker.nextNode();


### PR DESCRIPTION
Closes #3536

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
  - I can't find any related tests
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

- Use `useRadioGroup` in a component where there are focusable elements (button) within the group (See code snippet below)
- Focus a radio
- Hit arrow keys
- Focus is never given to buttons, only radio inputs

```tsx
import {useRadioGroupState} from 'react-stately';
import {useRadio, useRadioGroup} from 'react-aria';

let RadioContext = React.createContext(null);

function RadioGroup(props) {
  let { children, label } = props;
  let state = useRadioGroupState(props);
  let { radioGroupProps, labelProps } = useRadioGroup(props, state);

  return (
    <div {...radioGroupProps}>
      <span {...labelProps}>{label}</span>
      <RadioContext.Provider value={state}>
        {children}
      </RadioContext.Provider>
    </div>
  );
}

function Radio(props) {
  let { children } = props;
  let state = React.useContext(RadioContext);
  let ref = React.useRef(null);
  let { inputProps } = useRadio(props, state, ref);

  return (
    <label style={{ display: 'block' }}>
      <input {...inputProps} ref={ref} />
      <button tabIndex="-1">steal your arrow keys</button>
      {children}
    </label>
  );
}

<RadioGroup label="Favorite pet">
  <Radio value="dogs">Dogs</Radio>
  <Radio value="cats">Cats</Radio>
</RadioGroup>
```