### PR TITLE
Fix build revert custom resize icons

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -482,13 +482,13 @@ svg.spectrum-Table-sortedIcon {
 
 .resize-ew *,
 .spectrum-Table-columnResizer--ewresize {
-  cursor: url('data-url:./cursors/Cur_MoveHorizontal_9_9.svg'), ew-resize !important;
+  cursor: ew-resize !important;
 }
 .resize-e *,
 .spectrum-Table-columnResizer--eresize {
-  cursor: url('data-url:./cursors/Cur_MoveToRight_9_9.svg'), e-resize !important;
+  cursor: e-resize !important;
 }
 .resize-w *,
 .spectrum-Table-columnResizer--wresize {
-  cursor: url('data-url:./cursors/Cur_MoveToLeft_9_9.svg'), w-resize !important;
+  cursor: w-resize !important;
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Appears to be a parcel bug, reverting so people's builds can work again. Once this is merged, I'll create a PR to add them back and we can fix whatever is going on there.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
