### PR TITLE
Fix docs examples where braces are removed

### DIFF
--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -316,7 +316,7 @@ module.exports = new Transformer({
               if (node.properties?.className === 'comment' && /- begin highlight -/.test(node.children[0].value)) {
                 // Handle JSX-style comments, e.g. {/* foo */}
                 let prev = parent.children[index - 1];
-                if (prev?.children?.[0]?.value === '{') {
+                if (prev?.children?.[0]?.value === '{' && !node.children[0].value.startsWith('///')) {
                   prev.children = [];
                   prev = parent.children[index - 2];
                 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

dprint is affecting our code in such a way that sometimes when highlighting we end up removing a starting curly brace

see https://react-spectrum.adobe.com/react-aria/useDroppableCollection.html#reordering search for "...mergeProps(optionProps, dragProps, dropProps, focusProps)" to find the highlighted line in question

see this link to see what dprint is doing
https://dprint.dev/playground/#code/GYVwdgxgLglg9mABAJQKZwE4BNUYIYBGANqgDIwDOUAQnAB4AUADhnExQJSIDeAUIogyooIDEgb8BiADwA+SVJlEYCxYgD0mgLSICqAOYwkACxj7jy81ERbN61Yu4A6FwFtc+1AAVW7Bm1gEHzYKABpELHx9YPZwyLYYsMRgOAgQCkSOAF8HKTsdVDAsRFNzS2NrW01cgSFgAF5uOqz5etzpdWV5RQ7uxA4Abl4soA/language/typescript

this might be a dprint bug or might be fixable with one of its options, but I'm not super familiar with it, so starting here.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
