### PR TITLE
Fix error when edit page button is missing

### DIFF
--- a/packages/dev/docs/src/client.js
+++ b/packages/dev/docs/src/client.js
@@ -189,7 +189,8 @@ ReactDOM.render(<>
 </>, document.querySelector('.' + docsStyle.pageHeader));
 
 let pathToPage = document.querySelector('[data-github-src]').getAttribute('data-github-src');
-if (pathToPage) {
+let editPage = document.querySelector('#edit-page');
+if (pathToPage && editPage) {
   ReactDOM.render(
     <Link>
       <a
@@ -200,7 +201,7 @@ if (pathToPage) {
         </Flex>
       </a>
     </Link>,
-    document.querySelector('#edit-page')
+    editPage
   );
 }
 


### PR DESCRIPTION
The example on https://react-spectrum.adobe.com/react-aria/react-aria-components.html and in blog posts like https://react-spectrum.adobe.com/blog/drag-and-drop.html do not render because the code crashes while trying to render the edit page button which isn't present for those pages.