### PR TITLE
fix(#3804): usePopover: non-modal popover allows page and popover to scroll when target has position: fixed

### DIFF
--- a/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/combobox/stories/ComboBox.stories.tsx
@@ -509,6 +509,40 @@ storiesOf('ComboBox', module)
         {renderRow({validationState: 'invalid', isQuiet: true})}
       </Flex>
     )
+  )
+  .add(
+    'Fixed positioning',
+    () => (
+      <>
+        <div
+          style={{
+            position: 'fixed',
+            top: 'calc(50vh - var(--spectrum-global-dimension-size-400) - 1.3 * var(--spectrum-global-dimension-size-150)'
+          }}>
+          <AsyncLoadingExample />
+        </div>
+        <div
+          style={{
+            position: 'relative',
+            height: '200vh'
+          }}>
+          <div
+            style={{
+              position: 'absolute',
+              top: '0'
+            }}>
+            Top
+          </div>
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '0'
+            }}>
+            Bottom
+          </div>
+        </div>
+      </>
+    )
   );
 
 


### PR DESCRIPTION
Closes #3804

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue #3804](https://github.com/adobe/react-spectrum/issue/3804).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

Adobe/Accessibility
