### PR TITLE
TableView cosmetic fixes from testing session

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -55,8 +55,8 @@ governing permissions and limitations under the License.
 
   & .spectrum-Menu-sectionHeading {
     /* Support headings as LI */
-    margin-block-start: var(--spectrum-menu-margin-x);
-    margin-block-end: var(--spectrum-menu-margin-x);
+    margin-block-start: var(--spectrum-global-dimension-size-75);
+    margin-block-end: var(--spectrum-global-dimension-size-40);
   }
 
   &:focus {

--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -109,11 +109,10 @@ svg.spectrum-Table-sortedIcon {
 .spectrum-Table-columnResizer {
   display: flex;
   position: absolute;
-  /* -9 aligns us with already existing cell dividers inside the table itself */
-  inset-inline-end: -9px;
+  inset-inline-end: -10px;
   justify-content: center;
   box-sizing: border-box;
-  inline-size: 20px;
+  inline-size: 21px;
   block-size: 100%;
   user-select: none;
 
@@ -430,10 +429,10 @@ svg.spectrum-Table-sortedIcon {
 
 .spectrum-Table-colResizeIndicator {
   display: none;
-  height: calc(100% + 1px);
+  height: 100%;
   width: 2px;
   position: absolute;
-  top: 0;
+  top: 1px;
   inset-inline-end: 0;
   pointer-events: none;
   &.spectrum-Table-colResizeIndicator--visible {
@@ -443,7 +442,9 @@ svg.spectrum-Table-sortedIcon {
 .spectrum-Table-colResizeNubbin {
   display: none;
   position: absolute;
-  top: 0px;
+  /* svg top pixel is anti-aliased, this lets through the blue bar in the background, so we move the bar
+   down one pixel and the nubbin circle up one pixel to cover it completely */
+  top: -1px;
   width: 16px;
   height: 16px;
   inset-inline-start: -7px;

--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -581,14 +581,13 @@ function TableColumnHeader(props) {
 }
 
 let _TableColumnHeaderButton = (props, ref: FocusableRef<HTMLDivElement>) => {
+  let {focusProps, ...otherProps} = props;
   let {isEmpty} = useTableContext();
   let domRef = useFocusableRef(ref);
-  let {buttonProps} = useButton({...props, elementType: 'div', isDisabled: isEmpty}, domRef);
+  let {buttonProps} = useButton({...otherProps, elementType: 'div', isDisabled: isEmpty}, domRef);
   return (
     <div className={classNames(styles, 'spectrum-Table-headCellContents')}>
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
-        <div className={classNames(styles, 'spectrum-Table-headCellButton')} {...buttonProps} ref={domRef}>{props.children}</div>
-      </FocusRing>
+      <div className={classNames(styles, 'spectrum-Table-headCellButton')} {...mergeProps(buttonProps, focusProps)} ref={domRef}>{props.children}</div>
     </div>
   );
 };
@@ -616,6 +615,7 @@ function ResizableTableColumnHeader(props) {
   if (columnProps.width && columnProps.allowsResizing) {
     throw new Error('Controlled state is not yet supported with column resizing. Please use defaultWidth for uncontrolled column resizing or remove the allowsResizing prop.');
   }
+  let {isFocusVisible, focusProps} = useFocusRing();
 
   const onMenuSelect = (key) => {
     switch (key) {
@@ -679,6 +679,7 @@ function ResizableTableColumnHeader(props) {
               'is-sorted-desc': state.sortDescriptor?.column === column.key && state.sortDescriptor?.direction === 'descending',
               'is-sorted-asc': state.sortDescriptor?.column === column.key && state.sortDescriptor?.direction === 'ascending',
               'is-hovered': isHovered,
+              'focus-ring': isFocusVisible,
               'spectrum-Table-cell--hideHeader': columnProps.hideHeader
             },
             classNames(
@@ -692,7 +693,7 @@ function ResizableTableColumnHeader(props) {
           )
         }>
         <MenuTrigger>
-          <TableColumnHeaderButton ref={triggerRef}>
+          <TableColumnHeaderButton ref={triggerRef} focusProps={focusProps}>
             {columnProps.hideHeader ?
               <VisuallyHidden>{column.rendered}</VisuallyHidden> :
               column.rendered


### PR DESCRIPTION
Closes <!-- Github issue # here -->
allows resizing, header cell button has a 2px focus ring around it, except the top is only 1px it looks like (RS)
allowsResizing, column divider is offset by .5px with resizer (DG)
focus ring width is shortened by width of resizer. looks esp weird with dividers (DG)
The divider sticks out a bit above the resizer nubbin. See screenshot row 6 (DL)


Also included List/Menu Section fix
Section Titles seem a bit too close to the divider with too much trailing whitespace? Note, this spacing didn't change, but perhaps is more noticeable with descenders? (RS)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
