### PR TITLE
Fixes for Aria Components

### DIFF
--- a/packages/@react-aria/listbox/docs/useListBox.mdx
+++ b/packages/@react-aria/listbox/docs/useListBox.mdx
@@ -251,7 +251,7 @@ function Example() {
         <Item key="egg">Egg Salad</Item>
         <Item key="ham">Ham</Item>
       </ListBox>
-      <p>Current selection (controlled): {[...selected].join(', ')}</p>
+      <p>Current selection (controlled): {selected === 'all' ? 'all' : [...selected].join(', ')}</p>
     </>
   );
 }

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -30,7 +30,10 @@ export interface OptionAria extends SelectableItemStates {
   descriptionProps: DOMAttributes,
 
   /** Whether the option is currently focused. */
-  isFocused: boolean
+  isFocused: boolean,
+
+  /** Whether the option is keyboard focused. */
+  isFocusVisible: boolean
 }
 
 export interface AriaOptionProps {
@@ -155,6 +158,7 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
       id: descriptionId
     },
     isFocused,
+    isFocusVisible: isFocused && isFocusVisible(),
     isSelected,
     isDisabled,
     isPressed,

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -92,7 +92,6 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
 
   let isDisabled = props.isDisabled ?? state.disabledKeys.has(key);
   let isSelected = props.isSelected ?? state.selectionManager.isSelected(key);
-  let isFocused = state.selectionManager.focusedKey === key;
   let shouldSelectOnPressUp = props.shouldSelectOnPressUp ?? data.shouldSelectOnPressUp;
   let shouldFocusOnHover = props.shouldFocusOnHover ?? data.shouldFocusOnHover;
   let shouldUseVirtualFocus = props.shouldUseVirtualFocus ?? data.shouldUseVirtualFocus;
@@ -121,7 +120,7 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
     optionProps['aria-setsize'] = getItemCount(state.collection);
   }
 
