### PR TITLE
Fix nightly build of React Aria Components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ publish-nightly: build
 	yarn publish:nightly
 
 build:
-	parcel build packages/@react-{spectrum,aria,stately}/*/ packages/@internationalized/{message,string,date,number}/ --no-optimize
+	parcel build packages/@react-{spectrum,aria,stately}/*/ packages/@internationalized/{message,string,date,number}/ packages/react-aria-components --no-optimize
 	yarn lerna run prepublishOnly
 	for pkg in packages/@react-{spectrum,aria,stately}/*/  packages/@internationalized/{message,string,date,number}/ packages/@adobe/react-spectrum/ packages/react-aria/ packages/react-stately/; \
 		do cp $$pkg/dist/module.js $$pkg/dist/import.mjs; \

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -23,6 +23,7 @@
     "@react-types/grid": "^3.1.3",
     "@react-types/shared": "^3.13.1",
     "@react-types/table": "^3.3.1",
+    "@swc/helpers": "^0.4.14",
     "react-aria": "^3.17.0",
     "react-stately": "^3.15.0",
     "use-sync-external-store": "^1.2.0"


### PR DESCRIPTION
Adds it as a parcel target in the build command, and adds missing dependency.