### PR TITLE
Improve HTML form reset and submit

### DIFF
--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -13,7 +13,7 @@
 import {AriaColorAreaProps, ColorChannel} from '@react-types/color';
 import {ColorAreaState} from '@react-stately/color';
 import {DOMAttributes} from '@react-types/shared';
-import {focusWithoutScrolling, isAndroid, isIOS, mergeProps, useGlobalListeners, useLabels} from '@react-aria/utils';
+import {focusWithoutScrolling, isAndroid, isIOS, mergeProps, useFormReset, useGlobalListeners, useLabels} from '@react-aria/utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import React, {ChangeEvent, InputHTMLAttributes, RefObject, useCallback, useRef, useState} from 'react';
@@ -54,7 +54,9 @@ export function useColorArea(props: AriaColorAreaOptions, state: ColorAreaState)
     inputXRef,
     inputYRef,
     containerRef,
-    'aria-label': ariaLabel
+    'aria-label': ariaLabel,
+    xName,
+    yName
   } = props;
   let stringFormatter = useLocalizedStringFormatter(intlMessages);
 
@@ -68,8 +70,15 @@ export function useColorArea(props: AriaColorAreaOptions, state: ColorAreaState)
       focusWithoutScrolling(inputRef.current);
     }
   }, [inputXRef]);
-  let [valueChangedViaKeyboard, setValueChangedViaKeyboard] = useState(false);
 
+  useFormReset(inputXRef, [state.xValue, state.yValue], ([x, y]) => {
+    let newColor = state.value
+      .withChannelValue(state.channels.xChannel, x)
+      .withChannelValue(state.channels.yChannel, y);
+    state.setValue(newColor);
+  });
+
+  let [valueChangedViaKeyboard, setValueChangedViaKeyboard] = useState(false);
   let {xChannel, yChannel, zChannel} = state.channels;
   let xChannelStep = state.xChannelStep;
   let yChannelStep = state.yChannelStep;
@@ -410,6 +419,7 @@ export function useColorArea(props: AriaColorAreaOptions, state: ColorAreaState)
       'aria-valuetext': getAriaValueTextForChannel(xChannel),
       disabled: isDisabled,
       value: state.value.getChannelValue(xChannel),
+      name: xName,
       tabIndex: (isMobile || !focusedInput || focusedInput === 'x' ? undefined : -1),
       /*
         So that only a single "2d slider" control shows up when listing form elements for screen readers,
@@ -434,6 +444,7 @@ export function useColorArea(props: AriaColorAreaOptions, state: ColorAreaState)
       'aria-orientation': 'vertical',
       disabled: isDisabled,
       value: state.value.getChannelValue(yChannel),
+      name: yName,
       tabIndex: (isMobile || focusedInput === 'y' ? undefined : -1),
       /*
         So that only a single "2d slider" control shows up when listing form elements for screen readers,

--- a/packages/@react-aria/color/src/useColorSlider.ts
+++ b/packages/@react-aria/color/src/useColorSlider.ts
@@ -43,7 +43,7 @@ export interface ColorSliderAria {
  * Color sliders allow users to adjust an individual channel of a color value.
  */
 export function useColorSlider(props: AriaColorSliderOptions, state: ColorSliderState): ColorSliderAria {
-  let {trackRef, inputRef, orientation, channel, 'aria-label': ariaLabel} = props;
+  let {trackRef, inputRef, orientation, channel, 'aria-label': ariaLabel, name} = props;
 
   let {locale, direction} = useLocale();
 
@@ -58,6 +58,7 @@ export function useColorSlider(props: AriaColorSliderOptions, state: ColorSlider
     index: 0,
     orientation,
     isDisabled: props.isDisabled,
+    name,
     trackRef,
     inputRef
   }, state);

--- a/packages/@react-aria/color/src/useColorWheel.ts
+++ b/packages/@react-aria/color/src/useColorWheel.ts
@@ -13,7 +13,7 @@
 import {AriaColorWheelProps} from '@react-types/color';
 import {ColorWheelState} from '@react-stately/color';
 import {DOMAttributes} from '@react-types/shared';
-import {focusWithoutScrolling, mergeProps, useGlobalListeners, useLabels} from '@react-aria/utils';
+import {focusWithoutScrolling, mergeProps, useFormReset, useGlobalListeners, useLabels} from '@react-aria/utils';
 import React, {ChangeEvent, InputHTMLAttributes, RefObject, useCallback, useRef} from 'react';
 import {useKeyboard, useMove} from '@react-aria/interactions';
 import {useLocale} from '@react-aria/i18n';
@@ -43,7 +43,8 @@ export function useColorWheel(props: AriaColorWheelOptions, state: ColorWheelSta
     isDisabled,
     innerRadius,
     outerRadius,
-    'aria-label': ariaLabel
+    'aria-label': ariaLabel,
+    name
   } = props;
 
   let {addGlobalListener, removeGlobalListener} = useGlobalListeners();
@@ -55,6 +56,8 @@ export function useColorWheel(props: AriaColorWheelOptions, state: ColorWheelSta
       focusWithoutScrolling(inputRef.current);
     }
   }, [inputRef]);
+
+  useFormReset(inputRef, state.hue, state.setHue);
 
   let currentPosition = useRef<{x: number, y: number}>(null);
 
@@ -311,6 +314,7 @@ export function useColorWheel(props: AriaColorWheelOptions, state: ColorWheelSta
         'aria-valuetext': state.value.formatChannelValue('hue', locale),
         disabled: isDisabled,
         value: `${state.value.getChannelValue('hue')}`,
+        name,
         onChange: (e: ChangeEvent<HTMLInputElement>) => {
           state.setHue(parseFloat(e.target.value));
         }

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -155,7 +155,7 @@ export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>
     inputProps: {
       type: 'hidden',
       name: props.name,
-      value: state.value?.toString() || '',
+      value: state.value?.toString() || ''
     },
     descriptionProps,
     errorMessageProps

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -12,10 +12,10 @@
 
 import {AriaDateFieldProps as AriaDateFieldPropsBase, AriaTimeFieldProps, DateValue, TimeValue} from '@react-types/datepicker';
 import {createFocusManager, FocusManager} from '@react-aria/focus';
-import {DateFieldState} from '@react-stately/datepicker';
+import {DateFieldState, TimeFieldState} from '@react-stately/datepicker';
 import {DOMAttributes, KeyboardEvent} from '@react-types/shared';
-import {filterDOMProps, mergeProps, useDescription} from '@react-aria/utils';
-import {FocusEvent, RefObject, useEffect, useMemo, useRef} from 'react';
+import {filterDOMProps, mergeProps, useDescription, useFormReset} from '@react-aria/utils';
+import {FocusEvent, InputHTMLAttributes, RefObject, useEffect, useMemo, useRef} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {useDatePickerGroup} from './useDatePickerGroup';
@@ -24,13 +24,18 @@ import {useFocusWithin} from '@react-aria/interactions';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 // Allows this hook to also be used with TimeField
-export interface AriaDateFieldOptions<T extends DateValue> extends Omit<AriaDateFieldPropsBase<T>, 'value' | 'defaultValue' | 'onChange' | 'minValue' | 'maxValue' | 'placeholderValue'> {}
+export interface AriaDateFieldOptions<T extends DateValue> extends Omit<AriaDateFieldPropsBase<T>, 'value' | 'defaultValue' | 'onChange' | 'minValue' | 'maxValue' | 'placeholderValue'> {
+  /** A ref for the hidden input element for HTML form submission. */
+  inputRef?: RefObject<HTMLInputElement>
+}
 
 export interface DateFieldAria {
    /** Props for the field's visible label element, if any. */
   labelProps: DOMAttributes,
    /** Props for the field grouping element. */
   fieldProps: DOMAttributes,
+  /** Props for the hidden input element for HTML form submission. */
+  inputProps: InputHTMLAttributes<HTMLInputElement>,
   /** Props for the description element, if any. */
   descriptionProps: DOMAttributes,
   /** Props for the error message element, if any. */
@@ -125,6 +130,8 @@ export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>
     autoFocusRef.current = false;
   }, [focusManager]);
 
+  useFormReset(props.inputRef, state.value, state.setValue);
+
   let domProps = filterDOMProps(props);
   return {
     labelProps: {
@@ -145,9 +152,19 @@ export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>
         }
       }
     }),
+    inputProps: {
+      type: 'hidden',
+      name: props.name,
+      value: state.value?.toString() || '',
+    },
     descriptionProps,
     errorMessageProps
   };
+}
+
+export interface AriaTimeFieldOptions<T extends TimeValue> extends AriaTimeFieldProps<T> {
+  /** A ref for the hidden input element for HTML form submission. */
+  inputRef?: RefObject<HTMLInputElement>
 }
 
 /**
@@ -155,6 +172,8 @@ export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>
  * A time field allows users to enter and edit time values using a keyboard.
  * Each part of a time value is displayed in an individually editable segment.
  */
-export function useTimeField<T extends TimeValue>(props: AriaTimeFieldProps<T>, state: DateFieldState, ref: RefObject<Element>): DateFieldAria {
-  return useDateField(props, state, ref);
+export function useTimeField<T extends TimeValue>(props: AriaTimeFieldOptions<T>, state: TimeFieldState, ref: RefObject<Element>): DateFieldAria {
+  let res = useDateField(props, state, ref);
+  res.inputProps.value = state.timeValue?.toString() || '';
+  return res;
 }

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -130,7 +130,8 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       isReadOnly: props.isReadOnly,
       isRequired: props.isRequired,
       validationState: state.validationState,
-      autoFocus: props.autoFocus
+      autoFocus: props.autoFocus,
+      name: props.name
     },
     descriptionProps,
     errorMessageProps,

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -164,13 +164,15 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
       ...commonFieldProps,
       value: state.value?.start,
       onChange: start => state.setDateTime('start', start),
-      autoFocus: props.autoFocus
+      autoFocus: props.autoFocus,
+      name: props.startName
     },
     endFieldProps: {
       ...endFieldProps,
       ...commonFieldProps,
       value: state.value?.end,
-      onChange: end => state.setDateTime('end', end)
+      onChange: end => state.setDateTime('end', end),
+      name: props.endName
     },
     descriptionProps,
     errorMessageProps,

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -838,7 +838,7 @@ function shouldPreventDefaultKeyboard(target: Element, key: string) {
   }
 
   if (target instanceof HTMLButtonElement) {
-    return target.type !== 'submit';
+    return target.type !== 'submit' && target.type !== 'reset';
   }
 
   return true;

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -185,6 +185,7 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
   let {labelProps, inputProps: textFieldProps, descriptionProps, errorMessageProps} = useFormattedTextField({
     ...otherProps,
     ...domProps,
+    name: undefined,
     label,
     autoFocus,
     isDisabled,

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -13,7 +13,7 @@
 import {AriaButtonProps} from '@react-types/button';
 import {AriaNumberFieldProps} from '@react-types/numberfield';
 import {DOMAttributes, TextInputDOMProps} from '@react-types/shared';
-import {filterDOMProps, isAndroid, isIOS, isIPhone, mergeProps, useId} from '@react-aria/utils';
+import {filterDOMProps, isAndroid, isIOS, isIPhone, mergeProps, useFormReset, useId} from '@react-aria/utils';
 import {
   InputHTMLAttributes,
   LabelHTMLAttributes,
@@ -208,6 +208,8 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
     description,
     errorMessage
   }, state, inputRef);
+
+  useFormReset(inputRef, state.numberValue, state.setNumberValue);
 
   let inputProps = mergeProps(
     spinButtonProps,

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaRadioProps} from '@react-types/radio';
-import {filterDOMProps, mergeProps} from '@react-aria/utils';
+import {filterDOMProps, mergeProps, useFormReset} from '@react-aria/utils';
 import {InputHTMLAttributes, RefObject} from 'react';
 import {radioGroupDescriptionIds, radioGroupErrorMessageIds, radioGroupNames} from './utils';
 import {RadioGroupState} from '@react-stately/radio';
@@ -72,6 +72,8 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
   if (isDisabled) {
     tabIndex = undefined;
   }
+
+  useFormReset(ref, state.selectedValue, state.setSelectedValue);
 
   return {
     inputProps: mergeProps(domProps, {

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -225,7 +225,7 @@ export function useSliderThumb(
   ) : {};
 
   useFormReset(inputRef, value, (v) => {
-    stateRef.current.setThumbValue(index, v);
+    state.setThumbValue(index, v);
   });
 
   // We install mouse handlers for the drag motion on the thumb div, but

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -50,7 +50,8 @@ export function useSliderThumb(
     validationState,
     trackRef,
     inputRef,
-    orientation = state.orientation
+    orientation = state.orientation,
+    name
   } = opts;
 
   let isDisabled = opts.isDisabled || state.isDisabled;
@@ -239,6 +240,7 @@ export function useSliderThumb(
       max: state.getThumbMaxValue(index),
       step: state.step,
       value: value,
+      name,
       disabled: isDisabled,
       'aria-orientation': orientation,
       'aria-valuetext': state.getThumbValueLabel(index),

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -1,5 +1,5 @@
 import {AriaSliderThumbProps} from '@react-types/slider';
-import {clamp, focusWithoutScrolling, mergeProps, useGlobalListeners} from '@react-aria/utils';
+import {clamp, focusWithoutScrolling, mergeProps, useFormReset, useGlobalListeners} from '@react-aria/utils';
 import {DOMAttributes} from '@react-types/shared';
 import {getSliderThumbId, sliderIds} from './utils';
 import React, {ChangeEvent, InputHTMLAttributes, LabelHTMLAttributes, RefObject, useCallback, useEffect, useRef} from 'react';
@@ -222,6 +222,10 @@ export function useSliderThumb(
       onTouchStart: (e: React.TouchEvent) => {onDown(e.changedTouches[0].identifier);}
     }
   ) : {};
+
+  useFormReset(inputRef, value, (v) => {
+    stateRef.current.setThumbValue(index, v);
+  });
 
   // We install mouse handlers for the drag motion on the thumb div, but
   // not the key handler for moving the thumb with the slider.  Instead,

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -20,7 +20,7 @@ import {
   RefObject
 } from 'react';
 import {DOMAttributes} from '@react-types/shared';
-import {filterDOMProps, mergeProps} from '@react-aria/utils';
+import {filterDOMProps, mergeProps, useFormReset} from '@react-aria/utils';
 import {useField} from '@react-aria/label';
 import {useFocusable} from '@react-aria/focus';
 
@@ -112,6 +112,8 @@ export function useTextField<T extends TextFieldIntrinsicElements = DefaultEleme
     isReadOnly = false,
     validationState,
     type = 'text',
+    value,
+    defaultValue,
     onChange = () => {}
   }: AriaTextFieldOptions<TextFieldIntrinsicElements> = props;
   let {focusableProps} = useFocusable(props, ref);
@@ -122,6 +124,8 @@ export function useTextField<T extends TextFieldIntrinsicElements = DefaultEleme
     type,
     pattern: props.pattern
   };
+
+  useFormReset(ref, value ?? defaultValue ?? '', onChange);
 
   return {
     labelProps,

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaToggleProps} from '@react-types/checkbox';
-import {filterDOMProps, mergeProps} from '@react-aria/utils';
+import {filterDOMProps, mergeProps, useFormReset} from '@react-aria/utils';
 import {InputHTMLAttributes, RefObject} from 'react';
 import {ToggleState} from '@react-stately/toggle';
 import {useFocusable} from '@react-aria/focus';
@@ -69,6 +69,8 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
   let {focusableProps} = useFocusable(props, ref);
   let interactions = mergeProps(pressProps, focusableProps);
   let domProps = filterDOMProps(props, {labelable: true});
+
+  useFormReset(ref, state.isSelected, state.setSelected);
 
   return {
     inputProps: mergeProps(domProps, {

--- a/packages/@react-aria/utils/src/index.ts
+++ b/packages/@react-aria/utils/src/index.ts
@@ -36,3 +36,4 @@ export {clamp, snapValueToStep} from '@react-stately/utils';
 export {isVirtualClick, isVirtualPointerEvent} from './isVirtualEvent';
 export {useEffectEvent} from './useEffectEvent';
 export {useDeepMemo} from './useDeepMemo';
+export {useFormReset} from './useFormReset';

--- a/packages/@react-aria/utils/src/useFormReset.ts
+++ b/packages/@react-aria/utils/src/useFormReset.ts
@@ -25,9 +25,10 @@ export function useFormReset<T>(
   });
 
   useEffect(() => {
-    ref?.current?.form?.addEventListener('reset', handleReset);
+    let form = ref?.current?.form;
+    form?.addEventListener('reset', handleReset);
     return () => {
-      ref?.current?.form?.removeEventListener('reset', handleReset);
-    }
+      form?.removeEventListener('reset', handleReset);
+    };
   }, [ref, handleReset]);
 }

--- a/packages/@react-aria/utils/src/useFormReset.ts
+++ b/packages/@react-aria/utils/src/useFormReset.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import {RefObject, useEffect, useRef} from 'react';
+import {useEffectEvent} from './useEffectEvent';
+
+export function useFormReset<T>(
+  ref: RefObject<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  initialValue: T,
+  onReset: (value: T) => void
+) {
+  let resetValue = useRef(initialValue);
+  let handleReset = useEffectEvent(() => {
+    if (onReset) {
+      onReset(resetValue.current);
+    }
+  });
+
+  useEffect(() => {
+    ref?.current?.form?.addEventListener('reset', handleReset);
+    return () => {
+      ref?.current?.form?.removeEventListener('reset', handleReset);
+    }
+  }, [ref, handleReset]);
+}

--- a/packages/@react-spectrum/checkbox/test/Checkbox.test.js
+++ b/packages/@react-spectrum/checkbox/test/Checkbox.test.js
@@ -261,4 +261,27 @@ describe('Checkbox', function () {
     expect(checkbox.checked).toBeFalsy();
     expect(onChangeSpy).not.toHaveBeenCalled();
   });
+
+  it('supports form reset', () => {
+    function Test() {
+      let [isSelected, setSelected] = React.useState(false);
+      return (
+        <form>
+          <Checkbox data-testid="checkbox" isSelected={isSelected} onChange={setSelected}>Checkbox</Checkbox>
+          <input type="reset" data-testid="reset" />
+        </form>
+      );
+    }
+
+    let {getByTestId} = render(<Test />);
+    let input = getByTestId('checkbox');
+
+    expect(input).not.toBeChecked();
+    act(() => userEvent.click(input));
+    expect(input).toBeChecked();
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(input).not.toBeChecked();
+  });
 });

