### PR TITLE
issue-2216: setting null to value should reset NumberField to blank

### DIFF
--- a/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
@@ -251,26 +251,8 @@ storiesOf('NumberField', module)
   )
   .add(
     'reset controlled state to blank with null',
-    () => renderControlledState()
+    () => <NumberFieldControlledStateReset />
   );
-
-function renderControlledState() {
-  const [controlledValue, setControlledValue] = useState(12);
-  return (
-    <>
-      <NumberField
-        value={controlledValue}
-        onChange={(value) => setControlledValue(value)}
-      />
-      <Button
-        variant={"primary"}
-        onPress={() => setControlledValue(null)}
-      >
-        Reset
-      </Button>
-    </>
-  );
-}
 
 function render(props: any = {}) {
   return (
@@ -330,6 +312,22 @@ function NumberFieldWithCurrencySelect(props) {
         {item => <Item key={item.value}>{item.label}</Item>}
       </Picker>
     </Form>
+  );
+}
+
+function NumberFieldControlledStateReset() {
+  const [controlledValue, setControlledValue] = useState(12);
+  return (
+    <>
+      <NumberField
+        value={controlledValue}
+        onChange={(value) => setControlledValue(value)}/>
+      <Button
+        variant={"primary"}
+        onPress={() => setControlledValue(null)}>
+        Reset
+      </Button>
+    </>
   );
 }
 

--- a/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
@@ -11,6 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
+import {Button} from '@react-spectrum/button';
 import {chain} from '@react-aria/utils';
 import {Content} from '@react-spectrum/view';
 import {ContextualHelp} from '@react-spectrum/contextualhelp';
@@ -247,7 +248,29 @@ storiesOf('NumberField', module)
       onCopy: action('onCopy'), onCut: action('onCut'), onPaste: action('onPaste'), onCompositionStart: action('onCompositionStart'), onCompositionEnd: action('onCompositionEnd'),
       onCompositionUpdate: action('onCompositionUpdate'), onSelect: action('onSelect'), onBeforeInput: action('onBeforeInput'), onInput: action('onInput')
     })
+  )
+  .add(
+    'reset controlled state to blank with null',
+    () => renderControlledState()
   );
+
+function renderControlledState() {
+  const [controlledValue, setControlledValue] = useState(12);
+  return (
+    <>
+      <NumberField
+        value={controlledValue}
+        onChange={(value) => setControlledValue(value)}
+      />
+      <Button
+        variant={"primary"}
+        onPress={() => setControlledValue(null)}
+      >
+        Reset
+      </Button>
+    </>
+  );
+}
 
 function render(props: any = {}) {
   return (

--- a/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/numberfield/stories/NumberField.stories.tsx
@@ -321,9 +321,9 @@ function NumberFieldControlledStateReset() {
     <>
       <NumberField
         value={controlledValue}
-        onChange={(value) => setControlledValue(value)}/>
+        onChange={(value) => setControlledValue(value)} />
       <Button
-        variant={"primary"}
+        variant={'primary'}
         onPress={() => setControlledValue(null)}>
         Reset
       </Button>

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -2163,8 +2163,8 @@ describe('NumberField', function () {
       let {onChange} = props;
       let [value, setValue] = useState(10);
       return (
-        <Provider theme={theme} scale='medium' locale='en-US'>
-          <NumberField {...props} label='reset to blank using null' value={value} onChange={value => setValue(value)} />
+        <Provider theme={theme} scale="medium" locale="en-US">
+          <NumberField {...props} label="reset to blank using null" value={value} onChange={value => setValue(value)} />
           <Button
             variant={'primary'}
             onPress={() => chain(setValue(null), onChange())}>

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -11,6 +11,7 @@
  */
 
 import {act, fireEvent, render, triggerPress, typeText, within} from '@react-spectrum/test-utils';
+import {Button} from '@react-spectrum/button';
 import {chain} from '@react-aria/utils';
 import messages from '../../../@react-aria/numberfield/intl/*';
 import {NumberField} from '../';
@@ -2155,5 +2156,34 @@ describe('NumberField', function () {
         expect(textField).toHaveAttribute('value', '123.456.789');
       });
     });
+  });
+
+  it('can be reset to blank using null', () => {
+    function NumberFieldControlled(props) {
+      let {onChange} = props;
+      let [value, setValue] = useState(10);
+      return (
+        <Provider theme={theme} scale="medium" locale="en-US">
+          <NumberField {...props} label="reset to blank using null" value={value} onChange={value => setValue(value)} />
+          <Button
+            variant={"primary"}
+            onPress={() => chain(setValue(null), onChange())}
+          >
+            Reset
+          </Button>
+        </Provider>
+      );
+    }
+    let resetSpy = jest.fn();
+    let {container, getByText} = render(<NumberFieldControlled onChange={resetSpy} />);
+    container = within(container).queryByRole('group');
+    let textField = container.firstChild;
+    let resetButton = getByText('Reset');
+
+    textField = textField.firstChild;
+    expect(textField).toHaveAttribute('value', '10');
+    triggerPress(resetButton);
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+    expect(textField).toHaveAttribute('value', '');
   });
 });

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -2163,12 +2163,11 @@ describe('NumberField', function () {
       let {onChange} = props;
       let [value, setValue] = useState(10);
       return (
-        <Provider theme={theme} scale="medium" locale="en-US">
-          <NumberField {...props} label="reset to blank using null" value={value} onChange={value => setValue(value)} />
+        <Provider theme={theme} scale='medium' locale='en-US'>
+          <NumberField {...props} label='reset to blank using null' value={value} onChange={value => setValue(value)} />
           <Button
-            variant={"primary"}
-            onPress={() => chain(setValue(null), onChange())}
-          >
+            variant={'primary'}
+            onPress={() => chain(setValue(null), onChange())}>
             Reset
           </Button>
         </Provider>

--- a/packages/@react-stately/numberfield/src/useNumberFieldState.ts
+++ b/packages/@react-stately/numberfield/src/useNumberFieldState.ts
@@ -94,7 +94,7 @@ export function useNumberFieldState(
   let numberingSystem = useMemo(() => numberParser.getNumberingSystem(inputValue), [numberParser, inputValue]);
   let formatter = useMemo(() => new NumberFormatter(locale, {...formatOptions, numberingSystem}), [locale, formatOptions, numberingSystem]);
   let intlOptions = useMemo(() => formatter.resolvedOptions(), [formatter]);
-  let format = useCallback((value: number) => isNaN(value) ? '' : formatter.format(value), [formatter]);
+  let format = useCallback((value: number) => (isNaN(value) || value === null) ? '' : formatter.format(value), [formatter]);
 
   let clampStep = !isNaN(step) ? step : 1;
   if (intlOptions.style === 'percent' && isNaN(step)) {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2216

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Check if setting `null` to value resets `NumberField` to blank, I've added a storybook example & a test for this in the PR.

Before - 
<img width="267" alt="Screen Shot 2022-11-03 at 11 43 39 AM" src="https://user-images.githubusercontent.com/19467235/199807869-7f2443e1-3a7d-4ffc-924c-3e34ab718f17.png">

After clicking the Reset button - 
<img width="248" alt="Screen Shot 2022-11-03 at 11 43 45 AM" src="https://user-images.githubusercontent.com/19467235/199807920-ab339f4b-221a-4428-9cf8-df2de2c6cadc.png">

## 🧢 Your Project:
