### PR TITLE
Rename MenuDialogTrigger

### DIFF
--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -103,7 +103,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
   } = props;
   let {direction} = useLocale();
 
-  let isMenuDialogTrigger = state.collection.getItem(key).hasChildNodes;
+  let isTrigger = !!hasPopup;
   let isOpen = state.expandedKeys.has(key);
 
   let isDisabled = props.isDisabled ?? state.disabledKeys.has(key);
@@ -133,7 +133,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
     // will need to disable this lint rule when using useEffectEvent https://react.dev/learn/separating-events-from-effects#logic-inside-effects-is-reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  let onAction = isMenuDialogTrigger ? onActionMenuDialogTrigger : props.onAction || data.onAction;
+  let onAction = isTrigger ? onActionMenuDialogTrigger : props.onAction || data.onAction;
 
   let role = 'menuitem';
   if (state.selectionManager.selectionMode === 'single') {
@@ -182,7 +182,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
 
       // Pressing a menu item should close by default in single selection mode but not multiple
       // selection mode, except if overridden by the closeOnSelect prop.
-      if (!isMenuDialogTrigger && onClose && (closeOnSelect ?? state.selectionManager.selectionMode !== 'multiple')) {
+      if (!isTrigger && onClose && (closeOnSelect ?? state.selectionManager.selectionMode !== 'multiple')) {
         onClose();
       }
     }
@@ -196,11 +196,11 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
     allowsDifferentPressOrigin: true
   });
 
