### PR TITLE
Fix TableView column does not respect minWidth #3368

### DIFF
--- a/packages/@react-spectrum/table/test/TableSizing.test.js
+++ b/packages/@react-spectrum/table/test/TableSizing.test.js
@@ -507,11 +507,66 @@ describe('TableViewSizing', function () {
         }
       });
 
+      it('should support minWidth and width working together', function () {
+        let tree = render(
+          <TableView aria-label="Table" selectionMode="multiple">
+            <TableHeader>
+              <Column key="foo" minWidth={200} width={100}>Foo</Column>
+              <Column key="bar" minWidth={500}>Bar</Column>
+              <Column key="baz">Baz</Column>
+            </TableHeader>
+            <TableBody items={items}>
+              {item =>
+                (<Row key={item.foo}>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </TableView>
+        );
+
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('38px');
+          expect(row.childNodes[1].style.width).toBe('200px');
+          expect(row.childNodes[2].style.width).toBe('500px');
+          expect(row.childNodes[3].style.width).toBe('262px');
+        }
+      });
+
       it('should support maxWidth', function () {
         let tree = render(
           <TableView aria-label="Table">
             <TableHeader>
               <Column key="foo" width={200}>Foo</Column>
+              <Column key="bar" maxWidth={300}>Bar</Column>
+              <Column key="baz">Baz</Column>
+            </TableHeader>
+            <TableBody items={items}>
+              {item =>
+                (<Row key={item.foo}>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </TableView>
+        );
+
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('200px');
+          expect(row.childNodes[1].style.width).toBe('300px');
+          expect(row.childNodes[2].style.width).toBe('500px');
+        }
+      });
+
+      it('should support maxWidth and width working together', function () {
+        let tree = render(
+          <TableView aria-label="Table">
+            <TableHeader>
+              <Column key="foo" maxWidth={500} width={200}>Foo</Column>
               <Column key="bar" maxWidth={300}>Bar</Column>
               <Column key="baz">Baz</Column>
             </TableHeader>

--- a/packages/@react-stately/table/src/useTableColumnResizeState.ts
+++ b/packages/@react-stately/table/src/useTableColumnResizeState.ts
@@ -1,5 +1,4 @@
-
-import {ColumnProps} from '@react-types/table';
+import {ColumnProps, ColumnStaticWidth, ColumnWidth} from '@react-types/table';
 import {getContentWidth, getDynamicColumnWidths, getMaxWidth, getMinWidth, isStatic, parseStaticWidth} from './utils';
 import {GridNode} from '@react-types/grid';
 import {Key, MutableRefObject, useCallback, useRef, useState} from 'react';
@@ -35,7 +34,7 @@ export interface TableColumnResizeState<T> {
 
 export interface TableColumnResizeStateProps {
   /** Callback to determine what the default width of a column should be. */
-  getDefaultWidth?: (props) => string | number,
+  getDefaultWidth?: (props) => ColumnWidth,
   /** Callback that is invoked during the entirety of the resize event. */
   onColumnResize?: (affectedColumnWidths: AffectedColumnWidths) => void,
   /** Callback that is invoked when the resize event is ended. */
@@ -73,7 +72,7 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps,
     returns the resolved column width in this order:
     previously calculated width -> controlled width prop -> uncontrolled defaultWidth prop -> dev assigned width -> default dynamic width
   */
-  let getResolvedColumnWidth = useCallback((column: GridNode<T>): (number | string) => {
+  let getResolvedColumnWidth = useCallback((column: GridNode<T>): ColumnWidth => {
     let columnProps = column.props as ColumnProps<T>;
     return resizedColumns?.has(column.key) ? columnWidthsRef.current.get(column.key) : columnProps.width ?? columnProps.defaultWidth ?? getDefaultWidth?.(column.props) ?? '1fr';
   }, [getDefaultWidth, resizedColumns]);
@@ -91,7 +90,7 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps,
 
     staticColumns.forEach(column => {
       let width = getResolvedColumnWidth(column);
-      let w = parseStaticWidth(width, tableWidth.current);
+      let w = parseStaticWidth(width as ColumnStaticWidth, tableWidth.current);
       widths.set(column.key, w);
       remainingSpace -= w;
     });

--- a/packages/@react-stately/table/src/utils.ts
+++ b/packages/@react-stately/table/src/utils.ts
@@ -1,3 +1,4 @@
+import {ColumnDynamicWidth, ColumnStaticWidth, ColumnWidth} from '@react-types/table';
 import {GridNode} from '@react-types/grid';
 import {Key} from 'react';
 
@@ -12,11 +13,11 @@ export function getContentWidth(widths: Map<Key, number>): number {
 }
 
 // numbers and percents are considered static. *fr units or a lack of units are considered dynamic.
-export function isStatic(width: number | string): boolean {
+export function isStatic(width: ColumnWidth): boolean {
   return width != null && (!isNaN(width as number) || (String(width)).match(/^(\d+)(?=%$)/) !== null);
 }
 
-function parseFractionalUnit(width: string): number {
+function parseFractionalUnit(width: ColumnDynamicWidth): number {
   if (!width) {
     return 1;
   }
@@ -30,7 +31,7 @@ function parseFractionalUnit(width: string): number {
   return parseInt(match[0], 10);
 }
 
-export function parseStaticWidth(width: number | string, tableWidth: number): number {
+export function parseStaticWidth(width: ColumnStaticWidth, tableWidth: number): number {
   if (typeof width === 'string') {
     let match = width.match(/^(\d+)(?=%$)/);
     if (!match) {
@@ -42,13 +43,13 @@ export function parseStaticWidth(width: number | string, tableWidth: number): nu
 }
 
 
-export function getMaxWidth(maxWidth: number | string, tableWidth: number): number {
+export function getMaxWidth(maxWidth: ColumnStaticWidth, tableWidth: number): number {
   return maxWidth != null
         ? parseStaticWidth(maxWidth, tableWidth)
         : Number.MAX_SAFE_INTEGER;
 }
 
-export function getMinWidth(minWidth: number | string, tableWidth: number): number {
+export function getMinWidth(minWidth: ColumnStaticWidth, tableWidth: number): number {
   return minWidth != null
       ? parseStaticWidth(minWidth, tableWidth)
       : 75;

--- a/packages/@react-stately/table/src/utils.ts
+++ b/packages/@react-stately/table/src/utils.ts
@@ -49,10 +49,10 @@ export function getMaxWidth(maxWidth: ColumnStaticWidth, tableWidth: number): nu
         : Number.MAX_SAFE_INTEGER;
 }
 
-export function getMinWidth(minWidth: ColumnStaticWidth, tableWidth: number): number {
-  return minWidth != null
-      ? parseStaticWidth(minWidth, tableWidth)
-      : 75;
+export function getMinWidth(minWidth: ColumnStaticWidth, width: ColumnStaticWidth, tableWidth: number): number | undefined {
+  const parsedMinWidth: number = parseStaticWidth(minWidth, tableWidth);
+  const parsedWidth: number = parseStaticWidth(width, tableWidth);
+  return (parsedMinWidth && parsedWidth) ? Math.max(parsedMinWidth, parsedWidth) : parsedWidth ?? parsedMinWidth ?? 75;
 }
 
 function mapDynamicColumns<T>(dynamicColumns: GridNode<T>[], availableSpace: number, tableWidth: number): mappedColumn<T>[] {
@@ -65,7 +65,7 @@ function mapDynamicColumns<T>(dynamicColumns: GridNode<T>[], availableSpace: num
     const targetWidth =
           (parseFractionalUnit(column.props.defaultWidth) * availableSpace) / fractions;
     const delta = Math.max(
-      getMinWidth(column.props.minWidth, tableWidth) - targetWidth,
+      getMinWidth(column.props.minWidth,  column.props.width, tableWidth) - targetWidth,
       targetWidth - getMaxWidth(column.props.maxWidth, tableWidth)
     );
 
@@ -89,7 +89,7 @@ function findDynamicColumnWidths<T>(dynamicColumns: mappedColumn<T>[], available
     const targetWidth =
       (parseFractionalUnit(column.props.defaultWidth) * availableSpace) / fractions;
     let width = Math.max(
-      getMinWidth(column.props.minWidth, tableWidth),
+      getMinWidth(column.props.minWidth, column.props.width, tableWidth),
       Math.min(Math.floor(targetWidth), getMaxWidth(column.props.maxWidth, tableWidth))
     );
     column.calculatedWidth = width;

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -141,7 +141,7 @@ export type CellElement = ReactElement<CellProps>;
 export type CellRenderer = (columnKey: Key) => CellElement;
 
 export interface TableCollection<T> extends GridCollection<T> {
-  // TODO perhaps elaborate on this? maybe not clear enought, essentially returns the table header rows (e.g. in a tiered headers table, will return the nodes containing the top tier column, next tier, etc)
+  // TODO perhaps elaborate on this? maybe not clear enough, essentially returns the table header rows (e.g. in a tiered headers table, will return the nodes containing the top tier column, next tier, etc)
   /** A list of header row nodes in the table. */
   headerRows: GridNode<T>[],
   /** A list of column nodes in the table. */

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -67,16 +67,16 @@ export interface ColumnProps<T> {
   /** A list of child columns used when dynamically rendering nested child columns. */
   childColumns?: T[],
   /** The width of the column. */
-  width?: number | string,
+  width?: ColumnStaticWidth,
   /** The minimum width of the column. */
-  minWidth?: number | string,
+  minWidth?: ColumnStaticWidth,
   /** The maximum width of the column. */
-  maxWidth?: number | string,
+  maxWidth?: ColumnStaticWidth,
   /**
    * The default width of the column.
    * @private
    */
-  defaultWidth?: number | string,
+  defaultWidth?: ColumnWidth,
   /**
    * Whether the column allows resizing.
    * @private
@@ -151,3 +151,9 @@ export interface TableCollection<T> extends GridCollection<T> {
   /** The node that makes up the body of the table. */
   body: GridNode<T>
 }
+/** The width value from input property. */
+export type ColumnStaticWidth = number | `${number}` | `${number}%`; // match regex: /^(\d+)(?=%$)/
+/** The width value calculated dynamically according to the available space since there's no input property value. */
+export type ColumnDynamicWidth = `${number}fr`; // match regex: /^(\d+)(?=fr$)/
+/** The width value from input property or calculated dynamically. */
+export type ColumnWidth = ColumnStaticWidth | ColumnDynamicWidth;


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/3368

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue 3368](https://github.com/adobe/react-spectrum/issues/3368).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
-Run the examples on TableSizing.test.js
-Create a storybook with a table whose column has minWidth greater than width, minWidth should be displayed instead of width

## 🧢 Your Project: