### PR TITLE
fix(#4188): RangeSlider Default storybook example is labeled twice

### DIFF
--- a/packages/@react-spectrum/slider/stories/RangeSlider.stories.tsx
+++ b/packages/@react-spectrum/slider/stories/RangeSlider.stories.tsx
@@ -43,7 +43,7 @@ storiesOf('Slider/RangeSlider', module)
   })
   .add(
     'Default',
-    args => render({...args, 'aria-label': 'Label'})
+    args => render({...args, 'aria-label': 'Label', label: undefined})
   )
   .add(
     'label',


### PR DESCRIPTION
Closes #4188 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 4188](https://github.com/adobe/react-spectrum/issue/4188).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/c16b909d9ea6b53bdfec53d08aa16f663bdbbeea/storybook/index.html?path=/story/slider-rangeslider--default
2. Inspect the div with role="group" that wraps the RangeSlider control
3. I should be labeled using `aria-label` and not have `aria-labelledby`.

## 🧢 Your Project:

Adobe/Accessibility
