### PR TITLE
feat: adding spectrum provider prop to determine portal container to …

### DIFF
--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -21,6 +21,7 @@ import overrideStyles from './overlays.css';
 import React, {forwardRef, MutableRefObject, ReactNode, RefObject, useRef, useState} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/popover/vars.css';
 import {Underlay} from './Underlay';
+import {useProvider} from '@react-spectrum/provider';
 
 interface PopoverProps extends Omit<AriaPopoverProps, 'popoverRef' | 'maxHeight'>, FocusWithinProps, StyleProps {
   children: ReactNode,
@@ -74,9 +75,10 @@ function Popover(props: PopoverProps, ref: DOMRef<HTMLDivElement>) {
   } = props;
   let domRef = useDOMRef(ref);
   let wrapperRef = useRef<HTMLDivElement>(null);
+  let {portalContainer} = useProvider();
 
   return (
-    <Overlay {...otherProps} isOpen={state.isOpen} nodeRef={wrapperRef}>
+    <Overlay {...otherProps} container={portalContainer} isOpen={state.isOpen} nodeRef={wrapperRef}>
       <PopoverWrapper ref={domRef} {...props} wrapperRef={wrapperRef}>
         {children}
       </PopoverWrapper>

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -37,6 +37,7 @@ function Provider(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
   let prevContext = useProvider();
   let prevColorScheme = prevContext && prevContext.colorScheme;
   let prevBreakpoints = prevContext && prevContext.breakpoints;
+  let prevPortalContainer = prevContext && prevContext.portalContainer;
   let {
     theme = prevContext && prevContext.theme,
     defaultColorScheme
@@ -57,6 +58,7 @@ function Provider(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
     scale = prevContext ? prevContext.scale : autoScale,
     locale = prevContext ? prevLocale : null,
     breakpoints = prevContext ? prevBreakpoints : DEFAULT_BREAKPOINTS,
+    portalContainer = prevPortalContainer,
     children,
     isQuiet,
     isEmphasized,
@@ -79,7 +81,8 @@ function Provider(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
     isDisabled,
     isRequired,
     isReadOnly,
-    validationState
+    validationState,
+    portalContainer
   };
 
   let matchedBreakpoints = useMatchedBreakpoints(breakpoints);

--- a/packages/@react-types/provider/src/index.d.ts
+++ b/packages/@react-types/provider/src/index.d.ts
@@ -88,7 +88,11 @@ export interface ProviderProps extends ContextProps, DOMProps, StyleProps {
    * Do not use `base` property.
    * @default {S:380,M:768,L:1024}
    */
-  breakpoints?: Breakpoints
+  breakpoints?: Breakpoints,
+  /**
+   * The HTML container for overlay portals to render into (default is document.body).
+   */
+  portalContainer?: HTMLElement
 }
 
 export interface ProviderContext extends ContextProps {
@@ -111,5 +115,9 @@ export interface ProviderContext extends ContextProps {
   /**
    * The breakpoints of the nearest parent Provider used for styleProps.
    */
-  breakpoints: Breakpoints
+  breakpoints: Breakpoints,
+  /**
+   * The HTML container for overlay portals to render into (default is document.body).
+   */
+  portalContainer?: HTMLElement
 }


### PR DESCRIPTION
This PR is not done yet.  I am making this to get early feedback, and see if the react spectrum team is open to this idea or not.

## The Problem

Every time a react spectrum overlay is rendered, it renders this overlay in a portal as a direct descendent of `document.body`, see:
- https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/overlays/src/Overlay.tsx#L43
- https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/overlays/src/useModal.tsx#L128

This is causing us a 0.5-1 second recalculation style every time such overlay gets closed in our application.

This is the way that the HTML body looks by default when an overlay is open:

```
body
  > div#root 
  > focus-trap-scope
  > react-spectrum-provider
  > end-focus-trap-scope
```

Adding/removing these 3 nodes into the body is being very expensive for us.

![Home](https://github.com/adobe/react-spectrum/assets/5473697/7d75deb9-606a-4453-b796-c6e9e0549495)

## My proposed solution

Now, if we have another portal div container for spectrum to render to that is not directly the body itself, there is no expensive recalculation.  Our HTML body then looks like this when the overlay is open:

```
body
  > div#root 
  > div#portal-container-for-spectrum
    > focus-trap-scope
    > react-spectrum-provider
    > end-focus-trap-scope
```

Adding/removing these 3 nodes into a child of `document.body` is going very fast.  We are getting no lag, no console warnings, or expensive recalculations.

## What's next

If you guys are ok with this approach, then I would add this prop `container` to the other areas that are rendering `Overlay`.  I saw that there are no usages of `useProvider` inside of the `packages/@react-aria` directory, so that is why I'm not using it directly in `Overlay` itself, but rather in the packages of `packages/@react-spectrum` that render `Overlay`.  Let me know if I am thinking about this wrong.



Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

Adobe Workfront
