### PR TITLE
Button and ActionButton design updates

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -99,17 +99,29 @@ governing permissions and limitations under the License.
 
     .spectrum-ActionGroup-item {
       position: relative;
-      border-radius: 0;
+      --spectrum-button-border-radius: 0px;
       z-index: 1;
 
       &:first-child {
         border-start-start-radius: var(--spectrum-actionbutton-border-radius);
         border-end-start-radius: var(--spectrum-actionbutton-border-radius);
+
+        /* focus ring */
+        &:after {
+          border-start-start-radius: calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-alias-focus-ring-gap));
+          border-end-start-radius: calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-alias-focus-ring-gap));
+        }
       }
 
       &:last-child {
         border-start-end-radius: var(--spectrum-actionbutton-border-radius);
         border-end-end-radius: var(--spectrum-actionbutton-border-radius);
+
+        /* focus ring */
+        &:after {
+          border-start-end-radius: calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-alias-focus-ring-gap));
+          border-end-end-radius: calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-alias-focus-ring-gap));
+        }
       }
 
       &.spectrum-ActionGroup-item--isDisabled {

--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -41,6 +41,8 @@ governing permissions and limitations under the License.
   margin: 0;
 
   border-style: solid;
+  border-radius: var(--spectrum-button-border-radius);
+  border-width: var(--spectrum-button-border-width);
 
   /* Remove the inheritance of text transform on button in Edge, Firefox, and IE. */
   text-transform: none;
@@ -113,8 +115,8 @@ governing permissions and limitations under the License.
 }
 
 %spectrum-ButtonWithFocusRing {
-  &:after {
-    border-radius: calc(var(--spectrum-button-primary-border-radius) + var(--spectrum-alias-focus-ring-gap));
+&:after {
+  border-radius: calc(var(--spectrum-button-border-radius) + var(--spectrum-alias-focus-ring-gap));
     content: '';
     display: block;
     position: absolute;
@@ -131,7 +133,7 @@ governing permissions and limitations under the License.
 
   &:focus-ring {
     &:after {
-      margin: calc(var(--spectrum-alias-focus-ring-gap) * -2);
+      margin: calc(var(--spectrum-alias-focus-ring-gap) * -1 - var(--spectrum-button-border-width));
     }
   }
 }
@@ -140,9 +142,9 @@ governing permissions and limitations under the License.
   @inherit: %spectrum-BaseButton;
   @inherit: %spectrum-ButtonWithFocusRing;
 
-  border-width: var(--spectrum-button-primary-border-size);
   border-style: solid;
-  border-radius: var(--spectrum-button-primary-border-radius);
+  --spectrum-button-border-radius: var(--spectrum-button-primary-border-radius);
+  --spectrum-button-border-width: var(--spectrum-button-primary-border-size);
 
   min-block-size: var(--spectrum-button-primary-height);
   block-size: 0%;
@@ -188,6 +190,7 @@ a.spectrum-ActionButton {
 
 .spectrum-ActionButton {
   @inherit: %spectrum-BaseButton;
+  @inherit: %spectrum-ButtonWithFocusRing;
   position: relative;
 
   block-size: var(--spectrum-actionbutton-height);
@@ -196,8 +199,8 @@ a.spectrum-ActionButton {
   /* Use icon padding by default as it's smaller */
   padding: 0;
 
-  border-width: var(--spectrum-actionbutton-border-size);
-  border-radius: var(--spectrum-actionbutton-border-radius);
+  --spectrum-button-border-radius: var(--spectrum-actionbutton-border-radius);
+  --spectrum-button-border-width: var(--spectrum-actionbutton-border-size);
 
   font-size: var(--spectrum-actionbutton-text-size);
   font-weight: var(--spectrum-actionbutton-text-font-weight);
@@ -276,23 +279,6 @@ a.spectrum-ActionButton {
   font-weight: var(--spectrum-actionbutton-quiet-text-font-weight);
 }
 
-.spectrum-ActionButton--emphasized,
-.spectrum-ActionButton--staticColor {
-  @inherit: %spectrum-ButtonWithFocusRing;
-
-  &:after {
-    /* Override border-radius set in %spectrum-ButtonWithFocusRing since this is not a pill button */
-    border-radius: calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-alias-focus-ring-gap));
-  }
-
-  &:focus-ring {
-    &:after {
-      /* action buttons only have a 1px border, not 2px */
-      margin: calc(calc(var(--spectrum-alias-focus-ring-gap) * -1) - var(--spectrum-actionbutton-quiet-border-size));
-    }
-  }
-}
-
 .spectrum-LogicButton {
   @inherit: %spectrum-BaseButton;
   @inherit: %spectrum-ButtonWithFocusRing;
@@ -300,17 +286,12 @@ a.spectrum-ActionButton {
   block-size: var(--spectrum-logicbutton-and-height);
   padding: var(--spectrum-logicbutton-and-padding-x);
 
-  border-width: var(--spectrum-logicbutton-and-border-size);
-  border-radius: var(--spectrum-logicbutton-and-border-radius);
+  --spectrum-button-border-width: var(--spectrum-logicbutton-and-border-size);
+  --spectrum-button-border-radius: var(--spectrum-logicbutton-and-border-radius);
 
   font-size: var(--spectrum-logicbutton-and-text-size);
   font-weight: var(--spectrum-logicbutton-and-text-font-weight);
   line-height: 0;
-
-  &:after {
-    /* Override border-radius set in %spectrum-ButtonWithFocusRing since this is not a pill button */
-    border-radius: calc(var(--spectrum-logicbutton-and-border-radius) + var(--spectrum-alias-focus-ring-gap));
-  }
 }
 
 .spectrum-FieldButton {
@@ -375,7 +356,8 @@ a.spectrum-ActionButton {
   inline-size: var(--spectrum-clearbutton-medium-width);
   block-size: var(--spectrum-clearbutton-medium-height);
 
-  border-radius: 100%;
+  --spectrum-button-border-radius: 100%;
+  --spectrum-button-border-width: 0px;
 
   padding: 0;
   margin: 0;
@@ -386,15 +368,6 @@ a.spectrum-ActionButton {
     /* @safari10 Workaround for https://bugs.webkit.org/show_bug.cgi?id=169700 */
     margin-block: 0;
     margin-inline: auto;
-  }
-}
-
-.spectrum-ClearButton--overBackground {
-  &:focus-ring {
-    &:after {
-      /* Adjust margin because ClearButton does not have a border */
-      margin: calc(var(--spectrum-alias-focus-ring-gap) * -1);
-    }
   }
 }
 

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -452,6 +452,7 @@ governing permissions and limitations under the License.
 
   &:focus-ring {
     background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-key-focus));
+    border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-border-color-hover));
     color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-text-color-key-focus));
 
     .spectrum-Icon {
@@ -553,6 +554,7 @@ governing permissions and limitations under the License.
 
     &:focus-ring {
       background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus));
+      border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-border-color-selected-hover));
       color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus));
 
       .spectrum-Icon {

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -16,6 +16,74 @@ governing permissions and limitations under the License.
   /* Interactions with overbackground button should match background. Not a DNA token, overridden in WHCM. */
   --spectrum-button-over-background-color: inherit;
 
+  --spectrum-actionbutton-background-color-selected: var(--spectrum-global-color-gray-600);
+  --spectrum-actionbutton-background-color-selected-hover: var(--spectrum-global-color-gray-700);
+  --spectrum-actionbutton-background-color-selected-key-focus: var(--spectrum-global-color-gray-700);
+  --spectrum-actionbutton-background-color-selected-down: var(--spectrum-global-color-gray-800);
+  --spectrum-actionbutton-background-color-disabled: transparent;
+  --spectrum-actionbutton-border-color-selected: var(--spectrum-actionbutton-background-color-selected);
+  --spectrum-actionbutton-border-color-selected-hover: var(--spectrum-actionbutton-background-color-selected-hover);
+  --spectrum-actionbutton-border-color-selected-key-focus: var(--spectrum-actionbutton-background-color-selected-key-focus);
+  --spectrum-actionbutton-border-color-selected-down: var(--spectrum-actionbutton-background-color-selected-down);
+  --spectrum-actionbutton-border-color-disabled: var(--spectrum-global-color-gray-300);
+  --spectrum-actionbutton-text-color-selected: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-text-color-selected-hover: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-text-color-selected-key-focus: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-text-color-selected-down: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-icon-color-selected: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-icon-color-selected-hover: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-icon-color-selected-key-focus: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-icon-color-selected-down: var(--spectrum-global-color-gray-50);
+
+  --spectrum-actionbutton-quiet-background-color-hover: var(--spectrum-global-color-gray-200);
+  --spectrum-actionbutton-quiet-background-color-key-focus:  var(--spectrum-global-color-gray-200);
+  --spectrum-actionbutton-quiet-background-color-down: var(--spectrum-global-color-gray-300);
+  --spectrum-actionbutton-quiet-background-color-selected: var(--spectrum-actionbutton-background-color-selected);
+  --spectrum-actionbutton-quiet-background-color-selected-hover: var(--spectrum-actionbutton-background-color-selected-hover);
+  --spectrum-actionbutton-quiet-background-color-selected-key-focus: var(--spectrum-actionbutton-background-color-selected-key-focus);
+  --spectrum-actionbutton-quiet-background-color-selected-down: var(--spectrum-actionbutton-background-color-selected-down);
+  --spectrum-actionbutton-quiet-border-color-selected: var(--spectrum-actionbutton-border-color-selected);
+  --spectrum-actionbutton-quiet-border-color-selected-hover: var(--spectrum-actionbutton-border-color-selected-hover);
+  --spectrum-actionbutton-quiet-border-color-selected-key-focus: var(--spectrum-actionbutton-border-color-selected-key-focus);
+  --spectrum-actionbutton-quiet-border-color-selected-down: var(--spectrum-actionbutton-border-color-selected-down);
+  --spectrum-actionbutton-quiet-text-color-selected: var(--spectrum-actionbutton-text-color-selected);
+  --spectrum-actionbutton-quiet-text-color-selected-hover: var(--spectrum-actionbutton-text-color-selected-hover);
+  --spectrum-actionbutton-quiet-text-color-selected-key-focus: var(--spectrum-actionbutton-text-color-selected-key-focus);
+  --spectrum-actionbutton-quiet-text-color-selected-down: var(--spectrum-actionbutton-text-color-selected-down);
+
+  --spectrum-actionbutton-emphasized-background-color: var(--spectrum-actionbutton-background-color);
+  --spectrum-actionbutton-emphasized-background-color-hover: var(--spectrum-actionbutton-background-color-hover);
+  --spectrum-actionbutton-emphasized-background-color-key-focus: var(--spectrum-actionbutton-background-color-key-focus);
+  --spectrum-actionbutton-emphasized-background-color-down: var(--spectrum-actionbutton-background-color-down);
+  --spectrum-actionbutton-emphasized-background-color-disabled: var(--spectrum-actionbutton-background-color-disabled);
+  --spectrum-actionbutton-emphasized-background-color-selected: var(--spectrum-global-color-blue-500);
+  --spectrum-actionbutton-emphasized-background-color-selected-hover: var(--spectrum-global-color-blue-600);
+  --spectrum-actionbutton-emphasized-background-color-selected-key-focus: var(--spectrum-global-color-blue-600);
+  --spectrum-actionbutton-emphasized-background-color-selected-down: var(--spectrum-global-color-blue-700);
+  --spectrum-actionbutton-emphasized-border-color: var(--spectrum-actionbutton-border-color);
+  --spectrum-actionbutton-emphasized-border-color-hover: var(--spectrum-actionbutton-border-color-hover);
+  --spectrum-actionbutton-emphasized-border-color-key-focus: var(--spectrum-actionbutton-border-color-key-focus);
+  --spectrum-actionbutton-emphasized-border-color-down: var(--spectrum-actionbutton-border-color-down);
+  --spectrum-actionbutton-emphasized-border-color-disabled: var(--spectrum-actionbutton-border-color-disabled);
+  --spectrum-actionbutton-emphasized-border-color-selected: var(--spectrum-actionbutton-emphasized-background-color-selected);
+  --spectrum-actionbutton-emphasized-border-color-selected-hover: var(--spectrum-actionbutton-emphasized-background-color-selected-hover);
+  --spectrum-actionbutton-emphasized-border-color-selected-key-focus: var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus);
+  --spectrum-actionbutton-emphasized-border-color-selected-down: var(--spectrum-actionbutton-emphasized-background-color-selected-down);
+
+  --spectrum-actionbutton-static-black-border-color: rgba(0, 0, 0, 0.4);
+  --spectrum-actionbutton-static-black-border-color-hover: rgba(0, 0, 0, 0.55);
+  --spectrum-actionbutton-static-black-border-color-key-focus: rgba(0, 0, 0, 0.55);
+  --spectrum-actionbutton-static-black-border-color-down: rgba(0, 0, 0, 0.7);
+  --spectrum-actionbutton-static-black-border-color-disabled: rgba(0, 0, 0, 0.1);
+  --spectrum-actionbutton-static-black-background-color: transparent;
+
+  --spectrum-actionbutton-static-white-border-color: rgba(255, 255, 255, 0.4);
+  --spectrum-actionbutton-static-white-border-color-hover: rgba(255, 255, 255, 0.55);
+  --spectrum-actionbutton-static-white-border-color-key-focus: rgba(255, 255, 255, 0.55);
+  --spectrum-actionbutton-static-white-border-color-down: rgba(255, 255, 255, 0.7);
+  --spectrum-actionbutton-static-white-border-color-disabled: rgba(255, 255, 255, 0.1);
+  --spectrum-actionbutton-static-white-background-color: transparent;
+
   /* TBD on new tokens. This passes contrast for now. */
   --spectrum-logicbutton-and-background-color: var(--spectrum-global-color-static-blue-600);
   --spectrum-logicbutton-and-background-color-hover: var(--spectrum-global-color-static-blue-700);
@@ -29,7 +97,7 @@ governing permissions and limitations under the License.
 
 .spectrum-LogicButton,
 .spectrum-Button,
