### PR TITLE
increase useTypeSelect() debounce buffer rate to 1000ms

### DIFF
--- a/packages/@react-aria/selection/src/useTypeSelect.ts
+++ b/packages/@react-aria/selection/src/useTypeSelect.ts
@@ -14,6 +14,11 @@ import {DOMAttributes, KeyboardDelegate} from '@react-types/shared';
 import {Key, KeyboardEvent, useRef} from 'react';
 import {MultipleSelectionManager} from '@react-stately/selection';
 
+/**
+ * Controls how long to wait before clearing the typeahead buffer.
+ */
+const TYPEAHEAD_DEBOUNCE_WAIT_MS = 1000; // 1 second
+
 export interface AriaTypeSelectOptions {
   /**
    * A delegate that returns collection item keys with respect to visual layout.
@@ -84,7 +89,7 @@ export function useTypeSelect(options: AriaTypeSelectOptions): TypeSelectAria {
     clearTimeout(state.timeout);
     state.timeout = setTimeout(() => {
       state.search = '';
-    }, 500);
+    }, TYPEAHEAD_DEBOUNCE_WAIT_MS);
   };
 
   return {


### PR DESCRIPTION
The previous value (500ms) is a bit too tight, and makes keyboard navigation through long lists of items with similar prefixes difficult.

Increasing the buffer to 1 second.

Closes #3500

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

* Implement a component that leverages useTypeSelect()
* For this example we can use the [document example for useSelect()](https://react-spectrum.adobe.com/react-aria/useSelect.html#example)
* See example below
* Click/Keyboard focus on the select
* Type at different rates to observe behavior
* For example "M", "I", "S", "S" (should result in Mississippi)
* Observe that after 1 second, the typeahead buffer is clear and you can start again

Example for testing purposes:

```tsx
<Select label="US States/Territories">
  <Item>Alaska</Item>
  <Item>Alabama</Item>
  <Item>Arkansas</Item>
  <Item>Arizona</Item>
  <Item>California</Item>
  <Item>Colorado</Item>
  <Item>Connecticut</Item>
  <Item>District of Columbia</Item>
  <Item>Florida</Item>
  <Item>Georgia</Item>
  <Item>Hawaii</Item>
  <Item>Iowa</Item>
  <Item>Idaho</Item>
  <Item>Illinois</Item>
  <Item>Indiana</Item>
  <Item>Kansas</Item>
  <Item>Kentucky</Item>
  <Item>Louisiana</Item>
  <Item>Massachusetts</Item>
  <Item>Maryland</Item>
  <Item>Maine</Item>
  <Item>Michigan</Item>
  <Item>Minnesota</Item>
  <Item>Missouri</Item>
  <Item>Mississippi</Item>
  <Item>Montana</Item>
  <Item>North Carolina</Item>
  <Item>North Dakota</Item>
  <Item>Nebraska</Item>
  <Item>New Hampshire</Item>
  <Item>New Jersey</Item>
  <Item>New Mexico</Item>
  <Item>Nevada</Item>
  <Item>New York</Item>
  <Item>Ohio</Item>
  <Item>Oklahoma</Item>
  <Item>Oregon</Item>
  <Item>Pennsylvania</Item>
  <Item>Puerto Rico</Item>
  <Item>Rhode Island</Item>
  <Item>South Carolina</Item>
  <Item>South Dakota</Item>
  <Item>Tennessee</Item>
  <Item>Texas</Item>
  <Item>Utah</Item>
  <Item>Virginia</Item>
  <Item>Vermont</Item>
  <Item>Washington</Item>
  <Item>Wisconsin</Item>
  <Item>West Virginia</Item>
  <Item>Wyoming</Item>
  <Item>Delaware</Item>
</Select>
```

## 🧢 Your Project:

Company: [AngelList Venture](https://www.angellist.com)
Repository (private): https://github.com/angellist/adapt

## Demo

https://user-images.githubusercontent.com/3002968/192945582-e21cc1a0-3141-492d-8049-d9253fdd6b98.mp4

