### PR TITLE
Expose ListCollection in `react-stately` from `@react-stately/list`

### DIFF
--- a/packages/react-stately/src/index.ts
+++ b/packages/react-stately/src/index.ts
@@ -39,7 +39,7 @@ export {useDateFieldState, useDatePickerState, useDateRangePickerState, useTimeF
 export {useDraggableCollectionState, useDroppableCollectionState} from '@react-stately/dnd';
 export {Item, Section, useCollection} from '@react-stately/collections';
 export {useAsyncList, useListData, useTreeData} from '@react-stately/data';
-export {useListState, useSingleSelectListState} from '@react-stately/list';
+export {ListCollection, useListState, useSingleSelectListState} from '@react-stately/list';
 export {useMenuTriggerState} from '@react-stately/menu';
 export {useNumberFieldState} from '@react-stately/numberfield';
 export {useOverlayTriggerState} from '@react-stately/overlays';


### PR DESCRIPTION
In LaunchDarkly's design system, [Launchpad](https://github.com/launchdarkly/launchpad-ui), and have historically used individual `@react-aria`/`@react-stately` packages but are experimenting with using the bundled packages. When we made the switch locally, we realized the `ListCollection` export we were using [here](https://github.com/launchdarkly/launchpad-ui/blob/main/packages/select/src/useFilter.ts) on from `@react-stately/list` is not exposed in `react-stately`. This PR simply adds that export.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:
https://github.com/launchdarkly/launchpad-ui
<!--- Company/project for pull request -->
