### PR TITLE
[WIP] SearchAutocomplete: remove internal selection state

### DIFF
--- a/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useSearchAutocomplete.ts
@@ -93,7 +93,8 @@ export function useSearchAutocomplete<T>(props: AriaSearchAutocompleteOptions<T>
       listBoxRef,
       inputRef,
       onFocus: undefined,
-      onBlur: undefined
+      onBlur: undefined,
+      selectedKey: null
     },
     state
   );

--- a/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
@@ -89,9 +89,8 @@ function _SearchAutocompleteBase<T extends object>(props: SpectrumSearchAutocomp
       defaultFilter: contains,
       allowsEmptyCollection: isAsync,
       allowsCustomValue: true,
-      onSelectionChange: (key) => key !== null && onSubmit(null, key),
-      selectedKey: undefined,
-      defaultSelectedKey: undefined
+      selectedKey: null,
+      defaultSelectedKey: null
     }
   );
   let layout = useListBoxLayout(state);


### PR DESCRIPTION
SearchAutocomplete shouldn't have a concept of selected keys (differing from Combobox).

When a selection occurs from the menu, the input should be filled and selection should be removed. The menu should also be closed until the input gets updated.

TODO: handle onSubmit behavior.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
