### PR TITLE
Add negative margin on VisuallyHidden on both sides

### DIFF
--- a/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
+++ b/packages/@react-aria/live-announcer/src/LiveAnnouncer.tsx
@@ -71,7 +71,7 @@ class LiveAnnouncer {
       clip: 'rect(0 0 0 0)',
       clipPath: 'inset(50%)',
       height: '1px',
-      margin: '0 -1px -1px 0',
+      margin: '-1px',
       overflow: 'hidden',
       padding: 0,
       position: 'absolute',

--- a/packages/@react-aria/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/@react-aria/visually-hidden/src/VisuallyHidden.tsx
@@ -34,7 +34,7 @@ const styles: CSSProperties = {
   clip: 'rect(0 0 0 0)',
   clipPath: 'inset(50%)',
   height: 1,
-  margin: '0 -1px -1px 0',
+  margin: -1,
   overflow: 'hidden',
   padding: 0,
   position: 'absolute',


### PR DESCRIPTION
Closes #4176 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/4176).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Open reproduction from the issue and change margin on VisuallyHidden component

## 🧢 Your Project:

ChiliPiper https://www.chilipiper.com/