### PR TITLE
Generate table row textValue from row header cells by default

### DIFF
--- a/packages/@react-aria/dnd/src/useDraggableItem.ts
+++ b/packages/@react-aria/dnd/src/useDraggableItem.ts
@@ -116,7 +116,8 @@ export function useDraggableItem(props: DraggableItemProps, state: DraggableColl
     if (isSelected) {
       dragButtonLabel = stringFormatter.format('dragSelectedItems', {count: numKeysForDrag});
     } else {
-      dragButtonLabel = stringFormatter.format('dragItem', {itemText: item?.textValue ?? ''});
+      let itemText = state.collection.getTextValue?.(props.key) ?? item?.textValue ?? '';
+      dragButtonLabel = stringFormatter.format('dragItem', {itemText});
     }
   }
 

--- a/packages/@react-aria/dnd/src/useDropIndicator.ts
+++ b/packages/@react-aria/dnd/src/useDropIndicator.ts
@@ -49,7 +49,7 @@ export function useDropIndicator(props: DropIndicatorProps, state: DroppableColl
   let dragSession = DragManager.useDragSession();
   let {dropProps} = useDroppableItem(props, state, ref);
   let id = useId();
-  let getText = (key: Key) => collection.getItem(key)?.textValue;
+  let getText = (key: Key) => collection.getTextValue?.(key) ?? collection.getItem(key)?.textValue;
 
   let label = '';
   let labelledBy: string;

--- a/packages/@react-aria/grid/src/useGridSelectionAnnouncement.ts
+++ b/packages/@react-aria/grid/src/useGridSelectionAnnouncement.ts
@@ -38,7 +38,7 @@ interface GridSelectionState<T> {
 
 export function useGridSelectionAnnouncement<T>(props: GridSelectionAnnouncementProps, state: GridSelectionState<T>) {
   let {
-    getRowText = (key) => state.collection.getItem(key)?.textValue
+    getRowText = (key) => state.collection.getTextValue?.(key) ?? state.collection.getItem(key)?.textValue
   } = props;
   let stringFormatter = useLocalizedStringFormatter(intlMessages);
 

--- a/packages/@react-aria/table/src/useTable.ts
+++ b/packages/@react-aria/table/src/useTable.ts
@@ -11,7 +11,6 @@
  */
 
 import {announce} from '@react-aria/live-announcer';
-import {getChildNodes} from '@react-stately/collections';
 import {GridAria, GridProps, useGrid} from '@react-aria/grid';
 import {gridIds} from './utils';
 // @ts-ignore
@@ -64,38 +63,7 @@ export function useTable<T>(props: AriaTableProps<T>, state: TableState<T>, ref:
   let {gridProps} = useGrid({
     ...props,
     id,
-    keyboardDelegate: delegate,
-    getRowText(key): string {
-      let added = state.collection.getItem(key);
-      if (!added) {
-        return '';
-      }
-
-      // If the row has a textValue, use that.
-      if (added.textValue != null) {
-        return added.textValue;
-      }
-
-      // Otherwise combine the text of each of the row header columns.
-      let rowHeaderColumnKeys = state.collection.rowHeaderColumnKeys;
-      if (rowHeaderColumnKeys) {
-        let text = [];
-        for (let cell of getChildNodes(added, state.collection)) {
-          let column = state.collection.columns[cell.index];
-          if (rowHeaderColumnKeys.has(column.key) && cell.textValue) {
-            text.push(cell.textValue);
-          }
-
-          if (text.length === rowHeaderColumnKeys.size) {
-            break;
-          }
-        }
-
-        return text.join(' ');
-      }
-
-      return '';
-    }
+    keyboardDelegate: delegate
   }, state, ref);
 
   // Override to include header rows

--- a/packages/@react-spectrum/table/stories/TableDnDExamples.tsx
+++ b/packages/@react-spectrum/table/stories/TableDnDExamples.tsx
@@ -12,8 +12,8 @@ import {useListData} from '@react-stately/data';
 let onSelectionChange = action('onSelectionChange');
 
 let columns = [
-  {name: 'First name', key: 'first_name'},
-  {name: 'Last name', key: 'last_name'},
+  {name: 'First name', key: 'first_name', isRowHeader: true},
+  {name: 'Last name', key: 'last_name', isRowHeader: true},
   {name: 'Email', key: 'email'},
   {name: 'Department', key: 'department'},
   {name: 'Job Title', key: 'job_title'},
@@ -56,11 +56,11 @@ export function DragExample(props?) {
   return (
     <TableView aria-label="TableView with dragging enabled" selectionMode="multiple" width={400} height={300} onSelectionChange={s => onSelectionChange([...s])} dragAndDropHooks={dragAndDropHooks} {...tableViewProps}>
       <TableHeader columns={columns}>
-        {column => <Column minWidth={100}>{column.name}</Column>}
+        {column => <Column minWidth={100} isRowHeader={column.isRowHeader}>{column.name}</Column>}
       </TableHeader>
       <TableBody items={items}>
         {item => (
-          <Row key={item.id} textValue={`${item.first_name} ${item.last_name}`}>
+          <Row>
             {key => <Cell>{item[key]}</Cell>}
           </Row>
         )}
@@ -136,11 +136,11 @@ export function ReorderExample(props) {
   return (
     <TableView aria-label="Reorderable TableView" selectionMode="multiple" width={400} height={300} dragAndDropHooks={dragAndDropHooks} {...tableViewProps}>
       <TableHeader columns={columns}>
-        {column => <Column minWidth={100}>{column.name}</Column>}
+        {column => <Column minWidth={100} isRowHeader={column.isRowHeader}>{column.name}</Column>}
       </TableHeader>
       <TableBody items={list.items}>
         {item => (
-          <Row key={item.id} textValue={`${item.first_name} ${item.last_name}`}>
+          <Row>
             {key => <Cell>{item[key]}</Cell>}
           </Row>
         )}
@@ -247,7 +247,7 @@ export function DragOntoRowExample(props) {
       </TableHeader>
       <TableBody items={list.items}>
         {item => (
-          <Row key={item.id} textValue={item.name}>
+          <Row>
             <Cell>{item.id}</Cell>
             <Cell>{item.type}</Cell>
             <Cell>{item.name}</Cell>
@@ -380,7 +380,7 @@ export function DragBetweenTablesExample(props) {
           </TableHeader>
           <TableBody items={list1.items}>
             {(item: any) => (
-              <Row key={item.id} textValue={item.name}>
+              <Row>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -395,7 +395,7 @@ export function DragBetweenTablesExample(props) {
           </TableHeader>
           <TableBody items={list2.items}>
             {(item: any) => (
-              <Row key={item.id} textValue={item.name}>
+              <Row>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -530,11 +530,11 @@ export function DragBetweenTablesRootOnlyExample(props) {
         <Text alignSelf="center">Table 1</Text>
         <TableView aria-label="First TableView" selectionMode="multiple" width={400} dragAndDropHooks={dragAndDropHooksFirst} {...tableViewProps}>
           <TableHeader columns={itemColumns}>
-            {column => <Column minWidth={100}>{column.name}</Column>}
+            {column => <Column minWidth={100} isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list1.items}>
             {(item: any) => (
-              <Row key={item.id} textValue={item.name}>
+              <Row>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -545,11 +545,11 @@ export function DragBetweenTablesRootOnlyExample(props) {
         <Text alignSelf="center">Table 2</Text>
         <TableView aria-label="Second TableView" selectionMode="multiple" width={400} dragAndDropHooks={dragAndDropHooksSecond} {...tableViewProps}>
           <TableHeader columns={itemColumns}>
-            {column => <Column minWidth={100}>{column.name}</Column>}
+            {column => <Column minWidth={100} isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list2.items}>
             {(item: any) => (
-              <Row key={item.id} textValue={item.name}>
+              <Row>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}

--- a/packages/@react-spectrum/table/stories/TableDnDUtilExamples.tsx
+++ b/packages/@react-spectrum/table/stories/TableDnDUtilExamples.tsx
@@ -78,11 +78,11 @@ export function DragExampleUtilHandlers(props) {
   return (
     <TableView aria-label="TableView with dnd util handlers" selectionMode="multiple" width={400} height={200} onSelectionChange={s => onSelectionChange([...s])} dragAndDropHooks={dragAndDropHooks} {...tableViewProps}>
       <TableHeader columns={columns}>
-        {column => <Column>{column.name}</Column>}
+        {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
       </TableHeader>
       <TableBody items={list.items}>
         {item => (
-          <Row key={item.identifier} textValue={item.name}>
+          <Row key={item.identifier}>
             {key => <Cell>{item[key]}</Cell>}
           </Row>
         )}
@@ -97,7 +97,7 @@ export function ReorderExampleUtilHandlers(props) {
     initialItems: folderList1,
     getKey: (item) => item.identifier
   });
-  
+
 
   let acceptedDragTypes = ['file', 'folder', 'text/plain'];
   let {dragAndDropHooks} = useDragAndDrop({
@@ -146,17 +146,17 @@ export function ReorderExampleUtilHandlers(props) {
   return (
     <TableView aria-label="Reorderable TableView with util handlers" selectionMode="multiple" width={400} height={200} onSelectionChange={s => onSelectionChange([...s])} dragAndDropHooks={dragAndDropHooks} {...tableViewProps}>
       <TableHeader columns={columns}>
-        {column => <Column>{column.name}</Column>}
+        {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
       </TableHeader>
       <TableBody items={list.items}>
         {item => (
-          <Row key={item.identifier} textValue={item.name}>
+          <Row key={item.identifier}>
             {key => <Cell>{item[key]}</Cell>}
           </Row>
         )}
       </TableBody>
     </TableView>
-    
+
   );
 }
 
@@ -203,11 +203,11 @@ export function ItemDropExampleUtilHandlers(props) {
   return (
     <TableView aria-label="Row droppable TableView from dnd hook util handlers" selectionMode="multiple" width={400} height={200} onSelectionChange={s => onSelectionChange([...s])} dragAndDropHooks={dragAndDropHooks} {...tableViewProps}>
       <TableHeader columns={columns}>
-        {column => <Column>{column.name}</Column>}
+        {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
       </TableHeader>
       <TableBody items={list.items}>
         {item => (
-          <Row key={item.identifier} textValue={item.name}>
+          <Row key={item.identifier}>
             {key => <Cell>{item[key]}</Cell>}
           </Row>
         )}
@@ -267,11 +267,11 @@ export function RootDropExampleUtilHandlers(props) {
         <Text alignSelf="center">Table 1</Text>
         <TableView aria-label="First TableView" selectionMode="multiple" width={300} dragAndDropHooks={table1Hooks} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list1.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -282,11 +282,11 @@ export function RootDropExampleUtilHandlers(props) {
         <Text alignSelf="center">Table 2</Text>
         <TableView aria-label="Second TableView" selectionMode="multiple" width={300} dragAndDropHooks={table2Hooks} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list2.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -357,11 +357,11 @@ export function InsertExampleUtilHandlers(props) {
         <Text alignSelf="center">Table 1</Text>
         <TableView aria-label="First TableView" selectionMode="multiple" width={300} dragAndDropHooks={table1Hooks} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list1.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -372,11 +372,11 @@ export function InsertExampleUtilHandlers(props) {
         <Text alignSelf="center">Table 2</Text>
         <TableView aria-label="Second TableView" selectionMode="multiple" width={300} dragAndDropHooks={table2Hooks} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list2.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -426,11 +426,11 @@ export function FinderDropUtilHandlers(props) {
         <Text alignSelf="center">Table 1</Text>
         <TableView aria-label="TableView that accepts directory drops only" selectionMode="multiple" width={300} dragAndDropHooks={table1Hooks} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list1.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -441,11 +441,11 @@ export function FinderDropUtilHandlers(props) {
         <Text alignSelf="center">Table 2</Text>
         <TableView aria-label="TableView that accepts all drag types" selectionMode="multiple" width={300} dragAndDropHooks={table2Hooks} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list2.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -638,11 +638,11 @@ export function DragBetweenTablesComplex(props) {
         <Text alignSelf="center">Table 1</Text>
         <TableView aria-label="First TableView in drag between table example" selectionMode="multiple" width={300} dragAndDropHooks={dragAndDropHooksTable1} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list1.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -653,11 +653,11 @@ export function DragBetweenTablesComplex(props) {
         <Text alignSelf="center">Table 2</Text>
         <TableView aria-label="Second TableView in drag between table example" selectionMode="multiple" width={300} dragAndDropHooks={dragAndDropHooksTable2} {...tableViewProps}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list2.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -754,11 +754,11 @@ export function DragBetweenTablesOverride(props) {
         <Text alignSelf="center">Table 1</Text>
         <TableView aria-label="TableView that accepts directory drops only" selectionMode="multiple" width={300} dragAndDropHooks={dragAndDropHooksTable1} {...props}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list1.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}
@@ -769,11 +769,11 @@ export function DragBetweenTablesOverride(props) {
         <Text alignSelf="center">Table 2</Text>
         <TableView aria-label="TableView that accepts all drag types" selectionMode="multiple" width={300} dragAndDropHooks={dragAndDropHooksTable2} {...props}>
           <TableHeader columns={columns}>
-            {column => <Column>{column.name}</Column>}
+            {column => <Column isRowHeader={column.key === 'name'}>{column.name}</Column>}
           </TableHeader>
           <TableBody items={list2.items}>
             {(item) => (
-              <Row key={item.identifier} textValue={item.name}>
+              <Row key={item.identifier}>
                 {key => <Cell>{item[key]}</Cell>}
               </Row>
             )}

--- a/packages/@react-spectrum/table/test/TableDnd.test.js
+++ b/packages/@react-spectrum/table/test/TableDnd.test.js
@@ -145,7 +145,7 @@ describe('TableView', function () {
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
         let row = rows[0];
-        let cell = within(row).getByRole('rowheader');
+        let cell = within(row).getAllByRole('rowheader')[0];
         let cellText = getAllByText(cell.textContent);
         expect(cellText).toHaveLength(1);
 
@@ -179,7 +179,7 @@ describe('TableView', function () {
         let rows = within(rowgroups[1]).getAllByRole('row');
         let row = rows[0];
         expect(row).toHaveAttribute('draggable', 'true');
-        let cell = within(row).getByRole('rowheader');
+        let cell = within(row).getAllByRole('rowheader')[0];
         expect(cell).toHaveTextContent('Vin');
 
         let dataTransfer = new DataTransfer();
@@ -255,19 +255,19 @@ describe('TableView', function () {
 
         expect(new Set(onSelectionChange.mock.calls[3][0])).toEqual(new Set(['a', 'b', 'c', 'd']));
 
-        let cellA = within(rows[0]).getByRole('rowheader');
+        let cellA = within(rows[0]).getAllByRole('rowheader')[0];
         expect(cellA).toHaveTextContent('Vin');
         expect(rows[0]).toHaveAttribute('draggable', 'true');
 
-        let cellB = within(rows[1]).getByRole('rowheader');
+        let cellB = within(rows[1]).getAllByRole('rowheader')[0];
         expect(cellB).toHaveTextContent('Lexy');
         expect(rows[1]).toHaveAttribute('draggable', 'true');
 
-        let cellC = within(rows[2]).getByRole('rowheader');
+        let cellC = within(rows[2]).getAllByRole('rowheader')[0];
         expect(cellC).toHaveTextContent('Robbi');
         expect(rows[2]).toHaveAttribute('draggable', 'true');
 
-        let cellD = within(rows[3]).getByRole('rowheader');
+        let cellD = within(rows[3]).getAllByRole('rowheader')[0];
         expect(cellD).toHaveTextContent('Dodie');
         expect(rows[3]).toHaveAttribute('draggable', 'true');
 
@@ -335,7 +335,7 @@ describe('TableView', function () {
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
         let row = rows[0];
-        let cell = within(row).getByRole('rowheader');
+        let cell = within(row).getAllByRole('rowheader')[0];
         expect(cell).toHaveTextContent('Vin');
         expect(row).not.toHaveAttribute('draggable', 'true');
 
@@ -354,7 +354,7 @@ describe('TableView', function () {
         let grid = getByRole('grid');
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
-        let cell = within(rows[2]).getByRole('rowheader');
+        let cell = within(rows[2]).getAllByRole('rowheader')[0];
         let dataTransfer = new DataTransfer();
         let event = new DragEvent('dragstart', {dataTransfer, clientX: 5, clientY: 5});
 
@@ -381,7 +381,7 @@ describe('TableView', function () {
 
         expect(new Set(onSelectionChange.mock.calls[3][0])).toEqual(new Set(['a', 'b', 'c', 'd']));
 
-        let cellA = within(rows[0]).getByRole('rowheader');
+        let cellA = within(rows[0]).getAllByRole('rowheader')[0];
 
         let dataTransfer = new DataTransfer();
         fireEvent.pointerDown(cellA, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -418,7 +418,7 @@ describe('TableView', function () {
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
         act(() => userEvent.click(within(rows[0]).getByRole('checkbox')));
-        let cellA = within(rows[0]).getByRole('rowheader');
+        let cellA = within(rows[0]).getAllByRole('rowheader')[0];
 
         let dataTransfer = new DataTransfer();
         fireEvent.pointerDown(cellA, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -474,7 +474,7 @@ describe('TableView', function () {
         let internalFolder = rows[2];
 
         act(() => userEvent.click(within(rows[0]).getByRole('checkbox')));
-        let dragCell = within(rows[0]).getByRole('rowheader');
+        let dragCell = within(rows[0]).getAllByRole('rowheader')[0];
         let dataTransfer = new DataTransfer();
 
         // Dragging over a invalid drop target should not update dropCollectionRef
@@ -504,7 +504,7 @@ describe('TableView', function () {
         function dragWithinList(rows, dropTarget, targetX = 1, targetY = 1) {
           act(() => userEvent.click(within(rows[0]).getByRole('checkbox')));
           act(() => userEvent.click(within(rows[1]).getByRole('checkbox')));
-          let dragCell = within(rows[0]).getByRole('rowheader');
+          let dragCell = within(rows[0]).getAllByRole('rowheader')[0];
 
           let dataTransfer = new DataTransfer();
           fireEvent.pointerDown(dragCell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -524,7 +524,7 @@ describe('TableView', function () {
         function dragBetweenLists(sourceRows, dropTarget, targetX = 1, targetY = 1) {
           act(() => userEvent.click(within(sourceRows[0]).getByRole('checkbox')));
           act(() => userEvent.click(within(sourceRows[1]).getByRole('checkbox')));
-          let dragCell = within(sourceRows[0]).getByRole('rowheader');
+          let dragCell = within(sourceRows[0]).getAllByRole('rowheader')[0];
 
           let dataTransfer = new DataTransfer();
           fireEvent.pointerDown(dragCell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -1047,7 +1047,7 @@ describe('TableView', function () {
           let table2Rows = within(rowgroups2[1]).getAllByRole('row');
           act(() => userEvent.click(within(table2Rows[0]).getByRole('checkbox')));
           act(() => userEvent.click(within(table2Rows[1]).getByRole('checkbox')));
-          let dragCell = within(table2Rows[0]).getByRole('rowheader');
+          let dragCell = within(table2Rows[0]).getAllByRole('rowheader')[0];
 
           let dataTransfer = new DataTransfer();
           fireEvent.pointerDown(dragCell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -1329,7 +1329,7 @@ describe('TableView', function () {
           let table2Rows = within(rowgroups2[1]).getAllByRole('row');
           act(() => userEvent.click(within(table2Rows[0]).getByRole('checkbox')));
           act(() => userEvent.click(within(table2Rows[6]).getByRole('checkbox')));
-          let dragCell = within(table2Rows[0]).getByRole('rowheader');
+          let dragCell = within(table2Rows[0]).getAllByRole('rowheader')[0];
 
           let dataTransfer = new DataTransfer();
           fireEvent.pointerDown(dragCell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
@@ -1642,7 +1642,7 @@ describe('TableView', function () {
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
         let row = rows[0];
-        let cell = within(row).getByRole('rowheader');
+        let cell = within(row).getAllByRole('rowheader')[0];
         expect(cell).toHaveTextContent('Vin');
         expect(row).toHaveAttribute('draggable', 'true');
 
@@ -1691,19 +1691,19 @@ describe('TableView', function () {
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
 
-        let cellA = within(rows[0]).getByRole('rowheader');
+        let cellA = within(rows[0]).getAllByRole('rowheader')[0];
         expect(cellA).toHaveTextContent('Vin');
         expect(rows[0]).toHaveAttribute('draggable', 'true');
 
-        let cellB = within(rows[1]).getByRole('rowheader');
+        let cellB = within(rows[1]).getAllByRole('rowheader')[0];
         expect(cellB).toHaveTextContent('Lexy');
         expect(rows[1]).toHaveAttribute('draggable', 'true');
 
-        let cellC = within(rows[2]).getByRole('rowheader');
+        let cellC = within(rows[2]).getAllByRole('rowheader')[0];
         expect(cellC).toHaveTextContent('Robbi');
         expect(rows[2]).toHaveAttribute('draggable', 'true');
 
-        let cellD = within(rows[3]).getByRole('rowheader');
+        let cellD = within(rows[3]).getAllByRole('rowheader')[0];
         expect(cellD).toHaveTextContent('Dodie');
         expect(rows[3]).toHaveAttribute('draggable', 'true');
 
@@ -1856,8 +1856,8 @@ describe('TableView', function () {
           let grids = tree.getAllByRole('grid');
           let rowgroup = within(grids[0]).getAllByRole('rowgroup')[1];
           let row = within(rowgroup).getAllByRole('row')[0];
-          let cell = within(row).getByRole('rowheader');
-          expect(cell).toHaveTextContent('1');
+          let cell = within(row).getAllByRole('rowheader')[0];
+          expect(cell).toHaveTextContent('Adobe Photoshop');
           expect(row).toHaveAttribute('draggable', 'true');
 
           userEvent.tab();
@@ -2406,9 +2406,9 @@ describe('TableView', function () {
         let grid = getByRole('grid');
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
-        expect(within(rows[0]).getByRole('rowheader')).toHaveTextContent('Vin');
-        expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Lexy');
-        expect(within(rows[2]).getByRole('rowheader')).toHaveTextContent('Robbi');
+        expect(within(rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Vin');
+        expect(within(rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Lexy');
+        expect(within(rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Robbi');
 
         userEvent.tab();
         let draghandle = within(rows[0]).getAllByRole('button')[0];
@@ -2439,9 +2439,9 @@ describe('TableView', function () {
         rowgroups = within(grid).getAllByRole('rowgroup');
         rows = within(rowgroups[1]).getAllByRole('row');
         // TODO
-        // expect(within(rows[0]).getByRole('rowheader')).toHaveTextContent('Lexy');
-        // expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Vin');
-        // expect(within(rows[2]).getByRole('rowheader')).toHaveTextContent('Robbi');
+        // expect(within(rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Lexy');
+        // expect(within(rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Vin');
+        // expect(within(rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Robbi');
 
         // expect(document.activeElement).toBe(rows[1]);
       });
@@ -2452,10 +2452,10 @@ describe('TableView', function () {
         let grid = getByRole('grid');
         let rowgroups = within(grid).getAllByRole('rowgroup');
         let rows = within(rowgroups[1]).getAllByRole('row');
-        expect(within(rows[0]).getByRole('rowheader')).toHaveTextContent('Vin');
-        expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Lexy');
-        expect(within(rows[2]).getByRole('rowheader')).toHaveTextContent('Robbi');
-        expect(within(rows[3]).getByRole('rowheader')).toHaveTextContent('Dodie');
+        expect(within(rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Vin');
+        expect(within(rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Lexy');
+        expect(within(rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Robbi');
+        expect(within(rows[3]).getAllByRole('rowheader')[0]).toHaveTextContent('Dodie');
 
         userEvent.tab();
 
@@ -2495,11 +2495,11 @@ describe('TableView', function () {
         grid = getByRole('grid');
         rowgroups = within(grid).getAllByRole('rowgroup');
         rows = within(rowgroups[1]).getAllByRole('row');
-        expect(within(rows[0]).getByRole('rowheader')).toHaveTextContent('Vin');
+        expect(within(rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Vin');
         // TODO
-        // expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Dodie');
-        // expect(within(rows[2]).getByRole('rowheader')).toHaveTextContent('Lexy');
-        // expect(within(rows[3]).getByRole('rowheader')).toHaveTextContent('Robbi');
+        // expect(within(rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Dodie');
+        // expect(within(rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Lexy');
+        // expect(within(rows[3]).getAllByRole('rowheader')[0]).toHaveTextContent('Robbi');
 
         // expect(document.activeElement).toBe(rows[3]);
       });
@@ -2514,13 +2514,13 @@ describe('TableView', function () {
         let rowgroups2 = within(table2).getAllByRole('rowgroup');
         let table1rows = within(rowgroups1[1]).getAllByRole('row');
         let table2rows = within(rowgroups2[1]).getAllByRole('row');
-        expect(within(table1rows[0]).getByRole('rowheader')).toHaveTextContent('Item One');
-        expect(within(table1rows[1]).getByRole('rowheader')).toHaveTextContent('Item Two');
-        expect(within(table1rows[2]).getByRole('rowheader')).toHaveTextContent('Item Three');
+        expect(within(table1rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item One');
+        expect(within(table1rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Two');
+        expect(within(table1rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Three');
 
-        expect(within(table2rows[0]).getByRole('rowheader')).toHaveTextContent('Item Seven');
-        expect(within(table2rows[1]).getByRole('rowheader')).toHaveTextContent('Item Eight');
-        expect(within(table2rows[2]).getByRole('rowheader')).toHaveTextContent('Item Nine');
+        expect(within(table2rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Seven');
+        expect(within(table2rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Eight');
+        expect(within(table2rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Nine');
 
         userEvent.tab();
 
@@ -2556,13 +2556,13 @@ describe('TableView', function () {
         table1rows = within(rowgroups1[1]).getAllByRole('row');
         table2rows = within(rowgroups2[1]).getAllByRole('row');
 
-        expect(within(table1rows[0]).getByRole('rowheader')).toHaveTextContent('Item Two');
-        expect(within(table1rows[1]).getByRole('rowheader')).toHaveTextContent('Item Three');
-        expect(within(table1rows[2]).getByRole('rowheader')).toHaveTextContent('Item Four');
+        expect(within(table1rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Two');
+        expect(within(table1rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Three');
+        expect(within(table1rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Four');
 
-        expect(within(table2rows[0]).getByRole('rowheader')).toHaveTextContent('Item One');
-        expect(within(table2rows[1]).getByRole('rowheader')).toHaveTextContent('Item Seven');
-        expect(within(table2rows[2]).getByRole('rowheader')).toHaveTextContent('Item Eight');
+        expect(within(table2rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item One');
+        expect(within(table2rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Seven');
+        expect(within(table2rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Eight');
 
         expect(document.activeElement).toBe(table2rows[0]);
       });
@@ -2579,13 +2579,13 @@ describe('TableView', function () {
         let table1rows = within(rowgroups1[1]).getAllByRole('row');
         let table2rows = within(rowgroups2[1]).getAllByRole('row');
 
-        expect(within(table1rows[0]).getByRole('rowheader')).toHaveTextContent('Item One');
-        expect(within(table1rows[1]).getByRole('rowheader')).toHaveTextContent('Item Two');
-        expect(within(table1rows[2]).getByRole('rowheader')).toHaveTextContent('Item Three');
+        expect(within(table1rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item One');
+        expect(within(table1rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Two');
+        expect(within(table1rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Three');
 
-        expect(within(table2rows[0]).getByRole('rowheader')).toHaveTextContent('Item Seven');
-        expect(within(table2rows[1]).getByRole('rowheader')).toHaveTextContent('Item Eight');
-        expect(within(table2rows[2]).getByRole('rowheader')).toHaveTextContent('Item Nine');
+        expect(within(table2rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Seven');
+        expect(within(table2rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Eight');
+        expect(within(table2rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Nine');
 
         userEvent.tab();
 
@@ -2628,13 +2628,13 @@ describe('TableView', function () {
         table2rows = within(rowgroups2[1]).getAllByRole('row');
 
         // TODO
-        // expect(within(table1rows[0]).getByRole('rowheader')).toHaveTextContent('Item Two');
-        // expect(within(table1rows[1]).getByRole('rowheader')).toHaveTextContent('Item Four');
-        // expect(within(table1rows[2]).getByRole('rowheader')).toHaveTextContent('Item Five');
+        // expect(within(table1rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Two');
+        // expect(within(table1rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Four');
+        // expect(within(table1rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Five');
 
-        // expect(within(table2rows[0]).getByRole('rowheader')).toHaveTextContent('Item One');
-        // expect(within(table2rows[1]).getByRole('rowheader')).toHaveTextContent('Item Three');
-        // expect(within(table2rows[2]).getByRole('rowheader')).toHaveTextContent('Item Seven');
+        // expect(within(table2rows[0]).getAllByRole('rowheader')[0]).toHaveTextContent('Item One');
+        // expect(within(table2rows[1]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Three');
+        // expect(within(table2rows[2]).getAllByRole('rowheader')[0]).toHaveTextContent('Item Seven');
 
         // expect(document.activeElement).toBe(table2rows[0]);
       });
@@ -2727,7 +2727,7 @@ describe('TableView', function () {
       let grid = getByRole('grid');
       let rowgroups = within(grid).getAllByRole('rowgroup');
       let rows = within(rowgroups[1]).getAllByRole('row');
-      let cellA = within(rows[0]).getByRole('rowheader');
+      let cellA = within(rows[0]).getAllByRole('rowheader')[0];
       userEvent.click(cellA, {pointerType: 'mouse'});
       expect(document.activeElement).toBe(cellA);
       let dragHandle = within(rows[0]).getAllByRole('button')[0];

--- a/packages/@react-stately/table/src/TableCollection.ts
+++ b/packages/@react-stately/table/src/TableCollection.ts
@@ -324,4 +324,36 @@ export class TableCollection<T> extends GridCollection<T> implements ITableColle
     const keys = [...this.getKeys()];
     return this.getItem(keys[idx]);
   }
+
+  getTextValue(key: Key): string {
+    let row = this.getItem(key);
+    if (!row) {
+      return '';
+    }
+
+    // If the row has a textValue, use that.
+    if (row.textValue) {
+      return row.textValue;
+    }
+
+    // Otherwise combine the text of each of the row header columns.
+    let rowHeaderColumnKeys = this.rowHeaderColumnKeys;
+    if (rowHeaderColumnKeys) {
+      let text = [];
+      for (let cell of row.childNodes) {
+        let column = this.columns[cell.index];
+        if (rowHeaderColumnKeys.has(column.key) && cell.textValue) {
+          text.push(cell.textValue);
+        }
+
+        if (text.length === rowHeaderColumnKeys.size) {
+          break;
+        }
+      }
+
+      return text.join(' ');
+    }
+
+    return '';
+  }
 }

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -151,7 +151,10 @@ export interface Collection<T> extends Iterable<T> {
   getLastKey(): Key | null,
 
   /** Iterate over the child items of the given key. */
-  getChildren?(key: Key): Iterable<T>
+  getChildren?(key: Key): Iterable<T>,
+
+  /** Returns a string representation of the item's contents. */
+  getTextValue?(key: Key): string
 }
 
 export interface Node<T> {

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -146,6 +146,34 @@ class TableCollection<T> extends BaseCollection<T> implements ITableCollection<T
     collection.body = this.body;
     return collection;
   }
+
+  getTextValue(key: Key): string {
+    let row = this.getItem(key);
+    if (!row) {
+      return '';
+    }
+
+    // If the row has a textValue, use that.
+    if (row.textValue) {
+      return row.textValue;
+    }
+
+    // Otherwise combine the text of each of the row header columns.
+    let rowHeaderColumnKeys = this.rowHeaderColumnKeys;
+    let text = [];
+    for (let cell of this.getChildren(key)) {
+      let column = this.columns[cell.index];
+      if (rowHeaderColumnKeys.has(column.key) && cell.textValue) {
+        text.push(cell.textValue);
+      }
+
+      if (text.length === rowHeaderColumnKeys.size) {
+        break;
+      }
+    }
+
+    return text.join(' ');
+  }
 }
 
 interface InternalTableContextValue {

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -160,9 +160,9 @@ class TableCollection<T> extends BaseCollection<T> implements ITableCollection<T
 
     // Otherwise combine the text of each of the row header columns.
     let rowHeaderColumnKeys = this.rowHeaderColumnKeys;
-    let text = [];
+    let text: string[] = [];
     for (let cell of this.getChildren(key)) {
-      let column = this.columns[cell.index];
+      let column = this.columns[cell.index!];
       if (rowHeaderColumnKeys.has(column.key) && cell.textValue) {
         text.push(cell.textValue);
       }


### PR DESCRIPTION
 When a `textValue` is not explicitly provided to the `<Row>` component, this generates it based on the row header columns within that row. We already had this for our custom selection announcements, but not in drag and drop, so this moves the `getRowText` function that we had in `useTable` into `TableCollection` in order to allow it to be reused. A new `getTextValue` method is added to the `Collection` interface to allow collections to generate a text value for their nodes dynamically if they need to.

For now there are two implementations: one in the old TableCollection in stately, and the other in react-aria-components. Eventually we'll consolidate this when moving to the new collections in spectrum.