### PR TITLE
Bailout early if Virtualizer is bouncing between two rect sizes constantly

### DIFF
--- a/packages/@react-aria/virtualizer/src/Virtualizer.tsx
+++ b/packages/@react-aria/virtualizer/src/Virtualizer.tsx
@@ -181,9 +181,14 @@ export function useVirtualizer<T extends object, V extends ReactNode, W>(props: 
   // Handle scrolling, and call onLoadMore when nearing the bottom.
   let isLoadingRef = useRef(isLoading);
   let prevProps = useRef(props);
-  let onVisibleRectChange = useCallback((rect: Rect) => {
-    state.setVisibleRect(rect);
+  let rectTracker = useRef({
+    // Track the last two visible rect sizes
+    lastTwoRects: [],
+    // Number of times the newest visible rect size has matched the last two sizes
+    sameSizeCounter: 0
+  }).current;
 
+  let onVisibleRectChange = useCallback((rect: Rect) => {
     if (!isLoadingRef.current && onLoadMore) {
       let scrollOffset = state.virtualizer.contentSize.height - rect.height * 2;
       if (rect.y > scrollOffset) {
@@ -191,7 +196,25 @@ export function useVirtualizer<T extends object, V extends ReactNode, W>(props: 
         onLoadMore();
       }
     }
-  }, [onLoadMore, state]);
+
+    if (rectTracker.lastTwoRects.length > 1) {
+      if (rectTracker.lastTwoRects.some(oldRect => rect.equals(oldRect))) {
+        ++rectTracker.sameSizeCounter;
+        if (rectTracker.sameSizeCounter > 5) {
+          return;
+        }
+      } else {
+        rectTracker.sameSizeCounter = 0;
+      }
+
+      rectTracker.lastTwoRects.shift();
+      rectTracker.lastTwoRects.push(rect);
+    } else {
+      rectTracker.lastTwoRects.push(rect);
+    }
+
+    state.setVisibleRect(rect);
+  }, [onLoadMore, state, rectTracker]);
 
   let lastContentSize = useRef(0);
   useLayoutEffect(() => {


### PR DESCRIPTION
we have had customer issues where tableview has been crashing due to an infinite rerender but havent been able to reproduce it locally but this change seems to fix it. This PR is to start a discussion on how best we want to handle this, code comes from https://github.com/adobe/react-spectrum/pull/4846/files/858512a3cbdff8f07bae43c1d7fd5b0b1ba23ee7.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Test virtualizer components and double check that you don't ever get React error 185 issue crash (maximum update depth)

## 🧢 Your Project:

RSP
