### PR TITLE
HCM ProgressBar/Meter fill color fix

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/barloader/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/skin.css
@@ -10,11 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-:root {
-  --spectrum-barloader-large-track-fill-color: var(--spectrum-accent-color-900);
-}
-
 .spectrum-BarLoader {
+  --spectrum-barloader-large-track-fill-color: var(--spectrum-accent-color-900);
+
   .spectrum-BarLoader-fill {
     background: var(--spectrum-barloader-large-track-fill-color);
   }
@@ -69,6 +67,7 @@ governing permissions and limitations under the License.
   .spectrum-BarLoader-track {
     forced-color-adjust: none;
     --spectrum-barloader-large-track-fill-color: ButtonText;
+    --spectrum-barloader-large-over-background-track-fill-color: ButtonText;
     --spectrum-barloader-large-track-color: ButtonFace;
     border: 1px solid ButtonText;
   }

--- a/packages/@adobe/spectrum-css-temp/components/barloader/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/skin.css
@@ -68,6 +68,9 @@ governing permissions and limitations under the License.
     forced-color-adjust: none;
     --spectrum-barloader-large-track-fill-color: ButtonText;
     --spectrum-barloader-large-over-background-track-fill-color: ButtonText;
+    --spectrum-meter-large-track-color-positive: ButtonText;
+    --spectrum-meter-large-track-color-warning: ButtonText;
+    --spectrum-meter-large-track-color-critical: ButtonText;
     --spectrum-barloader-large-track-color: ButtonFace;
     border: 1px solid ButtonText;
   }


### PR DESCRIPTION
Closes #4105

Fixing fill style for HCM ProgressBar and adding support for overBackground and Meter fill colors.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Check the ProgressBar and Meter in HCM to confirm fill is properly overridden.

## 🧢 Your Project:
RSP