### PR TITLE
Fix SSR issues with React Aria Components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ publish-nightly: build
 build:
 	parcel build packages/@react-{spectrum,aria,stately}/*/ packages/@internationalized/{message,string,date,number}/ packages/react-aria-components --no-optimize
 	yarn lerna run prepublishOnly
-	for pkg in packages/@react-{spectrum,aria,stately}/*/  packages/@internationalized/{message,string,date,number}/ packages/@adobe/react-spectrum/ packages/react-aria/ packages/react-stately/; \
+	for pkg in packages/@react-{spectrum,aria,stately}/*/  packages/@internationalized/{message,string,date,number}/ packages/@adobe/react-spectrum/ packages/react-aria/ packages/react-stately/ packages/react-aria-components/; \
 		do cp $$pkg/dist/module.js $$pkg/dist/import.mjs; \
 	done
 	sed -i.bak s/\.js/\.mjs/ packages/@react-aria/i18n/dist/import.mjs

--- a/packages/@react-aria/interactions/package.json
+++ b/packages/@react-aria/interactions/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@react-aria/utils": "^3.15.0",
+    "@react-aria/ssr": "^3.5.0",
     "@react-types/shared": "^3.17.0",
     "@swc/helpers": "^0.4.14"
   },

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -17,6 +17,7 @@
 
 import {isMac, isVirtualClick} from '@react-aria/utils';
 import {useEffect, useState} from 'react';
+import {useIsSSR} from '@react-aria/ssr';
 
 export type Modality = 'keyboard' | 'pointer' | 'virtual';
 type HandlerEvent = PointerEvent | MouseEvent | KeyboardEvent | FocusEvent;
@@ -192,7 +193,7 @@ export function useInteractionModality(): Modality {
     };
   }, []);
 
-  return modality;
+  return useIsSSR() ? null : modality;
 }
 
 /**

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -19,6 +19,7 @@ import {ComboBox, Item, Section} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import scaleMedium from '@adobe/spectrum-css-temp/vars/spectrum-medium-unique.css';
+import {SSRProvider} from '@react-aria/ssr';
 import themeLight from '@adobe/spectrum-css-temp/vars/spectrum-light-unique.css';
 import {useAsyncList} from '@react-stately/data';
 import {useFilter} from '@react-aria/i18n';
@@ -1209,6 +1210,18 @@ describe('ComboBox', function () {
 
         expect(queryByRole('listbox')).toBeNull();
       });
+    });
+
+    it('works with SSR', () => {
+      let {getByRole} = render(<SSRProvider><ExampleComboBox selectedKey="2" /></SSRProvider>);
+
+      let button = getByRole('button');
+      triggerPress(button);
+      act(() => jest.runAllTimers());
+
+      let listbox = getByRole('listbox');
+      let items = within(listbox).getAllByRole('option');
+      expect(items).toHaveLength(3);
     });
   });
 

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -7,6 +7,11 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    "types": "./dist/types.d.ts",
+    "import": "./dist/import.mjs",
+    "require": "./dist/main.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -13,7 +13,7 @@ import {CollectionBase} from '@react-types/shared';
 import {createPortal} from 'react-dom';
 import {DOMProps, RenderProps} from './utils';
 import {Collection as ICollection, Node, SelectionBehavior, SelectionMode, ItemProps as SharedItemProps, SectionProps as SharedSectionProps} from 'react-stately';
-import {mergeProps} from 'react-aria';
+import {mergeProps, useIsSSR} from 'react-aria';
 import React, {cloneElement, createContext, Key, ReactElement, ReactNode, ReactPortal, useCallback, useContext, useMemo} from 'react';
 import {useLayoutEffect} from '@react-aria/utils';
 import {useSyncExternalStore} from 'use-sync-external-store/shim/index.js';
@@ -643,7 +643,7 @@ export function useCollectionChildren<T extends object>(props: CachedChildrenOpt
 const ShallowRenderContext = createContext(false);
 
 interface CollectionResult<C> {
-  portal: ReactPortal,
+  portal: ReactPortal | null,
   collection: C
 }
 
@@ -660,7 +660,7 @@ export function useCollection<T extends object, C extends BaseCollection<T>>(pro
       {children}
     </ShallowRenderContext.Provider>
   ), [children]);
-  let portal = createPortal(wrappedChildren, document as unknown as Element);
+  let portal = useIsSSR() ? null : createPortal(wrappedChildren, document as unknown as Element);
 
   useLayoutEffect(() => {
     if (document.dirtyNodes.size > 0) {


### PR DESCRIPTION
This fixes some issues I found while testing React Aria Components with Next.js:

* Adds a Node ESM build to the package like our others
* Skips rendering a portal in collection components on the server and during hydration because portals aren't supported by React in SSR
* Only returns true from `useIsSSR` during initial hydration. Previously, it would return true when any component first mounted within an SSRProvider, even after hydration. This was breaking overlay positioning, and caused the error in combobox with ariaHideOutside where the popoverRef wasn't defined yet due to an SSR check on mount. Fixes #3293. Fixes #3787.
* Makes `useInteractionModality` check `useIsSSR` and return `null` if it is on the server or hydrating. This was causing a hydration warning to sometimes appear in Picker due to un-matched tab index if you moved the mouse before hydration completed. Fixes #3758.