--- a/packages/@react-spectrum/checkbox/test/CheckboxGroup.test.js
+++ b/packages/@react-spectrum/checkbox/test/CheckboxGroup.test.js
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
+import {act, render, within} from '@react-spectrum/test-utils';
 import {Checkbox, CheckboxGroup} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
-import {render, within} from '@react-spectrum/test-utils';
 import {theme} from '@react-spectrum/theme-default';
 import userEvent from '@testing-library/user-event';
 
@@ -371,5 +371,40 @@ describe('CheckboxGroup', () => {
 
     let description = document.getElementById(group.getAttribute('aria-describedby'));
     expect(description).toHaveTextContent('Error message');
+  });
+
+  it('supports form reset', () => {
+    function Test() {
+      let [value, setValue] = React.useState(['dogs']);
+      return (
+        <Provider theme={theme}>
+          <form>
+            <CheckboxGroup name="pets" label="Pets" value={value} onChange={setValue}>
+              <Checkbox value="dogs">Dogs</Checkbox>
+              <Checkbox value="cats">Cats</Checkbox>
+              <Checkbox value="dragons">Dragons</Checkbox>
+            </CheckboxGroup>
+            <input type="reset" data-testid="reset" />
+          </form>
+        </Provider>
+      );
+    }
+
+    let {getAllByRole, getByTestId} = render(<Test />);
+    let checkboxes = getAllByRole('checkbox');
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+    act(() => userEvent.click(checkboxes[1]));
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
   });
 });

--- a/packages/@react-spectrum/color/test/ColorArea.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorArea.test.tsx
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
+import {act, fireEvent, installMouseEvent, installPointerEvent, render} from '@react-spectrum/test-utils';
 import {ColorArea} from '../';
 import {composeStories} from '@storybook/testing-react';
 import {defaultTheme} from '@adobe/react-spectrum';
-import {fireEvent, installMouseEvent, installPointerEvent, render} from '@react-spectrum/test-utils';
 import {parseColor} from '@react-stately/color';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -631,4 +631,42 @@ describe('ColorArea', () => {
       expect(document.activeElement).toBe(zSlider);
     });
   });
+
+  describe('forms', () => {
+    it('supports form name', () => {
+      let {getAllByRole} = render(<ColorArea xName="red" yName="green" />);
+      let inputs = getAllByRole('slider', {hidden: true});
+      expect(inputs[0]).toHaveAttribute('name', 'red');
+      expect(inputs[0]).toHaveValue('255');
+      expect(inputs[1]).toHaveAttribute('name', 'green');
+      expect(inputs[1]).toHaveValue('255');
+    });
+
+    it('supports form reset', () => {
+      function Test() {
+        let [value, setValue] = React.useState(parseColor('rgb(100, 200, 0)'));
+        return (
+          <form>
+            <ColorArea value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getAllByRole} = render(<Test />);
+      let inputs = getAllByRole('slider', {hidden: true});
+
+      expect(inputs[0]).toHaveValue('100');
+      expect(inputs[1]).toHaveValue('200');
+      fireEvent.change(inputs[0], {target: {value: '10'}});
+      fireEvent.change(inputs[1], {target: {value: '20'}});
+      expect(inputs[0]).toHaveValue('10');
+      expect(inputs[1]).toHaveValue('20');
+
+      let button = getByTestId('reset');
+      act(() => userEvent.click(button));
+      expect(inputs[0]).toHaveValue('100');
+      expect(inputs[1]).toHaveValue('200');
+    });
+  })
 });

--- a/packages/@react-spectrum/color/test/ColorArea.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorArea.test.tsx
@@ -668,5 +668,5 @@ describe('ColorArea', () => {
       expect(inputs[0]).toHaveValue('100');
       expect(inputs[1]).toHaveValue('200');
     });
-  })
+  });
 });

--- a/packages/@react-spectrum/color/test/ColorSlider.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorSlider.test.tsx
@@ -259,6 +259,36 @@ describe('ColorSlider', () => {
     expect(document.activeElement).toBe(buttonA);
   });
 
