### PR TITLE
Remove unnecessary props from docs

### DIFF
--- a/packages/@react-spectrum/menu/chromatic/MenuTrigger.chromatic.tsx
+++ b/packages/@react-spectrum/menu/chromatic/MenuTrigger.chromatic.tsx
@@ -127,7 +127,7 @@ const customMenuItem = (item) => {
   let Icon = iconMap[item.icon];
   return (
     <Item childItems={item.children} textValue={item.name} key={item.name}>
-      {item.icon && <Icon size="S" />}
+      {item.icon && <Icon />}
       <Text>{item.name}</Text>
       {item.shortcut && <Keyboard>{item.shortcut}</Keyboard>}
     </Item>

--- a/packages/@react-spectrum/menu/docs/ActionMenu.mdx
+++ b/packages/@react-spectrum/menu/docs/ActionMenu.mdx
@@ -168,17 +168,17 @@ Items within ActionMenu also allow for additional content used to better communi
 import {Keyboard, Text} from '@react-spectrum/text';
 <ActionMenu>
   <Item key="cut" textValue="cut">
-    <Cut size="S"/>
+    <Cut />
     <Text>Cut</Text>
     <Keyboard>⌘X</Keyboard>
   </Item>
   <Item key="copy" textValue="copy">
-    <Copy size="S"/>
+    <Copy />
     <Text>Copy</Text>
     <Keyboard>⌘C</Keyboard>
   </Item>
   <Item key="paste" textValue="paste">
-    <Paste size="S"/>
+    <Paste />
     <Text>Paste</Text>
     <Keyboard>⌘V</Keyboard>
   </Item>

--- a/packages/@react-spectrum/menu/docs/Menu.mdx
+++ b/packages/@react-spectrum/menu/docs/Menu.mdx
@@ -269,17 +269,17 @@ import {Keyboard, Text} from '@react-spectrum/text';
   </ActionButton>
   <Menu>
     <Item key="cut" textValue="cut">
-      <Cut size="S"/>
+      <Cut />
       <Text>Cut</Text>
       <Keyboard>⌘X</Keyboard>
     </Item>
     <Item key="copy" textValue="copy">
-      <Copy size="S"/>
+      <Copy />
       <Text>Copy</Text>
       <Keyboard>⌘C</Keyboard>
     </Item>
     <Item key="paste" textValue="paste">
-      <Paste size="S"/>
+      <Paste />
       <Text>Paste</Text>
       <Keyboard>⌘V</Keyboard>
     </Item>

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -507,34 +507,34 @@ export const MenuWithSemanticElementsStatic = () => (
       <Menu onAction={action('action')}>
         <Section title="Section 1">
           <Item textValue="Copy">
-            <Copy size="S" />
+            <Copy />
             <Text>Copy</Text>
             <Keyboard>⌘C</Keyboard>
           </Item>
           <Item textValue="Cut">
-            <Cut size="S" />
+            <Cut />
             <Text>Cut</Text>
             <Keyboard>⌘X</Keyboard>
           </Item>
           <Item textValue="Paste">
-            <Paste size="S" />
+            <Paste />
             <Text>Paste</Text>
             <Keyboard>⌘V</Keyboard>
           </Item>
         </Section>
         <Section title="Section 2">
           <Item textValue="Puppy">
-            <AlignLeft size="S" />
+            <AlignLeft />
             <Text>Puppy</Text>
             <Text slot="description">Puppy description super long as well geez</Text>
           </Item>
           <Item textValue="Doggo with really really really long long long text">
-            <AlignCenter size="S" />
+            <AlignCenter />
             <Text>Doggo with really really really long long long text</Text>
             <Text slot="end">Value</Text>
           </Item>
           <Item textValue="Floof">
-            <AlignRight size="S" />
+            <AlignRight />
             <Text>Floof</Text>
           </Item>
           <Item>Basic Item</Item>
@@ -669,7 +669,7 @@ let customMenuItem = (item) => {
   let Icon = iconMap[item.icon];
   return (
     <Item childItems={item.children} textValue={item.name} key={item.name}>
-      {item.icon && <Icon size="S" />}
+      {item.icon && <Icon />}
       <Text>{item.name}</Text>
       {item.shortcut && <Keyboard>{item.shortcut}</Keyboard>}
     </Item>

--- a/packages/@react-spectrum/tabs/stories/Tabs.stories.tsx
+++ b/packages/@react-spectrum/tabs/stories/Tabs.stories.tsx
@@ -664,12 +664,12 @@ interface DynamicTabItem {
 }
 
 let items = [
-  {name: 'Tab 1', children: 'Tab Body 1', icon: <Dashboard size="S" />},
-  {name: 'Tab 2', children: 'Tab Body 2', icon: <Calendar size="S" />},
-  {name: 'Tab 3', children: 'Tab Body 3', icon: <Bookmark size="S" />},
-  {name: 'Tab 4', children: 'Tab Body 4', icon: <Dashboard size="S" />},
-  {name: 'Tab 5', children: 'Tab Body 5', icon: <Calendar size="S" />},
-  {name: 'Tab 6', children: 'Tab Body 6', icon: <Bookmark size="S" />}
+  {name: 'Tab 1', children: 'Tab Body 1', icon: <Dashboard />},
+  {name: 'Tab 2', children: 'Tab Body 2', icon: <Calendar />},
+  {name: 'Tab 3', children: 'Tab Body 3', icon: <Bookmark />},
+  {name: 'Tab 4', children: 'Tab Body 4', icon: <Dashboard />},
+  {name: 'Tab 5', children: 'Tab Body 5', icon: <Calendar />},
+  {name: 'Tab 6', children: 'Tab Body 6', icon: <Bookmark />}
 ] as DynamicTabItem[];
 
 let DynamicTabs = (props: Omit<SpectrumTabsProps<DynamicTabItem>, 'children'>) => {

--- a/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
+++ b/packages/dev/docs/pages/blog/introducing-react-spectrum.mdx
@@ -138,17 +138,17 @@ We’ve designed the APIs in React Spectrum to be easy to use. The following exa
 <Picker label="Options">
   <Section title="Permission">
     <Item textValue="Read">
-      <Book size="S" />
+      <Book />
       <Text>Read</Text>
       <Text slot="description">Read Only</Text>
     </Item>
     <Item textValue="Write">
-      <Draw size="S" />
+      <Draw />
       <Text>Write</Text>
       <Text slot="description">Read and Write Only</Text>
     </Item>
     <Item textValue="Admin">
-      <BulkEditUsers size="S" />
+      <BulkEditUsers />
       <Text>Admin</Text>
       <Text slot="description">Full access</Text>
     </Item>

--- a/packages/dev/docs/pages/react-spectrum/layout.mdx
+++ b/packages/dev/docs/pages/react-spectrum/layout.mdx
@@ -258,17 +258,17 @@ placed using the `slot` prop to specify a named area.
 ```tsx example
 <Picker label="Permission" defaultSelectedKey="read">
   <Item textValue="Read" key="read">
-    <Book size="S" />
+    <Book />
     <Text>Read</Text>
     <Text slot="description">Read only</Text>
   </Item>
   <Item textValue="Write" key="write">
-    <Draw size="S" />
+    <Draw />
     <Text>Write</Text>
     <Text slot="description">Read and write only</Text>
   </Item>
   <Item textValue="Admin" key="admin">
-    <BulkEditUsers size="S" />
+    <BulkEditUsers />
     <Text>Admin</Text>
     <Text slot="description">Full access</Text>
   </Item>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/4814

Menus, pickers, and tabs in RSP do not need icons with a specified size, they will override it. This lead to confusion as to why the prop wasn't being respected when set to some other value.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
