### PR TITLE
Increase specificity of textfield icon

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/textfield/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/index.css
@@ -247,7 +247,7 @@ governing permissions and limitations under the License.
 }
 
 /* styles the left icon for textfield, assumes usage of workflow icon sizing (18px by 18px) */
-.spectrum-Textfield-icon {
+.spectrum-Textfield .spectrum-Textfield-icon {
   display: block;
   position: absolute;
   height: var(--spectrum-icon-info-medium-height);


### PR DESCRIPTION
prevents specificity war between the icon own height/width and the one dictated by the textfield. Discovered via chromatic

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