+  it('supports form name', () => {
+    let {getByRole} = render(<ColorSlider defaultValue="#7f0000" channel="red" name="redColor" />);
+    let input = getByRole('slider');
+    expect(input).toHaveAttribute('name', 'redColor');
+    expect(input).toHaveValue('127');
+  });
+
+  it('supports form reset', () => {
+    function Test() {
+      let [value, setValue] = React.useState(parseColor('#7f0000'));
+      return (
+        <form>
+          <ColorSlider channel="red" value={value} onChange={setValue} />
+          <input type="reset" data-testid="reset" />
+        </form>
+      );
+    }
+
+    let {getByTestId, getByRole} = render(<Test />);
+    let input = getByRole('slider');
+
+    expect(input).toHaveValue('127');
+    fireEvent.change(input, {target: {value: '255'}});
+    expect(input).toHaveValue('255');
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(input).toHaveValue('127');
+  });
+
   describe('keyboard events', () => {
     it('works', () => {
       let defaultColor = parseColor('#000000');

--- a/packages/@react-spectrum/color/test/ColorWheel.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorWheel.test.tsx
@@ -94,6 +94,36 @@ describe('ColorWheel', () => {
     expect(document.activeElement).toBe(buttonA);
   });
 
+  it('supports form name', () => {
+    let {getByRole} = render(<ColorWheel name="hue" />);
+    let input = getByRole('slider');
+    expect(input).toHaveAttribute('name', 'hue');
+    expect(input).toHaveValue('0');
+  });
+
+  it('supports form reset', () => {
+    function Test() {
+      let [value, setValue] = React.useState(parseColor('hsl(15, 100%, 50%)'));
+      return (
+        <form>
+          <ColorWheel value={value} onChange={setValue} />
+          <input type="reset" data-testid="reset" />
+        </form>
+      );
+    }
+
+    let {getByTestId, getByRole} = render(<Test />);
+    let input = getByRole('slider');
+
+    expect(input).toHaveValue('15');
+    fireEvent.change(input, {target: {value: '30'}});
+    expect(input).toHaveValue('30');
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(input).toHaveValue('15');
+  });
+
   describe('labelling', () => {
     it('should support a custom aria-label', () => {
       let {getByRole} = render(<ColorWheel aria-label="Color hue" />);

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -73,8 +73,14 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
     direction = 'bottom',
     isQuiet,
     loadingState,
-    onLoadMore
+    onLoadMore,
+    allowsCustomValue,
+    name,
+    formValue = 'text'
   } = props;
+  if (allowsCustomValue) {
+    formValue = 'text';
+  }
 
   let stringFormatter = useLocalizedStringFormatter(intlMessages);
   let isAsync = loadingState != null;
@@ -104,7 +110,8 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
       popoverRef: unwrappedPopoverRef,
       listBoxRef,
       inputRef: inputRef,
-      menuTrigger
+      menuTrigger,
+      name: formValue === 'text' ? name : undefined
     },
     state
   );
@@ -150,6 +157,7 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
           triggerProps={buttonProps}
           triggerRef={buttonRef} />
       </Field>
+      {name && formValue === 'key' && <input type="hidden" name={name} value={state.selectedKey} />}
       <Popover
         state={state}
         UNSAFE_style={style}

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -54,9 +54,7 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
     isReadOnly,
     name,
     formValue = 'text',
-    allowsCustomValue,
-    isRequired,
-    requiredBehavior
+    allowsCustomValue
   } = props;
   if (allowsCustomValue) {
     formValue = 'text';
@@ -95,16 +93,6 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
     name,
     value: formValue === 'text' ? state.inputValue : state.selectedKey
   };
-
-  if (isRequired && requiredBehavior === 'native') {
-    // Use a hidden <input type="text"> rather than <input type="hidden">
-    // so that an empty value blocks HTML form submission when the field is required.
-    inputProps.type = 'text';
-    inputProps.hidden = true;
-    inputProps.required = true;
-    // Ignore react warning.
-    inputProps.onChange = () => {};
-  }
 
   let inputRef = useRef<HTMLInputElement>(null);
   useFormReset(inputRef, inputProps.value, formValue === 'text' ? state.setInputValue : state.setSelectedKey);

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -27,9 +27,9 @@ import {FocusRing, focusSafely, FocusScope} from '@react-aria/focus';
 import intlMessages from '../intl/*.json';
 import labelStyles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
 import {ListBoxBase, useListBoxLayout} from '@react-spectrum/listbox';
-import {mergeProps, useId} from '@react-aria/utils';
+import {mergeProps, useFormReset, useId} from '@react-aria/utils';
 import {ProgressCircle} from '@react-spectrum/progress';
-import React, {HTMLAttributes, ReactElement, ReactNode, RefObject, useCallback, useEffect, useRef, useState} from 'react';
+import React, {HTMLAttributes, InputHTMLAttributes, ReactElement, ReactNode, RefObject, useCallback, useEffect, useRef, useState} from 'react';
 import searchStyles from '@adobe/spectrum-css-temp/components/search/vars.css';
 import {setInteractionModality, useHover} from '@react-aria/interactions';
 import {SpectrumComboBoxProps} from '@react-types/combobox';
@@ -51,8 +51,16 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
     isQuiet,
     isDisabled,
     validationState,
-    isReadOnly
+    isReadOnly,
+    name,
+    formValue = 'text',
+    allowsCustomValue,
+    isRequired,
+    requiredBehavior
   } = props;
+  if (allowsCustomValue) {
+    formValue = 'text';
+  }
 
   let {contains} = useFilter({sensitivity: 'base'});
   let state = useComboBoxState({
@@ -82,6 +90,25 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
     }
   };
 
+  let inputProps: InputHTMLAttributes<HTMLInputElement> = {
+    type: 'hidden',
+    name,
+    value: formValue === 'text' ? state.inputValue : state.selectedKey
+  };
+
+  if (isRequired && requiredBehavior === 'native') {
+    // Use a hidden <input type="text"> rather than <input type="hidden">
+    // so that an empty value blocks HTML form submission when the field is required.
+    inputProps.type = 'text';
+    inputProps.hidden = true;
+    inputProps.required = true;
+    // Ignore react warning.
+    inputProps.onChange = () => {};
+  }
+
+  let inputRef = useRef<HTMLInputElement>(null);
+  useFormReset(inputRef, inputProps.value, formValue === 'text' ? state.setInputValue : state.setSelectedKey);
+
   return (
     <>
       <Field
@@ -101,6 +128,7 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
           {state.inputValue || props.placeholder || ''}
         </ComboBoxButton>
       </Field>
+      {name && <input {...inputProps} ref={inputRef} />}
       <Tray state={state} isFixedHeight {...overlayProps}>
         <ComboBoxTray
           {...props}
@@ -301,7 +329,9 @@ function ComboBoxTray(props: ComboBoxTrayProps) {
       buttonRef: unwrapDOMRef(buttonRef),
       popoverRef: popoverRef,
       listBoxRef,
-      inputRef
+      inputRef,
+      // Handled outside the tray.
+      name: undefined
     },
     state
   );

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -5169,17 +5169,6 @@ describe('ComboBox', function () {
         jest.clearAllMocks();
       });
 
-      it('should support requiredBehavior', () => {
-        let {getByRole, rerender} = render(<ExampleComboBox isRequired />);
-        let input = getByRole('combobox');
-        expect(input).toHaveAttribute('aria-required', 'true');
-        expect(input).not.toHaveAttribute('required');
-
-        rerender(<ExampleComboBox isRequired requiredBehavior="native" />);
-        expect(input).not.toHaveAttribute('aria-required', 'true');
-        expect(input).toHaveAttribute('required');
-      });
-
       it('should support form reset', () => {
         let {getByRole, getByTestId} = render(
           <form>
@@ -5234,18 +5223,6 @@ describe('ComboBox', function () {
       afterEach(() => {
         act(() => jest.runAllTimers());
         jest.clearAllMocks();
-      });
-
-      it('should support requiredBehavior', () => {
-        let {rerender} = render(<ExampleComboBox name="test" isRequired />);
-        let input = document.querySelector('input[name=test]');
-        expect(input).not.toHaveAttribute('required');
-        expect(input).toHaveAttribute('type', 'hidden');
-
-        rerender(<ExampleComboBox name="test" isRequired requiredBehavior="native" />);
-        expect(input).toHaveAttribute('required');
-        expect(input).toHaveAttribute('type', 'text');
-        expect(input).toHaveAttribute('hidden');
       });
 
       it('should support form reset', () => {

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -4724,7 +4724,7 @@ describe('ComboBox', function () {
     });
 
     afterAll(function () {
-      jest.restoreAllMocks();
+      jest.clearAllMocks();
     });
     // NVDA workaround so that letters are read out when user presses left/right arrow to navigate through what they typed
     it('clears aria-activedescendant when user presses left/right arrow (NVDA fix)', function () {
@@ -5155,6 +5155,143 @@ describe('ComboBox', function () {
         expect(queryAllByRole('checkbox')).toEqual([]);
         expect(getByRole('combobox')).toBeVisible();
         expect(getByRole('listbox')).toBeVisible();
+      });
+    });
+  });
+
+  describe('forms', () => {
+    describe('desktop', () => {
+      beforeAll(function () {
+        jest.spyOn(window.screen, 'width', 'get').mockImplementation(() => 1024);
+      });
+
+      afterAll(function () {
+        jest.clearAllMocks();
+      });
+
+      it('should support requiredBehavior', () => {
+        let {getByRole, rerender} = render(<ExampleComboBox isRequired />);
+        let input = getByRole('combobox');
+        expect(input).toHaveAttribute('aria-required', 'true');
+        expect(input).not.toHaveAttribute('required');
+
+        rerender(<ExampleComboBox isRequired requiredBehavior="native" />);
+        expect(input).not.toHaveAttribute('aria-required', 'true');
+        expect(input).toHaveAttribute('required');
+      });
+
+      it('should support form reset', () => {
+        let {getByRole, getByTestId} = render(
+          <form>
+            <ExampleComboBox name="test" />
+            <input type="reset" data-testid="reset" />
+          </form>
+        );
+
+        let combobox = getByRole('combobox');
+        expect(combobox).toHaveAttribute('name', 'test');
+        typeText(combobox, 'Tw');
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        let listbox = getByRole('listbox');
+        let items = within(listbox).getAllByRole('option');
+        act(() => {
+          triggerPress(items[0]);
+          jest.runAllTimers();
+        });
+
+        expect(combobox).toHaveValue('Two');
+
+        let button = getByTestId('reset');
+        act(() => userEvent.click(button));
+        expect(combobox).toHaveValue('');
+      });
+
+      it('should support formValue', () => {
+        let {getByRole, rerender} = render(<ExampleComboBox name="test" selectedKey="2" />);
+        let input = getByRole('combobox');
+        expect(input).toHaveAttribute('name', 'test');
+        expect(input).toHaveValue('Two');
+        expect(document.querySelector('input[type=hidden]')).toBeNull();
+
+        rerender(<ExampleComboBox name="test" formValue="key" selectedKey="2" />);
+        expect(input).not.toHaveAttribute('name');
+
+        let hiddenInput = document.querySelector('input[type=hidden]');
+        expect(hiddenInput).toHaveAttribute('name', 'test');
+        expect(hiddenInput).toHaveValue('2');
+      });
+    });
+
+    describe('mobile', () => {
+      beforeEach(() => {
+        jest.spyOn(window.screen, 'width', 'get').mockImplementation(() => 700);
+      });
+
+      afterEach(() => {
+        act(() => jest.runAllTimers());
+        jest.clearAllMocks();
+      });
+
+      it('should support requiredBehavior', () => {
+        let {rerender} = render(<ExampleComboBox name="test" isRequired />);
+        let input = document.querySelector('input[name=test]');
+        expect(input).not.toHaveAttribute('required');
+        expect(input).toHaveAttribute('type', 'hidden');
+
+        rerender(<ExampleComboBox name="test" isRequired requiredBehavior="native" />);
+        expect(input).toHaveAttribute('required');
+        expect(input).toHaveAttribute('type', 'text');
+        expect(input).toHaveAttribute('hidden');
+      });
+
+      it('should support form reset', () => {
+        let {getByRole, getAllByRole, getByTestId} = render(
+          <form>
+            <ExampleComboBox name="test" />
+            <input type="reset" data-testid="reset" />
+          </form>
+        );
+
+        let button = getAllByRole('button')[0];
+
+        triggerPress(button);
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        let tray = getByTestId('tray');
+        expect(tray).toBeVisible();
+        let combobox = getByRole('searchbox');
+        expect(combobox).not.toHaveAttribute('name');
+        let listbox = getByRole('listbox');
+
+        let items = within(listbox).getAllByRole('option');
+        act(() => {
+          triggerPress(items[0]);
+          jest.runAllTimers();
+        });
+
+        let input = document.querySelector('input[name=test]');
+        expect(input).toHaveValue('One');
+
+        let reset = getByTestId('reset');
+        act(() => userEvent.click(reset));
+        expect(input).toHaveValue('');
+      });
+
+      it('should support formValue', () => {
+        let {rerender} = render(<ExampleComboBox name="test" selectedKey="2" />);
+        let input = document.querySelector('input[name=test]');
+        expect(input).toHaveAttribute('type', 'hidden');
+        expect(input).toHaveAttribute('name', 'test');
+        expect(input).toHaveValue('Two');
+
+        rerender(<ExampleComboBox name="test" formValue="key" selectedKey="2" />);
+        expect(input).toHaveValue('2');
       });
     });
   });

--- a/packages/@react-spectrum/datepicker/src/DateField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateField.tsx
@@ -43,8 +43,12 @@ function DateField<T extends DateValue>(props: SpectrumDateFieldProps<T>, ref: F
     createCalendar
   });
 
+  let fieldRef = useRef(null);
   let inputRef = useRef(null);
-  let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useDateField(props, state, inputRef);
+  let {labelProps, fieldProps, inputProps, descriptionProps, errorMessageProps} = useDateField({
+    ...props,
+    inputRef
+  }, state, fieldRef);
 
   // Note: this description is intentionally not passed to useDatePicker.
   // The format help text is unnecessary for screen reader users because each segment already has a label.
@@ -65,7 +69,7 @@ function DateField<T extends DateValue>(props: SpectrumDateFieldProps<T>, ref: F
       validationState={state.validationState}
       wrapperClassName={classNames(datepickerStyles, 'react-spectrum-Datepicker-fieldWrapper')}>
       <Input
-        ref={inputRef}
+        ref={fieldRef}
         fieldProps={fieldProps}
         isDisabled={isDisabled}
         isQuiet={isQuiet}
@@ -81,6 +85,7 @@ function DateField<T extends DateValue>(props: SpectrumDateFieldProps<T>, ref: F
             isReadOnly={isReadOnly}
             isRequired={isRequired} />)
         )}
+        <input {...inputProps} ref={inputRef} />
       </Input>
     </Field>
   );

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -41,7 +41,8 @@ export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps
     createCalendar
   });
 
-  let {fieldProps} = useDateField(props, state, ref);
+  let inputRef = useRef();
+  let {fieldProps, inputProps} = useDateField({...props, inputRef}, state, ref);
 
   return (
     <div {...fieldProps} data-testid={props['data-testid']} className={classNames(datepickerStyles, 'react-spectrum-Datepicker-segments', inputClassName)} ref={ref}>
@@ -54,6 +55,7 @@ export function DatePickerField<T extends DateValue>(props: DatePickerFieldProps
           isReadOnly={isReadOnly}
           isRequired={isRequired} />)
       )}
+      <input {...inputProps} ref={inputRef} />
     </div>
   );
 }

--- a/packages/@react-spectrum/datepicker/src/TimeField.tsx
+++ b/packages/@react-spectrum/datepicker/src/TimeField.tsx
@@ -41,8 +41,12 @@ function TimeField<T extends TimeValue>(props: SpectrumTimeFieldProps<T>, ref: F
     locale
   });
 
+  let fieldRef = useRef(null);
   let inputRef = useRef(null);
-  let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useTimeField(props, state, inputRef);
+  let {labelProps, fieldProps, inputProps, descriptionProps, errorMessageProps} = useTimeField({
+    ...props,
+    inputRef
+  }, state, fieldRef);
 
   return (
     <Field
@@ -55,7 +59,7 @@ function TimeField<T extends TimeValue>(props: SpectrumTimeFieldProps<T>, ref: F
       validationState={state.validationState}
       wrapperClassName={classNames(datepickerStyles, 'react-spectrum-TimeField-fieldWrapper')}>
       <Input
-        ref={inputRef}
+        ref={fieldRef}
         fieldProps={fieldProps}
         isDisabled={isDisabled}
         isQuiet={isQuiet}
@@ -71,6 +75,7 @@ function TimeField<T extends TimeValue>(props: SpectrumTimeFieldProps<T>, ref: F
             isReadOnly={isReadOnly}
             isRequired={isRequired} />)
         )}
+        <input {...inputProps} ref={inputRef} />
       </Input>
     </Field>
   );

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -1471,4 +1471,43 @@ describe('DateRangePicker', function () {
       expectPlaceholder(endDate, 'mm/dd/yyyy');
     });
   });
+
+  describe('forms', () => {
+    it('supports form reset', () => {
+      function Test() {
+        let [value, setValue] = React.useState({start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2022, 4, 8)});
+        return (
+          <form>
+            <DateRangePicker startName="start" endName="end" label="Value" value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole, getAllByRole} = render(<Test />);
+      let group = getByRole('group');
+      let start = document.querySelector('input[name=start]');
+      let end = document.querySelector('input[name=end]');
+      let segments = getAllByRole('spinbutton');
+
+      let getDescription = () => group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
+      expect(getDescription()).toBe('Selected Range: February 3, 2020 to April 8, 2022');
+
+      expect(start).toHaveValue('2020-02-03');
+      expect(end).toHaveValue('2022-04-08');
+      expect(start).toHaveAttribute('name', 'start');
+      expect(end).toHaveAttribute('name', 'end');
+      fireEvent.keyDown(segments[0], {key: 'ArrowUp'});
+      fireEvent.keyUp(segments[0], {key: 'ArrowUp'});
+      expect(getDescription()).toBe('Selected Range: March 3, 2020 to April 8, 2022');
+      expect(start).toHaveValue('2020-03-03');
+      expect(end).toHaveValue('2022-04-08');
+
+      let button = getByTestId('reset');
+      act(() => userEvent.click(button));
+      expect(getDescription()).toBe('Selected Range: February 3, 2020 to April 8, 2022');
+      expect(start).toHaveValue('2020-02-03');
+      expect(end).toHaveValue('2022-04-08');
+    });
+  });
 });

