### PR TITLE
Setup package for feature flags

### DIFF
--- a/packages/@react-stately/flags/README.md
+++ b/packages/@react-stately/flags/README.md
@@ -1,0 +1,3 @@
+# @react-stately/flags
+
+This package is part of [react-spectrum](https://github.com/adobe/react-spectrum). See the repo for more details.

--- a/packages/@react-stately/flags/index.ts
+++ b/packages/@react-stately/flags/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './src';

--- a/packages/@react-stately/flags/package.json
+++ b/packages/@react-stately/flags/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@react-stately/flags",
+  "version": "3.0.0-alpha.1",
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
+  "exports": {
+    "types": "./dist/types.d.ts",
+    "import": "./dist/import.mjs",
+    "require": "./dist/main.js"
+  },
+  "source": "src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/react-spectrum"
+  },
+  "dependencies": {
+    "@swc/helpers": "^0.4.14"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-stately/flags/src/index.ts
+++ b/packages/@react-stately/flags/src/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export let enableUnavailableMenuItems = false;
+export let enableTableNestedRows = false;
+
+export function setFlags(values: Record<string, boolean>) {
+  enableUnavailableMenuItems = values.enableUnavailableMenuItems ?? false;
+  enableTableNestedRows = values.enableTableNestedRows ?? false;
+}

--- a/packages/@react-stately/flags/src/index.ts
+++ b/packages/@react-stately/flags/src/index.ts
@@ -10,10 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-export let enableUnavailableMenuItems = false;
-export let enableTableNestedRows = false;
+export let unavailableMenuItems = false;
+export let tableNestedRows = false;
 
-export function setFlags(values: Record<string, boolean>) {
-  enableUnavailableMenuItems = values.enableUnavailableMenuItems ?? false;
-  enableTableNestedRows = values.enableTableNestedRows ?? false;
+export function enableUnavailableMenuItems() {
+  unavailableMenuItems = true;
+}
+
+export function enableTableNestedRows() {
+  tableNestedRows = true;
 }


### PR DESCRIPTION
Problem: we need a way to develop new features for existing, non-pre release components like Table and Menu. We want to be able to release these new features for teams to test before they are stable, without breaking anything in existing apps.

Solution: feature flags! We'll keep them in the `@react-stately/flags` package as exported booleans. Any package that wants to put code behind these flags will import this package and check the flags in an if statement. This might mean enabling new things, or even swapping out the entire implementation of something. An app can also import this package, and call a function to to enable some features they want to try out.

This approach is the easiest because the flags can be accessed from anywhere. However, one downside is that flags are enabled for all instances of a component across the whole app, not for one specific table for example. We could do that with context, but then the flags would need to be wired to more places that aren't allowed to access classes (e.g. classes, non-hook functions, etc.). The flags also need to be set before anything is rendered in the app or things may break unexpectedly, so libraries like quarry should not be enabling flags, they should be enabled in apps. Like any other package, there must be only one copy installed or things will also not work.

It will be expected that we add and remove flags from this package over time. Once a feature is stable, the flag will be completely removed and all code will be non-conditional. Setting the value of that flag will do nothing. Thus, the type accepted by the `setFlags` function is intentionally vague (`Record<string, boolean>` rather than listing the names of the flags).