### PR TITLE
Fix console error with Preact on key down in select trigger

### DIFF
--- a/packages/@react-aria/interactions/src/createEventHandler.ts
+++ b/packages/@react-aria/interactions/src/createEventHandler.ts
@@ -23,8 +23,15 @@ export function createEventHandler<T extends SyntheticEvent>(handler: (e: BaseEv
 
   let shouldStopPropagation = true;
   return (e: T) => {
-    let event: BaseEvent<T> = {
-      ...e,
+    // Mutates the original event object to support Preact because we aren't dealing
+    // with synthetic events. The event object that Preact passes to this function
+    // does not have very many of its "own" properties; rather, it inherits most of
+    // its properties from KeyboardEvents, which means using the spread operator will
+    // not transfer the properties to our new `event` object. If we were to either
+    // try to copying the properties from the original event's prototype or using
+    // that original event as the prototype of this new object, we would actually get
+    // an illegal-invokation error as soon as we started using it.
+    let event: BaseEvent<T> = Object.assign(e, {
       preventDefault() {
         e.preventDefault();
       },
@@ -37,7 +44,7 @@ export function createEventHandler<T extends SyntheticEvent>(handler: (e: BaseEv
       continuePropagation() {
         shouldStopPropagation = false;
       }
-    };
+    });
 
     handler(event);
 

--- a/packages/@react-aria/interactions/src/createEventHandler.ts
+++ b/packages/@react-aria/interactions/src/createEventHandler.ts
@@ -32,12 +32,6 @@ export function createEventHandler<T extends SyntheticEvent>(handler: (e: BaseEv
     // that original event as the prototype of this new object, we would actually get
     // an illegal-invokation error as soon as we started using it.
     let event: BaseEvent<T> = Object.assign(e, {
-      preventDefault() {
-        e.preventDefault();
-      },
-      isDefaultPrevented() {
-        return e.isDefaultPrevented();
-      },
       stopPropagation() {
         console.error('stopPropagation is now the default behavior for events in React Spectrum. You can use continuePropagation() to revert this behavior.');
       },


### PR DESCRIPTION
Hi @devongovett, I was digging through some history on this repo and found [your issue on adding Preact support](https://github.com/adobe/react-spectrum/issues/781) and even [a fix you made in Preact itself](https://github.com/preactjs/preact/pull/2740) in support of this effort. I've just started integrating the `react-aria` select code into my project that supports Preact, and I found an error that I tried to fix.

My solution probably needs some work, but I wanted to create a pull request rather than an issue so this conversation can happen closer to the code. What I've done here does not respect the immutability that the function author originally intended, but I didn't see any other way around that. I understand if my solution isn't acceptable. I just wanted to share my findings and start a conversation.

## Summary

Fixes a console error that is printed when you key down on a select's trigger button when you are using Preact instead of React. The error looks like this:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at $fb3050f43d946246$var$getStringForKey
```

The [error is thrown from this line](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/selection/src/useTypeSelect.ts#L55) in `useTypeSelect`'s `onKeyDown` handler, and it stems from the [event object created here](https://github.com/adobe/react-spectrum/blob/8d367e0253073dcb7700896957e6db073517adab/packages/%40react-aria/interactions/src/createEventHandler.ts#L26). Basically, that event object that is created only has those four functions defined in that `createEventHandler` function and nothing else, so when other code starts to try to access the keyboard event's properties, it fails. See the code comment for more details.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Configure your build system to replace React with Preact
2. Implement a select-style combobox using [useSelect](https://react-spectrum.adobe.com/react-aria/useSelect.html) according to the documentation
3. When interacting with this select, focus on the trigger button, and then press a key (like <kbd>ALT</kbd>)
4. Check the console. On the main branch, you'll see an error. With this fix applied, there should be no error.

## 🧢 Your Project:

<!--- Company/project for pull request -->
