### PR TITLE
TagGroup: don't remove tags on Space press

### DIFF
--- a/packages/@react-aria/tag/src/useTag.ts
+++ b/packages/@react-aria/tag/src/useTag.ts
@@ -60,7 +60,7 @@ export function useTag<T>(props: TagProps<T>, state: TagGroupState<T>, ref: RefO
   let onRemove = chain(props.onRemove, state.onRemove);
 
   let onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Delete' || e.key === 'Backspace' || e.key === ' ') {
+    if (e.key === 'Delete' || e.key === 'Backspace') {
       onRemove(item.key);
       e.preventDefault();
     }

--- a/packages/@react-spectrum/tag/test/TagGroup.test.js
+++ b/packages/@react-spectrum/tag/test/TagGroup.test.js
@@ -316,7 +316,6 @@ describe('TagGroup', function () {
     Name                         | props
     ${'on `Delete` keypress'}    | ${{keyPress: 'Delete'}}
     ${'on `Backspace` keypress'} | ${{keyPress: 'Backspace'}}
-    ${'on `space` keypress'}     | ${{keyPress: ' '}}
   `('Remove tag $Name', function ({Name, props}) {
     let {getByText} = render(
       <Provider theme={theme}>
@@ -333,6 +332,23 @@ describe('TagGroup', function () {
     fireEvent.keyUp(tag, {key: props.keyPress});
     expect(onRemoveSpy).toHaveBeenCalledTimes(1);
     expect(onRemoveSpy).toHaveBeenCalledWith('1');
+  });
+
+  it('Space does not trigger removal', function () {
+    let {getByText} = render(
+      <Provider theme={theme}>
+        <TagGroup aria-label="tag group" allowsRemoving onRemove={onRemoveSpy}>
+          <Item key="1" aria-label="Tag 1">Tag 1</Item>
+          <Item key="2" aria-label="Tag 2">Tag 2</Item>
+          <Item key="3" aria-label="Tag 3">Tag 3</Item>
+        </TagGroup>
+      </Provider>
+    );
+
+    let tag = getByText('Tag 1');
+    fireEvent.keyDown(tag, {key: ' '});
+    fireEvent.keyUp(tag, {key: ' '});
+    expect(onRemoveSpy).toHaveBeenCalledTimes(0);
   });
 
   it('should remove tag when remove button is clicked', function () {
@@ -360,7 +376,6 @@ describe('TagGroup', function () {
     Name                         | props
     ${'on `Delete` keypress'}    | ${{keyPress: 'Delete'}}
     ${'on `Backspace` keypress'} | ${{keyPress: 'Backspace'}}
-    ${'on `space` keypress'}     | ${{keyPress: ' '}}
   `('Can move focus after removing tag $Name', function ({Name, props}) {
 
     function TagGroupWithDelete(props) {


### PR DESCRIPTION
Removal of tags via keyboard should only happen via `Backspace` or `Delete`. `Space` should be reserved for potential future support for selection.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
