### PR TITLE
Fix dnd issues in docs examples

### DIFF
--- a/packages/@react-aria/dnd/docs/useDraggableCollection.mdx
+++ b/packages/@react-aria/dnd/docs/useDraggableCollection.mdx
@@ -586,16 +586,12 @@ function DropIndicator(props) {
     return null;
   }
 
-  let className = props.target.type === 'item'
-    ? `drop-indicator ${isDropTarget ? 'drop-target' : ''}`
-    : '';
-
   return (
     <li
       {...dropIndicatorProps}
       role="option"
       ref={ref}
-      className={className} />
+      className={`drop-indicator ${isDropTarget ? 'drop-target' : ''}`} />
   );
 }
 ///- end highlight -///

--- a/packages/@react-aria/dnd/docs/useDroppableCollection.mdx
+++ b/packages/@react-aria/dnd/docs/useDroppableCollection.mdx
@@ -266,16 +266,12 @@ function DropIndicator(props) {
     return null;
   }
 
-  let className = props.target.type === 'item'
-    ? `drop-indicator ${isDropTarget ? 'drop-target' : ''}`
-    : '';
-
   return (
     <li
       {...dropIndicatorProps}
       role="option"
       ref={ref}
-      className={className} />
+      className={`drop-indicator ${isDropTarget ? 'drop-target' : ''}`} />
   );
 }
 ```


### PR DESCRIPTION
Fixes the keyboard order of drop targets. Previously, when tabbing through drop targets, you'd get to the end of the page and go back to the initial dragged element, and then go back to the drop targets before that which was weird. Also, in NVDA, when using virtual cursor mode, starting a drag wouldn't move you to the nearest drop target (fine), but tabbing would take you to the start of the page. Now, we shuffle the order of the drop targets so the first one is the nearest to the initial drag target.

Also fixed the root drop indicator not being accessible with iOS VO in examples.