-.spectrum-ActionButton--emphasized {
+.spectrum-ActionButton {
   &:focus-ring,
   &.is-focused {
     &:after {
@@ -376,13 +444,7 @@ governing permissions and limitations under the License.
 
   &:focus-ring {
     background-color: var(--spectrum-actionbutton-background-color-key-focus);
-    border-color: var(--spectrum-actionbutton-border-color-key-focus);
-    box-shadow: 0 0 0 var(--spectrum-button-primary-border-size-increase-key-focus) var(--spectrum-actionbutton-border-color-key-focus);
     color: var(--spectrum-actionbutton-text-color-key-focus);
-
-    &.is-active {
-      border-color: var(--spectrum-actionbutton-border-color-key-focus);
-    }
 
     .spectrum-Icon {
       fill: var(--spectrum-actionbutton-icon-color-key-focus);
@@ -439,12 +501,7 @@ governing permissions and limitations under the License.
 
     &:focus-ring {
       background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-border-color-selected-key-focus);
       color: var(--spectrum-actionbutton-text-color-selected-key-focus);
-
-      &.is-active {
-        border-color: var(--spectrum-actionbutton-border-color-key-focus);
-      }
 
       .spectrum-Icon {
         fill: var(--spectrum-actionbutton-icon-color-selected-key-focus);
@@ -558,13 +615,6 @@ governing permissions and limitations under the License.
     }
   }
 
-  &.spectrum-ActionButton--quiet {
-    &:focus-ring {
-      border-color: var(--spectrum-actionbutton-quiet-border-color);
-      box-shadow: none;
-    }
-  }
-
   &.spectrum-ActionButton--quiet.is-selected,
   &.is-selected {
     background-color: var(--spectrum-actionbutton-emphasized-background-color-selected);
@@ -577,13 +627,7 @@ governing permissions and limitations under the License.
 
     &:focus-ring {
       background-color: var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-emphasized-border-color-selected);
-      box-shadow: none;
       color: var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus);
-
-      &.is-active {
-        border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-down);
-      }
 
       .spectrum-Icon {
         fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-key-focus);
@@ -636,8 +680,6 @@ governing permissions and limitations under the License.
 
   &:focus-ring {
     background-color: var(--spectrum-actionbutton-quiet-background-color-key-focus);
-    box-shadow: 0 0 0 var(--spectrum-actionbutton-quiet-border-size-key-focus) var(--spectrum-actionbutton-quiet-border-color-key-focus);
-    border-color: var(--spectrum-actionbutton-quiet-border-color-key-focus);
     color: var(--spectrum-actionbutton-quiet-text-color-key-focus);
   }
 
@@ -667,7 +709,6 @@ governing permissions and limitations under the License.
 
     &:focus-ring {
       background-color: var(--spectrum-actionbutton-quiet-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-quiet-border-color-selected-key-focus);
       color: var(--spectrum-actionbutton-quiet-text-color-selected-key-focus);
     }
 
@@ -688,17 +729,23 @@ governing permissions and limitations under the License.
 
 .spectrum-ActionButton--staticWhite {
   mix-blend-mode: screen;
-  --spectrum-actionbutton-static-background-color-hover: rgba(255, 255, 255, 0.1);
-  --spectrum-actionbutton-static-background-color-focus: rgba(255, 255, 255, 0.1);
-  --spectrum-actionbutton-static-background-color-active: rgba(255, 255, 255, 0.2);
-  --spectrum-actionbutton-static-border-color: rgba(255, 255, 255, 0.3);
-  --spectrum-actionbutton-static-border-color-hover: white;
-  --spectrum-actionbutton-static-border-color-active: white;
-  --spectrum-actionbutton-static-border-color-focus: white;
-  --spectrum-actionbutton-static-border-disabled: rgba(255, 255, 255, 0.15);
+  --spectrum-actionbutton-static-background-color: var(--spectrum-actionbutton-static-white-background-color);
+  --spectrum-actionbutton-static-background-color-hover: rgba(255, 255, 255, 0.25);
+  --spectrum-actionbutton-static-background-color-focus: rgba(255, 255, 255, 0.25);
+  --spectrum-actionbutton-static-background-color-active: rgba(255, 255, 255, 0.4);
+  --spectrum-actionbutton-static-background-color-selected: rgba(255, 255, 255, 0.9);
+  --spectrum-actionbutton-static-background-color-selected-hover: white;
+  --spectrum-actionbutton-static-background-color-selected-focus: white;
+  --spectrum-actionbutton-static-background-color-selected-active: white;
+  --spectrum-actionbutton-static-background-color-selected-disabled: var(--spectrum-actionbutton-static-white-border-color-disabled);
+  --spectrum-actionbutton-static-border-color: var(--spectrum-actionbutton-static-white-border-color);
+  --spectrum-actionbutton-static-border-color-hover: var(--spectrum-actionbutton-static-white-border-color-hover);
+  --spectrum-actionbutton-static-border-color-active: var(--spectrum-actionbutton-static-white-border-color-down);
+  --spectrum-actionbutton-static-border-color-focus: var(--spectrum-actionbutton-static-white-border-color-key-focus);
+  --spectrum-actionbutton-static-border-disabled: var(--spectrum-actionbutton-static-white-border-color-disabled);
   --spectrum-actionbutton-static-color: white;
   --spectrum-actionbutton-static-color-selected: black; /* becomes the background of the parent element due to mix-blend-mode */
-  --spectrum-actionbutton-static-color-disabled: rgba(255, 255, 255, 0.15);
+  --spectrum-actionbutton-static-color-disabled: rgba(255, 255, 255, 0.55);
 }
 
 .spectrum-ActionButton--staticWhite.spectrum-ActionButton--quiet {
@@ -709,17 +756,23 @@ governing permissions and limitations under the License.
 
 .spectrum-ActionButton--staticBlack {
   mix-blend-mode: multiply;
-  --spectrum-actionbutton-static-background-color-hover: rgba(0, 0, 0, 0.1);
-  --spectrum-actionbutton-static-background-color-focus: rgba(0, 0, 0, 0.1);
-  --spectrum-actionbutton-static-background-color-active: rgba(0, 0, 0, 0.2);
-  --spectrum-actionbutton-static-border-color: rgba(0, 0, 0, 0.3);
-  --spectrum-actionbutton-static-border-color-hover: black;
-  --spectrum-actionbutton-static-border-color-active: black;
-  --spectrum-actionbutton-static-border-color-focus: black;
-  --spectrum-actionbutton-static-border-disabled: rgba(0, 0, 0, 0.15);
+  --spectrum-actionbutton-static-background-color: var(--spectrum-actionbutton-static-black-background-color);
+  --spectrum-actionbutton-static-background-color-hover: rgba(0, 0, 0, 0.25);
+  --spectrum-actionbutton-static-background-color-focus: rgba(0, 0, 0, 0.25);
+  --spectrum-actionbutton-static-background-color-active: rgba(0, 0, 0, 0.4);
+  --spectrum-actionbutton-static-background-color-selected: rgba(0, 0, 0, 0.9);
+  --spectrum-actionbutton-static-background-color-selected-hover: black;
+  --spectrum-actionbutton-static-background-color-selected-focus: black;
+  --spectrum-actionbutton-static-background-color-selected-active: black;
+  --spectrum-actionbutton-static-background-color-selected-disabled: var(--spectrum-actionbutton-static-black-border-color-disabled);
+  --spectrum-actionbutton-static-border-color: var(--spectrum-actionbutton-static-black-border-color);
+  --spectrum-actionbutton-static-border-color-hover: var(--spectrum-actionbutton-static-black-border-color-hover);
+  --spectrum-actionbutton-static-border-color-active: var(--spectrum-actionbutton-static-black-border-color-down);
+  --spectrum-actionbutton-static-border-color-focus: var(--spectrum-actionbutton-static-black-border-color-key-focus);
+  --spectrum-actionbutton-static-border-disabled: var(--spectrum-actionbutton-static-black-border-color-disabled);
   --spectrum-actionbutton-static-color: black;
   --spectrum-actionbutton-static-color-selected: white; /* becomes the background of the parent element due to mix-blend-mode */
-  --spectrum-actionbutton-static-color-disabled: rgba(0, 0, 0, 0.15);
+  --spectrum-actionbutton-static-color-disabled: rgba(0, 0, 0, 0.55);
 }
 
 .spectrum-ActionButton--staticBlack.spectrum-ActionButton--quiet {
@@ -729,7 +782,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ActionButton--staticColor {
-  background-color: transparent;
+  background-color: var(--spectrum-actionbutton-static-background-color);
   border-color: var(--spectrum-actionbutton-static-border-color);
   color: var(--spectrum-actionbutton-static-color);
 
@@ -762,7 +815,7 @@ governing permissions and limitations under the License.
     }
 
     &.is-active {
-      border-color: var(--spectrum-actionbutton-static-color-focus);
+      border-color: var(--spectrum-actionbutton-static-border-color-focus);
     }
 
     .spectrum-Icon {
@@ -774,7 +827,7 @@ governing permissions and limitations under the License.
     }
 
     &:after {
-      box-shadow: 0 0 0 var(--spectrum-button-primary-focus-ring-size-key-focus) var(--spectrum-actionbutton-static-border-color-focus);
+      box-shadow: 0 0 0 var(--spectrum-button-primary-focus-ring-size-key-focus) var(--spectrum-actionbutton-static-color);
     }
   }
 
@@ -805,8 +858,8 @@ governing permissions and limitations under the License.
 
   &.spectrum-ActionButton--quiet.is-selected,
   &.is-selected {
-    background-color: var(--spectrum-actionbutton-static-color);
-    border-color: var(--spectrum-actionbutton-static-color);
+    background-color: var(--spectrum-actionbutton-static-background-color-selected);
+    border-color: var(--spectrum-actionbutton-static-background-color-selected);
     color: var(--spectrum-actionbutton-static-color-selected);
 
     .spectrum-Icon {
@@ -814,16 +867,10 @@ governing permissions and limitations under the License.
     }
 
     &:focus-ring {
-      background-color: var(--spectrum-actionbutton-static-color);
-      border-color: var(--spectrum-actionbutton-static-color);
+      background-color: var(--spectrum-actionbutton-static-background-color-selected-focus);
+      border-color: var(--spectrum-actionbutton-static-background-color-selected-focus);
       color: var(--spectrum-actionbutton-static-color-selected);
       box-shadow: none;
-
-      &.is-active {
-        /* change 1px of focus ring blue to match the rest of the active state */
-        box-shadow: none;
-        border-color: var(--spectrum-actionbutton-static-color);
-      }
 
       .spectrum-Icon {
         fill: var(--spectrum-actionbutton-static-color-selected);
@@ -832,8 +879,8 @@ governing permissions and limitations under the License.
 
     &:hover,
     &.is-active {
-      background-color: var(--spectrum-actionbutton-static-color);
-      border-color: var(--spectrum-actionbutton-static-color);
+      background-color: var(--spectrum-actionbutton-static-background-color-selected-hover);
+      border-color: var(--spectrum-actionbutton-static-background-color-selected-hover);
       color: var(--spectrum-actionbutton-static-color-selected);
 
       .spectrum-Icon {
@@ -843,7 +890,7 @@ governing permissions and limitations under the License.
 
     &:disabled,
     &.is-disabled {
-      background-color: transparent;
+      background-color: var(--spectrum-actionbutton-static-background-color-selected-disabled);
       border-color: var(--spectrum-actionbutton-static-border-disabled);
       color: var(--spectrum-actionbutton-static-color-disabled);
 
@@ -853,6 +900,19 @@ governing permissions and limitations under the License.
 
       .spectrum-ActionButton-hold {
         fill: var(--spectrum-actionbutton-static-color-disabled);
+      }
+    }
+  }
+
+  &.spectrum-ActionButton--quiet {
+    &,
+    &:hover,
+    &.is-active,
+    &:disabled,
+    &.is-disabled {
+      &,
+      &.is-selected {
+        border-color: transparent;
       }
     }
   }

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -38,33 +38,11 @@ governing permissions and limitations under the License.
   --spectrum-actionbutton-quiet-background-color-hover: var(--spectrum-global-color-gray-200);
   --spectrum-actionbutton-quiet-background-color-key-focus:  var(--spectrum-global-color-gray-200);
   --spectrum-actionbutton-quiet-background-color-down: var(--spectrum-global-color-gray-300);
-  --spectrum-actionbutton-quiet-background-color-selected: var(--spectrum-actionbutton-background-color-selected);
-  --spectrum-actionbutton-quiet-background-color-selected-hover: var(--spectrum-actionbutton-background-color-selected-hover);
-  --spectrum-actionbutton-quiet-background-color-selected-key-focus: var(--spectrum-actionbutton-background-color-selected-key-focus);
-  --spectrum-actionbutton-quiet-background-color-selected-down: var(--spectrum-actionbutton-background-color-selected-down);
-  --spectrum-actionbutton-quiet-border-color-selected: var(--spectrum-actionbutton-border-color-selected);
-  --spectrum-actionbutton-quiet-border-color-selected-hover: var(--spectrum-actionbutton-border-color-selected-hover);
-  --spectrum-actionbutton-quiet-border-color-selected-key-focus: var(--spectrum-actionbutton-border-color-selected-key-focus);
-  --spectrum-actionbutton-quiet-border-color-selected-down: var(--spectrum-actionbutton-border-color-selected-down);
-  --spectrum-actionbutton-quiet-text-color-selected: var(--spectrum-actionbutton-text-color-selected);
-  --spectrum-actionbutton-quiet-text-color-selected-hover: var(--spectrum-actionbutton-text-color-selected-hover);
-  --spectrum-actionbutton-quiet-text-color-selected-key-focus: var(--spectrum-actionbutton-text-color-selected-key-focus);
-  --spectrum-actionbutton-quiet-text-color-selected-down: var(--spectrum-actionbutton-text-color-selected-down);
 
-  --spectrum-actionbutton-emphasized-background-color: var(--spectrum-actionbutton-background-color);
-  --spectrum-actionbutton-emphasized-background-color-hover: var(--spectrum-actionbutton-background-color-hover);
-  --spectrum-actionbutton-emphasized-background-color-key-focus: var(--spectrum-actionbutton-background-color-key-focus);
-  --spectrum-actionbutton-emphasized-background-color-down: var(--spectrum-actionbutton-background-color-down);
-  --spectrum-actionbutton-emphasized-background-color-disabled: var(--spectrum-actionbutton-background-color-disabled);
   --spectrum-actionbutton-emphasized-background-color-selected: var(--spectrum-accent-background-color-default);
   --spectrum-actionbutton-emphasized-background-color-selected-hover: var(--spectrum-accent-background-color-hover);
   --spectrum-actionbutton-emphasized-background-color-selected-key-focus: var(--spectrum-accent-background-color-key-focus);
   --spectrum-actionbutton-emphasized-background-color-selected-down: var(--spectrum-accent-background-color-down);
-  --spectrum-actionbutton-emphasized-border-color: var(--spectrum-actionbutton-border-color);
-  --spectrum-actionbutton-emphasized-border-color-hover: var(--spectrum-actionbutton-border-color-hover);
-  --spectrum-actionbutton-emphasized-border-color-key-focus: var(--spectrum-actionbutton-border-color-key-focus);
-  --spectrum-actionbutton-emphasized-border-color-down: var(--spectrum-actionbutton-border-color-down);
-  --spectrum-actionbutton-emphasized-border-color-disabled: var(--spectrum-actionbutton-border-color-disabled);
   --spectrum-actionbutton-emphasized-border-color-selected: var(--spectrum-actionbutton-emphasized-background-color-selected);
   --spectrum-actionbutton-emphasized-border-color-selected-hover: var(--spectrum-actionbutton-emphasized-background-color-selected-hover);
   --spectrum-actionbutton-emphasized-border-color-selected-key-focus: var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus);
@@ -430,13 +408,15 @@ governing permissions and limitations under the License.
 }
 
 @media (forced-colors: active) {
-  .spectrum-Button {
+  .spectrum-Button,
+  .spectrum-ActionButton {
     forced-color-adjust: none;
 
     --spectrum-high-contrast-transparent: transparent;
     --spectrum-high-contrast-button-face: ButtonFace;
     --spectrum-high-contrast-button-text: ButtonText;
     --spectrum-high-contrast-highlight: Highlight;
+    --spectrum-high-contrast-highlight-text: HighlightText;
     --spectrum-high-contrast-gray-text: GrayText;
 
     --spectrum-high-contrast-focus-ring-color: var(--spectrum-high-contrast-button-text);
@@ -444,25 +424,25 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ActionButton {
-  background-color: var(--spectrum-actionbutton-background-color);
-  border-color: var(--spectrum-actionbutton-border-color);
-  color: var(--spectrum-actionbutton-text-color);
+  background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color));
+  border-color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-border-color));
+  color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-text-color));
 
   .spectrum-Icon {
-    fill: var(--spectrum-actionbutton-icon-color);
+    fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-icon-color));
   }
 
   .spectrum-ActionButton-hold {
-    fill: var(--spectrum-actionbutton-hold-icon-color);
+    fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-hold-icon-color));
   }
 
   &:hover {
-    background-color: var(--spectrum-actionbutton-background-color-hover);
-    border-color: var(--spectrum-actionbutton-border-color-hover);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-hover));
+    border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-border-color-hover));
     color: var(--spectrum-actionbutton-text-color-hover);
 
     .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-icon-color-hover);
