### PR TITLE
fix(#4078): MobileComboBox: searchbox should not have aria-expanded property

### DIFF
--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -331,8 +331,10 @@ function ComboBoxTray(props: ComboBoxTrayProps) {
   // VoiceOver on iOS reads "double tap to collapse" when focused on the input rather than
   // "double tap to edit text", as with a textbox or searchbox. We'd like double tapping to
   // open the virtual keyboard rather than closing the tray.
+  // Unlike "combobox", "aria-expanded" is not a valid attribute on "searchbox".
   inputProps.role = 'searchbox';
   inputProps['aria-haspopup'] = 'listbox';
+  delete inputProps['aria-expanded'];
   delete inputProps.onTouchEnd;
 
   let clearButton = (

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -3621,7 +3621,7 @@ describe('ComboBox', function () {
       expect(dialog).toHaveAttribute('aria-labelledby', input.getAttribute('aria-labelledby'));
 
       expect(input).toHaveAttribute('role', 'searchbox');
-      expect(input).toHaveAttribute('aria-expanded', 'true');
+      expect(input).not.toHaveAttribute('aria-expanded');
       expect(input).toHaveAttribute('aria-controls', listbox.id);
       expect(input).toHaveAttribute('aria-haspopup', 'listbox');
 


### PR DESCRIPTION
Closes #4078 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 4078](https://github.com/adobe/react-spectrum/issue/4078).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

Adobe/Accessibility
