### PR TITLE
Remove unnecessary `onColumnResize/Start/End` from useTableColumnResizeState

### DIFF
--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -87,7 +87,7 @@ export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, st
       lastSize.current = state.onColumnResize(item.key, state.getColumnWidth(item.key));
     }
     if (isResizing.current) {
-      state.onColumnResizeEnd(item.key);
+      state.onColumnResizeEnd();
       onResizeEnd?.(lastSize.current);
     }
     isResizing.current = false;

--- a/packages/@react-stately/table/src/useTableColumnResizeState.ts
+++ b/packages/@react-stately/table/src/useTableColumnResizeState.ts
@@ -64,6 +64,7 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps<
     getDefaultMinWidth,
     onColumnResizeStart: propsOnColumnResizeStart,
     onColumnResizeEnd: propsOnColumnResizeEnd,
+    onColumnResize: propsOnColumnResize,
     tableWidth = 0
   } = props;
 
@@ -101,9 +102,9 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps<
     let map = new Map(Array.from(uncontrolledColumns).map(([key]) => [key, newSizes.get(key)]));
     map.set(key, width);
     setUncontrolledWidths(map);
-
+    propsOnColumnResize(newSizes);
     return newSizes;
-  }, [controlledColumns, uncontrolledColumns, setUncontrolledWidths, tableWidth, columnLayout, state.collection, uncontrolledWidths]);
+  }, [controlledColumns, uncontrolledColumns, setUncontrolledWidths, tableWidth, columnLayout, state.collection, uncontrolledWidths, propsOnColumnResize]);
 
   let onColumnResizeEnd = useCallback((key: Key) => {
     setResizingColumn(null);

--- a/packages/@react-stately/table/src/useTableColumnResizeState.ts
+++ b/packages/@react-stately/table/src/useTableColumnResizeState.ts
@@ -25,13 +25,7 @@ export interface TableColumnResizeStateProps<T> {
   /** A function that is called to find the default width for a given column. */
   getDefaultWidth?: (node: GridNode<T>) => ColumnSize | null | undefined,
   /** A function that is called to find the default minWidth for a given column. */
-  getDefaultMinWidth?: (node: GridNode<T>) => ColumnSize | null | undefined,
-  /** Callback that is invoked during the entirety of the resize event. */
-  onColumnResize?: (widths: Map<Key, ColumnSize>) => void,
-  /** Callback that is invoked when the resize event is started. */
-  onColumnResizeStart?: (key: Key) => void,
-  /** Callback that is invoked when the resize event is ended. */
-  onColumnResizeEnd?: (key: Key) => void
+  getDefaultMinWidth?: (node: GridNode<T>) => ColumnSize | null | undefined
 }
 export interface TableColumnResizeState<T> {
   /**
@@ -42,7 +36,7 @@ export interface TableColumnResizeState<T> {
   /** Callback for when onColumnResize has started. */
   onColumnResizeStart: (key: Key) => void,
   /** Callback for when onColumnResize has ended. */
-  onColumnResizeEnd: (key: Key) => void,
+  onColumnResizeEnd: () => void,
   /** Gets the current width for the specified column. */
   getColumnWidth: (key: Key) => number,
   /** Gets the current minWidth for the specified column. */
@@ -62,9 +56,6 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps<
   let {
     getDefaultWidth,
     getDefaultMinWidth,
-    onColumnResizeStart: propsOnColumnResizeStart,
-    onColumnResizeEnd: propsOnColumnResizeEnd,
-    onColumnResize: propsOnColumnResize,
     tableWidth = 0
   } = props;
 
@@ -92,8 +83,7 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps<
 
   let onColumnResizeStart = useCallback((key: Key) => {
     setResizingColumn(key);
-    propsOnColumnResizeStart?.(key);
-  }, [propsOnColumnResizeStart, setResizingColumn]);
+  }, [setResizingColumn]);
 
   let onColumnResize = useCallback((key: Key, width: number): Map<Key, ColumnSize> => {
     let newControlled = new Map(Array.from(controlledColumns).map(([key, entry]) => [key, entry.props.width]));
@@ -102,14 +92,12 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps<
     let map = new Map(Array.from(uncontrolledColumns).map(([key]) => [key, newSizes.get(key)]));
     map.set(key, width);
     setUncontrolledWidths(map);
-    propsOnColumnResize?.(newSizes);
     return newSizes;
-  }, [controlledColumns, uncontrolledColumns, setUncontrolledWidths, tableWidth, columnLayout, state.collection, uncontrolledWidths, propsOnColumnResize]);
+  }, [controlledColumns, uncontrolledColumns, setUncontrolledWidths, tableWidth, columnLayout, state.collection, uncontrolledWidths]);
 
-  let onColumnResizeEnd = useCallback((key: Key) => {
+  let onColumnResizeEnd = useCallback(() => {
     setResizingColumn(null);
-    propsOnColumnResizeEnd?.(key);
-  }, [propsOnColumnResizeEnd, setResizingColumn]);
+  }, [setResizingColumn]);
 
   let columnWidths = useMemo(() =>
       columnLayout.buildColumnWidths(tableWidth, state.collection, colWidths)

--- a/packages/@react-stately/table/src/useTableColumnResizeState.ts
+++ b/packages/@react-stately/table/src/useTableColumnResizeState.ts
@@ -102,7 +102,7 @@ export function useTableColumnResizeState<T>(props: TableColumnResizeStateProps<
     let map = new Map(Array.from(uncontrolledColumns).map(([key]) => [key, newSizes.get(key)]));
     map.set(key, width);
     setUncontrolledWidths(map);
-    propsOnColumnResize(newSizes);
+    propsOnColumnResize?.(newSizes);
     return newSizes;
   }, [controlledColumns, uncontrolledColumns, setUncontrolledWidths, tableWidth, columnLayout, state.collection, uncontrolledWidths, propsOnColumnResize]);
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
