### PR TITLE
fix(#4067): Storybook Provider addon: Express input:checkbox requires id to be labelled by htmlFor prop

### DIFF
--- a/.storybook/custom-addons/provider/register.js
+++ b/.storybook/custom-addons/provider/register.js
@@ -111,7 +111,7 @@ function ProviderFieldSetter({api}) {
       </div>
       <div style={{marginRight: '10px'}}>
         <label htmlFor="express">Express: </label>
-        <input type="checkbox" name="express" onChange={onExpressChange} checked={values.express} />
+        <input type="checkbox" id="express" name="express" onChange={onExpressChange} checked={values.express} />
       </div>
     </div>
   )


### PR DESCRIPTION
https://github.com/adobe/react-spectrum/blob/e9f08177302590b4bf8c650dda579a15f0c5ffcb/.storybook/custom-addons/provider/register.js#L113-L114

should be

```tsx
 <label htmlFor="express">Express: </label>
 <input type="checkbox" id="express" name="express" onChange={onExpressChange} checked={values.express} />
```


Closes #4067 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 4067](https://github.com/adobe/react-spectrum/issue/4067).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open [Storybook](https://reactspectrum.blob.core.windows.net/reactspectrum/1676f4a74d0a3d86de7fdb1a6e74f17ecb23d559/storybook/index.html?path=/story/accordion--default)
2. Mouse click on the "Express:" `label` or the "express" checkbox input in the Provider settings toolbar above the story.
<img width="1184" alt="Screenshot showing toolbar with Express: label circled in red" src="https://user-images.githubusercontent.com/154077/219113552-88e6d3b8-d22e-46d1-b46d-b2d7d1e8001c.png" />
3. Mouse clicking the `label` should toggle the checkbox when the label is properly associated with the input using `htmlFor` and a proper IDREF.

## 🧢 Your Project:

Adobe/Accessibility
