### PR TITLE
HCM: ActionButton/ToggleButton hover state color fixes

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -1044,7 +1044,7 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-static-background-color-selected-focus: Highlight;
     --spectrum-actionbutton-static-background-color-selected-active: Highlight;
     --spectrum-actionbutton-static-border-color: ButtonText;
-    --spectrum-actionbutton-static-border-color-hover: ButtonText;
+    --spectrum-actionbutton-static-border-color-hover: Highlight;
     --spectrum-actionbutton-static-border-color-active: ButtonText;
     --spectrum-actionbutton-static-border-color-focus: CanvasText;
     --spectrum-actionbutton-static-border-disabled: GrayText;

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -436,7 +436,7 @@ governing permissions and limitations under the License.
   &:hover {
     background-color: xvar(--spectrum-high-contrast-button-face, var(--spectrum-actionbutton-background-color-hover));
     border-color: xvar(--spectrum-high-contrast-highlight, var(--spectrum-actionbutton-border-color-hover));
-    color: var(--spectrum-actionbutton-text-color-hover);
+    color: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-text-color-hover));
 
     .spectrum-Icon {
       fill: xvar(--spectrum-high-contrast-button-text, var(--spectrum-actionbutton-icon-color-hover));


### PR DESCRIPTION
Closes #4054, #4052, #4022

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

For both ActionButton and ToggleButton, in storybook with HCM enabled:
- Test the text color during hover (you should be able to see text in light/lightest themes)
- Test staticColor="white" and staticColor="black" and ensure border changes color on hover

## 🧢 Your Project:

RSP
