### PR TITLE
Fixes for Inline Alert

### DIFF
--- a/packages/@react-spectrum/inlinealert/chromatic/InlineAlert.chromatic.tsx
+++ b/packages/@react-spectrum/inlinealert/chromatic/InlineAlert.chromatic.tsx
@@ -16,13 +16,9 @@ import {Meta} from '@storybook/react';
 import React from 'react';
 import {SpectrumInlineAlertProps} from '@react-types/inlinealert';
 
-// see https://github.com/storybookjs/storybook/issues/8426#issuecomment-669021940
-const StoryFn = ({storyFn}) => storyFn();
-
 const meta: Meta<SpectrumInlineAlertProps> = {
   title: 'InlineAlert',
-  component: InlineAlert,
-  decorators: [storyFn => <StoryFn storyFn={storyFn} />]
+  component: InlineAlert
 };
 
 export default meta;
@@ -88,14 +84,14 @@ export const Negative = {
 
 export const LongContent = {
   args: {
-    variant: 'info',
-    render: (args) => (
-      <div style={{width: '300px'}}>
-        <InlineAlert {...args}>
-          <Header>In-line Alert Header that goes on and on my friend</Header>
-          <Content>This is a React Spectrum InlineAlert that started announcing without knowing what it was. This is the inline alert that doesn't end. Yes, it goes on and on, my friend.</Content>
-        </InlineAlert>
-      </div>
-    )
-  }
+    variant: 'info'
+  },
+  render: (args) => (
+    <div style={{width: '300px'}}>
+      <InlineAlert {...args}>
+        <Header>In-line Alert Header that goes on and on my friend</Header>
+        <Content>This is a React Spectrum InlineAlert that started announcing without knowing what it was. This is the inline alert that doesn't end. Yes, it goes on and on, my friend.</Content>
+      </InlineAlert>
+    </div>
+  )
 };


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Noticed in chromatic that the long content wasn't rendering https://www.chromatic.com/test?appId=5f0dd5ad2b5fc10022a2e320&id=646fa09c5605027e487f21cb

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