+      fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-icon-color-hover));
     }
 
     .spectrum-ActionButton-hold {
@@ -471,287 +451,175 @@ governing permissions and limitations under the License.
   }
 
   &:focus-ring {
-    background-color: var(--spectrum-actionbutton-background-color-key-focus);
-    color: var(--spectrum-actionbutton-text-color-key-focus);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-key-focus));
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-text-color-key-focus));
 
     .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-icon-color-key-focus);
+      fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-icon-color-key-focus));
     }
 
     .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-hold-icon-color-key-focus);
+      fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-hold-icon-color-key-focus));
     }
   }
 
   &.is-active {
-    background-color: var(--spectrum-actionbutton-background-color-down);
-    border-color: var(--spectrum-actionbutton-border-color-down);
-    color: var(--spectrum-actionbutton-text-color-down);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-down));
+    border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-border-color-down));
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-text-color-down));
 
     .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-hold-icon-color-down);
+      fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-hold-icon-color-down));
     }
   }
 
   &:disabled,
   &.is-disabled {
-    background-color: var(--spectrum-actionbutton-background-color-disabled);
-    border-color: var(--spectrum-actionbutton-border-color-disabled);
-    color: var(--spectrum-actionbutton-text-color-disabled);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-disabled));
+    border-color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-border-color-disabled));
+    color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-text-color-disabled));
 
     .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-icon-color-disabled);
+      fill: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-icon-color-disabled));
     }
 
     .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-hold-icon-color-disabled);
+      fill: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-hold-icon-color-disabled));
     }
   }
 
   &.is-selected {
-    background-color: var(--spectrum-actionbutton-background-color-selected);
-    border-color: var(--spectrum-actionbutton-border-color-selected);
-    color: var(--spectrum-actionbutton-text-color-selected);
+    background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-background-color-selected));
+    border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-border-color-selected));
+    color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-text-color-selected));
 
     .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-icon-color-selected);
+      fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-icon-color-selected));
     }
 
     &:hover {
-      background-color: var(--spectrum-actionbutton-background-color-selected-hover);
-      border-color: var(--spectrum-actionbutton-border-color-selected-hover);
-      color: var(--spectrum-actionbutton-text-color-selected-hover);
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-background-color-selected-hover));
+      border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-border-color-selected-hover));
+      color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-text-color-selected-hover));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-icon-color-selected-hover);
+        fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-icon-color-selected-hover));
       }
     }
 
     &:focus-ring {
-      background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
-      color: var(--spectrum-actionbutton-text-color-selected-key-focus);
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-background-color-selected-key-focus));
+      color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-text-color-selected-key-focus));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-icon-color-selected-key-focus);
+        fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-icon-color-selected-key-focus));
       }
     }
 
     &.is-active {
-      background-color: var(--spectrum-actionbutton-background-color-selected-down);
-      border-color: var(--spectrum-actionbutton-border-color-selected-down);
-      color: var(--spectrum-actionbutton-text-color-selected-down);
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-background-color-selected-down));
+      border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-border-color-selected-down));
+      color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-text-color-selected-down));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-icon-color-selected-down);
+        fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-icon-color-selected-down));
       }
     }
 
     &:disabled,
     &.is-disabled {
-      background-color: var(--spectrum-actionbutton-background-color-selected-disabled);
-      border-color: var(--spectrum-actionbutton-border-color-selected-disabled);
-      color: var(--spectrum-actionbutton-text-color-selected-disabled);
+      background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-selected-disabled));
+      border-color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-border-color-selected-disabled));
+      color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-text-color-selected-disabled));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-icon-color-selected-disabled);
+        fill: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-icon-color-selected-disabled));
       }
     }
   }
 }
 
 .spectrum-ActionButton--emphasized {
-  background-color: var(--spectrum-actionbutton-emphasized-background-color);
-  border-color: var(--spectrum-actionbutton-emphasized-border-color);
-  color: var(--spectrum-actionbutton-emphasized-text-color);
-
-  .spectrum-Icon {
-    fill: var(--spectrum-actionbutton-emphasized-icon-color);
-  }
-
-  .spectrum-ActionButton-hold {
-    fill: var(--spectrum-actionbutton-emphasized-hold-icon-color);
-  }
-
-  &.is-selected {
-    .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-selected);
-    }
-
-    &:hover {
-      .spectrum-ActionButton-hold {
-        fill: var(--spectrum-actionbutton-emphasized-text-color-selected-hover);
-      }
-    }
-  }
-
-  &:hover {
-    background-color: var(--spectrum-actionbutton-emphasized-background-color-hover);
-    border-color: var(--spectrum-actionbutton-emphasized-border-color-hover);
-    box-shadow: none;
-    color: var(--spectrum-actionbutton-emphasized-text-color-hover);
-
-    .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-emphasized-icon-color-hover);
-    }
-
-    .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-hover);
-    }
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-actionbutton-emphasized-background-color-key-focus);
-    border-color: var(--spectrum-actionbutton-emphasized-border-color);
-    box-shadow: none;
-    color: var(--spectrum-actionbutton-emphasized-text-color-key-focus);
-
-    &.is-active {
-      border-color: var(--spectrum-actionbutton-emphasized-border-color-down);
-    }
-
-    .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-emphasized-icon-color-key-focus);
-    }
-
-    .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-key-focus);
-    }
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-actionbutton-emphasized-background-color-down);
-    border-color: var(--spectrum-actionbutton-emphasized-border-color-down);
-    color: var(--spectrum-actionbutton-emphasized-text-color-down);
-
-    .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-down);
-    }
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-actionbutton-emphasized-background-color-disabled);
-    border-color: var(--spectrum-actionbutton-emphasized-border-color-disabled);
-    color: var(--spectrum-actionbutton-emphasized-text-color-disabled);
-
-    .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-emphasized-icon-color-disabled);
-    }
-
-    .spectrum-ActionButton-hold {
-      fill: var(--spectrum-actionbutton-emphasized-hold-icon-color-disabled);
-    }
-  }
-
   &.spectrum-ActionButton--quiet.is-selected,
   &.is-selected {
-    background-color: var(--spectrum-actionbutton-emphasized-background-color-selected);
-    border-color: var(--spectrum-actionbutton-emphasized-border-color-selected);
-    color: var(--spectrum-actionbutton-emphasized-text-color-selected);
+    background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-emphasized-background-color-selected));
+    border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-border-color-selected));
+    color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-text-color-selected));
 
     .spectrum-Icon {
-      fill: var(--spectrum-actionbutton-emphasized-icon-color-selected);
+      fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-icon-color-selected));
     }
 
     &:focus-ring {
-      background-color: var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus);
-      color: var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus);
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-emphasized-background-color-selected-key-focus));
+      color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-text-color-selected-key-focus));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-key-focus);
+        fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-icon-color-selected-key-focus));
       }
     }
 
     &:hover {
-      background-color: var(--spectrum-actionbutton-emphasized-background-color-selected-hover);
-      border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-hover);
-      color: var(--spectrum-actionbutton-emphasized-text-color-selected-hover);
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-emphasized-background-color-selected-hover));
+      border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-border-color-selected-hover));
+      color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-text-color-selected-hover));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-hover);
+        fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-icon-color-selected-hover));
       }
     }
 
     &.is-active {
-      background-color: var(--spectrum-actionbutton-emphasized-background-color-selected-down);
-      border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-down);
-      color: var(--spectrum-actionbutton-emphasized-text-color-selected-down);
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-emphasized-background-color-selected-down));
+      border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-border-color-selected-down));
+      color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-text-color-selected-down));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-down);
+        fill: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-emphasized-icon-color-selected-down));
       }
     }
 
     &:disabled,
     &.is-disabled {
-      background-color: var(--spectrum-actionbutton-emphasized-background-color-selected-disabled);
-      border-color: var(--spectrum-actionbutton-emphasized-border-color-selected-disabled);
-      color: var(--spectrum-actionbutton-emphasized-text-color-selected-disabled);
+      background-color:  xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-emphasized-background-color-selected-disabled));
+      border-color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-emphasized-border-color-selected-disabled));
+      color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-emphasized-text-color-selected-disabled));
 
       .spectrum-Icon {
-        fill: var(--spectrum-actionbutton-emphasized-icon-color-selected-disabled);
+        fill: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-emphasized-icon-color-selected-disabled));
       }
     }
   }
 }
 
 .spectrum-ActionButton--quiet {
-  background-color: var(--spectrum-actionbutton-quiet-background-color);
-  border-color: var(--spectrum-actionbutton-quiet-border-color);
-  color: var(--spectrum-actionbutton-quiet-text-color);
+  background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-quiet-background-color));
+  border-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-quiet-border-color));
+  color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-quiet-text-color));
 
   &:hover {
-    background-color: var(--spectrum-actionbutton-quiet-background-color-hover);
-    border-color: var(--spectrum-actionbutton-quiet-border-color-hover);
-    color: var(--spectrum-actionbutton-quiet-text-color-hover);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-quiet-background-color-hover));
+    border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-quiet-border-color-hover));
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-quiet-text-color-hover));
   }
 
   &:focus-ring {
-    background-color: var(--spectrum-actionbutton-quiet-background-color-key-focus);
-    color: var(--spectrum-actionbutton-quiet-text-color-key-focus);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-quiet-background-color-key-focus));
+    border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-quiet-border-color-hover));
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-quiet-text-color-key-focus));
   }
 
   &.is-active {
-    background-color: var(--spectrum-actionbutton-quiet-background-color-down);
-    border-color: var(--spectrum-actionbutton-quiet-border-color-down);
-    color: var(--spectrum-actionbutton-quiet-text-color-down);
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-quiet-background-color-down));
+    border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-quiet-border-color-down));
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-quiet-text-color-down));
   }
 
   &:disabled,
   &.is-disabled {
-    background-color: var(--spectrum-actionbutton-quiet-background-color-disabled);
-    border-color: var(--spectrum-actionbutton-quiet-border-color-disabled);
-    color: var(--spectrum-actionbutton-quiet-text-color-disabled);
-  }
-
-  &.is-selected {
-    background-color: var(--spectrum-actionbutton-quiet-background-color-selected);
-    border-color: var(--spectrum-actionbutton-quiet-border-color-selected);
-    color: var(--spectrum-actionbutton-quiet-text-color-selected);
-
-    &:hover {
-      background-color: var(--spectrum-actionbutton-quiet-background-color-selected-hover);
-      border-color: var(--spectrum-actionbutton-quiet-border-color-selected-hover);
-      color: var(--spectrum-actionbutton-quiet-text-color-selected-hover);
-    }
-
-    &:focus-ring {
-      background-color: var(--spectrum-actionbutton-quiet-background-color-selected-key-focus);
-      color: var(--spectrum-actionbutton-quiet-text-color-selected-key-focus);
-    }
-
-    &.is-active {
-      background-color: var(--spectrum-actionbutton-quiet-background-color-selected-down);
-      border-color: var(--spectrum-actionbutton-quiet-border-color-selected-down);
-      color: var(--spectrum-actionbutton-quiet-text-color-selected-down);
-    }
-
-    &:disabled,
-    &.is-disabled {
-      background-color: var(--spectrum-actionbutton-quiet-background-color-selected-disabled);
-      border-color: var(--spectrum-actionbutton-quiet-border-color-selected-disabled);
-      color: var(--spectrum-actionbutton-quiet-text-color-selected-disabled);
-    }
+    background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-quiet-background-color-disabled));
+    border-color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-quiet-border-color-disabled));
+    color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-actionbutton-quiet-text-color-disabled));
   }
 }
 
