### PR TITLE
Fix root drop interaction for iOS VO

### DIFF
--- a/packages/@react-spectrum/list/src/RootDropIndicator.tsx
+++ b/packages/@react-spectrum/list/src/RootDropIndicator.tsx
@@ -19,9 +19,8 @@ export default function RootDropIndicator() {
     <div role="row" aria-hidden={dropIndicatorProps['aria-hidden']}>
       <div
         role="gridcell"
-        aria-selected="false"
-        {...visuallyHiddenProps}>
-        <div role="button" {...dropIndicatorProps} ref={ref} />
+        aria-selected="false">
+        <div role="button" {...visuallyHiddenProps} {...dropIndicatorProps} ref={ref} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Test the root drop ListView DnD stories. You should be able to swipe onto the root drop indicator via iOS VO

## 🧢 Your Project:

RSP
