### PR TITLE
Properly hide invalid drop targets in reorderable only ListViews

### DIFF
--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -10,13 +10,31 @@
  * governing permissions and limitations under the License.
  */
 
-import {clearGlobalDnDState, globalDndState, isInternalDropOperation, setDropCollectionRef, useDroppableCollectionId} from './utils';
-import {Collection, DropEvent, DropOperation, DroppableCollectionDropEvent, DroppableCollectionProps, DropPosition, DropTarget, DropTargetDelegate, KeyboardDelegate, Node} from '@react-types/shared';
-import {DIRECTORY_DRAG_TYPE, getTypes} from './utils';
+import {
+  clearGlobalDnDState,
+  DIRECTORY_DRAG_TYPE,
+  droppableCollectionMap,
+  getTypes,
+  globalDndState,
+  isInternalDropOperation,
+  setDropCollectionRef
+} from './utils';
+import {
+  Collection,
+  DropEvent,
+  DropOperation,
+  DroppableCollectionDropEvent,
+  DroppableCollectionProps,
+  DropPosition,
+  DropTarget,
+  DropTargetDelegate,
+  KeyboardDelegate,
+  Node
+} from '@react-types/shared';
 import * as DragManager from './DragManager';
 import {DroppableCollectionState} from '@react-stately/dnd';
 import {HTMLAttributes, Key, RefObject, useCallback, useEffect, useRef} from 'react';
-import {mergeProps, useLayoutEffect} from '@react-aria/utils';
+import {mergeProps, useId, useLayoutEffect} from '@react-aria/utils';
 import {setInteractionModality} from '@react-aria/interactions';
 import {useAutoScroll} from './useAutoScroll';
 import {useDrop} from './useDrop';
@@ -617,7 +635,8 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
     });
   }, [localState, ref, onDrop]);
 
-  let id = useDroppableCollectionId(state);
+  let id = useId();
+  droppableCollectionMap.set(state, {id, ref});
   return {
     collectionProps: mergeProps(dropProps, {
       id,

--- a/packages/@react-aria/dnd/src/useDroppableItem.ts
+++ b/packages/@react-aria/dnd/src/useDroppableItem.ts
@@ -13,7 +13,7 @@
 import * as DragManager from './DragManager';
 import {DroppableCollectionState} from '@react-stately/dnd';
 import {DropTarget} from '@react-types/shared';
-import {getTypes, globalDndState, isInternalDropOperation} from './utils';
+import {getDroppableCollectionRef, getTypes, globalDndState, isInternalDropOperation} from './utils';
 import {HTMLAttributes, RefObject, useEffect} from 'react';
 import {useVirtualDrop} from './useVirtualDrop';
 
@@ -28,7 +28,7 @@ export interface DroppableItemResult {
 
 export function useDroppableItem(options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement>): DroppableItemResult {
   let {dropProps} = useVirtualDrop();
-
+  let droppableCollectionRef = getDroppableCollectionRef(state);
   useEffect(() => {
     if (ref.current) {
       return DragManager.registerDropItem({
@@ -36,7 +36,7 @@ export function useDroppableItem(options: DroppableItemOptions, state: Droppable
         target: options.target,
         getDropOperation(types, allowedOperations) {
           let {draggingKeys} = globalDndState;
-          let isInternal = isInternalDropOperation();
+          let isInternal = isInternalDropOperation(droppableCollectionRef);
           return state.getDropOperation({
             target: options.target,
             types,
@@ -51,7 +51,7 @@ export function useDroppableItem(options: DroppableItemOptions, state: Droppable
 
   let dragSession = DragManager.useDragSession();
   let {draggingKeys} = globalDndState;
-  let isInternal = isInternalDropOperation();
+  let isInternal = isInternalDropOperation(droppableCollectionRef);
   let isValidDropTarget = dragSession && state.getDropOperation({
     target: options.target,
     types: getTypes(dragSession.dragTarget.items),

--- a/packages/@react-aria/dnd/src/useDroppableItem.ts
+++ b/packages/@react-aria/dnd/src/useDroppableItem.ts
@@ -47,7 +47,7 @@ export function useDroppableItem(options: DroppableItemOptions, state: Droppable
         }
       });
     }
-  }, [ref, options.target, state]);
+  }, [ref, options.target, state, droppableCollectionRef]);
 
   let dragSession = DragManager.useDragSession();
   let {draggingKeys} = globalDndState;

--- a/packages/@react-aria/dnd/src/utils.ts
+++ b/packages/@react-aria/dnd/src/utils.ts
@@ -15,24 +15,31 @@ import {DirectoryItem, DragItem, DropItem, FileItem, DragTypes as IDragTypes} fr
 import {DroppableCollectionState} from '@react-stately/dnd';
 import {getInteractionModality, useInteractionModality} from '@react-aria/interactions';
 import {Key, RefObject} from 'react';
-import {useId} from '@react-aria/utils';
 
-const droppableCollectionIds = new WeakMap<DroppableCollectionState, string>();
-export const DIRECTORY_DRAG_TYPE = Symbol();
-
-export function useDroppableCollectionId(state: DroppableCollectionState) {
-  let id = useId();
-  droppableCollectionIds.set(state, id);
-  return id;
+interface DroppableCollectionMap {
+  id: string,
+  ref: RefObject<HTMLElement>
 }
 
+export const droppableCollectionMap = new WeakMap<DroppableCollectionState, DroppableCollectionMap>();
+export const DIRECTORY_DRAG_TYPE = Symbol();
+
 export function getDroppableCollectionId(state: DroppableCollectionState) {
-  let id = droppableCollectionIds.get(state);
+  let {id} = droppableCollectionMap.get(state);
   if (!id) {
     throw new Error('Droppable item outside a droppable collection');
   }
 
   return id;
+}
+
+export function getDroppableCollectionRef(state: DroppableCollectionState) {
+  let {ref} = droppableCollectionMap.get(state);
+  if (!ref) {
+    throw new Error('Droppable item outside a droppable collection');
+  }
+
+  return ref;
 }
 
 export function getTypes(items: DragItem[]): Set<string> {


### PR DESCRIPTION
Closes <!-- Github issue # here -->


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test the ListView-> Drag and Drop -> Util Handlers -> drag within list (reorder) story with a mobile screen reader. Only the insertion indicators between the rows should be focusable when performing a drag operation

## 🧢 Your Project:

RSP
