### PR TITLE
Do not close overlays on blur if relatedTarget is null

### DIFF
--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -125,10 +125,16 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element>): Ov
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,
     onBlurWithin: (e) => {
+      // Do not close if relatedTarget is null, which means focus is lost to the body.
+      // That can happen when switching tabs, or due to a VoiceOver/Chrome bug with Control+Option+Arrow navigation.
+      // Clicking on the body to close the overlay should already be handled by useInteractOutside.
+      // https://github.com/adobe/react-spectrum/issues/4130
+      // https://github.com/adobe/react-spectrum/issues/4922
+      //
       // If focus is moving into a child focus scope (e.g. menu inside a dialog),
       // do not close the outer overlay. At this point, the active scope should
       // still be the outer overlay, since blur events run before focus.
-      if (e.relatedTarget && isElementInChildOfActiveScope(e.relatedTarget)) {
+      if (!e.relatedTarget || isElementInChildOfActiveScope(e.relatedTarget)) {
         return;
       }
 


### PR DESCRIPTION
In collaboration with @LFDanLu

Fixes #4922, fixes #4130, fixes #4384, fixes https://github.com/adobe/react-spectrum/issues/4533

When debugging #4922, we found a Chrome bug where extraneous blur events are fired with `relatedTarget = null` when navigating with the VoiceOver cursor (via Control + Option + Arrow keys). https://bugs.chromium.org/p/chromium/issues/detail?id=1473752 Note that this affects more than just DatePicker - it also affects any button contained within a Popover.

In addition, Chrome and Firefox fire blur events with `relatedTarget = null ` when switching tabs, which causes overlays to close.

This changes the logic in `useOverlay` to not close in those cases. We haven't thought of a case where `relatedTarget` was `null` where we _wouldn't_ want to close the overlay. Clicking on the body should already be handled by `useInteractOutside`.

Note: this will change the behavior of iframes as well. Popovers will no longer close when clicking outside an iframe.