### PR TITLE
Prevent ComboBox item selection if menu is closing 

### DIFF
--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -306,12 +306,26 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
     setFocusedState(isFocused);
   };
 
+  let selectionManagerProxy = useMemo(() => {
+    let proxy = new Proxy(selectionManager, {
+      get(target, prop, receiver) {
+        // If the menu is closed, don't update the selected key.
+        if (prop === 'replaceSelection' && !triggerState.isOpen) {
+          return () => {};
+        }
+        return Reflect.get(target, prop, receiver);
+      }
+    });
+
+    return proxy;
+  }, [selectionManager, triggerState.isOpen]);
+
   return {
     ...triggerState,
     toggle,
     open,
     close,
-    selectionManager,
+    selectionManager: selectionManagerProxy,
     selectedKey,
     setSelectedKey,
     disabledKeys,

--- a/packages/@react-stately/combobox/test/useComboBoxState.test.js
+++ b/packages/@react-stately/combobox/test/useComboBoxState.test.js
@@ -217,7 +217,7 @@ describe('useComboBoxState tests', function () {
       let {result} = renderHook((props) => useComboBoxState(props), {initialProps});
 
       act(() => result.current.selectionManager.replaceSelection('1'));
-      expect(result.current.selectionManager.selectedKeys).toContain(new Set({}));
+      expect(result.current.selectionManager.selectedKeys.size).toEqual(0);
       expect(onSelectionChange).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/@react-stately/combobox/test/useComboBoxState.test.js
+++ b/packages/@react-stately/combobox/test/useComboBoxState.test.js
@@ -177,6 +177,7 @@ describe('useComboBoxState tests', function () {
       expect(result.current.selectionManager.selectedKeys).toContain('0');
       expect(result.current.selectionManager.selectedKeys).not.toContain('1');
 
+      act(() => {result.current.open();});
       act(() => result.current.selectionManager.replaceSelection('1'));
       expect(result.current.selectionManager.selectedKeys).toContain('0');
       expect(result.current.selectionManager.selectedKeys).not.toContain('1');
@@ -190,22 +191,34 @@ describe('useComboBoxState tests', function () {
       expect(result.current.selectionManager.selectedKeys).toContain('0');
       expect(result.current.selectionManager.selectedKeys).not.toContain('1');
 
+      act(() => {result.current.open();});
       act(() => result.current.selectionManager.replaceSelection('1'));
       expect(result.current.selectionManager.selectedKeys).toContain('1');
       expect(result.current.selectionManager.selectedKeys).not.toContain('0');
       expect(onSelectionChange).toHaveBeenCalledWith('1');
     });
 
-    it('supports sdefault no selection', function () {
+    it('supports default no selection', function () {
       let initialProps = {...defaultProps};
       let {result} = renderHook((props) => useComboBoxState(props), {initialProps});
       expect(result.current.selectionManager.selectionMode).toBe('single');
       expect(result.current.selectionManager.selectedKeys.size).toBe(0);
 
+      act(() => {result.current.open();});
       act(() => result.current.selectionManager.replaceSelection('1'));
       expect(result.current.selectionManager.selectedKeys).toContain('1');
       expect(result.current.selectionManager.selectedKeys).not.toContain('0');
       expect(onSelectionChange).toHaveBeenCalledWith('1');
+    });
+
+    it('won\'t perform replace a selection if the combobox is closed', function () {
+      // This case covers if a option in the menu is clicked while the menu is closing
+      let initialProps = {...defaultProps};
+      let {result} = renderHook((props) => useComboBoxState(props), {initialProps});
+
+      act(() => result.current.selectionManager.replaceSelection('1'));
+      expect(result.current.selectionManager.selectedKeys).toContain(new Set({}));
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/2181

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to a combobox story and type in the field in such a way that you have a list that is much shorter than the original list
2. Click right below the menu so that it closes it
3. No option should be selected

## 🧢 Your Project:

RSP
