### PR TITLE
Fix mobile column resizing

### DIFF
--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -14,7 +14,14 @@ import ArrowDownSmall from '@spectrum-icons/ui/ArrowDownSmall';
 import {chain, mergeProps, useLayoutEffect} from '@react-aria/utils';
 import {Checkbox} from '@react-spectrum/checkbox';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
-import {classNames, useDOMRef, useFocusableRef, useStyleProps, useUnwrapDOMRef} from '@react-spectrum/utils';
+import {
+  classNames,
+  useDOMRef,
+  useFocusableRef,
+  useIsMobileDevice,
+  useStyleProps,
+  useUnwrapDOMRef
+} from '@react-spectrum/utils';
 import {DOMRef, FocusableRef, MoveMoveEvent} from '@react-types/shared';
 import {FocusRing, FocusScope, useFocusRing} from '@react-aria/focus';
 import {getInteractionModality, useHover, usePress} from '@react-aria/interactions';
@@ -653,18 +660,26 @@ function ResizableTableColumnHeader(props) {
     return options;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allowsSorting]);
+  let isMobile = useIsMobileDevice();
 
   useEffect(() => {
     if (columnState.currentlyResizingColumn === column.key) {
       // focusSafely won't actually focus because the focus moves from the menuitem to the body during the after transition wait
       // without the immediate timeout, Android Chrome doesn't move focus to the resizer
+      if (isMobile) {
+        setTimeout(() => {
+          resizingRef.current.focus();
+          onFocusedResizer();
+        }, 400);
+        return;
+      }
       setTimeout(() => {
         resizingRef.current.focus();
         onFocusedResizer();
       }, 0);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnState.currentlyResizingColumn, column.key]);
+  }, [columnState.currentlyResizingColumn, column.key, isMobile]);
 
   let showResizer = !isEmpty && ((headerRowHovered && getInteractionModality() !== 'keyboard') || columnState.currentlyResizingColumn != null);
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

This fixes the case where the Tray must animate out before focus can be sent to the Resizer. Animating out is 350ms, so we wait 400ms to be safe.
Other changes were deemed too sweeping before release. We explored adding onExited (and other transition props) to all our triggers so we could know when to move focus after the FocusScope was unmounted. We also explored adding isExiting to Overlays so that we can end focus containment as a component is animating out.

Both of these added API's and changed core functionality that we didn't feel comfortable putting in the release with so little testing.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Using a mobile device, go to a Table story with resizing columns. Try to enter resizing mode via touch interactions.

## 🧢 Your Project:

<!--- Company/project for pull request -->
