### PR TITLE
Chrome 105 sticky crashing pinned to v105

### DIFF
--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -454,11 +454,11 @@ export class TableLayout<T> extends ListLayout<T> {
 
     let isChrome105;
     if (window.navigator['userAgentData']) {
-      isChrome105 = window.navigator['userAgentData']?.brands.some(b => b.brand === 'Chromium' && Number(b.version) >= 105);
+      isChrome105 = window.navigator['userAgentData']?.brands.some(b => b.brand === 'Chromium' && Number(b.version) === 105);
     } else {
       let regex = /Chrome\/(\d+)/;
       let matches = regex.exec(window.navigator.userAgent);
-      isChrome105 = matches && matches.length >= 2 && Number(matches[1]) >= 105;
+      isChrome105 = matches && matches.length >= 2 && Number(matches[1]) === 105;
     }
 
     return isChrome105;


### PR DESCRIPTION
Closes

Chrome 105 had a crash with table and sticky. It's fixed in 106 so pinning the code to only 105.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

use chrome 105 and chrome 106
goto stories like many columns and rows and renderEmptyState where there is a checkbox in the header and scroll. 
These stories should not break
In 105 the checkbox is not sticky, while in 106 it is.

## 🧢 Your Project:
RSP