### PR TITLE
Add 'since' version to new releases docs

### DIFF
--- a/packages/@react-spectrum/actionbar/docs/ActionBar.mdx
+++ b/packages/@react-spectrum/actionbar/docs/ActionBar.mdx
@@ -40,7 +40,8 @@ keywords: [actionbar, selection, actions, collections, toolbar]
   componentNames={['ActionBar', 'ActionBarContainer']}
   sourceData={[
     {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/action-bar/'}
-  ]} />
+  ]},
+  since="3.27.0"  />
 
 ## Example
 ```tsx example

--- a/packages/@react-spectrum/actionbar/docs/ActionBar.mdx
+++ b/packages/@react-spectrum/actionbar/docs/ActionBar.mdx
@@ -40,7 +40,7 @@ keywords: [actionbar, selection, actions, collections, toolbar]
   componentNames={['ActionBar', 'ActionBarContainer']}
   sourceData={[
     {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/action-bar/'}
-  ]},
+  ]}
   since="3.27.0"  />
 
 ## Example

--- a/packages/@react-spectrum/avatar/docs/Avatar.mdx
+++ b/packages/@react-spectrum/avatar/docs/Avatar.mdx
@@ -31,7 +31,7 @@ keywords: [avatar]
 <HeaderInfo
   packageData={packageData}
   componentNames={['Avatar']}
-  sourceData={[{type: 'Spectrum', url: 'https://spectrum.adobe.com/page/avatar/'}]},
+  sourceData={[{type: 'Spectrum', url: 'https://spectrum.adobe.com/page/avatar/'}]}
   since="3.26.0" />
 
 ## Example

--- a/packages/@react-spectrum/avatar/docs/Avatar.mdx
+++ b/packages/@react-spectrum/avatar/docs/Avatar.mdx
@@ -31,7 +31,8 @@ keywords: [avatar]
 <HeaderInfo
   packageData={packageData}
   componentNames={['Avatar']}
-  sourceData={[{type: 'Spectrum', url: 'https://spectrum.adobe.com/page/avatar/'}]} />
+  sourceData={[{type: 'Spectrum', url: 'https://spectrum.adobe.com/page/avatar/'}]},
+  since="3.26.0" />
 
 ## Example
 

--- a/packages/@react-spectrum/tag/docs/TagGroup.mdx
+++ b/packages/@react-spectrum/tag/docs/TagGroup.mdx
@@ -39,7 +39,8 @@ keywords: [TagGroup, status]
   componentNames={['TagGroup', 'Item']}
   sourceData={[
     {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/tag/'}
-  ]} />
+  ]},
+  since="3.27.0" />
 
 ## Example
 ```tsx example

--- a/packages/@react-spectrum/tag/docs/TagGroup.mdx
+++ b/packages/@react-spectrum/tag/docs/TagGroup.mdx
@@ -39,7 +39,7 @@ keywords: [TagGroup, status]
   componentNames={['TagGroup', 'Item']}
   sourceData={[
     {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/tag/'}
-  ]},
+  ]}
   since="3.27.0" />
 
 ## Example


### PR DESCRIPTION
Missing monopackage version in rsp docs
