### PR TITLE
Add support for standalone RAC popovers

### DIFF
--- a/packages/react-aria-components/docs/Popover.mdx
+++ b/packages/react-aria-components/docs/Popover.mdx
@@ -395,6 +395,29 @@ The example below will maintain at least 50px between the popover and the edge o
 </DialogTrigger>
 ```
 
+### Controlled open state
+
+The above examples have shown `Popover` used within a `<DialogTrigger>`, which handles opening the popover when a button is clicked, and positioning relative to the trigger. This is convenient, but there are cases where you want to show a popover programmatically rather than as a result of a user action, or render the `<Popover>` in a different part of the JSX tree.
+
+To do this, you can manage the popover's `isOpen` state yourself and provide it as a prop to the `<Popover>` element. The `onOpenChange` prop will be called when the user closes the popover, and should be used to update your state. In addition, the `triggerRef` prop must be set to the element that the popover should be positioned relative to.
+
+```tsx example
+function Example() {
+  let [isOpen, setOpen] = React.useState(false);
+  let triggerRef = React.useRef(null);
+
+  return (
+    <>
+      <Button onPress={() => setOpen(true)}>Trigger</Button>
+      <span ref={triggerRef} style={{paddingLeft: 12}}>Popover will be positioned relative to me</span>
+      <MyPopover triggerRef={triggerRef} isOpen={isOpen} onOpenChange={setOpen}>
+        This is a popover.
+      </MyPopover>
+    </>
+  );
+}
+```
+
 ## Advanced customization
 
 ### Hooks

--- a/packages/react-aria-components/src/Popover.tsx
+++ b/packages/react-aria-components/src/Popover.tsx
@@ -14,10 +14,10 @@ import {AriaPopoverProps, DismissButton, Overlay, PlacementAxis, PositionProps, 
 import {ContextValue, forwardRefType, HiddenContext, RenderProps, SlotProps, useContextProps, useEnterAnimation, useExitAnimation, useRenderProps} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {OverlayArrowContext} from './OverlayArrow';
-import {OverlayTriggerState} from 'react-stately';
+import {OverlayTriggerProps, OverlayTriggerState, useOverlayTriggerState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, RefObject} from 'react';
 
-export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPopoverProps, 'popoverRef' | 'triggerRef'>, RenderProps<PopoverRenderProps>, SlotProps {
+export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPopoverProps, 'popoverRef' | 'triggerRef'>, OverlayTriggerProps, RenderProps<PopoverRenderProps>, SlotProps {
   /**
    * The ref for the element which the popover positions itself with respect to.
    *
@@ -55,7 +55,10 @@ export const PopoverContext = createContext<ContextValue<PopoverContextValue, HT
 
 function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
   [props, ref] = useContextProps(props, ref, PopoverContext);
-  let {preserveChildren, state, triggerRef} = props as PopoverContextValue;
+  let ctx = props as PopoverContextValue;
+  // React components cannot be reparented so if there's context there should always be context.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  let state = ctx?.state ?? useOverlayTriggerState(props);
   let isExiting = useExitAnimation(ref, state.isOpen);
 
   if (state && !state.isOpen && !isExiting) {
@@ -68,13 +71,13 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
       });
     }
 
-    return preserveChildren ? <HiddenContext.Provider value>{children}</HiddenContext.Provider> : null;
+    return ctx.preserveChildren ? <HiddenContext.Provider value>{children}</HiddenContext.Provider> : null;
   }
 
   return (
     <PopoverInner
       {...props}
-      triggerRef={triggerRef}
+      triggerRef={ctx.triggerRef!}
       state={state}
       popoverRef={ref}
       isExiting={isExiting} />

--- a/packages/react-aria-components/test/Popover.test.js
+++ b/packages/react-aria-components/test/Popover.test.js
@@ -81,4 +81,22 @@ describe('Popover', () => {
     let dialog = getByRole('dialog');
     expect(dialog).toHaveTextContent('Popover at bottom');
   });
+
+  it('should support being used standalone', async () => {
+    let triggerRef = React.createRef();
+    let onOpenChange = jest.fn();
+    let {getByRole} = render(<>
+      <span ref={triggerRef}>Trigger</span>
+      <Popover isOpen triggerRef={triggerRef} onOpenChange={onOpenChange}>
+        <Dialog>A popover</Dialog>
+      </Popover>
+    </>);
+
+    let dialog = getByRole('dialog');
+    expect(dialog).toHaveTextContent('A popover');
+
+    userEvent.click(document.body);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
 });


### PR DESCRIPTION
This allows the RAC `Popover` component to be used standalone, outside a `DialogTrigger`, the same way as we already support for `Modal`. This means you can pass the `isOpen` and `onOpenChange` props directly to the popover, as well as the `triggerRef` prop to indicate which element to position it relative to. This enables more complex use cases, such as programmatically showing popovers (e.g. coach marks). The `isOpen` prop is also useful for integration with animation libraries like Framer Motion. It's also nice to have consistency between Modal and Popover here.