### PR TITLE
Updating stories for containerPadding

### DIFF
--- a/packages/@react-spectrum/dialog/chromatic/Dialog.chromatic.tsx
+++ b/packages/@react-spectrum/dialog/chromatic/Dialog.chromatic.tsx
@@ -157,6 +157,13 @@ storiesOf('Dialog', module)
     }
   )
   .add(
+    'popover: containerPadding',
+    () => renderTriggerProps({type: 'popover', containerPadding: 30, shouldFlip: false, placement: 'top'}), {
+      chromatic: {viewports: [1200]},
+      chromaticProvider: {colorSchemes: ['light'], locales: ['en-US'], scales: ['large'], disableAnimations: true}
+    }
+  )
+  .add(
     'mobileType fullscreenTakeover, modal',
     () => renderTriggerProps({type: 'modal', mobileType: 'fullscreenTakeover'}), {
       chromatic: {viewports: [320, 1200]},

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -34,7 +34,7 @@ storiesOf('DialogTrigger', module)
     args: {
       crossOffset: 0,
       offset: 0,
-      containerPadding: 0,
+      containerPadding: 12,
       placement: 'top',
       shouldFlip: false,
       isKeyboardDismissDisabled: false

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -31,14 +31,6 @@ import {Tooltip, TooltipTrigger} from '@react-spectrum/tooltip';
 storiesOf('DialogTrigger', module)
   .addParameters({
     providerSwitcher: {status: 'notice'},
-    args: {
-      crossOffset: 0,
-      offset: 0,
-      containerPadding: 12,
-      placement: 'top',
-      shouldFlip: false,
-      isKeyboardDismissDisabled: false
-    },
     argTypes: {
       crossOffset: {
         control: {


### PR DESCRIPTION
Discovered in testing. The default containerPadding set by the story was 0 which made it look like we broke the container padding calculations. Older builds of the storybook didn't have controls setup which made this change in behavior confusing. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test the DialogTrigger stories and verify that containerPadding is respected

## 🧢 Your Project:

RSP
