### PR TITLE
TagGroup docs fixing avatar and icon examples

### DIFF
--- a/packages/@react-spectrum/tag/docs/TagGroup.mdx
+++ b/packages/@react-spectrum/tag/docs/TagGroup.mdx
@@ -155,19 +155,19 @@ TagGroup supports an `onAction` handler that, when used with the `actionLabel` p
 
 ```tsx example
 <TagGroup aria-label="TagGroup with icons example">
-  <Item>
+  <Item textValue="News">
     <News />
     <Text>News</Text>
   </Item>
-  <Item>
+  <Item textValue="Travel">
     <Airplane />
     <Text>Travel</Text>
   </Item>
-  <Item>
+  <Item textValue="Gaming">
     <Game />
     <Text>Gaming</Text>
   </Item>
-  <Item>
+  <Item textValue="Shopping">
     <ShoppingCart />
     <Text>Shopping</Text>
   </Item>
@@ -178,19 +178,19 @@ TagGroup supports an `onAction` handler that, when used with the `actionLabel` p
 
 ```tsx example
 <TagGroup aria-label="TagGroup with avatars example">
-  <Item>
+  <Item textValue="Person 1">
     <Avatar src="https://i.imgur.com/kJOwAdv.png" />
     <Text>Person 1</Text>
   </Item>
-  <Item>
+  <Item textValue="Person 2">
     <Avatar src="https://i.imgur.com/kJOwAdv.png" />
     <Text>Person 2</Text>
   </Item>
-  <Item>
+  <Item textValue="Person 3">
     <Avatar src="https://i.imgur.com/kJOwAdv.png" />
     <Text>Person 3</Text>
   </Item>
-  <Item>
+  <Item textValue="Person 4">
     <Avatar src="https://i.imgur.com/kJOwAdv.png" />
     <Text>Person 4</Text>
   </Item>


### PR DESCRIPTION
found in testing

The TagGroup docs avatar and icon examples didn't set textValue on the <Item /> so they didn't announce their labels with VO.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Turn on VO.
Goto the TagGroup docs page.
Goto the With icons and With avatar examples.
Confirm that the TagGroup item labels announce.

## 🧢 Your Project:
RSP