### PR TITLE
Fix LabeledValue contextual help alignment for side label

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -214,6 +214,11 @@ governing permissions and limitations under the License.
 
   &.spectrum-Field--positionSide {
     align-items: first baseline;
+    
+    .spectrum-Field-contextualHelp {
+      position: relative;
+      top: var(--spectrum-global-dimension-size-40);
+    }
   }
 
   &.spectrum-Field--positionTop {

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -213,15 +213,7 @@ governing permissions and limitations under the License.
 .spectrum-LabeledValue {
 
   &.spectrum-Field--positionSide {
-    align-items: flex-start;
-    
-    .spectrum-FieldLabel.spectrum-FieldLabel {
-      padding-top: var(--spectrum-global-dimension-size-25);
-    }
-
-    .spectrum-Field-contextualHelp {
-      margin-top: 0;
-    }
+    align-items: first baseline;
   }
 
   &.spectrum-Field--positionTop {

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -213,7 +213,15 @@ governing permissions and limitations under the License.
 .spectrum-LabeledValue {
 
   &.spectrum-Field--positionSide {
-    align-items: first baseline;
+    align-items: flex-start;
+    
+    .spectrum-FieldLabel.spectrum-FieldLabel {
+      padding-top: var(--spectrum-global-dimension-size-25);
+    }
+
+    .spectrum-Field-contextualHelp {
+      margin-top: 0;
+    }
   }
 
   &.spectrum-Field--positionTop {

--- a/packages/@react-spectrum/labeledvalue/chromatic/LabeledValue.chromatic.tsx
+++ b/packages/@react-spectrum/labeledvalue/chromatic/LabeledValue.chromatic.tsx
@@ -133,3 +133,18 @@ export let WithContextualHelp: LabeledValueStory = {
   },
   name: 'contextual help'
 };
+
+export let LabelPostionSideWithContextualHelp: LabeledValueStory = {
+  args: {
+    label: 'Test',
+    value: 25,
+    labelPosition: 'side',
+    contextualHelp: (
+      <ContextualHelp>
+        <Heading>What is a segment?</Heading>
+        <Content>Segments identify who your visitors are, what devices and services they use, where they navigated from, and much more.</Content>
+      </ContextualHelp>
+    )
+  },
+  name: 'contextual help, labelPosition: side'
+};


### PR DESCRIPTION
Found in testing.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to LabeledValue -> Contextual Help story and enable side label position via controls.

Verify that label and contextual help are now aligned.

## 🧢 Your Project:

<!--- Company/project for pull request -->
