### PR TITLE
Prevent autoscrolling of focused collection elements when focus isn't in the non virtualized collection

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -14,6 +14,7 @@ import {DOMAttributes, FocusableElement, FocusStrategy, KeyboardDelegate} from '
 import {FocusEvent, Key, KeyboardEvent, RefObject, useEffect, useRef} from 'react';
 import {focusSafely, getFocusableTreeWalker} from '@react-aria/focus';
 import {focusWithoutScrolling, mergeProps, scrollIntoView, scrollIntoViewport, useEvent} from '@react-aria/utils';
+import {getInteractionModality} from '@react-aria/interactions';
 import {isCtrlKeyPressed, isNonContiguousSelectionModifier} from './utils';
 import {MultipleSelectionManager} from '@react-stately/selection';
 import {useLocale} from '@react-aria/i18n';
@@ -356,11 +357,14 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
   // If not virtualized, scroll the focused element into view when the focusedKey changes.
   // When virtualized, Virtualizer handles this internally.
   useEffect(() => {
+    let modality = getInteractionModality();
     if (!isVirtualized && manager.isFocused && manager.focusedKey && scrollRef?.current) {
       let element = scrollRef.current.querySelector(`[data-key="${manager.focusedKey}"]`) as HTMLElement;
       if (element) {
         scrollIntoView(scrollRef.current, element);
-        scrollIntoViewport(element, {containingElement: ref.current});
+        if (modality === 'keyboard') {
+          scrollIntoViewport(element, {containingElement: ref.current});
+        }
       }
     }
   }, [isVirtualized, scrollRef, manager.focusedKey, manager.isFocused, ref]);

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -356,14 +356,14 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
   // If not virtualized, scroll the focused element into view when the focusedKey changes.
   // When virtualized, Virtualizer handles this internally.
   useEffect(() => {
-    if (!isVirtualized && manager.focusedKey && scrollRef?.current) {
+    if (!isVirtualized && manager.isFocused && manager.focusedKey && scrollRef?.current) {
       let element = scrollRef.current.querySelector(`[data-key="${manager.focusedKey}"]`) as HTMLElement;
       if (element) {
         scrollIntoView(scrollRef.current, element);
         scrollIntoViewport(element, {containingElement: ref.current});
       }
     }
-  }, [isVirtualized, scrollRef, manager.focusedKey, ref]);
+  }, [isVirtualized, scrollRef, manager.focusedKey, manager.isFocused, ref]);
 
   let handlers = {
     onKeyDown,

--- a/packages/@react-spectrum/tabs/test/Tabs.test.js
+++ b/packages/@react-spectrum/tabs/test/Tabs.test.js
@@ -355,16 +355,6 @@ describe('Tabs', function () {
     let mockCalls = [
       function () {
         return {
-          left: 0
-        };
-      },
-      function () {
-        return {
-          right: 0
-        };
-      },
-      function () {
-        return {
           left: 0,
           right: 100
         };
@@ -657,16 +647,6 @@ describe('Tabs', function () {
   it('disabled tabs cannot be selected via collapse picker', function () {
     let target = [HTMLDivElement.prototype, 'getBoundingClientRect'];
     let mockCalls = [
-      function () {
-        return {
-          left: 0
-        };
-      },
-      function () {
-        return {
-          right: 0
-        };
-      },
       function () {
         return {
           left: 0,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/4132

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the Tabs docs. Confirm the page doesn't automatically scroll to the bottom of the page.
Sanity check non-virtualized collection components (aka useSelect story or any of the hooks components that don't have virtualized lists)

## 🧢 Your Project:

RSP
