### PR TITLE
Updating MobileSearchAutocomplete so icon comes before the "x" button

### DIFF
--- a/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
@@ -208,6 +208,10 @@ const SearchAutocompleteButton = React.forwardRef(function SearchAutocompleteBut
       classNames(
         styles,
         'spectrum-InputGroup-input-validationIcon'
+      ),
+      classNames(
+        searchStyles,
+        'spectrum-Search-validationIcon'
       )
     )
   });
@@ -264,6 +268,7 @@ const SearchAutocompleteButton = React.forwardRef(function SearchAutocompleteBut
             classNames(
               searchStyles,
               'spectrum-Search',
+              'spectrum-Search--loadable',
               {
                 'is-disabled': isDisabled,
                 'is-quiet': isQuiet,


### PR DESCRIPTION
Found in testing session, introduces parity with desktop SearchAutocomplete

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test SearchAutocomplete stories on mobile/mobile screen width emulation. Try applying various validation states

## 🧢 Your Project:

RSP
