### PR TITLE
Fix InlineAlert docs package data import

### DIFF
--- a/packages/@react-spectrum/inlinealert/docs/InlineAlert.mdx
+++ b/packages/@react-spectrum/inlinealert/docs/InlineAlert.mdx
@@ -12,7 +12,7 @@ export default Layout;
 
 import docs from 'docs:@react-spectrum/inlinealert';
 import {HeaderInfo, PropTable, PageDescription} from '@react-spectrum/docs';
-import packageData from '@react-spectrum/statuslight/package.json';
+import packageData from '@react-spectrum/inlinealert/package.json';
 
 ```jsx import
 import {InlineAlert} from '@react-spectrum/inlinealert';


### PR DESCRIPTION
This was causing the docs page for InlineAlert to show the import coming from the monopackage, even though this package is still RC.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