@@ -946,37 +814,6 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Button--warning.spectrum-Button--quiet {
-  background-color: var(--spectrum-button-quiet-warning-background-color);
-  border-color: var(--spectrum-button-quiet-warning-border-color);
-  color: var(--spectrum-button-quiet-warning-text-color);
-
-  &:hover {
-    background-color: var(--spectrum-button-quiet-warning-background-color-hover);
-    border-color: var(--spectrum-button-quiet-warning-border-color-hover);
-    color: var(--spectrum-button-quiet-warning-text-color-hover);
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-button-quiet-warning-background-color-key-focus);
-    border-color: var(--spectrum-button-quiet-warning-border-color-key-focus);
-    color: var(--spectrum-button-quiet-warning-text-color-key-focus);
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-button-quiet-warning-background-color-down);
-    border-color: var(--spectrum-button-quiet-warning-border-color-down);
-    color: var(--spectrum-button-quiet-warning-text-color-down);
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-quiet-warning-background-color-disabled);
-    border-color: var(--spectrum-button-quiet-warning-border-color-disabled);
-    color: var(--spectrum-button-quiet-warning-text-color-disabled);
-  }
-}
-
 .spectrum-LogicButton--and {
   background-color: var(--spectrum-logicbutton-and-background-color);
   border-color: var(--spectrum-logicbutton-and-border-color);
@@ -1142,134 +979,6 @@ governing permissions and limitations under the License.
   .spectrum-LogicButton,
   .spectrum-FieldButton {
     forced-color-adjust: none;
-  --spectrum-actionbutton-background-color: ButtonFace;
-  --spectrum-actionbutton-background-color-disabled: ButtonFace;
-  --spectrum-actionbutton-background-color-down: ButtonFace;
-  --spectrum-actionbutton-background-color-hover: ButtonFace;
-  --spectrum-actionbutton-background-color-key-focus: ButtonFace;
-  --spectrum-actionbutton-background-color-selected: Highlight;
-  --spectrum-actionbutton-background-color-selected-disabled: ButtonFace;
-  --spectrum-actionbutton-background-color-selected-down: Highlight;
-  --spectrum-actionbutton-background-color-selected-hover: Highlight;
-  --spectrum-actionbutton-background-color-selected-key-focus: Highlight;
-  --spectrum-actionbutton-border-color: ButtonText;
-  --spectrum-actionbutton-border-color-disabled: GrayText;
-  --spectrum-actionbutton-border-color-down: Highlight;
-  --spectrum-actionbutton-border-color-hover: Highlight;
-  --spectrum-actionbutton-border-color-key-focus: CanvasText;
-  --spectrum-actionbutton-border-color-selected: HighlightText;
-  --spectrum-actionbutton-border-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-border-color-selected-down: HighlightText;
-  --spectrum-actionbutton-border-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-border-color-selected-key-focus: CanvasText;
-  --spectrum-actionbutton-emphasized-background-color: ButtonFace;
-  --spectrum-actionbutton-emphasized-background-color-disabled: ButtonFace;
-  --spectrum-actionbutton-emphasized-background-color-down: Highlight;
-  --spectrum-actionbutton-emphasized-background-color-hover: Highlight;
-  --spectrum-actionbutton-emphasized-background-color-key-focus: ButtonFace;
-  --spectrum-actionbutton-emphasized-background-color-selected: Highlight;
-  --spectrum-actionbutton-emphasized-background-color-selected-disabled: ButtonFace;
-  --spectrum-actionbutton-emphasized-background-color-selected-down: Highlight;
-  --spectrum-actionbutton-emphasized-background-color-selected-hover: Highlight;
-  --spectrum-actionbutton-emphasized-background-color-selected-key-focus: Highlight;
-  --spectrum-actionbutton-emphasized-border-color: ButtonText;
-  --spectrum-actionbutton-emphasized-border-color-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-border-color-down: ButtonText;
-  --spectrum-actionbutton-emphasized-border-color-hover: ButtonText;
-  --spectrum-actionbutton-emphasized-border-color-selected: HighlightText;
-  --spectrum-actionbutton-emphasized-border-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-border-color-selected-downed: HighlightText;
-  --spectrum-actionbutton-emphasized-border-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-emphasized-hold-icon-color: ButtonText;
-  --spectrum-actionbutton-emphasized-hold-icon-color-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-hold-icon-color-down: HighlightText;
-  --spectrum-actionbutton-emphasized-hold-icon-color-hover: HighlightText;
-  --spectrum-actionbutton-emphasized-hold-icon-color-key-focus: ButtonText;
-  --spectrum-actionbutton-emphasized-hold-icon-color-selected: ButtonFace;
-  --spectrum-actionbutton-emphasized-icon-color: ButtonText;
-  --spectrum-actionbutton-emphasized-icon-color-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-icon-color-hover: HighlightText;
-  --spectrum-actionbutton-emphasized-icon-color-key-focus: ButtonText;
-  --spectrum-actionbutton-emphasized-icon-color-selected: HighlightText;
-  --spectrum-actionbutton-emphasized-icon-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-icon-color-selected-down: HighlightText;
-  --spectrum-actionbutton-emphasized-icon-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-emphasized-icon-color-selected-key-focus: HighlightText;
-  --spectrum-actionbutton-emphasized-text-color: ButtonText;
-  --spectrum-actionbutton-emphasized-text-color-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-text-color-down: HighlightText;
-  --spectrum-actionbutton-emphasized-text-color-hover: HighlightText;
-  --spectrum-actionbutton-emphasized-text-color-key-focus: ButtonText;
-  --spectrum-actionbutton-emphasized-text-color-selected: HighlightText;
-  --spectrum-actionbutton-emphasized-text-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-emphasized-text-color-selected-down: HighlightText;
-  --spectrum-actionbutton-emphasized-text-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-emphasized-text-color-selected-key-focus: HighlightText;
-  --spectrum-actionbutton-hold-icon-color: ButtonText;
-  --spectrum-actionbutton-hold-icon-color-disabled: GrayText;
-  --spectrum-actionbutton-hold-icon-color-down: ButtonText;
-  --spectrum-actionbutton-hold-icon-color-hover: ButtonText;
-  --spectrum-actionbutton-hold-icon-color-key-focus: ButtonText;
-  --spectrum-actionbutton-icon-color: ButtonText;
-  --spectrum-actionbutton-icon-color-disabled: GrayText;
-  --spectrum-actionbutton-icon-color-hover: ButtonText;
-  --spectrum-actionbutton-icon-color-key-focus: ButtonText;
-  --spectrum-actionbutton-icon-color-selected: HighlightText;
-  --spectrum-actionbutton-icon-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-icon-color-selected-down: HighlightText;
-  --spectrum-actionbutton-icon-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-icon-color-selected-key-focus: HighlightText;
-  --spectrum-actionbutton-quiet-background-color: ButtonFace;
-  --spectrum-actionbutton-quiet-background-color-disabled: ButtonFace;
-  --spectrum-actionbutton-quiet-background-color-down: ButtonFace;
-  --spectrum-actionbutton-quiet-background-color-hover: ButtonFace;
-  --spectrum-actionbutton-quiet-background-color-key-focus: ButtonFace;
-  --spectrum-actionbutton-quiet-background-color-selected: Highlight;
-  --spectrum-actionbutton-quiet-background-color-selected-disabled: ButtonFace;
-  --spectrum-actionbutton-quiet-background-color-selected-down: Highlight;
-  --spectrum-actionbutton-quiet-background-color-selected-hover: Highlight;
-  --spectrum-actionbutton-quiet-background-color-selected-key-focus: Highlight;
-  --spectrum-actionbutton-quiet-border-color: ButtonFace;
-  --spectrum-actionbutton-quiet-border-color-disabled: ButtonFace;
-  --spectrum-actionbutton-quiet-border-color-down: Highlight;
-  --spectrum-actionbutton-quiet-border-color-hover: Highlight;
-  --spectrum-actionbutton-quiet-border-color-key-focus: CanvasText;
-  --spectrum-actionbutton-quiet-border-color-selected: HighlightText;
-  --spectrum-actionbutton-quiet-border-color-selected-disabled: Canvas;
-  --spectrum-actionbutton-quiet-border-color-selected-down: HighlightText;
-  --spectrum-actionbutton-quiet-border-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-quiet-border-color-selected-key-focus: HighlightText;
-  --spectrum-actionbutton-quiet-text-color: ButtonText;
-  --spectrum-actionbutton-quiet-text-color-disabled: GrayText;
-  --spectrum-actionbutton-quiet-text-color-down: ButtonText;
-  --spectrum-actionbutton-quiet-text-color-hover: ButtonText;
-  --spectrum-actionbutton-quiet-text-color-key-focus: ButtonText;
-  --spectrum-actionbutton-quiet-text-color-selected: HighlightText;
-  --spectrum-actionbutton-quiet-text-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-quiet-text-color-selected-down: HighlightText;
-  --spectrum-actionbutton-quiet-text-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-quiet-text-color-selected-key-focus: HighlightText;
-  --spectrum-actionbutton-static-background-color-active: ButtonFace;
-  --spectrum-actionbutton-static-background-color-focus: ButtonFace;
-  --spectrum-actionbutton-static-background-color-hover: ButtonFace;
-  --spectrum-actionbutton-static-border-color: ButtonText;
-  --spectrum-actionbutton-static-border-color-active: ButtonText;
-  --spectrum-actionbutton-static-border-color-focus: Highlight;
-  --spectrum-actionbutton-static-border-color-hover: ButtonText;
-  --spectrum-actionbutton-static-color: Highlight;
-  --spectrum-actionbutton-static-color-disabled: GrayText;
-  --spectrum-actionbutton-static-color-focus: Highlight;
-  --spectrum-actionbutton-static-color-selected: ButtonFace;
-  --spectrum-actionbutton-text-color: ButtonText;
-  --spectrum-actionbutton-text-color-disabled: GrayText;
-  --spectrum-actionbutton-text-color-down: ButtonText;
-  --spectrum-actionbutton-text-color-hover: ButtonText;
-  --spectrum-actionbutton-text-color-key-focus: ButtonText;
-  --spectrum-actionbutton-text-color-selected: HighlightText;
-  --spectrum-actionbutton-text-color-selected-disabled: GrayText;
-  --spectrum-actionbutton-text-color-selected-down: HighlightText;
-  --spectrum-actionbutton-text-color-selected-hover: HighlightText;
-  --spectrum-actionbutton-text-color-selected-key-focus: HighlightText;
   --spectrum-clearbutton-medium-background-color: ButtonFace;
   --spectrum-clearbutton-medium-background-color-disabled: ButtonFace;
   --spectrum-clearbutton-medium-background-color-down: ButtonFace;
@@ -1337,6 +1046,10 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-static-background-color-hover: ButtonFace;
     --spectrum-actionbutton-static-background-color-focus: ButtonFace;
     --spectrum-actionbutton-static-background-color-active: ButtonFace;
+    --spectrum-actionbutton-static-background-color-selected: Highlight;
+    --spectrum-actionbutton-static-background-color-selected-hover: Highlight;
+    --spectrum-actionbutton-static-background-color-selected-focus: Highlight;
+    --spectrum-actionbutton-static-background-color-selected-active: Highlight;
     --spectrum-actionbutton-static-border-color: ButtonText;
     --spectrum-actionbutton-static-border-color-hover: ButtonText;
     --spectrum-actionbutton-static-border-color-active: ButtonText;
@@ -1347,17 +1060,6 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-static-color-disabled: GrayText;
   }
 
-  .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet {
-    --spectrum-actionbutton-emphasized-border-color-selected-disabled: ButtonFace;
-    --spectrum-actionbutton-quiet-background-color-hover: Highlight;
-    --spectrum-actionbutton-quiet-text-color-hover: HighlightText;
-    --spectrum-actionbutton-quiet-background-color-down: Highlight;
-    --spectrum-actionbutton-quiet-text-color-down: HighlightText;
-
-    &.is-active {
-      --spectrum-actionbutton-emphasized-icon-color-key-focus: HighlightText;
-    }
-  }
   .spectrum-FieldButton {
     &:focus-ring,
     &.is-focused {

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -98,10 +98,12 @@ governing permissions and limitations under the License.
 .spectrum-LogicButton,
 .spectrum-Button,
 .spectrum-ActionButton {
+  --spectrum-button-focus-ring-color: xvar(--spectrum-high-contrast-focus-ring-color, var(--spectrum-button-primary-focus-ring-color-key-focus));
+
   &:focus-ring,
   &.is-focused {
     &:after {
-      box-shadow: 0 0 0 var(--spectrum-button-primary-focus-ring-size-key-focus) var(--spectrum-button-primary-focus-ring-color-key-focus);
+      box-shadow: 0 0 0 var(--spectrum-button-primary-focus-ring-size-key-focus) var(--spectrum-button-focus-ring-color);
     }
   }
 }
@@ -157,261 +159,287 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Button--cta {
-  background-color: var(--spectrum-button-cta-background-color);
-  border-color: var(--spectrum-button-cta-border-color);
-  color: var(--spectrum-button-cta-text-color);
+.spectrum-Button {
+  &[data-style=fill] {
+    --spectrum-button-text-color: white;
+    --spectrum-button-text-color-hover: var(--spectrum-button-text-color);
+    --spectrum-button-text-color-down: var(--spectrum-button-text-color);
+    --spectrum-button-text-color-key-focus: var(--spectrum-button-text-color);
+    --spectrum-button-text-color-disabled: var(--spectrum-alias-text-color-disabled);
+    --spectrum-button-color-disabled: var(--spectrum-alias-background-color-disabled);
 
-  &:hover {
-    background-color: var(--spectrum-button-cta-background-color-hover);
-    border-color: var(--spectrum-button-cta-border-color-hover);
-    color: var(--spectrum-button-cta-text-color-hover);
-  }
+    /* high contrast overrides all colors */
+    /* xvar is passed through. without it, some postcss plugin breaks variable fallback... */
+    background-color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-color));
+    border-color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-color));
+    color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-button-text-color));
 
-  &:focus-ring {
-    background-color: var(--spectrum-button-cta-background-color-key-focus);
-    border-color: var(--spectrum-button-cta-border-color-key-focus);
-    color: var(--spectrum-button-cta-text-color-key-focus);
-  }
+    &:hover {
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-hover));
+      border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-hover));
+      color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-button-text-color-hover));
+    }
 
-  &.is-active {
-    background-color: var(--spectrum-button-cta-background-color-down);
-    border-color: var(--spectrum-button-cta-border-color-down);
-    color: var(--spectrum-button-cta-text-color-down);
-  }
+    &:focus-ring {
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-key-focus));
+      border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-key-focus));
+      color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-button-text-color-key-focus));
+    }
 
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-cta-background-color-disabled);
-    border-color: var(--spectrum-button-cta-border-color-disabled);
-    color: var(--spectrum-button-cta-text-color-disabled);
-  }
-}
+    &.is-active {
+      background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-down));
+      border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-down));
+      color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-button-text-color-down));
+    }
 
-.spectrum-Button--primary {
-  background-color: var(--spectrum-button-primary-background-color);
-  border-color: var(--spectrum-button-primary-border-color);
-  color: var(--spectrum-button-primary-text-color);
-
-  &:hover {
-    background-color: var(--spectrum-button-primary-background-color-hover);
-    border-color: var(--spectrum-button-primary-border-color-hover);
-    color: var(--spectrum-button-primary-text-color-hover);
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-button-primary-background-color-key-focus);
-    border-color: var(--spectrum-button-primary-border-color-key-focus);
-    color: var(--spectrum-button-primary-text-color-key-focus);
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-button-primary-background-color-down);
-    border-color: var(--spectrum-button-primary-border-color-down);
-    color: var(--spectrum-button-primary-text-color-down);
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-primary-background-color-disabled);
-    border-color: var(--spectrum-button-primary-border-color-disabled);
-    color: var(--spectrum-button-primary-text-color-disabled);
-  }
-}
-
-.spectrum-Button--secondary {
-  background-color: var(--spectrum-button-secondary-background-color);
-  border-color: var(--spectrum-button-secondary-border-color);
-  color: var(--spectrum-button-secondary-text-color);
-
-  &:hover {
-    background-color: var(--spectrum-button-secondary-background-color-hover);
-    border-color: var(--spectrum-button-secondary-border-color-hover);
-    color: var(--spectrum-button-secondary-text-color-hover);
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-button-secondary-background-color-key-focus);
-    border-color: var(--spectrum-button-secondary-border-color-key-focus);
-    color: var(--spectrum-button-secondary-text-color-key-focus);
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-button-secondary-background-color-down);
-    border-color: var(--spectrum-button-secondary-border-color-down);
-    color: var(--spectrum-button-secondary-text-color-down);
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-secondary-background-color-disabled);
-    border-color: var(--spectrum-button-secondary-border-color-disabled);
-    color: var(--spectrum-button-secondary-text-color-disabled);
-  }
-}
-
-.spectrum-Button--warning {
-  background-color: var(--spectrum-button-warning-background-color);
-  border-color: var(--spectrum-button-warning-border-color);
-  color: var(--spectrum-button-warning-text-color);
-
-  &:hover {
-    background-color: var(--spectrum-button-warning-background-color-hover);
-    border-color: var(--spectrum-button-warning-border-color-hover);
-    color: var(--spectrum-button-warning-text-color-hover);
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-button-warning-background-color-key-focus);
-    border-color: var(--spectrum-button-warning-border-color-key-focus);
-    color: var(--spectrum-button-warning-text-color-key-focus);
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-button-warning-background-color-down);
-    border-color: var(--spectrum-button-warning-border-color-down);
-    color: var(--spectrum-button-warning-text-color-down);
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-warning-background-color-disabled);
-    border-color: var(--spectrum-button-warning-border-color-disabled);
-    color: var(--spectrum-button-warning-text-color-disabled);
-  }
-}
-
-.spectrum-Button--overBackground {
-  background-color: var(--spectrum-button-over-background-background-color);
-  border-color: var(--spectrum-button-over-background-border-color);
-  color: var(--spectrum-button-over-background-text-color);
-
-  &:hover {
-    background-color: var(--spectrum-button-over-background-background-color-hover);
-    border-color: var(--spectrum-button-over-background-border-color-hover);
-    color: var(--spectrum-button-over-background-color);
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-button-over-background-background-color-hover);
-    border-color: var(--spectrum-button-over-background-border-color-hover);
-    color: var(--spectrum-button-over-background-color);;
-
-    &:after {
-      box-shadow: 0 0 0 var(--spectrum-alias-focus-ring-size) var(--spectrum-button-over-background-border-color-key-focus);
+    &:disabled,
+    &.is-disabled {
+      background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-button-color-disabled));
+      border-color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-button-color-disabled));
+      color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-button-text-color-disabled));
     }
   }
 
-  &.is-active {
-    background-color: var(--spectrum-button-over-background-background-color-down);
-    border-color: var(--spectrum-button-over-background-border-color-down);
-    color: var(--spectrum-button-over-background-color);;
-  }
+  &[data-style=outline] {
+    --spectrum-button-text-color: var(--spectrum-button-color);
+    --spectrum-button-text-color-hover: var(--spectrum-button-color-hover);
+    --spectrum-button-text-color-down: var(--spectrum-button-color-down);
+    --spectrum-button-text-color-key-focus: var(--spectrum-button-color-key-focus);
+    --spectrum-button-text-color-disabled: var(--spectrum-alias-text-color-disabled);
+    --spectrum-button-color-disabled: var(--spectrum-alias-background-color-disabled);
 
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-over-background-background-color-disabled);
-    border-color: var(--spectrum-button-over-background-border-color-disabled);
-    color: var(--spectrum-button-over-background-text-color-disabled);
-  }
-}
+    background-color: transparent;
+    border-color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-color));
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-text-color));
 
-.spectrum-Button--overBackground.spectrum-Button--quiet,
-.spectrum-ClearButton--overBackground {
-  background-color: var(--spectrum-button-quiet-over-background-background-color);
-  border-color: var(--spectrum-button-quiet-over-background-border-color);
-  color: var(--spectrum-button-quiet-over-background-text-color);
+    &:hover {
+      background-color: xvar(--spectrum-high-contrast-transparent, var(--spectrum-button-background-color-hover));
+      border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-hover));
+      color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-text-color-hover));
+    }
 
-  &:hover {
-    background-color: var(--spectrum-button-quiet-over-background-background-color-hover);
-    border-color: var(--spectrum-button-quiet-over-background-border-color-hover);
-    color: var(--spectrum-button-quiet-over-background-text-color-hover);
-  }
+    &:focus-ring {
+      background-color: xvar(--spectrum-high-contrast-transparent, var(--spectrum-button-background-color-key-focus));
+      border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-key-focus));
+      color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-text-color-key-focus));
+    }
 
-  &:focus-ring {
-    background-color: var(--spectrum-button-quiet-over-background-background-color-hover);
-    border-color: var(--spectrum-button-quiet-over-background-border-color-hover);
-    color: var(--spectrum-button-quiet-over-background-text-color-hover);
-    box-shadow: none;
+    &.is-active {
+      background-color: xvar(--spectrum-high-contrast-transparent, var(--spectrum-button-background-color-down));
+      border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-button-color-down));
+      color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-button-text-color-down));
+    }
 
-    &:after {
-      box-shadow: 0 0 0 var(--spectrum-alias-focus-ring-size) var(--spectrum-button-over-background-border-color-key-focus);
+    &:disabled,
+    &.is-disabled {
+      border-color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-button-color-disabled));
+      color: xvar(--spectrum-high-contrast-gray-text, var(--spectrum-button-text-color-disabled));
     }
   }
 
-  &.is-active {
-    background-color: var(--spectrum-button-quiet-over-background-background-color-down);
-    border-color: var(--spectrum-button-quiet-over-background-border-color-down);
-    color: var(--spectrum-button-quiet-over-background-text-color-down);
+  &[data-static-color=white] {
+    --spectrum-button-primary-focus-ring-color-key-focus: white;
+
+    &[data-variant=accent],
+    &[data-variant=negative],
+    &[data-variant=primary] {
+      &[data-style=fill] {
+        --spectrum-button-color: rgba(255, 255, 255, 0.9);
+        --spectrum-button-color-hover: white;
+        --spectrum-button-color-down: white;
+        --spectrum-button-color-key-focus: white;
+        --spectrum-button-color-disabled: rgba(255, 255, 255, 0.1);
+        --spectrum-button-text-color: black;
+        --spectrum-button-text-color-disabled: rgba(255, 255, 255, 0.55);
+      }
+    }
+
+    &[data-variant=secondary] {
+      &[data-style=fill] {
+        --spectrum-button-color: rgba(255, 255, 255, 0.1);
+        --spectrum-button-color-hover: rgba(255, 255, 255, 0.25);
+        --spectrum-button-color-down: rgba(255, 255, 255, 0.4);
+        --spectrum-button-color-key-focus: rgba(255, 255, 255, 0.25);
+        --spectrum-button-color-disabled: rgba(255, 255, 255, 0.1);
+        --spectrum-button-text-color: white;
+        --spectrum-button-text-color-disabled: rgba(255, 255, 255, 0.55);
+      }
+    }
+
+    &[data-style=outline] {
+      --spectrum-button-color: rgba(255, 255, 255, 0.25);
+      --spectrum-button-color-hover: rgba(255, 255, 255, 0.4);
+      --spectrum-button-color-down: rgba(255, 255, 255, 0.55);
+      --spectrum-button-color-key-focus: rgba(255, 255, 255, 0.4);
+      --spectrum-button-color-disabled: rgba(255, 255, 255, 0.25);
+      --spectrum-button-text-color: white;
+      --spectrum-button-text-color-hover: white;
+      --spectrum-button-text-color-down: white;
+      --spectrum-button-text-color-key-focus: white;
+      --spectrum-button-text-color-disabled: rgba(255, 255, 255, 0.55);
+      --spectrum-button-background-color-hover: rgba(255, 255, 255, 0.25);
+      --spectrum-button-background-color-down: rgba(255, 255, 255, 0.4);
+      --spectrum-button-background-color-key-focus: rgba(255, 255, 255, 0.25);
+    }
   }
 
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-quiet-over-background-background-color-disabled);
-    border-color: var(--spectrum-button-quiet-over-background-border-color-disabled);
-    color: var(--spectrum-button-quiet-over-background-text-color-disabled);
+  &[data-static-color=black] {
+    --spectrum-button-primary-focus-ring-color-key-focus: black;
+
+    &[data-variant=accent],
+    &[data-variant=negative],
+    &[data-variant=primary] {
+      &[data-style=fill] {
+        --spectrum-button-color: rgba(0, 0, 0, 0.9);
+        --spectrum-button-color-hover: black;
+        --spectrum-button-color-down: black;
+        --spectrum-button-color-key-focus: black;
+        --spectrum-button-color-disabled: rgba(0, 0, 0, 0.1);
+        --spectrum-button-text-color: white;
+        --spectrum-button-text-color-disabled: rgba(0, 0, 0, 0.55);
+      }
+
+      &[data-style=outline] {
+        --spectrum-button-color: rgba(0, 0, 0, 0.9);
+        --spectrum-button-color-hover: black;
+        --spectrum-button-color-down: black;
+        --spectrum-button-color-key-focus: black;
+        --spectrum-button-color-disabled: rgba(0, 0, 0, 0.25);
+        --spectrum-button-text-color: black;
+        --spectrum-button-text-color-hover: black;
+        --spectrum-button-text-color-down: black;
+        --spectrum-button-text-color-key-focus: black;
+        --spectrum-button-text-color-disabled: rgba(0, 0, 0, 0.55);
+        --spectrum-button-background-color-hover: rgba(0, 0, 0, 0.25);
+        --spectrum-button-background-color-down: rgba(0, 0, 0, 0.4);
+        --spectrum-button-background-color-key-focus: rgba(0, 0, 0, 0.25);
+      }
+    }
+
+    &[data-variant=secondary] {
+      &[data-style=fill] {
+        --spectrum-button-color: rgba(0, 0, 0, 0.1);
+        --spectrum-button-color-hover: rgba(0, 0, 0, 0.25);
+        --spectrum-button-color-down: rgba(0, 0, 0, 0.4);
+        --spectrum-button-color-key-focus: rgba(0, 0, 0, 0.25);
+        --spectrum-button-color-disabled: rgba(0, 0, 0, 0.1);
+        --spectrum-button-text-color: black;
+        --spectrum-button-text-color-disabled: rgba(0, 0, 0, 0.55);
+      }
+
+      &[data-style=outline] {
+        --spectrum-button-color: rgba(0, 0, 0, 0.25);
+        --spectrum-button-color-hover: rgba(0, 0, 0, 0.4);
+        --spectrum-button-color-down: rgba(0, 0, 0, 0.55);
+        --spectrum-button-color-key-focus: rgba(0, 0, 0, 0.4);
+        --spectrum-button-color-disabled: rgba(0, 0, 0, 0.25);
+        --spectrum-button-text-color: black;
+        --spectrum-button-text-color-hover: black;
+        --spectrum-button-text-color-down: black;
+        --spectrum-button-text-color-key-focus: black;
+        --spectrum-button-text-color-disabled: rgba(0, 0, 0, 0.55);
+        --spectrum-button-background-color-hover: rgba(0, 0, 0, 0.25);
+        --spectrum-button-background-color-down: rgba(0, 0, 0, 0.4);
+        --spectrum-button-background-color-key-focus: rgba(0, 0, 0, 0.25);
+      }
+    }
+  }
+
+  &:not([data-static-color]) {
+    &[data-variant=accent] {
+      &[data-style=fill] {
+        --spectrum-button-color: var(--spectrum-accent-background-color-default);
+        --spectrum-button-color-hover: var(--spectrum-accent-background-color-hover);
+        --spectrum-button-color-down: var(--spectrum-accent-background-color-down);
+        --spectrum-button-color-key-focus: var(--spectrum-accent-background-color-key-focus);
+      }
+
+      &[data-style=outline] {
+        --spectrum-button-color: var(--spectrum-blue-900);
+        --spectrum-button-color-hover: var(--spectrum-blue-1000);
+        --spectrum-button-color-down: var(--spectrum-blue-1100);
+        --spectrum-button-color-key-focus: var(--spectrum-blue-1000);
+        --spectrum-button-background-color-hover: var(--spectrum-blue-200);
+        --spectrum-button-background-color-down: var(--spectrum-blue-300);
+        --spectrum-button-background-color-key-focus: var(--spectrum-blue-200);
+      }
+    }
+
+    &[data-variant=negative] {
+      &[data-style=fill] {
+        --spectrum-button-color: var(--spectrum-negative-background-color-default);
+        --spectrum-button-color-hover: var(--spectrum-negative-background-color-hover);
+        --spectrum-button-color-down: var(--spectrum-negative-background-color-down);
+        --spectrum-button-color-key-focus: var(--spectrum-negative-background-color-key-focus);
+      }
+
+      &[data-style=outline] {
+        --spectrum-button-color: var(--spectrum-red-900);
+        --spectrum-button-color-hover: var(--spectrum-red-1000);
+        --spectrum-button-color-down: var(--spectrum-red-1100);
+        --spectrum-button-color-key-focus: var(--spectrum-red-1000);
+        --spectrum-button-background-color-hover: var(--spectrum-red-200);
+        --spectrum-button-background-color-down: var(--spectrum-red-300);
+        --spectrum-button-background-color-key-focus: var(--spectrum-red-200);
+      }
+    }
+
+    &[data-variant=primary] {
+      &[data-style=fill] {
+        --spectrum-button-color: var(--spectrum-neutral-background-color-default);
+        --spectrum-button-color-hover: var(--spectrum-neutral-background-color-hover);
+        --spectrum-button-color-down: var(--spectrum-neutral-background-color-down);
+        --spectrum-button-color-key-focus: var(--spectrum-neutral-background-color-key-focus);
+      }
+
+      &[data-style=outline] {
+        --spectrum-button-color: var(--spectrum-gray-800);
+        --spectrum-button-color-hover: var(--spectrum-gray-900);
+        --spectrum-button-color-down: var(--spectrum-gray-900);
+        --spectrum-button-color-key-focus: var(--spectrum-gray-900);
+        --spectrum-button-background-color-hover: var(--spectrum-gray-300);
+        --spectrum-button-background-color-down: var(--spectrum-gray-400);
+        --spectrum-button-background-color-key-focus: var(--spectrum-gray-300);
+      }
+    }
+
+    &[data-variant=secondary] {
+      --spectrum-button-text-color: var(--spectrum-gray-800);
+      --spectrum-button-text-color-hover: var(--spectrum-gray-900);
+      --spectrum-button-text-color-down: var(--spectrum-gray-900);
+      --spectrum-button-text-color-key-focus: var(--spectrum-gray-900);
+
+      &[data-style=fill] {
+        --spectrum-button-color: var(--spectrum-gray-200);
+        --spectrum-button-color-hover: var(--spectrum-gray-300);
+        --spectrum-button-color-down: var(--spectrum-gray-400);
+        --spectrum-button-color-key-focus: var(--spectrum-gray-300);
+      }
+
+      &[data-style=outline] {
+        --spectrum-button-color: var(--spectrum-gray-300);
+        --spectrum-button-color-hover: var(--spectrum-gray-400);
+        --spectrum-button-color-down: var(--spectrum-gray-500);
+        --spectrum-button-color-key-focus: var(--spectrum-gray-400);
+        --spectrum-button-background-color-hover: var(--spectrum-gray-300);
+        --spectrum-button-background-color-down: var(--spectrum-gray-400);
+        --spectrum-button-background-color-key-focus: var(--spectrum-gray-300);
+      }
+    }
   }
 }
 
