### PR TITLE
Add TagGroup component to RAC

### DIFF
--- a/packages/@react-aria/tag/src/useTagGroup.ts
+++ b/packages/@react-aria/tag/src/useTagGroup.ts
@@ -54,7 +54,7 @@ export const hookData = new WeakMap<ListState<any>, HookData>();
 
 /**
  * Provides the behavior and accessibility implementation for a tag group component.
- * A tag group is a focusable list of labels, categories, keywords, or other items, with support for keyboard navigation and removal.
+ * A tag group is a focusable list of labels, categories, keywords, filters, or other items, with support for keyboard navigation, selection, and removal.
  * @param props - Props to be applied to the tag group.
  * @param state - State for the tag group, as returned by `useListState`.
  * @param ref - A ref to a DOM element for the tag group.
@@ -68,7 +68,10 @@ export function useTagGroup<T>(props: AriaTagGroupOptions<T>, state: ListState<T
     direction,
     disabledKeys: state.disabledKeys
   });
-  let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useField(props);
+  let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useField({
+    ...props,
+    labelElementType: 'span'
+  });
   let {gridProps} = useGridList({
     ...props,
     ...fieldProps,

--- a/packages/react-aria-components/docs/TagGroup.mdx
+++ b/packages/react-aria-components/docs/TagGroup.mdx
@@ -82,7 +82,7 @@ import {TagGroup, TagList, Tag, Label} from 'react-aria-components';
     border: 1px solid var(--spectrum-gray-600);;
     border-radius: 4px;
     padding: 2px 8px;
-    font-size: small;
+    font-size: 0.929rem;
     outline: none;
     cursor: default;
     display: flex;

--- a/packages/react-aria-components/docs/TagGroup.mdx
+++ b/packages/react-aria-components/docs/TagGroup.mdx
@@ -1,0 +1,491 @@
+{/* Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. */}
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:react-aria-components';
+import {PropTable, HeaderInfo, PageDescription, StateTable} from '@react-spectrum/docs';
+import styles from '@react-spectrum/docs/src/docs.css';
+import packageData from 'react-aria-components/package.json';
+import Anatomy from '@react-aria/tag/docs/anatomy.svg';
+import ChevronRight from '@spectrum-icons/workflow/ChevronRight';
+import {ExampleCard} from '@react-spectrum/docs/src/ExampleCard';
+import Button from '@react-spectrum/docs/pages/assets/component-illustrations/ActionButton.svg';
+import Label from '@react-spectrum/docs/pages/assets/component-illustrations/Label.svg';
+
+---
+category: Collections
+keywords: [tag, aria]
+type: component
+---
+
+# TagGroup
+
+<PageDescription>{docs.exports.TagGroup.description}</PageDescription>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['TagGroup', 'TagList', 'Tag']}
+   sourceData={[
+    {type: 'W3C', url: 'https://www.w3.org/WAI/ARIA/apg/patterns/grid/'}
+  ]} />
+
+## Example
+
+```tsx example
+import {TagGroup, TagList, Tag, Label} from 'react-aria-components';
+
+<TagGroup selectionMode="multiple">
+  <Label>Categories</Label>
+  <TagList>
+    <Tag>News</Tag>
+    <Tag>Travel</Tag>
+    <Tag>Gaming</Tag>
+    <Tag>Shopping</Tag>
+  </TagList>
+</TagGroup>
+```
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
+
+```css
+.react-aria-TagGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: small;
+
+  [slot=description] {
+    font-size: 12px;
+  }
+
+  [slot=errorMessage] {
+    font-size: 12px;
+    color: var(--spectrum-global-color-red-600);
+  }
+}
+
+.react-aria-TagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  .react-aria-Tag {
+    border: 1px solid var(--spectrum-gray-600);;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: small;
+    outline: none;
+    cursor: default;
+    display: flex;
+    align-items: center;
+    transition: border-color 200ms;
+
+    &[data-hovered] {
+      border-color: var(--spectrum-gray-900);
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid slateblue;
+      outline-offset: 2px;
+    }
+
+    &[aria-selected=true] {
+      border-color: var(--spectrum-gray-900);
+      background: var(--spectrum-gray-900);
+      color: var(--spectrum-gray-50);
+    }
+
+    &[aria-disabled] {
+      opacity: 0.4;
+    }
+
+    [slot=remove] {
+      background: none;
+      border: none;
+      padding: 0;
+      margin-left: 8px;
+      color: var(--spectrum-gray-700);
+      transition: color 200ms;
+      outline: none;
+      font-size: 0.95em;
+
+      &[data-hovered] {
+        color: var(--spectrum-gray-900);
+      }
+    }
+  }
+}
+```
+
+</details>
+
+## Features
+
+A static tag list can be built using [&lt;ul&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul) or [&lt;ol&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol) HTML elements, but does not support any user interactions.
+HTML lists are meant for static content, rather than lists with rich interactions such as keyboard navigation, item selection, removal, etc.
+`TagGroup` helps achieve accessible and interactive tag list components that can be styled as needed.
+
+* **Keyboard navigation** – Tags can be navigated using the arrow keys, along with page up/down, home/end, etc.
+* **Removable** – Tags can be removed from the tag group by clicking a remove button or pressing the backspace key.
+* **Item selection** – Single or multiple selection, with support for disabled items and both `toggle` and `replace` selection behaviors.
+* **Accessible** – Follows the [ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/), with additional selection announcements via an ARIA live region. Extensively tested across many devices and [assistive technologies](accessibility.html#testing) to ensure announcements and behaviors are consistent.
+* **Styleable** – Items include builtin states for styling, such as hover, press, focus, selected, and disabled.
+
+## Anatomy
+
+<Anatomy />
+
+A tag group consists of label and a list of tags. Each tag should include a visual label, and may optionally include a remove button. If a visual label is not included in a tag group, then an `aria-label` or `aria-labelledby` prop must be passed to identify it to assistive technology.
+
+`TagGroup` also supports optional description and error message slots, which can be used
+to provide more context about the tag group, and any validation messages. These are linked with the
+tag group via the `aria-describedby` attribute.
+
+### Concepts
+
+`TagGroup` makes use of the following concepts:
+
+* [Collections](../react-stately/Collections.html)
+* [Selection](../react-stately/Selection.html)
+
+### Composed components
+
+A `TagGroup` uses the following components, which may also be used standalone or reused in other components.
+
+<section className={styles.cardGroup} data-size="small">
+
+<ExampleCard
+  url="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label"
+  title="Label"
+  description="A label provides context for an element.">
+  <Label />
+</ExampleCard>
+
+<ExampleCard
+  url="Button.html"
+  title="Button"
+  description="A button allows a user to perform an action.">
+  <Button />
+</ExampleCard>
+
+</section>
+
+## Props
+
+### TagGroup
+
+<PropTable component={docs.exports.TagGroup} links={docs.links} />
+
+### TagList
+
+A `<TagList>` is a list of tags within a `<TagGroup>`.
+
+<PropTable component={docs.exports.TagList} links={docs.links} />
+
+### Tag
+
+An `<Tag>` defines a single item within a `<TagList>`.
+
+<PropTable component={docs.exports.Tag} links={docs.links} />
+
+### Label
+
+A `<Label>` accepts all HTML attributes.
+
+### Text
+
+`<Text>` accepts all HTML attributes.
+
+## Styling
+
+React Aria components can be styled in many ways, including using CSS classes, inline styles, utility classes (e.g. Tailwind), CSS-in-JS (e.g. Styled Components), etc. By default, all components include a builtin `className` attribute which can be targeted using CSS selectors. These follow the `react-aria-ComponentName` naming convention.
+
+```css
+.react-aria-TagGroup {
+  /* ... */
+}
+```
+
+A custom `className` can also be specified on any component. This overrides the default `className` provided by React Aria with your own.
+
+```jsx
+<TagGroup className="my-tag-group">
+  {/* ... */}
+</TagGroup>
+```
+
+In addition, some components support multiple UI states (e.g. pressed, hovered, etc.). React Aria components expose states using DOM attributes, which you can target in CSS selectors. These are ARIA attributes wherever possible, or data attributes when a relevant ARIA attribute does not exist. For example:
+
+```css
+.react-aria-Tag[aria-selected=true] {
+  /* ... */
+}
+
+.react-aria-Tag[data-focused] {
+  /* ... */
+}
+```
+
+The `className` and `style` props also accept functions which receive states for styling. This lets you dynamically determine the classes or styles to apply, which is useful when using utility CSS libraries like [Tailwind](https://tailwindcss.com/).
+
+```jsx
+<Tag className={({isSelected}) => isSelected ? 'bg-blue-400' : 'bg-gray-100'}>
+  Item
+</Tag>
+```
+
+Render props may also be used as children to alter what elements are rendered based on the current state. For example, you could render a remove button only when removal is allowed.
+
+```jsx
+<Tag>
+  {({allowsRemoving}) => (
+    <>
+      Item
+      {allowsRemoving && <RemoveButton />}
+    </>
+  )}
+</Tag>
+```
+
+The states and selectors for each component used in a `TagGroup` are documented below.
+
+### TagGroup
+
+A `TagGroup` can be targeted with the `.react-aria-TagGroup` CSS selector, or by overriding with a custom `className`.
+
+### TagList
+
+A `TagList` can be targeted with the `.react-aria-TagList` CSS selector, or by overriding with a custom `className`.
+
+### Tag
+
+A `Tag` can be targeted with the `.react-aria-Tag` CSS selector, or by overriding with a custom `className`. It supports the following states and render props:
+
+<StateTable properties={docs.exports.TagRenderProps.properties} />
+
+Tags also accept a `<Button slot="remove">` element as a child, which allows them to be removed. This can be conditionally rendered using the `allowsRemoving` render prop, as shown below.
+
+### Label
+
+A `Label` can be targeted with the `.react-aria-Label` CSS selector, or by overriding with a custom `className`.
+
+### Text
+
+The help text elements within a `TagGroup` can be targeted with the `[slot=description]` and `[slot=errorMessage]` CSS selectors, or by adding a custom `className`.
+
+## Reusable wrappers
+
+If you will use a TagGroup in multiple places in your app, you can wrap all of the pieces into a reusable component. This way, the DOM structure, styling code, and other logic are defined in a single place and reused everywhere to ensure consistency.
+
+This example wraps `TagGroup` and all of its children together into a single component which accepts a `label` prop and `children`, which are passed through to the right places. It also shows how to use the `description` and `errorMessage` slots to render help text ([see below for details](#description)). The `Tag` component is also wrapped to automatically render a remove button when the `onRemove` prop is provided to the TagGroup.
+
+```tsx example export=true
+import type {TagGroupProps, TagListProps, TagProps} from 'react-aria-components';
+import {Button, Text} from 'react-aria-components';
+
+interface MyTagGroupProps<T> extends Omit<TagGroupProps, 'children'>, Pick<TagListProps<T>, 'items' | 'children' | 'renderEmptyState'> {
+  label?: string,
+  description?: string,
+  errorMessage?: string
+}
+
+function MyTagGroup<T extends object>({label, description, errorMessage, items, children, renderEmptyState, ...props}: MyTagGroupProps<T>) {
+  return (
+    <TagGroup {...props}>
+      <Label>{label}</Label>
+      <TagList items={items} renderEmptyState={renderEmptyState}>
+        {children}
+      </TagList>
+      {description && <Text slot="description">{description}</Text>}
+      {errorMessage && <Text slot="errorMessage">{errorMessage}</Text>}
+    </TagGroup>
+  );
+}
+
+function MyTag(props: TagProps) {
+  return (
+    <Tag {...props}>
+      {({allowsRemoving}) => (<>
+        {props.children}
+        {allowsRemoving && <Button slot="remove">ⓧ</Button>}
+      </>)}
+    </Tag>
+  );
+}
+
+<MyTagGroup label="Ice cream flavor" selectionMode="single">
+  <MyTag>Chocolate</MyTag>
+  <MyTag>Mint</MyTag>
+  <MyTag>Strawberry</MyTag>
+  <MyTag>Vanilla</MyTag>
+</MyTagGroup>
+```
+
+## Usage
+
+### Remove tags
+
+The `onRemove` prop can be used to allow the user to remove tags. In the above example, an additional `<Button slot="remove>` element is rendered when a tag group allows removing. The user can also press the backspace key while a tag is focused to remove the tag from the group. Additionally, when [selection](#selection) is enabled, all selected items will be deleted when pressing the backspace key on a selected tag.
+
+```tsx example
+import {useListData} from '@react-stately/data';
+
+function Example() {
+  let list = useListData({
+    initialItems: [
+      { id: 1, name: "News" },
+      { id: 2, name: "Travel" },
+      { id: 3, name: "Gaming" },
+      { id: 4, name: "Shopping" }
+    ]
+  });
+
+  return (
+    <MyTagGroup
+      label="Categories"
+      items={list.items}
+      ///- begin highlight -///
+      onRemove={keys => list.remove(...keys)}
+      ///- end highlight -///
+    >
+      {(item) => <MyTag>{item.name}</MyTag>}
+    </MyTagGroup>
+  );
+}
+```
+
+### Selection
+
+ TagGroup supports multiple selection modes. By default, selection is disabled, however this can be changed using the `selectionMode` prop.
+ Use `defaultSelectedKeys` to provide a default set of selected items (uncontrolled) and `selectedKeys` to set the selected items (controlled). The value of the selected keys must match the `id` prop of the items.
+ See the `react-stately` [Selection docs](../react-stately/selection.html) for more details.
+
+ ```tsx example
+ import type {Selection} from 'react-aria-components';
+
+ function Example() {
+   let [selected, setSelected] = React.useState<Selection>(new Set(['parking']));
+
+   return (
+     <>
+       <MyTagGroup
+         label="Amenities"
+         ///- begin highlight -///
+         selectionMode="multiple"
+         selectedKeys={selected}
+         onSelectionChange={setSelected}
+         ///- end highlight -///
+       >
+         <MyTag id="laundry">Laundry</MyTag>
+         <MyTag id="fitness">Fitness center</MyTag>
+         <MyTag id="parking">Parking</MyTag>
+         <MyTag id="pool">Swimming pool</MyTag>
+         <MyTag id="breakfast">Breakfast</MyTag>
+       </MyTagGroup>
+       <p>Current selection (controlled): {selected === 'all' ? 'all' : [...selected].join(', ')}</p>
+     </>
+   );
+ }
+ ```
+
+ ### Disabled tags
+
+ TagGroup supports marking items as disabled using the `disabledKeys` prop. Each key in this list
+ corresponds with the `id` prop passed to the `Tag` component, or automatically derived from the values passed
+ to the `items` prop. Disabled items are not focusable, selectable, or keyboard navigable.
+ See [Collections](../react-stately/collections.html) for more details.
+
+ ```tsx example
+ <MyTagGroup
+   label="Sandwich contents"
+   selectionMode="multiple"
+   ///- begin highlight -///
+   disabledKeys={['tuna']}
+   ///- end highlight -///
+ >
+   <MyTag id="lettuce">Lettuce</MyTag>
+   <MyTag id="tomato">Tomato</MyTag>
+   <MyTag id="cheese">Cheese</MyTag>
+   <MyTag id="tuna">Tuna Salad</MyTag>
+   <MyTag id="egg">Egg Salad</MyTag>
+   <MyTag id="ham">Ham</MyTag>
+ </MyTagGroup>
+ ```
+
+ ### Empty state
+
+Use the `renderEmptyState` prop to customize what a `TagList` will display if there are no items.
+
+```tsx example
+<TagGroup>
+  <Label>Categories</Label>
+  {/*- begin highlight -*/}
+  <TagList renderEmptyState={() => 'No categories.'}>
+  {/*- end highlight -*/}
+    {[]}
+  </TagList>
+</TagGroup>
+```
+
+### Description
+
+The `description` slot can be used to associate additional help text with a `TagGroup`.
+
+```tsx example
+<TagGroup>
+  <Label>Categories</Label>
+  <TagList>
+    <Tag>News</Tag>
+    <Tag>Travel</Tag>
+    <Tag>Gaming</Tag>
+    <Tag>Shopping</Tag>
+  </TagList>
+  {/*- begin highlight -*/}
+  <Text slot="description">Your selected categories.</Text>
+  {/*- end highlight -*/}
+</TagGroup>
+```
+
+### Error message
+
+The `errorMessage` slot can be used to help the user fix a validation error.
+
+```tsx example
+<TagGroup>
+  <Label>Categories</Label>
+  <TagList>
+    <Tag>News</Tag>
+    <Tag>Travel</Tag>
+    <Tag>Gaming</Tag>
+    <Tag>Shopping</Tag>
+  </TagList>
+  {/*- begin highlight -*/}
+  <Text slot="errorMessage">Invalid set of categories.</Text>
+  {/*- end highlight -*/}
+</TagGroup>
+```
+
+## Advanced customization
+
+### Composition
+
+If you need to customize one of the components within a `TagGroup`, such as `TagList` or `Tag`, in many cases you can create a wrapper component. This lets you customize the props passed to the component.
+
+```tsx
+function MyTag(props) {
+  return <Tag {...props} className="my-tag" />
+}
+```
+
+### Hooks
+
+If you need to customize things even further, such as accessing internal state or customizing DOM structure, you can drop down to the lower level Hook-based API. See [useTagGroup](useTagGroup.html) for more details.

--- a/packages/react-aria-components/docs/TagGroup.mdx
+++ b/packages/react-aria-components/docs/TagGroup.mdx
@@ -193,7 +193,7 @@ A `<TagList>` is a list of tags within a `<TagGroup>`.
 
 ### Tag
 
-An `<Tag>` defines a single item within a `<TagList>`.
+An `<Tag>` defines a single item within a `<TagList>`. If the children are not plain text, then the `textValue` prop must also be set to a plain text representation for accessibility.
 
 <PropTable component={docs.exports.Tag} links={docs.links} />
 
@@ -311,11 +311,12 @@ function MyTagGroup<T extends object>({label, description, errorMessage, items, 
   );
 }
 
-function MyTag(props: TagProps) {
+function MyTag({children, ...props}: TagProps) {
+  let textValue = typeof children === 'string' ? children : undefined;
   return (
-    <Tag {...props}>
+    <Tag textValue={textValue} {...props}>
       {({allowsRemoving}) => (<>
-        {props.children}
+        {children}
         {allowsRemoving && <Button slot="remove">ⓧ</Button>}
       </>)}
     </Tag>

--- a/packages/react-aria-components/docs/react-aria-components.mdx
+++ b/packages/react-aria-components/docs/react-aria-components.mdx
@@ -44,6 +44,7 @@ import DateField from '@react-spectrum/docs/pages/assets/component-illustrations
 import TimeField from '@react-spectrum/docs/pages/assets/component-illustrations/TimeField.svg';
 import DatePicker from '@react-spectrum/docs/pages/assets/component-illustrations/DatePicker.svg';
 import DateRangePicker from '@react-spectrum/docs/pages/assets/component-illustrations/DateRangePicker.svg';
+import TagGroup from '@react-spectrum/docs/pages/assets/component-illustrations/TagGroup.svg';
 
 ---
 category: Concepts
@@ -494,6 +495,13 @@ The documentation for each component includes many examples styled using vanilla
   title="Table"
   description="A table displays data in rows and columns, with row selection and sorting.">
   <Table />
+</ExampleCard>
+
+<ExampleCard
+  url="TagGroup.html"
+  title="TagGroup"
+  description="A tag group displays a list of items, with support for keyboard navigation, selection, and removal.">
+  <TagGroup />
 </ExampleCard>
 
 </section>

--- a/packages/react-aria-components/src/TagGroup.tsx
+++ b/packages/react-aria-components/src/TagGroup.tsx
@@ -17,7 +17,7 @@ import {ContextValue, DOMProps, forwardRefType, Provider, RenderProps, SlotProps
 import {filterDOMProps, mergeProps, mergeRefs, useObjectRef} from '@react-aria/utils';
 import {LabelContext} from './Label';
 import {ListState, Node, useListState} from 'react-stately';
-import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, Key, ReactNode, RefObject, useContext, useRef} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, Key, ReactNode, RefObject, useContext, useEffect, useRef} from 'react';
 import {TextContext} from './Text';
 
 export interface TagGroupProps extends Omit<AriaTagGroupProps<unknown>, 'children' | 'items' | 'label' | 'description' | 'errorMessage' | 'keyboardDelegate'>, DOMProps, SlotProps {}
@@ -171,7 +171,13 @@ export interface TagRenderProps extends Omit<ItemRenderProps, 'allowsDragging' |
 }
 
 export interface TagProps extends RenderProps<TagRenderProps> {
-  id?: Key
+  /** A unique id for the tag. */
+  id?: Key,
+  /**
+   * A string representation of the tags's contents, used for accessibility.
+   * Required if children is not a plain text string.
+   */
+  textValue?: string
 }
 
 function Tag(props: TagProps, ref: ForwardedRef<HTMLDivElement>) {
@@ -209,6 +215,12 @@ function TagItem({item}) {
       selectionBehavior: state.selectionManager.selectionBehavior
     }
   });
+
+  useEffect(() => {
+    if (!item.textValue) {
+      console.warn('A `textValue` prop is required for <Tag> elements with non-plain text children for accessibility.');
+    }
+  }, [item.textValue]);
 
   return (
     <div

--- a/packages/react-aria-components/src/TagGroup.tsx
+++ b/packages/react-aria-components/src/TagGroup.tsx
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {AriaTagGroupProps, useFocusRing, useHover, useTag, useTagGroup} from 'react-aria';
+import {BaseCollection, CollectionProps, Document, Item, ItemProps, ItemRenderProps, useCachedChildren, useCollectionDocument, useCollectionPortal} from './Collection';
+import {ButtonContext} from './Button';
+import {ContextValue, DOMProps, forwardRefType, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
+import {filterDOMProps, mergeProps, mergeRefs, useObjectRef} from '@react-aria/utils';
+import {LabelContext} from './Label';
+import {ListState, Node, useListState} from 'react-stately';
+import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, Key, ReactNode, RefObject, useContext, useRef} from 'react';
+import {TextContext} from './Text';
+
+export interface TagGroupProps extends Omit<AriaTagGroupProps<unknown>, 'children' | 'items' | 'label' | 'description' | 'errorMessage' | 'keyboardDelegate'>, DOMProps, SlotProps {}
+
+export interface TagListRenderProps {
+  /**
+   * Whether the tag list has no items and should display its empty state.
+   * @selector [data-empty]
+   */
+  isEmpty: boolean,
+  /**
+   * Whether the tag list is currently focused.
+   * @selector [data-focused]
+   */
+  isFocused: boolean,
+  /**
+   * Whether the tag list is currently keyboard focused.
+   * @selector [data-focus-visible]
+   */
+  isFocusVisible: boolean
+}
+
+export interface TagListProps<T> extends Omit<CollectionProps<T>, 'disabledKeys'>, StyleRenderProps<TagListRenderProps> {
+  /** Provides content to display when there are no items in the tag list. */
+  renderEmptyState?: () => ReactNode
+}
+
+interface InternalTagGroupContextValue {
+  state: ListState<any>,
+  document: Document<any, BaseCollection<any>>,
+  gridProps: HTMLAttributes<HTMLElement>,
+  tagListRef: RefObject<HTMLDivElement>
+}
+
+export const TagGroupContext = createContext<ContextValue<TagGroupProps, HTMLDivElement>>(null);
+const InternalTagGroupContext = createContext<InternalTagGroupContextValue | null>(null);
+
+function TagGroup(props: TagGroupProps, ref: ForwardedRef<HTMLDivElement>) {
+  [props, ref] = useContextProps(props, ref, TagGroupContext);
+  let tagListRef = useRef<HTMLDivElement>(null);
+  let [labelRef, label] = useSlot();
+  let {collection, document} = useCollectionDocument();
+  let state = useListState({
+    ...props,
+    children: undefined,
+    collection
+  });
+
+  // Prevent DOM props from going to two places.
+  let domProps = filterDOMProps(props);
+  let domPropOverrides = Object.fromEntries(Object.entries(domProps).map(([k]) => [k, undefined]));
+  let {
+    gridProps,
+    labelProps,
+    descriptionProps,
+    errorMessageProps
+  } = useTagGroup({
+    ...props,
+    ...domPropOverrides,
+    label
+  }, state, tagListRef);
+
+  return (
+    <div
+      {...domProps}
+      ref={ref}
+      slot={props.slot}
+      className={props.className ?? 'react-aria-TagGroup'}
+      style={props.style}>
+      <Provider
+        values={[
+          [LabelContext, {...labelProps, elementType: 'span', ref: labelRef}],
+          [InternalTagGroupContext, {state, document, gridProps, tagListRef}],
+          [TextContext, {
+            slots: {
+              description: descriptionProps,
+              errorMessage: errorMessageProps
+            }
+          }]
+        ]}>
+        {props.children}
+      </Provider>
+    </div>
+  );
+}
+
+/**
+ * A tag group is a focusable list of labels, categories, keywords, filters, or other items, with support for keyboard navigation, selection, and removal.
+ */
+const _TagGroup = /*#__PURE__*/ (forwardRef as forwardRefType)(TagGroup);
+export {_TagGroup as TagGroup};
+
+function TagList<T extends object>(props: TagListProps<T>, forwardedRef: ForwardedRef<HTMLDivElement>) {
+  let {state, document, gridProps, tagListRef} = useContext(InternalTagGroupContext)!;
+  let portal = useCollectionPortal(props, document);
+  let ref = mergeRefs(tagListRef, forwardedRef);
+
+  let children = useCachedChildren({
+    items: state.collection,
+    children: (item: Node<T>) => {
+      switch (item.type) {
+        case 'item':
+          return <TagItem item={item} />;
+        default:
+          throw new Error('Unsupported node type in TagList: ' + item.type);
+      }
+    }
+  });
+
+  let {focusProps, isFocused, isFocusVisible} = useFocusRing();
+  let renderProps = useRenderProps({
+    className: props.className,
+    style: props.style,
+    defaultClassName: 'react-aria-TagList',
+    values: {
+      isEmpty: state.collection.size === 0,
+      isFocused,
+      isFocusVisible
+    }
+  });
+
+  return (
+    <>
+      <div
+        {...mergeProps(gridProps, focusProps)}
+        {...renderProps}
+        {...filterDOMProps(props as any)}
+        ref={ref}
+        data-empty={state.collection.size === 0 || undefined}
+        data-focused={isFocused || undefined}
+        data-focus-visible={isFocusVisible || undefined}>
+        {state.collection.size === 0 && props.renderEmptyState ? props.renderEmptyState() : children}
+      </div>
+      {portal}
+    </>
+  );
+}
+
+/**
+ * A tag list is a container for tags within a TagGroup.
+ */
+const _TagList = /*#__PURE__*/ (forwardRef as forwardRefType)(TagList);
+export {_TagList as TagList};
+
+export interface TagRenderProps extends Omit<ItemRenderProps, 'allowsDragging' | 'isDragging' | 'isDropTarget'> {
+  /**
+   * Whether the tag group allows items to be removed.
+   * @selector [data-allows-removing]
+   */
+  allowsRemoving: boolean
+}
+
+export interface TagProps extends RenderProps<TagRenderProps> {
+  id?: Key
+}
+
+function Tag(props: TagProps, ref: ForwardedRef<HTMLDivElement>) {
+  // @ts-ignore
+  return <Item {...props} ref={ref} />;
+}
+
+/**
+ * A Tag is an individual item within a TagList.
+ */
+const _Tag = /*#__PURE__*/ (forwardRef as forwardRefType)(Tag);
+export {_Tag as Tag};
+
+function TagItem({item}) {
+  let {state} = useContext(InternalTagGroupContext)!;
+  let ref = useObjectRef<HTMLDivElement>(item.props.ref);
+  let {focusProps, isFocusVisible} = useFocusRing({within: true});
+  let {rowProps, gridCellProps, removeButtonProps, ...states} = useTag({item}, state, ref);
+
+  let {hoverProps, isHovered} = useHover({
+    isDisabled: !states.allowsSelection
+  });
+
+  let props: ItemProps<unknown> = item.props;
+  let renderProps = useRenderProps({
+    ...props,
+    id: undefined,
+    children: item.rendered,
+    defaultClassName: 'react-aria-Tag',
+    values: {
+      ...states,
+      isFocusVisible,
+      isHovered,
+      selectionMode: state.selectionManager.selectionMode,
+      selectionBehavior: state.selectionManager.selectionBehavior
+    }
+  });
+
+  return (
+    <div
+      ref={ref}
+      {...renderProps}
+      {...mergeProps(filterDOMProps(props as any), rowProps, focusProps, hoverProps)}
+      data-hovered={isHovered || undefined}
+      data-focused={states.isFocused || undefined}
+      data-focus-visible={isFocusVisible || undefined}
+      data-pressed={states.isPressed || undefined}
+      data-allows-removing={states.allowsRemoving || undefined}>
+      <div {...gridCellProps}>
+        <Provider
+          values={[
+            [ButtonContext, {
+              slots: {
+                remove: removeButtonProps
+              }
+            }]
+          ]}>
+          {renderProps.children}
+        </Provider>
+      </div>
+    </div>
+  );
+}

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -44,6 +44,7 @@ export {Slider, SliderOutput, SliderTrack, SliderThumb, SliderContext} from './S
 export {Switch, SwitchContext} from './Switch';
 export {Table, Row, Cell, Column, TableHeader, TableBody, TableContext, useTableOptions} from './Table';
 export {Tabs, TabList, TabPanel, Tab, TabsContext} from './Tabs';
+export {TagGroup, TagGroupContext, TagList, Tag} from './TagGroup';
 export {Text, TextContext} from './Text';
 export {TextField, TextFieldContext} from './TextField';
 export {ToggleButton, ToggleButtonContext} from './ToggleButton';
@@ -83,6 +84,7 @@ export type {SliderOutputProps, SliderProps, SliderRenderProps, SliderThumbProps
 export type {SwitchProps, SwitchRenderProps} from './Switch';
 export type {TableProps, TableRenderProps, TableHeaderProps, TableBodyProps, ColumnProps, ColumnRenderProps, RowProps, RowRenderProps, CellProps, CellRenderProps} from './Table';
 export type {TabListProps, TabListRenderProps, TabPanelProps, TabPanelRenderProps, TabProps, TabsProps, TabRenderProps, TabsRenderProps} from './Tabs';
+export type {TagGroupProps, TagListProps, TagListRenderProps, TagProps, TagRenderProps} from './TagGroup';
 export type {TextFieldProps} from './TextField';
 export type {TextProps} from './Text';
 export type {ToggleButtonProps, ToggleButtonRenderProps} from './ToggleButton';

--- a/packages/react-aria-components/test/TagGroup.test.js
+++ b/packages/react-aria-components/test/TagGroup.test.js
@@ -29,7 +29,7 @@ let TestTagGroup = ({tagGroupProps, tagListProps, itemProps}) => (
 );
 
 let RemovableTag = (props) => (
-  <Tag {...props}>
+  <Tag textValue={props.children} {...props}>
     {({allowsRemoving}) => (
       <>
         {props.children}

--- a/packages/react-aria-components/test/TagGroup.test.js
+++ b/packages/react-aria-components/test/TagGroup.test.js
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Button, Label, Tag, TagGroup, TagList, Text} from '../';
+import {fireEvent, render} from '@react-spectrum/test-utils';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+let TestTagGroup = ({tagGroupProps, tagListProps, itemProps}) => (
+  <TagGroup data-testid="group" {...tagGroupProps}>
+    <Label>Test</Label>
+    <TagList {...tagListProps}>
+      <RemovableTag {...itemProps} id="cat">Cat</RemovableTag>
+      <RemovableTag {...itemProps} id="dog">Dog</RemovableTag>
+      <RemovableTag {...itemProps} id="kangaroo">Kangaroo</RemovableTag>
+    </TagList>
+    <Text slot="description">Description</Text>
+    <Text slot="errorMessage">Error</Text>
+  </TagGroup>
+);
+
+let RemovableTag = (props) => (
+  <Tag {...props}>
+    {({allowsRemoving}) => (
+      <>
+        {props.children}
+        {allowsRemoving && <Button slot="remove">x</Button>}
+      </>
+    )}
+  </Tag>
+);
+
+let renderTagGroup = (tagGroupProps, tagListProps, itemProps) => render(<TestTagGroup {...{tagGroupProps, tagListProps, itemProps}} />);
+
+describe('TagGroup', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  it('should render with default classes', () => {
+    let {getByRole, getAllByRole, getByTestId} = renderTagGroup();
+    let group = getByTestId('group');
+    let grid = getByRole('grid');
+    expect(group).toHaveAttribute('class', 'react-aria-TagGroup');
+    expect(grid).toHaveAttribute('class', 'react-aria-TagList');
+
+    for (let row of getAllByRole('row')) {
+      expect(row).toHaveAttribute('class', 'react-aria-Tag');
+    }
+  });
+
+  it('should render with custom classes', () => {
+    let {getByRole, getAllByRole, getByTestId} = renderTagGroup({className: 'taggroup'}, {className: 'taglist'}, {className: 'item'});
+    let group = getByTestId('group');
+    let grid = getByRole('grid');
+    expect(group).toHaveAttribute('class', 'taggroup');
+    expect(grid).toHaveAttribute('class', 'taglist');
+
+    for (let row of getAllByRole('row')) {
+      expect(row).toHaveAttribute('class', 'item');
+    }
+  });
+
+  it('should support DOM props', () => {
+    let {getByRole, getAllByRole, getByTestId} = renderTagGroup({'data-foo': 'bar'}, {'data-baz': 'baz'}, {'data-bar': 'foo'});
+    let group = getByTestId('group');
+    let grid = getByRole('grid');
+    expect(group).toHaveAttribute('data-foo', 'bar');
+    expect(grid).toHaveAttribute('data-baz', 'baz');
+
+    for (let row of getAllByRole('row')) {
+      expect(row).toHaveAttribute('data-bar', 'foo');
+    }
+  });
+
+  it('should support refs', () => {
+    let tagGroupRef = React.createRef();
+    let tagListRef = React.createRef();
+    let itemRef = React.createRef();
+    render(
+      <TagGroup aria-label="Test" ref={tagGroupRef}>
+        <TagList ref={tagListRef}>
+          <Tag ref={itemRef}>Cat</Tag>
+        </TagList>
+      </TagGroup>
+    );
+    expect(tagGroupRef.current).toBeInstanceOf(HTMLElement);
+    expect(tagListRef.current).toBeInstanceOf(HTMLElement);
+    expect(itemRef.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it('provides slots for description and error message', () => {
+    let {getByRole} = renderTagGroup();
+
+    let grid = getByRole('grid');
+    expect(grid).toHaveAttribute('aria-labelledby');
+    let label = document.getElementById(grid.getAttribute('aria-labelledby'));
+    expect(label).toHaveAttribute('class', 'react-aria-Label');
+    expect(label).toHaveTextContent('Test');
+
+    expect(grid).toHaveAttribute('aria-describedby');
+    expect(grid.getAttribute('aria-describedby').split(' ').map(id => document.getElementById(id).textContent).join(' ')).toBe('Description Error');
+  });
+
+  it('should support hover', () => {
+    let {getAllByRole} = renderTagGroup({selectionMode: 'multiple'}, {}, {className: ({isHovered}) => isHovered ? 'hover' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).not.toHaveAttribute('data-hovered');
+    expect(row).not.toHaveClass('hover');
+
+    userEvent.hover(row);
+    expect(row).toHaveAttribute('data-hovered', 'true');
+    expect(row).toHaveClass('hover');
+
+    userEvent.unhover(row);
+    expect(row).not.toHaveAttribute('data-hovered');
+    expect(row).not.toHaveClass('hover');
+  });
+
+  it('should not show hover state when item is not interactive', () => {
+    let {getAllByRole} = renderTagGroup({}, {}, {className: ({isHovered}) => isHovered ? 'hover' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).not.toHaveAttribute('data-hovered');
+    expect(row).not.toHaveClass('hover');
+
+    userEvent.hover(row);
+    expect(row).not.toHaveAttribute('data-hovered');
+    expect(row).not.toHaveClass('hover');
+  });
+
+  it('should support focus ring', () => {
+    let {getAllByRole} = renderTagGroup({selectionMode: 'multiple'}, {}, {className: ({isFocusVisible}) => isFocusVisible ? 'focus' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).not.toHaveAttribute('data-focus-visible');
+    expect(row).not.toHaveClass('focus');
+
+    userEvent.tab();
+    expect(document.activeElement).toBe(row);
+    expect(row).toHaveAttribute('data-focus-visible', 'true');
+    expect(row).toHaveClass('focus');
+
+    fireEvent.keyDown(row, {key: 'ArrowDown'});
+    fireEvent.keyUp(row, {key: 'ArrowDown'});
+    expect(row).not.toHaveAttribute('data-focus-visible');
+    expect(row).not.toHaveClass('focus');
+  });
+
+  it('should support press state', () => {
+    let {getAllByRole} = renderTagGroup({selectionMode: 'multiple'}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).not.toHaveAttribute('data-pressed');
+    expect(row).not.toHaveClass('pressed');
+
+    fireEvent.mouseDown(row);
+    expect(row).toHaveAttribute('data-pressed', 'true');
+    expect(row).toHaveClass('pressed');
+
+    fireEvent.mouseUp(row);
+    expect(row).not.toHaveAttribute('data-pressed');
+    expect(row).not.toHaveClass('pressed');
+  });
+
+  it('should not show press state when not interactive', () => {
+    let {getAllByRole} = renderTagGroup({}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).not.toHaveAttribute('data-pressed');
+    expect(row).not.toHaveClass('pressed');
+
+    fireEvent.mouseDown(row);
+    expect(row).not.toHaveAttribute('data-pressed');
+    expect(row).not.toHaveClass('pressed');
+
+    fireEvent.mouseUp(row);
+    expect(row).not.toHaveAttribute('data-pressed');
+    expect(row).not.toHaveClass('pressed');
+  });
+
+  it('should support selection state', () => {
+    let {getAllByRole} = renderTagGroup({selectionMode: 'multiple'}, {}, {className: ({isSelected}) => isSelected ? 'selected' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).not.toHaveAttribute('aria-selected', 'true');
+    expect(row).not.toHaveClass('selected');
+
+    userEvent.click(row);
+    expect(row).toHaveAttribute('aria-selected', 'true');
+    expect(row).toHaveClass('selected');
+
+    userEvent.click(row);
+    expect(row).not.toHaveAttribute('aria-selected', 'true');
+    expect(row).not.toHaveClass('selected');
+  });
+
+  it('should support disabled state', () => {
+    let {getAllByRole} = renderTagGroup({selectionMode: 'multiple', disabledKeys: ['cat']}, {}, {className: ({isDisabled}) => isDisabled ? 'disabled' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).toHaveAttribute('aria-disabled', 'true');
+    expect(row).toHaveClass('disabled');
+  });
+
+  it('should support removing items', () => {
+    let onRemove = jest.fn();
+    let {getAllByRole} = renderTagGroup({onRemove}, {}, {className: ({allowsRemoving}) => allowsRemoving ? 'removable' : ''});
+    let row = getAllByRole('row')[0];
+
+    expect(row).toHaveAttribute('data-allows-removing', 'true');
+    expect(row).toHaveClass('removable');
+
+    let button = getAllByRole('button')[0];
+    expect(button).toHaveAttribute('aria-label', 'Remove');
+    userEvent.click(button);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support empty state', () => {
+    let {getByTestId} = render(
+      <TagGroup data-testid="group">
+        <Label>Test</Label>
+        <TagList data-testid="list" renderEmptyState={() => 'No results'}>
+          {[]}
+        </TagList>
+      </TagGroup>
+    );
+    let grid = getByTestId('list');
+    expect(grid).toHaveAttribute('data-empty', 'true');
+    expect(grid).toHaveTextContent('No results');
+  });
+});


### PR DESCRIPTION
This adds `TagGroup` to React Aria Components. The API looks like this:

```jsx
<TagGroup selectionMode="multiple">
  <Label>Categories</Label>
  <TagList>
    <Tag>News</Tag>
    <Tag>Travel</Tag>
    <Tag>Gaming</Tag>
    <Tag>Shopping</Tag>
  </TagList>
</TagGroup>
```

We use a separate `Tag` component rather than `Item` here due to the additional `allowsRemoving` render prop. A remove button can be added with `<Button slot="remove">` (slot prop just in case there are other buttons).