### PR TITLE
HCM Fixing disabled or LogicButton

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -851,8 +851,8 @@ governing permissions and limitations under the License.
 
   &:disabled,
   &.is-disabled {
-    background-color: var(--spectrum-button-secondary-background-color-disabled);
-    border-color: var(--spectrum-button-secondary-border-color-disabled);
+    background-color: var(--spectrum-logicbutton-and-background-color-disabled);
+    border-color: var(--spectrum-logicbutton-and-border-color-disabled);
     color: var(--spectrum-logicbutton-and-text-color-disabled);
   }
 }


### PR DESCRIPTION
Closes #4099

Checked the XD file and it didn't define "and" or "or" LogicButtons looking different when disabled. Updated the "or" button to mirror the "and" button. It made sense to keep the structure of the CSS rather than combine them into one rule.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Confirm that a disabled OR LogicButton looks okay inside and outside of HCM in all themes.

## 🧢 Your Project:
RSP