### PR TITLE
DnD: Focus an item after it has been dropped on

### DIFF
--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -219,14 +219,13 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
       // focus that item and show the focus ring to give the user feedback that the drop occurred.
       // Also show the focus ring if the focused key is not selected, e.g. in case of a reorder.
       let {state} = localState;
-      if (state.selectionManager.focusedKey === focusedKey) {
-        if (target.type === 'item' && target.dropPosition === 'on' && state.collection.getItem(target.key) != null) {
-          state.selectionManager.setFocusedKey(target.key);
-          state.selectionManager.setFocused(true);
-          setInteractionModality('keyboard');
-        } else if (!state.selectionManager.isSelected(focusedKey)) {
-          setInteractionModality('keyboard');
-        }
+
+      if (target.type === 'item' && target.dropPosition === 'on' && state.collection.getItem(target.key) != null) {
+        state.selectionManager.setFocusedKey(target.key);
+        state.selectionManager.setFocused(true);
+        setInteractionModality('keyboard');
+      } else if (!state.selectionManager.isSelected(focusedKey)) {
+        setInteractionModality('keyboard');
       }
 
       droppingState.current = null;

--- a/packages/@react-spectrum/list/test/ListViewDnd.test.js
+++ b/packages/@react-spectrum/list/test/ListViewDnd.test.js
@@ -561,6 +561,48 @@ describe('ListView', function () {
         expect(document.activeElement).toBe(list2rows[0]);
       });
 
+      it('should automatically focus an item after if it has been dropped on', async function () {
+        let {getByRole, getAllByRole} = render(
+          <DragIntoItemExample dragHookOptions={{onDragStart, onDragEnd}} listViewProps={{onSelectionChange, disabledKeys: []}} dropHookOptions={{onDrop}} />
+        );
+
+        let grid = getByRole('grid');
+        let rows = getAllByRole('row');
+        let cell = within(rows[1]).getByRole('gridcell');
+        expect(within(rows[0]).getByRole('gridcell')).toHaveTextContent('Folder 1 (Drop items here)');
+        expect(within(rows[1]).getByRole('gridcell')).toHaveTextContent('Item One');
+        expect(within(rows[2]).getByRole('gridcell')).toHaveTextContent('Item Two');
+        expect(rows).toHaveLength(9);
+
+        let dataTransfer = new DataTransfer();
+        fireEvent.pointerDown(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
+        fireEvent(cell, new DragEvent('dragstart', {dataTransfer, clientX: 0, clientY: 0}));
+        expect(onDragStart).toHaveBeenCalledTimes(1);
+
+        fireEvent.pointerMove(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 1, clientY: 350});
+        fireEvent(cell, new DragEvent('drag', {dataTransfer, clientX: 1, clientY: 350}));
+        fireEvent(grid, new DragEvent('dragover', {dataTransfer, clientX: 1, clientY: 350}));
+        fireEvent.pointerUp(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 1, clientY: 350});
+
+        fireEvent(grid, new DragEvent('drop', {dataTransfer, clientX: 1, clientY: 350}));
+        act(() => jest.runAllTimers());
+        await act(async () => Promise.resolve());
+        expect(onDrop).toHaveBeenCalledTimes(1);
+
+        fireEvent(cell, new DragEvent('dragend', {dataTransfer, clientX: 1, clientY: 350}));
+        expect(onDragEnd).toHaveBeenCalledTimes(1);
+
+        act(() => jest.runAllTimers());
+
+        rows = getAllByRole('row');
+        expect(within(rows[0]).getByRole('gridcell')).toHaveTextContent('Folder 1 (Drop items here)');
+        expect(within(rows[1]).getByRole('gridcell')).toHaveTextContent('Item Two');
+        expect(within(rows[2]).getByRole('gridcell')).toHaveTextContent('Item Three');
+
+        expect(rows).toHaveLength(8);
+        expect(document.activeElement).toBe(rows[7]);
+      });
+
       it('should update the global DnD state properly if dropping on a non-collection', function () {
         let {getAllByRole, getByRole, getByText} = render(
           <DraggableListView />
@@ -2647,6 +2689,48 @@ describe('ListView', function () {
 
         expect(document.activeElement).toBe(list2rows[0]);
       });
+
+      it('should automatically focus an item after if it has been dropped on', async function () {
+        let {getByRole} = render(
+          <DragIntoItemExample dragHookOptions={{onDragStart, onDragEnd}} listViewProps={{onSelectionChange, disabledKeys: []}} dropHookOptions={{onDrop}} />
+        );
+
+        let grid = getByRole('grid');
+        let rows = within(grid).getAllByRole('row');
+        expect(rows).toHaveLength(9);
+
+        userEvent.tab();
+
+        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
+        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
+
+        expect(document.activeElement).toBe(rows[1]);
+
+        fireEvent.keyDown(document.activeElement, {key: 'ArrowRight'});
+        fireEvent.keyUp(document.activeElement, {key: 'ArrowRight'});
+
+        fireEvent.keyDown(document.activeElement, {key: 'Enter'});
+        fireEvent.keyUp(document.activeElement, {key: 'Enter'});
+
+        expect(onDragStart).toHaveBeenCalledTimes(1);
+        act(() => jest.runAllTimers());
+
+        expect(document.activeElement).toHaveAttribute('aria-label', 'Drop on Folder 2');
+
+        fireEvent.keyDown(document.activeElement, {key: 'Enter'});
+        fireEvent.keyUp(document.activeElement, {key: 'Enter'});
+
+        await act(async () => Promise.resolve());
+        expect(onDrop).toHaveBeenCalledTimes(1);
+
+        act(() => jest.runAllTimers());
+
+        grid = getByRole('grid');
+        rows = within(grid).getAllByRole('row');
+        expect(rows).toHaveLength(8);
+
+        expect(document.activeElement).toBe(rows[7]);
+      });
     });
 
     it('should make row selection happen on pressUp if list is draggable', function () {
@@ -3018,48 +3102,6 @@ describe('ListView', function () {
           expect(row).toHaveAttribute('tabIndex', '0');
         }
       }
-    });
-
-    it('should focus an item if it is dropped on', async function () {
-      let {getByRole} = render(
-        <DragIntoItemExample dragHookOptions={{onDragStart, onDragEnd}} listViewProps={{onSelectionChange, disabledKeys: []}} dropHookOptions={{onDrop}} />
-      );
-
-      let grid = getByRole('grid');
-      let rows = within(grid).getAllByRole('row');
-      expect(rows).toHaveLength(9);
-
-      userEvent.tab();
-
-      fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
-      fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
-
-      expect(document.activeElement).toBe(rows[1]);
-
-      fireEvent.keyDown(document.activeElement, {key: 'ArrowRight'});
-      fireEvent.keyUp(document.activeElement, {key: 'ArrowRight'});
-
-      fireEvent.keyDown(document.activeElement, {key: 'Enter'});
-      fireEvent.keyUp(document.activeElement, {key: 'Enter'});
-
-      expect(onDragStart).toHaveBeenCalledTimes(1);
-      act(() => jest.runAllTimers());
-
-      expect(document.activeElement).toHaveAttribute('aria-label', 'Drop on Folder 2');
-
-      fireEvent.keyDown(document.activeElement, {key: 'Enter'});
-      fireEvent.keyUp(document.activeElement, {key: 'Enter'});
-
-      await act(async () => Promise.resolve());
-      expect(onDrop).toHaveBeenCalledTimes(1);
-
-      act(() => jest.runAllTimers());
-
-      grid = getByRole('grid');
-      rows = within(grid).getAllByRole('row');
-      expect(rows).toHaveLength(8);
-
-      expect(document.activeElement).toBe(rows[7]);
     });
 
     it('should support getAllowedDropOperations to limit allowed operations', () => {

--- a/packages/@react-spectrum/list/test/ListViewDnd.test.js
+++ b/packages/@react-spectrum/list/test/ListViewDnd.test.js
@@ -3020,6 +3020,48 @@ describe('ListView', function () {
       }
     });
 
+    it('should focus an item if it is dropped on', async function () {
+      let {getByRole} = render(
+        <DragIntoItemExample dragHookOptions={{onDragStart, onDragEnd}} listViewProps={{onSelectionChange, disabledKeys: []}} dropHookOptions={{onDrop}} />
+      );
+
+      let grid = getByRole('grid');
+      let rows = within(grid).getAllByRole('row');
+      expect(rows).toHaveLength(9);
+
+      userEvent.tab();
+
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
+      fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
+
+      expect(document.activeElement).toBe(rows[1]);
+
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowRight'});
+      fireEvent.keyUp(document.activeElement, {key: 'ArrowRight'});
+
+      fireEvent.keyDown(document.activeElement, {key: 'Enter'});
+      fireEvent.keyUp(document.activeElement, {key: 'Enter'});
+
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+      act(() => jest.runAllTimers());
+
+      expect(document.activeElement).toHaveAttribute('aria-label', 'Drop on Folder 2');
+
+      fireEvent.keyDown(document.activeElement, {key: 'Enter'});
+      fireEvent.keyUp(document.activeElement, {key: 'Enter'});
+
+      await act(async () => Promise.resolve());
+      expect(onDrop).toHaveBeenCalledTimes(1);
+
+      act(() => jest.runAllTimers());
+
+      grid = getByRole('grid');
+      rows = within(grid).getAllByRole('row');
+      expect(rows).toHaveLength(8);
+
+      expect(document.activeElement).toBe(rows[7]);
+    });
+
     it('should support getAllowedDropOperations to limit allowed operations', () => {
       let getAllowedDropOperations = jest.fn().mockImplementation(() => ['copy']);
       let {getAllByRole, getByText} = render(


### PR DESCRIPTION

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test DnD stories: When dropping on an item (i.e. ListView with folder), focus should then go to that item, instead of going to the list itself.

## 🧢 Your Project:

<!--- Company/project for pull request -->
