### PR TITLE
Update useTreeData move function to allow moving item to root

### DIFF
--- a/packages/@react-stately/data/docs/useTreeData.mdx
+++ b/packages/@react-stately/data/docs/useTreeData.mdx
@@ -166,6 +166,9 @@ tree.move('Sam', 'People', 0);
 
 // Move an item to a different parent
 tree.move('Sam', 'Animals', 1);
+
+// Move an item to the root
+tree.move('Sam', null, 1);
 ```
 
 ### Updating items

--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -104,7 +104,7 @@ export interface TreeData<T extends object> {
    * @param toParentKey - The key of the new parent to insert into.
    * @param index - The index within the new parent to insert at.
    */
-  move(key: Key, toParentKey: Key, index: number): void,
+  move(key: Key, toParentKey: Key | null, index: number): void,
 
   /**
    * Updates an item in the tree.
@@ -308,7 +308,7 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
     removeSelectedItems() {
       this.remove(...selectedKeys);
     },
-    move(key: Key, toParentKey: Key, index: number) {
+    move(key: Key, toParentKey: Key | null, index: number) {
       setItems(items => {
         let node = map.get(key);
         if (!node) {
@@ -322,6 +322,16 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
           parentKey: toParentKey
         };
 
+        // If parentKey is null, insert into the root.
+        if (toParentKey == null) {
+          return [
+            ...items.slice(0, index),
+            movedNode,
+            ...items.slice(index)
+          ];
+        }
+
+        // Otherwise, update the parent node and its ancestors.
         return updateTree(items, toParentKey, parentNode => ({
           key: parentNode.key,
           parentKey: parentNode.parentKey,

--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -567,6 +567,38 @@ describe('useTreeData', function () {
     expect(result.current.items[0].children[2]).toBe(initialResult.items[0].children[2]);
   });
 
+  it('should move an item to the root', function () {
+    let {result} = renderHook(() =>
+      useTreeData({initialItems: initial, getChildren, getKey})
+    );
+    let initialResult = result.current;
+
+    act(() => {
+      result.current.move('Stacy', null, 0);
+    });
+
+    expect(result.current.items).not.toBe(initialResult.items);
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items[0]).not.toBe(initialResult.items[0]);
+    expect(result.current.items[0].children).toHaveLength(0);
+    expect(result.current.items[0].value).toEqual({name: 'Stacy'});
+    expect(result.current.items[1]).not.toBe(initialResult.items[0]);
+    expect(result.current.items[1].children).toHaveLength(3);
+    expect(result.current.items[1].children[0]).toBe(
+      initialResult.items[0].children[0]
+    );
+    expect(result.current.items[1].children[1]).not.toBe(
+      initialResult.items[0].children[1]
+    );
+    expect(result.current.items[1].children[1].children).toHaveLength(1);
+    expect(result.current.items[1].children[1].children[0]).toEqual(
+      initialResult.items[0].children[1].children[1]
+    );
+    expect(result.current.items[1].children[2]).toBe(
+      initialResult.items[0].children[2]
+    );
+  });
+
   it('should move an item to a new index within its current parent', function () {
     let {result} = renderHook(() => useTreeData({initialItems: initial, getChildren, getKey}));
 


### PR DESCRIPTION
Closes #4074

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify new test in `useTreeData.test.js` passes:
```
it('should move an item to the root', function () {
  ...
}
```

## 🧢 Your Project:
