### PR TITLE
Add missing styled example to useMenu docs

### DIFF
--- a/packages/@react-aria/menu/docs/useMenu.mdx
+++ b/packages/@react-aria/menu/docs/useMenu.mdx
@@ -21,6 +21,8 @@ import {HeaderInfo, FunctionAPI, TypeContext, InterfaceType, TypeLink, PageDescr
 import packageData from '@react-aria/menu/package.json';
 import Anatomy from './menu-trigger-anatomy.svg';
 import ChevronRight from '@spectrum-icons/workflow/ChevronRight';
+import {ExampleCard} from '@react-spectrum/docs/src/ExampleCard';
+import tailwindPreview from 'url:./tailwind.png';
 
 ---
 category: Collections
@@ -306,6 +308,14 @@ function Button(props) {
 ```
 
 </details>
+
+## Styled examples
+
+<ExampleCard
+  url="https://codesandbox.io/s/awesome-boyd-c0gbv5?file=/src/Menu.tsx"
+  preview={tailwindPreview}
+  title="Tailwind CSS"
+  description="An example of styling a Menu with Tailwind." />
 
 ## Dynamic collections
 


### PR DESCRIPTION
This was originally added in #3308, but due to subsequent merge issues, it seems to have been lost.