### PR TITLE
Surface useOverlayPosition's updatePosition from usePopover

### DIFF
--- a/packages/@react-aria/overlays/src/usePopover.ts
+++ b/packages/@react-aria/overlays/src/usePopover.ts
@@ -57,7 +57,9 @@ export interface PopoverAria {
   /** Props to apply to the underlay element, if any. */
   underlayProps: DOMAttributes,
   /** Placement of the popover with respect to the trigger. */
-  placement: PlacementAxis
+  placement: PlacementAxis,
+  /** Updates the position of the overlay. */
+  updatePosition(): void
 }
 
 /**
@@ -84,7 +86,7 @@ export function usePopover(props: AriaPopoverProps, state: OverlayTriggerState):
     popoverRef
   );
 
-  let {overlayProps: positionProps, arrowProps, placement} = useOverlayPosition({
+  let {overlayProps: positionProps, arrowProps, placement, updatePosition} = useOverlayPosition({
     ...otherProps,
     targetRef: triggerRef,
     overlayRef: popoverRef,
@@ -116,6 +118,7 @@ export function usePopover(props: AriaPopoverProps, state: OverlayTriggerState):
     popoverProps: mergeProps(overlayProps, positionProps),
     arrowProps,
     underlayProps,
-    placement
+    placement,
+    updatePosition
   };
 }


### PR DESCRIPTION
The 'updatePosition' is still important when using popovers, eg if using react transitiongroup for a popover, as the position cannot be calculated while the contents is not mounted. This PR surfaces the callback.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
