### PR TITLE
Fix TagGroup label alignment

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tags/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tags/index.css
@@ -17,7 +17,13 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tags {
-  display: inline;
+  display: contents;
+}
+
+.spectrum-Tags-container {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--spectrum-tag-margin);
 }
 
 .spectrum-Tags-item {
@@ -30,7 +36,6 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   position: relative;
 
-  margin: var(--spectrum-tag-margin);
   padding-inline-start: calc(var(--spectrum-tag-padding-x) - var(--spectrum-tag-border-size));
   block-size: var(--spectrum-tag-height);
   max-inline-size: 100%;
@@ -96,13 +101,12 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tags-actions {
-  display: inline;
+  display: contents;
 
   .spectrum-Tags-actionButton {
     display: inline;
     height: var(--spectrum-tag-height);
     font-size: var(--spectrum-tag-text-size);
-    margin: var(--spectrum-tag-margin);
     
     &.spectrum-Tags-actionButton {
       > span {

--- a/packages/@adobe/spectrum-css-temp/components/tags/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tags/index.css
@@ -23,6 +23,7 @@ governing permissions and limitations under the License.
 .spectrum-Tags-container {
   /* Aligns tags with label. */
   margin-inline-start: calc(calc(var(--spectrum-taggroup-tag-gap-x) / 2) * -1);
+  margin-inline-end: calc(var(--spectrum-taggroup-tag-gap-x) / 2);
 }
 
 .spectrum-Tags-item {

--- a/packages/@adobe/spectrum-css-temp/components/tags/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tags/index.css
@@ -17,13 +17,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tags {
-  display: contents;
-}
-
-.spectrum-Tags-container {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: var(--spectrum-tag-margin);
+  display: inline;
 }
 
 .spectrum-Tags-item {
@@ -36,6 +30,7 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   position: relative;
 
+  margin: var(--spectrum-tag-margin);
   padding-inline-start: calc(var(--spectrum-tag-padding-x) - var(--spectrum-tag-border-size));
   block-size: var(--spectrum-tag-height);
   max-inline-size: 100%;
@@ -101,12 +96,13 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Tags-actions {
-  display: contents;
+  display: inline;
 
   .spectrum-Tags-actionButton {
     display: inline;
     height: var(--spectrum-tag-height);
     font-size: var(--spectrum-tag-text-size);
+    margin: var(--spectrum-tag-margin);
     
     &.spectrum-Tags-actionButton {
       > span {

--- a/packages/@adobe/spectrum-css-temp/components/tags/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tags/index.css
@@ -20,6 +20,11 @@ governing permissions and limitations under the License.
   display: inline;
 }
 
+.spectrum-Tags-container {
+  /* Aligns tags with label. */
+  margin-inline-start: calc(calc(var(--spectrum-taggroup-tag-gap-x) / 2) * -1);
+}
+
 .spectrum-Tags-item {
   @inherit: %spectrum-FocusRing;
   --spectrum-focus-ring-border-radius: var(--spectrum-tag-border-radius);

--- a/packages/@react-spectrum/tag/src/TagGroup.tsx
+++ b/packages/@react-spectrum/tag/src/TagGroup.tsx
@@ -167,7 +167,8 @@ function TagGroup<T extends object>(props: SpectrumTagGroupProps<T>, ref: DOMRef
           )
         }>
         <div
-          ref={containerRef}>
+          ref={containerRef}
+          className={classNames(styles, 'spectrum-Tags-container')}>
           <div
             ref={tagsRef}
             {...tagGroupProps}

--- a/packages/@react-spectrum/tag/src/TagGroup.tsx
+++ b/packages/@react-spectrum/tag/src/TagGroup.tsx
@@ -167,6 +167,7 @@ function TagGroup<T extends object>(props: SpectrumTagGroupProps<T>, ref: DOMRef
           )
         }>
         <div
+          className={classNames(styles, 'spectrum-Tags-container')}
           ref={containerRef}>
           <div
             ref={tagsRef}

--- a/packages/@react-spectrum/tag/src/TagGroup.tsx
+++ b/packages/@react-spectrum/tag/src/TagGroup.tsx
@@ -167,7 +167,6 @@ function TagGroup<T extends object>(props: SpectrumTagGroupProps<T>, ref: DOMRef
           )
         }>
         <div
-          className={classNames(styles, 'spectrum-Tags-container')}
           ref={containerRef}>
           <div
             ref={tagsRef}

--- a/packages/@react-spectrum/tag/src/TagGroup.tsx
+++ b/packages/@react-spectrum/tag/src/TagGroup.tsx
@@ -156,6 +156,7 @@ function TagGroup<T extends object>(props: SpectrumTagGroupProps<T>, ref: DOMRef
         errorMessageProps={errorMessageProps}
         showErrorIcon
         ref={domRef}
+        elementType="span"
         UNSAFE_className={
           classNames(
             styles,


### PR DESCRIPTION
- Uses span instead of label since we aren't labelling a form element
- Uses `gap` so that the tags line up with the label

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test TagGroup label is span, and left-most tags align vertically with the label above.

## 🧢 Your Project:

<!--- Company/project for pull request -->
