### PR TITLE
Update comment to properly reflect the units

### DIFF
--- a/packages/@internationalized/date/src/CalendarDate.ts
+++ b/packages/@internationalized/date/src/CalendarDate.ts
@@ -325,7 +325,7 @@ export class ZonedDateTime {
   public readonly millisecond: number;
   /** The IANA time zone identifier that this date and time is represented in. */
   public readonly timeZone: string;
-  /** The UTC offset for this time, in seconds. */
+  /** The UTC offset for this time, in milliseconds. */
   public readonly offset: number;
 
   constructor(year: number, month: number, day: number, timeZone: string, offset: number, hour?: number, minute?: number, second?: number, millisecond?: number);


### PR DESCRIPTION
ZonedDateTime.offset takes milliseconds not seconds (as was in comments).


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
