### PR TITLE
Safe triangle for submenus

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/popover/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/popover/index.css
@@ -48,7 +48,6 @@ governing permissions and limitations under the License.
 
   outline: none; /* Hide focus outline */
   box-sizing: border-box;
-  overflow: hidden;
 
   &.is-open {
     @inherit: %spectrum-overlay--open;

--- a/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
@@ -17,6 +17,8 @@ import {ItemProps} from '@react-types/shared';
 import {MenuDialogContext, useMenuStateContext} from './context';
 import {Modal, Popover} from '@react-spectrum/overlays';
 import React, {Key, ReactElement, useRef} from 'react';
+import {SafeTriangle} from './SafeTriangle';
+import {useInteractionModality} from '@react-aria/interactions';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 
 export interface SpectrumMenuDialogTriggerProps<T> extends ItemProps<T> {
@@ -65,6 +67,9 @@ function ContextualHelpTrigger<T>(props: SpectrumMenuDialogTriggerProps<T>): Rea
       }
     }
   };
+
+  let modality = useInteractionModality();
+
   return (
     <>
       <MenuDialogContext.Provider value={{isUnavailable, triggerRef}}>{trigger}</MenuDialogContext.Provider>
@@ -77,21 +82,24 @@ function ContextualHelpTrigger<T>(props: SpectrumMenuDialogTriggerProps<T>): Rea
               <DismissButton onDismiss={state.close} />
             </Modal>
           ) : (
-            <Popover
-              onExit={onExit}
-              onBlurWithin={onBlurWithin}
-              container={container.current}
-              state={state}
-              ref={popoverRef}
-              triggerRef={triggerRef}
-              placement="end top"
-              offset={-10}
-              hideArrow
-              isNonModal
-              enableBothDismissButtons
-              disableFocusManagement>
-              {content}
-            </Popover>
+            <>
+              <Popover
+                onExit={onExit}
+                onBlurWithin={onBlurWithin}
+                container={container.current}
+                state={state}
+                ref={popoverRef}
+                triggerRef={triggerRef}
+                placement="end top"
+                offset={-10}
+                hideArrow
+                isNonModal
+                enableBothDismissButtons
+                disableFocusManagement>
+                {content}
+              </Popover>
+              {state.isOpen && modality === 'pointer' && <SafeTriangle subMenuRef={popoverRef} triggerRef={triggerRef} />}
+            </>
           )
         }
       </SlotProvider>

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -30,6 +30,8 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
   } = props;
   let [mousePosition, setMousePosition] = useState<{mouseX: number, mouseY: number}>({mouseX: null, mouseY: null});
   let {mouseX, mouseY} = mousePosition;
+  let [style, setStyle] = useState<React.CSSProperties>({height: 0, width: 0});
+
   let updateMousePosition = (e: MouseEvent) => {
     setMousePosition({mouseX: e.clientX, mouseY: e.clientY});
   };
@@ -40,46 +42,37 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
     return () => window.removeEventListener('mousemove', updateMousePosition);
   }, []);
 
-  let x = 0;
-  let y = 0;
-  let width = 0;
-  let height = 0;
-  let direction: 'left' | 'right';
-  let subMenuNode = subMenuRef.current?.UNSAFE_getDOMNode() as HTMLElement;
-  if (subMenuNode) {
-    let rect = subMenuNode.getBoundingClientRect();
-    x = rect.left;
-    y = rect.top;
-    width = mouseX > x ? 0 : x - mouseX + 5;
-    height = rect.height;
-    direction = x > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
-  } else {
-    return null;
-  }
+  useEffect(() => {
+    if (subMenuRef.current && triggerRef.current) {
+      let {left: x, top: y, height} = (subMenuRef.current?.UNSAFE_getDOMNode() as HTMLElement).getBoundingClientRect();
+      let offset = triggerRef.current?.getBoundingClientRect().width;
+      let direction = x > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
 
-  if (direction === 'right' && mouseX > x) {
-    return null;
-  } else if (direction === 'left' && mouseX < x) {
-    return null;
-  }
+      let isVisible = (direction === 'right' && mouseX < x) || (direction === 'left' && mouseX > x);
 
-  let offset = triggerRef.current?.getBoundingClientRect().width;
-  let top = triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top;
-  let left = -1 * (x - mouseX) + offset - 7;
-  let clipPath = `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / height}%, 100% 100%)`;
+      setStyle(isVisible ? {
+        top: triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top,
+        left: -1 * (x - mouseX) + offset - 7,
+        height,
+        width: mouseX > x ? 0 : x - mouseX + 5,
+        clipPath: `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / height}%, 100% 100%)`
+      } : {
+        height: 0,
+        width: 0
+      });
+    }
+
+  }, [mouseX, mouseY, subMenuRef, triggerRef]);
 
   return (
     <div
+      aria-hidden="false"
       style={{
         zIndex: 1,
         position: 'absolute',
         // TODO: make transparent
         backgroundColor: 'red',
-        top,
-        left,
-        height,
-        width,
-        clipPath
+        ...style
       }} />
   );
 }

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -67,7 +67,7 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
 
   return (
     <div
-      aria-hidden="false"
+      aria-hidden="true"
       style={{
         zIndex: 1,
         position: 'absolute',

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -53,6 +53,8 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
     width = mouseX > x ? 0 : x - mouseX + 5;
     height = rect.height;
     direction = x > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
+  } else {
+    return null;
   }
 
   if (direction === 'right' && mouseX > x) {

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React, {MutableRefObject, ReactElement, useEffect, useState} from 'react';
+
+export interface AriaSafeAreaOptions {
+  /** Ref for the submenu. */
+  subMenuRef: MutableRefObject<any>,
+  /** Ref for the submenu's trigger element. */
+  triggerRef: MutableRefObject<HTMLLIElement>
+}
+
+/**
+ * Utility for rendering a safe area for a sub-menu.
+ * This allows the user to mouse to the sub-menu without it closing.
+ * @param props
+ */
+export function SafeTriangle(props: AriaSafeAreaOptions): ReactElement {
+  let {
+    subMenuRef,
+    triggerRef
+  } = props;
+
+  let [mousePosition, setMousePosition] = useState<{mouseX: number, mouseY: number}>({mouseX: null, mouseY: null});
+  let {mouseX, mouseY} = mousePosition;
+
+  let updateMousePosition = (e: MouseEvent) => {
+    setMousePosition({mouseX: e.clientX, mouseY: e.clientY});
+  };
+
+  useEffect(() => {
+    window.addEventListener('mousemove', updateMousePosition);
+
+    return () => window.removeEventListener('mousemove', updateMousePosition);
+  }, []);
+
+  let x = 0;
+  let y = 0;
+  let width = 0;
+  let height = 0;
+  let direction: 'left' | 'right';
+  let subMenuNode = subMenuRef.current?.UNSAFE_getDOMNode() as HTMLElement;
+  if (subMenuNode) {
+    let rect = subMenuNode.getBoundingClientRect();
+    x = rect.left;
+    y = rect.top;
+    width = mouseX > x ? 0 : x - mouseX + 5;
+    height = rect.height;
+    direction = x > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
+  }
+
+  let offset = triggerRef.current?.getBoundingClientRect().width;
+  let clipPath = mouseX > x ? undefined : `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / height}%, 100% 100%)`;
+  let right = mouseX > x ? -1 * (mouseX - (x + height)) : undefined;
+  let left =  mouseX > x ? undefined : -1 * (x - mouseX) + offset - 5;
+  let top = triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top;
+
+  if (direction === 'right' && mouseX > x) {
+    return null;
+  } else if (direction === 'left' && mouseX < x) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        // TODO: Increment above submenu's z-index
+        zIndex: 1,
+        position: 'absolute',
+        top,
+        // TODO: make transparent
+        backgroundColor: 'red',
+        right,
+        left,
+        height,
+        width,
+        clipPath
+      }} />
+  );
+}

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -12,7 +12,7 @@
 
 import React, {MutableRefObject, ReactElement, useEffect, useState} from 'react';
 
