### PR TITLE
Prevent unexpected column resizer input blur when focused via dropdown menu 

### DIFF
--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -199,7 +199,7 @@ export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, st
     if (prevResizingColumn.current !== resizingColumn && resizingColumn != null && resizingColumn === item.key) {
       wasFocusedOnResizeStart.current = document.activeElement === ref.current;
       startResize(item);
-      focusInput();
+      setTimeout(() => focusInput(), 0);
       // VoiceOver on iOS has problems focusing the input from a menu.
       let timeout = setTimeout(focusInput, 400);
       return () => clearTimeout(timeout);

--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -199,10 +199,14 @@ export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, st
     if (prevResizingColumn.current !== resizingColumn && resizingColumn != null && resizingColumn === item.key) {
       wasFocusedOnResizeStart.current = document.activeElement === ref.current;
       startResize(item);
-      setTimeout(() => focusInput(), 0);
+      // Delay focusing input until Android Chrome's delayed click after touchend happens: https://bugs.chromium.org/p/chromium/issues/detail?id=1150073
+      let timeout = setTimeout(() => focusInput(), 0);
       // VoiceOver on iOS has problems focusing the input from a menu.
-      let timeout = setTimeout(focusInput, 400);
-      return () => clearTimeout(timeout);
+      let VOTimeout = setTimeout(focusInput, 400);
+      return () => {
+        clearTimeout(timeout);
+        clearTimeout(VOTimeout);
+      };
     }
     prevResizingColumn.current = resizingColumn;
   }, [resizingColumn, item, focusInput, ref, startResize]);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test table column resizing via an Android device in Chrome or via Chrome dev tool emulation. Focusing the column resizer via the "resize column" option in the resizable column dropdown menu should work

## 🧢 Your Project:

RSP