-  let {itemProps, isPressed, hasAction, allowsSelection} = useSelectableItem({
+  let {itemProps, isPressed, isFocused, hasAction, allowsSelection} = useSelectableItem({
     selectionManager: state.selectionManager,
     key,
     ref,

--- a/packages/@react-aria/menu/docs/useMenu.mdx
+++ b/packages/@react-aria/menu/docs/useMenu.mdx
@@ -366,7 +366,7 @@ function Example() {
         <Item key='tools'>Tools</Item>
         <Item key='console'>Console</Item>
       </MenuButton>
-      <p>Current selection (controlled): {[...selected].join(', ')}</p>
+      <p>Current selection (controlled): {selected === 'all' ? 'all' : [...selected].join(', ')}</p>
     </>
   );
 }

--- a/packages/@react-spectrum/menu/docs/Menu.mdx
+++ b/packages/@react-spectrum/menu/docs/Menu.mdx
@@ -167,7 +167,7 @@ function Example() {
           <Item key='Console'>Console</Item>
         </Menu>
       </MenuTrigger>
-      <p>Current selection (controlled): {[...selected].join(', ')}</p>
+      <p>Current selection (controlled): {selected === 'all' ? 'all' : [...selected].join(', ')}</p>
     </>
   );
 }

--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -118,20 +118,13 @@ import {ComboBox, Label, Input, Button, Popover, ListBox, Item} from 'react-aria
 .react-aria-ListBox {
   --highlight-background: slateblue;
   --highlight-foreground: white;
-  --border-color: var(--spectrum-global-color-gray-400);
-  --background-color: var(--page-background);
   --text-color: var(--spectrum-alias-text-color);
   --text-color-disabled: var(--spectrum-alias-text-color-disabled);
 
   max-height: inherit;
   overflow: auto;
   padding: 2px;
-  border: 1px solid var(--border-color);
-  box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
-  border-radius: 6px;
-  background: var(--background-color);
-  width: var(--combobox-width);
-  box-sizing: border-box;
+  outline: none;
 
   .react-aria-Section:not(:first-child) {
     margin-top: 12px;
@@ -186,6 +179,19 @@ import {ComboBox, Label, Input, Button, Popover, ListBox, Item} from 'react-aria
       font-size: small;
     }
   }
+}
+
+.react-aria-Popover {
+  --background-color: var(--page-background);
+  --border-color: var(--spectrum-global-color-gray-400);
+
+  border: 1px solid var(--spectrum-global-color-gray-400);
+  width: var(--trigger-width);
+  box-sizing: border-box;
+  box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
+  border-radius: 6px;
+  background: var(--background-color);
+  outline: none;
 }
 
 @media (forced-colors: active) {
@@ -425,11 +431,11 @@ A [Button](Button.html) can be targeted with the `.react-aria-Button` CSS select
 
 The [Popover](Popover.html) component can be targeted with the `.react-aria-Popover` CSS selector, or by overriding with a custom `className`. Note that it renders in a [React Portal](https://reactjs.org/docs/portals.html), so it will not appear as a descendant of the ComboBox in the DOM.
 
-The `--combobox-width` CSS custom property will be set on the popover, which you can use to make the popover match the width of the combobox.
+The `--trigger-width` CSS custom property will be set on the popover, which you can use to make the popover match the width of the combobox.
 
 ```css render=false
 .react-aria-Popover {
-  width: var(--combobox-width);
+  width: var(--trigger-width);
 }
 ```
 

--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -185,7 +185,7 @@ import {ComboBox, Label, Input, Button, Popover, ListBox, Item} from 'react-aria
   --background-color: var(--page-background);
   --border-color: var(--spectrum-global-color-gray-400);
 
-  border: 1px solid var(--spectrum-global-color-gray-400);
+  border: 1px solid var(--border-color);
   width: var(--trigger-width);
   box-sizing: border-box;
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);

--- a/packages/react-aria-components/docs/Dialog.mdx
+++ b/packages/react-aria-components/docs/Dialog.mdx
@@ -291,18 +291,21 @@ import {Popover, OverlayArrow} from 'react-aria-components';
 
 ```css
 .react-aria-Popover {
-  border: 1px solid var(--spectrum-global-color-gray-400);
+  --background-color: var(--page-background);
+  --border-color: var(--spectrum-global-color-gray-400);
+
+  border: 1px solid var(--border-color);
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
   border-radius: 6px;
-  background: var(--page-background);
+  background: var(--background-color);
   outline: none;
   padding: 30px;
   max-width: 250px;
 
   & .react-aria-OverlayArrow svg {
     display: block;
-    fill: var(--page-background);
-    stroke: var(--spectrum-global-color-gray-400);
+    fill: var(--background-color);
+    stroke: var(--border-color);
     stroke-width: 1px;
   }
 
@@ -353,6 +356,13 @@ import {Popover, OverlayArrow} from 'react-aria-components';
   to {
     transform: translateY(0);
     opacity: 1;
+  }
+}
+
+@media (forced-colors: active) {
+  .react-aria-Popover {
+    --background-color: Canvas;
+    --border-color: ButtonBorder;
   }
 }
 ```

--- a/packages/react-aria-components/docs/Dialog.mdx
+++ b/packages/react-aria-components/docs/Dialog.mdx
@@ -273,7 +273,7 @@ A `Dialog` may be placed within a [Popover](Popover.html) to display it in conte
 import {Popover, OverlayArrow} from 'react-aria-components';
 
 <DialogTrigger>
-  <Button aria-label="Help">?⃝</Button>
+  <Button aria-label="Help">ⓘ</Button>
   <Popover>
     <OverlayArrow>
       <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>

--- a/packages/react-aria-components/docs/ListBox.mdx
+++ b/packages/react-aria-components/docs/ListBox.mdx
@@ -413,7 +413,7 @@ function Example() {
         <Item id="egg">Egg Salad</Item>
         <Item id="ham">Ham</Item>
       </ListBox>
-      <p>Current selection (controlled): {[...selected].join(', ')}</p>
+      <p>Current selection (controlled): {selected === 'all' ? 'all' : [...selected].join(', ')}</p>
     </>
   );
 }

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -593,7 +593,7 @@ function Example() {
         <Item id='tools'>Tools</Item>
         <Item id='console'>Console</Item>
       </MyMenuButton>
-      <p>Current selection (controlled): {[...selected].join(', ')}</p>
+      <p>Current selection (controlled): {selected === 'all' ? 'all' : [...selected].join(', ')}</p>
     </>
   );
 }

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -183,7 +183,7 @@ import {MenuTrigger, Button, Popover, Menu, Item} from 'react-aria-components';
   --background-color: var(--page-background);
   --border-color: var(--spectrum-global-color-gray-400);
 
