### PR TITLE
fix [RAC]: RadioGroup/Dialog Focus

### DIFF
--- a/packages/react-aria-components/example/index.css
+++ b/packages/react-aria-components/example/index.css
@@ -281,7 +281,7 @@ html {
   }
 
   &[data-focus-visible]:before {
-    box-shadow: 0 0 0 2px var(--spectrum-alias-background-color-default), 0 0 0 4px var(--selected-color);
+    box-shadow: 0 0 0 2px canvas, 0 0 0 4px var(--selected-color);
   }
 
   &[data-disabled] {

--- a/packages/react-aria-components/example/index.css
+++ b/packages/react-aria-components/example/index.css
@@ -206,3 +206,85 @@ html {
     border: 2px solid blue;
   }
 }
+
+.radiogroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &[aria-orientation=horizontal] {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  & [slot=description] {
+    font-size: 12px;
+  }
+
+  & [slot=errorMessage] {
+    font-size: 12px;
+    color: var(--spectrum-global-color-red-600);
+  }
+}
+
+.radio {
+  --label-color: var(--spectrum-alias-text-color);
+  --deselected-color: gray;
+  --deselected-color-pressed: dimgray;
+  --background-color: var(--spectrum-global-color-gray-50);
+  --selected-color: slateblue;
+  --selected-color-pressed: lch(from slateblue 38% c h);
+  --invalid-color: var(--spectrum-global-color-static-red-600);
+  --invalid-color-pressed: var(--spectrum-global-color-static-red-700);
+
+  display: flex;
+  align-items: center;
+  gap: 0.571rem;
+  font-size: 1.143rem;
+  color: var(--label-color);
+
+  &:before {
+    content: '';
+    display: block;
+    width: 1.286rem;
+    height: 1.286rem;
+    box-sizing: border-box;
+    border: 0.143rem solid var(--deselected-color);
+    background: var(--background-color);
+    border-radius: 1.286rem;
+    transition: all 200ms;
+  }
+
+  &[data-pressed]:before {
+    border-color: var(--deselected-color-pressed);
+  }
+
+  &[data-selected] {
+    &:before {
+      border-color: var(--selected-color);
+      border-width: 0.429rem;
+    }
+
+    &[data-pressed]:before {
+      border-color: var(--selected-color-pressed);
+    }
+  }
+
+  &[data-validation-state=invalid] {
+    &:before {
+      border-color: var(--invalid-color);
+    }
+
+    &[data-pressed]:before {
+      border-color: var(--invalid-color-pressed);
+    }
+  }
+
+  &[data-focus-visible]:before {
+    box-shadow: 0 0 0 2px var(--spectrum-alias-background-color-default), 0 0 0 4px var(--selected-color);
+  }
+
+  &[data-disabled] {
+    opacity: 0.4;
+  }
+}

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -229,7 +229,7 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLInputElement>) {
       data-validation-state={state.validationState || undefined}
       data-required={state.isRequired || undefined}>
       <VisuallyHidden elementType="span">
-        <input {...inputProps} {...focusProps} ref={domRef} />
+        <input {...mergeProps(inputProps, focusProps)} ref={domRef} />
       </VisuallyHidden>
       {renderProps.children}
     </label>

--- a/packages/react-aria-components/stories/index.stories.tsx
+++ b/packages/react-aria-components/stories/index.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {Button, Calendar, CalendarCell, CalendarGrid, Cell, Column, ComboBox, DateField, DateInput, DatePicker, DateRangePicker, DateSegment, Dialog, DialogTrigger, DropZone, FileTrigger, Group, Header, Heading, Input, Item, Keyboard, Label, Link, ListBox, ListBoxProps, Menu, MenuTrigger, Modal, ModalOverlay, NumberField, OverlayArrow, Popover, RangeCalendar, Row, Section, Select, SelectValue, Separator, Slider, SliderOutput, SliderThumb, SliderTrack, Tab, Table, TableBody, TableHeader, TabList, TabPanel, Tabs, TabsProps, Text, TimeField, Tooltip, TooltipTrigger, useDragAndDrop} from 'react-aria-components';
+import {Button, Calendar, CalendarCell, CalendarGrid, Cell, Column, ComboBox, DateField, DateInput, DatePicker, DateRangePicker, DateSegment, Dialog, DialogTrigger, DropZone, FileTrigger, Group, Header, Heading, Input, Item, Keyboard, Label, Link, ListBox, ListBoxProps, Menu, MenuTrigger, Modal, ModalOverlay, NumberField, OverlayArrow, Popover, Radio, RadioGroup, RangeCalendar, Row, Section, Select, SelectValue, Separator, Slider, SliderOutput, SliderThumb, SliderTrack, Tab, Table, TableBody, TableHeader, TabList, TabPanel, Tabs, TabsProps, Text, TimeField, Tooltip, TooltipTrigger, useDragAndDrop} from 'react-aria-components';
 import {classNames} from '@react-spectrum/utils';
 import clsx from 'clsx';
 import {FocusRing, mergeProps, useButton, useClipboard, useDrag} from 'react-aria';
@@ -1031,4 +1031,65 @@ ListBoxDnd.story = {
       options: ['horizontal', 'vertical']
     }
   }
+};
+
+export const RadioGroupExample = () => {
+  return (
+    <RadioGroup
+      className={styles.radiogroup}>
+      <Label>Favorite pet</Label>
+      <Radio className={styles.radio} value="dogs">Dog</Radio>
+      <Radio className={styles.radio} value="cats">Cat</Radio>
+      <Radio className={styles.radio} value="dragon">Dragon</Radio>
+    </RadioGroup>
+  );
+};
+
+export const RadioGroupInDialogExample = () => {
+  return (
+    <DialogTrigger>      
+      <Button>Open dialog</Button>
+      <ModalOverlay
+        style={{
+          position: 'fixed',
+          zIndex: 100,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          background: 'rgba(0, 0, 0, 0.5)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}>
+        <Modal
+          style={{
+            background: 'Canvas',
+            color: 'CanvasText',
+            border: '1px solid gray',
+            padding: 30
+          }}>
+          <Dialog
+            style={{
+              outline: '2px solid transparent',
+              outlineOffset: '2px',
+              position: 'relative'
+            }}>
+            {({close}) => (              
+              <>
+                <div>
+                  <RadioGroupExample />
+                </div>
+                <div>
+                  <Button onPress={close} style={{marginTop: 10}}>
+                    Close
+                  </Button>
+                </div>
+              </>
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
 };


### PR DESCRIPTION
Resolved issue with RadioGroup tab navigation within Dialog Component.

RadioGroup tab focus now complies with implementation of roving tabindex in accordance with [a11y radio guidelines](https://www.w3.org/TR/wai-aria-practices-1.1). 

Followed suggestion from @LFDanLu per https://github.com/adobe/react-spectrum/issues/4746#issuecomment-1629758418. Added Storybook examples from RadioGroup and RadioGroup in Dialog. Added tests to cover both use cases.

No change to documentation needed. 

Closes #4746 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

### Visual test
1. Open Storybook
2. Select RadioGroup Example under React Aria Components
4. Tab to first radio, observe has focus
5. Tab again, observe focus no longer in RadioGroup
6. Repeat steps 2 - 5 for RadioGroup in Dialog Example

### Unit Test
Run newly added tests in `react-aria-components/test/RadioGroup.test.js`
- "should not navigate within the group using Tab"
- "should not navigate within the group using Tab in Dialog"

## 🧢 Your Project:

N/A
