### PR TITLE
react-aria-components Table  - allow passing render prop to Cell

### DIFF
--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -656,8 +656,6 @@ export interface CellRenderProps {
 
 export interface CellProps extends RenderProps<CellRenderProps> {
   id?: Key,
-  /** The contents of the cell. */
-  children: ReactNode,
   /** A string representation of the cell's contents, used for features like typeahead. */
   textValue?: string
 }


### PR DESCRIPTION
Closes #4994
## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Try to pass `Cell` (`import Cell from 'react-aria-components'`) component render prop - and you won't see an error.

## 🧢 Your Project:

<!--- Company/project for pull request -->


## Notes:
Not sure what to do with the docs in this case.
