### PR TITLE
issue-2408: make useButton generic

### DIFF
--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -11,9 +11,9 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
-import {DOMAttributes, FocusableElement} from '@react-types/shared';
-import {ElementType, RefObject} from 'react';
+import {ElementType, HTMLAttributes, RefObject} from 'react';
 import {filterDOMProps} from '@react-aria/utils';
+import {FocusableElement} from '@react-types/shared';
 import {mergeProps} from '@react-aria/utils';
 import {useFocusable} from '@react-aria/focus';
 import {usePress} from '@react-aria/interactions';
@@ -26,21 +26,19 @@ export interface ButtonAria<T> {
   isPressed: boolean
 }
 
-type AriaButtonPropsElementType = 'button' | 'a' | 'div' | 'input' | 'span' | ElementType;
+export type AriaButtonPropsElementType = 'button' | 'a' | 'div' | 'input' | 'span' | ElementType;
 
-type HTMLAttributesElementType = HTMLButtonElement | HTMLAnchorElement | HTMLDivElement | HTMLInputElement | HTMLSpanElement;
+export type HTMLAttributesElementType = HTMLButtonElement | HTMLAnchorElement | HTMLDivElement | HTMLInputElement | HTMLSpanElement;
 
-type RefObjectElementType = HTMLAttributesElementType | Element;
+export type RefObjectElementType = HTMLAttributesElementType | Element;
 
-type ButtonAriaElementType<T = HTMLAttributesElementType> = T | DOMAttributes;
 /**
  * Provides the behavior and accessibility implementation for a button component. Handles mouse, keyboard, and touch interactions,
  * focus behavior, and ARIA props for both native button elements and custom element types.
  * @param props - Props to be applied to the button.
  * @param ref - A ref to a DOM element for the button.
  */
