### PR TITLE
useTextField: Fix typings for labelProp (htmlFor)

### DIFF
--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -15,6 +15,7 @@ import {
   ChangeEvent,
   DOMFactory,
   HTMLAttributes,
+  LabelHTMLAttributes,
   ReactDOM,
   RefObject
 } from 'react';
@@ -88,7 +89,7 @@ export interface TextFieldAria<T extends TextFieldIntrinsicElements = DefaultEle
   /** Props for the input element. */
   inputProps: TextFieldInputProps<T>,
   /** Props for the text field's visible label element, if any. */
-  labelProps: DOMAttributes,
+  labelProps: DOMAttributes | LabelHTMLAttributes<HTMLLabelElement>,
   /** Props for the text field's description element, if any. */
   descriptionProps: DOMAttributes,
   /** Props for the text field's error message element, if any. */


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/3669

## ✅ Pull Request Checklist:

- [+ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

