### PR TITLE
Docs: fix DateField events example

### DIFF
--- a/packages/@react-spectrum/datepicker/docs/DateField.mdx
+++ b/packages/@react-spectrum/datepicker/docs/DateField.mdx
@@ -205,7 +205,7 @@ function Example() {
   return (
     <>
       <DateField label="Birth date" value={date} onChange={setDate} />
-      <p>Selected date: {formatter.format(date.toDate(getLocalTimeZone()))}</p>
+      <p>Selected date: {date ? formatter.format(date.toDate(getLocalTimeZone())): '--'}</p>
     </>
   );
 }


### PR DESCRIPTION
Avoid error thrown when no date available to format:

> An error occurred while rendering the example.