-export interface AriaSafeAreaOptions {
+interface SafeTriangleProps {
   /** Ref for the submenu. */
   subMenuRef: MutableRefObject<any>,
   /** Ref for the submenu's trigger element. */
@@ -20,19 +20,16 @@ export interface AriaSafeAreaOptions {
 }
 
 /**
- * Utility for rendering a safe area for a sub-menu.
- * This allows the user to mouse to the sub-menu without it closing.
- * @param props
+ * Allows the user to move their pointer to the sub-menu without it closing
+ * due to the mouse leaving the trigger element.
  */
-export function SafeTriangle(props: AriaSafeAreaOptions): ReactElement {
+export function SafeTriangle(props: SafeTriangleProps): ReactElement {
   let {
     subMenuRef,
     triggerRef
   } = props;
-
   let [mousePosition, setMousePosition] = useState<{mouseX: number, mouseY: number}>({mouseX: null, mouseY: null});
   let {mouseX, mouseY} = mousePosition;
-
   let updateMousePosition = (e: MouseEvent) => {
     setMousePosition({mouseX: e.clientX, mouseY: e.clientY});
   };
@@ -58,28 +55,25 @@ export function SafeTriangle(props: AriaSafeAreaOptions): ReactElement {
     direction = x > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
   }
 
-  let offset = triggerRef.current?.getBoundingClientRect().width;
-  let clipPath = mouseX > x ? undefined : `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / height}%, 100% 100%)`;
-  let right = mouseX > x ? -1 * (mouseX - (x + height)) : undefined;
-  let left =  mouseX > x ? undefined : -1 * (x - mouseX) + offset - 5;
-  let top = triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top;
-
   if (direction === 'right' && mouseX > x) {
     return null;
   } else if (direction === 'left' && mouseX < x) {
     return null;
   }
 
+  let offset = triggerRef.current?.getBoundingClientRect().width;
+  let top = triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top;
+  let left = -1 * (x - mouseX) + offset - 7;
+  let clipPath = `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / height}%, 100% 100%)`;
+
   return (
     <div
       style={{
-        // TODO: Increment above submenu's z-index
         zIndex: 1,
         position: 'absolute',
-        top,
         // TODO: make transparent
         backgroundColor: 'red',
-        right,
+        top,
         left,
         height,
         width,

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -55,10 +55,8 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
           timeout.current = undefined;
         }
 
-        setStyle(shouldHide ? {
-          height: 0,
-          width: 0
-        } : {
+        setStyle({
+          display: shouldHide ? 'none' : undefined,
           top: triggerRect.top - triggerRef.current.parentElement.getBoundingClientRect().top,
           left: direction === 'right' ? mouseX - left + triggerRect.width - TOLERANCE : -TOLERANCE,
           height,

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -43,22 +43,23 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
   }, []);
 
   useEffect(() => {
-    if (subMenuRef.current && triggerRef.current) {
-      let {left: x, top: y, height} = (subMenuRef.current?.UNSAFE_getDOMNode() as HTMLElement).getBoundingClientRect();
+    if (subMenuRef.current && triggerRef.current && mouseY !== null) {
+      let {left, right, top, height} = (subMenuRef.current?.UNSAFE_getDOMNode() as HTMLElement).getBoundingClientRect();
       let offset = triggerRef.current?.getBoundingClientRect().width;
-      let direction = x > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
+      let direction = left > triggerRef.current?.getBoundingClientRect().left ? 'right' : 'left';
 
-      let isVisible = (direction === 'right' && mouseX < x) || (direction === 'left' && mouseX > x);
+      let isVisible = (direction === 'right' && mouseX < left) || (direction === 'left' && mouseX > right);
 
       setStyle(isVisible ? {
         top: triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top,
-        left: -1 * (x - mouseX) + offset - 7,
+        left: direction === 'right' ? -1 * (left - mouseX) + offset : undefined,
         height,
-        width: mouseX > x ? 0 : x - mouseX + 5,
-        clipPath: `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / height}%, 100% 100%)`
+        width: direction === 'right' ? left - mouseX : mouseX - right,
+        clipPath: direction === 'right' ? `polygon(100% 0%, 0% ${(100 * (mouseY - top)) / height}%, 100% 100%)` : `polygon(0% 0%, 100% ${(100 * (mouseY - top)) / height}%, 0% 100%)`
       } : {
         height: 0,
-        width: 0
+        width: 0,
+        display: 'none'
       });
     }
 

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -19,6 +19,8 @@ interface SafeTriangleProps {
   triggerRef: MutableRefObject<HTMLLIElement>
 }
 
+const TOLERANCE = 5;
+
 /**
  * Allows the user to move their pointer to the sub-menu without it closing when their mouse leaves the trigger element.
  * Renders an invisible triangle from the mouse position to the inside corners of the sub-menu.
@@ -46,9 +48,9 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
           width: 0
         } : {
           top: triggerRef.current?.getBoundingClientRect().top - triggerRef.current?.parentElement.getBoundingClientRect().top,
-          left: direction === 'right' ? mouseX - left + offset : undefined,
+          left: direction === 'right' ? mouseX - left + offset - TOLERANCE : -TOLERANCE,
           height,
-          width: direction === 'right' ? left - mouseX : mouseX - right,
+          width: direction === 'right' ? left - mouseX + TOLERANCE : mouseX - right + TOLERANCE,
           clipPath: direction === 'right' ? `polygon(100% 0%, 0% ${(100 * (mouseY - top)) / height}%, 100% 100%)` : `polygon(0% 0%, 100% ${(100 * (mouseY - top)) / height}%, 0% 100%)`
         });
       }

--- a/packages/@react-spectrum/menu/src/SafeTriangle.tsx
+++ b/packages/@react-spectrum/menu/src/SafeTriangle.tsx
@@ -34,7 +34,7 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
   let timeout = useRef<ReturnType<typeof setTimeout> | undefined>();
 
   useEffect(() => {
-    let onMouseMove = (e: MouseEvent) => {
+    let onPointerMove = (e: MouseEvent) => {
       if (subMenuRef.current && triggerRef.current) {
         let {clientX: mouseX, clientY: mouseY} = e;
         let {left, right, top, height} = (subMenuRef.current.UNSAFE_getDOMNode() as HTMLElement).getBoundingClientRect();
@@ -68,10 +68,10 @@ export function SafeTriangle(props: SafeTriangleProps): ReactElement {
       }
     };
   
-    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('pointermove', onPointerMove);
 
     return () => {
-      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('pointermove', onPointerMove);
       clearTimeout(timeout.current);
     };
   }, [subMenuRef, triggerRef]);

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -745,7 +745,7 @@ export let MenuItemUnavailable = {
       </ContextualHelpTrigger>
       <Item key="3">Three</Item>
       <ContextualHelpTrigger isUnavailable>
-        <Item key="bar">
+        <Item key="bar" textValue="Four">
           <Text>Four</Text>
           <Text slot={'description'}>Shut the door</Text>
         </Item>


### PR DESCRIPTION
Closes https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=30006503

We would like for users to be able to mouse from an item to the submenu that is opened when it was hovered. Sometimes the users mouse path might go outside of the item, which would close the submenu.

We can improve this experience by using a safe area (triangle) that users can mouse over without closing the submenu.

![SafeTriangle](https://github.com/adobe/react-spectrum/assets/8961049/8b546831-fa4a-445d-85da-6d021a0112d6)

TODO:
- remove red background

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
