### PR TITLE
Fix some RAC docs colors

### DIFF
--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -442,22 +442,22 @@ function Nav({currentPageName, pages}) {
           </h2>
         </a>
       </header>
-      {sections.map(section => {
+      {sections.map((section, i) => {
         let contents = categories.filter(c => section.pages[c]?.length).map(key => {
           const headingId = `${section.title ? section.title.toLowerCase() + '-' : ''}${key.trim().toLowerCase().replace(/\s+/g, '-')}-heading`;
           return (
-            <>
+            <React.Fragment key={headingId}>
               <h3 className={sideNavStyles['spectrum-SideNav-heading']} id={headingId}>{key}</h3>
               <ul className={sideNavStyles['spectrum-SideNav']} aria-labelledby={headingId}>
-                {section.pages[key].sort((a, b) => (a.order || 0) < (b.order || 0) || a.title < b.title ? -1 : 1).map(p => <SideNavItem {...p} preRelease={section.title === 'Components' ? '' : p.preRelease} />)}
+                {section.pages[key].sort((a, b) => (a.order || 0) < (b.order || 0) || a.title < b.title ? -1 : 1).map(p => <SideNavItem key={p.title} {...p} preRelease={section.title === 'Components' ? '' : p.preRelease} />)}
               </ul>
-            </>
+            </React.Fragment>
           );
         });
 
         if (section.title) {
           return (
-            <details open={section.isActive}>
+            <details key={section.title} open={section.isActive}>
               <summary style={{fontWeight: 'bold'}}>
                 <ChevronRight size="S" /> {section.title}
                 {section.title === 'Components' && <VersionBadge version={Object.values(section.pages)[0][0].preRelease} style={{marginLeft: 'auto', fontWeight: 'normal'}} />}
@@ -466,7 +466,7 @@ function Nav({currentPageName, pages}) {
             </details>
           );
         } else {
-          return <>{contents}</>;
+          return <React.Fragment key={i}>{contents}</React.Fragment>;
         }
       })}
     </nav>

--- a/packages/react-aria-components/docs/Checkbox.mdx
+++ b/packages/react-aria-components/docs/Checkbox.mdx
@@ -64,8 +64,8 @@ import {Checkbox} from 'react-aria-components';
   --selected-color: slateblue;
   --selected-color-pressed: lch(from slateblue calc(l - 10%) c h);
   --checkmark-color: white;
-  --invalid-color: var(--spectrum-global-color-static-red-600);
-  --invalid-color-pressed: var(--spectrum-global-color-static-red-700);
+  --invalid-color: var(--spectrum-global-color-red-600);
+  --invalid-color-pressed: var(--spectrum-global-color-red-700);
 
   display: flex;
   align-items: center;

--- a/packages/react-aria-components/docs/CheckboxGroup.mdx
+++ b/packages/react-aria-components/docs/CheckboxGroup.mdx
@@ -94,8 +94,8 @@ import {CheckboxGroup, Checkbox, Label} from 'react-aria-components';
   --selected-color: slateblue;
   --selected-color-pressed: lch(from slateblue calc(l - 10%) c h);
   --checkmark-color: white;
-  --invalid-color: var(--spectrum-global-color-static-red-600);
-  --invalid-color-pressed: var(--spectrum-global-color-static-red-700);
+  --invalid-color: var(--spectrum-global-color-red-600);
+  --invalid-color-pressed: var(--spectrum-global-color-red-700);
 
   display: flex;
   align-items: center;

--- a/packages/react-aria-components/docs/RadioGroup.mdx
+++ b/packages/react-aria-components/docs/RadioGroup.mdx
@@ -83,8 +83,8 @@ import {RadioGroup, Radio, Label} from 'react-aria-components';
   --background-color: var(--spectrum-global-color-gray-50);
   --selected-color: slateblue;
   --selected-color-pressed: lch(from slateblue calc(l - 10%) c h);
-  --invalid-color: var(--spectrum-global-color-static-red-600);
-  --invalid-color-pressed: var(--spectrum-global-color-static-red-700);
+  --invalid-color: var(--spectrum-global-color-red-600);
+  --invalid-color-pressed: var(--spectrum-global-color-red-700);
 
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes <!-- Github issue # here -->

There are a few more instances in the calendar components where the darker red is used, however, due to contrast, it's not as easy to fix. We can revisit another time, I think they look fine. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
