### PR TITLE
Do not add random prefix to ids during tests in React 18

### DIFF
--- a/packages/@react-aria/ssr/package.json
+++ b/packages/@react-aria/ssr/package.json
@@ -29,5 +29,16 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">= 12"
+  },
+  "targets": {
+    "main": {
+      "context": "node"
+    },
+    "module": {
+      "context": "node"
+    }
   }
 }

--- a/packages/@react-aria/ssr/src/SSRProvider.tsx
+++ b/packages/@react-aria/ssr/src/SSRProvider.tsx
@@ -152,7 +152,8 @@ function useLegacySSRSafeId(defaultId?: string): string {
   }
 
   let counter = useCounter(!!defaultId);
-  return defaultId || `react-aria${ctx.prefix}-${counter}`;
+  let prefix = ctx === defaultContext && process.env.NODE_ENV === 'test' ? 'react-aria' : `react-aria${ctx.prefix}`;
+  return defaultId || `${prefix}-${counter}`;
 }
 
 function useModernSSRSafeId(defaultId?: string): string {

--- a/packages/@react-aria/ssr/src/SSRProvider.tsx
+++ b/packages/@react-aria/ssr/src/SSRProvider.tsx
@@ -159,7 +159,7 @@ function useModernSSRSafeId(defaultId?: string): string {
   // @ts-ignore
   let id = React.useId();
   let [didSSR] = useState(useIsSSR());
-  let prefix = didSSR ? 'react-aria' : `react-aria${defaultContext.prefix}`;
+  let prefix = didSSR || process.env.NODE_ENV === 'test' ? 'react-aria' : `react-aria${defaultContext.prefix}`;
   return defaultId || `${prefix}-${id}`;
 }
 

--- a/packages/@react-aria/ssr/test/SSRProvider.test.js
+++ b/packages/@react-aria/ssr/test/SSRProvider.test.js
@@ -118,7 +118,18 @@ describe('SSRProvider', function () {
   });
 
   it('should generate a random prefix when not server rendered', function () {
+    let env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
     let tree = render(<Test />);
     expect(/^react-aria\d+-/.test(tree.getByTestId('test').id)).toBe(true);
+    process.env.NODE_ENV = env;
+  });
+
+  it('should not generate a random prefix in tests', function () {
+    let env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+    let tree = render(<Test />);
+    expect(/^react-aria-/.test(tree.getByTestId('test').id)).toBe(true);
+    process.env.NODE_ENV = env;
   });
 });


### PR DESCRIPTION
Fixes #4851

This ensures that we do not add a random prefix to ids generated by `useId` in test environments with React 18. Previously it was possible to use `SSRProvider` to ensure this, but `SSRProvider` is now a noop in React 18, and we determine whether we are SSRing in another way. But that's not set in a test environment. This will check whether the `NODE_ENV` environment variable is set to "test" and won't add a random prefix if so.