### PR TITLE
Remove invalid selector characters from React.useId

### DIFF
--- a/packages/@react-aria/ssr/src/SSRProvider.tsx
+++ b/packages/@react-aria/ssr/src/SSRProvider.tsx
@@ -157,7 +157,7 @@ function useLegacySSRSafeId(defaultId?: string): string {
 
 function useModernSSRSafeId(defaultId?: string): string {
   // @ts-ignore
-  let id = React.useId();
+  let id = CSS.escape(React.useId());
   let [didSSR] = useState(useIsSSR());
   let prefix = didSSR ? 'react-aria' : `react-aria${defaultContext.prefix}`;
   return defaultId || `${prefix}-${id}`;

--- a/packages/@react-aria/ssr/test/SSRProvider.test.js
+++ b/packages/@react-aria/ssr/test/SSRProvider.test.js
@@ -38,6 +38,25 @@ describe('SSRProvider', function () {
     }
   });
 
+  it('it should generate valid id', function () {
+    let tree = render(
+      <SSRProvider>
+        <Test />
+        <Test />
+      </SSRProvider>
+    );
+
+    let divs = tree.getAllByTestId('test');
+
+    // CSS selector regex
+    // This will match strings composed of letters, digits, dashes, underscores, colons, periods, hash symbols,
+    // commas, spaces, >, *, and square brackets.
+    // Invalid characters that aren't properly escaped with two backslashes will fail the test.
+    var regex = /^(\\.|[\w-]|[^0-9a-z])*$/i;
+
+    expect(regex.test(divs[0].id)).toBe(true);
+  });
+
   it('it should generate consistent unique ids with nested SSR providers', function () {
     let tree = render(
       <SSRProvider>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
