### PR TITLE
Adds check to detect Android pointer type as touch

### DIFF
--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -548,9 +548,6 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0}));
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0, clientX: 0, clientY: 0}));
 
-      expect(events).toEqual([]);
-
-      fireEvent.click(el);
       expect(events).toEqual([
         {
           type: 'pressstart',
@@ -591,7 +588,7 @@ describe('usePress', function () {
       ]);
     });
 
-    it('should not ignore virtual pointer events on android ', function () {
+    it.only('should not ignore virtual pointer events on android ', function () {
       let uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
 
       let events = [];

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -607,10 +607,7 @@ describe('usePress', function () {
       let el = res.getByText('test');
       fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0}));
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0, clientX: 0, clientY: 0}));
-
-      expect(events).not.toEqual([]);
-
-      fireEvent.click(el);
+      
       expect(events).toEqual([
         {
           type: 'pressstart',

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -591,6 +591,68 @@ describe('usePress', function () {
       ]);
     });
 
+    it('should not ignore virtual pointer events on android ', function () {
+      let uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
+
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPress={addEvent}
+          onPressUp={addEvent} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0}));
+      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0, clientX: 0, clientY: 0}));
+
+      expect(events).not.toEqual([]);
+
+      fireEvent.click(el);
+      expect(events).toEqual([
+        {
+          type: 'pressstart',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false,
+          altKey: false
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false,
+          altKey: false
+        },
+        {
+          type: 'pressend',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false,
+          altKey: false
+        },
+        {
+          type: 'press',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false,
+          altKey: false
+        }
+      ]);
+
+      uaMock.mockRestore();
+    });
+
     it('should detect Android TalkBack double tap', function () {
       let events = [];
       let addEvent = (e) => events.push(e);

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -591,7 +591,7 @@ describe('usePress', function () {
       ]);
     });
 
-    it.only('should not ignore virtual pointer events on android ', function () {
+    it('should not ignore virtual pointer events on android ', function () {
       let uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
 
       let events = [];

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -548,6 +548,9 @@ describe('usePress', function () {
       fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0}));
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', width: 0, height: 0, clientX: 0, clientY: 0}));
 
+      expect(events).toEqual([]);
+
+      fireEvent.click(el);
       expect(events).toEqual([
         {
           type: 'pressstart',

--- a/packages/@react-aria/utils/src/isVirtualEvent.ts
+++ b/packages/@react-aria/utils/src/isVirtualEvent.ts
@@ -47,8 +47,6 @@ export function isVirtualPointerEvent(event: PointerEvent) {
   // instead of .5, see https://bugs.webkit.org/show_bug.cgi?id=206216. event.pointerType === 'mouse' is to distingush
   // Talkback double tap from Windows Firefox touch screen press
 
-  console.log(!isAndroid());
-  console.log(event.width === 0 && event.height === 0);
 
   return (
     (!isAndroid() && event.width === 0 && event.height === 0) ||

--- a/packages/@react-aria/utils/src/isVirtualEvent.ts
+++ b/packages/@react-aria/utils/src/isVirtualEvent.ts
@@ -46,6 +46,10 @@ export function isVirtualPointerEvent(event: PointerEvent) {
   // Cannot use "event.pressure === 0" as the sole check due to Safari pointer events always returning pressure === 0
   // instead of .5, see https://bugs.webkit.org/show_bug.cgi?id=206216. event.pointerType === 'mouse' is to distingush
   // Talkback double tap from Windows Firefox touch screen press
+
+  console.log(!isAndroid());
+  console.log(event.width === 0 && event.height === 0);
+
   return (
     (!isAndroid() && event.width === 0 && event.height === 0) ||
     (event.width === 1 &&

--- a/packages/@react-aria/utils/src/isVirtualEvent.ts
+++ b/packages/@react-aria/utils/src/isVirtualEvent.ts
@@ -47,7 +47,7 @@ export function isVirtualPointerEvent(event: PointerEvent) {
   // instead of .5, see https://bugs.webkit.org/show_bug.cgi?id=206216. event.pointerType === 'mouse' is to distingush
   // Talkback double tap from Windows Firefox touch screen press
   return (
-    (event.width === 0 && event.height === 0) ||
+    (!isAndroid() || event.width === 0 && event.height === 0) ||
     (event.width === 1 &&
       event.height === 1 &&
       event.pressure === 0 &&

--- a/packages/@react-aria/utils/src/isVirtualEvent.ts
+++ b/packages/@react-aria/utils/src/isVirtualEvent.ts
@@ -47,7 +47,7 @@ export function isVirtualPointerEvent(event: PointerEvent) {
   // instead of .5, see https://bugs.webkit.org/show_bug.cgi?id=206216. event.pointerType === 'mouse' is to distingush
   // Talkback double tap from Windows Firefox touch screen press
   return (
-    (!isAndroid() || event.width === 0 && event.height === 0) ||
+    (!isAndroid() && event.width === 0 && event.height === 0) ||
     (event.width === 1 &&
       event.height === 1 &&
       event.pressure === 0 &&

--- a/packages/@react-aria/utils/src/isVirtualEvent.ts
+++ b/packages/@react-aria/utils/src/isVirtualEvent.ts
@@ -46,8 +46,6 @@ export function isVirtualPointerEvent(event: PointerEvent) {
   // Cannot use "event.pressure === 0" as the sole check due to Safari pointer events always returning pressure === 0
   // instead of .5, see https://bugs.webkit.org/show_bug.cgi?id=206216. event.pointerType === 'mouse' is to distingush
   // Talkback double tap from Windows Firefox touch screen press
-
-
   return (
     (!isAndroid() && event.width === 0 && event.height === 0) ||
     (event.width === 1 &&


### PR DESCRIPTION
Might close #3945 

Opened to investigate the problem. Adds a check (which Devon suggested) to `isVirtualPointerEvent` to see if it's `!isAndroid()` when the event width and height are 0.


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to [this page](https://reactspectrum.blob.core.windows.net/reactspectrum/c73d2d6b473a7a149b7ef35ea5962b6ae8e2a9a8/docs/react-aria/usePress.html#example) on the docs
Press the button that says "Press me!"
Should say 'press with touch' (if on mobile without screenreader)


## 🧢 Your Project:

<!--- Company/project for pull request -->
