### PR TITLE
Update `onRemove` type in `useTagGroup`

### DIFF
--- a/packages/@react-aria/tag/src/useTagGroup.ts
+++ b/packages/@react-aria/tag/src/useTagGroup.ts
@@ -35,7 +35,7 @@ export interface AriaTagGroupProps<T> extends CollectionBase<T>, MultipleSelecti
   /** How multiple selection should behave in the collection. */
   selectionBehavior?: SelectionBehavior,
   /** Handler that is called when a user deletes a tag.  */
-  onRemove?: (key: Set<Key>) => void
+  onRemove?: (keys: Set<Key>) => void
 }
 
 export interface AriaTagGroupOptions<T> extends Omit<AriaTagGroupProps<T>, 'children'> {


### PR DESCRIPTION
onRemove accepts a `Set` now, update the var to be plural.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

See TagGroup props for onRemove in the docs 

## 🧢 Your Project:

RSP
