### PR TITLE
fix-issues/4725: exported fromDate &  fromEpoch and fixed the documentations

### DIFF
--- a/packages/@internationalized/date/docs/ZonedDateTime.mdx
+++ b/packages/@internationalized/date/docs/ZonedDateTime.mdx
@@ -61,6 +61,19 @@ let date = parseAbsolute('2021-11-07T07:45:00Z', 'America/Los_Angeles');
 let date = parseAbsoluteToLocal('2021-11-07T07:45:00Z');
 ```
 
+You can also create a `ZonedDateTime` by using `Date` object or epoch time (milliseconds) using one of the following functions:
+
+* <TypeLink links={docs.links} type={docs.exports.fromDate} /> – This function uses a `Date` object with a time zone identifier, e.g. `America/Los_Angeles`, must be provided and the result will be converted into that time zone.
+* <TypeLink links={docs.links} type={docs.exports.fromEpoch} /> – This function uses an epoch time in milliseconds, e.g. `1688023843144` with a time zone identifier, e.g. `America/Los_Angeles`, must be provided and the result will be converted into that time zone.
+
+```tsx
+import {fromDate, fromEpoch} from '@internationalized/date';
+
+let date = fromDate(new Date(), 'America/Los_Angeles');
+let date = fromEpoch(1688023843144, 'America/Los_Angeles');
+```
+
+
 The current time can be retrieved using the <TypeLink links={docs.links} type={docs.exports.now} /> function. This requires a time zone identifier to be provided, which is used to determine the local time. The <TypeLink links={docs.links} type={docs.exports.getLocalTimeZone} /> function can be used to retrieve the user's current time zone.
 
 ```tsx

--- a/packages/@internationalized/date/src/conversion.ts
+++ b/packages/@internationalized/date/src/conversion.ts
@@ -173,6 +173,9 @@ export function toDate(dateTime: CalendarDate | CalendarDateTime, timeZone: stri
   return new Date(toAbsolute(dateTime, timeZone, disambiguation));
 }
 
+/**
+ * Takes epoch time (milliseconds) and convert it to the provided time zone.
+ */
 export function fromAbsolute(ms: number, timeZone: string): ZonedDateTime {
   let offset = getTimeZoneOffset(ms, timeZone);
   let date = new Date(ms + offset);
@@ -187,6 +190,9 @@ export function fromAbsolute(ms: number, timeZone: string): ZonedDateTime {
   return new ZonedDateTime(year, month, day, timeZone, offset, hour, minute, second, millisecond);
 }
 
+/**
+ * Takes `Date` object and convert it to the provided time zone.
+ */
 export function fromDate(date: Date, timeZone: string): ZonedDateTime {
   return fromAbsolute(date.getTime(), timeZone);
 }

--- a/packages/@internationalized/date/src/index.ts
+++ b/packages/@internationalized/date/src/index.ts
@@ -38,7 +38,17 @@ export {IslamicCivilCalendar, IslamicTabularCalendar, IslamicUmalquraCalendar} f
 export {HebrewCalendar} from './calendars/HebrewCalendar';
 export {EthiopicCalendar, EthiopicAmeteAlemCalendar, CopticCalendar} from './calendars/EthiopicCalendar';
 export {createCalendar} from './createCalendar';
-export {toCalendarDate, toCalendarDateTime, toTime, toCalendar, toZoned, toTimeZone, toLocalTimeZone} from './conversion';
+export {
+  toCalendarDate,
+  toCalendarDateTime,
+  toTime,
+  toCalendar,
+  toZoned,
+  toTimeZone,
+  toLocalTimeZone,
+  fromDate,
+  fromAbsolute as fromEpoch
+} from './conversion';
 export {
   isSameDay,
   isSameMonth,


### PR DESCRIPTION
## Exported `fromDate` &  `fromEpoch` and fixed the documentations

Closes https://github.com/adobe/react-spectrum/issues/4725

<img width="1110" alt="Screenshot 2023-06-29 at 1 43 48 PM" src="https://github.com/adobe/react-spectrum/assets/25560921/c1b4f9f0-4283-4d43-85a3-13c11629b63c">
<img width="779" alt="Screenshot 2023-06-29 at 1 43 57 PM" src="https://github.com/adobe/react-spectrum/assets/25560921/6d950d91-6ec7-499a-ad23-23054f762dd8">
<img width="890" alt="Screenshot 2023-06-29 at 1 44 03 PM" src="https://github.com/adobe/react-spectrum/assets/25560921/d8f46f20-fe46-4538-b099-c07647f1712f">


## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

* Just exported the existing functions, documentation 

## 📝 Test Instructions:
Now `fromDate` &  `fromEpoch` must be available from  `@internationalized/date`

## 🧢 Your Project:
Below test already covering the above exports
```js
  describe('fromAbsolute', function () {
    it('should convert a date from absolute using a timezone', function () {
      let date = fromAbsolute(new Date('2020-02-03T10:00Z').getTime(), 'America/Los_Angeles');
      expect(date).toEqual(new ZonedDateTime(2020, 2, 3, 'America/Los_Angeles', -28800000, 2));

      date = fromAbsolute(new Date('2020-02-03T10:00Z').getTime(), 'America/New_York');
      expect(date).toEqual(new ZonedDateTime(2020, 2, 3, 'America/New_York', -18000000, 5));
    });
  });
```
