### PR TITLE
Create FocusScope nodes top down and add them bottom up

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -130,7 +130,7 @@ export function FocusScope(props: FocusScopeProps) {
   useAutoFocus(scopeRef, autoFocus);
 
   // this layout effect needs to run last so that focusScopeTree cleanup happens at the last moment possible
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (scopeRef) {
       let activeElement = document.activeElement;
       let scope = null;


### PR DESCRIPTION
Simplification of #3878.

It works by creating the tree nodes during render (top down), and passing them down via context. In a layout effect (bottom up), it adds itself to its parent and to the tree. If the parent is already in the tree, then we consider `activeScope` as the parent.