### PR TITLE
Broaden allowed triggerRef elements for table column resizer

### DIFF
--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -11,7 +11,7 @@
  */
 
 import {ChangeEvent, Key, RefObject, useCallback, useRef} from 'react';
-import {DOMAttributes} from '@react-types/shared';
+import {DOMAttributes, FocusableElement} from '@react-types/shared';
 import {focusSafely} from '@react-aria/focus';
 import {focusWithoutScrolling, mergeProps, useId} from '@react-aria/utils';
 import {getColumnHeaderId} from './utils';
@@ -38,7 +38,7 @@ export interface AriaTableColumnResizeProps<T> {
    * Ref to the trigger if resizing was started from a column header menu. If it's provided,
    * focus will be returned there when resizing is done.
    * */
-  triggerRef?: RefObject<HTMLDivElement>,
+  triggerRef?: RefObject<FocusableElement>,
   /** If resizing is disabled. */
   isDisabled?: boolean,
   /** Called when resizing starts. */


### PR DESCRIPTION
Found when writing aria sandbox example. Div element is too restrictive since a button could be used instead

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
