### PR TITLE
Fix: SelectStateOptions is not exported in .d.ts

### DIFF
--- a/packages/@react-stately/select/src/index.ts
+++ b/packages/@react-stately/select/src/index.ts
@@ -3,7 +3,7 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
@@ -13,4 +13,4 @@
 export {useSelectState} from './useSelectState';
 
 export type {SelectProps} from '@react-types/select';
-export type {SelectState} from './useSelectState';
+export type {SelectState, SelectStateOptions} from './useSelectState';

--- a/packages/react-stately/src/index.ts
+++ b/packages/react-stately/src/index.ts
@@ -21,7 +21,7 @@ export type {MenuTriggerProps, MenuTriggerState} from '@react-stately/menu';
 export type {OverlayTriggerProps, OverlayTriggerState} from '@react-stately/overlays';
 export type {RadioGroupProps, RadioGroupState} from '@react-stately/radio';
 export type {SearchFieldProps, SearchFieldState} from '@react-stately/searchfield';
-export type {SelectProps, SelectState} from '@react-stately/select';
+export type {SelectProps, SelectState, SelectStateOptions} from '@react-stately/select';
 export type {SliderState, SliderStateOptions} from '@react-stately/slider';
 export type {MultipleSelectionManager, MultipleSelectionState, SingleSelectionState} from '@react-stately/selection';
 export type {NumberFieldState, NumberFieldStateOptions} from '@react-stately/numberfield';


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/4460

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
