### PR TITLE
live-announcer incorrectly copies visually hidden styles

### DIFF
--- a/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
+++ b/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
@@ -70,12 +70,12 @@ class LiveAnnouncer {
       border: 0,
       clip: 'rect(0 0 0 0)',
       clipPath: 'inset(50%)',
-      height: 1,
+      height: '1px',
       margin: '0 -1px -1px 0',
       overflow: 'hidden',
       padding: 0,
       position: 'absolute',
-      width: 1,
+      width: '1px',
       whiteSpace: 'nowrap'
     });
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/3791

`Object.assign` `node.style` does not accept `1` as a value for width and height; it requires `'1px'`

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

This code sandbox shows what bug this PR fixes: https://codesandbox.io/s/eager-jackson-gy3btv?file=/package.json

