### PR TITLE
HCM: fix Clear button background to be transparent

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -973,11 +973,6 @@ governing permissions and limitations under the License.
   .spectrum-LogicButton,
   .spectrum-FieldButton {
     forced-color-adjust: none;
-    --spectrum-clearbutton-medium-background-color: ButtonFace;
-    --spectrum-clearbutton-medium-background-color-disabled: ButtonFace;
-    --spectrum-clearbutton-medium-background-color-down: ButtonFace;
-    --spectrum-clearbutton-medium-background-color-hover: ButtonFace;
-    --spectrum-clearbutton-medium-background-color-key-focus: ButtonFace;
     --spectrum-clearbutton-medium-icon-color: ButtonText;
     --spectrum-clearbutton-medium-icon-color-disabled: GrayText;
     --spectrum-clearbutton-medium-icon-color-down: Highlight;


### PR DESCRIPTION
Closes #4141 

In SearchField, SearchAutocomplete, Mobile SearchAutocomplete, and MobileCombobox, the clear button should keep a transparent background in High Contrast Mode, so that it's background doesn't overlap surrounding elements. This helps prevent the following:
 
<img width="213" alt="Screenshot 2023-07-20 at 5 49 54 PM" src="https://github.com/adobe/react-spectrum/assets/8961049/3bccd326-05dc-4c73-bf72-c2c5a1a8c14a">


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Check clear button in HCM in SearchField, SearchAutocomplete, Mobile SearchAutocomplete, and MobileCombobox components.

## 🧢 Your Project:

RSP