### PR TITLE
Fix width of number field within a form

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/stepper/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/stepper/index.css
@@ -34,7 +34,8 @@ governing permissions and limitations under the License.
 
   block-size: max-content;
 
-  inline-size: var(--spectrum-stepper-default-width-desktop);
+  --spectrum-stepper-width: var(--spectrum-stepper-default-width-desktop);
+  inline-size: var(--spectrum-stepper-width);
   line-height: 0;
   transition: border-color var(--spectrum-global-animation-duration-100) ease-in-out, box-shadow var(--spectrum-global-animation-duration-100) ease-in-out;
 
@@ -59,7 +60,8 @@ governing permissions and limitations under the License.
     }
   }
   &.spectrum-Stepper--isMobile {
-    inline-size: var(--spectrum-stepper-default-width-mobile);
+    /* Use a variable here rather than inline-size directly so we don't conflict with form style override. */
+    --spectrum-stepper-width: var(--spectrum-stepper-default-width-mobile);
     grid-template-rows: auto;
     grid-template-columns: auto 1fr auto;
     grid-template-areas: 'decrement field increment';


### PR DESCRIPTION
Specificity of form selector that sets `width: 100%` should override the one for NumberField `isMobile`. Switched to setting a variable rather than the `inline-size` property directly so the specificity is always the same regardless of if it is mobile or desktop.