### PR TITLE
SearchAutocomplete: fix types

### DIFF
--- a/packages/@react-aria/autocomplete/src/index.ts
+++ b/packages/@react-aria/autocomplete/src/index.ts
@@ -10,4 +10,5 @@
  * governing permissions and limitations under the License.
  */
 export {useSearchAutocomplete} from './useSearchAutocomplete';
-export type {AriaSearchAutocompleteProps, SearchAutocompleteAria} from './useSearchAutocomplete';
+export type {SearchAutocompleteAria} from './useSearchAutocomplete';
+export type {AriaSearchAutocompleteProps} from '@react-types/autocomplete';

--- a/packages/@react-aria/autocomplete/src/index.ts
+++ b/packages/@react-aria/autocomplete/src/index.ts
@@ -10,5 +10,5 @@
  * governing permissions and limitations under the License.
  */
 export {useSearchAutocomplete} from './useSearchAutocomplete';
-export type {SearchAutocompleteAria} from './useSearchAutocomplete';
+export type {AriaSearchAutocompleteOptions, SearchAutocompleteAria} from './useSearchAutocomplete';
 export type {AriaSearchAutocompleteProps} from '@react-types/autocomplete';

--- a/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
@@ -12,25 +12,13 @@
 
 import {AriaButtonProps} from '@react-types/button';
 import {AriaListBoxOptions} from '@react-aria/listbox';
+import {AriaSearchAutocompleteProps} from '@react-types/autocomplete';
 import {ComboBoxState} from '@react-stately/combobox';
 import {DOMAttributes} from '@react-types/shared';
-import {InputHTMLAttributes, RefObject} from 'react';
-import {KeyboardDelegate} from '@react-types/shared';
+import {InputHTMLAttributes} from 'react';
 import {mergeProps} from '@react-aria/utils';
-import {SearchAutocompleteProps} from '@react-types/autocomplete';
 import {useComboBox} from '@react-aria/combobox';
 import {useSearchField} from '@react-aria/searchfield';
