### PR TITLE
ASSETS-25282: Fix UTC offset format acceptance in date parsers

### DIFF
--- a/packages/@internationalized/date/src/string.ts
+++ b/packages/@internationalized/date/src/string.ts
@@ -20,8 +20,8 @@ import {Mutable} from './utils';
 const TIME_RE = /^(\d{2})(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/;
 const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 const DATE_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}))?(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?$/;
-const ZONED_DATE_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}))?(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?(?:([+-]\d{2})(?::(\d{2}))?)?\[(.*?)\]$/;
-const ABSOLUTE_RE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}))?(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?(?:(?:([+-]\d{2})(?::(\d{2}))?)|Z)$/;
+const ZONED_DATE_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}))?(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?(?:([+-]\d{2})(?::?(\d{2}))?)?\[(.*?)\]$/;
+const ABSOLUTE_RE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}))?(?::(\d{2}))?(?::(\d{2}))?(\.\d+)?(?:(?:([+-]\d{2})(?::?(\d{2}))?)|Z)$/;
 const DATE_TIME_DURATION_RE =
     /^((?<negative>-)|\+)?P((?<years>\d*)Y)?((?<months>\d*)M)?((?<weeks>\d*)W)?((?<days>\d*)D)?((?<time>T)((?<hours>\d*[.,]?\d{1,9})H)?((?<minutes>\d*[.,]?\d{1,9})M)?((?<seconds>\d*[.,]?\d{1,9})S)?)?$/;
 const requiredDurationTimeGroups = ['hours', 'minutes', 'seconds'];
@@ -238,7 +238,7 @@ export function parseDuration(value: string): Required<DateTimeDuration> {
   }
 
   const durationStringIncludesTime = match.groups?.time;
