### PR TITLE
Fix combobox visible focus styling when opening the menu via keyboard

### DIFF
--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -102,6 +102,11 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
     if (props.onOpenChange) {
       props.onOpenChange(open, open ? menuOpenTrigger.current : undefined);
     }
+
+    selectionManager.setFocused(open);
+    if (!open) {
+      selectionManager.setFocusedKey(null);
+    }
   };
 
   let triggerState = useMenuTriggerState({...props, onOpenChange, isOpen: undefined, defaultOpen: undefined});
@@ -249,13 +254,6 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
     lastSelectedKey.current = selectedKey;
     lastSelectedKeyText.current = selectedItemText;
   });
-
-  useEffect(() => {
-    // Reset focused key when the menu closes
-    if (!triggerState.isOpen) {
-      selectionManager.setFocusedKey(null);
-    }
-  }, [triggerState.isOpen, selectionManager]);
 
   // Revert input value and close menu
   let revert = () => {

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -118,6 +118,7 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
 
       menuOpenTrigger.current = trigger;
       triggerState.open(focusStrategy);
+      selectionManager.setFocused(true);
     }
   };
 

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -137,6 +137,7 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
     // Only update the menuOpenTrigger if menu is currently closed
     if (!triggerState.isOpen) {
       menuOpenTrigger.current = trigger;
+      selectionManager.setFocused(true);
     }
 
     toggleMenu(focusStrategy);

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -123,7 +123,6 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
 
       menuOpenTrigger.current = trigger;
       triggerState.open(focusStrategy);
-      selectionManager.setFocused(true);
     }
   };
 
@@ -142,7 +141,6 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
     // Only update the menuOpenTrigger if menu is currently closed
     if (!triggerState.isOpen) {
       menuOpenTrigger.current = trigger;
-      selectionManager.setFocused(true);
     }
 
     toggleMenu(focusStrategy);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to the "static items" combobox story. 
2. Click on the input and type 'a'
3. Backspace so 'a' is deleted. Visible focus shouldn't appear in the menu still
4. Press arrow down/up. Visible focus should appear on the first/last item

## 🧢 Your Project:

RSP
