### PR TITLE
Correction of a mistake in useBreadCrumbs.ts

### DIFF
--- a/packages/@react-aria/breadcrumbs/src/useBreadcrumbs.ts
+++ b/packages/@react-aria/breadcrumbs/src/useBreadcrumbs.ts
@@ -24,7 +24,7 @@ export interface BreadcrumbsAria {
 
 /**
  * Provides the behavior and accessibility implementation for a breadcrumbs component.
- * Breadcrumbs display a heirarchy of links to the current page or resource in an application.
+ * Breadcrumbs display a hierarchy of links to the current page or resource in an application.
  */
 export function useBreadcrumbs(props: AriaBreadcrumbsProps): BreadcrumbsAria {
   let {


### PR DESCRIPTION
Just a small and baby correction on a word in `useBreadCrumbs.ts` :eyes:

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
