### PR TITLE
update SearchField docs with Spectrum link

### DIFF
--- a/packages/@react-spectrum/searchfield/docs/SearchField.mdx
+++ b/packages/@react-spectrum/searchfield/docs/SearchField.mdx
@@ -32,6 +32,9 @@ keywords: [search field, input]
 <HeaderInfo
   packageData={packageData}
   componentNames={['SearchField']}
+  sourceData={[
+  {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/search-field/'}
+  ]}
   since="3.0.0" />
 
 ## Example


### PR DESCRIPTION
adding https://spectrum.adobe.com/page/search-field/ to SearchField docs