### PR TITLE
Fix publishing nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chromatic": "NODE_ENV=production CHROMATIC=1 chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name 'build:chromatic'",
     "merge:css": "babel-node --presets @babel/env ./scripts/merge-spectrum-css.js",
     "release": "lerna publish from-package --yes",
-    "publish:nightly": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=* --no-push",
+    "publish:nightly": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=* --no-push --no-verify-access",
     "build:api-published": "node scripts/buildPublishedAPI.js",
     "build:api-branch": "node scripts/buildBranchAPI.js",
     "compare:apis": "node scripts/compareAPIs.js",


### PR DESCRIPTION
The new token is an npm automation token which isn't supported by our version of lerna: https://github.com/lerna/lerna/issues/2788. This just ignores the auth check for now.