### PR TITLE
Fix "Edit this page" link on production docs build

### DIFF
--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -123,6 +123,7 @@ function Page({children, currentPage, publicUrl, styles, scripts, pathToPage}) {
   let title = currentPage.title + (!INDEX_RE.test(currentPage.name) || isBlog ? ` – ${pageSection}` : '');
   let hero = (parts.length > 1 ? HERO[parts[0]] : '') || heroImageHome;
   let heroUrl = `https://${TLD}/${currentPage.image || path.basename(hero)}`;
+  let githubLink = pathToPage.startsWith('/tmp/') ? pathToPage.replace('/tmp/', '').substring(pathToPage.indexOf('/')) : pathToPage;
 
   return (
     <html
@@ -198,7 +199,7 @@ function Page({children, currentPage, publicUrl, styles, scripts, pathToPage}) {
         <meta property="og:image" content={heroUrl} />
         <meta property="og:description" content={description} />
         <meta property="og:locale" content="en_US" />
-        <meta data-github-src={pathToPage} />
+        <meta data-github-src={githubLink} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{__html: JSON.stringify(


### PR DESCRIPTION
Currently on production docs, the "Edit this page" link used is `/temp/{hash}/{correct_link}`, so this should fix it to be the correct link.


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
