### PR TITLE
RAC testing fixes

### DIFF
--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -297,6 +297,13 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
       // is some indication that items were added.
       if (state.selectionManager.focusedKey === droppingState.current.focusedKey) {
         let first = newKeys.keys().next().value;
+        let item = state.collection.getItem(first);
+
+        // If this is a cell, focus the parent row.
+        if (item?.type === 'cell') {
+          first = item.parentKey;
+        }
+
         state.selectionManager.setFocusedKey(first);
 
         if (state.selectionManager.selectionMode === 'none') {

--- a/packages/react-aria-components/docs/GridList.mdx
+++ b/packages/react-aria-components/docs/GridList.mdx
@@ -875,7 +875,7 @@ function DraggableGridList() {
 
   return (
     <MyGridList aria-label="Draggable list" selectionMode="multiple" items={items} dragAndDropHooks={dragAndDropHooks}>
-      {([id, item]) => <MyItem id={id} textValue={item.name}>{React.createElement(item.style, null, item.name)}</MyItem>}
+      {([id, item]) => <MyItem id={id} textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</MyItem>}
     </MyGridList>
   );
 }
@@ -1149,7 +1149,7 @@ function DroppableGridList() {
 
   return (
     <MyGridList aria-label="Droppable list" items={items} dragAndDropHooks={dragAndDropHooks} renderEmptyState={() => "Drop items here"}>
-      {item => <MyItem textValue={item.name}>{React.createElement(item.style, null, item.name)}</MyItem>}
+      {item => <MyItem textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</MyItem>}
     </MyGridList>
   );
 }

--- a/packages/react-aria-components/docs/ListBox.mdx
+++ b/packages/react-aria-components/docs/ListBox.mdx
@@ -834,7 +834,7 @@ function DraggableListBox() {
 
   return (
     <ListBox aria-label="Draggable list" selectionMode="multiple" items={items} dragAndDropHooks={dragAndDropHooks}>
-      {([id, item]) => <Item id={id} textValue={item.name}>{React.createElement(item.style, null, item.name)}</Item>}
+      {([id, item]) => <Item id={id} textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</Item>}
     </ListBox>
   );
 }
@@ -1098,7 +1098,7 @@ function DroppableListBox() {
 
   return (
     <ListBox aria-label="Droppable list" items={items} dragAndDropHooks={dragAndDropHooks} renderEmptyState={() => "Drop items here"}>
-      {item => <Item textValue={item.name}>{React.createElement(item.style, null, item.name)}</Item>}
+      {item => <Item textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</Item>}
     </ListBox>
   );
 }

--- a/packages/react-aria-components/docs/Meter.mdx
+++ b/packages/react-aria-components/docs/Meter.mdx
@@ -60,6 +60,7 @@ import {Meter, Label} from 'react-aria-components';
 ```css
 .react-aria-Meter {
   --bar-color: var(--spectrum-global-color-gray-500);
+  --fill-color: forestgreen;
   --text-color: var(--spectrum-alias-text-color);
 
   display: grid;
@@ -83,16 +84,16 @@ import {Meter, Label} from 'react-aria-components';
   }
 
   .fill {
-    background: forestgreen;
+    background: var(--fill-color);
     height: 100%;
   }
 }
 
 @media (forced-colors: active) {
   .react-aria-Meter {
-    forced-color-adjust: none;
     --bar-color: ButtonFace;
     --text-color: ButtonText;
+    --fill-color: Highlight;
 
     .bar {
       border: 1px solid ButtonBorder;

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -301,7 +301,7 @@ function GridListItem({item}) {
         renderDropIndicator({type: 'item', key: item.key, dropPosition: 'before'})
       }
       {dropIndicator && !dropIndicator.isHidden &&
-        <div role="row">
+        <div role="row" ref={fixGap}>
           <div role="gridcell">
             <div role="button" {...visuallyHiddenProps} {...dropIndicator?.dropIndicatorProps} ref={dropIndicatorRef} />
           </div>
@@ -402,10 +402,25 @@ function RootDropIndicator() {
   }
 
   return (
-    <div role="row" aria-hidden={dropIndicatorProps['aria-hidden']}>
+    <div role="row" aria-hidden={dropIndicatorProps['aria-hidden']} ref={fixGap}>
       <div role="gridcell">
         <div role="button" {...visuallyHiddenProps} {...dropIndicatorProps} ref={ref} />
       </div>
     </div>
   );
+}
+
+// Applies a negative margin to offset the gap of a parent flex or grid layout.
+function fixGap(element: HTMLElement | null) {
+  if (element && element.parentElement) {
+    let {display, rowGap, columnGap} = window.getComputedStyle(element.parentElement);
+    if (/flex|grid/.test(display)) {
+      if (rowGap && rowGap !== 'normal') {
+        element.style.marginTop = '-' + rowGap;
+      }
+      if (columnGap && columnGap !== 'normal') {
+        element.style.marginLeft = '-' + columnGap;
+      }
+    }
+  }
 }


### PR DESCRIPTION
More fixes from testing for React Aria Components.

* Fixes dropping on table focusing the cell rather than the row.
* Fixes meter in high contrast mode
* Fixes a crash in the onDragEnd and getAllowedDropOperations examples on drop
* Fixes flex gap affecting hidden drop indicators (seen in Firefox GridList examples).