### PR TITLE
fix ListView focus when removing item from collection

### DIFF
--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -24,6 +24,7 @@ import {ItemDropTarget} from '@react-types/shared';
 import {Link} from '@react-spectrum/link';
 import NoSearchResults from '@spectrum-icons/illustrations/src/NoSearchResults';
 import React, {useEffect, useState} from 'react';
+import RemoveCircle from '@spectrum-icons/workflow/RemoveCircle';
 import {storiesOf} from '@storybook/react';
 import {useAsyncList, useListData} from '@react-stately/data';
 import {useDragAndDrop} from '@react-spectrum/dnd';
@@ -244,6 +245,9 @@ storiesOf('ListView', module)
         <Text slot="description">As a first grader, Mike Wazowski begins to dream of becoming a Scarer</Text>
       </Item>
     </ListView>
+  ))
+  .add('focus example', () => (
+    <FocusExample />
   ));
 
 storiesOf('ListView/Actions', module)
@@ -2137,3 +2141,24 @@ function DragBetweenListsOverride(props) {
     </Flex>
   );
 }
+
+const FocusExample = () => {
+  const list = useListData({
+    getKey: (item) => item.cheese,
+    initialItems: [{name: 'Aardvark', cheese: 1}, {name: 'Kangaroo', cheese: 2}, {name: 'Snake', cheese: 3}],
+    initialSelectedKeys: ['Kangaroo']
+  });
+
+  return (
+    <ListView width="250px" items={list.items}>
+      {(item) => (
+        <Item key={item.name}>
+          <Text>{item.name}</Text>
+          <ActionButton isQuiet onPress={() => list.remove(item.cheese)}>
+            <RemoveCircle />
+          </ActionButton>
+        </Item>
+      )}
+    </ListView>
+  );
+};


### PR DESCRIPTION
Helps with #3039 

---

Currently, when a collection item is removed from from a `ListView`, if the item being removed is the item that is currently focused, after removal the focus is given to to the entire `ListView` component. For long lists this is an accessibility problem, and instead focus should be returned to the next item in the list (if one exists, if not then the previous item in the list).

I've discussed this change a little internally with @snowystinger. I'm thinking that the ideal situation would be to have a argument passed to `useListState` that controls the focus behaviour (whether to focus on the entire list, or the next item down, if the focus item is removed), however initially I have not done this, as I want to check this approach is correct first.

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] ~~Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open the [ListView focus example](http://localhost:9003/?path=/story/listview--focus-example&providerSwitcher-toastPosition=bottom) story in storybook.
2. Using the keyboard, tab into the list
3. Use the down arrow key to navigate to the middle list item
4. Use the right arrow key to navigate onto the remove button for that list item
5. Press enter/space to remove the item
6. Observe that the focus has been given to the last list item, instead of the entire ListView

## 🧢 Your Project:

Admin Console (React Migration)
