### PR TITLE
Improve ListView item drag button icon alignment

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/icon/ui-icons.css
+++ b/packages/@adobe/spectrum-css-temp/components/icon/ui-icons.css
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 :root {
-  --spectrum-icon-listgripper-width: var(--spectrum-global-dimension-size-75);
+  --spectrum-icon-listgripper-width: var(--spectrum-global-dimension-size-65);
   --spectrum-icon-listgripper-height: var(--spectrum-global-dimension-size-150);
 }
 


### PR DESCRIPTION
Minor style fix for alignment of icon in drag buttons on ListView items.

Old:
<img width="292" alt="Previous unaligned drag icon button" src="https://user-images.githubusercontent.com/8961049/192064125-a7084e14-c118-4935-94fe-b90dd5ce88a8.png">

New:
<img width="270" alt="Updated aligned drag icon button" src="https://user-images.githubusercontent.com/8961049/192064129-b12d01d1-3c95-4f38-9925-f4d9144e7c66.png">



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
