### PR TITLE
TagGroup: Prevent focus of remove button via hook

### DIFF
--- a/packages/@react-aria/tag/src/useTag.ts
+++ b/packages/@react-aria/tag/src/useTag.ts
@@ -73,7 +73,8 @@ export function useTag<T>(props: TagProps<T>, state: TagGroupState<T>, ref: RefO
       'aria-label': removeString,
       'aria-labelledby': `${buttonId} ${labelId}`,
       id: buttonId,
-      onPress: () => allowsRemoving && onRemove ? onRemove(item.key) : null
+      onPress: () => allowsRemoving && onRemove ? onRemove(item.key) : null,
+      excludeFromTabOrder: true
     },
     labelProps: {
       id: labelId

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -87,11 +87,8 @@ function TagRemoveButton(props) {
   let {styleProps} = useStyleProps(props);
 
   return (
-    <span
-      {...styleProps}>
-      <ClearButton
-        preventFocus
-        {...props} />
+    <span {...styleProps}>
+      <ClearButton {...props} />
     </span>
   );
 }


### PR DESCRIPTION
Previously, preventing focus of the remove button was handled in React Spectrum. This handles that in `useTag` instead so the same behavior applies to components created with the hooks.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
