### PR TITLE
Fix resize menu with onExited instead

### DIFF
--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -73,7 +73,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
   let overlay;
   if (isMobile) {
     overlay = (
-      <Tray state={state}>
+      <Tray state={state} onExited={props.onExited}>
         {menu}
       </Tray>
     );

--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -654,18 +654,6 @@ function ResizableTableColumnHeader(props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allowsSorting]);
 
-  useEffect(() => {
-    if (columnState.currentlyResizingColumn === column.key) {
-      // focusSafely won't actually focus because the focus moves from the menuitem to the body during the after transition wait
-      // without the immediate timeout, Android Chrome doesn't move focus to the resizer
-      setTimeout(() => {
-        resizingRef.current.focus();
-        onFocusedResizer();
-      }, 0);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnState.currentlyResizingColumn, column.key]);
-
   let showResizer = !isEmpty && ((headerRowHovered && getInteractionModality() !== 'keyboard') || columnState.currentlyResizingColumn != null);
 
   return (
@@ -697,7 +685,16 @@ function ResizableTableColumnHeader(props) {
             )
           )
         }>
-        <MenuTrigger>
+        <MenuTrigger onExited={() => {
+          if (columnState.currentlyResizingColumn === column.key) {
+            // focusSafely won't actually focus because the focus moves from the menuitem to the body during the after transition wait
+            // without the immediate timeout, Android Chrome doesn't move focus to the resizer
+            setTimeout(() => {
+              resizingRef.current.focus();
+              onFocusedResizer();
+            }, 0);
+          }
+        }}>
           <TableColumnHeaderButton ref={triggerRef} focusProps={focusProps}>
             {columnProps.allowsSorting &&
               <ArrowDownSmall UNSAFE_className={classNames(styles, 'spectrum-Table-sortedIcon')} />


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
