### PR TITLE
Use span for VisuallyHidden when inside a <label>

### DIFF
--- a/packages/react-aria-components/src/Checkbox.tsx
+++ b/packages/react-aria-components/src/Checkbox.tsx
@@ -222,7 +222,7 @@ function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLInputElement>) {
       data-readonly={isReadOnly || undefined}
       data-validation-state={props.validationState || groupState?.validationState || undefined}
       data-required={props.isRequired || undefined}>
-      <VisuallyHidden>
+      <VisuallyHidden elementType="span">
         <input {...inputProps} {...focusProps} ref={ref} />
       </VisuallyHidden>
       {renderProps.children}

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -201,7 +201,7 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLInputElement>) {
       data-readonly={state.isReadOnly || undefined}
       data-validation-state={state.validationState || undefined}
       data-required={state.isRequired || undefined}>
-      <VisuallyHidden>
+      <VisuallyHidden elementType="span">
         <input {...inputProps} {...focusProps} ref={domRef} />
       </VisuallyHidden>
       {renderProps.children}

--- a/packages/react-aria-components/src/Switch.tsx
+++ b/packages/react-aria-components/src/Switch.tsx
@@ -116,7 +116,7 @@ function Switch(props: SwitchProps, ref: ForwardedRef<HTMLInputElement>) {
       data-focus-visible={isFocusVisible || undefined}
       data-disabled={isDisabled || undefined}
       data-readonly={isReadOnly || undefined}>
-      <VisuallyHidden>
+      <VisuallyHidden elementType="span">
         <input {...inputProps} {...focusProps} ref={ref} />
       </VisuallyHidden>
       {renderProps.children}


### PR DESCRIPTION
Not really sure why it would matter anymore now that CSS can make any element block or inline, but the HTML validator still fails if you put a `<div>` inside a `<label>`. So for Checkbox, Radio, and Switch, use a `<span>` to render the VisuallyHidden instead of a div.