### PR TITLE
Adding invalid icon to RAC DatePicker and DateRangePicker

### DIFF
--- a/packages/react-aria-components/docs/DatePicker.mdx
+++ b/packages/react-aria-components/docs/DatePicker.mdx
@@ -113,6 +113,16 @@ import {DatePicker, Label, Group, Popover, Dialog, Calendar, CalendarGrid, Calen
     font-size: 12px;
     color: var(--text-color-invalid);
   }
+
+  &[data-validation-state=invalid] {
+    .react-aria-DateInput:after {
+      content: '🚫' / '';
+      content: '🚫';
+      alt: ' ';
+      flex: 1;
+      text-align: end;
+    }
+  }
 }
 
 .react-aria-DateInput {

--- a/packages/react-aria-components/docs/DateRangePicker.mdx
+++ b/packages/react-aria-components/docs/DateRangePicker.mdx
@@ -153,6 +153,17 @@ import {DateRangePicker, Label, Group, Popover, Dialog, RangeCalendar, CalendarG
     font-size: 12px;
     color: var(--text-color-invalid);
   }
+
+  &[data-validation-state=invalid] {
+    [slot=end]:after {
+      content: '🚫' / '';
+      content: '🚫';
+      alt: ' ';
+      flex: 1;
+      text-align: end;
+      margin-right: -2rem;
+    }
+  }
 }
 
 .react-aria-DateInput {

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -230,7 +230,13 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
           }
         }]
       ]}>
-      <div {...mergeProps(focusProps, hoverProps)} {...DOMProps} {...renderProps} ref={ref} slot={props.slot} />
+      <div
+        {...mergeProps(focusProps, hoverProps)}
+        {...DOMProps}
+        {...renderProps}
+        ref={ref}
+        slot={props.slot}
+        data-validation-state={state.validationState || undefined} /> />
     </Provider>
   );
 }

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -236,7 +236,7 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
         {...renderProps}
         ref={ref}
         slot={props.slot}
-        data-validation-state={state.validationState || undefined} /> />
+        data-validation-state={state.validationState || undefined} />
     </Provider>
   );
 }


### PR DESCRIPTION
It was a task from the project board.

Dependent on changes from #4616. Merging into that branch to show the changes.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Goto RAC DatePicker and DateRangePicker docs.
For the invalid and min/max examples, when the dates are invalid there is now a visual indicator (besides color).

## 🧢 Your Project:
RSP