### PR TITLE
[WIP] Add DnD test util

### DIFF
--- a/packages/dev/test-utils/package.json
+++ b/packages/dev/test-utils/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-aria/dnd": "^3.0.1",
     "@react-aria/ssr": "^3.0.0",
     "@swc/helpers": "^0.4.14",
     "resolve": "^1.17.0"

--- a/packages/dev/test-utils/src/dnd.ts
+++ b/packages/dev/test-utils/src/dnd.ts
@@ -85,7 +85,6 @@ async function performDragAndDrop(source: Element, target: Element, delta: Delta
   } else if (type === 'touch') {
     fireEvent.touchEnd(source, current);
   }
-  console.log('here');
 
   fireEvent(source, new DragEvent('dragend', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));
   fireEvent(target, new DragEvent('drop', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));

--- a/packages/dev/test-utils/src/dnd.ts
+++ b/packages/dev/test-utils/src/dnd.ts
@@ -100,34 +100,40 @@ async function performDragAndDrop(source: Element, target: Element, delta: Delta
  */
 export function drag(source: Element) {
   return {
+    /** Drag an element onto the center of another element. */
     to: (target: Element) => ({
       with: async (type: DragPointerType) => {
         return await performDragAndDrop(source, target, {x: 0, y: 0}, type);
       }
     }),
+    /** Drag an element by a specific delta. */
     by: ({x, y}: Delta) => ({
       with: async (type: DragPointerType) => {
         return await performDragAndDrop(source, null, {x, y}, type);
       }
     }),
+    /** Drag an element just above another element. */
     above: (target: Element) => ({
       with: async (type: DragPointerType) => {
         let delta = {x: 0, y: -target.getBoundingClientRect().height / 2 - 1};
         return await performDragAndDrop(source, target, delta, type);
       }
     }),
+    /** Drag an element just below another element. */
     below: (target: Element) => ({
       with: async (type: DragPointerType) => {
         let delta = {x: 0, y: target.getBoundingClientRect().height / 2 + 1};
         return await performDragAndDrop(source, target, delta, type);
       }
     }),
+    /** Drag an element just to the left of another element. */
     before: (target: Element) => ({
       with: async (type: DragPointerType) => {
         let delta = {x: 0, y: -target.getBoundingClientRect().height / 2 - 1};
         return await performDragAndDrop(source, target, delta, type);
       }
     }),
+    /** Drag an element just to the right of another element. */
     after: (target: Element) => ({
       with: async (type: DragPointerType) => {
         let delta = {x: 0, y: target.getBoundingClientRect().height / 2 + 1};

--- a/packages/dev/test-utils/src/dnd.ts
+++ b/packages/dev/test-utils/src/dnd.ts
@@ -18,18 +18,19 @@ async function performDragAndDrop(source: Element, target: Element, delta: Delta
   let from = getElementCenter(source);
   let to = {x: 0, y: 0};
 
-  if (target) {
+  if (delta && target) {
+    let targetCenter = getElementCenter(target);
+    to = {x: targetCenter.x + delta.x, y: targetCenter.y + delta.y};
+  } else if (target) {
     to = getElementCenter(target);
   } else if (delta) {
     to = {x: from.x + delta.x, y: from.y + delta.y};
   }
 
-
   let step = {
     x: (to.x - from.x) / steps,
     y: (to.y - from.y) / steps
   };
-
 
   let current = {
     clientX: from.x,
@@ -107,6 +108,30 @@ export function drag(source: Element) {
     by: ({x, y}: Delta) => ({
       with: async (type: DragPointerType) => {
         return await performDragAndDrop(source, null, {x, y}, type);
+      }
+    }),
+    above: (target: Element) => ({
+      with: async (type: DragPointerType) => {
+        let delta = {x: 0, y: -target.getBoundingClientRect().height / 2 - 1};
+        return await performDragAndDrop(source, target, delta, type);
+      }
+    }),
+    below: (target: Element) => ({
+      with: async (type: DragPointerType) => {
+        let delta = {x: 0, y: target.getBoundingClientRect().height / 2 + 1};
+        return await performDragAndDrop(source, target, delta, type);
+      }
+    }),
+    before: (target: Element) => ({
+      with: async (type: DragPointerType) => {
+        let delta = {x: 0, y: -target.getBoundingClientRect().height / 2 - 1};
+        return await performDragAndDrop(source, target, delta, type);
+      }
+    }),
+    after: (target: Element) => ({
+      with: async (type: DragPointerType) => {
+        let delta = {x: 0, y: target.getBoundingClientRect().height / 2 + 1};
+        return await performDragAndDrop(source, target, delta, type);
       }
     })
   };

--- a/packages/dev/test-utils/src/dnd.ts
+++ b/packages/dev/test-utils/src/dnd.ts
@@ -14,7 +14,7 @@ function getElementCenter(element: Element) {
   };
 }
 
-async function performDrag(source: Element, target: Element, delta: Delta, type: DragPointerType = 'mouse', steps = 1, duration = 0) {
+async function performDragAndDrop(source: Element, target: Element, delta: Delta, type: DragPointerType = 'mouse', steps = 1, duration = 0) {
   let from = getElementCenter(source);
   let to = {x: 0, y: 0};
 
@@ -95,19 +95,19 @@ async function performDrag(source: Element, target: Element, delta: Delta, type:
 /**
  * Drag an element onto another element, or by a specific delta.
  * @example
- * drag(source).to(target).with('mouse');
- * drag(source).by({x: 100, y: 100}).with('touch');
+ * let dataTransfer = await drag(source).to(target).with('mouse');
+ * let dataTransfer = await drag(source).by({x: 100, y: 100}).with('touch');
  */
 export function drag(source: Element) {
   return {
     to: (target: Element) => ({
       with: async (type: DragPointerType) => {
-        return await performDrag(source, target, {x: 0, y: 0}, type);
+        return await performDragAndDrop(source, target, {x: 0, y: 0}, type);
       }
     }),
     by: ({x, y}: Delta) => ({
       with: async (type: DragPointerType) => {
-        return await performDrag(source, null, {x, y}, type);
+        return await performDragAndDrop(source, null, {x, y}, type);
       }
     })
   };

--- a/packages/dev/test-utils/src/dnd.ts
+++ b/packages/dev/test-utils/src/dnd.ts
@@ -1,0 +1,114 @@
+import {act, fireEvent} from '@testing-library/react';
+// eslint-disable-next-line monorepo/no-internal-import
+import {DataTransfer, DragEvent} from '@react-aria/dnd/test/mocks';
+
+type DragPointerType = 'mouse' | 'touch' | 'pointer';
+
+type Delta = {x: number, y: number}
+
+function getElementCenter(element: Element) {
+  let {left, top, width, height} = element.getBoundingClientRect();
+  return {
+    x: left + width / 2,
+    y: top + height / 2
+  };
+}
+
+async function performDrag(source: Element, target: Element, delta: Delta, type: DragPointerType = 'mouse', steps = 1, duration = 0) {
+  let from = getElementCenter(source);
+  let to = {x: 0, y: 0};
+
+  if (target) {
+    to = getElementCenter(target);
+  } else if (delta) {
+    to = {x: from.x + delta.x, y: from.y + delta.y};
+  }
+
+
+  let step = {
+    x: (to.x - from.x) / steps,
+    y: (to.y - from.y) / steps
+  };
+
+
+  let current = {
+    clientX: from.x,
+    clientY: from.y
+  };
+
+  if (type === 'mouse') {
+    fireEvent.mouseEnter(source, current);
+    fireEvent.mouseOver(source, current);
+    fireEvent.mouseMove(source, current);
+    fireEvent.mouseDown(source, current);
+  } else if (type === 'pointer') {
+    fireEvent.pointerEnter(source, current);
+    fireEvent.pointerOver(source, current);
+    fireEvent.pointerMove(source, current);
+    fireEvent.pointerDown(source, current);
+  } else if (type === 'touch') {
+    fireEvent.touchStart(source, current);
+    fireEvent.touchMove(source, current);
+  }
+
+  let dataTransfer = new DataTransfer();
+  fireEvent(source, new DragEvent('dragstart', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));
+  await act(async () => Promise.resolve());
+
+  for (let i = 0; i < steps; i++) {
+    current.clientX += step.x;
+    current.clientY += step.y;
+
+    if (duration !== 0 && steps > 1) {
+      await new Promise(resolve => {
+        setTimeout(resolve, duration / steps);
+      });
+    }
+
+    if (type === 'mouse') {
+      fireEvent.mouseMove(source, current);
+    } else if (type === 'pointer') {
+      fireEvent.pointerMove(source, current);
+    } else if (type === 'touch') {
+      fireEvent.touchMove(source, current);
+    }
+
+    fireEvent(source, new DragEvent('drag', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));
+    fireEvent(target, new DragEvent('dragover', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));
+  }
+
+
+  if (type === 'mouse') {
+    fireEvent.mouseUp(source, current);
+  } else if (type === 'pointer') {
+    fireEvent.pointerUp(source, current);
+  } else if (type === 'touch') {
+    fireEvent.touchEnd(source, current);
+  }
+  console.log('here');
+
+  fireEvent(source, new DragEvent('dragend', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));
+  fireEvent(target, new DragEvent('drop', {dataTransfer, clientX: current.clientX, clientY: current.clientY}));
+  return dataTransfer;
+}
+
+/**
+ * Drag an element onto another element, or by a specific delta.
+ * @example
+ * drag(source).to(target).with('mouse');
+ * drag(source).by({x: 100, y: 100}).with('touch');
+ */
+export function drag(source: Element) {
+  return {
+    to: (target: Element) => ({
+      with: async (type: DragPointerType) => {
+        return await performDrag(source, target, {x: 0, y: 0}, type);
+      }
+    }),
+    by: ({x, y}: Delta) => ({
+      with: async (type: DragPointerType) => {
+        return await performDrag(source, null, {x, y}, type);
+      }
+    })
+  };
+}


### PR DESCRIPTION
Experimenting with a DnD test util that may be useful as we add DnD functionality to more components. And if we decided to export it (https://github.com/adobe/react-spectrum/issues/3703), users could take advantage of it.

Potential API:

```js
let dataTransfer = await drag(source).to(target).with('mouse');
```

and

```js
let dataTransfer = await drag(source).by({x: 100, y: 100}).with('touch');
```
 
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
