### PR TITLE
Get rid of dupe id in DatePicker/useDatePicker

### DIFF
--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -53,6 +53,7 @@ export interface DatePickerAria {
 export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>, state: DatePickerState, ref: RefObject<Element>): DatePickerAria {
   let buttonId = useId();
   let dialogId = useId();
+  let fieldId = useId();
   let stringFormatter = useLocalizedStringFormatter(intlMessages);
 
   let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useField({
@@ -79,7 +80,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
     onFocusWithin: props.onFocus,
     onFocusWithinChange: props.onFocusChange
   });
-  console.log('fieldProps', fieldProps)
+
   return {
     groupProps: mergeProps(domProps, groupProps, fieldProps, descProps, focusWithinProps, {
       role: 'group',
@@ -112,6 +113,8 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       }
     },
     fieldProps: {
+      ...fieldProps,
+      id: fieldId,
       [roleSymbol]: 'presentation',
       'aria-describedby': ariaDescribedBy,
       value: state.value,

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -79,7 +79,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
     onFocusWithin: props.onFocus,
     onFocusWithinChange: props.onFocusChange
   });
-
+  console.log('fieldProps', fieldProps)
   return {
     groupProps: mergeProps(domProps, groupProps, fieldProps, descProps, focusWithinProps, {
       role: 'group',
@@ -112,7 +112,6 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       }
     },
     fieldProps: {
-      ...fieldProps,
       [roleSymbol]: 'presentation',
       'aria-describedby': ariaDescribedBy,
       value: state.value,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/3969

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the DatePicker stories and make sure the accessiblity tab doesn't warn about duplicate ids. Also check the useDatePicker docs and make sure the presentational field div doesn't have the same id as the group

## 🧢 Your Project:

RSP
