### PR TITLE
issue-1605: use two selectors to avoid css overwrite

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/colorwheel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/colorwheel/index.css
@@ -27,7 +27,8 @@
   pointer-events: none;
 }
 
-.spectrum-ColorWheel {
+/* Use two class selectors as a workaround for the issue: https://github.com/adobe/react-spectrum/issues/1605 */
+.spectrum-ColorWheel.spectrum-ColorWheel {
   position: relative;
   display: block;
   width: var(--spectrum-colorwheel-width);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/1605

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
Check if ColorWheel still gets stretched out inside a Form
```
<Form>
  <ColorWheel/>
</Form>
```

The example below demonstrates that the issue is gone regardless of whether it's wrapped in a Flex (or div)
![Screen Shot 2022-11-02 at 12 22 29 PM](https://user-images.githubusercontent.com/19467235/199612417-03bf5711-8b7b-43ec-9ba5-3b8e660d7afe.png)

## 🧢 Your Project:
