### PR TITLE
Update datepicker documentation which has missing import

### DIFF
--- a/packages/@react-aria/datepicker/docs/useDatePicker.mdx
+++ b/packages/@react-aria/datepicker/docs/useDatePicker.mdx
@@ -144,6 +144,7 @@ The `DateField` component implements the keyboard editable input used in a `Date
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show code</summary>
 
 ```tsx example export=true render=false
+import { createCalendar } from '@internationalized/date';
 import {useLocale} from '@react-aria/i18n';
 import {useDateFieldState} from '@react-stately/datepicker';
 import {useDateField, useDateSegment} from '@react-aria/datepicker';


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Copy the code into an IDE and see that there is no longer an error that `createCalendar` is not defined

## 🧢 Your Project:

<!--- Company/project for pull request -->
