### PR TITLE
Preventing tabs storybook collapse behavior from having no items

### DIFF
--- a/packages/@react-spectrum/tabs/stories/Tabs.stories.tsx
+++ b/packages/@react-spectrum/tabs/stories/Tabs.stories.tsx
@@ -446,9 +446,11 @@ let DynamicTabs = (props: Omit<SpectrumTabsProps<DynamicTabItem>, 'children'>) =
   };
 
   let removeTab = () => {
-    let newTabs = [...tabs];
-    newTabs.pop();
-    setTabs(newTabs);
+    if (tabs.length > 1) {
+      let newTabs = [...tabs];
+      newTabs.pop();
+      setTabs(newTabs);
+    }
   };
 
   return (


### PR DESCRIPTION
found during testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Goto the Tabs -> Collapse behavior story and try to remove all the tabs. You can no longer so that. There must always be one tab.

## 🧢 Your Project:
RSP