### PR TITLE
fix(#4023): ActionMenu: Items in Dynamic storybook story all have the same key which breaks interaction

### DIFF
--- a/packages/@react-spectrum/menu/stories/ActionMenu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/ActionMenu.stories.tsx
@@ -173,9 +173,9 @@ export const WithTooltip = () => (
 
 export const Dynamic = () => {
   const items = [
-    {key: 'a', label: 'Cut'},
-    {key: 'a', label: 'Copy'},
-    {key: 'a', label: 'Paste'}
+    {key: 'cut', label: 'Cut'},
+    {key: 'copy', label: 'Copy'},
+    {key: 'paste', label: 'Paste'}
   ];
 
   return (


### PR DESCRIPTION
Closes #4023 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 4023](https://github.com/adobe/react-spectrum/issue/4023).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

### Without fix:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/9e92106b3067ba326d34bf35274d3fcc2c5dc1b7/storybook/index.html?path=/story/actionmenu--dynamic&providerSwitcher-express=false&providerSwitcher-toastPosition=bottom
2. Focus ActionMenu button.
3. Press Space, Enter or ArrowDown to expand Menu
4. Last item in Menu, "Paste", will have focus.
5. Press ArrowUp to move focus to previous menu item, "Copy."
6. Focus does not move, because the items have the same key, so only the last item receives focus.

### With fix:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/96175f786204872d5cbf648940e6d6760482edc3/storybook/index.html?path=/story/actionmenu--dynamic&providerSwitcher-express=false&providerSwitcher-toastPosition=bottom
2. Focus ActionMenu button.
3. Press Space, Enter or ArrowDown to expand Menu
4. First item in Menu, "Cut", will have focus.
5. Press ArrowDown to move focus to next menu item, "Copy."
6. Focus moves, because the items have unique keys, so focus can move between them.


## 🧢 Your Project:

Adobe/Accessibility
