### PR TITLE
Fix missing required in Select (& HiddenSelect)

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -30,7 +30,10 @@ export interface AriaHiddenSelectProps {
   name?: string,
 
   /** Sets the disabled state of the select and input. */
-  isDisabled?: boolean
+  isDisabled?: boolean,
+
+  /** Whether user input is required on the input before form submission. */
+  isRequired?: boolean
 }
 
 export interface HiddenSelectProps<T> extends AriaHiddenSelectProps {
@@ -52,7 +55,7 @@ export interface AriaHiddenSelectOptions extends AriaHiddenSelectProps {
  * navigation, and native HTML form submission.
  */
 export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: SelectState<T>, triggerRef: RefObject<FocusableElement>) {
-  let {autoComplete, name, isDisabled} = props;
+  let {autoComplete, name, isDisabled, isRequired} = props;
   let modality = useInteractionModality();
   let {visuallyHiddenProps} = useVisuallyHidden();
 
@@ -87,7 +90,8 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
       tabIndex: modality == null || state.isFocused || state.isOpen ? -1 : 0,
       style: {fontSize: 16},
       onFocus: () => triggerRef.current.focus(),
-      disabled: isDisabled
+      disabled: isDisabled,
+      required: isRequired
     },
     selectProps: {
       tabIndex: -1,

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -170,7 +170,8 @@ function Select<T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLD
           triggerRef={buttonRef}
           label={label}
           name={props.name}
-          isDisabled={props.isDisabled} />
+          isDisabled={props.isDisabled}
+          isRequired={props.isRequired} />
       </Provider>
     </>
   );

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -186,4 +186,13 @@ describe('Select', () => {
 
     expect(document.activeElement).toBe(document.body);
   });
+
+  it('should send required prop to the hidden field', () => {
+    let {container} = render(
+      <TestSelect isRequired />
+    );
+
+    let input = container.querySelector('input');
+    expect(input).toHaveAttribute('required');
+  });
 });


### PR DESCRIPTION
Hi,

I noticed the lack of a `required` prop on the `Select` comps, but I need it to block form submission. Hope it's alright to jump straight to PR without a prior issue, it seemed pretty clear to me that this will be needed.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
