### PR TITLE
Fixing two broken links in docs

### DIFF
--- a/packages/@react-spectrum/color/docs/ColorArea.mdx
+++ b/packages/@react-spectrum/color/docs/ColorArea.mdx
@@ -178,7 +178,7 @@ function Example() {
 
 ## Creating a color picker
 
-To build a fully functional color picker, combine a ColorArea, which adjusts two channels of a color value stored in state, with a separate control, like a [ColorSlider](ColorSlider.html) or [ColorWheel](useColorWheel.html), for
+To build a fully functional color picker, combine a ColorArea, which adjusts two channels of a color value stored in state, with a separate control, like a [ColorSlider](ColorSlider.html) or [ColorWheel](ColorWheel.html), for
 adjusting the value of the third channel within the color space for the color value stored in state.
 The current color space for a color can be returned using the `color.getColorSpace` method.
 An array of channel names for a color can be returned using the `color.getColorChannels` method.

--- a/packages/@react-spectrum/searchfield/docs/SearchField.mdx
+++ b/packages/@react-spectrum/searchfield/docs/SearchField.mdx
@@ -211,7 +211,7 @@ import {Content, ContextualHelp, Heading} from '@adobe/react-spectrum';
 ```
 
 ### Custom icon
-The icon in the SearchField can be changed to suit the theme of a search. For instance, if the SearchField was for searching users, an icon relating to that would help convey meaning. See the [Icons page](./Icon.html) for more.
+The icon in the SearchField can be changed to suit the theme of a search. For instance, if the SearchField was for searching users, an icon relating to that would help convey meaning. See the [Icons page](./workflow-icons.html) for more.
 ```tsx example
 <SearchField label="Search for users" icon={<User />} />
 ```


### PR DESCRIPTION
Closes no issue

Found two broken links while running docs differ. ColorArea in "Creating a color picker" had a link to "useColorWheel" instead of "ColorWheel" and SearchField had a link to icons instead of Workflow Icons.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Goto the two pages in the docs build and confirm the two previously broken links goto the page you'd expect.

## 🧢 Your Project:
RSP