### PR TITLE
Export `TreeCollection` and `TableCollection`

### DIFF
--- a/packages/@react-stately/table/src/index.ts
+++ b/packages/@react-stately/table/src/index.ts
@@ -22,3 +22,4 @@ export {Column} from './Column';
 export {Row} from './Row';
 export {Cell} from './Cell';
 export {Section} from '@react-stately/collections';
+export {TableCollection} from './TableCollection';

--- a/packages/@react-stately/tree/src/index.ts
+++ b/packages/@react-stately/tree/src/index.ts
@@ -11,3 +11,4 @@
  */
 export type {TreeProps, TreeState} from './useTreeState';
 export {useTreeState} from './useTreeState';
+export {TreeCollection} from './TreeCollection';


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

This change shouldn't need any additional tests. We are building some utilities that want to access these collection classes. `ListCollection` is already exported (https://github.com/adobe/react-spectrum/blob/main/packages/%40react-stately/list/src/index.ts#L17) but these collection classes are not, so I'm assuming it'd be OK to export these.

- [?] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [N/A] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [N/A] Filled out test instructions.
- [N/A] Updated documentation (if it already exists for this component).
- [N/A] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

N/A

## 🧢 Your Project:

<!--- Company/project for pull request -->

Stripe :)