-.spectrum-Button--primary.spectrum-Button--quiet {
-  background-color: var(--spectrum-button-quiet-primary-background-color);
-  border-color: var(--spectrum-button-quiet-primary-border-color);
-  color: var(--spectrum-button-quiet-primary-text-color);
+@media (forced-colors: active) {
+  .spectrum-Button {
+    forced-color-adjust: none;
 
-  &:hover {
-    background-color: var(--spectrum-button-quiet-primary-background-color-hover);
-    border-color: var(--spectrum-button-quiet-primary-border-color-hover);
-    color: var(--spectrum-button-quiet-primary-text-color-hover);
-  }
+    --spectrum-high-contrast-transparent: transparent;
+    --spectrum-high-contrast-button-face: ButtonFace;
+    --spectrum-high-contrast-button-text: ButtonText;
+    --spectrum-high-contrast-highlight: Highlight;
+    --spectrum-high-contrast-gray-text: GrayText;
 
-  &:focus-ring {
-    background-color: var(--spectrum-button-quiet-primary-background-color-key-focus);
-    border-color: var(--spectrum-button-quiet-primary-border-color-key-focus);
-    color: var(--spectrum-button-quiet-primary-text-color-key-focus);
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-button-quiet-primary-background-color-down);
-    border-color: var(--spectrum-button-quiet-primary-border-color-down);
-    color: var(--spectrum-button-quiet-primary-text-color-down);
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-quiet-primary-background-color-disabled);
-    border-color: var(--spectrum-button-quiet-primary-border-color-disabled);
-    color: var(--spectrum-button-quiet-primary-text-color-disabled);
-  }
-}
-
-.spectrum-Button--secondary.spectrum-Button--quiet {
-  background-color: var(--spectrum-button-quiet-secondary-background-color);
-  border-color: var(--spectrum-button-quiet-secondary-border-color);
-  color: var(--spectrum-button-quiet-secondary-text-color);
-
-  &:hover {
-    background-color: var(--spectrum-button-quiet-secondary-background-color-hover);
-    border-color: var(--spectrum-button-quiet-secondary-border-color-hover);
-    color: var(--spectrum-button-quiet-secondary-text-color-hover);
-  }
-
-  &:focus-ring {
-    background-color: var(--spectrum-button-quiet-secondary-background-color-key-focus);
-    border-color: var(--spectrum-button-quiet-secondary-border-color-key-focus);
-    color: var(--spectrum-button-quiet-secondary-text-color-key-focus);
-  }
-
-  &.is-active {
-    background-color: var(--spectrum-button-quiet-secondary-background-color-down);
-    border-color: var(--spectrum-button-quiet-secondary-border-color-down);
-    color: var(--spectrum-button-quiet-secondary-text-color-down);
-  }
-
-  &:disabled,
-  &.is-disabled {
-    background-color: var(--spectrum-button-quiet-secondary-background-color-disabled);
-    border-color: var(--spectrum-button-quiet-secondary-border-color-disabled);
-    color: var(--spectrum-button-quiet-secondary-text-color-disabled);
+    --spectrum-high-contrast-focus-ring-color: var(--spectrum-high-contrast-button-text);
   }
 }
 