-  let {pressProps, isPressed} = usePress({onPressStart, onPressUp, isDisabled: isDisabled || (isMenuDialogTrigger && state.expandedKeys.has(key))});
+  let {pressProps, isPressed} = usePress({onPressStart, onPressUp, isDisabled: isDisabled || (isTrigger && state.expandedKeys.has(key))});
   let {hoverProps} = useHover({
     isDisabled,
     onHoverStart() {
-      if (!isFocusVisible() && !(isMenuDialogTrigger && state.expandedKeys.has(key))) {
+      if (!isFocusVisible() && !(isTrigger && state.expandedKeys.has(key))) {
         state.selectionManager.setFocused(true);
         state.selectionManager.setFocusedKey(key);
         // focus immediately so that a focus scope opened on hover has the correct restore node
@@ -211,7 +211,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
       }
     },
     onHoverChange: isHovered => {
-      if (isHovered && isMenuDialogTrigger && !state.expandedKeys.has(key)) {
+      if (isHovered && isTrigger && !state.expandedKeys.has(key)) {
         if (!openTimeout.current) {
           openTimeout.current = setTimeout(() => {
             onSubmenuOpen();
@@ -234,25 +234,25 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
 
       switch (e.key) {
         case ' ':
-          if (!isDisabled && state.selectionManager.selectionMode === 'none' && !isMenuDialogTrigger && closeOnSelect !== false && onClose) {
+          if (!isDisabled && state.selectionManager.selectionMode === 'none' && !isTrigger && closeOnSelect !== false && onClose) {
             onClose();
           }
           break;
         case 'Enter':
           // The Enter key should always close on select, except if overridden.
-          if (!isDisabled && closeOnSelect !== false && !isMenuDialogTrigger && onClose) {
+          if (!isDisabled && closeOnSelect !== false && !isTrigger && onClose) {
             onClose();
           }
           break;
         case 'ArrowRight':
-          if (isMenuDialogTrigger && direction === 'ltr') {
+          if (isTrigger && direction === 'ltr') {
             onSubmenuOpen();
           } else {
             e.continuePropagation();
           }
           break;
         case 'ArrowLeft':
-          if (isMenuDialogTrigger && direction === 'rtl') {
+          if (isTrigger && direction === 'rtl') {
             onSubmenuOpen();
           } else {
             e.continuePropagation();

--- a/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
@@ -24,7 +24,7 @@ export interface SpectrumMenuDialogTriggerProps<T> extends ItemProps<T> {
   targetKey: Key
 }
 
-function MenuDialogTrigger<T>(props: SpectrumMenuDialogTriggerProps<T>): ReactElement {
+function ContextualHelpTrigger<T>(props: SpectrumMenuDialogTriggerProps<T>): ReactElement {
   let {isUnavailable} = props;
 
   let triggerRef = useRef<HTMLLIElement>(null);
@@ -99,20 +99,20 @@ function MenuDialogTrigger<T>(props: SpectrumMenuDialogTriggerProps<T>): ReactEl
   );
 }
 
-MenuDialogTrigger.getCollectionNode = function* getCollectionNode<T>(props: ItemProps<T>) {
+ContextualHelpTrigger.getCollectionNode = function* getCollectionNode<T>(props: ItemProps<T>) {
   let [trigger] = React.Children.toArray(props.children) as ReactElement[];
   let [, content] = props.children as [ReactElement, ReactElement];
 
   yield {
     element: React.cloneElement(trigger, {...trigger.props, hasChildItems: true}),
     wrapper: (element) => (
-      <MenuDialogTrigger key={element.key} targetKey={element.key} {...props}>
+      <ContextualHelpTrigger key={element.key} targetKey={element.key} {...props}>
         {element}
         {content}
-      </MenuDialogTrigger>
+      </ContextualHelpTrigger>
     )
   };
 };
 
-let _Item = MenuDialogTrigger as <T>(props: ItemProps<T> & {isUnavailable?: boolean}) => JSX.Element;
-export {_Item as MenuDialogTrigger};
+let _Item = ContextualHelpTrigger as <T>(props: ItemProps<T> & {isUnavailable?: boolean}) => JSX.Element;
+export {_Item as ContextualHelpTrigger};

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -85,7 +85,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
       closeOnSelect,
       isVirtualized,
       onAction,
-      'aria-haspopup': isMenuDialogTrigger ? 'dialog' : undefined
+      'aria-haspopup': isMenuDialogTrigger && isUnavailable ? 'dialog' : undefined
     },
     state,
     ref

--- a/packages/@react-spectrum/menu/src/index.ts
+++ b/packages/@react-spectrum/menu/src/index.ts
@@ -15,7 +15,7 @@
 export {MenuTrigger} from './MenuTrigger';
 export {Menu} from './Menu';
 export {ActionMenu} from './ActionMenu';
-export {MenuDialogTrigger} from './MenuDialogTrigger';
+export {ContextualHelpTrigger} from './ContextualHelpTrigger';
 export {Item, Section} from '@react-stately/collections';
 export type {SpectrumActionMenuProps, SpectrumMenuProps, SpectrumMenuTriggerProps} from '@react-types/menu';
-export type {SpectrumMenuDialogTriggerProps} from './MenuDialogTrigger';
+export type {SpectrumMenuDialogTriggerProps} from './ContextualHelpTrigger';

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -18,14 +18,15 @@ import AlignRight from '@spectrum-icons/workflow/AlignRight';
 import Blower from '@spectrum-icons/workflow/Blower';
 import Book from '@spectrum-icons/workflow/Book';
 import {Content, Footer} from '@react-spectrum/view';
+import {ContextualHelpTrigger, Item, Menu, MenuTrigger, Section} from '../';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
 import {Dialog} from '@react-spectrum/dialog';
 import {Heading, Keyboard, Text} from '@react-spectrum/text';
-import {Item, Menu, MenuDialogTrigger, MenuTrigger, Section} from '../';
 import {Link} from '@react-spectrum/link';
 import Paste from '@spectrum-icons/workflow/Paste';
 import React, {useState} from 'react';
+import {ToggleButton} from '@adobe/react-spectrum';
 import {TranslateMenu} from './../chromatic/MenuTriggerLanguages.chromatic';
 
 let iconMap = {
@@ -728,22 +729,22 @@ export let MenuItemUnavailable = {
   render: () => render(
     <Menu onAction={action('onAction')}>
       <Item key="1">One</Item>
-      <MenuDialogTrigger isUnavailable>
+      <ContextualHelpTrigger isUnavailable>
         <Item key="foo">Two</Item>
         <Dialog>
           <Heading>hello</Heading>
           <Content>Is it me you're looking for?</Content>
         </Dialog>
-      </MenuDialogTrigger>
-      <MenuDialogTrigger isUnavailable>
+      </ContextualHelpTrigger>
+      <ContextualHelpTrigger isUnavailable>
         <Item key="baz">Two point five</Item>
         <Dialog>
           <Heading>hello</Heading>
           <Content>Is it me you're looking for?</Content>
         </Dialog>
-      </MenuDialogTrigger>
+      </ContextualHelpTrigger>
       <Item key="3">Three</Item>
-      <MenuDialogTrigger isUnavailable>
+      <ContextualHelpTrigger isUnavailable>
         <Item key="bar">
           <Text>Four</Text>
           <Text slot={'description'}>Shut the door</Text>
@@ -753,7 +754,7 @@ export let MenuItemUnavailable = {
           <Content>Is it me you're looking for?</Content>
           <Footer><Link>Learn more</Link></Footer>
         </Dialog>
-      </MenuDialogTrigger>
+      </ContextualHelpTrigger>
       <Item key="5">Five</Item>
     </Menu>
   )
@@ -765,13 +766,13 @@ export let MenuItemUnavailableDynamic = {
       {(item) => {
         if (item.name === 'Kangaroo') {
           return (
-            <MenuDialogTrigger isUnavailable>
+            <ContextualHelpTrigger isUnavailable>
               <Item key={item.name}>{item.name}</Item>
               <Dialog>
                 <Heading>hello</Heading>
                 <Content>Is it me you're looking for?</Content>
               </Dialog>
-            </MenuDialogTrigger>
+            </ContextualHelpTrigger>
           );
         }
         return <Item key={item.name}>{item.name}</Item>;
@@ -779,3 +780,53 @@ export let MenuItemUnavailableDynamic = {
     </Menu>
   )
 };
+
+export let MenuItemUnavailableToggling = {
+  render: () => <MenuWithUnavailableSometimes />
+};
+
+function MenuWithUnavailableSometimes(props) {
+  let [isUnavailable, setIsUnavailable] = useState(false);
+  return (
+    <>
+      <ToggleButton isSelected={isUnavailable} onChange={setIsUnavailable}>Toggle item 2</ToggleButton>
+      <div style={{display: 'flex', width: 'auto', margin: '250px 0'}}>
+        <MenuTrigger onOpenChange={action('onOpenChange')} {...props}>
+          <ActionButton>
+            Menu Button
+          </ActionButton>
+          <Menu onAction={action('onAction')}>
+            <Item key="1">One</Item>
+            <ContextualHelpTrigger isUnavailable={isUnavailable}>
+              <Item key="foo">Two</Item>
+              <Dialog>
+                <Heading>hello</Heading>
+                <Content>Is it me you're looking for?</Content>
+              </Dialog>
+            </ContextualHelpTrigger>
+            <ContextualHelpTrigger isUnavailable>
+              <Item key="baz">Two point five</Item>
+              <Dialog>
+                <Heading>hello</Heading>
+                <Content>Is it me you're looking for?</Content>
+              </Dialog>
+            </ContextualHelpTrigger>
+            <Item key="3">Three</Item>
+            <ContextualHelpTrigger isUnavailable>
+              <Item key="bar">
+                <Text>Four</Text>
+                <Text slot={'description'}>Shut the door</Text>
+              </Item>
+              <Dialog>
+                <Heading>hello</Heading>
+                <Content>Is it me you're looking for?</Content>
+                <Footer><Link>Learn more</Link></Footer>
+              </Dialog>
+            </ContextualHelpTrigger>
+            <Item key="5">Five</Item>
+          </Menu>
+        </MenuTrigger>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Renamed MenuDialogTrigger to ContextualHelpTrigger and used isUnavailable to toggle it on or off allowing regular menu interactions with the item when it's false and showing the ContextualHelp when it's true

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
