### PR TITLE
Fix TextArea not using full height when custom height provided

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -71,6 +71,7 @@ governing permissions and limitations under the License.
                          "field field field"
                          "helpText helpText helpText";
     grid-template-columns: auto auto minmax(0, 1fr);
+    grid-template-rows: auto 1fr auto;
     align-content: start;
     width: var(--spectrum-field-default-width);
 

--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -188,6 +188,10 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-Textfield-wrapper.spectrum-Textfield-wrapper--quiet{
+  grid-template-rows: auto;
+}
+
 .spectrum-Textfield-wrapper .spectrum-Textfield--multiline {
   /* when textarea is inside a label wrapper, make it flex to take up remaining height. */
   flex: 1 1 auto;

--- a/packages/@react-spectrum/textfield/chromatic/TextArea.chromatic.js
+++ b/packages/@react-spectrum/textfield/chromatic/TextArea.chromatic.js
@@ -82,6 +82,9 @@ storiesOf('TextArea', module)
   .add('custom width',
     () => render({icon: <Info />, validationState: 'invalid', width: 275})
   )
+  .add('custom height',
+    () => render({icon: <Info />, validationState: 'invalid', height: 350})
+  )
   .add(
     'value: 測試, icon: Info, labelPosition: side, validationState: valid',
     () => render({value: '測試', icon: <Info />, labelPosition: 'side', validationState: 'valid'})

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -143,7 +143,15 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
       labelProps={labelProps}
       descriptionProps={descriptionProps}
       errorMessageProps={errorMessageProps}
-      wrapperClassName={classNames(styles, 'spectrum-Textfield-wrapper')}
+      wrapperClassName={
+        classNames(
+          styles,
+          'spectrum-Textfield-wrapper',
+          {
+            'spectrum-Textfield-wrapper--quiet': isQuiet
+          }
+        )
+      }
       showErrorIcon={false}
       ref={domRef}>
       {textField}


### PR DESCRIPTION
Seems to have broken in https://github.com/adobe/react-spectrum/pull/3521

For labelPosition: top, when a fixed height is provided, the textarea doesn't fill the height of its container.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

In Storybook, go to TextArea -> Custom height with label

Verify that textarea now fills its container.

Double check other TextArea stories and height behavior when typing.

Ensure that quiet TextArea grows to a max of the specified height when typing, and the help text is just below the line.

## 🧢 Your Project:

<!--- Company/project for pull request -->
