### PR TITLE
rac dropzone fix file upload dialog

### DIFF
--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps} from '@react-types/shared';
-import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
+import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
 import {DropOptions, mergeProps, useClipboard, useDrop, useFocusRing, useHover, useId, VisuallyHidden} from 'react-aria';
 import {FileTriggerContext} from './FileTrigger';
 import {filterDOMProps, useLabels} from '@react-aria/utils';
@@ -40,7 +40,7 @@ export interface DropZoneRenderProps {
    */
   isDropTarget: boolean
 }
-// note: possibly add isDisabled prop in the future
+
 export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint'>, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps {}
 
 export const DropZoneContext = createContext<ContextValue<DropZoneProps, HTMLDivElement>>(null);
@@ -51,7 +51,10 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   let {dropProps, dropButtonProps, isDropTarget} = useDrop({...props, ref: buttonRef, hasDropButton: true});
   let {hoverProps, isHovered} = useHover({});
   let {focusProps, isFocused, isFocusVisible} = useFocusRing();
-  let [fileTriggerRef] = useSlot(); 
+
+  // about adding VO stuff to dropzone, we are able to read out the contents of the dropzone if they provide a <Text> 
+  // and say that there is not content in the dropzone, what will we read in that case? i think we'll need some default anyway
+  // and i guess that begs the question of whether we want to include a TextContext anyway? 
   
   let textId = useId();
   let labelProps = useLabels({'aria-labelledby': textId});
@@ -77,7 +80,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   return (
     <Provider
       values={[
-        [FileTriggerContext, {ref: fileTriggerRef}],
+        [FileTriggerContext, {}],
         [TextContext, {id: textId, slot: 'heading'}]
       ]}>
       {/* eslint-disable-next-line */}

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -51,10 +51,6 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   let {dropProps, dropButtonProps, isDropTarget} = useDrop({...props, ref: buttonRef, hasDropButton: true});
   let {hoverProps, isHovered} = useHover({});
   let {focusProps, isFocused, isFocusVisible} = useFocusRing();
-
-  // about adding VO stuff to dropzone, we are able to read out the contents of the dropzone if they provide a <Text> 
-  // and say that there is not content in the dropzone, what will we read in that case? i think we'll need some default anyway
-  // and i guess that begs the question of whether we want to include a TextContext anyway? 
   
   let textId = useId();
   let labelProps = useLabels({'aria-labelledby': textId});

--- a/packages/react-aria-components/src/FileTrigger.tsx
+++ b/packages/react-aria-components/src/FileTrigger.tsx
@@ -53,7 +53,8 @@ function FileTrigger(props: FileTriggerProps, ref: ForwardedRef<HTMLDivElement>)
       <PressResponder onPress={() => inputRef.current?.click()}>
         {children}
       </PressResponder>
-      <VisuallyHidden>
+      {/* so bc of this visually hidden, we are actually able to focus onn the input even tho it is hidden...is this what we want? */}
+      <VisuallyHidden> 
         <Input 
           type="file" 
           ref={inputRef} 

--- a/packages/react-aria-components/src/FileTrigger.tsx
+++ b/packages/react-aria-components/src/FileTrigger.tsx
@@ -16,7 +16,6 @@ import {filterDOMProps} from '@react-aria/utils';
 import {Input} from './Input';
 import {PressResponder} from '@react-aria/interactions';
 import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
-import {VisuallyHidden} from 'react-aria';
 
 export interface FileTriggerProps extends SlotProps, DOMProps, AriaLabelingProps {
   /**
@@ -53,16 +52,14 @@ function FileTrigger(props: FileTriggerProps, ref: ForwardedRef<HTMLDivElement>)
       <PressResponder onPress={() => inputRef.current?.click()}>
         {children}
       </PressResponder>
-      {/* so bc of this visually hidden, we are actually able to focus onn the input even tho it is hidden...is this what we want? */}
-      <VisuallyHidden> 
-        <Input 
-          type="file" 
-          ref={inputRef} 
-          accept={acceptedFileTypes?.toString()} 
-          onChange={(e) => onChange?.(e.target.files)} 
-          capture={defaultCamera} 
-          multiple={allowsMultiple} /> 
-      </VisuallyHidden>
+      <Input 
+        type="file" 
+        ref={inputRef}
+        style={{display: 'none'}}
+        accept={acceptedFileTypes?.toString()} 
+        onChange={(e) => onChange?.(e.target.files)} 
+        capture={defaultCamera} 
+        multiple={allowsMultiple} /> 
     </div>
   );
 }


### PR DESCRIPTION
Fixes file upload dialog that was found during testing. It should no longer tab through the input twice.

Also removes some comments and unused stuff

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test FileTrigger Button, FileTrigger Link

you should only be able to tab to either the button/link and not the input

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
