### PR TITLE
fix(#4208): Form includes label prop inherited from SpectrumLabelableProps that goes unused

### DIFF
--- a/packages/@react-types/form/src/index.d.ts
+++ b/packages/@react-types/form/src/index.d.ts
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, DOMProps, SpectrumLabelableProps, StyleProps, ValidationState} from '@react-types/shared';
 import {FormEventHandler, ReactElement} from 'react';
 
-export interface SpectrumFormProps extends DOMProps, AriaLabelingProps, StyleProps, Omit<SpectrumLabelableProps, 'contextualHelp'> {
+export interface SpectrumFormProps extends DOMProps, AriaLabelingProps, StyleProps, Omit<SpectrumLabelableProps, 'contextualHelp' | 'label'> {
   /** The contents of the Form. */
   children: ReactElement<SpectrumLabelableProps> | ReactElement<SpectrumLabelableProps>[],
   /** Whether the Form elements are displayed with their quiet style. */


### PR DESCRIPTION
Closes #4208 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue #4208](https://github.com/adobe/react-spectrum/issue/4208).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Verify that `label` is not listed as a prop in Form documentation: https://reactspectrum.blob.core.windows.net/reactspectrum/ac82aa5dfd1e59654194ae56d00260b08e78d84f/docs/react-spectrum/Form.html#props


## 🧢 Your Project:

Adobe/Accessibility