-
-export interface AriaSearchAutocompleteProps<T> extends SearchAutocompleteProps<T> {
-  /** The ref for the input element. */
-  inputRef: RefObject<HTMLInputElement>,
-  /** The ref for the list box popover. */
-  popoverRef: RefObject<HTMLDivElement>,
-  /** The ref for the list box. */
-  listBoxRef: RefObject<HTMLElement>,
-  /** An optional keyboard delegate implementation, to override the default. */
-  keyboardDelegate?: KeyboardDelegate
-}
 
 export interface SearchAutocompleteAria<T> {
   /** Props for the label element. */

--- a/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
@@ -14,8 +14,8 @@ import {AriaButtonProps} from '@react-types/button';
 import {AriaListBoxOptions} from '@react-aria/listbox';
 import {AriaSearchAutocompleteProps} from '@react-types/autocomplete';
 import {ComboBoxState} from '@react-stately/combobox';
-import {DOMAttributes} from '@react-types/shared';
-import {InputHTMLAttributes} from 'react';
+import {DOMAttributes, KeyboardDelegate} from '@react-types/shared';
+import {InputHTMLAttributes, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {useComboBox} from '@react-aria/combobox';
 import {useSearchField} from '@react-aria/searchfield';
@@ -31,13 +31,24 @@ export interface SearchAutocompleteAria<T> {
   clearButtonProps: AriaButtonProps
 }
 
+export interface AriaSearchAutocompleteOptions<T> extends AriaSearchAutocompleteProps<T> {
+  /** The ref for the input element. */
+  inputRef: RefObject<HTMLInputElement>,
+  /** The ref for the list box popover. */
+  popoverRef: RefObject<HTMLDivElement>,
+  /** The ref for the list box. */
+  listBoxRef: RefObject<HTMLElement>,
+  /** An optional keyboard delegate implementation, to override the default. */
+  keyboardDelegate?: KeyboardDelegate
+}
+
 /**
  * Provides the behavior and accessibility implementation for a search autocomplete component.
  * A search autocomplete combines a combobox with a searchfield, allowing users to filter a list of options to items matching a query.
  * @param props - Props for the search autocomplete.
  * @param state - State for the search autocomplete, as returned by `useSearchAutocomplete`.
  */
-export function useSearchAutocomplete<T>(props: AriaSearchAutocompleteProps<T>, state: ComboBoxState<T>): SearchAutocompleteAria<T> {
+export function useSearchAutocomplete<T>(props: AriaSearchAutocompleteOptions<T>, state: ComboBoxState<T>): SearchAutocompleteAria<T> {
   let {
     popoverRef,
     inputRef,

--- a/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
@@ -179,7 +179,7 @@ let SearchAutocompleteBase = React.forwardRef(_SearchAutocompleteBase) as <T>(pr
 
 interface SearchAutocompleteInputProps<T> extends SpectrumSearchAutocompleteProps<T> {
   inputProps: InputHTMLAttributes<HTMLInputElement>,
-  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  inputRef: RefObject<HTMLInputElement>,
   style?: React.CSSProperties,
   className?: string,
   isOpen?: boolean,

--- a/packages/@react-types/autocomplete/src/index.d.ts
+++ b/packages/@react-types/autocomplete/src/index.d.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaLabelingProps, AsyncLoadable, CollectionBase, DOMProps, KeyboardDelegate, LoadingState, SpectrumLabelableProps, SpectrumTextInputBase, StyleProps} from '@react-types/shared';
-import {Key, ReactElement, RefObject} from 'react';
+import {AriaLabelingProps, AsyncLoadable, CollectionBase, DOMProps, LoadingState, SpectrumLabelableProps, SpectrumTextInputBase, StyleProps} from '@react-types/shared';
+import {Key, ReactElement} from 'react';
 import {MenuTriggerAction} from '@react-types/combobox';
 import {SearchFieldProps} from '@react-types/searchfield';
 
@@ -46,16 +46,7 @@ export interface SearchAutocompleteProps<T> extends CollectionBase<T>, Omit<Sear
   icon?: ReactElement | null
 }
 
-export interface AriaSearchAutocompleteProps<T> extends SearchAutocompleteProps<T>, DOMProps, AriaLabelingProps {
-  /** The ref for the input element. */
-  inputRef: RefObject<HTMLInputElement>,
-  /** The ref for the list box popover. */
-  popoverRef: RefObject<HTMLDivElement>,
-  /** The ref for the list box. */
-  listBoxRef: RefObject<HTMLElement>,
-  /** An optional keyboard delegate implementation, to override the default. */
-  keyboardDelegate?: KeyboardDelegate
-}
+export interface AriaSearchAutocompleteProps<T> extends SearchAutocompleteProps<T>, DOMProps, AriaLabelingProps {}
 
 export interface SpectrumSearchAutocompleteProps<T> extends SpectrumTextInputBase, Omit<AriaSearchAutocompleteProps<T>, 'menuTrigger'>, SpectrumLabelableProps, StyleProps, Omit<AsyncLoadable, 'isLoading'> {
   /**

--- a/packages/@react-types/autocomplete/src/index.d.ts
+++ b/packages/@react-types/autocomplete/src/index.d.ts
@@ -41,9 +41,7 @@ export interface SearchAutocompleteProps<T> extends CollectionBase<T>, Omit<Sear
    * A `key` will be passed if the submission is a selected item (e.g. a user clicks or presses enter on an option).
    * If the input is a custom value, `key` will be null.
    */
-  onSubmit?: (value: string | null, key: Key | null) => void,
-  /** An icon to display at the start of the input. */
-  icon?: ReactElement | null
+  onSubmit?: (value: string | null, key: Key | null) => void
 }
 
 export interface AriaSearchAutocompleteProps<T> extends SearchAutocompleteProps<T>, DOMProps, AriaLabelingProps {}
@@ -68,5 +66,7 @@ export interface SpectrumSearchAutocompleteProps<T> extends SpectrumTextInputBas
    * @default true
    */
   shouldFlip?: boolean,
-  onLoadMore?: () => void
+  onLoadMore?: () => void,
+  /** An icon to display at the start of the input. */
+  icon?: ReactElement | null
 }

--- a/packages/@react-types/autocomplete/src/index.d.ts
+++ b/packages/@react-types/autocomplete/src/index.d.ts
@@ -10,12 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaSearchFieldProps} from '@react-types/searchfield';
-import {AsyncLoadable, CollectionBase, LoadingState, SpectrumLabelableProps, SpectrumTextInputBase, StyleProps} from '@react-types/shared';
-import {Key, ReactElement} from 'react';
+import {AriaLabelingProps, AsyncLoadable, CollectionBase, DOMProps, KeyboardDelegate, LoadingState, SpectrumLabelableProps, SpectrumTextInputBase, StyleProps} from '@react-types/shared';
+import {Key, ReactElement, RefObject} from 'react';
 import {MenuTriggerAction} from '@react-types/combobox';
+import {SearchFieldProps} from '@react-types/searchfield';
 
-export interface SearchAutocompleteProps<T> extends CollectionBase<T>, Omit<AriaSearchFieldProps, 'onSubmit'> {
+export interface SearchAutocompleteProps<T> extends CollectionBase<T>, Omit<SearchFieldProps, 'onSubmit' | 'defaultValue' | 'value'> {
   /** The list of SearchAutocomplete items (uncontrolled). */
   defaultItems?: Iterable<T>,
   /** The list of SearchAutocomplete items (controlled). */
@@ -46,7 +46,18 @@ export interface SearchAutocompleteProps<T> extends CollectionBase<T>, Omit<Aria
   icon?: ReactElement | null
 }
 
-export interface SpectrumSearchAutocompleteProps<T> extends SpectrumTextInputBase, Omit<SearchAutocompleteProps<T>, 'menuTrigger'>, SpectrumLabelableProps, StyleProps, Omit<AsyncLoadable, 'isLoading'> {
+export interface AriaSearchAutocompleteProps<T> extends SearchAutocompleteProps<T>, DOMProps, AriaLabelingProps {
+  /** The ref for the input element. */
+  inputRef: RefObject<HTMLInputElement>,
+  /** The ref for the list box popover. */
+  popoverRef: RefObject<HTMLDivElement>,
+  /** The ref for the list box. */
+  listBoxRef: RefObject<HTMLElement>,
+  /** An optional keyboard delegate implementation, to override the default. */
+  keyboardDelegate?: KeyboardDelegate
+}
+
+export interface SpectrumSearchAutocompleteProps<T> extends SpectrumTextInputBase, Omit<AriaSearchAutocompleteProps<T>, 'menuTrigger'>, SpectrumLabelableProps, StyleProps, Omit<AsyncLoadable, 'isLoading'> {
   /**
    * The interaction required to display the SearchAutocomplete menu. Note that this prop has no effect on the mobile SearchAutocomplete experience.
    * @default 'input'


### PR DESCRIPTION
- removes `value` and `defaultValue` from prop types, since we use `inputValue` and `defaultInputValue` instead (found by @ktabors)
- fixes `SearchAutocompleteProps` to extend `SearchFieldProps` instead of `AriaSearchFieldProps`. Had to move `AriaSearchAutocompleteProps` to `@react-types` to avoid a circular dependency.

I can break this out if we only want to get bullet one in now.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
