### PR TITLE
Add preventDefault to onDragEnter and onDragLeave for iPad

### DIFF
--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -164,6 +164,7 @@ export function useDrop(options: DropOptions): DropResult {
   };
 
   let onDragEnter = (e: DragEvent) => {
+    e.preventDefault();
     e.stopPropagation();
     state.dragOverElements.add(e.target as Element);
     if (state.dragOverElements.size > 1) {
@@ -200,6 +201,7 @@ export function useDrop(options: DropOptions): DropResult {
   };
 
   let onDragLeave = (e: DragEvent) => {
+    e.preventDefault();
     e.stopPropagation();
 
     // We would use e.relatedTarget to detect if the drag is still inside the drop target,


### PR DESCRIPTION
Previously, I noticed that sometimes dropping items on iPad would cause Safari to do a google search for the dropped data. I have not been able to reproduce this after adding `preventDefault` in the onDragEnter and onDragLeave events.