### PR TITLE
fix(#3559): DatePicker: aria-live not announcing new months

### DIFF
--- a/packages/@react-aria/aria-modal-polyfill/src/index.ts
+++ b/packages/@react-aria/aria-modal-polyfill/src/index.ts
@@ -34,6 +34,7 @@ export function watchModals(selector:string = 'body', {document = currentDocumen
   let undo: Revert | undefined;
 
   let observer = new MutationObserver((mutationRecord) => {
+    const liveAnnouncer: HTMLElement =  document.querySelector('[data-live-announcer="true"]');
     for (let mutation of mutationRecord) {
       if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
         let addNode: Element = (Array.from(mutation.addedNodes).find((node: any) => node.querySelector?.('[aria-modal="true"], [data-ismodal="true"]')) as HTMLElement);
@@ -41,7 +42,7 @@ export function watchModals(selector:string = 'body', {document = currentDocumen
           modalContainers.push(addNode);
           let modal = addNode.querySelector('[aria-modal="true"], [data-ismodal="true"]') as HTMLElement;
           undo?.();
-          undo = hideOthers(modal);
+          undo = hideOthers([modal, liveAnnouncer]);
         }
       } else if (mutation.type === 'childList' && mutation.removedNodes.length > 0) {
         let removedNodes = Array.from(mutation.removedNodes);
@@ -51,7 +52,7 @@ export function watchModals(selector:string = 'body', {document = currentDocumen
           modalContainers = modalContainers.filter((val, i) => i !== nodeIndexRemove);
           if (modalContainers.length > 0) {
             let modal = modalContainers[modalContainers.length - 1].querySelector('[aria-modal="true"], [data-ismodal="true"]');
-            undo = hideOthers(modal);
+            undo = hideOthers([modal, liveAnnouncer]);
           } else {
             undo = undefined;
           }

--- a/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
+++ b/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
@@ -110,6 +110,14 @@ class LiveAnnouncer {
       return;
     }
 
+    // Make sure that the LiveAnnouncer is not hidden from assistive technology by aria-modal-polyfill.
+    if (this.node.hasAttribute('aria-hidden')) {
+      this.node.removeAttribute('aria-hidden');
+      if (this.node.dataset.ariaHidden) {
+        delete this.node.dataset.ariaHidden;
+      }
+    }
+
     let node = document.createElement('div');
     node.textContent = message;
 

--- a/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
+++ b/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
@@ -110,14 +110,6 @@ class LiveAnnouncer {
       return;
     }
 
-    // Make sure that the LiveAnnouncer is not hidden from assistive technology by aria-modal-polyfill.
-    if (this.node.hasAttribute('aria-hidden')) {
-      this.node.removeAttribute('aria-hidden');
-      if (this.node.dataset.ariaHidden) {
-        delete this.node.dataset.ariaHidden;
-      }
-    }
-
     let node = document.createElement('div');
     node.textContent = message;
 


### PR DESCRIPTION
When clicking on the right or left chevron, there should be an aria-live announcement that announces the newly displayed month. This is what occurs when opening the picker initially and reading through; however after you close and reopen the picker, it will no longer announce when clicking the chevron. If you remount the component by refreshing the page, it will work again as described above. I'm using VoiceOver on Mac in Chrome and in Safari.

When you first open the Calendar overlay in the [DatePicker Example](https://react-spectrum.adobe.com/react-spectrum/DatePicker.html#example), the LiveAnnouncer will not have initialized, because there has never been a need to announce anything. When you then navigate between months, a LiveAnnouncer region gets added at the start of the DOM, and is explicitly excluded from the elements to be hidden by `ariaHideOutside` (see [ariaHideOutside.ts#L33-L36](https://github.com/adobe/react-spectrum/blob/892d41e82dc781fb4651455d0e29c324376659ed/packages/%40react-aria/overlays/src/ariaHideOutside.ts#L33-L36) and [ariaHideOutside.ts#L88-L98](https://github.com/adobe/react-spectrum/blob/892d41e82dc781fb4651455d0e29c324376659ed/packages/%40react-aria/overlays/src/ariaHideOutside.ts#L88-L98)), which allows the live region to announce. However, when the Calendar overlay gets opened after the LiveAnnouncer has initialized, the `aria-modal-polyfill`, used to hide elements outside of the React-Spectrum provider, fails to omit the `LiveAnnouncer` region from the elements to be hidden from assistive technology. `LiveAnnouncer` fails to announce because it has been marked as `aria-hidden="true"`.


Closes #3559 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 3559](https://github.com/adobe/react-spectrum/issue/3559).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. With VoiceOver or NVDA running, open https://react-spectrum.adobe.com/react-spectrum/DatePicker.html#example, which exhibits the bug described in #3559.
2. Expand the DatePicker Calendar popover dialog
3. Use Next or Previous buttons to advance the the previous or next month.
4. Screen reader should announce new month and year.
5. Close the Calendar popover by pressing the Esc key.
6. Expand the DatePicker Calendar popover dialog a second time.
7. Use Next or Previous buttons to advance the the previous or next month.
8. Without this fix, the screen reader will no longer announce the new month and year.

9. Open https://reactspectrum.blob.core.windows.net/reactspectrum/866f13209f6ba7e3b12c1e492a4c9821a94e8310/docs/react-spectrum/DatePicker.html#example, which contains the fix in #3564.
10. Expand the DatePicker Calendar popover dialog
11. Use Next or Previous buttons to advance the the previous or next month.
12. Screen reader should announce new month and year.
13.  Close the Calendar popover by pressing the Esc key.
14. Expand the DatePicker Calendar popover dialog a second time.
15. Use Next or Previous buttons to advance the the previous or next month.
8. With the fix, the screen reader will announce the new month and year.

## 🧢 Your Project:

Adobe/Accessibility/RSP
