### PR TITLE
fix(#4010): Update axe-core version for Storybook Accessibility panel to ^4.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
     "autoprefixer": "^9.6.0",
-    "axe-core": "^3.0.3",
+    "axe-core": "^4.6.3",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-macros": "^3.0.1",
     "babel-plugin-react-remove-properties": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5653,7 +5653,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
-axe-core@^3.0.3, axe-core@^3.3.2:
+axe-core@^3.3.2:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
@@ -5662,6 +5662,11 @@ axe-core@^4.2.0, axe-core@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+
+axe-core@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.3.tgz#fc0db6fdb65cc7a80ccf85286d91d64ababa3ece"
+  integrity sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==
 
 axios@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
Closes #4010

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue #4010](https://github.com/adobe/react-spectrum/issue/4010).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/96cd5e6bb2ce928ebc8f1cec0b612e6e336ad9a2/storybook/index.html?path=/story/switch--default&providerSwitcher-express=false
2. Switch to Accessibility Tab in the Storybook Add-Ons panel
3. Verify that there are 0 Violations. (There will be 1 Incomplete warning to manually verify color contrast compliance.)

## 🧢 Your Project:

Adobe/Accessibility
