### PR TITLE
Code changes for React Aria Components

### DIFF
--- a/packages/@react-aria/calendar/src/useCalendarCell.ts
+++ b/packages/@react-aria/calendar/src/useCalendarCell.ts
@@ -172,7 +172,7 @@ export function useCalendarCell(props: AriaCalendarCellProps, state: CalendarSta
     // again to trigger onPressStart. Cancel presses immediately when the pointer exits.
     shouldCancelOnPointerExit: 'anchorDate' in state && !!state.anchorDate,
     preventFocusOnPress: true,
-    isDisabled: !isSelectable,
+    isDisabled: !isSelectable || state.isReadOnly,
     onPressStart(e) {
       if (state.isReadOnly) {
         state.setFocusedDate(date);

--- a/packages/@react-aria/checkbox/src/useCheckbox.ts
+++ b/packages/@react-aria/checkbox/src/useCheckbox.ts
@@ -17,7 +17,15 @@ import {useToggle} from '@react-aria/toggle';
 
 export interface CheckboxAria {
   /** Props for the input element. */
-  inputProps: InputHTMLAttributes<HTMLInputElement>
+  inputProps: InputHTMLAttributes<HTMLInputElement>,
+  /** Whether the checkbox is selected. */
+  isSelected: boolean,
+  /** Whether the checkbox is in a pressed state. */
+  isPressed: boolean,
+  /** Whether the checkbox is disabled. */
+  isDisabled: boolean,
+  /** Whether the checkbox is read only. */
+  isReadOnly: boolean
 }
 
 /**
@@ -29,8 +37,7 @@ export interface CheckboxAria {
  * @param inputRef - A ref for the HTML input element.
  */
 export function useCheckbox(props: AriaCheckboxProps, state: ToggleState, inputRef: RefObject<HTMLInputElement>): CheckboxAria {
-  let {inputProps} = useToggle(props, state, inputRef);
-  let {isSelected} = state;
+  let {inputProps, isSelected, isPressed, isDisabled, isReadOnly} = useToggle(props, state, inputRef);
 
   let {isIndeterminate} = props;
   useEffect(() => {
@@ -45,6 +52,10 @@ export function useCheckbox(props: AriaCheckboxProps, state: ToggleState, inputR
     inputProps: {
       ...inputProps,
       checked: isSelected
-    }
+    },
+    isSelected,
+    isPressed,
+    isDisabled,
+    isReadOnly
   };
 }

--- a/packages/@react-aria/checkbox/src/useCheckboxGroupItem.ts
+++ b/packages/@react-aria/checkbox/src/useCheckboxGroupItem.ts
@@ -41,7 +41,7 @@ export function useCheckboxGroupItem(props: AriaCheckboxGroupItemProps, state: C
     }
   });
 
-  let {inputProps} = useCheckbox({
+  let res = useCheckbox({
     ...props,
     isReadOnly: props.isReadOnly || state.isReadOnly,
     isDisabled: props.isDisabled || state.isDisabled,
@@ -49,8 +49,9 @@ export function useCheckboxGroupItem(props: AriaCheckboxGroupItemProps, state: C
   }, toggleState, inputRef);
 
   return {
+    ...res,
     inputProps: {
-      ...inputProps,
+      ...res.inputProps,
       'aria-describedby': [
         state.validationState === 'invalid' ? checkboxGroupErrorMessageIds.get(state) : null,
         checkboxGroupDescriptionIds.get(state)

--- a/packages/@react-aria/combobox/docs/useComboBox.mdx
+++ b/packages/@react-aria/combobox/docs/useComboBox.mdx
@@ -76,6 +76,8 @@ A combo box can be built using the [&lt;datalist&gt;](https://developer.mozilla.
 * Custom localized announcements for option focusing, filtering, and selection using an ARIA live region to work around VoiceOver bugs
 * Support for description and error message help text linked to the input via ARIA
 
+Read our [blog post](../blog/building-a-combobox.html) for more details about the interactions and accessibility features implemented by `useComboBox`.
+
 ## Anatomy
 
 <Anatomy />

--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -19,7 +19,7 @@ import {BaseEvent, DOMAttributes, KeyboardDelegate, PressEvent} from '@react-typ
 import {chain, isAppleDevice, mergeProps, useLabels} from '@react-aria/utils';
 import {ComboBoxState} from '@react-stately/combobox';
 import {FocusEvent, InputHTMLAttributes, KeyboardEvent, RefObject, TouchEvent, useEffect, useMemo, useRef} from 'react';
-import {getItemCount} from '@react-stately/collections';
+import {getChildNodes, getItemCount} from '@react-stately/collections';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ListKeyboardDelegate, useSelectableCollection} from '@react-aria/selection';
@@ -27,7 +27,7 @@ import {useLocalizedStringFormatter} from '@react-aria/i18n';
 import {useMenuTrigger} from '@react-aria/menu';
 import {useTextField} from '@react-aria/textfield';
 
-export interface AriaComboBoxOptions<T> extends AriaComboBoxProps<T> {
+export interface AriaComboBoxOptions<T> extends Omit<AriaComboBoxProps<T>, 'children'> {
   /** The ref for the input element. */
   inputRef: RefObject<HTMLInputElement>,
   /** The ref for the list box popover. */
@@ -252,7 +252,7 @@ export function useComboBox<T>(props: AriaComboBoxOptions<T>, state: ComboBoxSta
       let announcement = stringFormatter.format('focusAnnouncement', {
         isGroupChange: section && sectionKey !== lastSection.current,
         groupTitle: sectionTitle,
-        groupCount: section ? [...section.childNodes].length : 0,
+        groupCount: section ? [...getChildNodes(section, state.collection)].length : 0,
         optionText: focusedItem['aria-label'] || focusedItem.textValue || '',
         isSelected
       });

--- a/packages/@react-aria/datepicker/docs/useDateRangePicker.mdx
+++ b/packages/@react-aria/datepicker/docs/useDateRangePicker.mdx
@@ -40,7 +40,7 @@ keywords: [input, form, field, date, time]
 
 ## Features
 
-A date range picker can be built using two separate `<input type="date">` elements, but this is very limited in functionality, lacking in internationalization capabilities, inconsistent between browsers, and difficult to style. `useDatePicker` helps achieve accessible and international date and time range pickers that can be styled as needed.
+A date range picker can be built using two separate `<input type="date">` elements, but this is very limited in functionality, lacking in internationalization capabilities, inconsistent between browsers, and difficult to style. `useDateRangePicker` helps achieve accessible and international date and time range pickers that can be styled as needed.
 
 * **Dates and times** – Support for dates and times with configurable granularity.
 * **International** – Support for 13 calendar systems used around the world, including Gregorian, Buddhist, Islamic, Persian, and more. Locale-specific formatting, number systems, hour cycles, and right-to-left support are available as well.

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaDatePickerProps, AriaTimeFieldProps, DateValue, TimeValue} from '@react-types/datepicker';
+import {AriaDateFieldProps as AriaDateFieldPropsBase, AriaTimeFieldProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {createFocusManager, FocusManager} from '@react-aria/focus';
 import {DateFieldState} from '@react-stately/datepicker';
 import {DOMAttributes, KeyboardEvent} from '@react-types/shared';
@@ -24,7 +24,7 @@ import {useFocusWithin} from '@react-aria/interactions';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 // Allows this hook to also be used with TimeField
-export interface AriaDateFieldProps<T extends DateValue> extends Omit<AriaDatePickerProps<T>, 'value' | 'defaultValue' | 'onChange' | 'minValue' | 'maxValue' | 'placeholderValue'> {}
+export interface AriaDateFieldProps<T extends DateValue> extends Omit<AriaDateFieldPropsBase<T>, 'value' | 'defaultValue' | 'onChange' | 'minValue' | 'maxValue' | 'placeholderValue'> {}
 
 export interface DateFieldAria {
    /** Props for the field's visible label element, if any. */

--- a/packages/@react-aria/grid/package.json
+++ b/packages/@react-aria/grid/package.json
@@ -28,6 +28,7 @@
     "@react-aria/live-announcer": "^3.2.0",
     "@react-aria/selection": "^3.13.0",
     "@react-aria/utils": "^3.15.0",
+    "@react-stately/collections": "^3.6.0",
     "@react-stately/grid": "^3.5.0",
     "@react-stately/selection": "^3.12.0",
     "@react-stately/virtualizer": "^3.5.0",

--- a/packages/@react-aria/grid/src/useGrid.ts
+++ b/packages/@react-aria/grid/src/useGrid.ts
@@ -81,14 +81,15 @@ export function useGrid<T>(props: GridProps, state: GridState<T, GridCollection<
   // When virtualized, the layout object will be passed in as a prop and override this.
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let {direction} = useLocale();
+  let disabledBehavior = state.selectionManager.disabledBehavior;
   let delegate = useMemo(() => keyboardDelegate || new GridKeyboardDelegate({
     collection: state.collection,
-    disabledKeys: state.disabledKeys,
+    disabledKeys: disabledBehavior === 'selection' ? new Set() : state.disabledKeys,
     ref,
     direction,
     collator,
     focusMode
-  }), [keyboardDelegate, state.collection, state.disabledKeys, ref, direction, collator, focusMode]);
+  }), [keyboardDelegate, state.collection, state.disabledKeys, disabledBehavior, ref, direction, collator, focusMode]);
 
   let {collectionProps} = useSelectableCollection({
     ref,

--- a/packages/@react-aria/grid/src/useGridRow.ts
+++ b/packages/@react-aria/grid/src/useGridRow.ts
@@ -15,7 +15,7 @@ import {GridCollection} from '@react-types/grid';
 import {gridMap} from './utils';
 import {GridState} from '@react-stately/grid';
 import {RefObject} from 'react';
-import {useSelectableItem} from '@react-aria/selection';
+import {SelectableItemStates, useSelectableItem} from '@react-aria/selection';
 
 export interface GridRowProps<T> {
   /** An object representing the grid row. Contains all the relevant information that makes up the grid row. */
@@ -32,7 +32,7 @@ export interface GridRowProps<T> {
   onAction?: () => void
 }
 
-export interface GridRowAria {
+export interface GridRowAria extends SelectableItemStates {
   /** Props for the grid row element. */
   rowProps: DOMAttributes,
   /** Whether the row is currently in a pressed state. */
@@ -53,7 +53,7 @@ export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T
   } = props;
 
   let {actions: {onRowAction}} = gridMap.get(state);
-  let {itemProps, isPressed} = useSelectableItem({
+  let {itemProps, ...states} = useSelectableItem({
     selectionManager: state.selectionManager,
     key: node.key,
     ref,
@@ -68,6 +68,7 @@ export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T
   let rowProps: DOMAttributes = {
     role: 'row',
     'aria-selected': state.selectionManager.selectionMode !== 'none' ? isSelected : undefined,
+    'aria-disabled': states.isDisabled || undefined,
     ...itemProps
   };
 
@@ -77,6 +78,6 @@ export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T
 
   return {
     rowProps,
-    isPressed
+    ...states
   };
 }

--- a/packages/@react-aria/link/src/useLink.ts
+++ b/packages/@react-aria/link/src/useLink.ts
@@ -69,6 +69,7 @@ export function useLink(props: AriaLinkOptions, ref: RefObject<FocusableElement>
       ...interactionHandlers,
       ...linkProps,
       'aria-disabled': isDisabled || undefined,
+      'aria-current': props['aria-current'],
       onClick: (e) => {
         pressProps.onClick(e);
         if (deprecatedOnClick) {

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -103,7 +103,7 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
 
   let optionProps = {
     role: 'option',
-    'aria-disabled': isDisabled,
+    'aria-disabled': isDisabled || undefined,
     'aria-selected': state.selectionManager.selectionMode !== 'none' ? isSelected : undefined
   };
 

--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -98,7 +98,6 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
 
   let isDisabled = props.isDisabled ?? state.disabledKeys.has(key);
   let isSelected = props.isSelected ?? state.selectionManager.isSelected(key);
-  let isFocused = state.selectionManager.focusedKey === key;
 
   let data = menuData.get(state);
   let onClose = props.onClose || data.onClose;
@@ -116,7 +115,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
   let keyboardId = useSlotId();
 
   let ariaProps = {
-    'aria-disabled': isDisabled,
+    'aria-disabled': isDisabled || undefined,
     role,
     'aria-label': props['aria-label'],
     'aria-labelledby': labelId,
@@ -174,7 +173,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
     }
   };
 
-  let {itemProps} = useSelectableItem({
+  let {itemProps, isFocused} = useSelectableItem({
     selectionManager: state.selectionManager,
     key,
     ref,

--- a/packages/@react-aria/overlays/src/useOverlayTrigger.ts
+++ b/packages/@react-aria/overlays/src/useOverlayTrigger.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
-import {DOMAttributes} from '@react-types/shared';
+import {DOMProps} from '@react-types/shared';
 import {onCloseMap} from './useCloseOnScroll';
 import {OverlayTriggerState} from '@react-stately/overlays';
 import {RefObject, useEffect} from 'react';
@@ -27,7 +27,7 @@ export interface OverlayTriggerAria {
   triggerProps: AriaButtonProps,
 
   /** Props for the overlay container element. */
-  overlayProps: DOMAttributes
+  overlayProps: DOMProps
 }
 
 /**

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -24,7 +24,9 @@ export interface RadioAria {
   /** Whether the radio is disabled. */
   isDisabled: boolean,
   /** Whether the radio is currently selected. */
-  isSelected: boolean
+  isSelected: boolean,
+  /** Whether the radio is in a pressed state. */
+  isPressed: boolean
 }
 
 /**
@@ -57,7 +59,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
     state.setSelectedValue(value);
   };
 
-  let {pressProps} = usePress({
+  let {pressProps, isPressed} = usePress({
     isDisabled
   });
 
@@ -87,6 +89,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
       ].filter(Boolean).join(' ') || undefined
     }),
     isDisabled,
-    isSelected: checked
+    isSelected: checked,
+    isPressed
   };
 }

--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -23,7 +23,7 @@ import {useCollator} from '@react-aria/i18n';
 import {useField} from '@react-aria/label';
 import {useMenuTrigger} from '@react-aria/menu';
 
-export interface AriaSelectOptions<T> extends AriaSelectProps<T> {
+export interface AriaSelectOptions<T> extends Omit<AriaSelectProps<T>, 'children'> {
   /**
    * An optional keyboard delegate implementation for type to select,
    * to override the default.

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -67,6 +67,8 @@ export interface SelectableItemStates {
   isPressed: boolean,
   /** Whether the item is currently selected. */
   isSelected: boolean,
+  /** Whether the item is currently focused. */
+  isFocused: boolean,
   /**
    * Whether the item is non-interactive, i.e. both selection and actions are disabled and the item may
    * not be focused. Dependent on `disabledKeys` and `disabledBehavior`.
@@ -312,6 +314,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
     ),
     isPressed,
     isSelected: manager.isSelected(key),
+    isFocused: manager.isFocused && manager.focusedKey === key,
     isDisabled,
     allowsSelection,
     hasAction

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -45,7 +45,7 @@ export function useSliderThumb(
   state: SliderState
 ): SliderThumbAria {
   let {
-    index,
+    index = 0,
     isRequired,
     validationState,
     trackRef,

--- a/packages/@react-aria/switch/src/useSwitch.ts
+++ b/packages/@react-aria/switch/src/useSwitch.ts
@@ -17,7 +17,15 @@ import {useToggle} from '@react-aria/toggle';
 
 export interface SwitchAria {
   /** Props for the input element. */
-  inputProps: InputHTMLAttributes<HTMLInputElement>
+  inputProps: InputHTMLAttributes<HTMLInputElement>,
+  /** Whether the switch is selected. */
+  isSelected: boolean,
+  /** Whether the switch is in a pressed state. */
+  isPressed: boolean,
+  /** Whether the switch is disabled. */
+  isDisabled: boolean,
+  /** Whether the switch is read only. */
+  isReadOnly: boolean
 }
 
 /**
@@ -28,14 +36,17 @@ export interface SwitchAria {
  * @param ref - Ref to the HTML input element.
  */
 export function useSwitch(props: AriaSwitchProps, state: ToggleState, ref: RefObject<HTMLInputElement>): SwitchAria {
-  let {inputProps} = useToggle(props, state, ref);
-  let {isSelected} = state;
+  let {inputProps, isSelected, isPressed, isDisabled, isReadOnly} = useToggle(props, state, ref);
 
   return {
     inputProps: {
       ...inputProps,
       role: 'switch',
       checked: isSelected
-    }
+    },
+    isSelected,
+    isPressed,
+    isDisabled,
+    isReadOnly
   };
 }

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -29,6 +29,7 @@
     "@react-aria/live-announcer": "^3.2.0",
     "@react-aria/selection": "^3.13.0",
     "@react-aria/utils": "^3.15.0",
+    "@react-stately/collections": "^3.6.0",
     "@react-stately/table": "^3.8.0",
     "@react-stately/virtualizer": "^3.5.0",
     "@react-types/checkbox": "^3.4.2",

--- a/packages/@react-aria/table/src/TableKeyboardDelegate.ts
+++ b/packages/@react-aria/table/src/TableKeyboardDelegate.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {getChildNodes, getFirstItem, getNthItem} from '@react-stately/collections';
 import {GridKeyboardDelegate} from '@react-aria/grid';
 import {Key} from 'react';
 import {Node} from '@react-types/shared';
@@ -30,7 +31,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
     // If focus was on a column, then focus the first child column if any,
     // or find the corresponding cell in the first row.
     if (startItem.type === 'column') {
-      let child = [...startItem.childNodes][0];
+      let child = getFirstItem(getChildNodes(startItem, this.collection));
       if (child) {
         return child.key;
       }
@@ -41,7 +42,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
       }
 
       let firstItem = this.collection.getItem(firstKey);
-      return [...firstItem.childNodes][startItem.index].key;
+      return getNthItem(getChildNodes(firstItem, this.collection), startItem.index).key;
     }
 
     return super.getKeyBelow(key);
@@ -88,7 +89,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
 
     // Wrap around to the first column
     let row = this.collection.headerRows[column.level];
-    for (let item of row.childNodes) {
+    for (let item of getChildNodes(row, this.collection)) {
       if (item.type === 'column') {
         return item.key;
       }
@@ -104,7 +105,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
 
     // Wrap around to the last column
     let row = this.collection.headerRows[column.level];
-    let childNodes = [...row.childNodes];
+    let childNodes = [...getChildNodes(row, this.collection)];
     for (let i = childNodes.length - 1; i >= 0; i--) {
       let item = childNodes[i];
       if (item.type === 'column') {
@@ -167,7 +168,7 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
       let item = collection.getItem(key);
 
       // Check each of the row header cells in this row for a match
-      for (let cell of item.childNodes) {
+      for (let cell of getChildNodes(item, this.collection)) {
         let column = collection.columns[cell.index];
         if (collection.rowHeaderColumnKeys.has(column.key) && cell.textValue) {
           let substring = cell.textValue.slice(0, search.length);

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -49,14 +49,15 @@ export function useTable<T>(props: AriaTableProps<T>, state: TableState<T>, ref:
   // When virtualized, the layout object will be passed in as a prop and override this.
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let {direction} = useLocale();
+  let disabledBehavior = state.selectionManager.disabledBehavior;
   let delegate = useMemo(() => keyboardDelegate || new TableKeyboardDelegate({
     collection: state.collection,
-    disabledKeys: state.disabledKeys,
+    disabledKeys: disabledBehavior === 'selection' ? new Set() : state.disabledKeys,
     ref,
     direction,
     collator,
     layout
-  }), [keyboardDelegate, state.collection, state.disabledKeys, ref, direction, collator, layout]);
+  }), [keyboardDelegate, state.collection, state.disabledKeys, disabledBehavior, ref, direction, collator, layout]);
   let id = useId(props.id);
   gridIds.set(state, id);
 

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -11,6 +11,7 @@
  */
 
 import {announce} from '@react-aria/live-announcer';
+import {getChildNodes} from '@react-stately/collections';
 import {GridAria, GridProps, useGrid} from '@react-aria/grid';
 import {gridIds} from './utils';
 // @ts-ignore
@@ -78,7 +79,7 @@ export function useTable<T>(props: AriaTableProps<T>, state: TableState<T>, ref:
       let rowHeaderColumnKeys = state.collection.rowHeaderColumnKeys;
       if (rowHeaderColumnKeys) {
         let text = [];
-        for (let cell of added.childNodes) {
+        for (let cell of getChildNodes(added, state.collection)) {
           let column = state.collection.columns[cell.index];
           if (rowHeaderColumnKeys.has(column.key) && cell.textValue) {
             text.push(cell.textValue);

--- a/packages/@react-aria/table/src/useTableRow.ts
+++ b/packages/@react-aria/table/src/useTableRow.ts
@@ -24,12 +24,12 @@ import {TableState} from '@react-stately/table';
  */
 export function useTableRow<T>(props: GridRowProps<T>, state: TableState<T>, ref: RefObject<FocusableElement>): GridRowAria {
   let {node} = props;
-  let {rowProps, isPressed} = useGridRow<T, TableCollection<T>, TableState<T>>(props, state, ref);
+  let {rowProps, ...states} = useGridRow<T, TableCollection<T>, TableState<T>>(props, state, ref);
   return {
     rowProps: {
       ...rowProps,
       'aria-labelledby': getRowLabelledBy(state, node.key)
     },
-    isPressed
+    ...states
   };
 }

--- a/packages/@react-aria/table/stories/example-backwards-compat.tsx
+++ b/packages/@react-aria/table/stories/example-backwards-compat.tsx
@@ -50,7 +50,7 @@ export function Table(props) {
       <TableRowGroup type="thead" style={{borderBottom: '2px solid gray', display: 'block'}}>
         {collection.headerRows.map(headerRow => (
           <TableHeaderRow key={headerRow.key} item={headerRow} state={state}>
-            {[...headerRow.childNodes].map(column =>
+            {[...state.collection.getChildren(headerRow.key)].map(column =>
               column.props.isSelectionCell
                 ? <TableSelectAllCell key={column.key} column={column} state={state} />
                 : <TableColumnHeader key={column.key} column={column} state={state} />
@@ -59,9 +59,9 @@ export function Table(props) {
         ))}
       </TableRowGroup>
       <TableRowGroup ref={bodyRef} type="tbody" style={{display: 'block', overflow: 'auto', maxHeight: '200px'}}>
-        {[...collection.body.childNodes].map(row => (
+        {[...collection].map(row => (
           <TableRow key={row.key} item={row} state={state} onAction={onAction}>
-            {[...row.childNodes].map(cell =>
+            {[...state.collection.getChildren(row.key)].map(cell =>
               cell.props.isSelectionCell
                 ? <TableCheckboxCell key={cell.key} cell={cell} state={state} />
                 : <TableCell key={cell.key} cell={cell} state={state} />

--- a/packages/@react-aria/table/stories/example-resizing.tsx
+++ b/packages/@react-aria/table/stories/example-resizing.tsx
@@ -8,7 +8,7 @@
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
- */
+*/
 
 import ariaStyles from './resizing.css';
 import {
@@ -83,7 +83,7 @@ export function Table(props) {
       <TableRowGroup type="thead" className={classNames(ariaStyles, 'aria-table-rowGroup', 'aria-table-rowGroupHeader')}>
         {collection.headerRows.map(headerRow => (
           <TableHeaderRow key={headerRow.key} item={headerRow} state={state} className={classNames(ariaStyles, 'aria-table-row', 'aria-table-headerRow')}>
-            {[...headerRow.childNodes].map(column =>
+            {[...state.collection.getChildren(headerRow.key)].map(column =>
               column.props.isSelectionCell
                 ? <TableSelectAllCell key={column.key} column={column} state={state} widths={widths} />
                 : <TableColumnHeader key={column.key} column={column} state={state} widths={widths} layout={layout} onResizeStart={props.onResizeStart} onResize={props.onResize} onResizeEnd={props.onResizeEnd} />
@@ -92,9 +92,9 @@ export function Table(props) {
         ))}
       </TableRowGroup>
       <TableRowGroup type="tbody" ref={bodyRef} className={classNames(ariaStyles, 'aria-table-rowGroup')}>
-        {[...collection.body.childNodes].map(row => (
+        {[...collection].map(row => (
           <TableRow key={row.key} item={row} state={state} className={classNames(ariaStyles, 'aria-table-row')}>
-            {[...row.childNodes].map(cell =>
+            {[...state.collection.getChildren(row.key)].map(cell =>
               cell.props.isSelectionCell
                 ? <TableCheckboxCell key={cell.key} cell={cell} state={state} widths={widths} />
                 : <TableCell key={cell.key} cell={cell} state={state} widths={widths} />

--- a/packages/@react-aria/table/stories/example.tsx
+++ b/packages/@react-aria/table/stories/example.tsx
@@ -50,7 +50,7 @@ export function Table(props) {
       <TableRowGroup type="thead" style={{borderBottom: '2px solid gray', display: 'block'}}>
         {collection.headerRows.map(headerRow => (
           <TableHeaderRow key={headerRow.key} item={headerRow} state={state}>
-            {[...headerRow.childNodes].map(column =>
+            {[...state.collection.getChildren(headerRow.key)].map(column =>
               column.props.isSelectionCell
                 ? <TableSelectAllCell key={column.key} column={column} state={state} />
                 : <TableColumnHeader key={column.key} column={column} state={state} />
@@ -59,9 +59,9 @@ export function Table(props) {
         ))}
       </TableRowGroup>
       <TableRowGroup ref={bodyRef} type="tbody" style={{display: 'block', overflow: 'auto', maxHeight: '200px'}}>
-        {[...collection.body.childNodes].map(row => (
+        {[...collection].map(row => (
           <TableRow key={row.key} item={row} state={state}>
-            {[...row.childNodes].map(cell =>
+            {[...state.collection.getChildren(row.key)].map(cell =>
               cell.props.isSelectionCell
                 ? <TableCheckboxCell key={cell.key} cell={cell} state={state} />
                 : <TableCell key={cell.key} cell={cell} state={state} />

--- a/packages/@react-aria/table/test/useTable.test.tsx
+++ b/packages/@react-aria/table/test/useTable.test.tsx
@@ -66,7 +66,7 @@ function Table(props) {
       <TableRowGroup type="thead" style={{borderBottom: '2px solid gray', display: 'block'}}>
         {collection.headerRows.map(headerRow => (
           <TableHeaderRow key={headerRow.key} item={headerRow} state={state}>
-            {[...headerRow.childNodes].map(column =>
+            {[...state.collection.getChildren(headerRow.key)].map(column =>
               column.props.isSelectionCell
                 ? <TableSelectAllCell key={column.key} column={column} state={state} />
                 : <TableColumnHeader key={column.key} column={column} state={state} />
@@ -75,9 +75,9 @@ function Table(props) {
         ))}
       </TableRowGroup>
       <TableRowGroup ref={bodyRef} type="tbody" style={{display: 'block', overflow: 'auto', maxHeight: '200px'}}>
-        {[...collection.body.childNodes].map(row => (
+        {[...collection].map(row => (
           <TableRow key={row.key} item={row} state={state}>
-            {[...row.childNodes].map(cell =>
+            {[...state.collection.getChildren(row.key)].map(cell =>
               cell.props.isSelectionCell
                 ? <TableCheckboxCell key={cell.key} cell={cell} state={state} />
                 : <TableCell key={cell.key} cell={cell} state={state} />

--- a/packages/@react-aria/table/test/useTableBackwardCompat.test.tsx
+++ b/packages/@react-aria/table/test/useTableBackwardCompat.test.tsx
@@ -59,7 +59,7 @@ function Table(props) {
       <TableRowGroup type="thead" style={{borderBottom: '2px solid gray', display: 'block'}}>
         {collection.headerRows.map(headerRow => (
           <TableHeaderRow key={headerRow.key} item={headerRow} state={state}>
-            {[...headerRow.childNodes].map(column =>
+            {[...state.collection.getChildren(headerRow.key)].map(column =>
               column.props.isSelectionCell
                 ? <TableSelectAllCell key={column.key} column={column} state={state} />
                 : <TableColumnHeader key={column.key} column={column} state={state} />
@@ -68,9 +68,9 @@ function Table(props) {
         ))}
       </TableRowGroup>
       <TableRowGroup ref={bodyRef} type="tbody" style={{display: 'block', overflow: 'auto', maxHeight: '200px'}}>
-        {[...collection.body.childNodes].map(row => (
+        {[...collection].map(row => (
           <TableRow key={row.key} item={row} state={state} onAction={onAction}>
-            {[...row.childNodes].map(cell =>
+            {[...state.collection.getChildren(row.key)].map(cell =>
               cell.props.isSelectionCell
                 ? <TableCheckboxCell key={cell.key} cell={cell} state={state} />
                 : <TableCell key={cell.key} cell={cell} state={state} />

--- a/packages/@react-aria/tabs/docs/useTabList.mdx
+++ b/packages/@react-aria/tabs/docs/useTabList.mdx
@@ -210,7 +210,7 @@ When `Tabs` is used with dynamic items as described below, the key of each item 
 See the `react-stately` [Selection docs](../react-stately/selection.html) for more details.
 
 ```tsx example
-<Tabs aria-label="Keyboard Settings" defaultSelectedKey="keyboard">
+<Tabs aria-label="Input settings" defaultSelectedKey="keyboard">
   <Item key="mouse">Mouse Settings</Item>
   <Item key="keyboard">Keyboard Settings</Item>
   <Item key="gamepad">Gamepad Settings</Item>
@@ -340,7 +340,7 @@ By default, tabs are horizontally oriented. The `orientation` prop can be set to
 All tabs can be disabled using the `isDisabled` prop.
 
 ```tsx example
-<Tabs aria-label="Mesozoic time periods" isDisabled>
+<Tabs aria-label="Input settings" isDisabled>
   <Item key="mouse">Mouse Settings</Item>
   <Item key="keyboard">Keyboard Settings</Item>
   <Item key="gamepad">Gamepad Settings</Item>

--- a/packages/@react-aria/tabs/src/useTab.ts
+++ b/packages/@react-aria/tabs/src/useTab.ts
@@ -23,7 +23,9 @@ export interface TabAria {
   /** Whether the tab is currently selected. */
   isSelected: boolean,
   /** Whether the tab is disabled. */
-  isDisabled: boolean
+  isDisabled: boolean,
+  /** Whether the tab is currently in a pressed state. */
+  isPressed: boolean
 }
 
 /**
@@ -41,7 +43,7 @@ export function useTab<T>(
   let isSelected = key === selectedKey;
 
   let isDisabled = propsDisabled || state.isDisabled || state.disabledKeys.has(key);
-  let {itemProps} = useSelectableItem({
+  let {itemProps, isPressed} = useSelectableItem({
     selectionManager: manager,
     key,
     ref,
@@ -63,7 +65,8 @@ export function useTab<T>(
       role: 'tab'
     },
     isSelected,
-    isDisabled
+    isDisabled,
+    isPressed
   };
 }
 

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -21,7 +21,15 @@ export interface ToggleAria {
   /**
    * Props to be spread on the input element.
    */
-  inputProps: InputHTMLAttributes<HTMLInputElement>
+  inputProps: InputHTMLAttributes<HTMLInputElement>,
+  /** Whether the toggle is selected. */
+  isSelected: boolean,
+  /** Whether the toggle is in a pressed state. */
+  isPressed: boolean,
+  /** Whether the toggle is disabled. */
+  isDisabled: boolean,
+  /** Whether the toggle is read only. */
+  isReadOnly: boolean
 }
 
 /**
@@ -30,8 +38,8 @@ export interface ToggleAria {
 export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefObject<HTMLInputElement>): ToggleAria {
   let {
     isDisabled = false,
-    isRequired,
-    isReadOnly,
+    isRequired = false,
+    isReadOnly = false,
     value,
     name,
     children,
@@ -54,7 +62,7 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
   }
 
   // This handles focusing the input on pointer down, which Safari does not do by default.
-  let {pressProps} = usePress({
+  let {pressProps, isPressed} = usePress({
     isDisabled
   });
 
@@ -75,6 +83,10 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
       name,
       type: 'checkbox',
       ...interactions
-    })
+    }),
+    isSelected: state.isSelected,
+    isPressed,
+    isDisabled,
+    isReadOnly
   };
 }

--- a/packages/@react-aria/utils/src/mergeRefs.ts
+++ b/packages/@react-aria/utils/src/mergeRefs.ts
@@ -16,6 +16,10 @@ import {ForwardedRef} from 'react';
  * Merges multiple refs into one. Works with either callback or object refs.
  */
 export function mergeRefs<T>(...refs: ForwardedRef<T>[]): ForwardedRef<T> {
+  if (refs.length === 1) {
+    return refs[0];
+  }
+
   return (value: T) => {
     for (let ref of refs) {
       if (typeof ref === 'function') {

--- a/packages/@react-aria/utils/src/useObjectRef.ts
+++ b/packages/@react-aria/utils/src/useObjectRef.ts
@@ -40,6 +40,14 @@ export function useObjectRef<T>(forwardedRef?: ((instance: T | null) => void) | 
     } else {
       forwardedRef.current = objRef.current;
     }
+
+    return () => {
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(null);
+      } else {
+        forwardedRef.current = null;
+      }
+    };
   }, [forwardedRef]);
 
   return objRef;

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -956,7 +956,7 @@ describe('ActionGroup', function () {
 
       const itemThree = within(menu).getByRole('menuitem', {name: 'Three'});
       expect(itemThree).toBeVisible();
-      expect(itemThree).toHaveAttribute('aria-disabled', 'false');
+      expect(itemThree).not.toHaveAttribute('aria-disabled');
 
       const itemFour = within(menu).getByRole('menuitem', {name: 'Four'});
       expect(itemFour).toBeVisible();

--- a/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
+++ b/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
@@ -897,7 +897,6 @@ describe('RangeCalendar', () => {
       act(() => userEvent.click(cell));
       expect(grid).not.toHaveAttribute('aria-activedescendant');
       expect(cell.parentElement).not.toHaveAttribute('aria-selected');
-      expect(document.activeElement).toBe(cell);
     });
 
     it('does not enter selection mode with the mouse on range end if isReadOnly', () => {
@@ -916,7 +915,6 @@ describe('RangeCalendar', () => {
 
       cell = getByText('15').closest('[role="button"]');
       act(() => userEvent.click(cell));
-      expect(document.activeElement).toBe(cell);
 
       selectedDates = getAllByLabelText('selected', {exact: false});
       expect(selectedDates[0].textContent).toBe('10');

--- a/packages/@react-spectrum/card/src/BaseLayout.tsx
+++ b/packages/@react-spectrum/card/src/BaseLayout.tsx
@@ -11,6 +11,7 @@
  */
 
 import {Direction, KeyboardDelegate, Node} from '@react-types/shared';
+import {getChildNodes, getFirstItem} from '@react-stately/collections';
 import {GridCollection} from '@react-stately/grid';
 import {InvalidationContext, Layout, LayoutInfo, Rect, Size} from '@react-stately/virtualizer';
 import {Key} from 'react';
@@ -146,7 +147,7 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     let layoutInfo = this.getLayoutInfo(parentRowKey);
     let rect = new Rect(layoutInfo.rect.x, layoutInfo.rect.maxY + 1, layoutInfo.rect.width, this.virtualizer.visibleRect.height);
     let closestRow = this.collection.getItem(this._findClosest(layoutInfo.rect, rect)?.key);
-    return closestRow?.childNodes[0]?.key;
+    return getFirstItem(getChildNodes(closestRow, this.collection))?.key;
   }
 
   getKeyAbove(key: Key) {
@@ -155,7 +156,7 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     let layoutInfo = this.getLayoutInfo(parentRowKey);
     let rect = new Rect(layoutInfo.rect.x, 0, layoutInfo.rect.width, layoutInfo.rect.y - 1);
     let closestRow = this.collection.getItem(this._findClosest(layoutInfo.rect, rect)?.key);
-    return closestRow?.childNodes[0]?.key;
+    return getFirstItem(getChildNodes(closestRow, this.collection))?.key;
   }
 
   getKeyRightOf(key: Key) {
@@ -167,7 +168,7 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
       let item = this.collection.getItem(key);
       // Don't check if item is disabled because we want to be able to focus disabled items in a grid (double check this)
       if (item.type === 'item') {
-        return item.childNodes[0].key;
+        return getFirstItem(getChildNodes(item, this.collection))?.key;
       }
       key = this.direction === 'rtl' ?  this.collection.getKeyBefore(key) : this.collection.getKeyAfter(key);
     }
@@ -181,7 +182,7 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
       let item = this.collection.getItem(key);
       // Don't check if item is disabled because we want to be able to focus disabled items in a grid (double check this)
       if (item.type === 'item') {
-        return item.childNodes[0].key;
+        return getFirstItem(getChildNodes(item, this.collection))?.key;
       }
 
       key = this.direction === 'rtl' ?  this.collection.getKeyAfter(key) : this.collection.getKeyBefore(key);
@@ -190,12 +191,12 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
 
   getFirstKey() {
     let firstRow = this.collection.getItem(this.collection.getFirstKey());
-    return firstRow.childNodes[0].key;
+    return getFirstItem(getChildNodes(firstRow, this.collection))?.key;
   }
 
   getLastKey() {
     let lastRow = this.collection.getItem(this.collection.getLastKey());
-    return lastRow.childNodes[0].key;
+    return getFirstItem(getChildNodes(lastRow, this.collection))?.key;
   }
 
   // TODO: pretty unwieldy because it needs to bounce back and forth between the parent key and the child key
@@ -214,14 +215,14 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
 
       if (layoutInfo && layoutInfo.rect.y > pageY) {
         while (layoutInfo && layoutInfo.rect.y > pageY) {
-          let childKey = this.collection.getItem(layoutInfo.key).childNodes[0].key;
+          let childKey = getFirstItem(getChildNodes(this.collection.getItem(layoutInfo.key), this.collection))?.key;
           let keyAbove = this.collection.getItem(this.getKeyAbove(childKey))?.parentKey;
           layoutInfo = this.getLayoutInfo(keyAbove);
         }
       }
 
       if (layoutInfo) {
-        let childKey = this.collection.getItem(layoutInfo.key).childNodes[0].key;
+        let childKey = getFirstItem(getChildNodes(this.collection.getItem(layoutInfo.key), this.collection))?.key;
         return childKey;
       }
     }
@@ -243,14 +244,14 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
       layoutInfo = this.getLayoutInfo(keyBelow);
       if (layoutInfo && layoutInfo.rect.y < pageY) {
         while (layoutInfo && layoutInfo.rect.y < pageY) {
-          let childKey = this.collection.getItem(layoutInfo.key).childNodes[0].key;
+          let childKey = getFirstItem(getChildNodes(this.collection.getItem(layoutInfo.key), this.collection))?.key;
           let keyBelow = this.collection.getItem(this.getKeyBelow(childKey))?.parentKey;
           layoutInfo = this.getLayoutInfo(keyBelow);
         }
       }
 
       if (layoutInfo) {
-        let childKey = this.collection.getItem(layoutInfo.key).childNodes[0].key;
+        let childKey = getFirstItem(getChildNodes(this.collection.getItem(layoutInfo.key), this.collection))?.key;
         return childKey;
       }
     }
@@ -274,7 +275,7 @@ export class BaseLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
       if (item.textValue) {
         let substring = item.textValue.slice(0, search.length);
         if (this.collator.compare(substring, search) === 0) {
-          return [...item.childNodes][0].key;
+          return getFirstItem(getChildNodes(item, this.collection))?.key;
         }
       }
 

--- a/packages/@react-spectrum/card/src/GridLayout.tsx
+++ b/packages/@react-spectrum/card/src/GridLayout.tsx
@@ -11,6 +11,7 @@
  */
 
 import {BaseLayout, BaseLayoutOptions} from './BaseLayout';
+import {getChildNodes, getFirstItem} from '@react-stately/collections';
 import {Key} from 'react';
 import {LayoutInfo, Rect, Size} from '@react-stately/virtualizer';
 import {Node, Orientation} from '@react-types/shared';
@@ -255,7 +256,8 @@ export class GridLayout<T> extends BaseLayout<T> {
       return null;
     }
 
-    return this.collection.rows[indexRowBelow]?.childNodes[0].key || null;
+    let row = this.collection.rows[indexRowBelow];
+    return getFirstItem(getChildNodes(row, this.collection))?.key;
   }
 
   getKeyAbove(key: Key) {
@@ -269,6 +271,7 @@ export class GridLayout<T> extends BaseLayout<T> {
       return null;
     }
 
-    return this.collection.rows[indexRowAbove]?.childNodes[0].key || null;
+    let row = this.collection.rows[indexRowAbove];
+    return getFirstItem(getChildNodes(row, this.collection))?.key;
   }
 }

--- a/packages/@react-spectrum/card/src/WaterfallLayout.tsx
+++ b/packages/@react-spectrum/card/src/WaterfallLayout.tsx
@@ -11,6 +11,7 @@
  */
 
 import {BaseLayout, BaseLayoutOptions} from './BaseLayout';
+import {getChildNodes, getFirstItem} from '@react-stately/collections';
 import {InvalidationContext, LayoutInfo, Rect, Size} from '@react-stately/virtualizer';
 import {Key} from 'react';
 import {KeyboardDelegate, Node} from '@react-types/shared';
@@ -207,7 +208,8 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
       key = this._findClosest(layoutInfo.rect, rect)?.key;
     }
 
-    return this.collection.getItem(key)?.childNodes[0]?.key;
+    let item = this.collection.getItem(key);
+    return getFirstItem(getChildNodes(item, this.collection))?.key;
   }
 
   getClosestLeft(key: Key) {
@@ -221,7 +223,8 @@ export class WaterfallLayout<T> extends BaseLayout<T> implements KeyboardDelegat
       key = this._findClosest(layoutInfo.rect, rect)?.key;
     }
 
-    return this.collection.getItem(key)?.childNodes[0]?.key;
+    let item = this.collection.getItem(key);
+    return getFirstItem(getChildNodes(item, this.collection))?.key;
   }
 
   getKeyRightOf(key: Key) {

--- a/packages/@react-spectrum/datepicker/src/utils.ts
+++ b/packages/@react-spectrum/datepicker/src/utils.ts
@@ -19,7 +19,7 @@ import {useImperativeHandle, useMemo, useRef, useState} from 'react';
 import {useLayoutEffect} from '@react-aria/utils';
 import {useProvider} from '@react-spectrum/provider';
 
-export function useFormatHelpText(props: Pick<SpectrumDatePickerBase<any>, 'description' | 'showFormatHelpText'>) {
+export function useFormatHelpText(props: Pick<SpectrumDatePickerBase, 'description' | 'showFormatHelpText'>) {
   let formatter = useDateFormatter({dateStyle: 'short'});
   let displayNames = useDisplayNames();
   return useMemo(() => {

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -110,7 +110,7 @@ describe('ListBox', function () {
     for (let item of items) {
       expect(item).toHaveAttribute('tabindex');
       expect(item).not.toHaveAttribute('aria-selected');
-      expect(item).toHaveAttribute('aria-disabled');
+      expect(item).not.toHaveAttribute('aria-disabled');
       expect(item).toHaveAttribute('aria-posinset', '' + i++);
       expect(item).toHaveAttribute('aria-setsize');
     }

--- a/packages/@react-spectrum/menu/src/MenuSection.tsx
+++ b/packages/@react-spectrum/menu/src/MenuSection.tsx
@@ -11,6 +11,7 @@
  */
 
 import {classNames} from '@react-spectrum/utils';
+import {getChildNodes} from '@react-stately/collections';
 import {MenuItem} from './MenuItem';
 import {Node} from '@react-types/shared';
 import React, {Fragment, Key} from 'react';
@@ -68,7 +69,7 @@ export function MenuSection<T>(props: MenuSectionProps<T>) {
               'spectrum-Menu'
             )
           }>
-          {[...item.childNodes].map(node => {
+          {[...getChildNodes(item, state.collection)].map(node => {
             let item = (
               <MenuItem
                 key={node.key}

--- a/packages/@react-spectrum/menu/test/Menu.test.js
+++ b/packages/@react-spectrum/menu/test/Menu.test.js
@@ -98,7 +98,7 @@ describe('Menu', function () {
     expect(items.length).toBe(5);
     for (let item of items) {
       expect(item).toHaveAttribute('tabindex');
-      expect(item).toHaveAttribute('aria-disabled');
+      expect(item).not.toHaveAttribute('aria-disabled');
     }
     let item1 = within(menu).getByText('Foo');
     let item2 = within(menu).getByText('Bar');

--- a/packages/@react-spectrum/progress/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressCircle.tsx
@@ -98,7 +98,7 @@ function ProgressCircle(props: SpectrumProgressCircleProps, ref: DOMRef<HTMLDivE
 }
 
 /**
- * ProgressCircles show the progression of a system operation such as downloading, uploading, processing, etc. in a visual way.
+ * ProgressCircles show the progression of a system operation such as downloading, uploading, or processing, in a visual way.
  * They can represent determinate or indeterminate progress.
  */
 let _ProgressCircle = React.forwardRef(ProgressCircle);

--- a/packages/@react-stately/collections/src/Section.ts
+++ b/packages/@react-stately/collections/src/Section.ts
@@ -31,7 +31,7 @@ Section.getCollectionNode = function* getCollectionNode<T>(props: SectionProps<T
         if (!items) {
           throw new Error('props.children was a function but props.items is missing');
         }
-    
+
         for (let item of items) {
           yield {
             type: 'item',

--- a/packages/@react-stately/collections/src/getChildNodes.ts
+++ b/packages/@react-stately/collections/src/getChildNodes.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type {Collection, Node} from '@react-types/shared';
+
+export function getChildNodes<T>(node: Node<T>, collection: Collection<Node<T>>): Iterable<Node<T>> {
+  // New API: call collection.getChildren with the node key.
+  if (typeof collection.getChildren === 'function') {
+    return collection.getChildren(node.key);
+  }
+
+  // Old API: access childNodes directly.
+  return node.childNodes;
+}
+
+export function getFirstItem<T>(iterable: Iterable<T>): T | undefined {
+  return getNthItem(iterable, 0);
+}
+
+export function getNthItem<T>(iterable: Iterable<T>, index: number): T | undefined {
+  if (index < 0) {
+    return undefined;
+  }
+
+  let i = 0;
+  for (let item of iterable) {
+    if (i === index) {
+      return item;
+    }
+
+    i++;
+  }
+}
+
+export function getLastItem<T>(iterable: Iterable<T>): T | undefined {
+  let lastItem = undefined;
+  for (let value of iterable) {
+    lastItem = value;
+  }
+
+  return lastItem;
+}

--- a/packages/@react-stately/collections/src/getItemCount.ts
+++ b/packages/@react-stately/collections/src/getItemCount.ts
@@ -10,25 +10,29 @@
  * governing permissions and limitations under the License.
  */
 
-import {Node} from '@react-types/shared';
+import {Collection, Node} from '@react-types/shared';
+import {getChildNodes} from './getChildNodes';
 
 const cache = new WeakMap<Iterable<unknown>, number>();
 
-export function getItemCount<T>(collection: Iterable<Node<T>>): number {
+export function getItemCount<T>(collection: Collection<Node<T>>): number {
   let count = cache.get(collection);
   if (count != null) {
     return count;
   }
 
   count = 0;
-  for (let item of collection) {
-    if (item.type === 'section') {
-      count += getItemCount(item.childNodes);
-    } else {
-      count++;
+  let countItems = (items: Iterable<Node<T>>) => {
+    for (let item of items) {
+      if (item.type === 'section') {
+        countItems(getChildNodes(item, collection));
+      } else {
+        count++;
+      }
     }
-  }
+  };
 
+  countItems(collection);
   cache.set(collection, count);
   return count;
 }

--- a/packages/@react-stately/collections/src/index.ts
+++ b/packages/@react-stately/collections/src/index.ts
@@ -15,3 +15,4 @@ export {Item} from './Item';
 export {Section} from './Section';
 export {useCollection} from './useCollection';
 export {getItemCount} from './getItemCount';
+export {getChildNodes, getFirstItem, getLastItem, getNthItem} from './getChildNodes';

--- a/packages/@react-stately/collections/src/useCollection.ts
+++ b/packages/@react-stately/collections/src/useCollection.ts
@@ -10,21 +10,25 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, CollectionBase, Node} from '@react-types/shared';
+import {Collection, CollectionBase, CollectionStateBase, Node} from '@react-types/shared';
 import {CollectionBuilder} from './CollectionBuilder';
 import {useMemo, useRef} from 'react';
 
 type CollectionFactory<T, C extends Collection<Node<T>>> = (node: Iterable<Node<T>>, prev: C | null) => C;
 
-export function useCollection<T extends object, C extends Collection<Node<T>> = Collection<Node<T>>>(props: CollectionBase<T>, factory: CollectionFactory<T, C>, context?: unknown, invalidators: Array<any> = []): C {
+export function useCollection<T extends object, C extends Collection<Node<T>> = Collection<Node<T>>>(props: CollectionStateBase<T, C>, factory: CollectionFactory<T, C>, context?: unknown, invalidators: Array<any> = []): C {
   let builder = useMemo(() => new CollectionBuilder<T>(), []);
 
   let prev = useRef<C>(null);
   return useMemo(() => {
-    let nodes = builder.build(props, context);
+    if (props.collection) {
+      return props.collection;
+    }
+
+    let nodes = builder.build(props as CollectionBase<T>, context);
     prev.current = factory(nodes, prev.current);
     return prev.current;
   // Don't invalidate when any prop changes, just the two we care about.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [builder, props.children, props.items, context, ...invalidators]);
+  }, [builder, props.children, props.items, props.collection, context, ...invalidators]);
 }

--- a/packages/@react-stately/combobox/package.json
+++ b/packages/@react-stately/combobox/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-stately/collections": "^3.6.0",
     "@react-stately/list": "^3.7.0",
     "@react-stately/menu": "^3.5.0",
     "@react-stately/select": "^3.4.0",

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -10,8 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, FocusStrategy, Node} from '@react-types/shared';
+import {Collection, CollectionStateBase, FocusStrategy, Node} from '@react-types/shared';
 import {ComboBoxProps, MenuTriggerAction} from '@react-types/combobox';
+import {getChildNodes} from '@react-stately/collections';
 import {ListCollection, useSingleSelectListState} from '@react-stately/list';
 import {SelectState} from '@react-stately/select';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -35,7 +36,7 @@ export interface ComboBoxState<T> extends SelectState<T> {
 
 type FilterFn = (textValue: string, inputValue: string) => boolean;
 
-export interface ComboBoxStateOptions<T> extends ComboBoxProps<T> {
+export interface ComboBoxStateOptions<T> extends Omit<ComboBoxProps<T>, 'children'>, CollectionStateBase<T> {
   /** The filter function used to determine if a option should be included in the combo box list. */
   defaultFilter?: FilterFn,
   /** Whether the combo box allows the menu to be open when the collection is empty. */
@@ -357,14 +358,14 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
 }
 
 function filterCollection<T extends object>(collection: Collection<Node<T>>, inputValue: string, filter: FilterFn): Collection<Node<T>> {
-  return new ListCollection(filterNodes(collection, inputValue, filter));
+  return new ListCollection(filterNodes(collection, collection, inputValue, filter));
 }
 
-function filterNodes<T>(nodes: Iterable<Node<T>>, inputValue: string, filter: FilterFn): Iterable<Node<T>> {
+function filterNodes<T>(collection: Collection<Node<T>>, nodes: Iterable<Node<T>>, inputValue: string, filter: FilterFn): Iterable<Node<T>> {
   let filteredNode = [];
   for (let node of nodes) {
     if (node.type === 'section' && node.hasChildNodes) {
-      let filtered = filterNodes(node.childNodes, inputValue, filter);
+      let filtered = filterNodes(collection, getChildNodes(node, collection), inputValue, filter);
       if ([...filtered].length > 0) {
         filteredNode.push({...node, childNodes: filtered});
       }

--- a/packages/@react-stately/grid/package.json
+++ b/packages/@react-stately/grid/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-stately/collections": "^3.6.0",
     "@react-stately/selection": "^3.12.0",
     "@react-types/grid": "^3.1.6",
     "@react-types/shared": "^3.17.0",

--- a/packages/@react-stately/grid/src/GridCollection.ts
+++ b/packages/@react-stately/grid/src/GridCollection.ts
@@ -155,4 +155,9 @@ export class GridCollection<T> implements IGridCollection<T> {
     const keys = [...this.getKeys()];
     return this.getItem(keys[idx]);
   }
+
+  getChildren(key: Key): Iterable<GridNode<T>> {
+    let node = this.keyMap.get(key);
+    return node?.childNodes || [];
+  }
 }

--- a/packages/@react-stately/grid/src/useGridState.ts
+++ b/packages/@react-stately/grid/src/useGridState.ts
@@ -1,3 +1,4 @@
+import {getChildNodes, getFirstItem, getLastItem} from '@react-stately/collections';
 import {GridCollection, GridNode} from '@react-types/grid';
 import {Key, useEffect, useMemo, useRef} from 'react';
 import {MultipleSelectionStateProps, SelectionManager, useMultipleSelectionState} from '@react-stately/selection';
@@ -34,11 +35,11 @@ export function useGridState<T extends object, C extends GridCollection<T>>(prop
     if (focusMode === 'cell' && key != null) {
       let item = collection.getItem(key);
       if (item?.type === 'item') {
-        let children = [...item.childNodes];
+        let children = getChildNodes(item, collection);
         if (child === 'last') {
-          key = children[children.length - 1]?.key;
+          key = getLastItem(children)?.key;
         } else {
-          key = children[0]?.key;
+          key = getFirstItem(children)?.key;
         }
       }
     }
@@ -88,7 +89,7 @@ export function useGridState<T extends object, C extends GridCollection<T>>(prop
         }
       }
       if (newRow) {
-        const childNodes = newRow.hasChildNodes ? [...newRow.childNodes] : [];
+        const childNodes = newRow.hasChildNodes ? [...getChildNodes(newRow, collection)] : [];
         const keyToFocus =
           newRow.hasChildNodes &&
           parentNode !== node &&

--- a/packages/@react-stately/layout/package.json
+++ b/packages/@react-stately/layout/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-stately/collections": "^3.6.0",
     "@react-stately/table": "^3.8.0",
     "@react-stately/virtualizer": "^3.5.0",
     "@react-types/grid": "^3.1.6",

--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -11,6 +11,7 @@
  */
 
 import {Collection, DropTarget, DropTargetDelegate, KeyboardDelegate, Node} from '@react-types/shared';
+import {getChildNodes} from '@react-stately/collections';
 import {InvalidationContext, Layout, LayoutInfo, Point, Rect, Size} from '@react-stately/virtualizer';
 import {Key} from 'react';
 // import { DragTarget, DropTarget, DropPosition } from '@react-types/shared';
@@ -312,7 +313,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate, 
     let startY = y;
     let skipped = 0;
     let children = [];
-    for (let child of node.childNodes) {
+    for (let child of getChildNodes(node, this.collection)) {
       let rowHeight = (this.rowHeight ?? this.estimatedRowHeight);
 
       // Skip rows before the valid rectangle unless they are already cached.
@@ -328,7 +329,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate, 
 
       if (y > this.validRect.maxY) {
         // Estimate the remaining height for rows that we don't need to layout right now.
-        y += ([...node.childNodes].length - (children.length + skipped)) * rowHeight;
+        y += ([...getChildNodes(node, this.collection)].length - (children.length + skipped)) * rowHeight;
         break;
       }
     }

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -11,6 +11,7 @@
  */
 
 import {ColumnSize, TableCollection} from '@react-types/table';
+import {getChildNodes} from '@react-stately/collections';
 import {GridNode} from '@react-types/grid';
 import {InvalidationContext, LayoutInfo, Point, Rect, Size} from '@react-stately/virtualizer';
 import {Key} from 'react';
@@ -181,7 +182,7 @@ export class TableLayout<T> extends ListLayout<T> {
 
     let height = 0;
     let columns: LayoutNode[] = [];
-    for (let cell of headerRow.childNodes) {
+    for (let cell of getChildNodes(headerRow, this.collection)) {
       let layoutNode = this.buildChild(cell, x, y);
       layoutNode.layoutInfo.parentKey = row.key;
       x = layoutNode.layoutInfo.rect.maxX;
@@ -275,7 +276,7 @@ export class TableLayout<T> extends ListLayout<T> {
     let skipped = 0;
     let width = 0;
     let children: LayoutNode[] = [];
-    for (let node of this.collection.body.childNodes) {
+    for (let node of this.collection) {
       let rowHeight = (this.rowHeight ?? this.estimatedRowHeight) + 1;
 
       // Skip rows before the valid rectangle unless they are already cached.
@@ -353,7 +354,7 @@ export class TableLayout<T> extends ListLayout<T> {
 
     let children: LayoutNode[] = [];
     let height = 0;
-    for (let child of node.childNodes) {
+    for (let child of getChildNodes(node, this.collection)) {
       if (x > this.validRect.maxX) {
         // Adjust existing cached layoutInfo to ensure that it is out of view.
         // This can happen due to column resizing.

--- a/packages/@react-stately/list/src/ListCollection.ts
+++ b/packages/@react-stately/list/src/ListCollection.ts
@@ -99,4 +99,9 @@ export class ListCollection<T> implements Collection<Node<T>> {
     const keys = [...this.getKeys()];
     return this.getItem(keys[idx]);
   }
+
+  getChildren(key: Key): Iterable<Node<T>> {
+    let node = this.keyMap.get(key);
+    return node?.childNodes || [];
+  }
 }

--- a/packages/@react-stately/list/src/useListState.ts
+++ b/packages/@react-stately/list/src/useListState.ts
@@ -10,13 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, CollectionBase, Node} from '@react-types/shared';
+import {Collection, CollectionStateBase, Node} from '@react-types/shared';
 import {Key, useEffect, useMemo, useRef} from 'react';
 import {ListCollection} from './ListCollection';
 import {MultipleSelectionStateProps, SelectionManager, useMultipleSelectionState} from '@react-stately/selection';
 import {useCollection} from '@react-stately/collections';
 
-export interface ListProps<T> extends CollectionBase<T>, MultipleSelectionStateProps {
+export interface ListProps<T> extends CollectionStateBase<T>, MultipleSelectionStateProps {
   /** Filter function to generate a filtered list of nodes. */
   filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>,
   /** @private */

--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -10,13 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionBase, SingleSelection} from '@react-types/shared';
+import {CollectionStateBase, SingleSelection} from '@react-types/shared';
 import {Key, useMemo} from 'react';
 import {ListState, useListState} from './useListState';
 import {Node} from '@react-types/shared';
 import {useControlledState} from '@react-stately/utils';
 
-export interface SingleSelectListProps<T> extends CollectionBase<T>, Omit<SingleSelection, 'disallowEmptySelection'> {
+export interface SingleSelectListProps<T> extends CollectionStateBase<T>, Omit<SingleSelection, 'disallowEmptySelection'> {
   /** Filter function to generate a filtered list of nodes. */
   filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>,
   /** @private */

--- a/packages/@react-stately/radio/src/useRadioGroupState.ts
+++ b/packages/@react-stately/radio/src/useRadioGroupState.ts
@@ -29,6 +29,12 @@ export interface RadioGroupState {
   /** Whether the radio group is read only. */
   readonly isReadOnly: boolean,
 
+  /** Whether the radio group is required. */
+  readonly isRequired: boolean,
+
+  /** Whether the radio group is valid or invalid. */
+  readonly validationState: ValidationState | null,
+
   /** The currently selected value. */
   readonly selectedValue: string | null,
 
@@ -39,10 +45,7 @@ export interface RadioGroupState {
   readonly lastFocusedValue: string | null,
 
   /** Sets the last focused value. */
-  setLastFocusedValue(value: string): void,
-
-  /** The current validation state of the radio group. */
-  validationState: ValidationState
+  setLastFocusedValue(value: string): void
 }
 
 let instance = Math.round(Math.random() * 10000000000);
@@ -72,6 +75,7 @@ export function useRadioGroupState(props: RadioGroupProps): RadioGroupState  {
     setLastFocusedValue,
     isDisabled: props.isDisabled || false,
     isReadOnly: props.isReadOnly || false,
-    validationState: props.validationState
+    isRequired: props.isRequired || false,
+    validationState: props.validationState || null
   };
 }

--- a/packages/@react-stately/select/src/useSelectState.ts
+++ b/packages/@react-stately/select/src/useSelectState.ts
@@ -10,10 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+import {CollectionStateBase} from '@react-types/shared';
 import {MenuTriggerState, useMenuTriggerState} from '@react-stately/menu';
 import {SelectProps} from '@react-types/select';
 import {SingleSelectListState, useSingleSelectListState} from '@react-stately/list';
 import {useState} from 'react';
+
+export interface SelectStateOptions<T> extends Omit<SelectProps<T>, 'children'>, CollectionStateBase<T> {}
 
 export interface SelectState<T> extends SingleSelectListState<T>, MenuTriggerState {
   /** Whether the select is currently focused. */
@@ -28,7 +31,7 @@ export interface SelectState<T> extends SingleSelectListState<T>, MenuTriggerSta
  * of items from props, handles the open state for the popup menu, and manages
  * multiple selection state.
  */
-export function useSelectState<T extends object>(props: SelectProps<T>): SelectState<T>  {
+export function useSelectState<T extends object>(props: SelectStateOptions<T>): SelectState<T>  {
   let triggerState = useMenuTriggerState(props);
   let listState = useSingleSelectListState({
     ...props,

--- a/packages/@react-stately/selection/src/SelectionManager.ts
+++ b/packages/@react-stately/selection/src/SelectionManager.ts
@@ -21,6 +21,7 @@ import {
   SelectionBehavior,
   SelectionMode
 } from '@react-types/shared';
+import {getChildNodes, getFirstItem} from '@react-stately/collections';
 import {Key} from 'react';
 import {MultipleSelectionManager, MultipleSelectionState} from './types';
 import {Selection} from './Selection';
@@ -385,7 +386,7 @@ export class SelectionManager implements MultipleSelectionManager {
 
           // Add child keys. If cell selection is allowed, then include item children too.
           if (item.hasChildNodes && (this.allowsCellSelection || item.type !== 'item')) {
-            addKeys([...item.childNodes][0].key);
+            addKeys(getFirstItem(getChildNodes(item, this.collection)).key);
           }
         }
 

--- a/packages/@react-stately/table/src/TableCollection.ts
+++ b/packages/@react-stately/table/src/TableCollection.ts
@@ -9,8 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import {getFirstItem, getLastItem} from '@react-stately/collections';
 import {GridCollection} from '@react-stately/grid';
 import {GridNode} from '@react-types/grid';
+import {TableCollection as ITableCollection} from '@react-types/table';
 import {Key} from 'react';
 
 interface GridCollectionOptions {
@@ -19,7 +21,12 @@ interface GridCollectionOptions {
 
 const ROW_HEADER_COLUMN_KEY = 'row-header-column-' + Math.random().toString(36).slice(2);
 
-function buildHeaderRows<T>(keyMap: Map<Key, GridNode<T>>, columnNodes: GridNode<T>[]): GridNode<T>[] {
+/** @private */
+export function buildHeaderRows<T>(keyMap: Map<Key, GridNode<T>>, columnNodes: GridNode<T>[]): GridNode<T>[] {
+  if (columnNodes.length === 0) {
+    return [];
+  }
+
   let columns: GridNode<T>[][] = [];
   let seen = new Map();
   for (let column of columnNodes) {
@@ -28,6 +35,9 @@ function buildHeaderRows<T>(keyMap: Map<Key, GridNode<T>>, columnNodes: GridNode
 
     while (parentKey) {
       let parent: GridNode<T> = keyMap.get(parentKey);
+      if (!parent) {
+        break;
+      }
 
       // If we've already seen this parent, than it is shared
       // with a previous column. If the current column is taller
@@ -158,14 +168,14 @@ function buildHeaderRows<T>(keyMap: Map<Key, GridNode<T>>, columnNodes: GridNode
   });
 }
 
-export class TableCollection<T> extends GridCollection<T> {
+export class TableCollection<T> extends GridCollection<T> implements ITableCollection<T> {
   headerRows: GridNode<T>[];
   columns: GridNode<T>[];
   rowHeaderColumnKeys: Set<Key>;
   body: GridNode<T>;
   _size: number = 0;
 
-  constructor(nodes: Iterable<GridNode<T>>, prev?: TableCollection<T>, opts?: GridCollectionOptions) {
+  constructor(nodes: Iterable<GridNode<T>>, prev?: ITableCollection<T>, opts?: GridCollectionOptions) {
     let rowHeaderColumnKeys: Set<Key> = new Set();
     let body: GridNode<T>;
     let columns = [];
@@ -266,12 +276,11 @@ export class TableCollection<T> extends GridCollection<T> {
   }
 
   getFirstKey() {
-    return [...this.body.childNodes][0]?.key;
+    return getFirstItem(this.body.childNodes)?.key;
   }
 
   getLastKey() {
-    let rows = [...this.body.childNodes];
-    return rows[rows.length - 1]?.key;
+    return getLastItem(this.body.childNodes)?.key;
   }
 
   getItem(key: Key) {

--- a/packages/@react-stately/table/src/useTableState.ts
+++ b/packages/@react-stately/table/src/useTableState.ts
@@ -69,7 +69,11 @@ export function useTableState<T extends object>(props: TableStateProps<T>): Tabl
     (nodes, prev) => new TableCollection(nodes, prev, context),
     context
   );
-  let {disabledKeys, selectionManager} = useGridState({...props, collection, disabledBehavior: 'selection'});
+  let {disabledKeys, selectionManager} = useGridState({
+    ...props,
+    collection,
+    disabledBehavior: props.disabledBehavior || 'selection'
+  });
 
   return {
     collection,

--- a/packages/@react-stately/table/src/useTableState.ts
+++ b/packages/@react-stately/table/src/useTableState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionBase, Node, SelectionMode, Sortable, SortDescriptor, SortDirection} from '@react-types/shared';
+import {CollectionStateBase, Node, SelectionMode, Sortable, SortDescriptor, SortDirection} from '@react-types/shared';
 import {GridState, useGridState} from '@react-stately/grid';
 import {TableCollection as ITableCollection} from '@react-types/table';
 import {Key, useMemo, useState} from 'react';
@@ -39,7 +39,7 @@ export interface CollectionBuilderContext<T> {
   columns: Node<T>[]
 }
 
-export interface TableStateProps<T> extends CollectionBase<T>, MultipleSelectionStateProps, Sortable {
+export interface TableStateProps<T> extends CollectionStateBase<T, ITableCollection<T>>, MultipleSelectionStateProps, Sortable {
   /** Whether the row selection checkboxes should be displayed. */
   showSelectionCheckboxes?: boolean
 }
@@ -64,7 +64,7 @@ export function useTableState<T extends object>(props: TableStateProps<T>): Tabl
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [props.children, props.showSelectionCheckboxes, selectionMode]);
 
-  let collection = useCollection<T, TableCollection<T>>(
+  let collection = useCollection<T, ITableCollection<T>>(
     props,
     (nodes, prev) => new TableCollection(nodes, prev, context),
     context

--- a/packages/@react-stately/tabs/package.json
+++ b/packages/@react-stately/tabs/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@react-stately/list": "^3.7.0",
     "@react-stately/utils": "^3.6.0",
+    "@react-types/shared": "^3.17.0",
     "@react-types/tabs": "^3.2.0",
     "@swc/helpers": "^0.4.14"
   },

--- a/packages/@react-stately/tabs/src/index.ts
+++ b/packages/@react-stately/tabs/src/index.ts
@@ -13,4 +13,4 @@
 export {useTabListState} from './useTabListState';
 
 export type {TabListProps} from '@react-types/tabs';
-export type {TabListState} from './useTabListState';
+export type {TabListStateOptions, TabListState} from './useTabListState';

--- a/packages/@react-stately/tabs/src/useTabListState.ts
+++ b/packages/@react-stately/tabs/src/useTabListState.ts
@@ -10,10 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+import {CollectionStateBase} from '@react-types/shared';
 import {SingleSelectListState, useSingleSelectListState} from '@react-stately/list';
 import {TabListProps} from '@react-types/tabs';
 import {useRef} from 'react';
 
+export interface TabListStateOptions<T> extends Omit<TabListProps<T>, 'children'>, CollectionStateBase<T> {}
 
 export interface TabListState<T> extends SingleSelectListState<T> {
   /** Whether the tab list is disabled. */
@@ -24,7 +26,7 @@ export interface TabListState<T> extends SingleSelectListState<T> {
  * Provides state management for a Tabs component. Tabs include a TabList which tracks
  * which tab is currently selected and displays the content associated with that Tab in a TabPanel.
  */
-export function useTabListState<T extends object>(props: TabListProps<T>): TabListState<T> {
+export function useTabListState<T extends object>(props: TabListStateOptions<T>): TabListState<T> {
   let state = useSingleSelectListState<T>({
     ...props,
     suppressTextValueWarning: true
@@ -49,12 +51,15 @@ export function useTabListState<T extends object>(props: TabListProps<T>): TabLi
     if (state.disabledKeys.has(selectedKey) && selectedKey === collection.getLastKey()) {
       selectedKey = collection.getFirstKey();
     }
-    // directly set selection because replace/toggle selection won't consider disabled keys
-    selectionManager.setSelectedKeys([selectedKey]);
+
+    if (selectedKey != null) {
+      // directly set selection because replace/toggle selection won't consider disabled keys
+      selectionManager.setSelectedKeys([selectedKey]);
+    }
   }
 
   // If the tablist doesn't have focus and the selected key changes or if there isn't a focused key yet, change focused key to the selected key if it exists.
-  if (selectionManager.focusedKey == null || (!selectionManager.isFocused && selectedKey !== lastSelectedKey.current)) {
+  if (selectedKey != null && selectionManager.focusedKey == null || (!selectionManager.isFocused && selectedKey !== lastSelectedKey.current)) {
     selectionManager.setFocusedKey(selectedKey);
   }
   lastSelectedKey.current = selectedKey;

--- a/packages/@react-stately/tree/src/useTreeState.ts
+++ b/packages/@react-stately/tree/src/useTreeState.ts
@@ -10,14 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, CollectionBase, Expandable, MultipleSelection, Node} from '@react-types/shared';
+import {Collection, CollectionStateBase, Expandable, MultipleSelection, Node} from '@react-types/shared';
 import {Key, useEffect, useMemo} from 'react';
 import {SelectionManager, useMultipleSelectionState} from '@react-stately/selection';
 import {TreeCollection} from './TreeCollection';
 import {useCollection} from '@react-stately/collections';
 import {useControlledState} from '@react-stately/utils';
 
-export interface TreeProps<T> extends CollectionBase<T>, Expandable, MultipleSelection {}
+export interface TreeProps<T> extends CollectionStateBase<T>, Expandable, MultipleSelection {}
 export interface TreeState<T> {
   /** A collection of items in the tree. */
   readonly collection: Collection<Node<T>>,

--- a/packages/@react-types/datepicker/src/index.d.ts
+++ b/packages/@react-types/datepicker/src/index.d.ts
@@ -34,7 +34,7 @@ type MappedDateValue<T> =
   never;
 
 export type Granularity = 'day' | 'hour' | 'minute' | 'second';
-interface DatePickerBase<T extends DateValue> extends InputBase, Validation, FocusableProps, LabelableProps, HelpTextProps, OverlayTriggerProps {
+interface DateFieldBase<T extends DateValue> extends InputBase, Validation, FocusableProps, LabelableProps, HelpTextProps, OverlayTriggerProps {
   /** The minimum allowed date that a user may select. */
   minValue?: DateValue,
   /** The maximum allowed date that a user may select. */
@@ -54,10 +54,15 @@ interface DatePickerBase<T extends DateValue> extends InputBase, Validation, Foc
   hideTimeZone?: boolean
 }
 
+interface AriaDateFieldBaseProps<T extends DateValue> extends DateFieldBase<T>, AriaLabelingProps, DOMProps {}
+export interface DateFieldProps<T extends DateValue> extends DateFieldBase<T>, ValueBase<T, MappedDateValue<T>> {}
+export interface AriaDateFieldProps<T extends DateValue> extends DateFieldProps<T>, AriaDateFieldBaseProps<T> {}
+
+interface DatePickerBase<T extends DateValue> extends DateFieldBase<T>, OverlayTriggerProps {}
 export interface AriaDatePickerBaseProps<T extends DateValue> extends DatePickerBase<T>, AriaLabelingProps, DOMProps {}
 
 export interface DatePickerProps<T extends DateValue> extends DatePickerBase<T>, ValueBase<T, MappedDateValue<T>> {}
-export interface AriaDatePickerProps<T extends DateValue> extends AriaDatePickerBaseProps<T>, DatePickerProps<T> {}
+export interface AriaDatePickerProps<T extends DateValue> extends DatePickerProps<T>, AriaDatePickerBaseProps<T> {}
 
 export type DateRange = RangeValue<DateValue>;
 export interface DateRangePickerProps<T extends DateValue> extends DatePickerBase<T>, ValueBase<RangeValue<T>, RangeValue<MappedDateValue<T>>> {
@@ -70,7 +75,7 @@ export interface DateRangePickerProps<T extends DateValue> extends DatePickerBas
 
 export interface AriaDateRangePickerProps<T extends DateValue> extends AriaDatePickerBaseProps<T>, DateRangePickerProps<T> {}
 
-interface SpectrumDatePickerBase<T extends DateValue> extends AriaDatePickerBaseProps<T>, SpectrumLabelableProps, StyleProps {
+interface SpectrumDateFieldBase extends SpectrumLabelableProps, HelpTextProps, StyleProps {
   /**
    * Whether the date picker should be displayed with a quiet style.
    * @default false
@@ -80,7 +85,10 @@ interface SpectrumDatePickerBase<T extends DateValue> extends AriaDatePickerBase
    * Whether to show the localized date format as help text below the field.
    * @default false
    */
-  showFormatHelpText?: boolean,
+  showFormatHelpText?: boolean
+}
+
+interface SpectrumDatePickerBase extends SpectrumDateFieldBase, SpectrumLabelableProps, StyleProps {
   /**
    * The maximum number of months to display at once in the calendar popover, if screen space permits.
    * @default 1
@@ -93,9 +101,9 @@ interface SpectrumDatePickerBase<T extends DateValue> extends AriaDatePickerBase
   shouldFlip?: boolean
 }
 
-export interface SpectrumDatePickerProps<T extends DateValue> extends DatePickerProps<T>, SpectrumDatePickerBase<T> {}
-export interface SpectrumDateRangePickerProps<T extends DateValue> extends DateRangePickerProps<T>, SpectrumDatePickerBase<T> {}
-export interface SpectrumDateFieldProps<T extends DateValue> extends Omit<SpectrumDatePickerProps<T>, 'maxVisibleMonths'> {}
+export interface SpectrumDatePickerProps<T extends DateValue> extends AriaDatePickerProps<T>, SpectrumDatePickerBase {}
+export interface SpectrumDateRangePickerProps<T extends DateValue> extends AriaDateRangePickerProps<T>, SpectrumDatePickerBase {}
+export interface SpectrumDateFieldProps<T extends DateValue> extends AriaDateFieldProps<T>, SpectrumDateFieldBase {}
 
 export type TimeValue = Time | CalendarDateTime | ZonedDateTime;
 type MappedTimeValue<T> =

--- a/packages/@react-types/menu/src/index.d.ts
+++ b/packages/@react-types/menu/src/index.d.ts
@@ -21,7 +21,14 @@ export interface MenuTriggerProps extends OverlayTriggerProps {
    * How the menu is triggered.
    * @default 'press'
    */
-  trigger?: MenuTriggerType,
+  trigger?: MenuTriggerType
+}
+
+export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
+  /**
+   * The contents of the MenuTrigger - a trigger and a Menu.
+   */
+  children: ReactElement[],
   /**
    * Alignment of the menu relative to the trigger.
    * @default 'start'
@@ -33,22 +40,15 @@ export interface MenuTriggerProps extends OverlayTriggerProps {
    */
   direction?: 'bottom' | 'top' | 'left' | 'right' | 'start' | 'end',
   /**
-   * Whether the Menu closes when a selection is made.
-   * @default true
-   */
-  closeOnSelect?: boolean,
-  /**
    * Whether the menu should automatically flip direction when space is limited.
    * @default true
    */
-  shouldFlip?: boolean
-}
-
-export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
+   shouldFlip?: boolean,
   /**
-   * The contents of the MenuTrigger - a trigger and a Menu.
+   * Whether the Menu closes when a selection is made.
+   * @default true
    */
-  children: ReactElement[]
+  closeOnSelect?: boolean
 }
 
 export interface MenuProps<T> extends CollectionBase<T>, MultipleSelection {

--- a/packages/@react-types/menu/src/index.d.ts
+++ b/packages/@react-types/menu/src/index.d.ts
@@ -43,7 +43,7 @@ export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
    * Whether the menu should automatically flip direction when space is limited.
    * @default true
    */
-   shouldFlip?: boolean,
+  shouldFlip?: boolean,
   /**
    * Whether the Menu closes when a selection is made.
    * @default true
@@ -65,22 +65,7 @@ export interface MenuProps<T> extends CollectionBase<T>, MultipleSelection {
 export interface AriaMenuProps<T> extends MenuProps<T>, DOMProps, AriaLabelingProps {}
 export interface SpectrumMenuProps<T> extends AriaMenuProps<T>, StyleProps {}
 
-export interface SpectrumActionMenuProps<T> extends CollectionBase<T>, MenuTriggerProps, StyleProps, DOMProps, AriaLabelingProps {
-  /**
-   * Alignment of the menu relative to the trigger.
-   * @default 'start'
-   */
-  align?: Alignment,  // from shared types
-  /**
-   * Where the Menu opens relative to its trigger.
-   * @default 'bottom'
-   */
-  direction?: 'bottom' | 'top' | 'left' | 'right' | 'start' | 'end',
-  /**
-   * Whether the menu should automatically flip direction when space is limited.
-   * @default true
-   */
-  shouldFlip?: boolean,
+export interface SpectrumActionMenuProps<T> extends CollectionBase<T>, Omit<SpectrumMenuTriggerProps, 'children'>, StyleProps, DOMProps, AriaLabelingProps {
   /** Whether the button is disabled. */
   isDisabled?: boolean,
   /** Whether the button should be displayed with a [quiet style](https://spectrum.adobe.com/page/action-button/#Quiet). */

--- a/packages/@react-types/progress/src/index.d.ts
+++ b/packages/@react-types/progress/src/index.d.ts
@@ -34,8 +34,6 @@ interface ProgressBaseProps {
 export interface ProgressBarBaseProps extends ProgressBaseProps {
   /** The content to display as the label. */
   label?: ReactNode,
-  /** Whether the value's label is displayed. True by default if there's a label, false by default if not. */
-  showValueLabel?: boolean,
   /**
    * The display format of the value label.
    * @default {style: 'percent'}
@@ -84,7 +82,9 @@ export interface SpectrumProgressBarBaseProps extends AriaProgressBarBaseProps, 
    * The label's overall position relative to the element it is labeling.
    * @default 'top'
    */
-  labelPosition?: LabelPosition
+  labelPosition?: LabelPosition,
+  /** Whether the value's label is displayed. True by default if there's a label, false by default if not. */
+  showValueLabel?: boolean
 }
 
 export interface SpectrumProgressBarProps extends SpectrumProgressBarBaseProps, ProgressBarProps {

--- a/packages/@react-types/select/src/index.d.ts
+++ b/packages/@react-types/select/src/index.d.ts
@@ -29,7 +29,7 @@ import {
   Validation
 } from '@react-types/shared';
 
-export interface SelectProps<T> extends CollectionBase<T>, AsyncLoadable, Omit<InputBase, 'isReadOnly'>, Validation, HelpTextProps, LabelableProps, TextInputBase, Omit<SingleSelection, 'disallowEmptySelection'>, FocusableProps {
+export interface SelectProps<T> extends CollectionBase<T>, Omit<InputBase, 'isReadOnly'>, Validation, HelpTextProps, LabelableProps, TextInputBase, Omit<SingleSelection, 'disallowEmptySelection'>, FocusableProps {
   /** Sets the open state of the menu. */
   isOpen?: boolean,
   /** Sets the default open state of the menu. */
@@ -49,7 +49,7 @@ export interface AriaSelectProps<T> extends SelectProps<T>, DOMProps, AriaLabeli
   name?: string
 }
 
-export interface SpectrumPickerProps<T> extends AriaSelectProps<T>, SpectrumLabelableProps, StyleProps  {
+export interface SpectrumPickerProps<T> extends AriaSelectProps<T>, AsyncLoadable, SpectrumLabelableProps, StyleProps  {
   /** Whether the textfield should be displayed with a quiet style. */
   isQuiet?: boolean,
   /** Alignment of the menu relative to the input target.

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -62,6 +62,11 @@ export interface CollectionBase<T> {
   disabledKeys?: Iterable<Key>
 }
 
+export interface CollectionStateBase<T, C extends Collection<Node<T>> = Collection<Node<T>>> extends Partial<CollectionBase<T>> {
+  /** A pre-constructed collection to use instead of building one from items and children. */
+  collection?: C
+}
+
 export interface Expandable {
   /** The currently expanded keys in the collection (controlled). */
   expandedKeys?: Iterable<Key>,
@@ -143,7 +148,10 @@ export interface Collection<T> extends Iterable<T> {
   getFirstKey(): Key | null,
 
   /** Get the last key in the collection. */
-  getLastKey(): Key | null
+  getLastKey(): Key | null,
+
+  /** Iterate over the child items of the given key. */
+  getChildren?(key: Key): Iterable<T>
 }
 
 export interface Node<T> {
@@ -157,7 +165,10 @@ export interface Node<T> {
   level: number,
   /** Whether this item has children, even if not loaded yet. */
   hasChildNodes: boolean,
-  /** The loaded children of this node. */
+  /**
+   * The loaded children of this node.
+   * @deprecated Use `collection.getChildren(node.key)` instead.
+   */
   childNodes: Iterable<Node<T>>,
   /** The rendered contents of this node (e.g. JSX). */
   rendered: ReactNode,

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -52,8 +52,11 @@ export interface SliderThumbProps extends FocusableProps, Validation, LabelableP
   orientation?: Orientation,
   /** Whether the Thumb is disabled. */
   isDisabled?: boolean,
-  /** Index of the thumb for accessing purposes. */
-  index: number
+  /** 
+   * Index of the thumb within the slider.
+   * @default 0
+   */
+  index?: number
 }
 
 export interface AriaSliderProps<T = number | number[]> extends SliderProps<T>, DOMProps, AriaLabelingProps {}

--- a/packages/react-aria/src/index.ts
+++ b/packages/react-aria/src/index.ts
@@ -59,7 +59,7 @@ export type {FocusProps, FocusResult, FocusVisibleProps, FocusVisibleResult, Foc
 export type {AriaFieldProps, FieldAria, LabelAria, LabelAriaProps} from '@react-aria/label';
 export type {AriaLinkOptions, LinkAria} from '@react-aria/link';
 export type {AriaListBoxOptions, AriaListBoxProps, AriaListBoxSectionProps, AriaOptionProps, ListBoxAria, ListBoxSectionAria, OptionAria} from '@react-aria/listbox';
-export type {AriaGridListOptions, GridListAria, AriaGridListItemOptions, GridListItemAria, AriaGridSelectionCheckboxProps, GridSelectionCheckboxAria} from '@react-aria/gridlist';
+export type {AriaGridListOptions, AriaGridListProps, GridListAria, AriaGridListItemOptions, GridListItemAria, AriaGridSelectionCheckboxProps, GridSelectionCheckboxAria} from '@react-aria/gridlist';
 export type {AriaMenuProps, AriaMenuItemProps, AriaMenuOptions, AriaMenuSectionProps, AriaMenuTriggerProps, MenuAria, MenuItemAria, MenuSectionAria, MenuTriggerAria} from '@react-aria/menu';
 export type {AriaMeterProps, MeterAria} from '@react-aria/meter';
 export type {AriaNumberFieldProps, NumberFieldAria} from '@react-aria/numberfield';

--- a/packages/react-stately/src/index.ts
+++ b/packages/react-stately/src/index.ts
@@ -13,7 +13,7 @@
 export type {CalendarState, CalendarStateOptions, RangeCalendarState, RangeCalendarStateOptions} from '@react-stately/calendar';
 export type {CheckboxGroupProps, CheckboxGroupState} from '@react-stately/checkbox';
 export type {ComboBoxState, ComboBoxStateOptions} from '@react-stately/combobox';
-export type {DateFieldState, DateFieldStateOptions, DatePickerState, DatePickerStateOptions, DateRangePickerState, DateRangePickerStateOptions, DateSegment, TimeFieldStateOptions} from '@react-stately/datepicker';
+export type {DateFieldState, DateFieldStateOptions, DatePickerState, DatePickerStateOptions, DateRangePickerState, DateRangePickerStateOptions, DateSegment, SegmentType as DateSegmentType, TimeFieldStateOptions} from '@react-stately/datepicker';
 export type {DraggableCollectionStateOptions, DraggableCollectionState, DroppableCollectionStateOptions, DroppableCollectionState} from '@react-stately/dnd';
 export type {AsyncListData, AsyncListOptions, ListData, ListOptions, TreeData, TreeOptions} from '@react-stately/data';
 export type {ListProps, ListState, SingleSelectListProps, SingleSelectListState} from '@react-stately/list';


### PR DESCRIPTION
This PR is the first in a series, implementing the [React Aria Components RFC](https://github.com/adobe/react-spectrum/pull/4058). This pulls out the code changes to our existing hooks necessary to support the new implementation. I tried to separate the code into individual commits for different areas:

* Returning interaction states from more of the hooks, e.g. `isPressed`, `isFocused`, `isSelected`, etc.
* Improving the TypeScript definitions to be more reusable/correct. There were also some Spectrum-specific things in some of the types that shouldn't have been there.
* Updates to support the new collections implementation:
  * You can now pass in a `collection` as an option to the Stately hooks, which will be used instead of the default implementation which walks the JSX tree. Closes #3405.
  * The `childNodes` property of a `Node` is deprecated in favor of a `collection.getChildren(key)` method, which allows immutable Node objects to be more easily cloned without needing to do so recursively to all parents. I added an internal util which supports both options for backward compatibility.
* Implements the `disabledBehavior` prop for `useTable` and `useGrid` as we have in `useGridList` (though not currently in the Spectrum implementation).
* Fixes a couple bugs with our `mergeRefs` and `useObjectRefs` utilities.
* Some very minor documentation fixes.