### PR TITLE
Automatically providing visually hidden styles to the resizer input

### DIFF
--- a/packages/@react-aria/focus/src/useHasTabbableChild.ts
+++ b/packages/@react-aria/focus/src/useHasTabbableChild.ts
@@ -23,7 +23,10 @@ interface AriaHasTabbableChildOptions {
 // are empty they can have a message with a tabbable element, which is like them
 // being not empty, when it comes to focus and tab order.
 
-/** Returns whether an element has a tabbable child, and updates as children change. */
+/**
+ * Returns whether an element has a tabbable child, and updates as children change.
+ * @private
+ */
 export function useHasTabbableChild(ref: RefObject<Element>, options?: AriaHasTabbableChildOptions): boolean {
   let isDisabled = options?.isDisabled;
   let [hasTabbableChild, setHasTabbableChild] = useState(false);

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -29,6 +29,7 @@
     "@react-aria/live-announcer": "^3.2.0",
     "@react-aria/selection": "^3.13.1",
     "@react-aria/utils": "^3.15.0",
+    "@react-aria/visually-hidden": "^3.7.0",
     "@react-stately/collections": "^3.6.0",
     "@react-stately/table": "^3.8.0",
     "@react-stately/virtualizer": "^3.5.0",

--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -21,6 +21,7 @@ import intlMessages from '../intl/*.json';
 import {TableColumnResizeState} from '@react-stately/table';
 import {useInteractionModality, useKeyboard, useMove, usePress} from '@react-aria/interactions';
 import {useLocale, useLocalizedStringFormatter} from '@react-aria/i18n';
+import {useVisuallyHidden} from '@react-aria/visually-hidden';
 
 export interface TableColumnResizeAria {
   /** Props for the visually hidden input element. */
@@ -236,6 +237,7 @@ export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, st
       }
     }
   });
+  let {visuallyHiddenProps} = useVisuallyHidden();
 
   return {
     resizerProps: mergeProps(
@@ -244,12 +246,9 @@ export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, st
       pressProps
     ),
     inputProps: mergeProps(
+      visuallyHiddenProps,
       {
         id,
-        // Override browser default margin. Without this, scrollIntoViewport will think we need to scroll the input into view
-        style: {
-          margin: '0px'
-        },
         onFocus: () => {
           let resizeOnFocus = !!triggerRef?.current;
           if (resizeOnFocus) {

--- a/packages/@react-aria/table/stories/example-docs.tsx
+++ b/packages/@react-aria/table/stories/example-docs.tsx
@@ -19,7 +19,6 @@ import {useFocusRing} from '@react-aria/focus';
 import {useRef} from 'react';
 import {useTable, useTableCell, useTableColumnHeader, useTableColumnResize, useTableHeaderRow, useTableRow, useTableRowGroup} from '@react-aria/table';
 import {useTableColumnResizeState, useTableState} from '@react-stately/table';
-import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 export function Table(props) {
   let {

--- a/packages/@react-aria/table/stories/example-docs.tsx
+++ b/packages/@react-aria/table/stories/example-docs.tsx
@@ -168,11 +168,9 @@ function Resizer(props) {
       role="presentation"
       className={classNames(ariaStyles, 'aria-table-resizer', {'focus': isFocusVisible, 'resizing': isResizing})}
       {...resizerProps}>
-      <VisuallyHidden>
-        <input
-          ref={ref}
-          {...mergeProps(inputProps, focusProps)} />
-      </VisuallyHidden>
+      <input
+        ref={ref}
+        {...mergeProps(inputProps, focusProps)} />
     </div>
   );
 }

--- a/packages/@react-spectrum/table/src/Resizer.tsx
+++ b/packages/@react-spectrum/table/src/Resizer.tsx
@@ -17,7 +17,6 @@ import styles from '@adobe/spectrum-css-temp/components/table/vars.css';
 import {useLocale, useLocalizedStringFormatter} from '@react-aria/i18n';
 import {useTableColumnResize} from '@react-aria/table';
 import {useTableContext, useVirtualizerContext} from './TableView';
-import {VisuallyHidden} from '@react-aria/visually-hidden';
 // @ts-ignore
 import wCursor from 'bundle-text:./cursors/Cur_MoveToLeft_9_9.svg';
 

--- a/packages/@react-spectrum/table/src/Resizer.tsx
+++ b/packages/@react-spectrum/table/src/Resizer.tsx
@@ -111,11 +111,9 @@ function Resizer<T>(props: ResizerProps<T>, ref: RefObject<HTMLInputElement>) {
           style={style}
           className={classNames(styles, 'spectrum-Table-columnResizer')}
           {...resizerProps}>
-          <VisuallyHidden>
-            <input
-              ref={ref}
-              {...inputProps} />
-          </VisuallyHidden>
+          <input
+            ref={ref}
+            {...inputProps} />
         </div>
       </FocusRing>
       {/* Placeholder so that the title doesn't intersect with space reserved by the resizer when it appears. */}


### PR DESCRIPTION
Closes <!-- Github issue # here -->
From audit

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test TableView resizing and the useTable "docs example" stories. Resizing should work as expected, the input should still be visually hidden, and focusing/blurring the input should still enter/exit resize mode

## 🧢 Your Project:

RSP