-  
+
   if (durationStringIncludesTime) {
     const hasRequiredDurationTimeGroups = requiredDurationTimeGroups.some(group => match.groups?.[group]);
     if (!hasRequiredDurationTimeGroups) {

--- a/packages/@internationalized/date/tests/string.test.js
+++ b/packages/@internationalized/date/tests/string.test.js
@@ -224,6 +224,18 @@ describe('string conversion', function () {
       let date = parseZonedDateTime('2020-02-03T12:24:45-08:00[America/Los_Angeles]');
       let expected = new ZonedDateTime(2020, 2, 3, 'America/Los_Angeles', -28800000, 12, 24, 45);
       expect(date).toEqual(expected);
+
+      date = parseZonedDateTime('2020-02-03T12:24:45-0800[America/Los_Angeles]');
+      expected = new ZonedDateTime(2020, 2, 3, 'America/Los_Angeles', -28800000, 12, 24, 45);
+      expect(date).toEqual(expected);
+
+      date = parseZonedDateTime('2020-02-03T12:24:45-08[America/Los_Angeles]');
+      expected = new ZonedDateTime(2020, 2, 3, 'America/Los_Angeles', -28800000, 12, 24, 45);
+      expect(date).toEqual(expected);
+
+      date = parseZonedDateTime('2020-02-03T12:24:45+0000[UTC]');
+      expected = new ZonedDateTime(2020, 2, 3, 'UTC', 0, 12, 24, 45);
+      expect(date).toEqual(expected);
     });
 
     it('should parse a date with a time with milliseconds and an offset', function () {
@@ -329,6 +341,18 @@ describe('string conversion', function () {
       date = parseAbsolute('2021-11-07T01:00-08:00', 'America/Los_Angeles');
       expected = new ZonedDateTime(2021, 11, 7, 'America/Los_Angeles', -28800000, 1, 0, 0);
       expect(date).toEqual(expected);
+
+      date = parseAbsolute('2021-11-07T01:00-0800', 'America/Los_Angeles');
+      expected = new ZonedDateTime(2021, 11, 7, 'America/Los_Angeles', -28800000, 1, 0, 0);
+      expect(date).toEqual(expected);
+
+      date = parseAbsolute('2021-11-07T01:00-08', 'America/Los_Angeles');
+      expected = new ZonedDateTime(2021, 11, 7, 'America/Los_Angeles', -28800000, 1, 0, 0);
+      expect(date).toEqual(expected);
+
+      date = parseAbsolute('2021-11-07T01:00+0000', 'America/Los_Angeles');
+      expected = new ZonedDateTime(2021, 11, 6, 'America/Los_Angeles', -25200000, 18, 0, 0);
+      expect(date).toEqual(expected);
     });
 
     it('should error if missing offset or Z', function () {
@@ -366,7 +390,7 @@ describe('string conversion', function () {
         seconds: 5
       });
     });
-  
+
     it('parses an ISO 8601 duration string that contains years, months, weeks, days, hours, minutes, and fractional values for seconds expressed with a period and returns a DateTimeDuration object', function () {
       const duration = parseDuration('P3Y6M6W4DT12H30M5.5S');
       expect(duration).toStrictEqual({
@@ -379,7 +403,7 @@ describe('string conversion', function () {
         seconds: 5.5
       });
     });
-  
+
     it('parses an ISO 8601 duration string that contains years, months, weeks, days, hours, minutes, and fractional values for seconds expressed with a comma and returns a DateTimeDuration object', function () {
       const duration = parseDuration('P3Y6M6W4DT12H30M5,5S');
       expect(duration).toStrictEqual({
@@ -444,7 +468,7 @@ describe('string conversion', function () {
         seconds: 0
       });
     });
-  
+
     it('parses a negative ISO 8601 duration string that contains years, months, weeks, days, hours, minutes, and seconds and returns a DateTimeDuration object', function () {
       const duration = parseDuration('-P3Y6M6W4DT12H30M5S');
       expect(duration).toStrictEqual({
@@ -457,7 +481,7 @@ describe('string conversion', function () {
         seconds: -5
       });
     });
-  
+
     it('parses an ISO 8601 duration string that contains years, months, weeks, days, hours, minutes, and seconds with a preceding + sign and returns a DateTimeDuration object', function () {
       const duration = parseDuration('+P3Y6M6W4DT12H30M5S');
       expect(duration).toStrictEqual({
@@ -483,7 +507,7 @@ describe('string conversion', function () {
         seconds: 15
       });
     });
-  
+
     it('parses an ISO 8601 duration string that contains years, months, weeks, and days and returns a DateTimeDuration object', function () {
       const duration = parseDuration('P7Y8M14W6D');
       expect(duration).toStrictEqual({
@@ -496,7 +520,7 @@ describe('string conversion', function () {
         seconds: 0
       });
     });
-  
+
     it('parses an ISO 8601 duration string that contains years, months, hours, and seconds and returns a DateTimeDuration object', function () {
       const duration = parseDuration('P18Y7MT20H15S');
       expect(duration).toStrictEqual({
@@ -509,7 +533,7 @@ describe('string conversion', function () {
         seconds: 15
       });
     });
-  
+
     it('throws an error when passed an improperly formatted ISO 8601 duration string', function () {
       expect(() => {
         parseDuration('+-P18Y7MT20H15S');


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/4659

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
This should not throw an error with the new code:
parseAbsolute('2021-03-14T02:00-08:00', 'America/Los_Angeles')
parseAbsolute('2021-11-07T01:00-0800', 'America/Los_Angeles')
parseAbsolute('2021-11-07T01:00-08', 'America/Los_Angeles')
parseAbsolute('2021-11-07T01:00+0000', 'America/Los_Angeles')

parseZonedDateTime('2020-02-03T12:24:45-08:00[America/Los_Angeles]')
parseZonedDateTime('2020-02-03T12:24:45-0800[America/Los_Angeles]')

## 🧢 Your Project:

<!--- Company/project for pull request -->
