### PR TITLE
Properly restore original page scrollability for DialogContainer case

### DIFF
--- a/packages/@react-aria/overlays/test/usePreventScroll.test.js
+++ b/packages/@react-aria/overlays/test/usePreventScroll.test.js
@@ -48,6 +48,22 @@ describe('usePreventScroll', function () {
     expect(document.documentElement).not.toHaveStyle('overflow: hidden');
   });
 
+  it('should work with nested/multiple modals regardless of unmount order', function () {
+    expect(document.documentElement).not.toHaveStyle('overflow: hidden');
+
+    let one = render(<Example />);
+    expect(document.documentElement).toHaveStyle('overflow: hidden');
+
+    let two = render(<Example />);
+    expect(document.documentElement).toHaveStyle('overflow: hidden');
+
+    one.unmount();
+    expect(document.documentElement).toHaveStyle('overflow: hidden');
+
+    two.unmount();
+    expect(document.documentElement).not.toHaveStyle('overflow: hidden');
+  });
+
   it('should remove overflow: hidden when isDisabled option is true', function () {
     expect(document.documentElement).not.toHaveStyle('overflow: hidden');
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/3782

Some additional regression history for the prevent scroll issue: this issue was present with in the [original PR](https://github.com/adobe/react-spectrum/pull/3475) that introduced preventing scroll when popovers were open (note that said behavior was also [reverted](https://github.com/adobe/react-spectrum/pull/3583) until the new overlay hooks update happened). Prior to this open popovers didn’t prevent page scroll which is why this DialogContainer issue wasn’t a thing previously

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test the "Dialog triggered by a menu item" example in the DialogContainer docs on all browsers and platforms. You should be able to scroll after closing the final dialog

## 🧢 Your Project:

RSP
