### PR TITLE
Fix broken links to react-stately Collections and Selection pages

### DIFF
--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -249,8 +249,8 @@ identify it to assistive technology.
 
 `ComboBox` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ### Composed components
 

--- a/packages/react-aria-components/docs/GridList.mdx
+++ b/packages/react-aria-components/docs/GridList.mdx
@@ -329,8 +329,8 @@ If the list supports row selection, each row can optionally include a selection 
 
 `GridList` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ## Props
 

--- a/packages/react-aria-components/docs/ListBox.mdx
+++ b/packages/react-aria-components/docs/ListBox.mdx
@@ -182,8 +182,8 @@ Users can select one or more options by clicking, tapping, or navigating with th
 
 `ListBox` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ## Props
 

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -254,8 +254,8 @@ with a list of menu items or groups inside. Users can click, touch, or use the k
 
 `Menu` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ### Composed components
 

--- a/packages/react-aria-components/docs/Select.mdx
+++ b/packages/react-aria-components/docs/Select.mdx
@@ -316,8 +316,8 @@ prop must be passed instead to identify it to assistive technology.
 
 `Select` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ### Composed components
 

--- a/packages/react-aria-components/docs/Table.mdx
+++ b/packages/react-aria-components/docs/Table.mdx
@@ -399,8 +399,8 @@ If the table supports row selection, each row can optionally include a selection
 
 `Table` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ## Props
 

--- a/packages/react-aria-components/docs/Tabs.mdx
+++ b/packages/react-aria-components/docs/Tabs.mdx
@@ -185,8 +185,8 @@ Each tab can be clicked, tapped, or navigated to via arrow keys. Depending on th
 
 `Tabs` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ## Props
 

--- a/packages/react-aria-components/docs/TagGroup.mdx
+++ b/packages/react-aria-components/docs/TagGroup.mdx
@@ -187,8 +187,8 @@ tag group via the `aria-describedby` attribute.
 
 `TagGroup` makes use of the following concepts:
 
-* [Collections](../react-stately/Collections.html)
-* [Selection](../react-stately/Selection.html)
+- [Collections](../react-stately/collections.html)
+- [Selection](../react-stately/selection.html)
 
 ### Composed components
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
