### PR TITLE
fix docs: use label passed as property in the ModalTrigger example

### DIFF
--- a/packages/@react-aria/dialog/docs/useDialog.mdx
+++ b/packages/@react-aria/dialog/docs/useDialog.mdx
@@ -171,7 +171,7 @@ function ModalTrigger({label, children, ...props}) {
   let {triggerProps, overlayProps} = useOverlayTrigger({type: 'dialog'}, state);
 
   return <>
-    <Button {...triggerProps}>Open Dialog</Button>
+    <Button {...triggerProps}>{ label }</Button>
     {state.isOpen &&
       <Modal state={state}>
         {React.cloneElement(children(state.close), overlayProps)}


### PR DESCRIPTION
Small documentation fix - use label from property

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