--- a/packages/@react-spectrum/datepicker/test/TimeField.test.js
+++ b/packages/@react-spectrum/datepicker/test/TimeField.test.js
@@ -136,6 +136,8 @@ describe('TimeField', function () {
     it('should call blur when focus leaves', function () {
       let {getAllByRole} = render(<TimeField label="Time" onBlur={onBlurSpy} onFocus={onFocusSpy} onFocusChange={onFocusChangeSpy} />);
       let segments = getAllByRole('spinbutton');
+      // workaround bug in userEvent.tab(). hidden inputs aren't focusable.
+      document.querySelector('input[type=hidden]').tabIndex = -1;
 
       expect(onBlurSpy).not.toHaveBeenCalled();
       expect(onFocusChangeSpy).not.toHaveBeenCalled();
@@ -234,6 +236,40 @@ describe('TimeField', function () {
         expect(timezone.getAttribute('aria-label')).toBe('time zone, ');
         expect(within(timezone).getByText('PDT')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('forms', () => {
+    it('supports form reset', () => {
+      function Test() {
+        let [value, setValue] = React.useState(new Time(8, 30));
+        return (
+          <form>
+            <TimeField name="time" label="Value" value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole, getAllByRole} = render(<Test />);
+      let group = getByRole('group');
+      let input = document.querySelector('input[name=time]');
+      let segments = getAllByRole('spinbutton');
+
+      let getDescription = () => group.getAttribute('aria-describedby').split(' ').map(d => document.getElementById(d).textContent).join(' ');
+      expect(getDescription()).toBe('Selected Time: 8:30 AM');
+
+      expect(input).toHaveValue('08:30:00');
+      expect(input).toHaveAttribute('name', 'time');
+      fireEvent.keyDown(segments[0], {key: 'ArrowUp'});
+      fireEvent.keyUp(segments[0], {key: 'ArrowUp'});
+      expect(getDescription()).toBe('Selected Time: 9:30 AM');
+      expect(input).toHaveValue('09:30:00');
+
+      let button = getByTestId('reset');
+      act(() => userEvent.click(button));
+      expect(getDescription()).toBe('Selected Time: 8:30 AM');
+      expect(input).toHaveValue('08:30:00');
     });
   });
 });

--- a/packages/@react-spectrum/form/stories/Form.stories.tsx
+++ b/packages/@react-spectrum/form/stories/Form.stories.tsx
@@ -13,12 +13,14 @@
 import {action} from '@storybook/addon-actions';
 import {Button} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
+import {CalendarDate} from '@internationalized/date';
 import {chain} from '@react-aria/utils';
 import {Checkbox, CheckboxGroup} from '@react-spectrum/checkbox';
 import {ComboBox} from '@react-spectrum/combobox';
 import {Content, Header} from '@react-spectrum/view';
 import {ContextualHelp} from '@react-spectrum/contextualhelp';
 import {countries, states} from './data';
+import {DateField, DateRangePicker} from '@react-spectrum/datepicker';
 import {Flex} from '@react-spectrum/layout';
 import {Form} from '../';
 import {FormTranslatedText} from './../chromatic/FormLanguages.chromatic';
@@ -29,6 +31,7 @@ import {NumberField} from '@react-spectrum/numberfield';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
 import React, {Key, useEffect, useState} from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
+import {Slider} from '@react-spectrum/slider';
 import {StatusLight} from '@react-spectrum/statuslight';
 import {Switch} from '@react-spectrum/switch';
 import {TagGroup} from '@react-spectrum/tag';
@@ -458,161 +461,64 @@ function FormWithControls(props: any = {}) {
   let [favoritePet, setFavoritePet] = useState('cats');
   let [favoriteColor, setFavoriteColor] = useState('green' as Key);
   let [howIFeel, setHowIFeel] = useState('I feel good, o I feel so good!');
-  let [firstName2, setFirstName2] = useState('hello');
-  let [isHunter2, setIsHunter2] = useState(true);
-  let [favoritePet2, setFavoritePet2] = useState('cats');
-  let [favoriteColor2, setFavoriteColor2] = useState('green' as Key);
-  let [howIFeel2, setHowIFeel2] = useState('I feel good, o I feel so good!');
-  let [preventDefault, setPreventDefault] = useState(true);
+  let [birthday, setBirthday] = useState(new CalendarDate(1732, 2, 22));
+  let [money, setMoney] = useState(50);
+  let [superSpeed, setSuperSpeed] = useState(true);
 
   return (
-    <Flex>
-      <Checkbox alignSelf="start" isSelected={preventDefault} onChange={setPreventDefault}>Prevent Default onSubmit</Checkbox>
-      <Form
-        onSubmit={e => {
-          action('onSubmit')(e);
-          if (preventDefault) {
-            e.preventDefault();
-          }
-        }}
-        {...props}>
-        <TextField name="first-name" label="First Name controlled" value={firstName} onChange={setFirstName} />
-        <TextField name="last-name" label="Last Name default" defaultValue="world" />
-        <TextField name="street-address" label="Street Address none" />
-        <Picker name="country" label="Country none" items={countries}>
-          {item => <Item key={item.name}>{item.name}</Item>}
-        </Picker>
-        <Checkbox name="is-hunter" isSelected={isHunter} onChange={setIsHunter}>I am a hunter! controlled</Checkbox>
-        <Checkbox name="is-wizard" defaultSelected>I am a wizard! default</Checkbox>
-        <RadioGroup label="Favorite pet controlled" name="favorite-pet-group" value={favoritePet} onChange={setFavoritePet}>
-          <Radio value="dogs">Dogs</Radio>
-          <Radio value="cats">Cats</Radio>
-          <Radio value="dragons">Dragons</Radio>
-        </RadioGroup>
-        <RadioGroup label="Favorite pet none" name="favorite-pet-group2" defaultValue="cats">
-          <Radio value="dogs">Dogs</Radio>
-          <Radio value="cats">Cats</Radio>
-          <Radio value="dragons">Dragons</Radio>
-        </RadioGroup>
-        <Picker name="favorite-color" label="Favorite color controlled" selectedKey={favoriteColor} onSelectionChange={setFavoriteColor}>
-          <Item key="red">Red</Item>
-          <Item key="orange">Orange</Item>
-          <Item key="yellow">Yellow</Item>
-          <Item key="green">Green</Item>
-          <Item key="blue">Blue</Item>
-          <Item key="purple">Purple</Item>
-        </Picker>
-        <TextArea name="comments-controlled" label="Comments" value={howIFeel} onChange={setHowIFeel} />
-        <TextArea name="comments-uncontrolled" label="Comments" defaultValue="hello" />
-        <ComboBox label="Favorite Animal" name="favorite-animal">
-          <Item key="red panda">Red Panda</Item>
-          <Item key="aardvark">Aardvark</Item>
-          <Item key="kangaroo">Kangaroo</Item>
-          <Item key="snake">Snake</Item>
-        </ComboBox>
-        <TagGroup label="Favorite tags">
-          <Item key="1">Cool Tag 1</Item>
-          <Item key="2">Cool Tag 2</Item>
-          <Item key="3">Cool Tag 3</Item>
-          <Item key="4">Cool Tag 4</Item>
-          <Item key="5">Cool Tag 5</Item>
-          <Item key="6">Cool Tag 6</Item>
-        </TagGroup>
-        <ButtonGroup>
-          <Button variant="primary" type="submit">Submit</Button>
-        </ButtonGroup>
-      </Form>
-      <form
-        onSubmit={e => {
-          action('onSubmit')(e);
-          if (preventDefault) {
-            e.preventDefault();
-          }
-        }}
-        {...props}>
-        <Flex direction="column" gap="size-500" marginTop="size-500">
-          <label>
-            First Name controlled
-            <input type="text" value={firstName2} onChange={e => setFirstName2(e.target.value)} />
-          </label>
-          <label>
-            Last Name default
-            <input type="text" defaultValue="world" />
-          </label>
-          <label>
-            Street Address none
-            <input type="text" />
-          </label>
-          <label>
-            Country none
-            <select name="Country">
-              {countries.map(item => <option value={item.name}>{item.name}</option>)}
-            </select>
-          </label>
-          <label>
-            I am a hunter! controlled
-            <input type="checkbox" checked={isHunter2} onChange={e => setIsHunter2(e.target.checked)} />
-          </label>
-          <label>
-            I am a wizard! default
-            <input type="checkbox" defaultChecked />
-          </label>
-          <div style={{display: 'flex', flexDirection: 'column'}}>
-            Favorite Pet controlled
-            <label>
-              Dogs
-              <input type="radio" name="favorit-pet-group3" value="dogs" checked={favoritePet2 === 'dogs'} onChange={e => setFavoritePet2(e.target.value)} />
-            </label>
-            <label>
-              Cats
-              <input type="radio" name="favorit-pet-group3" value="cats" checked={favoritePet2 === 'cats'} onChange={e => setFavoritePet2(e.target.value)} />
-            </label>
-            <label>
-              Dragons
-              <input type="radio" name="favorit-pet-group3" value="dragons" checked={favoritePet2 === 'dragons'} onChange={e => setFavoritePet2(e.target.value)} />
-            </label>
-          </div>
-          <div style={{display: 'flex', flexDirection: 'column'}}>
-            Favorite Pet uncontrolled
-            <label>
-              Dogs
-              <input type="radio" name="favorit-pet-group4" value="dogs" />
-            </label>
-            <label>
-              Cats
-              <input type="radio" name="favorit-pet-group4" value="cats" defaultChecked />
-            </label>
-            <label>
-              Dragons
-              <input type="radio" name="favorit-pet-group4" value="dragons" />
-            </label>
-          </div>
-          <label>
-            Favorite Color controlled
-            <select onChange={e => setFavoriteColor2(e.target.value)}>
-              <option value="red" selected={favoriteColor2 === 'red'}>Red</option>
-              <option value="orange" selected={favoriteColor2 === 'orange'}>Orange</option>
-              <option value="yellow" selected={favoriteColor2 === 'yellow'}>Yellow</option>
-              <option value="green" selected={favoriteColor2 === 'green'}>Green</option>
-              <option value="blue" selected={favoriteColor2 === 'blue'}>Blue</option>
-              <option value="purple" selected={favoriteColor2 === 'purple'}>Purple</option>
-            </select>
-          </label>
-          <label>
-            Comments controlled
-            <textarea value={howIFeel2} onChange={e => setHowIFeel2(e.target.value)} />
-          </label>
-          <label>
-            Comments default
-            <textarea defaultValue="hello" />
-          </label>
-          <ButtonGroup>
-            <Button variant="secondary" type="reset">Reset</Button>
-            <Button variant="primary" type="submit">Submit</Button>
-          </ButtonGroup>
-        </Flex>
-      </form>
-    </Flex>
+    <Form
+      onSubmit={e => {
+        action('onSubmit')(Object.fromEntries(new FormData(e.target as HTMLFormElement).entries()));
+        e.preventDefault();
+      }}
+      {...props}>
+      <TextField name="first-name" label="First Name (controlled)" value={firstName} onChange={setFirstName} />
+      <TextField name="last-name" label="Last Name (uncontrolled)" defaultValue="world" />
+      <TextField name="street-address" label="Street Address (uncontrolled)" />
+      <Picker name="country" label="Country (uncontrolled)" items={countries}>
+        {item => <Item key={item.name}>{item.name}</Item>}
+      </Picker>
+      <NumberField name="age" label="Age (uncontrolled)" />
+      <NumberField name="money" label="Money (controlled)" formatOptions={{style: 'currency', currency: 'USD'}} value={money} onChange={setMoney} />
+      <Picker name="favorite-color" label="Favorite color (controlled)" selectedKey={favoriteColor} onSelectionChange={setFavoriteColor}>
+        <Item key="red">Red</Item>
+        <Item key="orange">Orange</Item>
+        <Item key="yellow">Yellow</Item>
+        <Item key="green">Green</Item>
+        <Item key="blue">Blue</Item>
+        <Item key="purple">Purple</Item>
+      </Picker>
+      <Checkbox name="is-hunter" isSelected={isHunter} onChange={setIsHunter}>I am a hunter! (controlled)</Checkbox>
+      <Checkbox name="is-wizard" defaultSelected>I am a wizard! (uncontrolled)</Checkbox>
+      <Switch name="airplane-mode">Airplane mode (uncontrolled)</Switch>
+      <Switch name="super-speed" isSelected={superSpeed} onChange={setSuperSpeed}>Super speed (controlled)</Switch>
+      <RadioGroup label="Favorite pet (controlled)" name="favorite-pet-group" value={favoritePet} onChange={setFavoritePet}>
+        <Radio value="dogs">Dogs</Radio>
+        <Radio value="cats">Cats</Radio>
+        <Radio value="dragons">Dragons</Radio>
+      </RadioGroup>
+      <RadioGroup label="Favorite pet (uncontrolled)" name="favorite-pet-group2" defaultValue="cats">
+        <Radio value="dogs">Dogs</Radio>
+        <Radio value="cats">Cats</Radio>
+        <Radio value="dragons">Dragons</Radio>
+      </RadioGroup>
+      <TextArea name="comments-controlled" label="Comments (controlled)" value={howIFeel} onChange={setHowIFeel} />
+      <TextArea name="comments-uncontrolled" label="Comments (uncontrolled)" defaultValue="hello" />
+      <ComboBox label="Favorite Animal (uncontrolled)" name="favorite-animal" formValue="key">
+        <Item key="red panda">Red Panda</Item>
+        <Item key="aardvark">Aardvark</Item>
+        <Item key="kangaroo">Kangaroo</Item>
+        <Item key="snake">Snake</Item>
+      </ComboBox>
+      <DateField name="date-uncontrolled" label="Birth date (uncontrolled)" />
+      <DateField name="date-controlled" label="Birth date (controlled)" value={birthday} onChange={setBirthday} />
+      <DateRangePicker startName="trip-start" endName="trip-end" label="Trip dates (uncontrolled)" />
+      <Slider name="cookies" label="Cookies (uncontrolled)" defaultValue={50} />
+      <ButtonGroup>
+        <Button variant="primary" type="submit">Submit</Button>
+        <Button variant="secondary" type="reset">Reset</Button>
+      </ButtonGroup>
+    </Form>
   );
 }
 

--- a/packages/@react-spectrum/numberfield/src/NumberField.tsx
+++ b/packages/@react-spectrum/numberfield/src/NumberField.tsx
@@ -16,6 +16,7 @@ import {Field} from '@react-spectrum/label';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
+import {NumberFieldState, useNumberFieldState} from '@react-stately/numberfield';
 import React, {HTMLAttributes, InputHTMLAttributes, RefObject, useRef} from 'react';
 import {SpectrumNumberFieldProps} from '@react-types/numberfield';
 import {StepButton} from './StepButton';
@@ -24,7 +25,6 @@ import {TextFieldBase} from '@react-spectrum/textfield';
 import {useHover} from '@react-aria/interactions';
 import {useLocale} from '@react-aria/i18n';
 import {useNumberField} from '@react-aria/numberfield';
-import {NumberFieldState, useNumberFieldState} from '@react-stately/numberfield';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
 
 function NumberField(props: SpectrumNumberFieldProps, ref: FocusableRef<HTMLElement>) {
@@ -111,7 +111,7 @@ interface NumberFieldInputProps extends SpectrumNumberFieldProps {
   decrementProps: AriaButtonProps,
   className?: string,
   style?: React.CSSProperties,
-  state: NumberFieldState,
+  state: NumberFieldState
 }
 
 const NumberFieldInput = React.forwardRef(function NumberFieldInput(props: NumberFieldInputProps, ref: RefObject<HTMLElement>) {

--- a/packages/@react-spectrum/numberfield/src/NumberField.tsx
+++ b/packages/@react-spectrum/numberfield/src/NumberField.tsx
@@ -24,7 +24,7 @@ import {TextFieldBase} from '@react-spectrum/textfield';
 import {useHover} from '@react-aria/interactions';
 import {useLocale} from '@react-aria/i18n';
 import {useNumberField} from '@react-aria/numberfield';
-import {useNumberFieldState} from '@react-stately/numberfield';
+import {NumberFieldState, useNumberFieldState} from '@react-stately/numberfield';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
 
 function NumberField(props: SpectrumNumberFieldProps, ref: FocusableRef<HTMLElement>) {
@@ -96,7 +96,8 @@ function NumberField(props: SpectrumNumberFieldProps, ref: FocusableRef<HTMLElem
         incrementProps={incrementButtonProps}
         decrementProps={decrementButtonProps}
         className={className}
-        style={style} />
+        style={style}
+        state={state} />
     </Field>
   );
 }
@@ -109,7 +110,8 @@ interface NumberFieldInputProps extends SpectrumNumberFieldProps {
   incrementProps: AriaButtonProps,
   decrementProps: AriaButtonProps,
   className?: string,
-  style?: React.CSSProperties
+  style?: React.CSSProperties,
+  state: NumberFieldState,
 }
 
 const NumberFieldInput = React.forwardRef(function NumberFieldInput(props: NumberFieldInputProps, ref: RefObject<HTMLElement>) {
@@ -125,7 +127,9 @@ const NumberFieldInput = React.forwardRef(function NumberFieldInput(props: Numbe
     isQuiet,
     isDisabled,
     hideStepper,
-    validationState
+    validationState,
+    name,
+    state
   } = props;
   let showStepper = !hideStepper;
 
@@ -172,6 +176,7 @@ const NumberFieldInput = React.forwardRef(function NumberFieldInput(props: Numbe
           <StepButton direction="down" isQuiet={isQuiet} {...decrementProps} />
         </>
         }
+        {name && <input type="hidden" name={name} value={state.numberValue} />}
       </div>
     </FocusRing>
   );

--- a/packages/@react-spectrum/numberfield/src/NumberField.tsx
+++ b/packages/@react-spectrum/numberfield/src/NumberField.tsx
@@ -176,7 +176,7 @@ const NumberFieldInput = React.forwardRef(function NumberFieldInput(props: Numbe
           <StepButton direction="down" isQuiet={isQuiet} {...decrementProps} />
         </>
         }
-        {name && <input type="hidden" name={name} value={state.numberValue} />}
+        {name && <input type="hidden" name={name} value={isNaN(state.numberValue) ? '' : state.numberValue} />}
       </div>
     </FocusRing>
   );

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -2203,4 +2203,30 @@ describe('NumberField', function () {
     expect(resetSpy).toHaveBeenCalledTimes(1);
     expect(textField).toHaveAttribute('value', '');
   });
+
+  it('supports form reset', async () => {
+    function Test() {
+      let [value, setValue] = React.useState(10);
+      return (
+        <Provider theme={theme}>
+          <form>
+            <NumberField data-testid="input" label="Value" value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        </Provider>
+      );
+    }
+
+    let {getByTestId} = render(<Test />);
+    let input = getByTestId('input');
+
+    expect(input).toHaveValue('10');
+    await act(() => userEvent.type(input, '0'));
+    expect(input).toHaveValue('100');
+
+    let button = getByTestId('reset');
+    act(() => input.blur());
+    act(() => userEvent.click(button));
+    expect(input).toHaveValue('10');
+  });
 });

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -2205,16 +2205,14 @@ describe('NumberField', function () {
   });
 
   it('supports form value', () => {
-    let {getByRole} = render(
-      <Provider theme={theme}>
-        <NumberField name="age" label="Age" value={30} />
-      </Provider>
-    );
-    let input = getByRole('textbox');
-    expect(input).not.toHaveAttribute('name');
+    let {textField, rerender} = renderNumberField({name: 'age', value: 30});
+    expect(textField).not.toHaveAttribute('name');
     let hiddenInput = document.querySelector('input[type=hidden]');
     expect(hiddenInput).toHaveAttribute('name', 'age');
     expect(hiddenInput).toHaveValue('30');
+
+    rerender({name: 'age', value: null});
+    expect(hiddenInput).toHaveValue('');
   });
 
   it('supports form reset', async () => {

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -2204,6 +2204,19 @@ describe('NumberField', function () {
     expect(textField).toHaveAttribute('value', '');
   });
 
+  it('supports form value', () => {
+    let {getByRole} = render(
+      <Provider theme={theme}>
+        <NumberField name="age" label="Age" value={30} />
+      </Provider>
+    );
+    let input = getByRole('textbox');
+    expect(input).not.toHaveAttribute('name');
+    let hiddenInput = document.querySelector('input[type=hidden]');
+    expect(hiddenInput).toHaveAttribute('name', 'age');
+    expect(hiddenInput).toHaveValue('30');
+  });
+
   it('supports form reset', async () => {
     function Test() {
       let [value, setValue] = React.useState(10);

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -2194,5 +2194,41 @@ describe('Picker', function () {
       expect(onSubmit).toHaveBeenCalledTimes(1);
       expect(value).toEqual('one');
     });
+
+    it('supports form reset', () => {
+      function Test() {
+        let [value, setValue] = React.useState('one');
+        return (
+          <Provider theme={theme}>
+            <form>
+              <Picker name="picker" data-testid="picker" label="Test" selectedKey={value} onSelectionChange={setValue}>
+                <Item key="one">One</Item>
+                <Item key="two">Two</Item>
+                <Item key="three">Three</Item>
+              </Picker>
+              <input type="reset" data-testid="reset" />
+            </form>
+          </Provider>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let picker = getByTestId('picker');
+      let input = document.querySelector('[name=picker]');
+
+      expect(input).toHaveValue('one');
+      triggerPress(picker);
+      act(() => jest.runAllTimers());
+
+      let listbox = getByRole('listbox');
+      let items = within(listbox).getAllByRole('option');
+      expect(items.length).toBe(3);
+      triggerPress(items[1]);
+      expect(input).toHaveValue('two');
+
+      let button = getByTestId('reset');
+      act(() => userEvent.click(button));
+      expect(input).toHaveValue('one');
+    })
   });
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -2229,6 +2229,6 @@ describe('Picker', function () {
       let button = getByTestId('reset');
       act(() => userEvent.click(button));
       expect(input).toHaveValue('one');
-    })
+    });
   });
 });

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -435,6 +435,41 @@ describe('Radios', function () {
     expect(description).toHaveTextContent('Error message');
   });
 
+  it('supports form reset', () => {
+    function Test() {
+      let [value, setValue] = React.useState('dogs');
+      return (
+        <Provider theme={theme}>
+          <form>
+            <RadioGroup name="pet" label="Favorite Pet" value={value} onChange={setValue}>
+              <Radio value="dogs">Dogs</Radio>
+              <Radio value="cats">Cats</Radio>
+              <Radio value="dragons">Dragons</Radio>
+            </RadioGroup>
+            <input type="reset" data-testid="reset" />
+          </form>
+        </Provider>
+      );
+    }
+
+    let {getAllByRole, getByTestId} = render(<Test />);
+    let radios = getAllByRole('radio');
+
+    expect(radios[0]).toBeChecked();
+    expect(radios[1]).not.toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+    act(() => userEvent.click(radios[1]));
+    expect(radios[0]).not.toBeChecked();
+    expect(radios[1]).toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(radios[0]).toBeChecked();
+    expect(radios[1]).not.toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+  });
+
   describe('Radio group supports roving tabIndex ', function () {
     afterEach(() => {
       radioBehavior.reset();

--- a/packages/@react-spectrum/slider/src/RangeSlider.tsx
+++ b/packages/@react-spectrum/slider/src/RangeSlider.tsx
@@ -58,7 +58,8 @@ function RangeSlider(props: SpectrumRangeSliderProps, ref: FocusableRef<HTMLDivE
               isDisabled={props.isDisabled}
               trackRef={trackRef}
               inputRef={inputRef}
-              state={state} />
+              state={state}
+              name={props.startName} />
             <div
               className={classNames(styles, 'spectrum-Slider-track')}
               style={{
@@ -70,7 +71,8 @@ function RangeSlider(props: SpectrumRangeSliderProps, ref: FocusableRef<HTMLDivE
               aria-label={stringFormatter.format('maximum')}
               isDisabled={props.isDisabled}
               trackRef={trackRef}
-              state={state} />
+              state={state}
+              name={props.endName} />
             <div
               className={classNames(styles, 'spectrum-Slider-track')}
               style={{

--- a/packages/@react-spectrum/slider/src/Slider.tsx
+++ b/packages/@react-spectrum/slider/src/Slider.tsx
@@ -103,7 +103,8 @@ function Slider(props: SpectrumSliderProps, ref: FocusableRef<HTMLDivElement>) {
               isDisabled={props.isDisabled}
               trackRef={trackRef}
               inputRef={inputRef}
-              state={state} />
+              state={state}
+              name={props.name} />
             {filledTrack}
             {upperTrack}
           </>

--- a/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
+++ b/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
@@ -183,6 +183,15 @@ describe('RangeSlider', function () {
     expect(sliderRight).toHaveAttribute('aria-valuetext', '60');
   });
 
+  it('supports form name', () => {
+    let {getAllByRole} = render(<RangeSlider label="Value" value={{start: 10, end: 40}} startName="minCookies" endName="maxCookies" />);
+    let inputs = getAllByRole('slider');
+    expect(inputs[0]).toHaveAttribute('name', 'minCookies');
+    expect(inputs[0]).toHaveValue('10');
+    expect(inputs[1]).toHaveAttribute('name', 'maxCookies');
+    expect(inputs[1]).toHaveValue('40');
+  });
+
   it('supports form reset', () => {
     function Test() {
       let [value, setValue] = React.useState({start: 10, end: 40});

--- a/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
+++ b/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {fireEvent, render} from '@react-spectrum/test-utils';
+import {act, fireEvent, render} from '@react-spectrum/test-utils';
 import {press, testKeypresses} from './utils';
 import {Provider} from '@adobe/react-spectrum';
 import {RangeSlider} from '../';
@@ -181,6 +181,35 @@ describe('RangeSlider', function () {
     fireEvent.change(sliderRight, {target: {value: '60'}});
     expect(output).toHaveTextContent('A5B60C');
     expect(sliderRight).toHaveAttribute('aria-valuetext', '60');
+  });
+
+  it('supports form reset', () => {
+    function Test() {
+      let [value, setValue] = React.useState({start: 10, end: 40});
+      return (
+        <Provider theme={theme}>
+          <form>
+            <RangeSlider label="Value" value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        </Provider>
+      );
+    }
+
+    let {getByTestId, getAllByRole} = render(<Test />);
+    let inputs = getAllByRole('slider');
+
+    expect(inputs[0]).toHaveValue('10');
+    expect(inputs[1]).toHaveValue('40');
+    fireEvent.change(inputs[0], {target: {value: '30'}});
+    fireEvent.change(inputs[1], {target: {value: '60'}});
+    expect(inputs[0]).toHaveValue('30');
+    expect(inputs[1]).toHaveValue('60');
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(inputs[0]).toHaveValue('10');
+    expect(inputs[1]).toHaveValue('40');
   });
 
   describe('formatOptions', () => {

--- a/packages/@react-spectrum/slider/test/Slider.test.tsx
+++ b/packages/@react-spectrum/slider/test/Slider.test.tsx
@@ -166,6 +166,13 @@ describe('Slider', function () {
     expect(slider).toHaveAttribute('aria-valuetext', '55');
   });
 
+  it('supports form name', () => {
+    let {getByRole} = render(<Slider label="Value" value={10} name="cookies" />);
+    let input = getByRole('slider');
+    expect(input).toHaveAttribute('name', 'cookies');
+    expect(input).toHaveValue('10');
+  });
+
   it('supports form reset', () => {
     function Test() {
       let [value, setValue] = React.useState(10);

--- a/packages/@react-spectrum/slider/test/Slider.test.tsx
+++ b/packages/@react-spectrum/slider/test/Slider.test.tsx
@@ -166,6 +166,31 @@ describe('Slider', function () {
     expect(slider).toHaveAttribute('aria-valuetext', '55');
   });
 
+  it('supports form reset', () => {
+    function Test() {
+      let [value, setValue] = React.useState(10);
+      return (
+        <Provider theme={theme}>
+          <form>
+            <Slider label="Value" value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        </Provider>
+      );
+    }
+
+    let {getByTestId, getByRole} = render(<Test />);
+    let input = getByRole('slider');
+
+    expect(input).toHaveValue('10');
+    fireEvent.change(input, {target: {value: '55'}});
+    expect(input).toHaveValue('55');
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(input).toHaveValue('10');
+  });
+
   describe('formatOptions', () => {
     it('prefixes the value with a plus sign if needed', function () {
       let {getByRole} = render(

--- a/packages/@react-spectrum/switch/test/Switch.test.js
+++ b/packages/@react-spectrum/switch/test/Switch.test.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import {act, render} from '@react-spectrum/test-utils';
 import React from 'react';
-import {render} from '@react-spectrum/test-utils';
 import {Switch} from '../';
 import userEvent from '@testing-library/user-event';
 
@@ -178,5 +178,28 @@ describe('Switch', function () {
     userEvent.click(checkbox);
     expect(checkbox.checked).toBeTruthy();
     expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  it('supports form reset', () => {
+    function Test() {
+      let [isSelected, setSelected] = React.useState(false);
+      return (
+        <form>
+          <Switch data-testid="switch" isSelected={isSelected} onChange={setSelected}>Switch</Switch>
+          <input type="reset" data-testid="reset" />
+        </form>
+      );
+    }
+
+    let {getByTestId} = render(<Test />);
+    let input = getByTestId('switch');
+
+    expect(input).not.toBeChecked();
+    act(() => userEvent.click(input));
+    expect(input).toBeChecked();
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(input).not.toBeChecked();
   });
 });

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -440,7 +440,7 @@ describe('Shared TextField behavior', () => {
     ${'v3 TextField'}   | ${TextField}
     ${'v3 TextArea'}    | ${TextArea}
     ${'v3 SearchField'} | ${SearchField}
-  `('$Name supports form reset', async ({Component}) => {
+  `('$Name supports form reset', ({Component}) => {
     function Test() {
       let [value, setValue] = React.useState('Devon');
       return (
@@ -455,7 +455,7 @@ describe('Shared TextField behavior', () => {
     let input = getByTestId('name');
 
     expect(input).toHaveValue('Devon');
-    await act(() => userEvent.type(input, ' test'));
+    typeText(input, ' test');
     expect(input).toHaveValue('Devon test');
 
     let button = getByTestId('reset');

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -434,4 +434,32 @@ describe('Shared TextField behavior', () => {
     let input = tree.getByTestId(testId);
     expect(input).toHaveAttribute('tabIndex', '-1');
   });
+
+  it.each`
+    Name                | Component
+    ${'v3 TextField'}   | ${TextField}
+    ${'v3 TextArea'}    | ${TextArea}
+    ${'v3 SearchField'} | ${SearchField}
+  `('$Name supports form reset', async ({Component}) => {
+    function Test() {
+      let [value, setValue] = React.useState('Devon');
+      return (
+        <form>
+          <Component data-testid="name" label="Name" value={value} onChange={setValue} />
+          <input type="reset" data-testid="reset" />
+        </form>
+      );
+    }
+
+    let {getByTestId} = render(<Test />);
+    let input = getByTestId('name');
+
+    expect(input).toHaveValue('Devon');
+    await act(() => userEvent.type(input, ' test'));
+    expect(input).toHaveValue('Devon test');
+
+    let button = getByTestId('reset');
+    act(() => userEvent.click(button));
+    expect(input).toHaveValue('Devon');
+  });
 });

--- a/packages/@react-stately/datepicker/src/index.ts
+++ b/packages/@react-stately/datepicker/src/index.ts
@@ -18,4 +18,4 @@ export {useTimeFieldState} from './useTimeFieldState';
 export type {DateFieldStateOptions, DateFieldState, DateSegment, SegmentType} from './useDateFieldState';
 export type {DatePickerStateOptions, DatePickerState} from './useDatePickerState';
 export type {DateRangePickerStateOptions, DateRangePickerState} from './useDateRangePickerState';
-export type {TimeFieldStateOptions} from './useTimeFieldState';
+export type {TimeFieldStateOptions, TimeFieldState} from './useTimeFieldState';

--- a/packages/@react-stately/datepicker/src/useDateFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDateFieldState.ts
@@ -236,7 +236,11 @@ export function useDateFieldState<T extends DateValue = DateValue>(props: DateFi
       return;
     }
 
-    if (Object.keys(validSegments).length >= Object.keys(allSegments).length) {
+    if (newValue == null) {
+      setDate(null);
+      setPlaceholderDate(createPlaceholderDate(props.placeholderValue, granularity, calendar, defaultTimeZone));
+      setValidSegments({});
+    } else if (Object.keys(validSegments).length >= Object.keys(allSegments).length) {
       // The display calendar should not have any effect on the emitted value.
       // Emit dates in the same calendar as the original value, if any, otherwise gregorian.
       newValue = toCalendar(newValue, v?.calendar || new GregorianCalendar());

--- a/packages/@react-stately/datepicker/src/useTimeFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useTimeFieldState.ts
@@ -21,12 +21,17 @@ export interface TimeFieldStateOptions<T extends TimeValue = TimeValue> extends 
   locale: string
 }
 
+export interface TimeFieldState extends DateFieldState {
+  /** The current time value. */
+  timeValue: Time
+}
+
 /**
  * Provides state management for a time field component.
  * A time field allows users to enter and edit time values using a keyboard.
  * Each part of a time value is displayed in an individually editable segment.
  */
-export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFieldStateOptions<T>): DateFieldState {
+export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFieldStateOptions<T>): TimeFieldState {
   let {
     placeholderValue = new Time(),
     minValue,
@@ -51,12 +56,13 @@ export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFi
   let minDate = useMemo(() => convertValue(minValue, day), [minValue, day]);
   let maxDate = useMemo(() => convertValue(maxValue, day), [maxValue, day]);
 
+  let timeValue = useMemo(() => value && 'day' in value ? toTime(value) : value as Time, [value]);
   let dateTime = useMemo(() => value == null ? null : convertValue(value), [value]);
   let onChange = newValue => {
     setValue(day || defaultValueTimeZone ? newValue : newValue && toTime(newValue));
   };
 
-  return useDateFieldState({
+  let state = useDateFieldState({
     ...props,
     value: dateTime,
     defaultValue: undefined,
@@ -69,6 +75,11 @@ export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFi
     // Calendar should not matter for time fields.
     createCalendar: () => new GregorianCalendar()
   });
+
+  return {
+    ...state,
+    timeValue
+  };
 }
 
 function convertValue(value: TimeValue, date: DateValue = today(getLocalTimeZone())) {

--- a/packages/@react-stately/numberfield/src/useNumberFieldState.ts
+++ b/packages/@react-stately/numberfield/src/useNumberFieldState.ts
@@ -42,6 +42,8 @@ export interface NumberFieldState {
   validate(value: string): boolean,
   /** Sets the current text value of the input. */
   setInputValue(val: string): void,
+  /** Sets the number value. */
+  setNumberValue(val: number): void,
   /**
    * Commits the current input value. The value is parsed to a number, clamped according
    * to the minimum and maximum values of the field, and snapped to the nearest step value.
@@ -240,6 +242,7 @@ export function useNumberFieldState(
     minValue,
     maxValue,
     numberValue: parsedValue,
+    setNumberValue,
     setInputValue,
     inputValue,
     commit

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -231,7 +231,7 @@ export function useSliderState<T extends number | number[]>(props: SliderStateOp
 
     // Round value to multiple of step, clamp value between min and max
     value = snapValueToStep(value, thisMin, thisMax, step);
-    let newValues = replaceIndex(values, index, value);
+    let newValues = replaceIndex(valuesRef.current, index, value);
     setValues(newValues);
   }
 

--- a/packages/@react-types/checkbox/src/index.d.ts
+++ b/packages/@react-types/checkbox/src/index.d.ts
@@ -18,6 +18,7 @@ import {
   FocusableProps,
   HelpTextProps,
   InputBase,
+  InputDOMProps,
   LabelableProps,
   Orientation,
   SpectrumHelpTextProps,
@@ -48,14 +49,10 @@ export interface ToggleProps extends InputBase, Validation, FocusableProps {
   /**
    * The value of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefvalue).
    */
-  value?: string,
-  /**
-   * The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
-   */
-  name?: string
+  value?: string
 }
 
-export interface AriaToggleProps extends ToggleProps, FocusableDOMProps, AriaLabelingProps, AriaValidationProps {
+export interface AriaToggleProps extends ToggleProps, FocusableDOMProps, AriaLabelingProps, AriaValidationProps, InputDOMProps {
   /**
    * Identifies the element (or elements) whose contents or presence are controlled by the current element.
    */
@@ -74,12 +71,7 @@ export interface CheckboxProps extends ToggleProps {
 
 export interface AriaCheckboxProps extends CheckboxProps, AriaToggleProps {}
 
-export interface AriaCheckboxGroupProps extends CheckboxGroupProps, DOMProps, AriaLabelingProps, AriaValidationProps {
-  /**
-   * The name of the CheckboxGroup, used when submitting an HTML form.
-   */
-  name?: string
-}
+export interface AriaCheckboxGroupProps extends CheckboxGroupProps, DOMProps, InputDOMProps, AriaLabelingProps, AriaValidationProps {}
 
 export interface AriaCheckboxGroupItemProps extends Omit<AriaCheckboxProps, 'isSelected' | 'defaultSelected'> {
   value: string

--- a/packages/@react-types/color/src/index.d.ts
+++ b/packages/@react-types/color/src/index.d.ts
@@ -19,6 +19,7 @@ import {
   FocusableProps,
   HelpTextProps,
   InputBase,
+  InputDOMProps,
   LabelableProps,
   SpectrumLabelableProps,
   SpectrumTextInputBase,
@@ -121,7 +122,7 @@ export interface ColorWheelProps extends Omit<ValueBase<string | Color>, 'onChan
   defaultValue?: string | Color
 }
 
-export interface AriaColorWheelProps extends ColorWheelProps, DOMProps, AriaLabelingProps {}
+export interface AriaColorWheelProps extends ColorWheelProps, InputDOMProps, DOMProps, AriaLabelingProps {}
 
 export interface SpectrumColorWheelProps extends AriaColorWheelProps, Omit<StyleProps, 'width' | 'height'> {
   /** The outer diameter of the ColorWheel. */
@@ -137,7 +138,7 @@ export interface ColorSliderProps extends Omit<SliderProps<string | Color>, 'min
   onChangeEnd?: (value: Color) => void
 }
 
-export interface AriaColorSliderProps extends ColorSliderProps, DOMProps, AriaLabelingProps {}
+export interface AriaColorSliderProps extends ColorSliderProps, InputDOMProps, DOMProps, AriaLabelingProps {}
 
 export interface SpectrumColorSliderProps extends AriaColorSliderProps, StyleProps {
   /** Whether the value label is displayed. True by default if there is a label, false by default if not. */
@@ -159,7 +160,16 @@ export interface ColorAreaProps extends Omit<ValueBase<string | Color>, 'onChang
   onChangeEnd?: (value: Color) => void
 }
 
-export interface AriaColorAreaProps extends ColorAreaProps, DOMProps, AriaLabelingProps {}
+export interface AriaColorAreaProps extends ColorAreaProps, DOMProps, AriaLabelingProps {
+  /**
+   * The name of the x channel input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  xName?: string,
+  /**
+   * The name of the y channel input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  yName?: string
+}
 
 export interface SpectrumColorAreaProps extends AriaColorAreaProps, Omit<StyleProps, 'width' | 'height'> {
   /** Size of the Color Area. */

--- a/packages/@react-types/combobox/src/index.d.ts
+++ b/packages/@react-types/combobox/src/index.d.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaLabelingProps, AsyncLoadable, CollectionBase, DOMProps, FocusableProps, HelpTextProps, InputBase, LabelableProps, LoadingState, SingleSelection, SpectrumLabelableProps, SpectrumTextInputBase, StyleProps, TextInputBase, Validation} from '@react-types/shared';
+import {AriaLabelingProps, AsyncLoadable, CollectionBase, DOMProps, FocusableProps, HelpTextProps, InputBase, InputDOMProps, LabelableProps, LoadingState, SingleSelection, SpectrumLabelableProps, SpectrumTextInputBase, StyleProps, TextInputBase, Validation} from '@react-types/shared';
 
 export type MenuTriggerAction = 'focus' | 'input' | 'manual';
 
@@ -38,14 +38,10 @@ export interface ComboBoxProps<T> extends CollectionBase<T>, Omit<SingleSelectio
   * The interaction required to display the ComboBox menu.
   * @default 'input'
   */
-  menuTrigger?: MenuTriggerAction,
-  /**
-   * The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
-   */
-  name?: string
+  menuTrigger?: MenuTriggerAction
 }
 
-export interface AriaComboBoxProps<T> extends ComboBoxProps<T>, DOMProps, AriaLabelingProps {
+export interface AriaComboBoxProps<T> extends ComboBoxProps<T>, DOMProps, InputDOMProps, AriaLabelingProps {
   /** Whether keyboard navigation is circular. */
   shouldFocusWrap?: boolean
 }

--- a/packages/@react-types/combobox/src/index.d.ts
+++ b/packages/@react-types/combobox/src/index.d.ts
@@ -65,5 +65,11 @@ export interface SpectrumComboBoxProps<T> extends SpectrumTextInputBase, Omit<Ar
    * Whether the menu should automatically flip direction when space is limited.
    * @default true
    */
-  shouldFlip?: boolean
+  shouldFlip?: boolean,
+  /**
+   * Whether the text or key of the selected item is submitted as part of an HTML form.
+   * When `allowsCustomValue` is `true`, this option does not apply and the text is always submitted.
+   * @default 'text'
+   */
+  formValue?: 'text' | 'key'
 }

--- a/packages/@react-types/datepicker/src/index.d.ts
+++ b/packages/@react-types/datepicker/src/index.d.ts
@@ -16,6 +16,7 @@ import {
   FocusableProps,
   HelpTextProps,
   InputBase,
+  InputDOMProps,
   LabelableProps,
   RangeValue,
   SpectrumLabelableProps,
@@ -62,7 +63,7 @@ interface DateFieldBase<T extends DateValue> extends InputBase, Validation, Focu
 
 interface AriaDateFieldBaseProps<T extends DateValue> extends DateFieldBase<T>, AriaLabelingProps, DOMProps {}
 export interface DateFieldProps<T extends DateValue> extends DateFieldBase<T>, ValueBase<T | null, MappedDateValue<T>> {}
-export interface AriaDateFieldProps<T extends DateValue> extends DateFieldProps<T>, AriaDateFieldBaseProps<T> {}
+export interface AriaDateFieldProps<T extends DateValue> extends DateFieldProps<T>, AriaDateFieldBaseProps<T>, InputDOMProps {}
 
 interface DatePickerBase<T extends DateValue> extends DateFieldBase<T>, OverlayTriggerProps {
   /**
@@ -74,7 +75,7 @@ interface DatePickerBase<T extends DateValue> extends DateFieldBase<T>, OverlayT
 export interface AriaDatePickerBaseProps<T extends DateValue> extends DatePickerBase<T>, AriaLabelingProps, DOMProps {}
 
 export interface DatePickerProps<T extends DateValue> extends DatePickerBase<T>, ValueBase<T | null, MappedDateValue<T>> {}
-export interface AriaDatePickerProps<T extends DateValue> extends DatePickerProps<T>, AriaDatePickerBaseProps<T> {}
+export interface AriaDatePickerProps<T extends DateValue> extends DatePickerProps<T>, AriaDatePickerBaseProps<T>, InputDOMProps {}
 
 export type DateRange = RangeValue<DateValue>;
 export interface DateRangePickerProps<T extends DateValue> extends DatePickerBase<T>, ValueBase<RangeValue<T> | null, RangeValue<MappedDateValue<T>>> {
@@ -85,7 +86,16 @@ export interface DateRangePickerProps<T extends DateValue> extends DatePickerBas
   allowsNonContiguousRanges?: boolean
 }
 
-export interface AriaDateRangePickerProps<T extends DateValue> extends AriaDatePickerBaseProps<T>, DateRangePickerProps<T> {}
+export interface AriaDateRangePickerProps<T extends DateValue> extends AriaDatePickerBaseProps<T>, DateRangePickerProps<T> {
+  /**
+   * The name of the start date input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  startName?: string,
+  /**
+   * The name of the end date input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  endName?: string
+}
 
 interface SpectrumDateFieldBase extends SpectrumLabelableProps, HelpTextProps, StyleProps {
   /**

--- a/packages/@react-types/numberfield/src/index.d.ts
+++ b/packages/@react-types/numberfield/src/index.d.ts
@@ -15,7 +15,7 @@ import {
   DOMProps,
   FocusableProps,
   HelpTextProps,
-  InputBase, LabelableProps,
+  InputBase, InputDOMProps, LabelableProps,
   RangeInputBase, SpectrumLabelableProps,
   StyleProps,
   TextInputBase,
@@ -39,7 +39,7 @@ export interface AriaNumberFieldProps extends NumberFieldProps, DOMProps, AriaLa
   incrementAriaLabel?: string
 }
 
-export interface SpectrumNumberFieldProps extends Omit<AriaNumberFieldProps, 'placeholder'>, StyleProps, SpectrumLabelableProps {
+export interface SpectrumNumberFieldProps extends Omit<AriaNumberFieldProps, 'placeholder'>, InputDOMProps, StyleProps, SpectrumLabelableProps {
   /** Whether the numberfield should be displayed with a quiet style. */
   isQuiet?: boolean,
   /** Whether to hide the increment and decrement buttons. */

--- a/packages/@react-types/radio/src/index.d.ts
+++ b/packages/@react-types/radio/src/index.d.ts
@@ -17,6 +17,7 @@ import {
   FocusableProps,
   HelpTextProps,
   InputBase,
+  InputDOMProps,
   LabelableProps,
   Orientation,
   SpectrumHelpTextProps,
@@ -27,17 +28,12 @@ import {
 } from '@react-types/shared';
 import {ReactElement, ReactNode} from 'react';
 
-export interface RadioGroupProps extends ValueBase<string>, InputBase, Validation, LabelableProps, HelpTextProps {
+export interface RadioGroupProps extends ValueBase<string>, InputBase, InputDOMProps, Validation, LabelableProps, HelpTextProps {
   /**
    * The axis the Radio Button(s) should align with.
    * @default 'vertical'
    */
-  orientation?: Orientation,
-  /**
-   * The name of the RadioGroup, used when submitting an HTML form.
-   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name_and_radio_buttons).
-   */
-  name?: string
+  orientation?: Orientation
 }
 
 export interface RadioProps extends FocusableProps {

--- a/packages/@react-types/shared/src/dom.d.ts
+++ b/packages/@react-types/shared/src/dom.d.ts
@@ -121,9 +121,16 @@ export interface TextInputDOMEvents {
    onInput?: FormEventHandler<HTMLInputElement>
 }
 
+export interface InputDOMProps {
+  /**
+   * The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  name?: string
+}
+
 // DOM props that apply to all text inputs
 // Ensure this is synced with useTextField
-export interface TextInputDOMProps extends DOMProps, TextInputDOMEvents {
+export interface TextInputDOMProps extends DOMProps, InputDOMProps, TextInputDOMEvents {
   /**
    * Describes the type of autocomplete functionality the input should provide if any. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefautocomplete).
    */
@@ -138,11 +145,6 @@ export interface TextInputDOMProps extends DOMProps, TextInputDOMEvents {
    * The minimum number of characters required by the input. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefminlength).
    */
   minLength?: number,
-
-  /**
-   * The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
-   */
-  name?: string,
 
   /**
    * Regex pattern that the value of the input must match to be valid. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern).

--- a/packages/@react-types/slider/src/index.d.ts
+++ b/packages/@react-types/slider/src/index.d.ts
@@ -4,6 +4,7 @@ import {
   DOMProps,
   FocusableDOMProps,
   FocusableProps,
+  InputDOMProps,
   LabelableProps,
   LabelPosition,
   Orientation,
@@ -52,7 +53,7 @@ export interface SliderThumbProps extends FocusableProps, Validation, LabelableP
   orientation?: Orientation,
   /** Whether the Thumb is disabled. */
   isDisabled?: boolean,
-  /** 
+  /**
    * Index of the thumb within the slider.
    * @default 0
    */
@@ -60,7 +61,7 @@ export interface SliderThumbProps extends FocusableProps, Validation, LabelableP
 }
 
 export interface AriaSliderProps<T = number | number[]> extends SliderProps<T>, DOMProps, AriaLabelingProps {}
-export interface AriaSliderThumbProps extends SliderThumbProps, DOMProps, FocusableDOMProps, AriaLabelingProps, AriaValidationProps {}
+export interface AriaSliderThumbProps extends SliderThumbProps, DOMProps, FocusableDOMProps, InputDOMProps, AriaLabelingProps, AriaValidationProps {}
 
 export interface SpectrumBarSliderBase<T> extends AriaSliderProps<T>, ValueBase<T>, StyleProps {
   /**
@@ -82,7 +83,7 @@ export interface SpectrumBarSliderBase<T> extends AriaSliderProps<T>, ValueBase<
   contextualHelp?: ReactNode
 }
 
-export interface SpectrumSliderProps extends SpectrumBarSliderBase<number> {
+export interface SpectrumSliderProps extends SpectrumBarSliderBase<number>, InputDOMProps {
   /**
    * Whether a fill color is shown between the start of the slider and the current value.
    * @see https://spectrum.adobe.com/page/slider/#Fill.
@@ -102,4 +103,13 @@ export interface SpectrumSliderProps extends SpectrumBarSliderBase<number> {
   trackGradient?: string[]
 }
 
-export interface SpectrumRangeSliderProps extends SpectrumBarSliderBase<RangeValue<number>> { }
+export interface SpectrumRangeSliderProps extends SpectrumBarSliderBase<RangeValue<number>> {
+  /**
+   * The name of the start input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  startName?: string,
+  /**
+   * The name of the end input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+   */
+  endName?: string
+}

--- a/packages/@react-types/switch/src/index.d.ts
+++ b/packages/@react-types/switch/src/index.d.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaLabelingProps, FocusableDOMProps, FocusableProps, InputBase, StyleProps} from '@react-types/shared';
+import {AriaLabelingProps, FocusableDOMProps, FocusableProps, InputBase, InputDOMProps, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
 interface SwitchBase extends InputBase, FocusableProps {
@@ -33,14 +33,10 @@ interface SwitchBase extends InputBase, FocusableProps {
   /**
    * The value of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefvalue).
    */
-  value?: string,
-  /**
-   * The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
-   */
-  name?: string
+  value?: string
 }
 export interface SwitchProps extends SwitchBase {}
-export interface AriaSwitchBase extends SwitchBase, FocusableDOMProps, AriaLabelingProps {
+export interface AriaSwitchBase extends SwitchBase, FocusableDOMProps, InputDOMProps, AriaLabelingProps {
   /**
    * Identifies the element (or elements) whose contents or presence are controlled by the current element.
    */

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -49,9 +49,15 @@ export interface ComboBoxRenderProps {
   state: Omit<ComboBoxState<unknown>, 'children' | 'setOpen' | 'toggle' | 'open' | 'close' | 'selectionManager' | 'setSelectedKey' | 'setFocused' | 'collection' | 'commit' | 'revert'>
 }
 
-export interface ComboBoxProps<T extends object> extends Omit<AriaComboBoxProps<T>, 'children' | 'placeholder' | 'name' | 'label' | 'description' | 'errorMessage'>, RenderProps<ComboBoxRenderProps>, SlotProps {
+export interface ComboBoxProps<T extends object> extends Omit<AriaComboBoxProps<T>, 'children' | 'placeholder' | 'label' | 'description' | 'errorMessage'>, RenderProps<ComboBoxRenderProps>, SlotProps {
   /** The filter function used to determine if a option should be included in the combo box list. */
-  defaultFilter?: (textValue: string, inputValue: string) => boolean
+  defaultFilter?: (textValue: string, inputValue: string) => boolean,
+  /**
+   * Whether the text or key of the selected item is submitted as part of an HTML form.
+   * When `allowsCustomValue` is `true`, this option does not apply and the text is always submitted.
+   * @default 'text'
+   */
+  formValue?: 'text' | 'key'
 }
 
 export const ComboBoxContext = createContext<ContextValue<ComboBoxProps<any>, HTMLDivElement>>(null);
@@ -59,6 +65,14 @@ export const ComboBoxContext = createContext<ContextValue<ComboBoxProps<any>, HT
 function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, ComboBoxContext);
   let [propsFromListBox, setListBoxProps] = useState<ListBoxProps<T>>({children: []});
+  let {
+    name,
+    formValue = 'text',
+    allowsCustomValue
+  } = props;
+  if (allowsCustomValue) {
+    formValue = 'text';
+  }
 
   let {contains} = useFilter({sensitivity: 'base'});
   let {portal, collection} = useCollection({
@@ -109,7 +123,8 @@ function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<H
     inputRef,
     buttonRef,
     listBoxRef,
-    popoverRef
+    popoverRef,
+    name: formValue === 'text' ? name : undefined
   },
   state);
 
@@ -173,6 +188,7 @@ function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<H
         data-validation-state={props.validationState || undefined}
         data-required={props.isRequired || undefined} />
       {portal}
+      {name && formValue === 'key' && <input type="hidden" name={name} value={state.selectedKey} />}
     </Provider>
   );
 }

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -55,7 +55,7 @@ export interface ComboBoxProps<T extends object> extends Omit<AriaComboBoxProps<
   /**
    * Whether the text or key of the selected item is submitted as part of an HTML form.
    * When `allowsCustomValue` is `true`, this option does not apply and the text is always submitted.
-   * @default 'text'
+   * @default 'key'
    */
   formValue?: 'text' | 'key'
 }

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -67,7 +67,7 @@ function ComboBox<T extends object>(props: ComboBoxProps<T>, ref: ForwardedRef<H
   let [propsFromListBox, setListBoxProps] = useState<ListBoxProps<T>>({children: []});
   let {
     name,
-    formValue = 'text',
+    formValue = 'key',
     allowsCustomValue
   } = props;
   if (allowsCustomValue) {

--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -15,8 +15,9 @@ import {createCalendar} from '@internationalized/date';
 import {DateFieldState, DateSegmentType, DateSegment as IDateSegment, useDateFieldState, useTimeFieldState, ValidationState} from 'react-stately';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {LabelContext} from './Label';
-import React, {cloneElement, createContext, ForwardedRef, forwardRef, HTMLAttributes, ReactElement, useContext, useRef} from 'react';
+import React, {cloneElement, createContext, ForwardedRef, forwardRef, HTMLAttributes, InputHTMLAttributes, ReactElement, RefObject, useContext, useRef} from 'react';
 import {TextContext} from './Text';
+import { InputDOMProps } from '@react-types/shared';
 
 export interface DateFieldRenderProps {
   /**
@@ -39,7 +40,9 @@ export interface TimeFieldProps<T extends TimeValue> extends Omit<AriaTimeFieldP
 
 interface DateInputContextValue extends SlotProps {
   state: DateFieldState,
-  fieldProps: HTMLAttributes<HTMLElement>
+  fieldProps: HTMLAttributes<HTMLElement>,
+  inputProps: InputHTMLAttributes<HTMLInputElement>,
+  inputRef: RefObject<HTMLInputElement>
 }
 
 export const DateFieldContext = createContext<ContextValue<DateFieldProps<any>, HTMLDivElement>>(null);
@@ -57,7 +60,8 @@ function DateField<T extends DateValue>(props: DateFieldProps<T>, ref: Forwarded
 
   let fieldRef = useRef<HTMLDivElement>(null);
   let [labelRef, label] = useSlot();
-  let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useDateField({...props, label}, state, fieldRef);
+  let inputRef = useRef<HTMLInputElement>(null);
+  let {labelProps, fieldProps, inputProps, descriptionProps, errorMessageProps} = useDateField({...props, label, inputRef}, state, fieldRef);
 
   let renderProps = useRenderProps({
     ...props,
@@ -75,7 +79,7 @@ function DateField<T extends DateValue>(props: DateFieldProps<T>, ref: Forwarded
   return (
     <Provider
       values={[
-        [DateInputContext, {state, fieldProps, ref: fieldRef}],
+        [DateInputContext, {state, fieldProps, ref: fieldRef, inputRef, inputProps}],
         [LabelContext, {...labelProps, ref: labelRef}],
         [TextContext, {
           slots: {
@@ -111,7 +115,8 @@ function TimeField<T extends TimeValue>(props: TimeFieldProps<T>, ref: Forwarded
 
   let fieldRef = useRef<HTMLDivElement>(null);
   let [labelRef, label] = useSlot();
-  let {labelProps, fieldProps, descriptionProps, errorMessageProps} = useTimeField({...props, label}, state, fieldRef);
+  let inputRef = useRef<HTMLInputElement>(null);
+  let {labelProps, fieldProps, inputProps, descriptionProps, errorMessageProps} = useTimeField({...props, label, inputRef}, state, fieldRef);
 
   let renderProps = useRenderProps({
     ...props,
@@ -129,7 +134,7 @@ function TimeField<T extends TimeValue>(props: TimeFieldProps<T>, ref: Forwarded
   return (
     <Provider
       values={[
-        [DateInputContext, {state, fieldProps, ref: fieldRef}],
+        [DateInputContext, {state, fieldProps, ref: fieldRef, inputRef, inputProps}],
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [TextContext, {
           slots: {
@@ -180,12 +185,12 @@ export interface DateInputRenderProps {
   isDisabled: boolean
 }
 
-export interface DateInputProps extends SlotProps, StyleRenderProps<DateInputRenderProps> {
+export interface DateInputProps extends InputDOMProps, SlotProps, StyleRenderProps<DateInputRenderProps> {
   children: (segment: IDateSegment) => ReactElement
 }
 
-function DateInput({children, slot, ...otherProps}: DateInputProps, ref: ForwardedRef<HTMLDivElement>) {
-  let [{state, fieldProps}, fieldRef] = useContextProps({slot} as DateInputProps & DateInputContextValue, ref, DateInputContext);
+function DateInput({children, slot, name, ...otherProps}: DateInputProps, ref: ForwardedRef<HTMLDivElement>) {
+  let [{state, fieldProps, inputProps, inputRef}, fieldRef] = useContextProps({slot} as DateInputProps & DateInputContextValue, ref, DateInputContext);
 
   let {hoverProps, isHovered} = useHover({});
   let {isFocused, isFocusVisible, focusProps} = useFocusRing({
@@ -211,6 +216,7 @@ function DateInput({children, slot, ...otherProps}: DateInputProps, ref: Forward
         data-disabled={state.isDisabled || undefined}>
         {state.segments.map((segment, i) => cloneElement(children(segment), {key: i}))}
       </div>
+      <input {...inputProps} ref={inputRef} name={name ?? inputProps.name} />
     </InternalDateInputContext.Provider>
   );
 }

--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -14,10 +14,10 @@ import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, StyleRen
 import {createCalendar} from '@internationalized/date';
 import {DateFieldState, DateSegmentType, DateSegment as IDateSegment, useDateFieldState, useTimeFieldState, ValidationState} from 'react-stately';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
+import {InputDOMProps} from '@react-types/shared';
 import {LabelContext} from './Label';
 import React, {cloneElement, createContext, ForwardedRef, forwardRef, HTMLAttributes, InputHTMLAttributes, ReactElement, RefObject, useContext, useRef} from 'react';
 import {TextContext} from './Text';
-import { InputDOMProps } from '@react-types/shared';
 
 export interface DateFieldRenderProps {
   /**

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -58,7 +58,7 @@ export interface DateRangePickerRenderProps extends Omit<DatePickerRenderProps, 
 }
 
 export interface DatePickerProps<T extends DateValue> extends Omit<AriaDatePickerProps<T>, 'label' | 'description' | 'errorMessage'>, RenderProps<DatePickerRenderProps>, SlotProps {}
-export interface DateRangePickerProps<T extends DateValue> extends Omit<AriaDateRangePickerProps<T>, 'label' | 'description' | 'errorMessage'>, RenderProps<DateRangePickerRenderProps>, SlotProps {}
+export interface DateRangePickerProps<T extends DateValue> extends Omit<AriaDateRangePickerProps<T>, 'label' | 'description' | 'errorMessage' | 'startName' | 'endName'>, RenderProps<DateRangePickerRenderProps>, SlotProps {}
 
 export const DatePickerContext = createContext<ContextValue<DatePickerProps<any>, HTMLDivElement>>(null);
 export const DateRangePickerContext = createContext<ContextValue<DateRangePickerProps<any>, HTMLDivElement>>(null);
@@ -87,8 +87,9 @@ function DatePicker<T extends DateValue>(props: DatePickerProps<T>, ref: Forward
   });
 
   let fieldRef = useRef<HTMLDivElement>(null);
+  let inputRef = useRef<HTMLInputElement>(null);
   let {focusProps, isFocused, isFocusVisible} = useFocusRing({within: true});
-  let {fieldProps: dateFieldProps} = useDateField({...fieldProps, label}, fieldState, fieldRef);
+  let {fieldProps: dateFieldProps, inputProps} = useDateField({...fieldProps, label, inputRef}, fieldState, fieldRef);
 
   let renderProps = useRenderProps({
     ...props,
@@ -109,7 +110,7 @@ function DatePicker<T extends DateValue>(props: DatePickerProps<T>, ref: Forward
     <Provider
       values={[
         [GroupContext, {...groupProps, ref: groupRef}],
-        [DateInputContext, {state: fieldState, fieldProps: dateFieldProps, ref: fieldRef}],
+        [DateInputContext, {state: fieldState, fieldProps: dateFieldProps, ref: fieldRef, inputProps, inputRef}],
         [ButtonContext, {...buttonProps, isPressed: state.isOpen}],
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [CalendarContext, calendarProps],
@@ -166,8 +167,9 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
   });
 
   let startFieldRef = useRef<HTMLDivElement>(null);
+  let startInputRef = useRef<HTMLInputElement>(null);
   let {focusProps, isFocused, isFocusVisible} = useFocusRing({within: true});
-  let {fieldProps: startDateFieldProps} = useDateField({...startFieldProps, label}, startFieldState, startFieldRef);
+  let {fieldProps: startDateFieldProps, inputProps: startInputProps} = useDateField({...startFieldProps, label, inputRef: startInputRef}, startFieldState, startFieldRef);
 
   let endFieldState = useDateFieldState({
     ...endFieldProps,
@@ -176,7 +178,8 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
   });
 
   let endFieldRef = useRef<HTMLDivElement>(null);
-  let {fieldProps: endDateFieldProps} = useDateField({...endFieldProps, label}, endFieldState, endFieldRef);
+  let endInputRef = useRef<HTMLInputElement>(null);
+  let {fieldProps: endDateFieldProps, inputProps: endInputProps} = useDateField({...endFieldProps, label, inputRef: endInputRef}, endFieldState, endFieldRef);
 
   let renderProps = useRenderProps({
     ...props,
@@ -207,12 +210,16 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
             start: {
               state: startFieldState,
               fieldProps: startDateFieldProps,
-              ref: startFieldRef
+              ref: startFieldRef,
+              inputRef: startInputRef,
+              inputProps: startInputProps
             },
             end: {
               state: endFieldState,
               fieldProps: endDateFieldProps,
-              ref: endFieldRef
+              ref: endFieldRef,
+              inputRef: endInputRef,
+              inputProps: endInputProps
             }
           }
         }],

--- a/packages/react-aria-components/src/NumberField.tsx
+++ b/packages/react-aria-components/src/NumberField.tsx
@@ -98,7 +98,7 @@ function NumberField(props: NumberFieldProps, ref: ForwardedRef<HTMLDivElement>)
         slot={props.slot}
         data-disabled={props.isDisabled || undefined}
         data-validation-state={props.validationState || undefined} />
-      {props.name && <input type="hidden" name={props.name} value={state.numberValue} />}
+      {props.name && <input type="hidden" name={props.name} value={isNaN(state.numberValue) ? '' : state.numberValue} />}
     </Provider>
   );
 }

--- a/packages/react-aria-components/src/NumberField.tsx
+++ b/packages/react-aria-components/src/NumberField.tsx
@@ -16,6 +16,7 @@ import {ContextValue, forwardRefType, Provider, RenderProps, SlotProps, useConte
 import {filterDOMProps} from '@react-aria/utils';
 import {GroupContext} from './Group';
 import {InputContext} from './Input';
+import {InputDOMProps} from '@react-types/shared';
 import {LabelContext} from './Label';
 import {NumberFieldState, useNumberFieldState, ValidationState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
@@ -38,7 +39,7 @@ export interface NumberFieldRenderProps {
   state: NumberFieldState
 }
 
-export interface NumberFieldProps extends Omit<AriaNumberFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage'>, RenderProps<NumberFieldRenderProps>, SlotProps {}
+export interface NumberFieldProps extends Omit<AriaNumberFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage'>, InputDOMProps, RenderProps<NumberFieldRenderProps>, SlotProps {}
 
 export const NumberFieldContext = createContext<ContextValue<NumberFieldProps, HTMLDivElement>>(null);
 
@@ -97,6 +98,7 @@ function NumberField(props: NumberFieldProps, ref: ForwardedRef<HTMLDivElement>)
         slot={props.slot}
         data-disabled={props.isDisabled || undefined}
         data-validation-state={props.validationState || undefined} />
+      {props.name && <input type="hidden" name={props.name} value={state.numberValue} />}
     </Provider>
   );
 }

--- a/packages/react-aria-components/test/ComboBox.test.js
+++ b/packages/react-aria-components/test/ComboBox.test.js
@@ -151,15 +151,14 @@ describe('ComboBox', () => {
   it('should support formValue', () => {
     let {getByRole, rerender} = render(<TestComboBox name="test" selectedKey="2" />);
     let input = getByRole('combobox');
-    expect(input).toHaveAttribute('name', 'test');
-    expect(input).toHaveValue('Dog');
-    expect(document.querySelector('input[type=hidden]')).toBeNull();
-
-    rerender(<TestComboBox name="test" formValue="key" selectedKey="2" />);
     expect(input).not.toHaveAttribute('name');
-
+    expect(input).toHaveValue('Dog');
     let hiddenInput = document.querySelector('input[type=hidden]');
     expect(hiddenInput).toHaveAttribute('name', 'test');
     expect(hiddenInput).toHaveValue('2');
+
+    rerender(<TestComboBox name="test" formValue="text" selectedKey="2" />);
+    expect(input).toHaveAttribute('name', 'test');
+    expect(document.querySelector('input[type=hidden]')).toBeNull();
   });
 });

--- a/packages/react-aria-components/test/ComboBox.test.js
+++ b/packages/react-aria-components/test/ComboBox.test.js
@@ -24,9 +24,9 @@ let TestComboBox = (props) => (
     <Text slot="errorMessage">Error</Text>
     <Popover>
       <ListBox>
-        <Item>Cat</Item>
-        <Item>Dog</Item>
-        <Item>Kangaroo</Item>
+        <Item id="1">Cat</Item>
+        <Item id="2">Dog</Item>
+        <Item id="3">Kangaroo</Item>
       </ListBox>
     </Popover>
   </ComboBox>
@@ -146,5 +146,20 @@ describe('ComboBox', () => {
 
     userEvent.click(button);
     expect(button).toHaveTextContent('close');
+  });
+
+  it('should support formValue', () => {
+    let {getByRole, rerender} = render(<TestComboBox name="test" selectedKey="2" />);
+    let input = getByRole('combobox');
+    expect(input).toHaveAttribute('name', 'test');
+    expect(input).toHaveValue('Dog');
+    expect(document.querySelector('input[type=hidden]')).toBeNull();
+
+    rerender(<TestComboBox name="test" formValue="key" selectedKey="2" />);
+    expect(input).not.toHaveAttribute('name');
+
+    let hiddenInput = document.querySelector('input[type=hidden]');
+    expect(hiddenInput).toHaveAttribute('name', 'test');
+    expect(hiddenInput).toHaveValue('2');
   });
 });

--- a/packages/react-aria-components/test/DateField.test.js
+++ b/packages/react-aria-components/test/DateField.test.js
@@ -164,4 +164,17 @@ describe('DateField', () => {
     let group = getByRole('group');
     expect(group).toHaveAttribute('data-validation-state', 'invalid');
   });
+
+  it('should support form value', () => {
+    render(
+      <DateField name="birthday" value={new CalendarDate(2020, 2, 3)}>
+        <Label>Birth date</Label>
+        <DateInput>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </DateField>
+    );
+    let input = document.querySelector('input[name=birthday]');
+    expect(input).toHaveValue('2020-02-03');
+  });
 });

--- a/packages/react-aria-components/test/DatePicker.test.js
+++ b/packages/react-aria-components/test/DatePicker.test.js
@@ -132,8 +132,14 @@ describe('DatePicker', () => {
         )}
       </DatePicker>
     );
-    
+
     let group = getByRole('group');
     expect(group).toHaveAttribute('data-validation-state', 'invalid');
+  });
+
+  it('should support form value', () => {
+    render(<TestDatePicker name="birthday" value={new CalendarDate(2020, 2, 3)} />);
+    let input = document.querySelector('input[name=birthday]');
+    expect(input).toHaveValue('2020-02-03');
   });
 });

--- a/packages/react-aria-components/test/DateRangePicker.test.js
+++ b/packages/react-aria-components/test/DateRangePicker.test.js
@@ -20,11 +20,11 @@ let TestDateRangePicker = (props) => (
   <DateRangePicker data-foo="bar" {...props}>
     <Label>Trip dates</Label>
     <Group>
-      <DateInput slot="start">
+      <DateInput slot="start" {...props.startInputProps}>
         {(segment) => <DateSegment segment={segment} />}
       </DateInput>
       <span aria-hidden="true">–</span>
-      <DateInput slot="end">
+      <DateInput slot="end" {...props.endInputProps}>
         {(segment) => <DateSegment segment={segment} />}
       </DateInput>
       <Button>▼</Button>
@@ -141,8 +141,16 @@ describe('DateRangePicker', () => {
         )}
       </DateRangePicker>
     );
-    
+
     let group = getByRole('group');
     expect(group).toHaveAttribute('data-validation-state', 'invalid');
+  });
+
+  it('should support form value', () => {
+    render(<TestDateRangePicker startInputProps={{name: 'start'}} endInputProps={{name: 'end'}} value={{start: new CalendarDate(2023, 1, 10), end: new CalendarDate(2023, 1, 20)}} />);
+    let start = document.querySelector('input[name=start]');
+    expect(start).toHaveValue('2023-01-10');
+    let end = document.querySelector('input[name=end]');
+    expect(end).toHaveValue('2023-01-20');
   });
 });

--- a/packages/react-aria-components/test/NumberField.test.js
+++ b/packages/react-aria-components/test/NumberField.test.js
@@ -120,4 +120,10 @@ describe('NumberField', () => {
     let label = document.getElementById(input.getAttribute('aria-labelledby'));
     expect(label).toHaveTextContent('Width (min: 300, max: 1400)');
   });
+
+  it('should support form value', () => {
+    render(<TestNumberField name="test" value={25} formatOptions={{style: 'currency', currency: 'USD'}} />);
+    let input = document.querySelector('input[name=test]');
+    expect(input).toHaveValue('25');
+  });
 });

--- a/packages/react-aria-components/test/NumberField.test.js
+++ b/packages/react-aria-components/test/NumberField.test.js
@@ -122,8 +122,11 @@ describe('NumberField', () => {
   });
 
   it('should support form value', () => {
-    render(<TestNumberField name="test" value={25} formatOptions={{style: 'currency', currency: 'USD'}} />);
+    let {rerender} = render(<TestNumberField name="test" value={25} formatOptions={{style: 'currency', currency: 'USD'}} />);
     let input = document.querySelector('input[name=test]');
     expect(input).toHaveValue('25');
+
+    rerender(<TestNumberField name="test" value={null} formatOptions={{style: 'currency', currency: 'USD'}} />)
+    expect(input).toHaveValue('');
   });
 });

--- a/packages/react-aria-components/test/NumberField.test.js
+++ b/packages/react-aria-components/test/NumberField.test.js
@@ -126,7 +126,7 @@ describe('NumberField', () => {
     let input = document.querySelector('input[name=test]');
     expect(input).toHaveValue('25');
 
-    rerender(<TestNumberField name="test" value={null} formatOptions={{style: 'currency', currency: 'USD'}} />)
+    rerender(<TestNumberField name="test" value={null} formatOptions={{style: 'currency', currency: 'USD'}} />);
     expect(input).toHaveValue('');
   });
 });

--- a/packages/react-aria-components/test/TimeField.test.js
+++ b/packages/react-aria-components/test/TimeField.test.js
@@ -103,4 +103,17 @@ describe('TimeField', () => {
     let group = getByRole('group');
     expect(group).toHaveAttribute('data-validation-state', 'invalid');
   });
+
+  it('should support form value', () => {
+    render(
+      <TimeField name="time" value={new Time(8, 30)}>
+        <Label>Time</Label>
+        <DateInput>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </TimeField>
+    );
+    let input = document.querySelector('input[name=time]');
+    expect(input).toHaveValue('08:30:00');
+  });
 });


### PR DESCRIPTION
Closes #1690, closes #2825

This improves support for HTML form reset and submit across many components that didn't previously support it. Extracted from #4640. Form validation support is being reworked a bit and will come in a separate PR.

* Adds support for native form reset, e.g. `<Button type="reset">`. This is implemented by subscribing to the `reset` event on the input's parent form, and triggering an onChange with the initially rendered value. Works with both uncontrolled and controlled inputs.
* Adds support for submitting the numeric value in NumberField rather than the formatted text. Previously the `name` prop wasn't passed through at all, so this is not a breaking change. It is implemented by rendering an extra `<input type="hidden">`.
* Adds support for `name` prop to slider and color components.
* Adds support for submitting a stringified version of the date value in all date picker components, using an `<input type="hidden">`.
* Adds support for submitting the key rather than the text value of a ComboBox, also using an `<input type="hidden">`. This can be controlled by setting the `formValue` prop. When `allowsCustomValue` is true, we always submit the text value.