### PR TITLE
Fix error during React Fast Refresh in storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,9 +18,9 @@ export const parameters = {
 };
 
 export const decorators = [
-  story => (
+  Story => (
     <VerticalCenter style={{alignItems: 'center', minHeight: '100vh', boxSizing: 'border-box', display: 'flex', justifyContent: 'center'}}>
-      {story()}
+      <Story />
     </VerticalCenter>
   ),
   withProviderSwitcher


### PR DESCRIPTION
Fixes the error often seen in storybook when saving a file: "rendered more hooks than during the previous render".