-export function useButton<T extends AriaButtonPropsElementType = 'button', V extends RefObjectElementType = HTMLButtonElement, W extends HTMLAttributesElementType = HTMLButtonElement>(
-  props: AriaButtonProps<T>, ref: RefObject<V>): ButtonAria<ButtonAriaElementType<W>> {
+export function useButton<T extends AriaButtonPropsElementType = 'button', V extends RefObjectElementType = HTMLButtonElement>(props: AriaButtonProps<T>, ref: RefObject<V>): ButtonAria<HTMLAttributes<any>> {
   let {
     elementType = 'button',
     isDisabled,

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -10,16 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {
-  AnchorHTMLAttributes,
-  ButtonHTMLAttributes,
-  ElementType,
-  HTMLAttributes,
-  InputHTMLAttributes,
-  RefObject
-} from 'react';
 import {AriaButtonProps} from '@react-types/button';
-import {DOMAttributes} from '@react-types/shared';
+import {DOMAttributes, FocusableElement} from '@react-types/shared';
+import {ElementType, RefObject} from 'react';
 import {filterDOMProps} from '@react-aria/utils';
 import {mergeProps} from '@react-aria/utils';
 import {useFocusable} from '@react-aria/focus';
@@ -33,20 +26,21 @@ export interface ButtonAria<T> {
   isPressed: boolean
 }
 
-// Order with overrides is important: 'button' should be default
-export function useButton(props: AriaButtonProps<'button'>, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-export function useButton(props: AriaButtonProps<'a'>, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-export function useButton(props: AriaButtonProps<'div'>, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-export function useButton(props: AriaButtonProps<'input'>, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-export function useButton(props: AriaButtonProps<'span'>, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-export function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<Element>): ButtonAria<DOMAttributes>;
+type AriaButtonPropsElementType = 'button' | 'a' | 'div' | 'input' | 'span' | ElementType;
+
+type HTMLAttributesElementType = HTMLButtonElement | HTMLAnchorElement | HTMLDivElement | HTMLInputElement | HTMLSpanElement;
+
+type RefObjectElementType = HTMLAttributesElementType | Element;
+
+type ButtonAriaElementType<T = HTMLAttributesElementType> = T | DOMAttributes;
 /**
  * Provides the behavior and accessibility implementation for a button component. Handles mouse, keyboard, and touch interactions,
  * focus behavior, and ARIA props for both native button elements and custom element types.
  * @param props - Props to be applied to the button.
  * @param ref - A ref to a DOM element for the button.
  */
-export function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
+export function useButton<T extends AriaButtonPropsElementType = 'button', V extends RefObjectElementType = HTMLButtonElement, W extends HTMLAttributesElementType = HTMLButtonElement>(
+  props: AriaButtonProps<T>, ref: RefObject<V>): ButtonAria<ButtonAriaElementType<W>> {
   let {
     elementType = 'button',
     isDisabled,
@@ -94,7 +88,7 @@ export function useButton(props: AriaButtonProps<ElementType>, ref: RefObject<an
     ref
   });
 
-  let {focusableProps} = useFocusable(props, ref);
+  let {focusableProps} = useFocusable(props, ref as RefObject<FocusableElement>);
   if (allowFocusWhenDisabled) {
     focusableProps.tabIndex = isDisabled ? -1 : focusableProps.tabIndex;
   }

--- a/packages/@react-aria/button/src/useToggleButton.ts
+++ b/packages/@react-aria/button/src/useToggleButton.ts
@@ -9,33 +9,18 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-import {
-  AnchorHTMLAttributes,
-  ButtonHTMLAttributes,
-  ElementType,
-  HTMLAttributes,
-  InputHTMLAttributes,
-  RefObject
-} from 'react';
+import {AriaButtonPropsElementType, ButtonAria, RefObjectElementType, useButton} from './useButton';
 import {AriaToggleButtonProps} from '@react-types/button';
-import {ButtonAria, useButton} from './useButton';
 import {chain} from '@react-aria/utils';
-import {DOMAttributes} from '@react-types/shared';
+import {HTMLAttributes, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {ToggleState} from '@react-stately/toggle';
 
-export function useToggleButton(props: AriaToggleButtonProps<'a'>, state: ToggleState, ref: RefObject<HTMLAnchorElement>): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-export function useToggleButton(props: AriaToggleButtonProps<'button'>, state: ToggleState, ref: RefObject<HTMLButtonElement>): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-export function useToggleButton(props: AriaToggleButtonProps<'div'>, state: ToggleState, ref: RefObject<HTMLDivElement>): ButtonAria<HTMLAttributes<HTMLDivElement>>;
-export function useToggleButton(props: AriaToggleButtonProps<'input'>, state: ToggleState, ref: RefObject<HTMLInputElement>): ButtonAria<InputHTMLAttributes<HTMLInputElement>>;
-export function useToggleButton(props: AriaToggleButtonProps<'span'>, state: ToggleState, ref: RefObject<HTMLSpanElement>): ButtonAria<HTMLAttributes<HTMLSpanElement>>;
-export function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<Element>): ButtonAria<DOMAttributes>;
 /**
  * Provides the behavior and accessibility implementation for a toggle button component.
  * ToggleButtons allow users to toggle a selection on or off, for example switching between two states or modes.
  */
-export function useToggleButton(props: AriaToggleButtonProps<ElementType>, state: ToggleState, ref: RefObject<any>): ButtonAria<HTMLAttributes<any>> {
+export function useToggleButton<T extends AriaButtonPropsElementType, V extends RefObjectElementType>(props: AriaToggleButtonProps<T>, state: ToggleState, ref: RefObject<V>): ButtonAria<HTMLAttributes<any>> {
   const {isSelected} = state;
   const {isPressed, buttonProps} = useButton({
     ...props,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2408

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
Makes sure - 
1. `useButton.test.js` passes
2. When hovering over the `useButton` hook, one can see the function signature and its doc

before - 
![135674785-d8093052-f177-4232-9c7d-c13a71f2a19c](https://user-images.githubusercontent.com/19467235/199855220-f2d5a4ac-8026-4fd3-a29d-c7814e9e5876.png)

after -
<img width="984" alt="Screen Shot 2022-11-03 at 4 32 39 PM" src="https://user-images.githubusercontent.com/19467235/199855149-66af1453-a3d3-4e38-b6c6-3d4bc78b8626.png">


## 🧢 Your Project:
