### PR TITLE
Fix secondary link color in Safari

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/link/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/link/skin.css
@@ -35,21 +35,19 @@ governing permissions and limitations under the License.
   }
 }
 
-@media (forced-colors: none) {
-  .spectrum-Link--secondary {
+.spectrum-Link--secondary {
+  color: inherit;
+
+  &:hover {
     color: inherit;
+  }
 
-    &:hover {
-      color: inherit;
-    }
+  &:active {
+    color: inherit;
+  }
 
-    &:active {
-      color: inherit;
-    }
-
-    &:focus {
-      color: inherit;
-    }
+  &:focus {
+    color: inherit;
   }
 }
 
@@ -75,14 +73,18 @@ governing permissions and limitations under the License.
 
 @media (forced-colors: active) {
   .spectrum-Link {
-    --spectrum-link-text-color: LinkText;
-    --spectrum-link-text-color-hover: LinkText;
-    --spectrum-link-text-color-down: LinkText;
-    --spectrum-link-text-color-key-focus: LinkText;
+    color: LinkText;
 
-    --spectrum-link-over-background-text-color: LinkText;
-    --spectrum-link-over-background-text-color-hover: LinkText;
-    --spectrum-link-over-background-text-color-down: LinkText;
-    --spectrum-link-over-background-text-color-key-focus: LinkText;
+    &:hover {
+      color: LinkText;
+    }
+
+    &:active {
+      color: LinkText;
+    }
+
+    &:focus {
+      color: LinkText;
+    }
   }
 }


### PR DESCRIPTION
Fixes regression from https://github.com/adobe/react-spectrum/pull/4799, since Safari doesn't support `forced-colors: none`.

The secondary variant should now use the inherited color in Safari, like previous behavior.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test that link colors are across themes, and in HCM. Check across browsers. 

Reference: https://spectrum.adobe.com/page/link/#Windows-high-contrast-mode

## 🧢 Your Project:

<!--- Company/project for pull request -->
