### PR TITLE
SearchAutocomplete: fix to clear selected item if searchfield is cleared

### DIFF
--- a/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
@@ -66,6 +66,7 @@ export function useSearchAutocomplete<T>(props: AriaSearchAutocompleteProps<T>, 
     autoComplete: 'off',
     onClear: () => {
       state.setInputValue('');
+      state.setSelectedKey(null);
       if (onClear) {
         onClear();
       }

--- a/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
@@ -66,7 +66,7 @@ export function useSearchAutocomplete<T>(props: AriaSearchAutocompleteProps<T>, 
     autoComplete: 'off',
     onClear: () => {
       state.setInputValue('');
-      state.setSelectedKey(null);
+      state.selectionManager.setSelectedKeys(new Set());
       if (onClear) {
         onClear();
       }

--- a/packages/@react-spectrum/autocomplete/test/SearchAutocomplete.test.js
+++ b/packages/@react-spectrum/autocomplete/test/SearchAutocomplete.test.js
@@ -816,6 +816,43 @@ describe('SearchAutocomplete', function () {
       expect(items).toHaveLength(1);
       expect(searchAutocomplete).not.toHaveAttribute('aria-activedescendant');
     });
+
+    it('should clear the selected item if searchfield is cleared', function () {
+      let {getByRole} = renderSearchAutocomplete();
+
+      let searchAutocomplete = getByRole('combobox');
+      typeText(searchAutocomplete, 'one');
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      let listbox = getByRole('listbox');
+      let items = within(listbox).getAllByRole('option');
+      expect(items).toHaveLength(1);
+      expect(searchAutocomplete).not.toHaveAttribute('aria-activedescendant');
+
+      act(() => {
+        fireEvent.keyDown(searchAutocomplete, {key: 'ArrowDown'});
+        fireEvent.keyUp(searchAutocomplete, {key: 'ArrowDown'});
+        fireEvent.keyDown(searchAutocomplete, {key: 'Enter'});
+        fireEvent.keyUp(searchAutocomplete, {key: 'Enter'});
+      });
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(searchAutocomplete.value).toBe('One');
+
+      act(() => {
+        fireEvent.keyDown(searchAutocomplete, {key: 'Esc'});
+        fireEvent.keyUp(searchAutocomplete, {key: 'Esc'});
+      });
+
+      expect(searchAutocomplete.value).toBe('');
+      expect(onClear).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('blur', function () {

--- a/packages/@react-spectrum/autocomplete/test/SearchAutocomplete.test.js
+++ b/packages/@react-spectrum/autocomplete/test/SearchAutocomplete.test.js
@@ -823,32 +823,20 @@ describe('SearchAutocomplete', function () {
       let searchAutocomplete = getByRole('combobox');
       typeText(searchAutocomplete, 'one');
 
-      act(() => {
-        jest.runAllTimers();
-      });
-
       let listbox = getByRole('listbox');
       let items = within(listbox).getAllByRole('option');
       expect(items).toHaveLength(1);
       expect(searchAutocomplete).not.toHaveAttribute('aria-activedescendant');
 
-      act(() => {
-        fireEvent.keyDown(searchAutocomplete, {key: 'ArrowDown'});
-        fireEvent.keyUp(searchAutocomplete, {key: 'ArrowDown'});
-        fireEvent.keyDown(searchAutocomplete, {key: 'Enter'});
-        fireEvent.keyUp(searchAutocomplete, {key: 'Enter'});
-      });
-
-      act(() => {
-        jest.runAllTimers();
-      });
+      fireEvent.keyDown(searchAutocomplete, {key: 'ArrowDown'});
+      fireEvent.keyUp(searchAutocomplete, {key: 'ArrowDown'});
+      fireEvent.keyDown(searchAutocomplete, {key: 'Enter'});
+      fireEvent.keyUp(searchAutocomplete, {key: 'Enter'});
 
       expect(searchAutocomplete.value).toBe('One');
 
-      act(() => {
-        fireEvent.keyDown(searchAutocomplete, {key: 'Esc'});
-        fireEvent.keyUp(searchAutocomplete, {key: 'Esc'});
-      });
+      fireEvent.keyDown(searchAutocomplete, {key: 'Esc'});
+      fireEvent.keyUp(searchAutocomplete, {key: 'Esc'});
 
       expect(searchAutocomplete.value).toBe('');
       expect(onClear).toHaveBeenCalledTimes(1);


### PR DESCRIPTION

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Type and select an item from the dropdown
2. Press Escape to clear the field

The searchfield should now clear.

## 🧢 Your Project:

<!--- Company/project for pull request -->
