### PR TITLE
React Aria Components API improvements

### DIFF
--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -140,6 +140,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       'aria-label': stringFormatter.format('calendar'),
       'aria-labelledby': `${labelledBy} ${buttonId}`,
       'aria-describedby': ariaDescribedBy,
+      'aria-expanded': state.isOpen || undefined,
       onPress: () => state.setOpen(true)
     },
     dialogProps: {

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -151,6 +151,7 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
       'aria-label': stringFormatter.format('calendar'),
       'aria-labelledby': `${labelledBy} ${buttonId}`,
       'aria-describedby': ariaDescribedBy,
+      'aria-expanded': state.isOpen || undefined,
       onPress: () => state.setOpen(true)
     },
     dialogProps: {

--- a/packages/react-aria-components/docs/Calendar.mdx
+++ b/packages/react-aria-components/docs/Calendar.mdx
@@ -258,12 +258,45 @@ A `<Button>` accepts its contents as `children`. Other props such as `onPress` a
 
 ### CalendarGrid
 
-A `<CalendarGrid>` renders an individual month within a `<Calendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+A `<CalendarGrid>` renders an individual month within a `<Calendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date. This renders a default `<CalendarGridHeader>`, which displays the weekday names in the column headers. This can be customized by providing a `<CalendarGridHeader>` and `<CalendarGridBody>` as children instead of a function.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
 <PropTable component={docs.exports.CalendarGrid} links={docs.links} />
+
+</details>
+
+### CalendarGridHeader
+
+A `<CalendarGridHeader>` renders the header within a `<CalendarGrid>`, displaying a list of weekday names. It accepts a function as its `children`, which is called with a day name abbreviation to render a `<CalendarHeaderCell>` for each column header.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridHeader} links={docs.links} />
+
+</details>
+
+### CalendarHeaderCell
+
+A `<CalendarHeaderCell>` renders a column header within a `<CalendarGridHeader>`. It typically displays a weekday name.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarHeaderCell} links={docs.links} />
+
+</details>
+
+### CalendarGridBody
+
+A `<CalendarGridBody>` renders the body within a `<CalendarGrid>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridBody} links={docs.links} />
 
 </details>
 
@@ -341,7 +374,39 @@ A [Button](Button.html) can be targeted with the `.react-aria-Button` CSS select
 
 ### CalendarGrid
 
-A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`.
+A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`. When a function is provided as children, a default `<CalendarGridHeader>` and `<CalendarGridBody>` are rendered. If you need to customize the styling of the header cells, you can render them yourself.
+
+```tsx example
+import {CalendarGridHeader, CalendarHeaderCell, CalendarGridBody} from 'react-aria-components';
+
+<Calendar aria-label="Appointment date">
+  <header>
+    <Button slot="previous">◀</Button>
+    <Heading />
+    <Button slot="next">▶</Button>
+  </header>
+  <CalendarGrid>
+    <CalendarGridHeader>
+      {day => <CalendarHeaderCell style={{color: 'var(--blue)'}}>{day}</CalendarHeaderCell>}
+    </CalendarGridHeader>
+    <CalendarGridBody>
+      {date => <CalendarCell date={date} />}
+    </CalendarGridBody>
+  </CalendarGrid>
+</Calendar>
+````
+
+### CalendarGridHeader
+
+A `CalendarGridHeader` can be targeted with the `.react-aria-CalendarGridHeader` CSS selector, or by overriding with a custom `className`.
+
+### CalendarHeaderCell
+
+A `CalendarHeaderCell` can be targeted with the `.react-aria-CalendarHeaderCell` CSS selector, or by overriding with a custom `className`.
+
+### CalendarGridBody
+
+A `CalendarGridBody` can be targeted with the `.react-aria-CalendarGridBody` CSS selector, or by overriding with a custom `className`.
 
 ### CalendarCell
 

--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -344,7 +344,7 @@ Within a `<ComboBox>`, most `<ListBox>` props are set automatically. The `<ListB
 
 ### Section
 
-A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element.
+A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element. If there is no header, then an `aria-label` must be provided to identify the section to assistive technologies.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>

--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -130,7 +130,7 @@ import {ComboBox, Label, Input, Button, Popover, ListBox, Item} from 'react-aria
     margin-top: 12px;
   }
 
-  .react-aria-Section header {
+  .react-aria-Header {
     font-size: 1.143rem;
     font-weight: bold;
     padding: 0 0.571rem 0 1.571rem;
@@ -344,7 +344,7 @@ Within a `<ComboBox>`, most `<ListBox>` props are set automatically. The `<ListB
 
 ### Section
 
-A `<Section>` defines the child items, and optional title for a section within a `<ListBox>`.
+A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
@@ -352,6 +352,10 @@ A `<Section>` defines the child items, and optional title for a section within a
 <PropTable component={docs.exports.Section} links={docs.links} />
 
 </details>
+
+### Header
+
+A `<Header>` defines the title for a `<Section>`. It accepts all DOM attributes.
 
 ### Item
 
@@ -453,7 +457,11 @@ A [ListBox](ListBox.html) can be targeted with the `.react-aria-ListBox` CSS sel
 
 ### Section
 
