### PR TITLE
Remove extraneous 'all' from Expandable type

### DIFF
--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -69,9 +69,9 @@ export interface CollectionStateBase<T, C extends Collection<Node<T>> = Collecti
 
 export interface Expandable {
   /** The currently expanded keys in the collection (controlled). */
-  expandedKeys?: 'all' | Iterable<Key>,
+  expandedKeys?: Iterable<Key>,
   /** The initial expanded keys in the collection (uncontrolled). */
-  defaultExpandedKeys?: 'all' | Iterable<Key>,
+  defaultExpandedKeys?: Iterable<Key>,
   /** Handler that is called when items are expanded or collapsed. */
   onExpandedChange?: (keys: Set<Key>) => any
 }


### PR DESCRIPTION
Expandable rows TableView and its related hooks use `UNSTABLE_expandedKeys` so they don't even use the Expandable
type
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
