### PR TITLE
Fix specificity for icons in labels

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/accordion/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/accordion/skin.css
@@ -64,10 +64,6 @@ governing permissions and limitations under the License.
       color: var(--spectrum-accordion-text-color-disabled);
       background-color: transparent;
     }
-
-    + .spectrum-Accordion-itemIndicator {
-      color: var(--spectrum-accordion-icon-color-disabled);
-    }
   }
 }
 @media (forced-colors: active) {

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/skin.css
@@ -16,10 +16,6 @@ governing permissions and limitations under the License.
 
   &.is-disabled {
     color: var(--spectrum-fieldlabel-text-color-disabled);
-
-    .spectrum-FieldLabel-requiredIcon {
-      color: var(--spectrum-fieldlabel-asterisk-color-disabled);
-    }
   }
 }
 .spectrum-FieldLabel-requiredIcon {

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/skin.css
@@ -18,6 +18,3 @@ governing permissions and limitations under the License.
     color: var(--spectrum-fieldlabel-text-color-disabled);
   }
 }
-.spectrum-FieldLabel-requiredIcon {
-  color: var(--spectrum-fieldlabel-asterisk-color);
-}


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Specificity problems revealed in Chromatic where the icon color inherit was being overridden by various specific selectors. The XD designs for TextField and other related components show that the required icon in the label should mimic the color of the label so I've gone ahead and removed the specific selectors 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
