### PR TITLE
Revert "DnD: Focus initial drop target when using iOS VO (#3283)"

### DIFF
--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -15,7 +15,6 @@ import {ariaHideOutside} from '@react-aria/overlays';
 import {DragEndEvent, DragItem, DropActivateEvent, DropEnterEvent, DropEvent, DropExitEvent, DropItem, DropOperation, DropTarget as DroppableCollectionTarget, FocusableElement} from '@react-types/shared';
 import {flushSync} from 'react-dom';
 import {getDragModality, getTypes} from './utils';
-import {getInteractionModality} from '@react-aria/interactions';
 import type {LocalizedStringFormatter} from '@internationalized/string';
 import {useEffect, useState} from 'react';
 
@@ -72,10 +71,7 @@ export function beginDragging(target: DragTarget, stringFormatter: LocalizedStri
   dragSession = new DragSession(target, stringFormatter);
   requestAnimationFrame(() => {
     dragSession.setup();
-    if (
-      getDragModality() === 'keyboard' ||
-      (getDragModality() === 'touch' && getInteractionModality() === 'virtual')
-    ) {
+    if (getDragModality() === 'keyboard') {
       let target = dragSession.findNearestDropTarget();
       dragSession.setCurrentDropTarget(target);
     }

--- a/packages/@react-aria/dnd/test/dnd.test.js
+++ b/packages/@react-aria/dnd/test/dnd.test.js
@@ -2480,7 +2480,7 @@ describe('useDrag and useDrop', function () {
 
       fireEvent.click(draggable);
       act(() => jest.runAllTimers());
-      expect(document.activeElement).toBe(droppable);
+      expect(document.activeElement).toBe(draggable);
       expect(draggable).toHaveAttribute('aria-describedby');
       expect(document.getElementById(draggable.getAttribute('aria-describedby'))).toHaveTextContent('Dragging. Double tap to cancel drag.');
       expect(announce).toHaveBeenCalledWith('Started dragging. Navigate to a drop target, then double tap to drop.');


### PR DESCRIPTION
This reverts #3283. As discussed in testing, moving focus immediately after starting a drag only announces the "navigate to a drop target" message, not that you've already moved to a target, so you might think you need to navigate and miss the first target.
