### PR TITLE
Revert "stop propagation of clicks on tooltips (#4479)"

### DIFF
--- a/packages/@react-aria/tooltip/src/useTooltip.ts
+++ b/packages/@react-aria/tooltip/src/useTooltip.ts
@@ -14,7 +14,7 @@ import {AriaTooltipProps} from '@react-types/tooltip';
 import {DOMAttributes} from '@react-types/shared';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {TooltipTriggerState} from '@react-stately/tooltip';
-import {useHover, usePress} from '@react-aria/interactions';
+import {useHover} from '@react-aria/interactions';
 
 export interface TooltipAria {
   /**
@@ -28,7 +28,6 @@ export interface TooltipAria {
  */
 export function useTooltip(props: AriaTooltipProps, state?: TooltipTriggerState): TooltipAria {
   let domProps = filterDOMProps(props, {labelable: true});
-  let {pressProps} = usePress({});
 
   let {hoverProps} = useHover({
     onHoverStart: () => state?.open(true),
@@ -36,7 +35,7 @@ export function useTooltip(props: AriaTooltipProps, state?: TooltipTriggerState)
   });
 
   return {
-    tooltipProps: mergeProps(domProps, hoverProps, pressProps, {
+    tooltipProps: mergeProps(domProps, hoverProps, {
       role: 'tooltip'
     })
   };

--- a/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
+++ b/packages/@react-spectrum/tooltip/stories/TooltipTrigger.stories.tsx
@@ -17,7 +17,7 @@ import Delete from '@spectrum-icons/workflow/Delete';
 import Edit from '@spectrum-icons/workflow/Edit';
 import {Flex} from '@react-spectrum/layout';
 import {Link} from '@react-spectrum/link';
-import React, {CSSProperties, useState} from 'react';
+import React, {useState} from 'react';
 import SaveTo from '@spectrum-icons/workflow/SaveTo';
 import {SpectrumTooltipTriggerProps} from '@react-types/tooltip';
 import {Tooltip, TooltipTrigger} from '../src';
@@ -174,25 +174,6 @@ export const TooltripTriggerInsideActionGroup: TooltipTriggerStory = {
       </TooltipTrigger>
     </ActionGroup>
   )
-};
-
-const TooltipDivRender = (props) => {
-  const [isDisabled, setIsDisabled] = useState(false);
-  const wrapperStyle: CSSProperties = {width: '400px', height: '400px', backgroundColor: 'red', position: 'absolute'};
-  return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-    <div onClick={() => setIsDisabled(!isDisabled)} style={wrapperStyle}>
-      <TooltipTrigger {...props} isOpen>
-        <ActionButton isDisabled={isDisabled} aria-label="Edit" UNSAFE_style={{top: '50px'}}>click red to disable</ActionButton>
-        <Tooltip>Click on tooltip doesn't propagate to parent</Tooltip>
-      </TooltipTrigger>
-    </div>
-  );
-};
-export const TooltripTriggerInsideDiv: TooltipTriggerStory = {
-  args: {delay: 0},
-  render: (args) => <TooltipDivRender {...args} />,
-  parameters: {description: {data: 'Event handlers are attached to the parent of the tooltip trigger. They should not be called when the tooltip itself is clicked.'}}
 };
 
 export const ArrowPositioningAtEdge: TooltipTriggerStory = {

--- a/packages/@react-spectrum/tooltip/test/Tooltip.test.js
+++ b/packages/@react-spectrum/tooltip/test/Tooltip.test.js
@@ -11,7 +11,7 @@
  */
 
 import React from 'react';
-import {render, triggerPress} from '@react-spectrum/test-utils';
+import {render} from '@react-spectrum/test-utils';
 import {Tooltip} from '../';
 
 describe('Tooltip', function () {
@@ -39,14 +39,5 @@ describe('Tooltip', function () {
     let {getByRole} = render(<Tooltip ref={ref}>This is a tooltip</Tooltip>);
     let tooltip = getByRole('tooltip');
     expect(ref.current.UNSAFE_getDOMNode()).toBe(tooltip);
-  });
-
-  it('click does not propagate to parent', () => {
-    let mockClick = jest.fn();
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-    let {getByRole} = render(<div onClick={mockClick}><Tooltip>This is a tooltip</Tooltip></div>);
-    let tooltip = getByRole('tooltip');
-    triggerPress(tooltip);
-    expect(mockClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -976,33 +976,4 @@ describe('TooltipTrigger', function () {
       expect(queryByRole('tooltip')).toBeNull();
     });
   });
-
-  it('does not propagate pointer or click through the portal', () => {
-    let onPointerDown = jest.fn();
-    let onPointerUp = jest.fn();
-    let onClick = jest.fn();
-
-    let {getByRole} = render(
-      <Provider theme={theme}>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-        <div onPointerDown={onPointerDown} onPointerUp={onPointerUp} onClick={onClick}>
-          <TooltipTrigger>
-            <ActionButton>Trigger</ActionButton>
-            <Tooltip>Helpful information.</Tooltip>
-          </TooltipTrigger>
-        </div>
-      </Provider>
-    );
-
-    let button = getByRole('button');
-    act(() => {
-      button.focus();
-    });
-
-    let tooltip = getByRole('tooltip');
-    triggerPress(tooltip);
-    expect(onPointerDown).not.toHaveBeenCalled();
-    expect(onPointerUp).not.toHaveBeenCalled();
-    expect(onClick).not.toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION
This reverts commit b677593429205473d8ed1af016f4ff101eaae0c1.

After a team discussion, we've decided to address this in all of our portalled components using something like https://github.com/facebook/react/issues/11387#issuecomment-1548827669
and provide guidance in our FAQ on how to ignore events that come through a portal.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