@@ -1110,7 +1138,6 @@ governing permissions and limitations under the License.
 
 @media (forced-colors: active) {
   .spectrum-ActionButton,
-  .spectrum-Button,
   .spectrum-ClearButton,
   .spectrum-LogicButton,
   .spectrum-FieldButton {
@@ -1243,134 +1270,6 @@ governing permissions and limitations under the License.
   --spectrum-actionbutton-text-color-selected-down: HighlightText;
   --spectrum-actionbutton-text-color-selected-hover: HighlightText;
   --spectrum-actionbutton-text-color-selected-key-focus: HighlightText;
-  --spectrum-button-cta-background-color: ButtonText;
-  --spectrum-button-cta-background-color-disabled: ButtonFace;
-  --spectrum-button-cta-background-color-down: Highlight;
-  --spectrum-button-cta-background-color-hover: Highlight;
-  --spectrum-button-cta-background-color-key-focus: Highlight;
-  --spectrum-button-cta-border-color: ButtonFace;
-  --spectrum-button-cta-border-color-disabled: GrayText;
-  --spectrum-button-cta-border-color-down: Highlight;
-  --spectrum-button-cta-border-color-hover: Highlight;
-  --spectrum-button-cta-border-color-key-focus: Highlight;
-  --spectrum-button-cta-text-color: ButtonFace;
-  --spectrum-button-cta-text-color-disabled: GrayText;
-  --spectrum-button-cta-text-color-down: ButtonFace;
-  --spectrum-button-cta-text-color-hover: ButtonFace;
-  --spectrum-button-cta-text-color-key-focus: ButtonFace;
-  --spectrum-button-over-background-background-color: ButtonFace;
-  --spectrum-button-over-background-background-color-disabled: ButtonFace;
-  --spectrum-button-over-background-background-color-down: ButtonFace;
-  --spectrum-button-over-background-background-color-hover: ButtonFace;
-  --spectrum-button-over-background-border-color: ButtonText;
-  --spectrum-button-over-background-border-color-disabled: GrayText;
-  --spectrum-button-over-background-border-color-down: Highlight;
-  --spectrum-button-over-background-border-color-hover: Highlight;
-  --spectrum-button-over-background-border-color-key-focus: Highlight;
-  --spectrum-button-over-background-text-color: ButtonText;
-  --spectrum-button-over-background-text-color-disabled: GrayText;
-  --spectrum-button-primary-background-color: ButtonFace;
-  --spectrum-button-primary-background-color-disabled: ButtonFace;
-  --spectrum-button-primary-background-color-down: ButtonFace;
-  --spectrum-button-primary-background-color-hover: ButtonFace;
-  --spectrum-button-primary-background-color-key-focus: ButtonFace;
-  --spectrum-button-primary-border-color: ButtonText;
-  --spectrum-button-primary-border-color-disabled: GrayText;
-  --spectrum-button-primary-border-color-down: Highlight;
-  --spectrum-button-primary-border-color-hover: Highlight;
-  --spectrum-button-primary-border-color-key-focus: Highlight;
-  --spectrum-button-primary-text-color: ButtonText;
-  --spectrum-button-primary-text-color-disabled: GrayText;
-  --spectrum-button-primary-text-color-down: ButtonText;
-  --spectrum-button-primary-text-color-hover: ButtonText;
-  --spectrum-button-primary-text-color-key-focus: ButtonText;
-  --spectrum-button-quiet-over-background-background-color: ButtonFace;
-  --spectrum-button-quiet-over-background-background-color-disabled: ButtonFace;
-  --spectrum-button-quiet-over-background-background-color-down: ButtonFace;
-  --spectrum-button-quiet-over-background-background-color-hover: ButtonFace;
-  --spectrum-button-quiet-over-background-border-color: ButtonFace;
-  --spectrum-button-quiet-over-background-border-color-disabled: ButtonFace;
-  --spectrum-button-quiet-over-background-border-color-down: Highlight;
-  --spectrum-button-quiet-over-background-border-color-hover: Highlight;
-  --spectrum-button-quiet-over-background-text-color: ButtonText;
-  --spectrum-button-quiet-over-background-text-color-disabled: GrayText;
-  --spectrum-button-quiet-over-background-text-color-down: ButtonText;
-  --spectrum-button-quiet-over-background-text-color-hover: ButtonText;
-  --spectrum-button-quiet-primary-background-color: ButtonFace;
-  --spectrum-button-quiet-primary-background-color-disabled: ButtonFace;
-  --spectrum-button-quiet-primary-background-color-down: ButtonFace;
-  --spectrum-button-quiet-primary-background-color-hover: ButtonFace;
-  --spectrum-button-quiet-primary-background-color-key-focus: ButtonFace;
-  --spectrum-button-quiet-primary-border-color: ButtonFace;
-  --spectrum-button-quiet-primary-border-color-disabled: ButtonFace;
-  --spectrum-button-quiet-primary-border-color-down: Highlight;
-  --spectrum-button-quiet-primary-border-color-hover: Highlight;
-  --spectrum-button-quiet-primary-border-color-key-focus: Highlight;
-  --spectrum-button-quiet-primary-text-color: ButtonText;
-  --spectrum-button-quiet-primary-text-color-disabled: GrayText;
-  --spectrum-button-quiet-primary-text-color-down: ButtonText;
-  --spectrum-button-quiet-primary-text-color-hover: ButtonText;
-  --spectrum-button-quiet-primary-text-color-key-focus: ButtonText;
-  --spectrum-button-quiet-secondary-background-color: ButtonFace;
-  --spectrum-button-quiet-secondary-background-color-disabled: ButtonFace;
-  --spectrum-button-quiet-secondary-background-color-down: ButtonFace;
-  --spectrum-button-quiet-secondary-background-color-hover: ButtonFace;
-  --spectrum-button-quiet-secondary-background-color-key-focus: ButtonFace;
-  --spectrum-button-quiet-secondary-border-color: ButtonFace;
-  --spectrum-button-quiet-secondary-border-color-disabled: ButtonFace;
-  --spectrum-button-quiet-secondary-border-color-down: Highlight;
-  --spectrum-button-quiet-secondary-border-color-hover: Highlight;
-  --spectrum-button-quiet-secondary-border-color-key-focus: Highlight;
-  --spectrum-button-quiet-secondary-text-color: ButtonText;
-  --spectrum-button-quiet-secondary-text-color-disabled: GrayText;
-  --spectrum-button-quiet-secondary-text-color-down: ButtonText;
-  --spectrum-button-quiet-secondary-text-color-hover: ButtonText;
-  --spectrum-button-quiet-secondary-text-color-key-focus: ButtonText;
-  --spectrum-button-quiet-warning-background-color: ButtonFace;
-  --spectrum-button-quiet-warning-background-color-disabled: ButtonFace;
-  --spectrum-button-quiet-warning-background-color-down: ButtonFace;
-  --spectrum-button-quiet-warning-background-color-hover: ButtonFace;
-  --spectrum-button-quiet-warning-background-color-key-focus: ButtonFace;
-  --spectrum-button-quiet-warning-border-color: ButtonFace;
-  --spectrum-button-quiet-warning-border-color-disabled: ButtonFace;
-  --spectrum-button-quiet-warning-border-color-down: Highlight;
-  --spectrum-button-quiet-warning-border-color-hover: Highlight;
-  --spectrum-button-quiet-warning-border-color-key-focus: Highlight;
-  --spectrum-button-quiet-warning-text-color: ButtonText;
-  --spectrum-button-quiet-warning-text-color-disabled: GrayText;
-  --spectrum-button-quiet-warning-text-color-down: ButtonText;
-  --spectrum-button-quiet-warning-text-color-hover: ButtonText;
-  --spectrum-button-quiet-warning-text-color-key-focus: ButtonText;
-  --spectrum-button-secondary-background-color: ButtonFace;
-  --spectrum-button-secondary-background-color-disabled: ButtonFace;
-  --spectrum-button-secondary-background-color-down: ButtonFace;
-  --spectrum-button-secondary-background-color-hover: ButtonFace;
-  --spectrum-button-secondary-background-color-key-focus: ButtonFace;
-  --spectrum-button-secondary-border-color: ButtonText;
-  --spectrum-button-secondary-border-color-disabled: GrayText;
-  --spectrum-button-secondary-border-color-down: Highlight;
-  --spectrum-button-secondary-border-color-hover: Highlight;
-  --spectrum-button-secondary-border-color-key-focus: Highlight;
-  --spectrum-button-secondary-text-color: ButtonText;
-  --spectrum-button-secondary-text-color-disabled: GrayText;
-  --spectrum-button-secondary-text-color-down: ButtonText;
-  --spectrum-button-secondary-text-color-hover: ButtonText;
-  --spectrum-button-secondary-text-color-key-focus: ButtonText;
-  --spectrum-button-warning-background-color: ButtonFace;
-  --spectrum-button-warning-background-color-disabled: ButtonFace;
-  --spectrum-button-warning-background-color-down: ButtonFace;
-  --spectrum-button-warning-background-color-hover: ButtonFace;
-  --spectrum-button-warning-background-color-key-focus: ButtonFace;
-  --spectrum-button-warning-border-color: ButtonText;
-  --spectrum-button-warning-border-color-disabled: GrayText;
-  --spectrum-button-warning-border-color-down: Highlight;
-  --spectrum-button-warning-border-color-hover: Highlight;
-  --spectrum-button-warning-border-color-key-focus: Highlight;
-  --spectrum-button-warning-text-color: ButtonText;
-  --spectrum-button-warning-text-color-disabled: GrayText;
-  --spectrum-button-warning-text-color-down: ButtonText;
-  --spectrum-button-warning-text-color-hover: ButtonText;
-  --spectrum-button-warning-text-color-key-focus: ButtonText;
   --spectrum-clearbutton-medium-background-color: ButtonFace;
   --spectrum-clearbutton-medium-background-color-disabled: ButtonFace;
   --spectrum-clearbutton-medium-background-color-down: ButtonFace;

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -56,10 +56,10 @@ governing permissions and limitations under the License.
   --spectrum-actionbutton-emphasized-background-color-key-focus: var(--spectrum-actionbutton-background-color-key-focus);
   --spectrum-actionbutton-emphasized-background-color-down: var(--spectrum-actionbutton-background-color-down);
   --spectrum-actionbutton-emphasized-background-color-disabled: var(--spectrum-actionbutton-background-color-disabled);
-  --spectrum-actionbutton-emphasized-background-color-selected: var(--spectrum-global-color-blue-500);
-  --spectrum-actionbutton-emphasized-background-color-selected-hover: var(--spectrum-global-color-blue-600);
-  --spectrum-actionbutton-emphasized-background-color-selected-key-focus: var(--spectrum-global-color-blue-600);
-  --spectrum-actionbutton-emphasized-background-color-selected-down: var(--spectrum-global-color-blue-700);
+  --spectrum-actionbutton-emphasized-background-color-selected: var(--spectrum-accent-background-color-default);
+  --spectrum-actionbutton-emphasized-background-color-selected-hover: var(--spectrum-accent-background-color-hover);
+  --spectrum-actionbutton-emphasized-background-color-selected-key-focus: var(--spectrum-accent-background-color-key-focus);
+  --spectrum-actionbutton-emphasized-background-color-selected-down: var(--spectrum-accent-background-color-down);
   --spectrum-actionbutton-emphasized-border-color: var(--spectrum-actionbutton-border-color);
   --spectrum-actionbutton-emphasized-border-color-hover: var(--spectrum-actionbutton-border-color-hover);
   --spectrum-actionbutton-emphasized-border-color-key-focus: var(--spectrum-actionbutton-border-color-key-focus);

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -16,24 +16,24 @@ governing permissions and limitations under the License.
   /* Interactions with overbackground button should match background. Not a DNA token, overridden in WHCM. */
   --spectrum-button-over-background-color: inherit;
 
-  --spectrum-actionbutton-background-color-selected: var(--spectrum-global-color-gray-600);
-  --spectrum-actionbutton-background-color-selected-hover: var(--spectrum-global-color-gray-700);
-  --spectrum-actionbutton-background-color-selected-key-focus: var(--spectrum-global-color-gray-700);
-  --spectrum-actionbutton-background-color-selected-down: var(--spectrum-global-color-gray-800);
+  --spectrum-actionbutton-background-color-selected: var(--spectrum-neutral-subdued-background-color-default);
+  --spectrum-actionbutton-background-color-selected-hover: var(--spectrum-neutral-subdued-background-color-hover);
+  --spectrum-actionbutton-background-color-selected-key-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
+  --spectrum-actionbutton-background-color-selected-down: var(--spectrum-neutral-subdued-background-color-down);
   --spectrum-actionbutton-background-color-disabled: transparent;
   --spectrum-actionbutton-border-color-selected: var(--spectrum-actionbutton-background-color-selected);
   --spectrum-actionbutton-border-color-selected-hover: var(--spectrum-actionbutton-background-color-selected-hover);
   --spectrum-actionbutton-border-color-selected-key-focus: var(--spectrum-actionbutton-background-color-selected-key-focus);
   --spectrum-actionbutton-border-color-selected-down: var(--spectrum-actionbutton-background-color-selected-down);
   --spectrum-actionbutton-border-color-disabled: var(--spectrum-global-color-gray-300);
-  --spectrum-actionbutton-text-color-selected: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-text-color-selected-hover: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-text-color-selected-key-focus: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-text-color-selected-down: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-icon-color-selected: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-icon-color-selected-hover: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-icon-color-selected-key-focus: var(--spectrum-global-color-gray-50);
-  --spectrum-actionbutton-icon-color-selected-down: var(--spectrum-global-color-gray-50);
+  --spectrum-actionbutton-text-color-selected: white;
+  --spectrum-actionbutton-text-color-selected-hover: white;
+  --spectrum-actionbutton-text-color-selected-key-focus: white;
+  --spectrum-actionbutton-text-color-selected-down: white;
+  --spectrum-actionbutton-icon-color-selected: white;
+  --spectrum-actionbutton-icon-color-selected-hover: white;
+  --spectrum-actionbutton-icon-color-selected-key-focus: white;
+  --spectrum-actionbutton-icon-color-selected-down: white;
 
   --spectrum-actionbutton-quiet-background-color-hover: var(--spectrum-global-color-gray-200);
   --spectrum-actionbutton-quiet-background-color-key-focus:  var(--spectrum-global-color-gray-200);
@@ -52,14 +52,14 @@ governing permissions and limitations under the License.
   --spectrum-actionbutton-static-black-border-color-hover: rgba(0, 0, 0, 0.55);
   --spectrum-actionbutton-static-black-border-color-key-focus: rgba(0, 0, 0, 0.55);
   --spectrum-actionbutton-static-black-border-color-down: rgba(0, 0, 0, 0.7);
-  --spectrum-actionbutton-static-black-border-color-disabled: rgba(0, 0, 0, 0.1);
+  --spectrum-actionbutton-static-black-border-color-disabled: rgba(0, 0, 0, 0.25);
   --spectrum-actionbutton-static-black-background-color: transparent;
 
   --spectrum-actionbutton-static-white-border-color: rgba(255, 255, 255, 0.4);
   --spectrum-actionbutton-static-white-border-color-hover: rgba(255, 255, 255, 0.55);
   --spectrum-actionbutton-static-white-border-color-key-focus: rgba(255, 255, 255, 0.55);
   --spectrum-actionbutton-static-white-border-color-down: rgba(255, 255, 255, 0.7);
-  --spectrum-actionbutton-static-white-border-color-disabled: rgba(255, 255, 255, 0.1);
+  --spectrum-actionbutton-static-white-border-color-disabled: rgba(255, 255, 255, 0.25);
   --spectrum-actionbutton-static-white-background-color: transparent;
 
   /* TBD on new tokens. This passes contrast for now. */
@@ -509,6 +509,7 @@ governing permissions and limitations under the License.
 
     &:focus-ring {
       background-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-background-color-selected-key-focus));
+      border-color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-border-color-selected-key-focus));
       color: xvar(--spectrum-high-contrast-highlight-text, var(--spectrum-actionbutton-text-color-selected-key-focus));
 
       .spectrum-Icon {
@@ -633,7 +634,7 @@ governing permissions and limitations under the License.
   --spectrum-actionbutton-static-background-color-selected-hover: white;
   --spectrum-actionbutton-static-background-color-selected-focus: white;
   --spectrum-actionbutton-static-background-color-selected-active: white;
-  --spectrum-actionbutton-static-background-color-selected-disabled: var(--spectrum-actionbutton-static-white-border-color-disabled);
+  --spectrum-actionbutton-static-background-color-selected-disabled: rgba(255, 255, 255, 0.1);
   --spectrum-actionbutton-static-border-color: var(--spectrum-actionbutton-static-white-border-color);
   --spectrum-actionbutton-static-border-color-hover: var(--spectrum-actionbutton-static-white-border-color-hover);
   --spectrum-actionbutton-static-border-color-active: var(--spectrum-actionbutton-static-white-border-color-down);
@@ -660,7 +661,7 @@ governing permissions and limitations under the License.
   --spectrum-actionbutton-static-background-color-selected-hover: black;
   --spectrum-actionbutton-static-background-color-selected-focus: black;
   --spectrum-actionbutton-static-background-color-selected-active: black;
-  --spectrum-actionbutton-static-background-color-selected-disabled: var(--spectrum-actionbutton-static-black-border-color-disabled);
+  --spectrum-actionbutton-static-background-color-selected-disabled: rgba(0, 0, 0, 0.1);
   --spectrum-actionbutton-static-border-color: var(--spectrum-actionbutton-static-black-border-color);
   --spectrum-actionbutton-static-border-color-hover: var(--spectrum-actionbutton-static-black-border-color-hover);
   --spectrum-actionbutton-static-border-color-active: var(--spectrum-actionbutton-static-black-border-color-down);
@@ -787,7 +788,7 @@ governing permissions and limitations under the License.
     &:disabled,
     &.is-disabled {
       background-color: var(--spectrum-actionbutton-static-background-color-selected-disabled);
-      border-color: var(--spectrum-actionbutton-static-border-disabled);
+      border-color: var(--spectrum-actionbutton-static-background-color-selected-disabled);
       color: var(--spectrum-actionbutton-static-color-disabled);
 
       .spectrum-Icon {

--- a/packages/@react-spectrum/button/chromatic/Button.chromatic.tsx
+++ b/packages/@react-spectrum/button/chromatic/Button.chromatic.tsx
@@ -12,74 +12,33 @@
 
 import Bell from '@spectrum-icons/workflow/Bell';
 import {Button} from '../';
+import {classNames} from '@react-spectrum/utils';
 import {Flex} from '@react-spectrum/layout';
+import {generatePowerset} from '@react-spectrum/story-utils';
+import {Grid, repeat} from '@react-spectrum/layout';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
+import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {Text} from '@react-spectrum/text';
 
+let states = [
+  {UNSAFE_className: classNames(styles, 'is-hovered'), 'data-hover': true},
+  {UNSAFE_className: classNames(styles, 'is-active'), 'data-active': true},
+  {UNSAFE_className: classNames(styles, 'focus-ring'), 'data-focus': true},
+  {style: 'fill'},
+  {style: 'outline'},
+  {staticColor: 'white'},
+  {staticColor: 'black'},
+  {isDisabled: true}
+];
+
+let combinations = generatePowerset(states, v => (v.UNSAFE_className && v.isDisabled) || (v['data-focus'] && (v['data-hover'] || v['data-active'])) || (v['data-hover'] && v['data-active']));
+
 storiesOf('Button', module)
-  .addParameters({chromaticProvider: {locales: ['en-US', 'ar-AE', 'zh-TW']}})
+  .addParameters({chromaticProvider: {locales: ['en-US']}})
   .add(
-    'variant: cta',
-    () => render({variant: 'cta'})
-  )
-  .add(
-    'with icon',
-    () => (
-      <Flex gap="size-200">
-        <Button variant="primary">
-          <Bell />
-          <Text>Default</Text>
-        </Button>
-        <Button
-          isDisabled
-          variant="primary">
-          <Text>Disabled</Text>
-          <Bell />
-        </Button>
-        <Button
-          isQuiet
-          variant="primary">
-          <Bell />
-          <Text>Quiet</Text>
-        </Button>
-        <Button
-          isQuiet
-          variant="primary">
-          <Bell />
-          <Text>هادئ</Text>
-        </Button>
-      </Flex>
-    )
-  )
-  .add(
-    'double text node',
-    () => (
-      <Flex gap="size-200">
-        <Button
-          variant="primary">
-          {0} Dogs
-        </Button>
-        <Button
-          isDisabled
-          variant="primary">
-          {0} Dogs
-        </Button>
-        <Button
-          isQuiet
-          variant="primary">
-          {0} Dogs
-        </Button>
-      </Flex>
-    )
-  )
-  .add(
-    'variant: overBackground',
-    () => (
-      <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
-        {render({variant: 'overBackground'})}
-      </div>
-    )
+    'variant: accent',
+    () => render({variant: 'accent'})
   )
   .add(
     'variant: primary',
@@ -96,36 +55,89 @@ storiesOf('Button', module)
   .add(
     'element: a',
     () => render({elementType: 'a', variant: 'primary'})
+  )
+  .add(
+    'with icon',
+    () => (
+      <Flex gap="size-200">
+        <Button variant="primary">
+          <Bell />
+          <Text>Default</Text>
+        </Button>
+        <Button
+          isDisabled
+          variant="primary">
+          <Text>Disabled</Text>
+          <Bell />
+        </Button>
+      </Flex>
+    ),
+    {chromaticProvider: {locales: ['en-US', 'ar-AE']}}
+  )
+  .add(
+    'icon only',
+    () => (
+      <Flex gap="size-200">
+        <Button variant="primary" aria-label="Notifications">
+          <Bell />
+        </Button>
+        <Button
+          isDisabled
+          variant="primary"
+          aria-label="Notifications">
+          <Bell />
+        </Button>
+      </Flex>
+    ),
+    {chromaticProvider: {locales: ['en-US', 'ar-AE']}}
+  )
+  .add(
+    'double text node',
+    () => (
+      <Flex gap="size-200">
+        <Button
+          variant="primary">
+          {0} Dogs
+        </Button>
+        <Button
+          isDisabled
+          variant="primary">
+          {0} Dogs
+        </Button>
+      </Flex>
+    )
   );
 
 function render(props: any = {}) {
   return (
-    <Flex gap="size-200">
-      <Button
-        {...props}>
-        Default
-      </Button>
-      <Button
-        isDisabled
-        {...props}>
-        Disabled
-      </Button>
-      {props.variant !== 'cta' && (
-      <Button
-        isQuiet
-        {...props}>
-        Quiet
-      </Button>
-      )}
-      <Button
-        {...props}>
-        默認
-      </Button>
-      <Button
-        aria-label="Icon only"
-        {...props}>
-        <Bell />
-      </Button>
-    </Flex>
+    <Grid columns={repeat(4, '1fr')} autoFlow="row" justifyItems="start" gap="size-300">
+      {combinations.map(c => {
+        let key = Object.keys(c).map(k => {
+          if (k === 'UNSAFE_className') {
+            return '';
+          }
+          return typeof c[k] === 'boolean' ? k.replace(/^data-/, '') : `${k}: ${c[k]}`;
+        }).filter(Boolean).reverse().join(', ');
+        if (!key) {
+          key = 'default';
+        }
+        let button = <Button key={key} {...props} {...c}>{key}</Button>;
+        if (props.variant === 'overBackground' || c.staticColor === 'white') {
+          return (
+            <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
+              {button}
+            </div>
+          );
+        }
+        if (c.staticColor === 'black') {
+          return (
+            <div style={{backgroundColor: 'rgb(206, 247, 243)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
+              {button}
+            </div>
+          );
+        }
+        return button;
+      })}
+    </Grid>
   );
 }

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -29,11 +29,6 @@ import {useButton} from '@react-aria/button';
 import {useHover} from '@react-aria/interactions';
 import {useProviderProps} from '@react-spectrum/provider';
 
-// todo: CSS hasn't caught up yet, map
-let VARIANT_MAPPING = {
-  negative: 'warning'
-};
-
 function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);
   props = useSlotProps(props, 'button');
@@ -41,7 +36,8 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
     elementType: ElementType = 'button',
     children,
     variant,
-    isQuiet,
+    style = variant === 'accent' || variant === 'cta' ? 'fill' : 'outline',
+    staticColor,
     isDisabled,
     autoFocus,
     ...otherProps
@@ -53,9 +49,11 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
   let hasLabel = useHasChild(`.${styles['spectrum-Button-label']}`, domRef);
   let hasIcon = useHasChild(`.${styles['spectrum-Icon']}`, domRef);
 
-  let buttonVariant = variant;
-  if (VARIANT_MAPPING[variant]) {
-    buttonVariant = VARIANT_MAPPING[variant];
+  if (variant === 'cta') {
+    variant = 'accent';
+  } else if (variant === 'overBackground') {
+    variant = 'primary';
+    staticColor = 'white';
   }
 
   return (
@@ -64,13 +62,14 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}
         ref={domRef}
+        data-variant={variant}
+        data-style={style}
+        data-static-color={staticColor || undefined}
         className={
           classNames(
             styles,
             'spectrum-Button',
-            `spectrum-Button--${buttonVariant}`,
             {
-              'spectrum-Button--quiet': isQuiet,
               'spectrum-Button--iconOnly': hasIcon && !hasLabel,
               'is-disabled': isDisabled,
               'is-active': isPressed,

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -23,13 +23,27 @@ import {Tooltip, TooltipTrigger} from '@react-spectrum/tooltip';
 
 const parameters = {
   args: {
-    variant: 'cta'
+    variant: 'cta',
+    style: undefined,
+    staticColor: undefined
   },
   argTypes: {
     variant: {
       control: {
         type: 'radio',
-        options: ['cta', 'primary', 'secondary', 'negative', 'overBackground']
+        options: ['accent', 'primary', 'secondary', 'negative', 'cta', 'overBackground']
+      }
+    },
+    style: {
+      control: {
+        type: 'radio',
+        options: [undefined, 'fill', 'outline']
+      }
+    },
+    staticColor: {
+      control: {
+        type: 'radio',
+        options: [undefined, 'white', 'black']
       }
     }
   }
@@ -72,10 +86,6 @@ storiesOf('Button', module)
     'user-select:none on press test',
     () => <Example />,
     {description: {data: 'Pressing and holding on either buttons shouldn\'t trigger text selection on the button labels (wait for buttons to turn red).'}}
-  )
-  .add(
-    'styles to check WHCM support',
-    () => renderStyles()
   );
 
 function render<T extends ElementType = 'button'>(props: SpectrumButtonProps<T> = {variant: 'primary'}) {
@@ -89,17 +99,20 @@ function render<T extends ElementType = 'button'>(props: SpectrumButtonProps<T> 
       <Button {...buttonProps} isDisabled>
         Disabled
       </Button>
-      {props.variant !== 'cta' && (
-        <Button {...buttonProps} isQuiet>
-          Quiet
-        </Button>
-      )}
     </Flex>
   );
 
-  if (props.variant === 'overBackground') {
+  if (props.variant === 'overBackground' || props.staticColor === 'white') {
     return (
       <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
+        {buttons}
+      </div>
+    );
+  }
+
+  if (props.staticColor === 'black') {
+    return (
+      <div style={{backgroundColor: 'rgb(206, 247, 243)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
         {buttons}
       </div>
     );
@@ -121,18 +134,20 @@ function renderIconText<T extends ElementType = 'button'>(props: SpectrumButtonP
         <Bell />
         <Text>Disabled</Text>
       </Button>
-      {props.variant !== 'cta' && (
-        <Button {...buttonProps} isQuiet>
-          <Bell />
-          <Text>Quiet</Text>
-        </Button>
-      )}
     </Flex>
   );
 
-  if (props.variant === 'overBackground') {
+  if (props.variant === 'overBackground' || props.staticColor === 'white') {
     return (
       <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
+        {buttons}
+      </div>
+    );
+  }
+
+  if (props.staticColor === 'black') {
+    return (
+      <div style={{backgroundColor: 'rgb(206, 247, 243)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
         {buttons}
       </div>
     );
@@ -158,20 +173,20 @@ function renderIconOnly<T extends ElementType = 'button'>(props: SpectrumButtonP
         </Button>
         <Tooltip>Notifications</Tooltip>
       </TooltipTrigger>
-      {props.variant !== 'cta' && (
-        <TooltipTrigger offset={2}>
-          <Button {...buttonProps} isQuiet aria-label="Notifications (quiet)">
-            <Bell />
-          </Button>
-          <Tooltip>Notifications</Tooltip>
-        </TooltipTrigger>
-      )}
     </Flex>
   );
 
-  if (props.variant === 'overBackground') {
+  if (props.variant === 'overBackground' || props.staticColor === 'white') {
     return (
       <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
+        {buttons}
+      </div>
+    );
+  }
+
+  if (props.staticColor === 'black') {
+    return (
+      <div style={{backgroundColor: 'rgb(206, 247, 243)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
         {buttons}
       </div>
     );
@@ -198,148 +213,6 @@ function Example() {
         onPressStart={() => setTimeout(() => setShow2(true), 3000)}>
         Press and hold (no overwrite)
       </Button>
-    </Flex>
-  );
-}
-
-function renderStyles<T extends ElementType = 'button'>(props: SpectrumButtonProps<T> = {variant: 'primary'}) {
-  return (
-    <Flex direction="column" gap="size-200">
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          {...props}
-          variant="cta">
-          CTA
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          {...props}
-          variant="cta">
-          Disabled
-        </Button>
-      </Flex>
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          {...props}>
-          Primary
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          {...props}>
-          Disabled
-        </Button>
-      </Flex>
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          {...props}
-          variant="secondary">
-          Secondary
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          {...props}
-          variant="secondary">
-          Disabled
-        </Button>
-      </Flex>
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          {...props}
-          variant="negative">
-          Warning
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          {...props}
-          variant="negative">
-          Disabled
-        </Button>
-      </Flex>
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isQuiet
-          {...props}>
-          Primary Quiet
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          isQuiet
-          {...props}>
-          Disabled
-        </Button>
-      </Flex>
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isQuiet
-          {...props}
-          variant="secondary">
-          Secondary Quiet
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          isQuiet
-          {...props}
-          variant="secondary">
-          Disabled
-        </Button>
-      </Flex>
-      <Flex gap="size-200">
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isQuiet
-          {...props}
-          variant="negative">
-          Warning Quiet
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled
-          isQuiet
-          {...props}
-          variant="negative">
-          Disabled
-        </Button>
-      </Flex>
     </Flex>
   );
 }

--- a/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ToggleButton.stories.tsx
@@ -17,39 +17,36 @@ import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {ToggleButton} from '../';
 
+const parameters = {
+  args: {
+    isQuiet: false,
+    isEmphasized: false,
+    isDisabled: false
+  }
+};
+
 storiesOf('Button/ToggleButton', module)
-  .addParameters({providerSwitcher: {status: 'positive'}})
+  .addParameters({providerSwitcher: {status: 'positive'}, ...parameters})
   .add(
     'default',
-    () => render()
-  ).add(
-    'emphasized',
-    () => render({isEmphasized: true})
-  ).add(
-    'isQuiet',
-    () => render({isQuiet: true})
-  ).add(
-    'isQuiet & emphasized',
-    () => render({isEmphasized: true, isQuiet: true})
+    args => render(args)
   )
   .add(
     'staticColor: white',
-    () => (
+    args => (
       <View backgroundColor="static-seafoam-600" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
-          {render({staticColor: 'white'})}
-          {render({staticColor: 'white', isQuiet: true})}
+          {render({...args, staticColor: 'white'})}
         </Flex>
       </View>
     )
   )
   .add(
     'staticColor: black',
-    () => (
+    args => (
       <View backgroundColor="static-yellow-400" padding="size-1000">
         <Flex direction="column" rowGap="size-150">
-          {render({staticColor: 'black'})}
-          {render({staticColor: 'black', isQuiet: true})}
+          {render({...args, staticColor: 'black'})}
         </Flex>
       </View>
     )
@@ -80,10 +77,6 @@ function render(props = {}) {
     <ToggleButton onChange={action('change')} onPress={action('press')} defaultSelected {...props}>
       <Add />
       <Text>Selected</Text>
-    </ToggleButton>
-    <ToggleButton defaultSelected isDisabled {...props}>
-      <Add />
-      <Text>Disabled + selected</Text>
     </ToggleButton>
   </Flex>);
 }

--- a/packages/@react-spectrum/provider/test/Provider.test.js
+++ b/packages/@react-spectrum/provider/test/Provider.test.js
@@ -14,7 +14,7 @@
 import MatchMediaMock from 'jest-matchmedia-mock';
 // eslint-disable-next-line rulesdir/sort-imports
 import {act, fireEvent, render, triggerPress} from '@react-spectrum/test-utils';
-import {Button} from '@react-spectrum/button';
+import {ActionButton, Button} from '@react-spectrum/button';
 import {Checkbox} from '@react-spectrum/checkbox';
 import {Provider} from '../';
 import React from 'react';
@@ -148,14 +148,14 @@ describe('Provider', () => {
     let {getByRole} = render(
       <Provider theme={theme} isDisabled>
         <Provider isQuiet>
-          <Button onPress={onPressSpy}>Hello!</Button>
+          <ActionButton onPress={onPressSpy}>Hello!</ActionButton>
         </Provider>
       </Provider>
     );
     let button = getByRole('button');
     triggerPress(button);
     expect(onPressSpy).not.toHaveBeenCalled();
-    expect(button.classList.contains('spectrum-Button--quiet')).toBeTruthy();
+    expect(button.classList.contains('spectrum-ActionButton--quiet')).toBeTruthy();
     onPressSpy.mockClear();
   });
 

--- a/packages/@react-spectrum/story-utils/src/GeneratePowerset.tsx
+++ b/packages/@react-spectrum/story-utils/src/GeneratePowerset.tsx
@@ -30,6 +30,11 @@ export function generatePowerset(states: Array<object>, exclude?: (merged) => bo
         });
       } else {
         let merged = mergeProps(combinations[j], states[i]);
+        let s = JSON.stringify(merged);
+        if (combinations.some(c => JSON.stringify(c) === s)) {
+          continue;
+        }
+
         if (!(exclude && exclude(merged))) {
           combinations.push(merged);
         }

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -65,10 +65,19 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
 export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
 export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, AriaBaseButtonProps, AriaButtonElementTypeProps<T> {}
 
+/** @deprecated */
+type LegacyButtonVariant = 'cta' | 'overBackground';
 export interface SpectrumButtonProps<T extends ElementType = 'button'> extends AriaBaseButtonProps, ButtonProps, LinkButtonProps<T>, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */
-  variant: 'cta' | 'overBackground' | 'primary' | 'secondary' | 'negative',
-  /** Whether the button should be displayed with a quiet style. */
+  variant: 'accent' | 'primary' | 'secondary' | 'negative' | LegacyButtonVariant,
+  /** The background style of the button. */
+  style?: 'fill' | 'outline',
+  /** The static color style to apply. Useful when the button appears over a color background. */
+  staticColor?: 'white' | 'black',
+  /**
+   * Whether the button should be displayed with a quiet style.
+   * @deprecated
+   */
   isQuiet?: boolean
 }
 


### PR DESCRIPTION
Depends on #3604.

This updates Button to support the new `accent` variant, `fill` and `outline` styles, and `staticColor` options. `isQuiet` is also deprecated. The CSS has been rewritten to simplify it using variables.

ActionButton now has a more contrasting selected state. It also now always has a halo focus ring.