### PR TITLE
Localize tag count

### DIFF
--- a/packages/@internationalized/string-compiler/src/stringCompiler.js
+++ b/packages/@internationalized/string-compiler/src/stringCompiler.js
@@ -66,6 +66,9 @@ function compileParts(parts, inline = false, pluralValue = '') {
         usesFormatter = true;
         break;
       case TYPE.number:
+        /** TODO: Eventually this will need to support the formatting options that are possible here.
+          * They're in part.parsedOptions. Would require changes to the formatter to support it though.
+          */
         res += '${formatter.number(args.' + part.value + ')}';
         usesFormatter = true;
         break;

--- a/packages/@internationalized/string-compiler/src/stringCompiler.js
+++ b/packages/@internationalized/string-compiler/src/stringCompiler.js
@@ -65,6 +65,10 @@ function compileParts(parts, inline = false, pluralValue = '') {
         res += '${formatter.number(' + pluralValue + ')}';
         usesFormatter = true;
         break;
+      case TYPE.number:
+        res += '${formatter.number(args.' + part.value + ')}';
+        usesFormatter = true;
+        break;
       default:
         throw new Error('Unsupported message type: ' + part.type);
     }

--- a/packages/@internationalized/string-compiler/src/stringCompiler.js
+++ b/packages/@internationalized/string-compiler/src/stringCompiler.js
@@ -67,7 +67,7 @@ function compileParts(parts, inline = false, pluralValue = '') {
         break;
       case TYPE.number:
         // TODO: Eventually this will need to support the formatting options that are possible here.
-        // They're in part.parsedOptions. Would require changes to the formatter to support it though.
+        //  They're in part.parsedOptions. Would require changes to the formatter to support it though.
         res += '${formatter.number(args.' + part.value + ')}';
         usesFormatter = true;
         break;

--- a/packages/@internationalized/string-compiler/src/stringCompiler.js
+++ b/packages/@internationalized/string-compiler/src/stringCompiler.js
@@ -66,9 +66,8 @@ function compileParts(parts, inline = false, pluralValue = '') {
         usesFormatter = true;
         break;
       case TYPE.number:
-        /** TODO: Eventually this will need to support the formatting options that are possible here.
-          * They're in part.parsedOptions. Would require changes to the formatter to support it though.
-          */
+        // TODO: Eventually this will need to support the formatting options that are possible here.
+        // They're in part.parsedOptions. Would require changes to the formatter to support it though.
         res += '${formatter.number(args.' + part.value + ')}';
         usesFormatter = true;
         break;

--- a/packages/@react-spectrum/tag/intl/ar-AE.json
+++ b/packages/@react-spectrum/tag/intl/ar-AE.json
@@ -1,5 +1,5 @@
 {
   "actions": "الإجراءات",
   "hideButtonLabel": "إظهار أقل",
-  "showAllButtonLabel": "إظهار الكل ({tagCount})"
+  "showAllButtonLabel": "إظهار الكل ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/bg-BG.json
+++ b/packages/@react-spectrum/tag/intl/bg-BG.json
@@ -1,5 +1,5 @@
 {
   "actions": "Действия",
   "hideButtonLabel": "Показване на по-малко",
-  "showAllButtonLabel": "Показване на всички ({tagCount})"
+  "showAllButtonLabel": "Показване на всички ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/cs-CZ.json
+++ b/packages/@react-spectrum/tag/intl/cs-CZ.json
@@ -1,5 +1,5 @@
 {
   "actions": "Akce",
   "hideButtonLabel": "Zobrazit méně",
-  "showAllButtonLabel": "Zobrazit vše ({tagCount})"
+  "showAllButtonLabel": "Zobrazit vše ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/da-DK.json
+++ b/packages/@react-spectrum/tag/intl/da-DK.json
@@ -1,5 +1,5 @@
 {
   "actions": "Handlinger",
   "hideButtonLabel": "Vis mindre",
-  "showAllButtonLabel": "Vis alle ({tagCount})"
+  "showAllButtonLabel": "Vis alle ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/de-DE.json
+++ b/packages/@react-spectrum/tag/intl/de-DE.json
@@ -1,5 +1,5 @@
 {
   "actions": "Aktionen",
   "hideButtonLabel": "Weniger zeigen",
-  "showAllButtonLabel": "Alle anzeigen ({tagCount})"
+  "showAllButtonLabel": "Alle anzeigen ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/el-GR.json
+++ b/packages/@react-spectrum/tag/intl/el-GR.json
@@ -1,5 +1,5 @@
 {
   "actions": "Ενέργειες",
   "hideButtonLabel": "Εμφάνιση λιγότερων",
-  "showAllButtonLabel": "Εμφάνιση όλων ({tagCount})"
+  "showAllButtonLabel": "Εμφάνιση όλων ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/en-US.json
+++ b/packages/@react-spectrum/tag/intl/en-US.json
@@ -1,5 +1,5 @@
 {
-  "showAllButtonLabel": "Show all ({tagCount})",
+  "showAllButtonLabel": "Show all ({tagCount, number})",
   "hideButtonLabel": "Show less",
   "actions": "Actions"
 }

--- a/packages/@react-spectrum/tag/intl/es-ES.json
+++ b/packages/@react-spectrum/tag/intl/es-ES.json
@@ -1,5 +1,5 @@
 {
   "actions": "Acciones",
   "hideButtonLabel": "Mostrar menos",
-  "showAllButtonLabel": "Mostrar todo ({tagCount})"
+  "showAllButtonLabel": "Mostrar todo ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/et-EE.json
+++ b/packages/@react-spectrum/tag/intl/et-EE.json
@@ -1,5 +1,5 @@
 {
   "actions": "Toimingud",
   "hideButtonLabel": "Kuva vähem",
-  "showAllButtonLabel": "Kuva kõik ({tagCount})"
+  "showAllButtonLabel": "Kuva kõik ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/fi-FI.json
+++ b/packages/@react-spectrum/tag/intl/fi-FI.json
@@ -1,5 +1,5 @@
 {
   "actions": "Toiminnot",
   "hideButtonLabel": "Näytä vähemmän",
-  "showAllButtonLabel": "Näytä kaikki ({tagCount})"
+  "showAllButtonLabel": "Näytä kaikki ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/fr-FR.json
+++ b/packages/@react-spectrum/tag/intl/fr-FR.json
@@ -1,5 +1,5 @@
 {
   "actions": "Actions",
   "hideButtonLabel": "Afficher moins",
-  "showAllButtonLabel": "Tout afficher ({tagCount})"
+  "showAllButtonLabel": "Tout afficher ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/he-IL.json
+++ b/packages/@react-spectrum/tag/intl/he-IL.json
@@ -1,5 +1,5 @@
 {
   "actions": "פעולות",
   "hideButtonLabel": "הצג פחות",
-  "showAllButtonLabel": "הצג הכל ({tagCount})"
+  "showAllButtonLabel": "הצג הכל ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/hr-HR.json
+++ b/packages/@react-spectrum/tag/intl/hr-HR.json
@@ -1,5 +1,5 @@
 {
   "actions": "Radnje",
   "hideButtonLabel": "Prikaži manje",
-  "showAllButtonLabel": "Prikaži sve ({tagCount})"
+  "showAllButtonLabel": "Prikaži sve ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/hu-HU.json
+++ b/packages/@react-spectrum/tag/intl/hu-HU.json
@@ -1,5 +1,5 @@
 {
   "actions": "Műveletek",
   "hideButtonLabel": "Mutass kevesebbet",
-  "showAllButtonLabel": "Összes megjelenítése ({tagCount})"
+  "showAllButtonLabel": "Összes megjelenítése ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/it-IT.json
+++ b/packages/@react-spectrum/tag/intl/it-IT.json
@@ -1,5 +1,5 @@
 {
   "actions": "Azioni",
   "hideButtonLabel": "Mostra meno",
-  "showAllButtonLabel": "Mostra tutto ({tagCount})"
+  "showAllButtonLabel": "Mostra tutto ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/ja-JP.json
+++ b/packages/@react-spectrum/tag/intl/ja-JP.json
@@ -1,5 +1,5 @@
 {
   "actions": "アクション",
   "hideButtonLabel": "表示を減らす",
-  "showAllButtonLabel": "({tagCount}) 個をすべて表示"
+  "showAllButtonLabel": "({tagCount, number}) 個をすべて表示"
 }

--- a/packages/@react-spectrum/tag/intl/ko-KR.json
+++ b/packages/@react-spectrum/tag/intl/ko-KR.json
@@ -1,5 +1,5 @@
 {
   "actions": "액션",
   "hideButtonLabel": "간단히 표시",
-  "showAllButtonLabel": "모두 표시 ({tagCount})"
+  "showAllButtonLabel": "모두 표시 ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/lt-LT.json
+++ b/packages/@react-spectrum/tag/intl/lt-LT.json
@@ -1,5 +1,5 @@
 {
   "actions": "Veiksmai",
   "hideButtonLabel": "Rodyti mažiau",
-  "showAllButtonLabel": "Rodyti viską ({tagCount})"
+  "showAllButtonLabel": "Rodyti viską ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/lv-LV.json
+++ b/packages/@react-spectrum/tag/intl/lv-LV.json
@@ -1,5 +1,5 @@
 {
   "actions": "Darbības",
   "hideButtonLabel": "Rādīt mazāk",
-  "showAllButtonLabel": "Rādīt visu ({tagCount})"
+  "showAllButtonLabel": "Rādīt visu ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/nb-NO.json
+++ b/packages/@react-spectrum/tag/intl/nb-NO.json
@@ -1,5 +1,5 @@
 {
   "actions": "Handlinger",
   "hideButtonLabel": "Vis mindre",
-  "showAllButtonLabel": "Vis alle ({tagCount})"
+  "showAllButtonLabel": "Vis alle ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/nl-NL.json
+++ b/packages/@react-spectrum/tag/intl/nl-NL.json
@@ -1,5 +1,5 @@
 {
   "actions": "Acties",
   "hideButtonLabel": "Minder weergeven",
-  "showAllButtonLabel": "Alles weergeven ({tagCount})"
+  "showAllButtonLabel": "Alles weergeven ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/pl-PL.json
+++ b/packages/@react-spectrum/tag/intl/pl-PL.json
@@ -1,5 +1,5 @@
 {
   "actions": "Działania",
   "hideButtonLabel": "Wyświetl mniej",
-  "showAllButtonLabel": "Wyświetl wszystkie ({tagCount})"
+  "showAllButtonLabel": "Wyświetl wszystkie ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/pt-BR.json
+++ b/packages/@react-spectrum/tag/intl/pt-BR.json
@@ -1,5 +1,5 @@
 {
   "actions": "Ações",
   "hideButtonLabel": "Mostrar menos",
-  "showAllButtonLabel": "Mostrar todos ({tagCount})"
+  "showAllButtonLabel": "Mostrar todos ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/pt-PT.json
+++ b/packages/@react-spectrum/tag/intl/pt-PT.json
@@ -1,5 +1,5 @@
 {
   "actions": "Ações",
   "hideButtonLabel": "Mostrar menos",
-  "showAllButtonLabel": "Mostrar tudo ({tagCount})"
+  "showAllButtonLabel": "Mostrar tudo ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/ro-RO.json
+++ b/packages/@react-spectrum/tag/intl/ro-RO.json
@@ -1,5 +1,5 @@
 {
   "actions": "Acțiuni",
   "hideButtonLabel": "Se afișează mai puțin",
-  "showAllButtonLabel": "Se afișează tot ({tagCount})"
+  "showAllButtonLabel": "Se afișează tot ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/ru-RU.json
+++ b/packages/@react-spectrum/tag/intl/ru-RU.json
@@ -1,5 +1,5 @@
 {
   "actions": "Действия",
   "hideButtonLabel": "Показать меньше",
-  "showAllButtonLabel": "Показать все ({tagCount})"
+  "showAllButtonLabel": "Показать все ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/sk-SK.json
+++ b/packages/@react-spectrum/tag/intl/sk-SK.json
@@ -1,5 +1,5 @@
 {
   "actions": "Akcie",
   "hideButtonLabel": "Zobraziť menej",
-  "showAllButtonLabel": "Zobraziť všetko ({tagCount})"
+  "showAllButtonLabel": "Zobraziť všetko ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/sl-SI.json
+++ b/packages/@react-spectrum/tag/intl/sl-SI.json
@@ -1,5 +1,5 @@
 {
   "actions": "Dejanja",
   "hideButtonLabel": "Prikaži manj",
-  "showAllButtonLabel": "Prikaži vse ({tagCount})"
+  "showAllButtonLabel": "Prikaži vse ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/sr-SP.json
+++ b/packages/@react-spectrum/tag/intl/sr-SP.json
@@ -1,5 +1,5 @@
 {
   "actions": "Radnje",
   "hideButtonLabel": "Prikaži manje",
-  "showAllButtonLabel": "Prikaži sve ({tagCount})"
+  "showAllButtonLabel": "Prikaži sve ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/sv-SE.json
+++ b/packages/@react-spectrum/tag/intl/sv-SE.json
@@ -1,5 +1,5 @@
 {
   "actions": "Åtgärder",
   "hideButtonLabel": "Visa mindre",
-  "showAllButtonLabel": "Visa allt ({tagCount})"
+  "showAllButtonLabel": "Visa allt ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/tr-TR.json
+++ b/packages/@react-spectrum/tag/intl/tr-TR.json
@@ -1,5 +1,5 @@
 {
   "actions": "Eylemler",
   "hideButtonLabel": "Daha az göster",
-  "showAllButtonLabel": "Tümünü göster ({tagCount})"
+  "showAllButtonLabel": "Tümünü göster ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/uk-UA.json
+++ b/packages/@react-spectrum/tag/intl/uk-UA.json
@@ -1,5 +1,5 @@
 {
   "actions": "Дії",
   "hideButtonLabel": "Показувати менше",
-  "showAllButtonLabel": "Показати всі ({tagCount})"
+  "showAllButtonLabel": "Показати всі ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/zh-CN.json
+++ b/packages/@react-spectrum/tag/intl/zh-CN.json
@@ -1,5 +1,5 @@
 {
   "actions": "操作",
   "hideButtonLabel": "显示更少",
-  "showAllButtonLabel": "显示全部 ({tagCount})"
+  "showAllButtonLabel": "显示全部 ({tagCount, number})"
 }

--- a/packages/@react-spectrum/tag/intl/zh-TW.json
+++ b/packages/@react-spectrum/tag/intl/zh-TW.json
@@ -1,5 +1,5 @@
 {
   "actions": "動作",
   "hideButtonLabel": "顯示較少",
-  "showAllButtonLabel": "顯示全部 ({tagCount})"
+  "showAllButtonLabel": "顯示全部 ({tagCount, number})"
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Found in chromatic story PR for tag group

this adds number to the string compiler, though right now it seems to always use the latin number. I checked this against drag and drop plural strings, it also always uses the latin number, so for the moment, this is correct until someone can answer if that is wrong.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
