### PR TITLE
fix chromatic accordion

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/accordion/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/accordion/skin.css
@@ -22,10 +22,6 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Accordion-itemIndicator {
-  color: var(--spectrum-alias-text-color);
-}
-
 .spectrum-Accordion-itemHeader {
   color: var(--spectrum-alias-text-color);
 
@@ -33,10 +29,6 @@ governing permissions and limitations under the License.
     color: var(--spectrum-alias-text-color-hover);
 
     background-color: var(--spectrum-accordion-background-color-hover);
-
-    + .spectrum-Accordion-itemIndicator {
-      color: var(--spectrum-alias-text-color-hover);
-    }
   }
 
   &:focus-ring {


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Found here https://www.chromatic.com/test?appId=5f0dd5ad2b5fc10022a2e320&id=6421ce82dacf8a735dc70f65

The CSS in this file did not reflect the actual dom structure and since the color should always be the same as the text we can make the previous specificity winner the default and use inherit instead of specifying colors directly for the chevron

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
