### PR TITLE
WIP Preventing an exception in FocusScope

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -451,7 +451,7 @@ function focusElement(element: FocusableElement | null, scroll = false) {
 
 let isScope = item => {
   return item.previousElementSibling != null && item.parentElement != null;
-}
+};
 
 function focusFirstInScope(scope: Element[], tabbable:boolean = true) {
   let newScope = [...scope];


### PR DESCRIPTION
Related to #3441 and #4149

Doesn't fix 3441, but does prevent an exception, but not happy about messing with the "scope".

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Do the steps to reproduce #3441 and there is no exception in the browser console anymore.

## 🧢 Your Project:
RSP