-  border: 1px solid var(--spectrum-global-color-gray-400);
+  border: 1px solid var(--border-color);
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
   border-radius: 6px;
   background: var(--background-color);
@@ -227,12 +227,6 @@ import {MenuTrigger, Button, Popover, Menu, Item} from 'react-aria-components';
     --separator-color: ButtonBorder;
     --text-color: ButtonText;
     --text-color-disabled: GrayText;
-  }
-
-  .react-aria-Popover {
-    forced-color-adjust: none;
-    --border-color: ButtonBorder;
-    --background-color: ButtonFace;
   }
 }
 ```

--- a/packages/react-aria-components/docs/Popover.mdx
+++ b/packages/react-aria-components/docs/Popover.mdx
@@ -62,18 +62,21 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow} from 'react-aria-c
 
 ```css
 .react-aria-Popover {
-  border: 1px solid var(--spectrum-global-color-gray-400);
+  --background-color: var(--page-background);
+  --border-color: var(--spectrum-global-color-gray-400);
+
+  border: 1px solid var(--border-color);
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
   border-radius: 6px;
-  background: var(--page-background);
+  background: var(--background-color);
   outline: none;
   padding: 30px;
   max-width: 250px;
 
   .react-aria-OverlayArrow svg {
     display: block;
-    fill: var(--page-background);
-    stroke: var(--spectrum-global-color-gray-400);
+    fill: var(--background-color);
+    stroke: var(--border-color);
     stroke-width: 1px;
   }
 
@@ -163,13 +166,8 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow} from 'react-aria-c
 
 @media (forced-colors: active) {
   .react-aria-Popover {
-    border-color: ButtonBorder;
-    background: Canvas;
-
-    .react-aria-OverlayArrow svg {
-      fill: Canvas;
-      stroke: ButtonBorder;
-    }
+    --background-color: Canvas;
+    --border-color: ButtonBorder;
   }
 }
 ```

--- a/packages/react-aria-components/docs/Select.mdx
+++ b/packages/react-aria-components/docs/Select.mdx
@@ -219,7 +219,7 @@ import {Select, SelectValue, Label, Button, Popover, ListBox, Item} from 'react-
   --background-color: var(--page-background);
   --border-color: var(--spectrum-global-color-gray-400);
 
-  border: 1px solid var(--spectrum-global-color-gray-400);
+  border: 1px solid var(--border-color);
   min-width: var(--trigger-width);
   max-width: 250px;
   box-sizing: border-box;

--- a/packages/react-aria-components/docs/Select.mdx
+++ b/packages/react-aria-components/docs/Select.mdx
@@ -152,8 +152,6 @@ import {Select, SelectValue, Label, Button, Popover, ListBox, Item} from 'react-
 .react-aria-ListBox {
   --highlight-background: slateblue;
   --highlight-foreground: white;
-  --border-color: var(--spectrum-global-color-gray-400);
-  --background-color: var(--page-background);
   --text-color: var(--spectrum-alias-text-color);
   --text-color-disabled: var(--spectrum-alias-text-color-disabled);
 
@@ -222,7 +220,7 @@ import {Select, SelectValue, Label, Button, Popover, ListBox, Item} from 'react-
   --border-color: var(--spectrum-global-color-gray-400);
 
   border: 1px solid var(--spectrum-global-color-gray-400);
-  min-width: var(--button-width);
+  min-width: var(--trigger-width);
   max-width: 250px;
   box-sizing: border-box;
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
@@ -506,7 +504,7 @@ A `SelectValue` can be targed with the `.react-aria-SelectValue` CSS selector, o
 
 The [Popover](Popover.html) component can be targeted with the `.react-aria-Popover` CSS selector, or by overriding with a custom `className`. Note that it renders in a [React Portal](https://reactjs.org/docs/portals.html), so it will not appear as a descendant of the Select in the DOM.
 
-The `--button-width` CSS custom property will be set on the popover, which you can use to make the popover match the width of the select button.
+The `--trigger-width` CSS custom property will be set on the popover, which you can use to make the popover match the width of the select button.
 
 ```css render=false
 .react-aria-Popover {

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@internationalized/date": "^3.0.0",
     "@react-aria/focus": "^3.6.1",
-    "@react-aria/interactions": "^3.10.0",
     "@react-aria/utils": "^3.13.1",
     "@react-stately/table": "^3.4.0",
     "@react-types/grid": "^3.1.3",

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -104,7 +104,7 @@ function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<H
           placement: 'bottom start',
           preserveChildren: true,
           isNonModal: true,
-          style: {'--combobox-width': menuWidth} as React.CSSProperties
+          style: {'--trigger-width': menuWidth} as React.CSSProperties
         }],
         [ListBoxContext, {state, [slotCallbackSymbol]: setListBoxProps, ...listBoxProps, ref: listBoxRef}],
         [TextContext, {

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -14,7 +14,6 @@ import {AriaListBoxOptions, AriaListBoxProps, mergeProps, useHover, useListBox, 
 import {CollectionProps, ItemProps, useCachedChildren, useCollection} from './Collection';
 import {ContextValue, forwardRefType, HiddenContext, Provider, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
-import {isFocusVisible} from '@react-aria/interactions';
 import {ListState, Node, SelectionBehavior, useListState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, RefObject, useContext, useRef} from 'react';
 import {Separator, SeparatorContext} from './Separator';
@@ -172,7 +171,6 @@ function Option<T>({item}: OptionProps<T>) {
   }
 
   let props: ItemProps<T> = item.props;
-  let focusVisible = states.isFocused && isFocusVisible();
   let renderProps = useRenderProps({
     ...props,
     id: undefined,
@@ -181,7 +179,6 @@ function Option<T>({item}: OptionProps<T>) {
     values: {
       ...states,
       isHovered,
-      isFocusVisible: focusVisible,
       selectionMode: state.selectionManager.selectionMode,
       selectionBehavior: state.selectionManager.selectionBehavior
     }
@@ -194,7 +191,7 @@ function Option<T>({item}: OptionProps<T>) {
       ref={ref}
       data-hovered={isHovered || undefined}
       data-focused={states.isFocused || undefined}
-      data-focus-visible={focusVisible || undefined}
+      data-focus-visible={states.isFocusVisible || undefined}
       data-pressed={states.isPressed || undefined}>
       <Provider
         values={[

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -12,10 +12,10 @@
 
 import {AriaListBoxOptions, AriaListBoxProps, mergeProps, useHover, useListBox, useListBoxSection, useOption} from 'react-aria';
 import {CollectionProps, ItemProps, useCachedChildren, useCollection} from './Collection';
-import {ContextValue, forwardRefType, Provider, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
+import {ContextValue, forwardRefType, HiddenContext, Provider, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {isFocusVisible} from '@react-aria/interactions';
-import {ListState, Node, OverlayTriggerState, SelectionBehavior, useListState} from 'react-stately';
+import {ListState, Node, SelectionBehavior, useListState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, RefObject, useContext, useRef} from 'react';
 import {Separator, SeparatorContext} from './Separator';
 import {TextContext} from './Text';
@@ -26,7 +26,7 @@ export interface ListBoxProps<T> extends Omit<AriaListBoxProps<T>, 'children'>, 
 }
 
 interface ListBoxContextValue<T> extends ListBoxProps<T> {
-  state?: ListState<T> & OverlayTriggerState
+  state?: ListState<T>
 }
 
 interface InternalListBoxContextValue {
@@ -40,9 +40,10 @@ const InternalListBoxContext = createContext<InternalListBoxContextValue>(null);
 function ListBox<T>(props: ListBoxProps<T>, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, ListBoxContext);
   let state = (props as ListBoxContextValue<T>).state;
+  let isHidden = useContext(HiddenContext);
 
   if (state) {
-    return state.isOpen ? <ListBoxInner state={state} props={props} listBoxRef={ref} /> : null;
+    return isHidden ? null : <ListBoxInner state={state} props={props} listBoxRef={ref} />;
   }
 
   return <ListBoxPortal props={props} listBoxRef={ref} />;

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -11,13 +11,12 @@
  */
 
 
-import {AriaMenuProps, useMenu, useMenuItem, useMenuSection, useMenuTrigger} from 'react-aria';
+import {AriaMenuProps, mergeProps, useFocusRing, useMenu, useMenuItem, useMenuSection, useMenuTrigger} from 'react-aria';
 import {BaseCollection, CollectionProps, ItemProps, ItemRenderProps, useCachedChildren, useCollection} from './Collection';
 import {MenuTriggerProps as BaseMenuTriggerProps, Node, TreeState, useMenuTriggerState, useTreeState} from 'react-stately';
 import {ButtonContext} from './Button';
 import {ContextValue, forwardRefType, Provider, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
-import {isFocusVisible} from '@react-aria/interactions';
 import {KeyboardContext} from './Keyboard';
 import {PopoverContext} from './Popover';
 import React, {createContext, ForwardedRef, forwardRef, ReactNode, RefObject, useContext, useRef} from 'react';
@@ -178,7 +177,7 @@ function MenuItem<T>({item}: MenuItemProps<T>) {
   let {menuItemProps, labelProps, descriptionProps, keyboardShortcutProps, ...states} = useMenuItem({key: item.key}, state, ref);
 
   let props: ItemProps<T> = item.props;
-  let focusVisible = states.isFocused && isFocusVisible();
+  let {isFocusVisible, focusProps} = useFocusRing();
   let renderProps = useRenderProps({
     ...props,
     id: undefined,
@@ -187,7 +186,7 @@ function MenuItem<T>({item}: MenuItemProps<T>) {
     values: {
       ...states,
       isHovered: states.isFocused,
-      isFocusVisible: focusVisible,
+      isFocusVisible,
       selectionMode: state.selectionManager.selectionMode,
       selectionBehavior: state.selectionManager.selectionBehavior
     }
@@ -195,12 +194,12 @@ function MenuItem<T>({item}: MenuItemProps<T>) {
 
   return (
     <div
-      {...menuItemProps}
+      {...mergeProps(menuItemProps, focusProps)}
       {...renderProps}
       ref={ref}
       data-hovered={states.isFocused || undefined}
       data-focused={states.isFocused || undefined}
-      data-focus-visible={focusVisible || undefined}
+      data-focus-visible={isFocusVisible || undefined}
       data-pressed={states.isPressed || undefined}>
       <Provider
         values={[

--- a/packages/react-aria-components/src/Popover.tsx
+++ b/packages/react-aria-components/src/Popover.tsx
@@ -11,10 +11,10 @@
  */
 
 import {AriaPopoverProps, DismissButton, Overlay, PlacementAxis, PositionProps, usePopover} from 'react-aria';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useEnterAnimation, useExitAnimation, useRenderProps} from './utils';
+import {ContextValue, HiddenContext, RenderProps, SlotProps, useContextProps, useEnterAnimation, useExitAnimation, useRenderProps} from './utils';
 import {OverlayArrowContext} from './OverlayArrow';
 import {OverlayTriggerState} from 'react-stately';
-import React, {createContext, ForwardedRef, forwardRef, ReactElement, RefObject} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, RefObject} from 'react';
 
 export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPopoverProps, 'popoverRef' | 'triggerRef'>, RenderProps<PopoverRenderProps>, SlotProps {
   /**
@@ -57,7 +57,7 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
   let isExiting = useExitAnimation(ref, state.isOpen);
 
   if (state && !state.isOpen && !isExiting) {
-    return preserveChildren ? props.children as ReactElement : null;
+    return preserveChildren ? <HiddenContext.Provider value>{props.children}</HiddenContext.Provider> : null;
   }
 
   return (

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -89,7 +89,7 @@ function Select<T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLD
           triggerRef: buttonRef,
           preserveChildren: true,
           placement: 'bottom start',
-          style: {'--button-width': buttonWidth} as React.CSSProperties
+          style: {'--trigger-width': buttonWidth} as React.CSSProperties
         }],
         [ListBoxContext, {state, [slotCallbackSymbol]: setListBoxProps, ...menuProps}],
         [TextContext, {

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -213,12 +213,13 @@ function useAnimation(ref: RefObject<HTMLElement>, isActive: boolean, onEnd: () 
       if (computedStyle.animationName !== 'none' && computedStyle.animation !== prevAnimation.current) {
         let onAnimationEnd = (e: AnimationEvent) => {
           if (e.target === ref.current) {
+            element.removeEventListener('animationend', onAnimationEnd);
             onEnd();
           }
         };
 
         let element = ref.current;
-        element.addEventListener('animationend', onAnimationEnd, {once: true});
+        element.addEventListener('animationend', onAnimationEnd);
         return () => {
           element.removeEventListener('animationend', onAnimationEnd);
         };

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -12,7 +12,7 @@
 
 import {AriaLabelingProps, DOMProps as SharedDOMProps} from '@react-types/shared';
 import {filterDOMProps, mergeProps, mergeRefs, useLayoutEffect, useObjectRef} from '@react-aria/utils';
-import React, {CSSProperties, ReactNode, RefCallback, RefObject, useCallback, useContext, useEffect, useRef, useState} from 'react';
+import React, {createContext, CSSProperties, ReactNode, RefCallback, RefObject, useCallback, useContext, useEffect, useRef, useState} from 'react';
 
 // Override forwardRef types so generics work.
 declare function forwardRef<T, P = {}>(
@@ -228,3 +228,5 @@ function useAnimation(ref: RefObject<HTMLElement>, isActive: boolean, onEnd: () 
     }
   }, [ref, isActive, onEnd]);
 }
+
+export const HiddenContext = createContext<boolean>(false);

--- a/packages/react-aria-components/test/ListBox.test.js
+++ b/packages/react-aria-components/test/ListBox.test.js
@@ -225,7 +225,7 @@ describe('ListBox', () => {
   it('should support focus ring', () => {
     let {getAllByRole} = renderListbox({selectionMode: 'multiple'}, {className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''});
     let option = getAllByRole('option')[0];
-    
+
     expect(option).not.toHaveAttribute('data-focus-visible');
     expect(option).not.toHaveClass('focus');
 
@@ -234,7 +234,8 @@ describe('ListBox', () => {
     expect(option).toHaveAttribute('data-focus-visible', 'true');
     expect(option).toHaveClass('focus');
 
-    userEvent.type(option, '{ArrowDown}');
+    fireEvent.keyDown(option, {key: 'ArrowDown'});
+    fireEvent.keyUp(option, {key: 'ArrowDown'});
     expect(option).not.toHaveAttribute('data-focus-visible');
     expect(option).not.toHaveClass('focus');
   });

--- a/packages/react-aria-components/test/Menu.test.js
+++ b/packages/react-aria-components/test/Menu.test.js
@@ -129,7 +129,7 @@ describe('Menu', () => {
   it('should support focus ring', () => {
     let {getAllByRole} = renderMenu({}, {className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''});
     let menuitem = getAllByRole('menuitem')[0];
-    
+
     expect(menuitem).not.toHaveAttribute('data-focus-visible');
     expect(menuitem).not.toHaveClass('focus');
 
@@ -138,7 +138,8 @@ describe('Menu', () => {
     expect(menuitem).toHaveAttribute('data-focus-visible', 'true');
     expect(menuitem).toHaveClass('focus');
 
-    userEvent.type(menuitem, '{ArrowDown}');
+    fireEvent.keyDown(menuitem, {key: 'ArrowDown'});
+    fireEvent.keyUp(menuitem, {key: 'ArrowDown'});
     expect(menuitem).not.toHaveAttribute('data-focus-visible');
     expect(menuitem).not.toHaveClass('focus');
   });


### PR DESCRIPTION
Depends on #4212.

* Fixes animation issue with Select popover
* Switches to using `--trigger-width` as a CSS custom property for both ComboBox and Select popovers for consistency
* Fixes animation of side modal example in Chrome, which previously got stuck open. This was due to an ordering issue where child animations completed before parents.
* Fix all docs examples with select all from displaying `a,l,l`
* Fix question mark in circle character on Windows - switched to i in circle. No font seems to support the question mark.
* Fixed some high contrast styling
* Fixes isFocused in useOption to only be true when the collection is actually focused.
* Added an isFocusVisible return value to useOption which works with virtual focus, and allows us to get rid of another dependency in aria components. Closes https://github.com/adobe/react-spectrum/issues/4163.