### PR TITLE
Fix clearing date picker by setting value to null

### DIFF
--- a/packages/@react-spectrum/datepicker/stories/DateRangePicker.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DateRangePicker.stories.tsx
@@ -308,7 +308,7 @@ function ControlledExample(props) {
 
   return (
     <Flex direction="column" alignItems="center" gap="size-150">
-      <DateRangePicker label="Controlled" {...props} value={value} onChange={chain(setValue, action('onChange'))} />
+      <DateRangePicker label="Controlled" {...props} granularity="minute" value={value} onChange={chain(setValue, action('onChange'))} />
       <ActionButton onPress={() => setValue({start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2020, 5, 4)})}>Change value</ActionButton>
       <ActionButton onPress={() => setValue(null)}>Clear</ActionButton>
     </Flex>

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -620,6 +620,74 @@ describe('DatePicker', function () {
       expect(dialog).not.toBeInTheDocument();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('should clear date and time when controlled value is set to null', function () {
+      function ControlledDatePicker() {
+        let [value, setValue] = React.useState(null);
+        return (<>
+          <DatePicker label="Date" granularity="minute" value={value} onChange={setValue} />
+          <button onClick={() => setValue(null)}>Clear</button>
+        </>);
+      }
+
+      let {getAllByRole, getAllByLabelText} = render(
+        <Provider theme={theme}>
+          <ControlledDatePicker />
+        </Provider>
+      );
+
+      let combobox = getAllByRole('group')[0];
+      let formatter = new Intl.DateTimeFormat('en-US', {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric'});
+      expectPlaceholder(combobox, 'mm/dd/yyyy, ––:–– AM');
+
+      let button = getAllByRole('button')[0];
+      triggerPress(button);
+
+      let cells = getAllByRole('gridcell');
+      let timeField = getAllByLabelText('Time')[0];
+      let todayCell = cells.find(cell => cell.firstChild.getAttribute('aria-label')?.startsWith('Today'));
+      triggerPress(todayCell.firstChild);
+
+      expect(todayCell).toHaveAttribute('aria-selected', 'true');
+
+      let hour = within(timeField).getByLabelText('hour');
+      act(() => hour.focus());
+      fireEvent.keyDown(hour, {key: 'ArrowUp'});
+      fireEvent.keyUp(hour, {key: 'ArrowUp'});
+      expect(hour).toHaveAttribute('aria-valuetext', '12 AM');
+
+      fireEvent.keyDown(hour, {key: 'ArrowRight'});
+      fireEvent.keyUp(hour, {key: 'ArrowRight'});
+      expect(document.activeElement).toHaveAttribute('aria-label', 'minute');
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowUp'});
+      fireEvent.keyUp(document.activeElement, {key: 'ArrowUp'});
+      expect(document.activeElement).toHaveAttribute('aria-valuetext', '00');
+
+      fireEvent.keyDown(hour, {key: 'ArrowRight'});
+      fireEvent.keyUp(hour, {key: 'ArrowRight'});
+      expect(document.activeElement).toHaveAttribute('aria-label', 'AM/PM');
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowUp'});
+      fireEvent.keyUp(document.activeElement, {key: 'ArrowUp'});
+      expect(document.activeElement).toHaveAttribute('aria-valuetext', 'AM');
+
+      userEvent.click(document.body);
+      act(() => jest.runAllTimers());
+
+      let value = toCalendarDateTime(today(getLocalTimeZone()));
+      expectPlaceholder(combobox, formatter.format(value.toDate(getLocalTimeZone())));
+
+      let clear = getAllByRole('button')[1];
+      triggerPress(clear);
+      expectPlaceholder(combobox, 'mm/dd/yyyy, ––:–– AM');
+
+      triggerPress(button);
+      cells = getAllByRole('gridcell');
+      let selected = cells.find(cell => cell.getAttribute('aria-selected') === 'true');
+      expect(selected).toBeUndefined();
+
+      timeField = getAllByLabelText('Time')[0];
+      expectPlaceholder(timeField, '––:–– AM');
+    });
   });
 
   describe('labeling', function () {

--- a/packages/@react-stately/datepicker/src/useDatePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerState.ts
@@ -91,6 +91,8 @@ export function useDatePickerState<T extends DateValue = DateValue>(props: DateP
 
   let commitValue = (date: DateValue, time: TimeValue) => {
     setValue('timeZone' in time ? time.set(toCalendarDate(date)) : toCalendarDateTime(date, time));
+    setSelectedDate(null);
+    setSelectedTime(null);
   };
 
   // Intercept setValue to make sure the Time section is not changed by date selection in Calendar

--- a/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
@@ -113,6 +113,8 @@ export function useDateRangePickerState<T extends DateValue = DateValue>(props: 
       start: 'timeZone' in timeRange.start ? timeRange.start.set(toCalendarDate(dateRange.start)) : toCalendarDateTime(dateRange.start, timeRange.start),
       end: 'timeZone' in timeRange.end ? timeRange.end.set(toCalendarDate(dateRange.end)) : toCalendarDateTime(dateRange.end, timeRange.end)
     });
+    setSelectedDateRange(null);
+    setSelectedTimeRange(null);
   };
 
   // Intercept setValue to make sure the Time section is not changed by date selection in Calendar


### PR DESCRIPTION
Fixes #3187.

This fixes an issue where setting the controlled value of a `DatePicker` or `DateRangePicker` to null with `granularity="minute"` did not clear the calendar or time fields within the popover. This was because we never reset our state for partial selection (e.g. only date or time) when we have a complete value entered. The fix is to reset those when we emit onChange.