### PR TITLE
TagGroup: fix types and item render

### DIFF
--- a/packages/@react-aria/tag/src/useTag.ts
+++ b/packages/@react-aria/tag/src/useTag.ts
@@ -30,8 +30,8 @@ export interface TagAria {
   gridCellProps: DOMAttributes,
   /** Props for the tag row element. */
   rowProps: DOMAttributes,
-  /** Props for the tag clear button. */
-  clearButtonProps: AriaButtonProps
+  /** Props for the tag remove button. */
+  removeButtonProps: AriaButtonProps
 }
 
 /**
@@ -75,7 +75,7 @@ export function useTag<T>(props: TagProps<T>, state: TagGroupState<T>, ref: RefO
   let domProps = filterDOMProps(props);
   let isFocused = item.key === state.selectionManager.focusedKey;
   return {
-    clearButtonProps: {
+    removeButtonProps: {
       'aria-label': stringFormatter.format('removeButtonLabel', {label: item.textValue}),
       'aria-labelledby': `${buttonId} ${labelId}`,
       id: buttonId,

--- a/packages/@react-aria/tag/src/useTag.ts
+++ b/packages/@react-aria/tag/src/useTag.ts
@@ -11,8 +11,8 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
+import {AriaLabelingProps, DOMAttributes, DOMProps, FocusableElement} from '@react-types/shared';
 import {chain, filterDOMProps, mergeProps, useDescription, useId} from '@react-aria/utils';
-import {DOMAttributes, FocusableElement} from '@react-types/shared';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {KeyboardEvent, RefObject} from 'react';
@@ -34,13 +34,15 @@ export interface TagAria {
   removeButtonProps: AriaButtonProps
 }
 
+export interface AriaTagProps<T> extends TagProps<T>, DOMProps, AriaLabelingProps {}
+
 /**
  * Provides the behavior and accessibility implementation for a tag component.
  * @param props - Props to be applied to the tag.
  * @param state - State for the tag group, as returned by `useTagGroupState`.
  * @param ref - A ref to a DOM element for the tag.
  */
-export function useTag<T>(props: TagProps<T>, state: TagGroupState<T>, ref: RefObject<FocusableElement>): TagAria {
+export function useTag<T>(props: AriaTagProps<T>, state: TagGroupState<T>, ref: RefObject<FocusableElement>): TagAria {
   let {
     allowsRemoving,
     item

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -28,7 +28,6 @@ export interface SpectrumTagProps<T> extends TagProps<T> {
 
 export function Tag<T>(props: SpectrumTagProps<T>) {
   const {
-    children,
     allowsRemoving,
     item,
     state,
@@ -72,7 +71,7 @@ export function Tag<T>(props: SpectrumTagProps<T>) {
             text: {UNSAFE_className: classNames(styles, 'spectrum-Tag-content'), ...labelProps},
             avatar: {UNSAFE_className: classNames(styles, 'spectrum-Tag-avatar'), size: 'avatar-size-50'}
           }}>
-          {typeof children === 'string' ? <Text>{children}</Text> : children}
+          {typeof item.rendered === 'string' ? <Text>{item.rendered}</Text> : item.rendered}
           <ClearSlots>
             {allowsRemoving && <TagRemoveButton item={item} {...removeButtonProps} UNSAFE_className={classNames(styles, 'spectrum-Tag-removeButton')} />}
           </ClearSlots>

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -41,7 +41,7 @@ export function Tag<T>(props: SpectrumTagProps<T>) {
   let {hoverProps, isHovered} = useHover({});
   let {isFocused, isFocusVisible, focusProps} = useFocusRing({within: true});
   let ref = useRef();
-  let {clearButtonProps, labelProps, gridCellProps, rowProps} = useTag({
+  let {removeButtonProps, labelProps, gridCellProps, rowProps} = useTag({
     ...props,
     allowsRemoving,
     item,
@@ -74,7 +74,7 @@ export function Tag<T>(props: SpectrumTagProps<T>) {
           }}>
           {typeof children === 'string' ? <Text>{children}</Text> : children}
           <ClearSlots>
-            {allowsRemoving && <TagRemoveButton item={item} {...clearButtonProps} UNSAFE_className={classNames(styles, 'spectrum-Tag-removeButton')} />}
+            {allowsRemoving && <TagRemoveButton item={item} {...removeButtonProps} UNSAFE_className={classNames(styles, 'spectrum-Tag-removeButton')} />}
           </ClearSlots>
         </SlotProvider>
       </div>

--- a/packages/@react-types/tag/src/index.d.ts
+++ b/packages/@react-types/tag/src/index.d.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionBase, ItemProps, Node} from '@react-types/shared';
+import {CollectionBase, Node} from '@react-types/shared';
 import {Key} from 'react';
 
 export interface TagGroupProps<T> extends Omit<CollectionBase<T>, 'disabledKeys'> {
@@ -22,7 +22,7 @@ export interface TagGroupProps<T> extends Omit<CollectionBase<T>, 'disabledKeys'
   maxRows?: number
 }
 
-export interface TagProps<T> extends ItemProps<any> {
+export interface TagProps<T> {
   /** Whether the tag is removable. */
   allowsRemoving?: boolean,
   /** An object representing the tag. Contains all the relevant information that makes up the tag. */


### PR DESCRIPTION
- Renames `clearButtonProps` to `removeButtonProps`
- Removes `extends ItemProps<any>` from `TagProps`. As a result, we need a new `AriaTagProps` type that extends it. We also needed to change `children` to `item.rendered`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
