### PR TITLE
Add translations to RSP Dropzone

### DIFF
--- a/packages/@react-spectrum/dropzone/intl/en-US.json
+++ b/packages/@react-spectrum/dropzone/intl/en-US.json
@@ -1,0 +1,3 @@
+{
+  "message": "Drop file to replace"
+}

--- a/packages/@react-spectrum/dropzone/intl/en-US.json
+++ b/packages/@react-spectrum/dropzone/intl/en-US.json
@@ -1,3 +1,3 @@
 {
-  "message": "Drop file to replace"
+  "replaceMessage": "Drop file to replace"
 }

--- a/packages/@react-spectrum/dropzone/package.json
+++ b/packages/@react-spectrum/dropzone/package.json
@@ -37,11 +37,12 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-aria/i18n": "^3.8.1",
     "@react-aria/utils": "^3.19.0",
     "@react-spectrum/utils": "^3.10.1",
     "@react-types/shared": "^3.19.0",
-    "react-aria-components": "^1.0.0-alpha.6",
-    "@swc/helpers": "^0.5.0"
+    "@swc/helpers": "^0.5.0",
+    "react-aria-components": "^1.0.0-alpha.6"
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "3.0.0-alpha.1",

--- a/packages/@react-spectrum/dropzone/src/DropZone.tsx
+++ b/packages/@react-spectrum/dropzone/src/DropZone.tsx
@@ -68,7 +68,7 @@ function DropZone(props: SpectrumDropZoneProps, ref: DOMRef<HTMLDivElement>) {
             styleProps.className
           )
         }>
-        {replaceMessage ? replaceMessage : stringFormatter.format('message')}
+        {replaceMessage ? replaceMessage : stringFormatter.format('replaceMessage')}
       </div>
     </RACDropZone>
   );

--- a/packages/@react-spectrum/dropzone/src/DropZone.tsx
+++ b/packages/@react-spectrum/dropzone/src/DropZone.tsx
@@ -13,9 +13,12 @@
 import {AriaLabelingProps, DOMProps, DOMRef, StyleProps} from '@react-types/shared';
 import {classNames, SlotProvider, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DropZoneProps, DropZone as RACDropZone} from 'react-aria-components';
+// @ts-ignore
+import intlMessages from '../intl/*.json';
 import {mergeProps, useId} from '@react-aria/utils';
 import React, {ReactNode} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/dropzone/vars.css';
+import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 export interface SpectrumDropZoneProps extends DropZoneProps, DOMProps, StyleProps, AriaLabelingProps {
   /** The content to display in the drop zone. */
@@ -31,6 +34,7 @@ function DropZone(props: SpectrumDropZoneProps, ref: DOMRef<HTMLDivElement>) {
   let {styleProps} = useStyleProps(props);
   let domRef = useDOMRef(ref);
   let messageId = useId();
+  let stringFormatter = useLocalizedStringFormatter(intlMessages);
 
   return (
     <RACDropZone
@@ -64,7 +68,7 @@ function DropZone(props: SpectrumDropZoneProps, ref: DOMRef<HTMLDivElement>) {
             styleProps.className
           )
         }>
-        {replaceMessage ? replaceMessage : 'Drop file to replace'}
+        {replaceMessage ? replaceMessage : stringFormatter.format('message')}
       </div>
     </RACDropZone>
   );


### PR DESCRIPTION
There is still a hard-coded aria-label within RAC DropZone but given that we do not yet have translations set up for RAC Components and users can override this aria-label, we decided to leave it be. 

However, a translation for the filled message in RSP DropZone has been created. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
