### PR TITLE
Fix useListData so that reorder operations are correctly inserted at the correct index

### DIFF
--- a/packages/@react-spectrum/list/test/ListViewDnd.test.js
+++ b/packages/@react-spectrum/list/test/ListViewDnd.test.js
@@ -421,17 +421,17 @@ describe('ListView', function () {
         fireEvent(cell, new DragEvent('dragstart', {dataTransfer, clientX: 0, clientY: 0}));
         expect(onDragStart).toHaveBeenCalledTimes(1);
 
-        fireEvent.pointerMove(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 1, clientY: 110});
-        fireEvent(cell, new DragEvent('drag', {dataTransfer, clientX: 1, clientY: 110}));
-        fireEvent(grid, new DragEvent('dragover', {dataTransfer, clientX: 1, clientY: 110}));
-        fireEvent.pointerUp(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 1, clientY: 110});
+        fireEvent.pointerMove(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 1, clientY: 150});
+        fireEvent(cell, new DragEvent('drag', {dataTransfer, clientX: 1, clientY: 150}));
+        fireEvent(grid, new DragEvent('dragover', {dataTransfer, clientX: 1, clientY: 150}));
+        fireEvent.pointerUp(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 1, clientY: 150});
 
-        fireEvent(grid, new DragEvent('drop', {dataTransfer, clientX: 1, clientY: 110}));
+        fireEvent(grid, new DragEvent('drop', {dataTransfer, clientX: 1, clientY: 150}));
         act(() => jest.runAllTimers());
         await act(async () => Promise.resolve());
         expect(onDrop).toHaveBeenCalledTimes(1);
 
-        fireEvent(cell, new DragEvent('dragend', {dataTransfer, clientX: 1, clientY: 110}));
+        fireEvent(cell, new DragEvent('dragend', {dataTransfer, clientX: 1, clientY: 150}));
         expect(onDragEnd).toHaveBeenCalledTimes(1);
 
         act(() => jest.runAllTimers());

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -326,7 +326,7 @@ function insert<T>(state: ListState<T>, index: number, ...values: T[]): ListStat
 
 function move<T>(state: ListState<T>, indices: number[], toIndex: number): ListState<T> {
   // Shift the target down by the number of items being moved from before the target
-  toIndex = toIndex - indices.filter(index => index < toIndex).length;
+  toIndex -= indices.filter(index => index < toIndex).length;
 
   let moves = indices.map(from => ({
     from,

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -326,11 +326,7 @@ function insert<T>(state: ListState<T>, index: number, ...values: T[]): ListStat
 
 function move<T>(state: ListState<T>, indices: number[], toIndex: number): ListState<T> {
   // Shift the target down by the number of items being moved from before the target
-  for (let index of indices) {
-    if (index < toIndex) {
-      toIndex--;
-    }
-  }
+  toIndex = toIndex - indices.filter(index => index < toIndex).length;
 
   let moves = indices.map(from => ({
     from,

--- a/packages/@react-stately/data/test/useListData.test.js
+++ b/packages/@react-stately/data/test/useListData.test.js
@@ -601,6 +601,26 @@ describe('useListData', function () {
         many[5]
       ]);
     });
+
+    it('should move multiple items before another item to after that item', function () {
+      let {result} = renderHook(() => useListData({initialItems: many, getKey}));
+      let initialResult = result.current;
+
+      act(() => {
+        result.current.moveAfter('Five', ['Two', 'Three', 'Four']);
+      });
+
+      expect(result.current.items).not.toBe(initialResult.items);
+      expect(result.current.items).toHaveLength(6);
+      expect(result.current.items).toEqual([
+        many[0],
+        many[4],
+        many[1],
+        many[2],
+        many[3],
+        many[5]
+      ]);
+    });
   });
 
   it('should support filtering', function () {


### PR DESCRIPTION
Specifically fix it for cases where the user is reordering a set of sequential items (3 items or more) and is moving it to a drop position one below the last item being moved. Addresses the comment  made here https://github.com/adobe/react-spectrum/pull/3423#discussion_r982907881

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the ListView DnD reorder stories and select the top three items. Drag them after the fourth item and verify that the items are reordered correctly. 
To contrast, here is a broken example: https://reactspectrum.blob.core.windows.net/reactspectrum/842a0ed0ace6e17adee425286056456d0061d9a1/storybook/index.html?path=/story/listview-drag-and-drop-util-handlers--drag-within-list-reorder&providerSwitcher-toastPosition=bottom

Selecting and moving the top three items down one item actually moves them down two items (e.g. "Utilities" folder becomes the 2nd item in the list when it should have just moved the top three items after "Adobe inDesign")

## 🧢 Your Project:

RSP