-A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. The section title can be targeted with the `header` selector. The `title` prop also allows JSX elements and not just strings, which can enable custom formatting. However, keep in mind that interactive elements within a listbox are not allowed. See [sections](#sections) for examples.
+A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
+
+### Header
+
+A `Header` within a `Section` can be targeted with the `.react-aria-Header` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
 
 ### Item
 
@@ -619,15 +627,16 @@ any value within the field.
 
 ### Sections
 
-ComboBox supports sections in order to group options. Sections can be used by wrapping groups of items in a `Section` element. Each `Section` takes a `title` prop.
+ComboBox supports sections in order to group options. Sections can be used by wrapping groups of items in a `Section` element. A `<Header>` element may also be included to label the section.
 
 #### Static items
 
 ```tsx example
-import {Section} from 'react-aria-components';
+import {Section, Header} from 'react-aria-components';
 
 <MyComboBox label="Preferred fruit or vegetable">
-  <Section title="Fruit">
+  <Section>
+    <Header>Fruit</Header>
     <Item id="Apple">Apple</Item>
     <Item id="Banana">Banana</Item>
     <Item id="Orange">Orange</Item>
@@ -637,7 +646,8 @@ import {Section} from 'react-aria-components';
     <Item id="Cantaloupe">Cantaloupe</Item>
     <Item id="Pear">Pear</Item>
   </Section>
-  <Section title="Vegetable">
+  <Section>
+    <Header>Vegetable</Header>
     <Item id="Cabbage">Cabbage</Item>
     <Item id="Broccoli">Broccoli</Item>
     <Item id="Carrots">Carrots</Item>
@@ -652,9 +662,12 @@ import {Section} from 'react-aria-components';
 
 #### Dynamic items
 
-Sections used with dynamic items are populated from a hierarchical data structure. Please note that `Section` takes an array of data using the `items` prop only.
+Sections used with dynamic items are populated from a hierarchical data structure. Please note that `Section` takes an array of data using the `items` prop only. If the section also has a header,
+the <TypeLink links={docs.links} type={docs.exports.Collection} /> component can be used to render the child items.
 
 ```tsx example
+import {Collection} from 'react-aria-components';
+
 function Example() {
   let options = [
     {name: 'Fruit', children: [
@@ -681,9 +694,12 @@ function Example() {
 
   return (
     <MyComboBox label="Preferred fruit or vegetable" defaultItems={options}>
-      {item => (
-        <Section id={item.name} items={item.children} title={item.name}>
-          {item => <Item id={item.name}>{item.name}</Item>}
+      {section => (
+        <Section id={section.name}>
+          <Header>{section.name}</Header>
+          <Collection items={section.children}>
+            {item => <Item id={item.name}>{item.name}</Item>}
+          </Collection>
         </Section>
       )}
     </MyComboBox>

--- a/packages/react-aria-components/docs/DateField.mdx
+++ b/packages/react-aria-components/docs/DateField.mdx
@@ -289,7 +289,9 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### DateInput
 
-A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`.
+A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DateInputRenderProps.properties} />
 
 ### DateSegment
 

--- a/packages/react-aria-components/docs/DatePicker.mdx
+++ b/packages/react-aria-components/docs/DatePicker.mdx
@@ -644,11 +644,15 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### Group
 
-A `Group` can be targeted with the `.react-aria-Group` selector, or by overriding with a custom `className`.
+A `Group` can be targeted with the `.react-aria-Group` selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.GroupRenderProps.properties} />
 
 ### DateInput
 
-A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`.
+A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DateInputRenderProps.properties} />
 
 ### DateSegment
 

--- a/packages/react-aria-components/docs/DatePicker.mdx
+++ b/packages/react-aria-components/docs/DatePicker.mdx
@@ -530,12 +530,45 @@ A `<Calendar>` accepts one or more month grids as chilren, along with previous a
 
 ### CalendarGrid
 
-A `<CalendarGrid>` renders an individual month within a `<Calendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+A `<CalendarGrid>` renders an individual month within a `<Calendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date. This renders a default `<CalendarGridHeader>`, which displays the weekday names in the column headers. This can be customized by providing a `<CalendarGridHeader>` and `<CalendarGridBody>` as children instead of a function.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
 <PropTable component={docs.exports.CalendarGrid} links={docs.links} />
+
+</details>
+
+### CalendarGridHeader
+
+A `<CalendarGridHeader>` renders the header within a `<CalendarGrid>`, displaying a list of weekday names. It accepts a function as its `children`, which is called with a day name abbreviation to render a `<CalendarHeaderCell>` for each column header.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridHeader} links={docs.links} />
+
+</details>
+
+### CalendarHeaderCell
+
+A `<CalendarHeaderCell>` renders a column header within a `<CalendarGridHeader>`. It typically displays a weekday name.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarHeaderCell} links={docs.links} />
+
+</details>
+
+### CalendarGridBody
+
+A `<CalendarGridBody>` renders the body within a `<CalendarGrid>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridBody} links={docs.links} />
 
 </details>
 
@@ -645,7 +678,19 @@ A [Calendar](Calendar.html) can be targeted with the `.react-aria-Calendar` CSS 
 
 ### CalendarGrid
 
-A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`.
+A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`. When a function is provided as children, a default `<CalendarGridHeader>` and `<CalendarGridBody>` are rendered. If you need to customize the styling of the header cells, you can render them yourself. See the [Calendar](Calendar.html#calendargrid-1) docs for an example.
+
+### CalendarGridHeader
+
+A `CalendarGridHeader` can be targeted with the `.react-aria-CalendarGridHeader` CSS selector, or by overriding with a custom `className`.
+
+### CalendarHeaderCell
+
+A `CalendarHeaderCell` can be targeted with the `.react-aria-CalendarHeaderCell` CSS selector, or by overriding with a custom `className`.
+
+### CalendarGridBody
+
+A `CalendarGridBody` can be targeted with the `.react-aria-CalendarGridBody` CSS selector, or by overriding with a custom `className`.
 
 ### CalendarCell
 

--- a/packages/react-aria-components/docs/DateRangePicker.mdx
+++ b/packages/react-aria-components/docs/DateRangePicker.mdx
@@ -565,12 +565,45 @@ A `<RangeCalendar>` accepts one or more month grids as chilren, along with previ
 
 ### CalendarGrid
 
-A `<CalendarGrid>` renders an individual month within a `<RangeCalendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+A `<CalendarGrid>` renders an individual month within a `<RangeCalendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date. This renders a default `<CalendarGridHeader>`, which displays the weekday names in the column headers. This can be customized by providing a `<CalendarGridHeader>` and `<CalendarGridBody>` as children instead of a function.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
 <PropTable component={docs.exports.CalendarGrid} links={docs.links} />
+
+</details>
+
+### CalendarGridHeader
+
+A `<CalendarGridHeader>` renders the header within a `<CalendarGrid>`, displaying a list of weekday names. It accepts a function as its `children`, which is called with a day name abbreviation to render a `<CalendarHeaderCell>` for each column header.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridHeader} links={docs.links} />
+
+</details>
+
+### CalendarHeaderCell
+
+A `<CalendarHeaderCell>` renders a column header within a `<CalendarGridHeader>`. It typically displays a weekday name.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarHeaderCell} links={docs.links} />
+
+</details>
+
+### CalendarGridBody
+
+A `<CalendarGridBody>` renders the body within a `<CalendarGrid>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridBody} links={docs.links} />
 
 </details>
 
@@ -680,7 +713,19 @@ A [RangeCalendar](RangeCalendar.html) can be targeted with the `.react-aria-Rang
 
 ### CalendarGrid
 
-A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`.
+A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`. When a function is provided as children, a default `<CalendarGridHeader>` and `<CalendarGridBody>` are rendered. If you need to customize the styling of the header cells, you can render them yourself. See the [RangeCalendar](RangeCalendar.html#calendargrid-1) docs for an example.
+
+### CalendarGridHeader
+
+A `CalendarGridHeader` can be targeted with the `.react-aria-CalendarGridHeader` CSS selector, or by overriding with a custom `className`.
+
+### CalendarHeaderCell
+
+A `CalendarHeaderCell` can be targeted with the `.react-aria-CalendarHeaderCell` CSS selector, or by overriding with a custom `className`.
+
+### CalendarGridBody
+
+A `CalendarGridBody` can be targeted with the `.react-aria-CalendarGridBody` CSS selector, or by overriding with a custom `className`.
 
 ### CalendarCell
 

--- a/packages/react-aria-components/docs/DateRangePicker.mdx
+++ b/packages/react-aria-components/docs/DateRangePicker.mdx
@@ -679,11 +679,15 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### Group
 
-A `Group` can be targeted with the `.react-aria-Group` selector, or by overriding with a custom `className`.
+A `Group` can be targeted with the `.react-aria-Group` selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.GroupRenderProps.properties} />
 
 ### DateInput
 
-A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`.
+A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DateInputRenderProps.properties} />
 
 ### DateSegment
 

--- a/packages/react-aria-components/docs/ListBox.mdx
+++ b/packages/react-aria-components/docs/ListBox.mdx
@@ -95,7 +95,7 @@ import {ListBox, Item} from 'react-aria-components';
     margin-top: 12px;
   }
 
-  .react-aria-Section header {
+  .react-aria-Header {
     font-size: 1.143rem;
     font-weight: bold;
     padding: 0 0.714rem;
@@ -194,7 +194,7 @@ Users can select one or more options by clicking, tapping, or navigating with th
 
 ### Section
 
-A `<Section>` defines the child items, and optional title for a section within a `<ListBox>`.
+A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
@@ -202,6 +202,10 @@ A `<Section>` defines the child items, and optional title for a section within a
 <PropTable component={docs.exports.Section} links={docs.links} />
 
 </details>
+
+### Header
+
+A `<Header>` defines the title for a `<Section>`. It accepts all DOM attributes.
 
 ### Item
 
@@ -275,7 +279,11 @@ A `ListBox` can be targeted with the `.react-aria-ListBox` CSS selector, or by o
 
 ### Section
 
-A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. The section title can be targeted with the `header` selector. The `title` prop also allows JSX elements and not just strings, which can enable custom formatting. However, keep in mind that interactive elements within a listbox are not allowed. See [sections](#sections) for examples.
+A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
+
+### Header
+
+A `Header` within a `Section` can be targeted with the `.react-aria-Header` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
 
 ### Item
 
@@ -457,25 +465,28 @@ These selection behaviors are defined in [Aria Practices](https://w3c.github.io/
 
 ### Sections
 
-ListBox supports sections in order to group options. Sections can be used by wrapping groups of items in a `Section` element. Each `Section` takes a `title` prop.
+ListBox supports sections in order to group options. Sections can be used by wrapping groups of items in a `Section` element. A `<Header>` element may also be included to label the section.
 
 #### Static items
 
 ```tsx example
-import {Section} from 'react-aria-components';
+import {Section, Header} from 'react-aria-components';
 
 <ListBox aria-label="Sandwich contents" selectionMode="multiple">
-  <Section title="Veggies">
+  <Section>
+    <Header>Veggies</Header>
     <Item id="lettuce">Lettuce</Item>
     <Item id="tomato">Tomato</Item>
     <Item id="onion">Onion</Item>
   </Section>
-  <Section title="Protein">
+  <Section>
+    <Header>Protein</Header>
     <Item id="ham">Ham</Item>
     <Item id="tuna">Tuna</Item>
     <Item id="tofu">Tofu</Item>
   </Section>
-  <Section title="Condiments">
+  <Section>
+    <Header>Condiments</Header>
     <Item id="mayo">Mayonaise</Item>
     <Item id="mustard">Mustard</Item>
     <Item id="ranch">Ranch</Item>
@@ -486,10 +497,12 @@ import {Section} from 'react-aria-components';
 #### Dynamic items
 
 The above example shows sections with static items. Sections can also be populated from a heirarchical data structure.
-Similarly to the props on ListBox, `<Section>` takes an array of data using the `items` prop.
+Similarly to the props on ListBox, `<Section>` takes an array of data using the `items` prop. If the section also has a header,
+the <TypeLink links={docs.links} type={docs.exports.Collection} /> component can be used to render the child items.
 
 ```tsx example
 import type {Selection} from 'react-aria-components';
+import {Collection} from 'react-aria-components';
 
 function Example() {
   let options = [
@@ -513,9 +526,12 @@ function Example() {
       selectedKeys={selected}
       selectionMode="single"
       onSelectionChange={setSelected}>
-      {item => (
-        <Section id={item.name} items={item.children} title={item.name}>
-          {item => <Item>{item.name}</Item>}
+      {section => (
+        <Section id={section.name}>
+          <Header>{section.name}</Header>
+          <Collection items={section.children}>
+            {item => <Item>{item.name}</Item>}
+          </Collection>
         </Section>
       )}
     </ListBox>

--- a/packages/react-aria-components/docs/ListBox.mdx
+++ b/packages/react-aria-components/docs/ListBox.mdx
@@ -194,7 +194,7 @@ Users can select one or more options by clicking, tapping, or navigating with th
 
 ### Section
 
-A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element.
+A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element. If there is no header, then an `aria-label` must be provided to identify the section to assistive technologies.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -313,7 +313,7 @@ A `<Popover>` is a container to hold the `<Menu>`. By default, it has a `placeme
 
 ### Section
 
-A `<Section>` defines the child items for a section within a `<Menu>`. It may also contain an optional `<Header>` element.
+A `<Section>` defines the child items for a section within a `<Menu>`. It may also contain an optional `<Header>` element. If there is no header, then an `aria-label` must be provided to identify the section to assistive technologies.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -106,7 +106,7 @@ import {MenuTrigger, Button, Popover, Menu, Item} from 'react-aria-components';
     margin-top: 12px;
   }
 
-  .react-aria-Section header {
+  .react-aria-Header {
     font-size: 1.143rem;
     font-weight: bold;
     padding: 0 0.714rem;
@@ -313,7 +313,7 @@ A `<Popover>` is a container to hold the `<Menu>`. By default, it has a `placeme
 
 ### Section
 
-A `<Section>` defines the child items, and optional title for a section within a `<Menu>`.
+A `<Section>` defines the child items for a section within a `<Menu>`. It may also contain an optional `<Header>` element.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
@@ -321,6 +321,10 @@ A `<Section>` defines the child items, and optional title for a section within a
 <PropTable component={docs.exports.Section} links={docs.links} />
 
 </details>
+
+### Header
+
+A `<Header>` defines the title for a `<Section>`. It accepts all DOM attributes.
 
 ### Item
 
@@ -427,7 +431,11 @@ A `Menu` can be targeted with the `.react-aria-Menu` CSS selector, or by overrid
 
 ### Section
 
-A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. The section title can be targeted with the `header` selector. The `title` prop also allows JSX elements and not just strings, which can enable custom formatting. However, keep in mind that interactive elements within a menu are not allowed. See [sections](#sections) for examples.
+A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
+
+### Header
+
+A `Header` within a `Section` can be targeted with the `.react-aria-Header` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
 
 ### Item
 
@@ -615,19 +623,21 @@ import {Separator} from 'react-aria-components';
 
 ### Sections
 
-Menu supports sections with separators and headings in order to group options. Sections can be used by wrapping groups of Items in a `Section` component. Each `Section` takes a `title` prop.
+Menu supports sections with headings in order to group items. Sections can be used by wrapping groups of Items in a `Section` component. A `<Header>` element may also be included to label the section.
 
 #### Static items
 
 ```tsx example
-import {Section} from 'react-aria-components';
+import {Section, Header} from 'react-aria-components';
 
 <MyMenuButton label="Actions" onAction={alert}>
-  <Section title="Styles">
+  <Section>
+    <Header>Styles</Header>
     <Item id="bold">Bold</Item>
     <Item id="underline">Underline</Item>
   </Section>
-  <Section title="Align">
+  <Section>
+    <Header>Align</Header>
     <Item id="left">Left</Item>
     <Item id="middle">Middle</Item>
     <Item id="right">Right</Item>
@@ -638,10 +648,12 @@ import {Section} from 'react-aria-components';
 #### Dynamic items
 
 The above example shows sections with static items. Sections can also be populated from a heirarchical data structure.
-Similarly to the props on Menu, `<Section>` takes an array of data using the `items` prop.
+Similarly to the props on Menu, `<Section>` takes an array of data using the `items` prop. If the section also has a header,
+the <TypeLink links={docs.links} type={docs.exports.Collection} /> component can be used to render the child items.
 
 ```tsx example
 import type {Selection} from 'react-aria-components';
+import {Collection} from 'react-aria-components';
 
 function Example() {
   let [selected, setSelected] = React.useState<Selection>(new Set([1,3]));
@@ -671,9 +683,12 @@ function Example() {
       selectionMode="multiple"
       selectedKeys={selected}
       onSelectionChange={setSelected}>
-      {item => (
-        <Section items={item.children} title={item.name}>
-          {item => <Item>{item.name}</Item>}
+      {section => (
+        <Section>
+          <Header>{section.name}</Header>
+          <Collection items={section.children}>
+            {item => <Item>{item.name}</Item>}
+          </Collection>
         </Section>
       )}
     </MyMenuButton>

--- a/packages/react-aria-components/docs/NumberField.mdx
+++ b/packages/react-aria-components/docs/NumberField.mdx
@@ -294,11 +294,15 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### Group
 
-A `Group` can be targeted with the `.react-aria-Group` selector, or by overriding with a custom `className`.
+A `Group` can be targeted with the `.react-aria-Group` selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.GroupRenderProps.properties} />
 
 ### Input
 
-An `Input` can be targeted with the `.react-aria-Input` CSS selector, or by overriding with a custom `className`. It supports standard CSS pseudo classes such as `:focus` for states. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes) for details.
+An `Input` can be targeted with the `.react-aria-Input` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.InputRenderProps.properties} />
 
 ### Button
 

--- a/packages/react-aria-components/docs/RangeCalendar.mdx
+++ b/packages/react-aria-components/docs/RangeCalendar.mdx
@@ -280,12 +280,45 @@ A `<Button>` accepts its contents as `children`. Other props such as `onPress` a
 
 ### CalendarGrid
 
-A `<CalendarGrid>` renders an individual month within a `<Calendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+A `<CalendarGrid>` renders an individual month within a `<RangeCalendar>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date. This renders a default `<CalendarGridHeader>`, which displays the weekday names in the column headers. This can be customized by providing a `<CalendarGridHeader>` and `<CalendarGridBody>` as children instead of a function.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
 <PropTable component={docs.exports.CalendarGrid} links={docs.links} />
+
+</details>
+
+### CalendarGridHeader
+
+A `<CalendarGridHeader>` renders the header within a `<CalendarGrid>`, displaying a list of weekday names. It accepts a function as its `children`, which is called with a day name abbreviation to render a `<CalendarHeaderCell>` for each column header.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridHeader} links={docs.links} />
+
+</details>
+
+### CalendarHeaderCell
+
+A `<CalendarHeaderCell>` renders a column header within a `<CalendarGridHeader>`. It typically displays a weekday name.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarHeaderCell} links={docs.links} />
+
+</details>
+
+### CalendarGridBody
+
+A `<CalendarGridBody>` renders the body within a `<CalendarGrid>`. It accepts a function as its `children`, which is called to render a `<CalendarCell>` for each date.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.CalendarGridBody} links={docs.links} />
 
 </details>
 
@@ -363,7 +396,39 @@ A [Button](Button.html) can be targeted with the `.react-aria-Button` CSS select
 
 ### CalendarGrid
 
-A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`.
+A `CalendarGrid` can be targeted with the `.react-aria-CalendarGrid` CSS selector, or by overriding with a custom `className`. When a function is provided as children, a default `<CalendarGridHeader>` and `<CalendarGridBody>` are rendered. If you need to customize the styling of the header cells, you can render them yourself.
+
+```tsx example
+import {CalendarGridHeader, CalendarHeaderCell, CalendarGridBody} from 'react-aria-components';
+
+<RangeCalendar aria-label="Trip dates">
+  <header>
+    <Button slot="previous">◀</Button>
+    <Heading />
+    <Button slot="next">▶</Button>
+  </header>
+  <CalendarGrid>
+    <CalendarGridHeader>
+      {day => <CalendarHeaderCell style={{color: 'var(--blue)'}}>{day}</CalendarHeaderCell>}
+    </CalendarGridHeader>
+    <CalendarGridBody>
+      {date => <CalendarCell date={date} />}
+    </CalendarGridBody>
+  </CalendarGrid>
+</RangeCalendar>
+````
+
+### CalendarGridHeader
+
+A `CalendarGridHeader` can be targeted with the `.react-aria-CalendarGridHeader` CSS selector, or by overriding with a custom `className`.
+
+### CalendarHeaderCell
+
+A `CalendarHeaderCell` can be targeted with the `.react-aria-CalendarHeaderCell` CSS selector, or by overriding with a custom `className`.
+
+### CalendarGridBody
+
+A `CalendarGridBody` can be targeted with the `.react-aria-CalendarGridBody` CSS selector, or by overriding with a custom `className`.
 
 ### CalendarCell
 

--- a/packages/react-aria-components/docs/SearchField.mdx
+++ b/packages/react-aria-components/docs/SearchField.mdx
@@ -309,7 +309,9 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### Input
 
-An `Input` can be targeted with the `.react-aria-Input` CSS selector, or by overriding with a custom `className`.
+An `Input` can be targeted with the `.react-aria-Input` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.InputRenderProps.properties} />
 
 ### Button
 

--- a/packages/react-aria-components/docs/Select.mdx
+++ b/packages/react-aria-components/docs/Select.mdx
@@ -164,7 +164,7 @@ import {Select, SelectValue, Label, Button, Popover, ListBox, Item} from 'react-
     margin-top: 12px;
   }
 
-  .react-aria-Section header {
+  .react-aria-Header {
     font-size: 1.143rem;
     font-weight: bold;
     padding: 0 0.571rem 0 1.571rem;
@@ -411,7 +411,7 @@ Within a `<Select>`, most `<ListBox>` props are set automatically. The `<ListBox
 
 ### Section
 
-A `<Section>` defines the child items, and optional title for a section within a `<ListBox>`.
+A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
@@ -419,6 +419,10 @@ A `<Section>` defines the child items, and optional title for a section within a
 <PropTable component={docs.exports.Section} links={docs.links} />
 
 </details>
+
+### Header
+
+A `<Header>` defines the title for a `<Section>`. It accepts all DOM attributes.
 
 ### Item
 
@@ -522,7 +526,11 @@ A `ListBox` can be targeted with the `.react-aria-ListBox` CSS selector, or by o
 
 ### Section
 
-A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`.  The section title can be targeted with the `header` selector. The `title` prop also allows JSX elements and not just strings, which can enable custom formatting. However, keep in mind that interactive elements within a listbox are not allowed. See [sections](#sections) for examples.
+A `Section` can be targeted with the `.react-aria-Section` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
+
+### Header
+
+A `Header` within a `Section` can be targeted with the `.react-aria-Header` CSS selector, or by overriding with a custom `className`. See [sections](#sections) for examples.
 
 ### Item
 
@@ -669,15 +677,16 @@ function Example() {
 
 ### Sections
 
-Select supports sections in order to group options. Sections can be used by wrapping groups of items in a `Section` element. Each `Section` takes a `title` prop.
+Select supports sections in order to group options. Sections can be used by wrapping groups of items in a `Section` element. A `<Header>` element may also be included to label the section.
 
 #### Static items
 
 ```tsx example
-import {Section} from 'react-aria-components';
+import {Section, Header} from 'react-aria-components';
 
 <MySelect label="Preferred fruit or vegetable">
-  <Section title="Fruit">
+  <Section>
+    <Header>Fruit</Header>
     <Item id="Apple">Apple</Item>
     <Item id="Banana">Banana</Item>
     <Item id="Orange">Orange</Item>
@@ -687,7 +696,8 @@ import {Section} from 'react-aria-components';
     <Item id="Cantaloupe">Cantaloupe</Item>
     <Item id="Pear">Pear</Item>
   </Section>
-  <Section title="Vegetable">
+  <Section>
+    <Header>Vegetable</Header>
     <Item id="Cabbage">Cabbage</Item>
     <Item id="Broccoli">Broccoli</Item>
     <Item id="Carrots">Carrots</Item>
@@ -702,9 +712,12 @@ import {Section} from 'react-aria-components';
 
 #### Dynamic items
 
-Sections used with dynamic items are populated from a hierarchical data structure. Similarly to the props on Select, `<Section>` takes an array of data using the `items` prop.
+Sections used with dynamic items are populated from a hierarchical data structure. Similarly to the props on Select, `<Section>` takes an array of data using the `items` prop. If the section also has a header,
+the <TypeLink links={docs.links} type={docs.exports.Collection} /> component can be used to render the child items.
 
 ```tsx example
+import {Collection} from 'react-aria-components';
+
 function Example() {
   let options = [
     {name: 'Fruit', children: [
@@ -731,9 +744,12 @@ function Example() {
 
   return (
     <MySelect label="Preferred fruit or vegetable" items={options}>
-      {item => (
-        <Section id={item.name} items={item.children} title={item.name}>
-          {item => <Item id={item.name}>{item.name}</Item>}
+      {section => (
+        <Section id={section.name}>
+          <Header>{section.name}</Header>
+          <Collection items={section.children}>
+            {item => <Item id={item.name}>{item.name}</Item>}
+          </Collection>
         </Section>
       )}
     </MySelect>

--- a/packages/react-aria-components/docs/Select.mdx
+++ b/packages/react-aria-components/docs/Select.mdx
@@ -411,7 +411,7 @@ Within a `<Select>`, most `<ListBox>` props are set automatically. The `<ListBox
 
 ### Section
 
-A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element.
+A `<Section>` defines the child items for a section within a `<ListBox>`. It may also contain an optional `<Header>` element. If there is no header, then an `aria-label` must be provided to identify the section to assistive technologies.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>

--- a/packages/react-aria-components/docs/TextField.mdx
+++ b/packages/react-aria-components/docs/TextField.mdx
@@ -226,7 +226,9 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### Input
 
-An `Input` can be targeted with the `.react-aria-Input` CSS selector, or by overriding with a custom `className`.
+An `Input` can be targeted with the `.react-aria-Input` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.InputRenderProps.properties} />
 
 ### Text
 

--- a/packages/react-aria-components/docs/TimeField.mdx
+++ b/packages/react-aria-components/docs/TimeField.mdx
@@ -286,7 +286,9 @@ A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overr
 
 ### DateInput
 
-A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`.
+A `DateInput` can be targeted with the `.react-aria-DateInput` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DateInputRenderProps.properties} />
 
 ### DateSegment
 

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -252,7 +252,17 @@ export interface CalendarCellRenderProps {
 }
 
 export interface CalendarGridProps extends StyleProps {
-  children?: React.ReactChild | ((date: CalendarDate) => ReactElement),
+  /**
+   * Either a function to render calendar cells for each date in the month,
+   * or children containing a `<CalendarGridHeader>`` and `<CalendarGridBody>`
+   * when additional customization is needed.
+   */
+  children?: ReactElement | ((date: CalendarDate) => ReactElement),
+  /**
+   * An offset from the beginning of the visible date range that this
+   * CalendarGrid should display. Useful when displaying more than one
+   * month at a time.
+   */
   offset?: DateDuration
 }
 
@@ -308,6 +318,7 @@ const _CalendarGrid = forwardRef(CalendarGrid);
 export {_CalendarGrid as CalendarGrid};
 
 export interface CalendarGridHeaderProps extends StyleProps {
+  /** A function to render a `<CalendarHeaderCell>` for a weekday name. */
   children: (day: string) => ReactElement
 }
 
@@ -353,6 +364,7 @@ const CalendarHeaderCellForwardRef = forwardRef(CalendarHeaderCell);
 export {CalendarHeaderCellForwardRef as CalendarHeaderCell};
 
 export interface CalendarGridBodyProps extends StyleProps {
+  /** A function to render a `<CalendarCell>` for a given date. */
   children: (date: CalendarDate) => ReactElement
 }
 
@@ -387,6 +399,7 @@ const CalendarGridBodyForwardRef = forwardRef(CalendarGridBody);
 export {CalendarGridBodyForwardRef as CalendarGridBody};
 
 export interface CalendarCellProps extends RenderProps<CalendarCellRenderProps> {
+  /** The date to render in the cell. */
   date: CalendarDate
 }
 

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -13,8 +13,9 @@ import {CalendarProps as BaseCalendarProps, RangeCalendarProps as BaseRangeCalen
 import {ButtonContext} from './Button';
 import {CalendarDate, createCalendar, DateDuration, endOfMonth, getWeeksInMonth, isSameDay, isSameMonth} from '@internationalized/date';
 import {CalendarState, RangeCalendarState, useCalendarState, useRangeCalendarState} from 'react-stately';
-import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
+import {ContextValue, DOMProps, forwardRefType, Provider, RenderProps, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
 import {createContext, ForwardedRef, forwardRef, ReactElement, useContext} from 'react';
+import {DOMAttributes, FocusableElement} from '@react-types/shared';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {HeadingContext} from './Heading';
 import React from 'react';
@@ -39,7 +40,6 @@ export interface RangeCalendarProps<T extends DateValue> extends Omit<BaseRangeC
 export const CalendarContext = createContext<ContextValue<CalendarProps<any>, HTMLDivElement>>({});
 export const RangeCalendarContext = createContext<ContextValue<RangeCalendarProps<any>, HTMLDivElement>>({});
 const InternalCalendarContext = createContext<CalendarState | RangeCalendarState | null>(null);
-const InternalCalendarGridContext = createContext<CalendarDate | null>(null);
 
 function Calendar<T extends DateValue>(props: CalendarProps<T>, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, CalendarContext);
@@ -252,9 +252,17 @@ export interface CalendarCellRenderProps {
 }
 
 export interface CalendarGridProps extends StyleProps {
-  children: (date: CalendarDate) => ReactElement,
+  children?: React.ReactChild | ((date: CalendarDate) => ReactElement),
   offset?: DateDuration
 }
+
+interface InternalCalendarGridContextValue {
+  headerProps: DOMAttributes<FocusableElement>,
+  weekDays: string[],
+  startDate: CalendarDate
+}
+
+const InternalCalendarGridContext = createContext<InternalCalendarGridContextValue | null>(null);
 
 function CalendarGrid(props: CalendarGridProps, ref: ForwardedRef<HTMLTableElement>) {
   let state = useContext(InternalCalendarContext)!;
@@ -267,35 +275,26 @@ function CalendarGrid(props: CalendarGridProps, ref: ForwardedRef<HTMLTableEleme
     startDate,
     endDate: endOfMonth(startDate)
   }, state);
-  let {locale} = useLocale();
-
-  let weeksInMonth = getWeeksInMonth(startDate, locale);
 
   return (
-    <InternalCalendarGridContext.Provider value={startDate}>
+    <InternalCalendarGridContext.Provider value={{headerProps, weekDays, startDate}}>
       <table
         {...filterDOMProps(props as any)}
         {...gridProps}
         ref={ref}
         style={props.style}
         className={props.className ?? 'react-aria-CalendarGrid'}>
-        <thead {...headerProps}>
-          <tr>
-            {/* TODO: we might want to allow people to customize this? */}
-            {weekDays.map((day, index) => <th key={index}>{day}</th>)}
-          </tr>
-        </thead>
-        <tbody>
-          {[...new Array(weeksInMonth).keys()].map((weekIndex) => (
-            <tr key={weekIndex}>
-              {state.getDatesInWeek(weekIndex, startDate).map((date, i) => (
-                date
-                  ? React.cloneElement(props.children(date), {key: i})
-                  : <td key={i} />
-              ))}
-            </tr>
-          ))}
-        </tbody>
+        {typeof props.children !== 'function'
+          ? props.children
+          : (<>
+            <CalendarGridHeaderForwardRef>
+              {day => <CalendarHeaderCellForwardRef>{day}</CalendarHeaderCellForwardRef>}
+            </CalendarGridHeaderForwardRef>
+            <CalendarGridBodyForwardRef>
+              {props.children}
+            </CalendarGridBodyForwardRef>
+          </>)
+        }
       </table>
     </InternalCalendarGridContext.Provider>
   );
@@ -308,13 +307,92 @@ function CalendarGrid(props: CalendarGridProps, ref: ForwardedRef<HTMLTableEleme
 const _CalendarGrid = forwardRef(CalendarGrid);
 export {_CalendarGrid as CalendarGrid};
 
+export interface CalendarGridHeaderProps extends StyleProps {
+  children: (day: string) => ReactElement
+}
+
+function CalendarGridHeader({children, style, className}: CalendarGridHeaderProps, ref: ForwardedRef<HTMLTableSectionElement>) {
+  let {headerProps, weekDays} = useContext(InternalCalendarGridContext)!;
+
+  return (
+    <thead
+      {...headerProps}
+      ref={ref}
+      style={style}
+      className={className || 'react-aria-CalendarGridHeader'}>
+      <tr>
+        {weekDays.map((day, key) => React.cloneElement(children(day), {key}))}
+      </tr>
+    </thead>
+  );
+}
+
+/**
+ * A calendar grid header displays a row of week day names at the top of a month.
+ */
+const CalendarGridHeaderForwardRef = forwardRef(CalendarGridHeader);
+export {CalendarGridHeaderForwardRef as CalendarGridHeader};
+
+export interface CalendarHeaderCellProps extends DOMProps {}
+
+function CalendarHeaderCell({children, style, className}: CalendarHeaderCellProps, ref: ForwardedRef<HTMLTableCellElement>) {
+  return (
+    <th
+      ref={ref}
+      style={style}
+      className={className || 'react-aria-CalendarHeaderCell'}>
+      {children}
+    </th>
+  );
+}
+
+/**
+ * A calendar header cell displays a week day name at the top of a column within a calendar.
+ */
+const CalendarHeaderCellForwardRef = forwardRef(CalendarHeaderCell);
+export {CalendarHeaderCellForwardRef as CalendarHeaderCell};
+
+export interface CalendarGridBodyProps extends StyleProps {
+  children: (date: CalendarDate) => ReactElement
+}
+
+function CalendarGridBody({children, style, className}: CalendarGridBodyProps, ref: ForwardedRef<HTMLTableSectionElement>) {
+  let state = useContext(InternalCalendarContext)!;
+  let {startDate} = useContext(InternalCalendarGridContext)!;
+  let {locale} = useLocale();
+  let weeksInMonth = getWeeksInMonth(startDate, locale);
+
+  return (
+    <tbody
+      ref={ref}
+      style={style}
+      className={className || 'react-aria-CalendarGridBody'}>
+      {[...new Array(weeksInMonth).keys()].map((weekIndex) => (
+        <tr key={weekIndex}>
+          {state.getDatesInWeek(weekIndex, startDate).map((date, i) => (
+            date
+              ? React.cloneElement(children(date), {key: i})
+              : <td key={i} />
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  );
+}
+
+/**
+ * A calendar grid body displays a grid of calendar cells within a month.
+ */
+const CalendarGridBodyForwardRef = forwardRef(CalendarGridBody);
+export {CalendarGridBodyForwardRef as CalendarGridBody};
+
 export interface CalendarCellProps extends RenderProps<CalendarCellRenderProps> {
   date: CalendarDate
 }
 
 function CalendarCell({date, ...otherProps}: CalendarCellProps, ref: ForwardedRef<HTMLDivElement>) {
   let state = useContext(InternalCalendarContext)!;
-  let currentMonth = useContext(InternalCalendarGridContext)!;
+  let {startDate: currentMonth} = useContext(InternalCalendarGridContext)!;
   let objectRef = useObjectRef(ref);
   let {cellProps, buttonProps, ...states} = useCalendarCell(
     {date},

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -257,7 +257,7 @@ export interface CalendarGridProps extends StyleProps {
    * or children containing a `<CalendarGridHeader>`` and `<CalendarGridBody>`
    * when additional customization is needed.
    */
-  children?: ReactElement | ((date: CalendarDate) => ReactElement),
+  children?: ReactElement | ReactElement[] | ((date: CalendarDate) => ReactElement),
   /**
    * An offset from the beginning of the visible date range that this
    * CalendarGrid should display. Useful when displaying more than one

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -322,11 +322,13 @@ export interface CalendarGridHeaderProps extends StyleProps {
   children: (day: string) => ReactElement
 }
 
-function CalendarGridHeader({children, style, className}: CalendarGridHeaderProps, ref: ForwardedRef<HTMLTableSectionElement>) {
+function CalendarGridHeader(props: CalendarGridHeaderProps, ref: ForwardedRef<HTMLTableSectionElement>) {
+  let {children, style, className} = props;
   let {headerProps, weekDays} = useContext(InternalCalendarGridContext)!;
 
   return (
     <thead
+      {...filterDOMProps(props as any)}
       {...headerProps}
       ref={ref}
       style={style}
@@ -346,9 +348,11 @@ export {CalendarGridHeaderForwardRef as CalendarGridHeader};
 
 export interface CalendarHeaderCellProps extends DOMProps {}
 
-function CalendarHeaderCell({children, style, className}: CalendarHeaderCellProps, ref: ForwardedRef<HTMLTableCellElement>) {
+function CalendarHeaderCell(props: CalendarHeaderCellProps, ref: ForwardedRef<HTMLTableCellElement>) {
+  let {children, style, className} = props;
   return (
     <th
+      {...filterDOMProps(props as any)}
       ref={ref}
       style={style}
       className={className || 'react-aria-CalendarHeaderCell'}>
@@ -368,7 +372,8 @@ export interface CalendarGridBodyProps extends StyleProps {
   children: (date: CalendarDate) => ReactElement
 }
 
-function CalendarGridBody({children, style, className}: CalendarGridBodyProps, ref: ForwardedRef<HTMLTableSectionElement>) {
+function CalendarGridBody(props: CalendarGridBodyProps, ref: ForwardedRef<HTMLTableSectionElement>) {
+  let {children, style, className} = props;
   let state = useContext(InternalCalendarContext)!;
   let {startDate} = useContext(InternalCalendarGridContext)!;
   let {locale} = useLocale();
@@ -376,6 +381,7 @@ function CalendarGridBody({children, style, className}: CalendarGridBodyProps, r
 
   return (
     <tbody
+      {...filterDOMProps(props as any)}
       ref={ref}
       style={style}
       className={className || 'react-aria-CalendarGridBody'}>

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -743,7 +743,7 @@ export function Item<T extends object>(props: ItemProps<T>): JSX.Element {
   return <item multiple={{...props, rendered: props.children}} />;
 }
 
-export interface SectionProps<T> extends Omit<SharedSectionProps<T>, 'children'>, DOMProps {
+export interface SectionProps<T> extends Omit<SharedSectionProps<T>, 'children' | 'title'>, DOMProps {
   id?: Key,
   /** Static child items or a function to render children. */
   children?: ReactNode | ((item: T) => ReactElement)

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -299,17 +299,18 @@ export class ElementNode<T> extends BaseNode<T> {
 
   // Special property that React passes through as an object rather than a string via setAttribute.
   // See below for details.
-  set multiple(value: any) {
+  set multiple(obj: any) {
     let node = this.ownerDocument.getMutableNode(this);
-    node.props = value;
-    node.rendered = value.rendered;
-    node.value = value.value;
-    node.textValue = value.textValue || (typeof value.rendered === 'string' ? value.rendered : '') || value['aria-label'] || '';
-    if (value.id != null && value.id !== node.key) {
+    let {rendered, value, textValue, id, ...props} = obj;
+    node.props = props;
+    node.rendered = rendered;
+    node.value = value;
+    node.textValue = textValue || (typeof rendered === 'string' ? rendered : '') || obj['aria-label'] || '';
+    if (id != null && id !== node.key) {
       if (this.parentNode) {
         throw new Error('Cannot change the id of an item');
       }
-      node.key = value.id;
+      node.key = id;
     }
   }
 
@@ -593,11 +594,12 @@ export interface CollectionProps<T> extends Omit<CollectionBase<T>, 'children'> 
 }
 
 interface CachedChildrenOptions<T> extends CollectionProps<T> {
-  idScope?: Key
+  idScope?: Key,
+  addIdAndValue?: boolean
 }
 
 export function useCachedChildren<T extends object>(props: CachedChildrenOptions<T>) {
-  let {children, items, idScope} = props;
+  let {children, items, idScope, addIdAndValue} = props;
   let cache = useMemo(() => new WeakMap(), []);
   return useMemo(() => {
     if (items && typeof children === 'function') {
@@ -618,7 +620,10 @@ export function useCachedChildren<T extends object>(props: CachedChildrenOptions
               key = idScope + ':' + key;
             }
             // TODO: only works if wrapped Item passes through id...
-            rendered = cloneElement(rendered, {key, id: key, value: item});
+            rendered = cloneElement(
+              rendered,
+              addIdAndValue ? {key, id: key, value: item} : {key}
+            );
           }
           cache.set(item, rendered);
         }
@@ -628,7 +633,11 @@ export function useCachedChildren<T extends object>(props: CachedChildrenOptions
     } else {
       return children;
     }
-  }, [children, items, cache, idScope]);
+  }, [children, items, cache, idScope, addIdAndValue]);
+}
+
+export function useCollectionChildren<T extends object>(props: CachedChildrenOptions<T>) {
+  return useCachedChildren({...props, addIdAndValue: true});
 }
 
 const ShallowRenderContext = createContext(false);
@@ -645,7 +654,7 @@ export function useCollection<T extends object, C extends BaseCollection<T>>(pro
   let subscribe = useCallback((fn: () => void) => document.subscribe(fn), [document]);
   let getSnapshot = useCallback(() => document.getCollection(), [document]);
   let collection = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-  let children = useCachedChildren(props);
+  let children = useCollectionChildren(props);
   let wrappedChildren = useMemo(() => (
     <ShallowRenderContext.Provider value>
       {children}
@@ -756,7 +765,7 @@ export interface SectionProps<T> extends Omit<SharedSectionProps<T>, 'children' 
 }
 
 export function Section<T extends object>(props: SectionProps<T>): JSX.Element {
-  let children = useCachedChildren(props);
+  let children = useCollectionChildren(props);
 
   // @ts-ignore
   return <section multiple={{...props, rendered: props.title}}>{children}</section>;
@@ -772,7 +781,7 @@ export function Collection<T extends object>(props: CollectionProps<T>): JSX.Ele
   let renderer = typeof props.children === 'function' ? props.children : null;
   return (
     <CollectionRendererContext.Provider value={renderer}>
-      {useCachedChildren(props)}
+      {useCollectionChildren(props)}
     </CollectionRendererContext.Provider>
   );
 }

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -647,7 +647,7 @@ export function useCollection<T extends object, C extends BaseCollection<T>>(pro
   let collection = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   let children = useCachedChildren(props);
   let wrappedChildren = useMemo(() => (
-    <ShallowRenderContext.Provider value={true}>
+    <ShallowRenderContext.Provider value>
       {children}
     </ShallowRenderContext.Provider>
   ), [children]);

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -618,7 +618,7 @@ export function useCachedChildren<T extends object>(props: CachedChildrenOptions
               key = idScope + ':' + key;
             }
             // TODO: only works if wrapped Item passes through id...
-            rendered = cloneElement(rendered, {key, id: key});
+            rendered = cloneElement(rendered, {key, id: key, value: item});
           }
           cache.set(item, rendered);
         }
@@ -730,7 +730,10 @@ export interface ItemRenderProps {
 }
 
 export interface ItemProps<T = object> extends Omit<SharedItemProps<T>, 'children'>, RenderProps<ItemRenderProps> {
-  id?: Key
+  /** The unique id of the item. */
+  id?: Key,
+  /** The object value that this item represents. When using dynamic collections, this is set automatically. */
+  value?: T
 }
 
 export function Item<T extends object>(props: ItemProps<T>): JSX.Element {
@@ -744,7 +747,10 @@ export function Item<T extends object>(props: ItemProps<T>): JSX.Element {
 }
 
 export interface SectionProps<T> extends Omit<SharedSectionProps<T>, 'children' | 'title'>, DOMProps {
+  /** The unique id of the section. */
   id?: Key,
+  /** The object value that this section represents. When using dynamic collections, this is set automatically. */
+  value?: T,
   /** Static child items or a function to render children. */
   children?: ReactNode | ((item: T) => ReactElement)
 }

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -95,7 +95,7 @@ function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<H
     <Provider
       values={[
         [LabelContext, {...labelProps, ref: labelRef}],
-        [ButtonContext, {...buttonProps, ref: buttonRef}],
+        [ButtonContext, {...buttonProps, ref: buttonRef, isPressed: state.isOpen}],
         [InputContext, {...inputProps, ref: inputRef}],
         [PopoverContext, {
           state,

--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -9,14 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import {AriaDateFieldProps, AriaTimeFieldProps, DateValue, TimeValue, useDateField, useDateSegment, useLocale, useTimeField} from 'react-aria';
-import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, StyleProps, useContextProps, useRenderProps, useSlot} from './utils';
+import {AriaDateFieldProps, AriaTimeFieldProps, DateValue, TimeValue, mergeProps, useDateField, useDateSegment, useFocusRing, useHover, useLocale, useTimeField} from 'react-aria';
+import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {createCalendar} from '@internationalized/date';
 import {DateFieldState, DateSegmentType, DateSegment as IDateSegment, useDateFieldState, useTimeFieldState} from 'react-stately';
-import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {LabelContext} from './Label';
 import React, {cloneElement, createContext, ForwardedRef, forwardRef, HTMLAttributes, ReactElement, useContext, useRef} from 'react';
 import {TextContext} from './Text';
+import {useObjectRef} from '@react-aria/utils';
 
 export interface DateFieldProps<T extends DateValue> extends Omit<AriaDateFieldProps<T>, 'label' | 'description' | 'errorMessage'>, RenderProps<DateFieldState>, SlotProps {}
 export interface TimeFieldProps<T extends TimeValue> extends Omit<AriaTimeFieldProps<T>, 'label' | 'description' | 'errorMessage'>, RenderProps<DateFieldState>, SlotProps {}
@@ -121,21 +121,58 @@ export {_TimeField as TimeField};
 
 const InternalDateInputContext = createContext<DateFieldState| null>(null);
 
-export interface DateInputProps extends SlotProps, StyleProps {
+export interface DateInputRenderProps {
+  /**
+   * Whether the date input is currently hovered with a mouse.
+   * @selector [data-hovered]
+   */
+  isHovered: boolean,
+  /**
+   * Whether an element within the date input is focused, either via a mouse or keyboard.
+   * @selector :focus-within
+   */
+  isFocusWithin: boolean,
+  /**
+   * Whether an element within the date input is keyboard focused.
+   * @selector [data-focus-visible]
+   */
+  isFocusVisible: boolean,
+  /**
+   * Whether the date input is disabled.
+   * @selector [data-disabled]
+   */
+  isDisabled: boolean
+}
+
+export interface DateInputProps extends SlotProps, StyleRenderProps<DateInputRenderProps> {
   children: (segment: IDateSegment) => ReactElement
 }
 
-function DateInput({children, style, className, slot, ...otherProps}: DateInputProps, ref: ForwardedRef<HTMLDivElement>) {
+function DateInput({children, slot, ...otherProps}: DateInputProps, ref: ForwardedRef<HTMLDivElement>) {
   let [{state, fieldProps}, fieldRef] = useContextProps({slot} as DateInputProps & DateInputContextValue, ref, DateInputContext);
+
+  let {hoverProps, isHovered} = useHover({});
+  let {isFocused, isFocusVisible, focusProps} = useFocusRing({
+    within: true,
+    isTextInput: true
+  });
+
+  let renderProps = useRenderProps({
+    ...otherProps,
+    values: {isHovered, isFocusWithin: isFocused, isFocusVisible, isDisabled: state.isDisabled},
+    defaultClassName: 'react-aria-DateInput'
+  });
+
   return (
     <InternalDateInputContext.Provider value={state}>
       <div
-        {...filterDOMProps(otherProps)}
-        {...fieldProps}
+        {...mergeProps(fieldProps, focusProps, hoverProps)}
+        {...renderProps}
         ref={fieldRef}
         slot={slot}
-        style={style}
-        className={className ?? 'react-aria-DateInput'}>
+        data-hovered={isHovered || undefined}
+        data-focus-visible={isFocusVisible || undefined}
+        data-disabled={state.isDisabled || undefined}>
         {state.segments.map((segment, i) => cloneElement(children(segment), {key: i}))}
       </div>
     </InternalDateInputContext.Provider>

--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import {AriaDateFieldProps, AriaTimeFieldProps, DateValue, TimeValue, mergeProps, useDateField, useDateSegment, useFocusRing, useHover, useLocale, useTimeField} from 'react-aria';
+import {AriaDateFieldProps, AriaTimeFieldProps, DateValue, mergeProps, TimeValue, useDateField, useDateSegment, useFocusRing, useHover, useLocale, useTimeField} from 'react-aria';
 import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {createCalendar} from '@internationalized/date';
 import {DateFieldState, DateSegmentType, DateSegment as IDateSegment, useDateFieldState, useTimeFieldState} from 'react-stately';

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -66,7 +66,7 @@ function DatePicker<T extends DateValue>(props: DatePickerProps<T>, ref: Forward
       values={[
         [GroupContext, {...groupProps, ref: groupRef}],
         [DateInputContext, {state: fieldState, fieldProps: dateFieldProps, ref: fieldRef}],
-        [ButtonContext, buttonProps],
+        [ButtonContext, {...buttonProps, isPressed: state.isOpen}],
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [CalendarContext, calendarProps],
         [PopoverContext, {state, triggerRef: groupRef, placement: 'bottom start'}],
@@ -137,7 +137,7 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
     <Provider
       values={[
         [GroupContext, {...groupProps, ref: groupRef}],
-        [ButtonContext, buttonProps],
+        [ButtonContext, {...buttonProps, isPressed: state.isOpen}],
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [RangeCalendarContext, calendarProps],
         [PopoverContext, {state, triggerRef: groupRef, placement: 'bottom start'}],

--- a/packages/react-aria-components/src/Group.tsx
+++ b/packages/react-aria-components/src/Group.tsx
@@ -10,19 +10,60 @@
  * governing permissions and limitations under the License.
  */
 
-import {ContextValue, useContextProps} from './utils';
+import {ContextValue, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {mergeProps, useFocusRing, useHover} from 'react-aria';
 import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes} from 'react';
 
-export const GroupContext = createContext<ContextValue<HTMLAttributes<HTMLElement>, HTMLDivElement>>({});
+export interface GroupRenderProps {
+  /**
+   * Whether the group is currently hovered with a mouse.
+   * @selector [data-hovered]
+   */
+  isHovered: boolean,
+  /**
+   * Whether an element within the group is focused, either via a mouse or keyboard.
+   * @selector :focus-within
+   */
+  isFocusWithin: boolean,
+  /**
+   * Whether an element within the group is keyboard focused.
+   * @selector [data-focus-visible]
+   */
+  isFocusVisible: boolean
+}
 
-function Group(props: HTMLAttributes<HTMLElement>, ref: ForwardedRef<HTMLDivElement>) {
+export interface GroupProps extends Omit<HTMLAttributes<HTMLElement>, 'className' | 'style'>, StyleRenderProps<GroupRenderProps> {}
+
+export const GroupContext = createContext<ContextValue<GroupProps, HTMLDivElement>>({});
+
+function Group(props: GroupProps, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, GroupContext);
+
+  let {hoverProps, isHovered} = useHover({});
+  let {isFocused, isFocusVisible, focusProps} = useFocusRing({
+    within: true
+  });
+
+  let renderProps = useRenderProps({
+    ...props,
+    values: {isHovered, isFocusWithin: isFocused, isFocusVisible},
+    defaultClassName: 'react-aria-Group'
+  });
+
   return (
-    <div className="react-aria-Group" {...props} ref={ref}>
+    <div
+      {...mergeProps(props, focusProps, hoverProps)}
+      {...renderProps}
+      ref={ref}
+      data-hovered={isHovered || undefined}
+      data-focus-visible={isFocusVisible || undefined}>
       {props.children}
     </div>
   );
 }
 
+/**
+ * An group represents a set of related UI controls.
+ */
 const _Group = forwardRef(Group);
 export {_Group as Group};

--- a/packages/react-aria-components/src/Header.tsx
+++ b/packages/react-aria-components/src/Header.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {ContextValue, useContextProps} from './utils';
+import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes} from 'react';
+import {useShallowRender} from './Collection';
+
+export const HeaderContext = createContext<ContextValue<HTMLAttributes<HTMLElement>, HTMLElement>>({});
+
+function Header(props: HTMLAttributes<HTMLElement>, ref: ForwardedRef<HTMLElement>) {
+  [props, ref] = useContextProps(props, ref, HeaderContext);
+  let shallow = useShallowRender('header', props, ref);
+  if (shallow) {
+    return shallow;
+  }
+
+  return (
+    <header className="react-aria-Header" {...props} ref={ref}>
+      {props.children}
+    </header>
+  );
+}
+
+const _Header = forwardRef(Header);
+export {_Header as Header};

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -12,10 +12,10 @@
 
 import {AriaListBoxOptions, AriaListBoxProps, DraggableItemResult, DragPreviewRenderer, DroppableCollectionResult, DroppableItemResult, FocusScope, ListKeyboardDelegate, mergeProps, useFocusRing, useHover, useListBox, useListBoxSection, useOption} from 'react-aria';
 import {CollectionProps, ItemProps, useCachedChildren, useCollection} from './Collection';
-import {ContextValue, forwardRefType, HiddenContext, Provider, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {ContextValue, forwardRefType, HiddenContext, Provider, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {DragAndDropHooks, DropIndicator, DropIndicatorContext, DropIndicatorProps} from './useDragAndDrop';
 import {DraggableCollectionState, DroppableCollectionState, ListState, Node, SelectionBehavior, useListState} from 'react-stately';
-import {filterDOMProps, useObjectRef} from '@react-aria/utils';
+import {filterDOMProps, mergeRefs, useObjectRef} from '@react-aria/utils';
 import {Header} from './Header';
 import React, {createContext, ForwardedRef, forwardRef, ReactNode, RefObject, useContext, useEffect, useRef} from 'react';
 import {Separator, SeparatorContext} from './Separator';
@@ -238,8 +238,9 @@ interface ListBoxSectionProps<T> extends StyleProps {
 
 function ListBoxSection<T>({section, className, style, ...otherProps}: ListBoxSectionProps<T>) {
   let {state} = useContext(InternalListBoxContext)!;
+  let [headingRef, heading] = useSlot();
   let {headingProps, groupProps} = useListBoxSection({
-    heading: section.rendered,
+    heading,
     'aria-label': section['aria-label'] ?? undefined
   });
 
@@ -248,8 +249,15 @@ function ListBoxSection<T>({section, className, style, ...otherProps}: ListBoxSe
     children: item => {
       switch (item.type) {
         case 'header': {
-          let {rendered, ...otherProps} = item.props;
-          return <Header {...headingProps} {...otherProps}>{rendered}</Header>;
+          let {rendered, ref, ...otherProps} = item.props;
+          return (
+            <Header
+              {...headingProps}
+              {...otherProps}
+              ref={mergeRefs(headingRef, ref)}>
+              {rendered}
+            </Header>
+          );
         }
         case 'item':
           return <Option item={item} />;
@@ -265,11 +273,6 @@ function ListBoxSection<T>({section, className, style, ...otherProps}: ListBoxSe
       {...groupProps}
       className={className || section.props?.className || 'react-aria-Section'}
       style={style || section.props?.style}>
-      {section.rendered &&
-        <header {...headingProps}>
-          {section.rendered}
-        </header>
-      }
       {children}
     </section>
   );

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -16,6 +16,7 @@ import {ContextValue, forwardRefType, HiddenContext, Provider, SlotProps, StyleP
 import {DragAndDropHooks, DropIndicator, DropIndicatorContext, DropIndicatorProps} from './useDragAndDrop';
 import {DraggableCollectionState, DroppableCollectionState, ListState, Node, SelectionBehavior, useListState} from 'react-stately';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
+import {Header} from './Header';
 import React, {createContext, ForwardedRef, forwardRef, ReactNode, RefObject, useContext, useEffect, useRef} from 'react';
 import {Separator, SeparatorContext} from './Separator';
 import {TextContext} from './Text';
@@ -245,11 +246,16 @@ function ListBoxSection<T>({section, className, style, ...otherProps}: ListBoxSe
   let children = useCachedChildren({
     items: state.collection.getChildren!(section.key),
     children: item => {
-      if (item.type !== 'item') {
-        throw new Error('Only items are allowed within a section');
+      switch (item.type) {
+        case 'header': {
+          let {rendered, ...otherProps} = item.props;
+          return <Header {...headingProps} {...otherProps}>{rendered}</Header>;
+        }
+        case 'item':
+          return <Option item={item} />;
+        default:
+          throw new Error('Unsupported element type in Section: ' + item.type);
       }
-
-      return <Option item={item} />;
     }
   });
 

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -249,13 +249,13 @@ function ListBoxSection<T>({section, className, style, ...otherProps}: ListBoxSe
     children: item => {
       switch (item.type) {
         case 'header': {
-          let {rendered, ref, ...otherProps} = item.props;
+          let {ref, ...otherProps} = item.props;
           return (
             <Header
               {...headingProps}
               {...otherProps}
               ref={mergeRefs(headingRef, ref)}>
-              {rendered}
+              {item.rendered}
             </Header>
           );
         }

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -15,8 +15,8 @@ import {AriaMenuProps, mergeProps, useFocusRing, useMenu, useMenuItem, useMenuSe
 import {BaseCollection, CollectionProps, ItemProps, ItemRenderProps, useCachedChildren, useCollection} from './Collection';
 import {MenuTriggerProps as BaseMenuTriggerProps, Node, TreeState, useMenuTriggerState, useTreeState} from 'react-stately';
 import {ButtonContext} from './Button';
-import {ContextValue, forwardRefType, Provider, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
-import {filterDOMProps} from '@react-aria/utils';
+import {ContextValue, forwardRefType, Provider, SlotProps, StyleProps, useContextProps, useRenderProps, useSlot} from './utils';
+import {filterDOMProps, mergeRefs} from '@react-aria/utils';
 import {Header} from './Header';
 import {KeyboardContext} from './Keyboard';
 import {PopoverContext} from './Popover';
@@ -128,8 +128,9 @@ interface MenuSectionProps<T> extends StyleProps {
 
 function MenuSection<T>({section, className, style, ...otherProps}: MenuSectionProps<T>) {
   let state = useContext(InternalMenuContext)!;
+  let [headingRef, heading] = useSlot();
   let {headingProps, groupProps} = useMenuSection({
-    heading: section.rendered,
+    heading,
     'aria-label': section['aria-label'] ?? undefined
   });
 
@@ -138,8 +139,15 @@ function MenuSection<T>({section, className, style, ...otherProps}: MenuSectionP
     children: item => {
       switch (item.type) {
         case 'header': {
-          let {rendered, ...otherProps} = item.props;
-          return <Header {...headingProps} {...otherProps}>{rendered}</Header>;
+          let {rendered, ref, ...otherProps} = item.props;
+          return (
+            <Header
+              {...headingProps}
+              {...otherProps}
+              ref={mergeRefs(headingRef, ref)}>
+              {rendered}
+            </Header>
+          );
         }
         case 'item':
           return <MenuItem item={item} />;
@@ -155,11 +163,6 @@ function MenuSection<T>({section, className, style, ...otherProps}: MenuSectionP
       {...groupProps}
       className={className || section.props?.className || 'react-aria-Section'}
       style={style || section.props?.style}>
-      {section.rendered &&
-        <header {...headingProps}>
-          {section.rendered}
-        </header>
-      }
       {children}
     </section>
   );

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -139,13 +139,13 @@ function MenuSection<T>({section, className, style, ...otherProps}: MenuSectionP
     children: item => {
       switch (item.type) {
         case 'header': {
-          let {rendered, ref, ...otherProps} = item.props;
+          let {ref, ...otherProps} = item.props;
           return (
             <Header
               {...headingProps}
               {...otherProps}
               ref={mergeRefs(headingRef, ref)}>
-              {rendered}
+              {item.rendered}
             </Header>
           );
         }

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -17,6 +17,7 @@ import {MenuTriggerProps as BaseMenuTriggerProps, Node, TreeState, useMenuTrigge
 import {ButtonContext} from './Button';
 import {ContextValue, forwardRefType, Provider, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
+import {Header} from './Header';
 import {KeyboardContext} from './Keyboard';
 import {PopoverContext} from './Popover';
 import React, {createContext, ForwardedRef, forwardRef, ReactNode, RefObject, useContext, useRef} from 'react';
@@ -135,11 +136,16 @@ function MenuSection<T>({section, className, style, ...otherProps}: MenuSectionP
   let children = useCachedChildren({
     items: state.collection.getChildren!(section.key),
     children: item => {
-      if (item.type !== 'item') {
-        throw new Error('Only items are allowed within a section');
+      switch (item.type) {
+        case 'header': {
+          let {rendered, ...otherProps} = item.props;
+          return <Header {...headingProps} {...otherProps}>{rendered}</Header>;
+        }
+        case 'item':
+          return <MenuItem item={item} />;
+        default:
+          throw new Error('Unsupported element type in Section: ' + item.type);
       }
-
-      return <MenuItem item={item} />;
     }
   });
 

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -118,21 +118,21 @@ function Select<T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLD
 const _Select = (forwardRef as forwardRefType)(Select);
 export {_Select as Select};
 
-export interface SelectValueRenderProps {
+export interface SelectValueRenderProps<T> {
   /**
    * Whether the value is a placeholder.
    * @selector [data-placeholder]
    */
   isPlaceholder: boolean,
   /** The object value of the currently selected item. */
-  selectedItem: object | null,
+  selectedItem: T | null,
   /** The textValue of the currently selected item. */
   selectedText: string | null
 }
 
-export interface SelectValueProps extends Omit<HTMLAttributes<HTMLElement>, keyof RenderProps<unknown>>, RenderProps<SelectValueRenderProps> {}
+export interface SelectValueProps<T extends object> extends Omit<HTMLAttributes<HTMLElement>, keyof RenderProps<unknown>>, RenderProps<SelectValueRenderProps<T>> {}
 
-function SelectValue(props: SelectValueProps, ref: ForwardedRef<HTMLSpanElement>) {
+function SelectValue<T extends object>(props: SelectValueProps<T>, ref: ForwardedRef<HTMLSpanElement>) {
   let {state, valueProps} = useContext(InternalSelectContext)!;
   let rendered = state.selectedItem?.rendered;
   if (typeof rendered === 'function') {
@@ -156,7 +156,7 @@ function SelectValue(props: SelectValueProps, ref: ForwardedRef<HTMLSpanElement>
     defaultChildren: rendered || 'Select an item',
     defaultClassName: 'react-aria-SelectValue',
     values: {
-      selectedItem: state.selectedItem?.value ?? null,
+      selectedItem: state.selectedItem?.value as T ?? null,
       selectedText: state.selectedItem?.textValue ?? null,
       isPlaceholder: !state.selectedItem
     }
@@ -176,5 +176,5 @@ function SelectValue(props: SelectValueProps, ref: ForwardedRef<HTMLSpanElement>
  * SelectValue renders the current value of a Select, or a placeholder if no value is selected.
  * It is usually placed within the button element.
  */
-const _SelectValue = forwardRef(SelectValue);
+const _SelectValue = (forwardRef as forwardRefType)(SelectValue);
 export {_SelectValue as SelectValue};

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -14,13 +14,13 @@ import {AriaSelectProps, HiddenSelect, useSelect} from 'react-aria';
 import {ButtonContext} from './Button';
 import {ContextValue, forwardRefType, Provider, RenderProps, slotCallbackSymbol, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {createContext, ForwardedRef, HTMLAttributes, ReactNode, useCallback, useContext, useRef, useState} from 'react';
+import {ItemRenderProps, useCollection} from './Collection';
 import {LabelContext} from './Label';
 import {ListBoxContext, ListBoxProps} from './ListBox';
 import {PopoverContext} from './Popover';
 import React, {forwardRef} from 'react';
 import {SelectState, useSelectState} from 'react-stately';
 import {TextContext} from './Text';
-import {useCollection} from './Collection';
 import {useResizeObserver} from '@react-aria/utils';
 
 export interface SelectProps<T extends object> extends Omit<AriaSelectProps<T>, 'children' | 'label' | 'description' | 'errorMessage'>, RenderProps<SelectState<T>>, SlotProps {}
@@ -124,20 +124,40 @@ export interface SelectValueRenderProps {
    * @selector [data-placeholder]
    */
   isPlaceholder: boolean,
-  /** The rendered value of the currently selected item. */
-  selectedItem: ReactNode
+  /** The object value of the currently selected item. */
+  selectedItem: object | null,
+  /** The textValue of the currently selected item. */
+  selectedText: string | null
 }
 
 export interface SelectValueProps extends Omit<HTMLAttributes<HTMLElement>, keyof RenderProps<unknown>>, RenderProps<SelectValueRenderProps> {}
 
 function SelectValue(props: SelectValueProps, ref: ForwardedRef<HTMLSpanElement>) {
   let {state, valueProps} = useContext(InternalSelectContext)!;
+  let rendered = state.selectedItem?.rendered;
+  if (typeof rendered === 'function') {
+    // If the selected item has a function as a child, we need to call it to render to JSX.
+    let fn = rendered as (s: ItemRenderProps) => ReactNode;
+    rendered = fn({
+      isHovered: false,
+      isPressed: false,
+      isSelected: false,
+      isFocused: false,
+      isFocusVisible: false,
+      isDisabled: false,
+      selectionMode: 'single',
+      selectionBehavior: 'toggle'
+    });
+  }
+
   let renderProps = useRenderProps({
     ...props,
-    defaultChildren: state.selectedItem?.rendered || 'Select an item',
+    // TODO: localize this.
+    defaultChildren: rendered || 'Select an item',
     defaultClassName: 'react-aria-SelectValue',
     values: {
-      selectedItem: state.selectedItem?.rendered,
+      selectedItem: state.selectedItem?.value ?? null,
+      selectedText: state.selectedItem?.textValue ?? null,
       isPlaceholder: !state.selectedItem
     }
   });

--- a/packages/react-aria-components/src/Separator.tsx
+++ b/packages/react-aria-components/src/Separator.tsx
@@ -22,11 +22,6 @@ export const SeparatorContext = createContext<ContextValue<SeparatorProps, Eleme
 
 function Separator(props: SeparatorProps, ref: ForwardedRef<Element>) {
   [props, ref] = useContextProps(props, ref, SeparatorContext);
-  let shallow = useShallowRender('separator', props, ref);
-  if (shallow) {
-    return shallow;
-  }
-
   let {elementType, orientation, style, className} = props;
   let Element = (elementType as ElementType) || 'hr';
   if (Element === 'hr' && orientation === 'vertical') {
@@ -37,6 +32,11 @@ function Separator(props: SeparatorProps, ref: ForwardedRef<Element>) {
     elementType,
     orientation
   });
+
+  let shallow = useShallowRender('separator', props, ref);
+  if (shallow) {
+    return shallow;
+  }
 
   return (
     <Element

--- a/packages/react-aria-components/src/Separator.tsx
+++ b/packages/react-aria-components/src/Separator.tsx
@@ -14,6 +14,7 @@ import {SeparatorProps as AriaSeparatorProps, useSeparator} from 'react-aria';
 import {ContextValue, SlotProps, StyleProps, useContextProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import React, {createContext, ElementType, ForwardedRef, forwardRef} from 'react';
+import {useShallowRender} from './Collection';
 
 export interface SeparatorProps extends AriaSeparatorProps, StyleProps, SlotProps {}
 
@@ -21,6 +22,11 @@ export const SeparatorContext = createContext<ContextValue<SeparatorProps, Eleme
 
 function Separator(props: SeparatorProps, ref: ForwardedRef<Element>) {
   [props, ref] = useContextProps(props, ref, SeparatorContext);
+  let shallow = useShallowRender('separator', props, ref);
+  if (shallow) {
+    return shallow;
+  }
+
   let {elementType, orientation, style, className} = props;
   let Element = (elementType as ElementType) || 'hr';
   if (Element === 'hr' && orientation === 'vertical') {

--- a/packages/react-aria-components/src/Slider.tsx
+++ b/packages/react-aria-components/src/Slider.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaSliderProps, AriaSliderThumbProps, mergeProps, Orientation, useFocusRing, useNumberFormatter, useSlider, useSliderThumb, VisuallyHidden} from 'react-aria';
+import {AriaSliderProps, AriaSliderThumbProps, mergeProps, Orientation, useFocusRing, useHover, useNumberFormatter, useSlider, useSliderThumb, VisuallyHidden} from 'react-aria';
 import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {DOMAttributes} from '@react-types/shared';
 import {LabelContext} from './Label';
@@ -141,6 +141,11 @@ export interface SliderThumbRenderProps {
    */
   isDragging: boolean,
   /**
+   * Whether the thumb is currently hovered with a mouse.
+   * @selector [data-hovered]
+   */
+  isHovered: boolean,
+  /**
    * Whether the thumb is currently focused.
    * @selector [data-focused]
    */
@@ -173,19 +178,21 @@ function SliderThumb(props: SliderThumbProps, ref: ForwardedRef<HTMLDivElement>)
   }, state);
 
   let {focusProps, isFocusVisible} = useFocusRing();
+  let {hoverProps, isHovered} = useHover({});
 
   let renderProps = useRenderProps({
     ...props,
     defaultClassName: 'react-aria-SliderThumb',
-    values: {state, isDragging, isFocused, isFocusVisible, isDisabled}
+    values: {state, isHovered, isDragging, isFocused, isFocusVisible, isDisabled}
   });
 
   return (
     <div
-      {...thumbProps}
+      {...mergeProps(thumbProps, hoverProps)}
       {...renderProps}
       ref={ref}
       style={{...thumbProps.style, ...renderProps.style}}
+      data-hovered={isHovered || undefined}
       data-dragging={isDragging || undefined}
       data-focused={isFocused || undefined}
       data-focus-visible={isFocusVisible || undefined}

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -1,5 +1,5 @@
 import {AriaLabelingProps} from '@react-types/shared';
-import {BaseCollection, CollectionContext, CollectionProps, CollectionRendererContext, ItemRenderProps, NodeValue, useCachedChildren, useCollection} from './Collection';
+import {BaseCollection, CollectionContext, CollectionProps, CollectionRendererContext, ItemRenderProps, NodeValue, useCachedChildren, useCollection, useCollectionChildren} from './Collection';
 import {buildHeaderRows} from '@react-stately/table';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './Checkbox';
@@ -351,7 +351,7 @@ export interface TableHeaderProps<T> {
  * A header within a `<Table>`, containing the table columns.
  */
 export function TableHeader<T extends object>(props: TableHeaderProps<T>) {
-  let children = useCachedChildren({
+  let children = useCollectionChildren({
     children: props.children,
     items: props.columns
   });
@@ -408,7 +408,7 @@ export interface ColumnProps<T = object> extends RenderProps<ColumnRenderProps> 
 export function Column<T extends object>(props: ColumnProps<T>): JSX.Element {
   let render = useContext(CollectionRendererContext);
   let childColumns = typeof render === 'function' ? render : props.children;
-  let children = useCachedChildren({
+  let children = useCollectionChildren({
     children: (props.title || props.childColumns) ? childColumns : null,
     items: props.childColumns
   });
@@ -434,7 +434,7 @@ export interface TableBodyProps<T> extends CollectionProps<T>, StyleRenderProps<
  * The body of a `<Table>`, containing the table rows.
  */
 export function TableBody<T extends object>(props: TableBodyProps<T>) {
-  let children = useCachedChildren(props);
+  let children = useCollectionChildren(props);
 
   // @ts-ignore
   return <tablebody multiple={props}>{children}</tablebody>;
@@ -456,7 +456,7 @@ export interface RowProps<T> extends RenderProps<RowRenderProps> {
  * A row within a `<Table>`.
  */
 export function Row<T extends object>(props: RowProps<T>) {
-  let children = useCachedChildren({
+  let children = useCollectionChildren({
     children: props.children,
     items: props.columns,
     idScope: props.id

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -20,6 +20,7 @@ export {DatePicker, DateRangePicker, DatePickerContext, DateRangePickerContext} 
 export {DialogTrigger, Dialog, DialogContext} from './Dialog';
 export {GridList, GridListContext} from './GridList';
 export {Group, GroupContext} from './Group';
+export {Header} from './Header';
 export {Heading, HeadingContext} from './Heading';
 export {Input, InputContext} from './Input';
 export {Item, Section, Collection} from './Collection';

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -60,8 +60,9 @@ export type {DateFieldProps, DateInputProps, DateSegmentProps, DateSegmentRender
 export type {DatePickerProps, DateRangePickerProps} from './DatePicker';
 export type {DialogProps, DialogTriggerProps} from './Dialog';
 export type {GridListProps, GridListRenderProps} from './GridList';
+export type {GroupProps, GroupRenderProps} from './Group';
 export type {HeadingProps} from './Heading';
-export type {HTMLAttributes, InputHTMLAttributes} from 'react';
+export type {InputProps, InputRenderProps} from './Input';
 export type {ItemProps, ItemRenderProps, SectionProps} from './Collection';
 export type {LabelProps} from './Label';
 export type {LinkProps} from './Link';

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -12,7 +12,7 @@
 
 export {Breadcrumbs, BreadcrumbsContext} from './Breadcrumbs';
 export {Button, ButtonContext} from './Button';
-export {Calendar, CalendarGrid, CalendarCell, RangeCalendar, CalendarContext, RangeCalendarContext} from './Calendar';
+export {Calendar, CalendarGrid, CalendarGridHeader, CalendarGridBody, CalendarHeaderCell, CalendarCell, RangeCalendar, CalendarContext, RangeCalendarContext} from './Calendar';
 export {Checkbox, CheckboxGroup, CheckboxGroupContext, CheckboxContext} from './Checkbox';
 export {ComboBox, ComboBoxContext} from './ComboBox';
 export {DateField, DateInput, DateSegment, TimeField, DateFieldContext, TimeFieldContext} from './DateField';
@@ -53,7 +53,7 @@ export {DIRECTORY_DRAG_TYPE, isDirectoryDropItem, isFileDropItem, isTextDropItem
 
 export type {BreadcrumbsProps} from './Breadcrumbs';
 export type {ButtonProps, ButtonRenderProps} from './Button';
-export type {CalendarCellProps, CalendarProps, CalendarGridProps, CalendarCellRenderProps, RangeCalendarProps} from './Calendar';
+export type {CalendarCellProps, CalendarProps, CalendarGridProps, CalendarGridHeaderProps, CalendarGridBodyProps, CalendarHeaderCellProps, CalendarCellRenderProps, RangeCalendarProps} from './Calendar';
 export type {CheckboxGroupProps, CheckboxGroupRenderProps, CheckboxRenderProps, CheckboxProps} from './Checkbox';
 export type {ComboBoxProps} from './ComboBox';
 export type {DateFieldProps, DateInputProps, DateSegmentProps, DateSegmentRenderProps, TimeFieldProps} from './DateField';

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -56,7 +56,7 @@ export type {ButtonProps, ButtonRenderProps} from './Button';
 export type {CalendarCellProps, CalendarProps, CalendarGridProps, CalendarGridHeaderProps, CalendarGridBodyProps, CalendarHeaderCellProps, CalendarCellRenderProps, RangeCalendarProps} from './Calendar';
 export type {CheckboxGroupProps, CheckboxGroupRenderProps, CheckboxRenderProps, CheckboxProps} from './Checkbox';
 export type {ComboBoxProps} from './ComboBox';
-export type {DateFieldProps, DateInputProps, DateSegmentProps, DateSegmentRenderProps, TimeFieldProps} from './DateField';
+export type {DateFieldProps, DateInputProps, DateInputRenderProps, DateSegmentProps, DateSegmentRenderProps, TimeFieldProps} from './DateField';
 export type {DatePickerProps, DateRangePickerProps} from './DatePicker';
 export type {DialogProps, DialogTriggerProps} from './Dialog';
 export type {GridListProps, GridListRenderProps} from './GridList';

--- a/packages/react-aria-components/stories/index.stories.tsx
+++ b/packages/react-aria-components/stories/index.stories.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, Calendar, CalendarCell, CalendarGrid, Cell, Column, ComboBox, DateField, DateInput, DatePicker, DateRangePicker, DateSegment, Dialog, DialogTrigger, Group, Heading, Input, Item, Keyboard, Label, ListBox, Menu, MenuTrigger, Modal, ModalOverlay, NumberField, OverlayArrow, Popover, RangeCalendar, Row, Section, Select, SelectValue, Separator, Slider, SliderOutput, SliderThumb, SliderTrack, Tab, Table, TableBody, TableHeader, TabList, TabPanel, TabPanels, Tabs, Text, TimeField, Tooltip, TooltipTrigger} from 'react-aria-components';
+import {Button, Calendar, CalendarCell, CalendarGrid, Cell, Column, ComboBox, DateField, DateInput, DatePicker, DateRangePicker, DateSegment, Dialog, DialogTrigger, Group, Header, Heading, Input, Item, Keyboard, Label, ListBox, Menu, MenuTrigger, Modal, ModalOverlay, NumberField, OverlayArrow, Popover, RangeCalendar, Row, Section, Select, SelectValue, Separator, Slider, SliderOutput, SliderThumb, SliderTrack, Tab, Table, TableBody, TableHeader, TabList, TabPanel, TabPanels, Tabs, Text, TimeField, Tooltip, TooltipTrigger} from 'react-aria-components';
 import {classNames} from '@react-spectrum/utils';
 import clsx from 'clsx';
 import React from 'react';
@@ -50,13 +50,15 @@ export const ListBoxExample = () => (
 
 export const ListBoxSections = () => (
   <ListBox className={styles.menu} selectionMode="multiple" selectionBehavior="replace">
-    <Section title={<span style={{fontSize: '1.2em'}}>Section 1</span>} className={styles.group}>
+    <Section className={styles.group}>
+      <Header style={{fontSize: '1.2em'}}>Section 1</Header>
       <MyItem>Foo</MyItem>
       <MyItem>Bar</MyItem>
       <MyItem>Baz</MyItem>
     </Section>
     <Separator style={{borderTop: '1px solid gray', margin: '2px 5px'}} />
-    <Section title={<span style={{fontSize: '1.2em'}}>Section 2</span>} className={styles.group}>
+    <Section className={styles.group}>
+      <Header style={{fontSize: '1.2em'}}>Section 1</Header>
       <MyItem>Foo</MyItem>
       <MyItem>Bar</MyItem>
       <MyItem>Baz</MyItem>
@@ -103,13 +105,15 @@ export const MenuExample = () => (
     <Button aria-label="Menu">☰</Button>
     <Popover>
       <Menu className={styles.menu}>
-        <Section title={<span style={{fontSize: '1.2em'}}>Section 1</span>} className={styles.group}>
+        <Section className={styles.group}>
+          <Header style={{fontSize: '1.2em'}}>Section 1</Header>
           <MyItem>Foo</MyItem>
           <MyItem>Bar</MyItem>
           <MyItem>Baz</MyItem>
         </Section>
         <Separator style={{borderTop: '1px solid gray', margin: '2px 5px'}} />
-        <Section title={<span style={{fontSize: '1.2em'}}>Section 2</span>} className={styles.group}>
+        <Section className={styles.group}>
+          <Header style={{fontSize: '1.2em'}}>Section 2</Header>
           <MyItem>Foo</MyItem>
           <MyItem>Bar</MyItem>
           <MyItem>Baz</MyItem>

--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -11,7 +11,7 @@
  */
 
 import {act, fireEvent, render, within} from '@react-spectrum/test-utils';
-import {Button, Calendar, CalendarCell, CalendarContext, CalendarGrid, Heading} from 'react-aria-components';
+import {Button, Calendar, CalendarCell, CalendarContext, CalendarGrid, CalendarGridBody, CalendarGridHeader, CalendarHeaderCell, Heading} from 'react-aria-components';
 import {getLocalTimeZone, startOfMonth, startOfWeek, today} from '@internationalized/date';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -39,6 +39,14 @@ describe('Calendar', () => {
 
     let grid = getByRole('grid');
     expect(grid).toHaveAttribute('class', 'react-aria-CalendarGrid');
+
+    let rowgroups = within(grid).getAllByRole('rowgroup', {hidden: true});
+    expect(rowgroups[0]).toHaveAttribute('class', 'react-aria-CalendarGridHeader');
+    expect(rowgroups[1]).toHaveAttribute('class', 'react-aria-CalendarGridBody');
+
+    for (let cell of within(rowgroups[0]).getAllByRole('columnheader', {hidden: true})) {
+      expect(cell).toHaveAttribute('class', 'react-aria-CalendarHeaderCell');
+    }
 
     for (let cell of within(grid).getAllByRole('button')) {
       expect(cell).toHaveAttribute('class', 'react-aria-CalendarCell');
@@ -68,6 +76,41 @@ describe('Calendar', () => {
 
     for (let cell of within(grid).getAllByRole('button')) {
       expect(cell).toHaveAttribute('data-baz', 'foo');
+    }
+  });
+
+  it('should support custom CalendarGridHeader', () => {
+    let {getByRole} = render(
+      <Calendar aria-label="Appointment date">
+        <header>
+          <Button slot="previous">◀</Button>
+          <Heading />
+          <Button slot="next">▶</Button>
+        </header>
+        <CalendarGrid>
+          <CalendarGridHeader className="grid-header">
+            {(day) => (
+              <CalendarHeaderCell className="header-cell">
+                {day}
+              </CalendarHeaderCell>
+            )}
+          </CalendarGridHeader>
+          <CalendarGridBody className="grid-body">
+            {(date) => <CalendarCell date={date} />}
+          </CalendarGridBody>
+        </CalendarGrid>
+      </Calendar>
+    );
+
+    let grid = getByRole('grid');
+    expect(grid).toHaveAttribute('class', 'react-aria-CalendarGrid');
+
+    let rowgroups = within(grid).getAllByRole('rowgroup', {hidden: true});
+    expect(rowgroups[0]).toHaveAttribute('class', 'grid-header');
+    expect(rowgroups[1]).toHaveAttribute('class', 'grid-body');
+
+    for (let cell of within(rowgroups[0]).getAllByRole('columnheader', {hidden: true})) {
+      expect(cell).toHaveAttribute('class', 'header-cell');
     }
   });
 
@@ -131,7 +174,7 @@ describe('Calendar', () => {
     let {getByRole} = renderCalendar({}, {}, {className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''});
     let grid = getByRole('grid');
     let cell = within(grid).getAllByRole('button')[7];
-    
+
     expect(cell).not.toHaveAttribute('data-focus-visible');
     expect(cell).not.toHaveClass('focus');
 

--- a/packages/react-aria-components/test/ComboBox.test.js
+++ b/packages/react-aria-components/test/ComboBox.test.js
@@ -49,7 +49,7 @@ describe('ComboBox', () => {
 
     expect(input).toHaveAttribute('aria-describedby');
     expect(input.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ')).toBe('Description Error');
-  
+
     let button = getByRole('button');
     userEvent.click(button);
 
@@ -74,5 +74,14 @@ describe('ComboBox', () => {
     let combobox = getByRole('combobox');
     expect(combobox.closest('.react-aria-ComboBox')).toHaveAttribute('slot', 'test');
     expect(combobox).toHaveAttribute('aria-label', 'test');
+  });
+
+  it('should apply isPressed state to button when expanded', () => {
+    let {getByRole} = render(<TestComboBox />);
+    let button = getByRole('button');
+
+    expect(button).not.toHaveAttribute('data-pressed');
+    userEvent.click(button);
+    expect(button).toHaveAttribute('data-pressed');
   });
 });

--- a/packages/react-aria-components/test/DateField.test.js
+++ b/packages/react-aria-components/test/DateField.test.js
@@ -12,7 +12,8 @@
 
 import {DateField, DateFieldContext, DateInput, DateSegment, Label, Text} from '../';
 import React from 'react';
-import {render} from '@react-spectrum/test-utils';
+import {render, within} from '@react-spectrum/test-utils';
+import userEvent from '@testing-library/user-event';
 
 describe('DateField', () => {
   it('provides slots', () => {
@@ -83,5 +84,66 @@ describe('DateField', () => {
     let group = getByRole('group');
     expect(group.closest('.react-aria-DateField')).toHaveAttribute('slot', 'test');
     expect(group).toHaveAttribute('aria-label', 'test');
+  });
+
+  it('should support hover state', () => {
+    let {getByRole} = render(
+      <DateField>
+        <Label>Birth date</Label>
+        <DateInput className={({isHovered}) => isHovered ? 'hover' : ''}>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </DateField>
+    );
+    let group = getByRole('group');
+
+    expect(group).not.toHaveAttribute('data-hovered');
+    expect(group).not.toHaveClass('hover');
+
+    userEvent.hover(group);
+    expect(group).toHaveAttribute('data-hovered', 'true');
+    expect(group).toHaveClass('hover');
+
+    userEvent.unhover(group);
+    expect(group).not.toHaveAttribute('data-hovered');
+    expect(group).not.toHaveClass('hover');
+  });
+
+  it('should support focus visible state', () => {
+    let {getByRole} = render(
+      <DateField>
+        <Label>Birth date</Label>
+        <DateInput className={({isFocusVisible}) => isFocusVisible ? 'focus' : ''}>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </DateField>
+    );
+    let group = getByRole('group');
+
+    expect(group).not.toHaveAttribute('data-focus-visible');
+    expect(group).not.toHaveClass('focus');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(within(group).getAllByRole('spinbutton')[0]);
+    expect(group).toHaveAttribute('data-focus-visible', 'true');
+    expect(group).toHaveClass('focus');
+
+    userEvent.tab({shift: true});
+    expect(group).not.toHaveAttribute('data-focus-visible');
+    expect(group).not.toHaveClass('focus');
+  });
+
+  it('should support disabled state', () => {
+    let {getByRole} = render(
+      <DateField isDisabled>
+        <Label>Birth date</Label>
+        <DateInput className={({isDisabled}) => isDisabled ? 'disabled' : ''}>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </DateField>
+    );
+    let group = getByRole('group');
+    expect(group).toHaveAttribute('data-disabled');
+    expect(group).toHaveClass('disabled');
   });
 });

--- a/packages/react-aria-components/test/DatePicker.test.js
+++ b/packages/react-aria-components/test/DatePicker.test.js
@@ -91,4 +91,13 @@ describe('DatePicker', () => {
     expect(group.closest('.react-aria-DatePicker')).toHaveAttribute('slot', 'test');
     expect(group).toHaveAttribute('aria-label', 'test');
   });
+
+  it('should apply isPressed state to button when expanded', () => {
+    let {getByRole} = render(<TestDatePicker />);
+    let button = getByRole('button');
+
+    expect(button).not.toHaveAttribute('data-pressed');
+    userEvent.click(button);
+    expect(button).toHaveAttribute('data-pressed');
+  });
 });

--- a/packages/react-aria-components/test/DateRangePicker.test.js
+++ b/packages/react-aria-components/test/DateRangePicker.test.js
@@ -95,4 +95,13 @@ describe('DateRangePicker', () => {
     expect(group.closest('.react-aria-DateRangePicker')).toHaveAttribute('slot', 'test');
     expect(group).toHaveAttribute('aria-label', 'test');
   });
+
+  it('should apply isPressed state to button when expanded', () => {
+    let {getByRole} = render(<TestDateRangePicker />);
+    let button = getByRole('button');
+
+    expect(button).not.toHaveAttribute('data-pressed');
+    userEvent.click(button);
+    expect(button).toHaveAttribute('data-pressed');
+  });
 });

--- a/packages/react-aria-components/test/Dialog.test.js
+++ b/packages/react-aria-components/test/Dialog.test.js
@@ -131,7 +131,11 @@ describe('Dialog', () => {
     );
 
     let button = getByRole('button');
+    expect(button).not.toHaveAttribute('data-pressed');
+
     userEvent.click(button);
+
+    expect(button).toHaveAttribute('data-pressed');
 
     let dialog = getByRole('dialog');
     let heading = getByRole('heading');

--- a/packages/react-aria-components/test/ListBox.test.js
+++ b/packages/react-aria-components/test/ListBox.test.js
@@ -11,7 +11,7 @@
  */
 
 import {act, fireEvent, render, within} from '@react-spectrum/test-utils';
-import {Item, ListBox, ListBoxContext, Section, Text, useDragAndDrop} from '../';
+import {Header, Item, ListBox, ListBoxContext, Section, Text, useDragAndDrop} from '../';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
@@ -107,12 +107,14 @@ describe('ListBox', () => {
   it('should support sections', () => {
     let {getAllByRole} = render(
       <ListBox aria-label="Sandwich contents" selectionMode="multiple">
-        <Section title="Veggies">
+        <Section>
+          <Header>Veggies</Header>
           <Item id="lettuce">Lettuce</Item>
           <Item id="tomato">Tomato</Item>
           <Item id="onion">Onion</Item>
         </Section>
-        <Section title="Protein">
+        <Section>
+          <Header>Protein</Header>
           <Item id="ham">Ham</Item>
           <Item id="tuna">Tuna</Item>
           <Item id="tofu">Tofu</Item>

--- a/packages/react-aria-components/test/Menu.test.js
+++ b/packages/react-aria-components/test/Menu.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, Item, Keyboard, Menu, MenuContext, MenuTrigger, Popover, Section, Separator, Text} from '../';
+import {Button, Header, Item, Keyboard, Menu, MenuContext, MenuTrigger, Popover, Section, Separator, Text} from '../';
 import {fireEvent, render} from '@react-spectrum/test-utils';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -99,16 +99,30 @@ describe('Menu', () => {
     expect(separator).toHaveClass('react-aria-Separator');
   });
 
+  it('should support separators with custom class names', () => {
+    let {getByRole} = render(
+      <Menu aria-label="Actions">
+        <Item>Foo</Item>
+        <Separator className="my-separator" />
+        <Item>Bar</Item>
+      </Menu>
+    );
+
+    let separator = getByRole('separator');
+    expect(separator).toHaveClass('my-separator');
+  });
 
   it('should support sections', () => {
     let {getAllByRole} = render(
       <Menu aria-label="Sandwich contents" selectionMode="multiple">
-        <Section title="Veggies">
+        <Section>
+          <Header>Veggies</Header>
           <Item id="lettuce">Lettuce</Item>
           <Item id="tomato">Tomato</Item>
           <Item id="onion">Onion</Item>
         </Section>
-        <Section title="Protein">
+        <Section>
+          <Header>Protein</Header>
           <Item id="ham">Ham</Item>
           <Item id="tuna">Tuna</Item>
           <Item id="tofu">Tofu</Item>

--- a/packages/react-aria-components/test/Menu.test.js
+++ b/packages/react-aria-components/test/Menu.test.js
@@ -216,7 +216,10 @@ describe('Menu', () => {
     );
 
     let button = getByRole('button');
+    expect(button).not.toHaveAttribute('data-pressed');
+
     userEvent.click(button);
+    expect(button).toHaveAttribute('data-pressed');
 
     let menu = getByRole('menu');
     expect(getAllByRole('menuitem')).toHaveLength(5);

--- a/packages/react-aria-components/test/NumberField.test.js
+++ b/packages/react-aria-components/test/NumberField.test.js
@@ -13,11 +13,12 @@
 import {Button, Group, Input, Label, NumberField, NumberFieldContext, Text} from '../';
 import React from 'react';
 import {render} from '@react-spectrum/test-utils';
+import userEvent from '@testing-library/user-event';
 
 let TestNumberField = (props) => (
   <NumberField defaultValue={1024} minValue={0} data-foo="bar" {...props}>
     <Label>Width</Label>
-    <Group>
+    <Group {...props.groupProps}>
       <Button slot="decrement">-</Button>
       <Input />
       <Button slot="increment">+</Button>
@@ -33,6 +34,7 @@ describe('NumberField', () => {
 
     let group = getByRole('group');
     expect(group).toBeInTheDocument();
+    expect(group).toHaveAttribute('class', 'react-aria-Group');
 
     expect(group.closest('.react-aria-NumberField')).toHaveAttribute('data-foo', 'bar');
 
@@ -46,7 +48,7 @@ describe('NumberField', () => {
 
     expect(input).toHaveAttribute('aria-describedby');
     expect(input.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ')).toBe('Description Error');
-  
+
     let buttons = getAllByRole('button');
     expect(buttons[0]).toHaveAttribute('aria-label', 'Decrease');
     expect(buttons[1]).toHaveAttribute('aria-label', 'Increase');
@@ -62,5 +64,39 @@ describe('NumberField', () => {
     let textbox = getByRole('textbox');
     expect(textbox.closest('.react-aria-NumberField')).toHaveAttribute('slot', 'test');
     expect(textbox).toHaveAttribute('aria-label', 'test');
+  });
+
+  it('should support hover state', () => {
+    let {getByRole} = render(<TestNumberField groupProps={{className: ({isHovered}) => isHovered ? 'hover' : ''}} />);
+    let group = getByRole('group');
+
+    expect(group).not.toHaveAttribute('data-hovered');
+    expect(group).not.toHaveClass('hover');
+
+    userEvent.hover(group);
+    expect(group).toHaveAttribute('data-hovered', 'true');
+    expect(group).toHaveClass('hover');
+
+    userEvent.unhover(group);
+    expect(group).not.toHaveAttribute('data-hovered');
+    expect(group).not.toHaveClass('hover');
+  });
+
+  it('should support focus visible state', () => {
+    let {getByRole} = render(<TestNumberField groupProps={{className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''}} />);
+    let group = getByRole('group');
+    let input = getByRole('textbox');
+
+    expect(group).not.toHaveAttribute('data-focus-visible');
+    expect(group).not.toHaveClass('focus');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(input);
+    expect(group).toHaveAttribute('data-focus-visible', 'true');
+    expect(group).toHaveClass('focus');
+
+    userEvent.tab();
+    expect(group).not.toHaveAttribute('data-focus-visible');
+    expect(group).not.toHaveClass('focus');
   });
 });

--- a/packages/react-aria-components/test/RangeCalendar.test.js
+++ b/packages/react-aria-components/test/RangeCalendar.test.js
@@ -11,7 +11,7 @@
  */
 
 import {act, fireEvent, render, within} from '@react-spectrum/test-utils';
-import {Button, CalendarCell, CalendarGrid, Heading, RangeCalendar, RangeCalendarContext} from 'react-aria-components';
+import {Button, CalendarCell, CalendarGrid, CalendarGridBody, CalendarGridHeader, CalendarHeaderCell, Heading, RangeCalendar, RangeCalendarContext} from 'react-aria-components';
 import {getLocalTimeZone, startOfMonth, startOfWeek, today} from '@internationalized/date';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -39,6 +39,14 @@ describe('RangeCalendar', () => {
 
     let grid = getByRole('grid');
     expect(grid).toHaveAttribute('class', 'react-aria-CalendarGrid');
+
+    let rowgroups = within(grid).getAllByRole('rowgroup', {hidden: true});
+    expect(rowgroups[0]).toHaveAttribute('class', 'react-aria-CalendarGridHeader');
+    expect(rowgroups[1]).toHaveAttribute('class', 'react-aria-CalendarGridBody');
+
+    for (let cell of within(rowgroups[0]).getAllByRole('columnheader', {hidden: true})) {
+      expect(cell).toHaveAttribute('class', 'react-aria-CalendarHeaderCell');
+    }
 
     for (let cell of within(grid).getAllByRole('button')) {
       expect(cell).toHaveAttribute('class', 'react-aria-CalendarCell');
@@ -68,6 +76,41 @@ describe('RangeCalendar', () => {
 
     for (let cell of within(grid).getAllByRole('button')) {
       expect(cell).toHaveAttribute('data-baz', 'foo');
+    }
+  });
+
+  it('should support custom CalendarGridHeader', () => {
+    let {getByRole} = render(
+      <RangeCalendar aria-label="Trip dates">
+        <header>
+          <Button slot="previous">◀</Button>
+          <Heading />
+          <Button slot="next">▶</Button>
+        </header>
+        <CalendarGrid>
+          <CalendarGridHeader className="grid-header">
+            {(day) => (
+              <CalendarHeaderCell className="header-cell">
+                {day}
+              </CalendarHeaderCell>
+            )}
+          </CalendarGridHeader>
+          <CalendarGridBody className="grid-body">
+            {(date) => <CalendarCell date={date} />}
+          </CalendarGridBody>
+        </CalendarGrid>
+      </RangeCalendar>
+    );
+
+    let grid = getByRole('grid');
+    expect(grid).toHaveAttribute('class', 'react-aria-CalendarGrid');
+
+    let rowgroups = within(grid).getAllByRole('rowgroup', {hidden: true});
+    expect(rowgroups[0]).toHaveAttribute('class', 'grid-header');
+    expect(rowgroups[1]).toHaveAttribute('class', 'grid-body');
+
+    for (let cell of within(rowgroups[0]).getAllByRole('columnheader', {hidden: true})) {
+      expect(cell).toHaveAttribute('class', 'header-cell');
     }
   });
 
@@ -131,7 +174,7 @@ describe('RangeCalendar', () => {
     let {getByRole} = renderCalendar({}, {}, {className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''});
     let grid = getByRole('grid');
     let cell = within(grid).getAllByRole('button')[7];
-    
+
     expect(cell).not.toHaveAttribute('data-focus-visible');
     expect(cell).not.toHaveClass('focus');
 

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -39,6 +39,7 @@ describe('Select', () => {
 
     let button = getByRole('button');
     expect(button).toHaveTextContent('Select an item');
+    expect(button).not.toHaveAttribute('data-pressed');
 
     let select = button.closest('.react-aria-Select');
     expect(select).toHaveAttribute('data-foo', 'bar');
@@ -52,6 +53,8 @@ describe('Select', () => {
     expect(button.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ')).toBe('Description Error');
 
     userEvent.click(button);
+
+    expect(button).toHaveAttribute('data-pressed', 'true');
 
     let listbox = getByRole('listbox');
     expect(listbox).toHaveAttribute('class', 'react-aria-ListBox');

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -50,7 +50,7 @@ describe('Select', () => {
 
     expect(button).toHaveAttribute('aria-describedby');
     expect(button.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ')).toBe('Description Error');
-  
+
     userEvent.click(button);
 
     let listbox = getByRole('listbox');
@@ -74,5 +74,65 @@ describe('Select', () => {
     let button = getByRole('button');
     expect(button.closest('.react-aria-Select')).toHaveAttribute('slot', 'test');
     expect(button).toHaveAttribute('aria-label', 'test');
+  });
+
+  it('supports items with render props', () => {
+    let MyItem = (props) => (
+      <Item {...props}>
+        {({isSelected}) => (
+          <>
+            {props.children}
+            {isSelected ? ' (selected)' : ''}
+          </>
+        )}
+      </Item>
+    );
+
+    let {getByRole} = render(
+      <Select defaultSelectedKey="cat">
+        <Label>Favorite Animal</Label>
+        <Button>
+          <SelectValue />
+        </Button>
+        <Popover>
+          <ListBox>
+            <MyItem id="cat">Cat</MyItem>
+            <MyItem id="dog">Dog</MyItem>
+            <MyItem id="kangaroo">Kangaroo</MyItem>
+          </ListBox>
+        </Popover>
+      </Select>
+    );
+
+    let button = getByRole('button');
+    expect(button).toHaveTextContent('Cat');
+  });
+
+  it('supports custom select value', () => {
+    let items = [
+      {id: 1, name: 'Cat'},
+      {id: 2, name: 'Dog'}
+    ];
+
+    let {getByRole} = render(
+      <Select defaultSelectedKey={1}>
+        <Label>Favorite Animal</Label>
+        <Button>
+          <SelectValue>
+            {({selectedItem, selectedText}) => (
+              <span>{selectedItem ? `${selectedItem.id} - ${selectedText}` : ''}</span>
+            )}
+          </SelectValue>
+        </Button>
+        <Popover>
+          <ListBox items={items}>
+            {item => <Item>{item.name}</Item>}
+          </ListBox>
+        </Popover>
+      </Select>
+    );
+
+    let button = getByRole('button');
+    expect(button).toHaveTextContent('1 - Cat');
   });
 });

--- a/packages/react-aria-components/test/Slider.test.js
+++ b/packages/react-aria-components/test/Slider.test.js
@@ -69,7 +69,7 @@ describe('Slider', () => {
     let {getByRole} = renderSlider({}, {className: ({isFocusVisible}) => `thumb ${isFocusVisible ? 'focus' : ''}`});
     let slider = getByRole('slider');
     let thumb = slider.closest('.thumb');
-    
+
     expect(thumb).not.toHaveAttribute('data-focus-visible');
     expect(thumb).not.toHaveClass('focus');
 
@@ -97,6 +97,22 @@ describe('Slider', () => {
     fireEvent.mouseUp(thumb);
     expect(thumb).not.toHaveAttribute('data-dragging');
     expect(thumb).not.toHaveClass('dragging');
+  });
+
+  it('should support hover state', () => {
+    let {getByRole} = renderSlider({}, {className: ({isHovered}) => `thumb ${isHovered ? 'hovered' : ''}`});
+    let thumb = getByRole('slider').closest('.thumb');
+
+    expect(thumb).not.toHaveAttribute('data-hovered');
+    expect(thumb).not.toHaveClass('hovered');
+
+    userEvent.hover(thumb);
+    expect(thumb).toHaveAttribute('data-hovered', 'true');
+    expect(thumb).toHaveClass('hovered');
+
+    userEvent.unhover(thumb);
+    expect(thumb).not.toHaveAttribute('data-hovered');
+    expect(thumb).not.toHaveClass('hovered');
   });
 
   it('should support disabled state', () => {

--- a/packages/react-aria-components/test/TextField.test.js
+++ b/packages/react-aria-components/test/TextField.test.js
@@ -13,11 +13,12 @@
 import {Input, Label, Text, TextField, TextFieldContext} from '../';
 import React from 'react';
 import {render} from '@react-spectrum/test-utils';
+import userEvent from '@testing-library/user-event';
 
 let TestTextField = (props) => (
   <TextField defaultValue="test" data-foo="bar" {...props}>
     <Label>Test</Label>
-    <Input />
+    <Input {...props.inputProps} />
     <Text slot="description">Description</Text>
     <Text slot="errorMessage">Error</Text>
   </TextField>
@@ -29,6 +30,7 @@ describe('TextField', () => {
 
     let input = getByRole('textbox');
     expect(input).toHaveValue('test');
+    expect(input).toHaveAttribute('class', 'react-aria-Input');
 
     expect(input.closest('.react-aria-TextField')).toHaveAttribute('data-foo', 'bar');
 
@@ -51,5 +53,38 @@ describe('TextField', () => {
     let textbox = getByRole('textbox');
     expect(textbox.closest('.react-aria-TextField')).toHaveAttribute('slot', 'test');
     expect(textbox).toHaveAttribute('aria-label', 'test');
+  });
+
+  it('should support hover state', () => {
+    let {getByRole} = render(<TestTextField inputProps={{className: ({isHovered}) => isHovered ? 'hover' : ''}} />);
+    let input = getByRole('textbox');
+
+    expect(input).not.toHaveAttribute('data-hovered');
+    expect(input).not.toHaveClass('hover');
+
+    userEvent.hover(input);
+    expect(input).toHaveAttribute('data-hovered', 'true');
+    expect(input).toHaveClass('hover');
+
+    userEvent.unhover(input);
+    expect(input).not.toHaveAttribute('data-hovered');
+    expect(input).not.toHaveClass('hover');
+  });
+
+  it('should support focus visible state', () => {
+    let {getByRole} = render(<TestTextField inputProps={{className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''}} />);
+    let input = getByRole('textbox');
+
+    expect(input).not.toHaveAttribute('data-focus-visible');
+    expect(input).not.toHaveClass('focus');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(input);
+    expect(input).toHaveAttribute('data-focus-visible', 'true');
+    expect(input).toHaveClass('focus');
+
+    userEvent.tab();
+    expect(input).not.toHaveAttribute('data-focus-visible');
+    expect(input).not.toHaveClass('focus');
   });
 });


### PR DESCRIPTION
I've been making some examples with React Aria Components and Tailwind CSS, and came across a few things that were difficult to style. This PR includes some API changes meant to address them.

## Section headers

The `<Section>` component used within menus and listboxes previously accepted a `title` prop to render the header. This was one of the rare places where a component rendered multiple DOM elements. With something like Tailwind, this was a bit harder to style without using an [arbitrary variant](https://tailwindcss.com/docs/adding-custom-styles#arbitrary-variants) to target the `header` element inside the section.

This PR enables you to just render a `<Header>` element inside the `<Section>` yourself, removing the need for the `title` prop. This lets you easily style it.

```jsx
<Section>
  <Header className="...">Title</Header>
  <Item>Item</Item>
</Section>
```

For dynamic collections, you can use the `<Collection>` component to render the items.

```jsx
<Section>
  <Header>{section.name}</Header>
  <Collection items={section.children}>
    {item => <Item id={item.name}>{item.name}</Item>}
  </Collection>
</Section>
```

## Calendar header cells

`<CalendarGrid>` by default renders the entire month, and only lets you provide a function to render the cells. This means it's a bit challenging to style or customize the header cells (i.e. weekday names). Now you can optionally render a `<CalendarGridHeader>` and `<CalendarGridBody>` manually, which lets you render `<CalendarHeaderCell>` elements inside the header yourself and thus control the styling. This is optional - a function is still supported directly as children to CalendarGrid when this customization isn't needed.

```jsx
<CalendarGrid>
  <CalendarGridHeader>
    {day => <CalendarHeaderCell className="...">{day}</CalendarHeaderCell>}
  </CalendarGridHeader>
  <CalendarGridBody>
    {date => <CalendarCell date={date} />}
  </CalendarGridBody>
</CalendarGrid>
```

## Other

* Made separators actually accept a className when used inside a collection component like a menu. This works the same way as Header – there's a context that tells it that it is inside a collection, and it renders shallowly in that case. Then the collection component re-renders the real element later.
* Added `aria-expanded` to DatePicker buttons when the popover is open. I think this is correct anyway, but it is also useful for styling.
* Make `<SelectValue>` support `<Item>` elements with render prop children. Also pass the object value and textValue of the selected item to the custom render props of SelectValue itself.
* Apply the `data-hovered` and `data-focus-visible` states to more components, including `<Input>`, `<Group>`, `<DateInput>`, and `<SliderThumb>`.
* Apply the `data-pressed` state to buttons while an attached overlay is open. This was already true in some components and now it is true everywhere. Not totally sure if this is a good idea, or whether you'll want to have a different expanded state than pressed, but maybe it's a good default that you can override?