### PR TITLE
Fix docs side nav tag line break

### DIFF
--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -235,6 +235,7 @@ html, body {
 .sideNavItem > span {
   margin-left: 10px;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .sideNavItem:focus {


### PR DESCRIPTION
<img width="263" alt="image" src="https://user-images.githubusercontent.com/13805071/219257357-708b24ff-2543-4dcd-9f02-5e6bf0066f89.png">
<img width="255" alt="image" src="https://user-images.githubusercontent.com/13805071/219257374-f3cbb3b4-17b0-4ade-bba1-67052048ebf6.png">


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
