### PR TITLE
Add missing variants to Tailwind plugin

### DIFF
--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -274,6 +274,7 @@ function DateSegment({segment, ...otherProps}: DateSegmentProps, ref: ForwardedR
       {...mergeProps(filterDOMProps(otherProps as any), segmentProps)}
       {...renderProps}
       ref={domRef}
+      data-placeholder={segment.isPlaceholder || undefined}
       data-invalid={state.isInvalid || undefined}
       data-readonly={!segment.isEditable || undefined}
       data-type={segment.type} />

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -43,6 +43,11 @@ export interface ListBoxRenderProps {
    */
   isDropTarget: boolean,
   /**
+   * Whether the items are arranged in a stack or grid.
+   * @selector [data-layout="stack | grid"]
+   */
+  layout: 'stack' | 'grid',
+  /**
    * State of the listbox.
    */
   state: ListState<unknown>
@@ -231,6 +236,7 @@ function ListBoxInner<T>({state, props, listBoxRef}: ListBoxInnerProps<T>) {
       isEmpty: state.collection.size === 0,
       isFocused,
       isFocusVisible,
+      layout: props.layout || 'stack',
       state
     }
   });

--- a/packages/tailwindcss-react-aria-components/src/index.js
+++ b/packages/tailwindcss-react-aria-components/src/index.js
@@ -5,37 +5,60 @@ const attributes = {
     ['hover', 'hovered'],
     ['focus', 'focused'],
     'focus-visible',
+    'focus-within',
     'pressed',
     'disabled',
     'drop-target',
     'dragging',
     'empty',
+    'allows-dragging',
     'allows-removing',
     'allows-sorting',
     'placeholder',
     'selected',
     'indeterminate',
-    'readonly',
+    ['read-only', 'readonly'],
     'required',
     'entering',
     'exiting',
     'open',
     'unavailable',
+    'outside-month',
+    'outside-visible-range',
+    'selection-start',
+    'selection-end',
     'current',
-    'invalid'
+    'invalid',
+    'resizing'
   ],
   enum: {
     placement: ['left', 'right', 'top', 'bottom'],
     type: ['literal', 'year', 'month', 'day'],
     layout: ['grid', 'stack'],
-    orientation: ['horizontal', 'vertical']
+    orientation: ['horizontal', 'vertical'],
+    'selection-mode': ['single', 'multiple'],
+    'resizable-direction': ['right', 'left', 'both'],
+    'sort-direction': ['ascending', 'descending']
   }
+};
+
+const shortNames = {
+  'selection-mode': 'selection',
+  'resizable-direction': 'resizable',
+  'sort-direction': 'sort'
 };
 
 // Variants we use that are already defined by Tailwind:
 // https://github.com/tailwindlabs/tailwindcss/blob/a2fa6932767ab328515f743d6188c2164ad2a5de/src/corePlugins.js#L84
-const nativeVariants = ['indeterminate', 'required', 'invalid', 'empty', 'focus-visible', 'disabled'];
-const nativeVariantSelectors = new Map([...nativeVariants.map((variant) => [variant, `:${variant}`]), ['hovered', ':hover'], ['focused', ':focus'], ['open', '[open]']]);
+const nativeVariants = ['indeterminate', 'required', 'invalid', 'empty', 'focus-visible', 'focus-within', 'disabled'];
+const nativeVariantSelectors = new Map([
+  ...nativeVariants.map((variant) => [variant, `:${variant}`]),
+  ['hovered', ':hover'],
+  ['focused', ':focus'],
+  ['readonly', ':read-only'],
+  ['open', '[open]'],
+  ['placeholder', '::placeholder']
+]);
 
 // If no prefix is specified, we want to avoid overriding native variants on non-RAC components, so we only target elements with the data-rac attribute for those variants.
 let getSelector = (prefix, attributeName, attributeValue) => {
@@ -55,13 +78,18 @@ module.exports = plugin.withOptions((options) => (({addVariant}) => {
     let attributeName = Array.isArray(attribute) ? attribute[1] : attribute;
     let selector = getSelector(prefix, attributeName);
     addVariant(variantName, selector);
+    addVariant(`group-${variantName}`, `:merge(.group)${selector.slice(1)} &`);
+    addVariant(`peer-${variantName}`, `:merge(.peer)${selector.slice(1)} ~ &`);
   });
   Object.keys(attributes.enum).forEach((attributeName) => {
     attributes.enum[attributeName].forEach(
         (attributeValue) => {
-          let variantName = `${prefix}${attributeName}-${attributeValue}`;
+          let name = shortNames[attributeName] || attributeName;
+          let variantName = `${prefix}${name}-${attributeValue}`;
           let selector = getSelector(prefix, attributeName, attributeValue);
           addVariant(variantName, selector);
+          addVariant(`group-${variantName}`, `:merge(.group)${selector.slice(1)} &`);
+          addVariant(`peer-${variantName}`, `:merge(.peer)${selector.slice(1)} ~ &`);
         }
       );
   });

--- a/packages/tailwindcss-react-aria-components/src/index.js
+++ b/packages/tailwindcss-react-aria-components/src/index.js
@@ -14,7 +14,7 @@ const attributes = {
     'allows-dragging',
     'allows-removing',
     'allows-sorting',
-    'placeholder',
+    ['placeholder-shown', 'placeholder'],
     'selected',
     'indeterminate',
     ['read-only', 'readonly'],
@@ -57,7 +57,7 @@ const nativeVariantSelectors = new Map([
   ['focused', ':focus'],
   ['readonly', ':read-only'],
   ['open', '[open]'],
-  ['placeholder', '::placeholder']
+  ['placeholder', ':placeholder-shown']
 ]);
 
 // If no prefix is specified, we want to avoid overriding native variants on non-RAC components, so we only target elements with the data-rac attribute for those variants.

--- a/packages/tailwindcss-react-aria-components/src/index.test.js
+++ b/packages/tailwindcss-react-aria-components/src/index.test.js
@@ -23,7 +23,7 @@ function run({options, content}) {
 }
 
 test('variants', async () => {
-  let content = html`<div data-rac className="hover:bg-red focus:bg-red focus-visible:bg-red pressed:bg-red disabled:bg-red drop-target:bg-red dragging:bg-red empty:bg-red allows-removing:bg-red allows-sorting:bg-red placeholder:bg-red selected:bg-red indeterminate:bg-red readonly:bg-red required:bg-red entering:bg-red exiting:bg-red open:bg-red unavailable:bg-red current:bg-red invalid:bg-red placement-left:bg-red placement-right:bg-red placement-top:bg-red placement-bottom:bg-red type-literal:bg-red type-year:bg-red type-month:bg-red type-day:bg-red layout-grid:bg-red layout-stack:bg-red orientation-horizontal:bg-red orientation-vertical:bg-red"></div>`;
+  let content = html`<div data-rac className="hover:bg-red focus:bg-red focus-visible:bg-red focus-within:bg-red pressed:bg-red disabled:bg-red drop-target:bg-red dragging:bg-red empty:bg-red allows-dragging:bg-red allows-removing:bg-red allows-sorting:bg-red placeholder:bg-red selected:bg-red indeterminate:bg-red read-only:bg-red required:bg-red entering:bg-red exiting:bg-red open:bg-red unavailable:bg-red outside-month:bg-red outside-visible-range:bg-red selection-start:bg-red selection-end:bg-red current:bg-red invalid:bg-red resizing:bg-red placement-left:bg-red placement-right:bg-red placement-top:bg-red placement-bottom:bg-red type-literal:bg-red type-year:bg-red type-month:bg-red type-day:bg-red layout-grid:bg-red layout-stack:bg-red orientation-horizontal:bg-red orientation-vertical:bg-red selection-single:bg-red selection-multiple:bg-red resizable-right:bg-red resizable-left:bg-red resizable-both:bg-red sort-ascending:bg-red sort-descending:bg-red group-pressed:bg-red peer-pressed:bg-red"></div>`;
   return run({content}).then((result) => {
     expect(result.css).toContain(css`
 .hover\:bg-red:is([data-rac][data-hovered], :not([data-rac]):hover) {
@@ -38,7 +38,19 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
+.focus-within\:bg-red:is([data-rac][data-focus-within], :not([data-rac]):focus-within) {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
 .pressed\:bg-red[data-pressed] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group[data-pressed] .group-pressed\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.peer[data-pressed] ~ .peer-pressed\:bg-red {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -58,6 +70,10 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
+.allows-dragging\:bg-red[data-allows-dragging] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
 .allows-removing\:bg-red[data-allows-removing] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
@@ -66,7 +82,7 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.placeholder\:bg-red[data-placeholder] {
+.placeholder\:bg-red:is([data-rac][data-placeholder], :not([data-rac]))::placeholder {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -78,7 +94,7 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.readonly\:bg-red[data-readonly] {
+.read-only\:bg-red:is([data-rac][data-readonly], :not([data-rac]):read-only) {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -102,11 +118,31 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
+.outside-month\:bg-red[data-outside-month] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.outside-visible-range\:bg-red[data-outside-visible-range] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selection-start\:bg-red[data-selection-start] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selection-end\:bg-red[data-selection-end] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
 .current\:bg-red[data-current] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
 .invalid\:bg-red:is([data-rac][data-invalid], :not([data-rac]):invalid) {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.resizing\:bg-red[data-resizing] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -157,13 +193,41 @@ test('variants', async () => {
 .orientation-vertical\:bg-red[data-orientation="vertical"] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selection-single\:bg-red[data-selection-mode="single"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selection-multiple\:bg-red[data-selection-mode="multiple"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.resizable-right\:bg-red[data-resizable-direction="right"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.resizable-left\:bg-red[data-resizable-direction="left"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.resizable-both\:bg-red[data-resizable-direction="both"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.sort-ascending\:bg-red[data-sort-direction="ascending"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.sort-descending\:bg-red[data-sort-direction="descending"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }`
     );
   });
 });
 
 test('variants with prefix', async () => {
-  let content = html`<div data-rac className="rac-hover:bg-red rac-focus:bg-red rac-focus-visible:bg-red rac-pressed:bg-red rac-disabled:bg-red rac-drop-target:bg-red rac-dragging:bg-red rac-empty:bg-red rac-allows-removing:bg-red rac-allows-sorting:bg-red rac-placeholder:bg-red rac-selected:bg-red rac-indeterminate:bg-red rac-readonly:bg-red rac-required:bg-red rac-entering:bg-red rac-exiting:bg-red rac-open:bg-red rac-unavailable:bg-red rac-current:bg-red rac-invalid:bg-red rac-placement-left:bg-red rac-placement-right:bg-red rac-placement-top:bg-red rac-placement-bottom:bg-red rac-type-literal:bg-red rac-type-year:bg-red rac-type-month:bg-red rac-type-day:bg-red rac-layout-grid:bg-red rac-layout-stack:bg-red rac-orientation-horizontal:bg-red rac-orientation-vertical:bg-red"></div>`;
+  let content = html`<div data-rac className="rac-hover:bg-red rac-focus:bg-red rac-focus-visible:bg-red rac-focus-within:bg-red rac-pressed:bg-red rac-disabled:bg-red rac-drop-target:bg-red rac-dragging:bg-red rac-empty:bg-red rac-allows-dragging:bg-red rac-allows-removing:bg-red rac-allows-sorting:bg-red rac-placeholder:bg-red rac-selected:bg-red rac-indeterminate:bg-red rac-read-only:bg-red rac-required:bg-red rac-entering:bg-red rac-exiting:bg-red rac-open:bg-red rac-unavailable:bg-red rac-outside-month:bg-red rac-outside-visible-range:bg-red rac-selection-start:bg-red rac-selection-end:bg-red rac-current:bg-red rac-invalid:bg-red rac-resizing:bg-red rac-placement-left:bg-red rac-placement-right:bg-red rac-placement-top:bg-red rac-placement-bottom:bg-red rac-type-literal:bg-red rac-type-year:bg-red rac-type-month:bg-red rac-type-day:bg-red rac-layout-grid:bg-red rac-layout-stack:bg-red rac-orientation-horizontal:bg-red rac-orientation-vertical:bg-red rac-selection-single:bg-red rac-selection-multiple:bg-red rac-resizable-right:bg-red rac-resizable-left:bg-red rac-resizable-both:bg-red rac-sort-ascending:bg-red rac-sort-descending:bg-red group-rac-pressed:bg-red peer-rac-pressed:bg-red"></div>`;
   return run({content, options: {prefix: 'rac'}}).then((result) => {
     expect(result.css).toContain(css`
 .rac-hover\:bg-red[data-hovered] {
@@ -178,7 +242,19 @@ test('variants with prefix', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
+.rac-focus-within\:bg-red[data-focus-within] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
 .rac-pressed\:bg-red[data-pressed] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group[data-pressed] .group-rac-pressed\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.peer[data-pressed] ~ .peer-rac-pressed\:bg-red {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -195,6 +271,10 @@ test('variants with prefix', async () => {
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
 .rac-empty\:bg-red[data-empty] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-allows-dragging\:bg-red[data-allows-dragging] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -218,7 +298,7 @@ test('variants with prefix', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.rac-readonly\:bg-red[data-readonly] {
+.rac-read-only\:bg-red[data-readonly] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -242,11 +322,31 @@ test('variants with prefix', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
+.rac-outside-month\:bg-red[data-outside-month] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-outside-visible-range\:bg-red[data-outside-visible-range] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selection-start\:bg-red[data-selection-start] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selection-end\:bg-red[data-selection-end] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
 .rac-current\:bg-red[data-current] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
 .rac-invalid\:bg-red[data-invalid] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-resizing\:bg-red[data-resizing] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -295,6 +395,34 @@ test('variants with prefix', async () => {
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
 .rac-orientation-vertical\:bg-red[data-orientation="vertical"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selection-single\:bg-red[data-selection-mode="single"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selection-multiple\:bg-red[data-selection-mode="multiple"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-resizable-right\:bg-red[data-resizable-direction="right"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-resizable-left\:bg-red[data-resizable-direction="left"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-resizable-both\:bg-red[data-resizable-direction="both"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-sort-ascending\:bg-red[data-sort-direction="ascending"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-sort-descending\:bg-red[data-sort-direction="descending"] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }`

--- a/packages/tailwindcss-react-aria-components/src/index.test.js
+++ b/packages/tailwindcss-react-aria-components/src/index.test.js
@@ -23,7 +23,7 @@ function run({options, content}) {
 }
 
 test('variants', async () => {
-  let content = html`<div data-rac className="hover:bg-red focus:bg-red focus-visible:bg-red focus-within:bg-red pressed:bg-red disabled:bg-red drop-target:bg-red dragging:bg-red empty:bg-red allows-dragging:bg-red allows-removing:bg-red allows-sorting:bg-red placeholder:bg-red selected:bg-red indeterminate:bg-red read-only:bg-red required:bg-red entering:bg-red exiting:bg-red open:bg-red unavailable:bg-red outside-month:bg-red outside-visible-range:bg-red selection-start:bg-red selection-end:bg-red current:bg-red invalid:bg-red resizing:bg-red placement-left:bg-red placement-right:bg-red placement-top:bg-red placement-bottom:bg-red type-literal:bg-red type-year:bg-red type-month:bg-red type-day:bg-red layout-grid:bg-red layout-stack:bg-red orientation-horizontal:bg-red orientation-vertical:bg-red selection-single:bg-red selection-multiple:bg-red resizable-right:bg-red resizable-left:bg-red resizable-both:bg-red sort-ascending:bg-red sort-descending:bg-red group-pressed:bg-red peer-pressed:bg-red"></div>`;
+  let content = html`<div data-rac className="hover:bg-red focus:bg-red focus-visible:bg-red focus-within:bg-red pressed:bg-red disabled:bg-red drop-target:bg-red dragging:bg-red empty:bg-red allows-dragging:bg-red allows-removing:bg-red allows-sorting:bg-red placeholder-shown:bg-red selected:bg-red indeterminate:bg-red read-only:bg-red required:bg-red entering:bg-red exiting:bg-red open:bg-red unavailable:bg-red outside-month:bg-red outside-visible-range:bg-red selection-start:bg-red selection-end:bg-red current:bg-red invalid:bg-red resizing:bg-red placement-left:bg-red placement-right:bg-red placement-top:bg-red placement-bottom:bg-red type-literal:bg-red type-year:bg-red type-month:bg-red type-day:bg-red layout-grid:bg-red layout-stack:bg-red orientation-horizontal:bg-red orientation-vertical:bg-red selection-single:bg-red selection-multiple:bg-red resizable-right:bg-red resizable-left:bg-red resizable-both:bg-red sort-ascending:bg-red sort-descending:bg-red group-pressed:bg-red peer-pressed:bg-red"></div>`;
   return run({content}).then((result) => {
     expect(result.css).toContain(css`
 .hover\:bg-red:is([data-rac][data-hovered], :not([data-rac]):hover) {
@@ -82,7 +82,7 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.placeholder\:bg-red:is([data-rac][data-placeholder], :not([data-rac]))::placeholder {
+.placeholder-shown\:bg-red:is([data-rac][data-placeholder], :not([data-rac]):placeholder-shown) {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
@@ -227,7 +227,7 @@ test('variants', async () => {
 });
 
 test('variants with prefix', async () => {
-  let content = html`<div data-rac className="rac-hover:bg-red rac-focus:bg-red rac-focus-visible:bg-red rac-focus-within:bg-red rac-pressed:bg-red rac-disabled:bg-red rac-drop-target:bg-red rac-dragging:bg-red rac-empty:bg-red rac-allows-dragging:bg-red rac-allows-removing:bg-red rac-allows-sorting:bg-red rac-placeholder:bg-red rac-selected:bg-red rac-indeterminate:bg-red rac-read-only:bg-red rac-required:bg-red rac-entering:bg-red rac-exiting:bg-red rac-open:bg-red rac-unavailable:bg-red rac-outside-month:bg-red rac-outside-visible-range:bg-red rac-selection-start:bg-red rac-selection-end:bg-red rac-current:bg-red rac-invalid:bg-red rac-resizing:bg-red rac-placement-left:bg-red rac-placement-right:bg-red rac-placement-top:bg-red rac-placement-bottom:bg-red rac-type-literal:bg-red rac-type-year:bg-red rac-type-month:bg-red rac-type-day:bg-red rac-layout-grid:bg-red rac-layout-stack:bg-red rac-orientation-horizontal:bg-red rac-orientation-vertical:bg-red rac-selection-single:bg-red rac-selection-multiple:bg-red rac-resizable-right:bg-red rac-resizable-left:bg-red rac-resizable-both:bg-red rac-sort-ascending:bg-red rac-sort-descending:bg-red group-rac-pressed:bg-red peer-rac-pressed:bg-red"></div>`;
+  let content = html`<div data-rac className="rac-hover:bg-red rac-focus:bg-red rac-focus-visible:bg-red rac-focus-within:bg-red rac-pressed:bg-red rac-disabled:bg-red rac-drop-target:bg-red rac-dragging:bg-red rac-empty:bg-red rac-allows-dragging:bg-red rac-allows-removing:bg-red rac-allows-sorting:bg-red rac-placeholder-shown:bg-red rac-selected:bg-red rac-indeterminate:bg-red rac-read-only:bg-red rac-required:bg-red rac-entering:bg-red rac-exiting:bg-red rac-open:bg-red rac-unavailable:bg-red rac-outside-month:bg-red rac-outside-visible-range:bg-red rac-selection-start:bg-red rac-selection-end:bg-red rac-current:bg-red rac-invalid:bg-red rac-resizing:bg-red rac-placement-left:bg-red rac-placement-right:bg-red rac-placement-top:bg-red rac-placement-bottom:bg-red rac-type-literal:bg-red rac-type-year:bg-red rac-type-month:bg-red rac-type-day:bg-red rac-layout-grid:bg-red rac-layout-stack:bg-red rac-orientation-horizontal:bg-red rac-orientation-vertical:bg-red rac-selection-single:bg-red rac-selection-multiple:bg-red rac-resizable-right:bg-red rac-resizable-left:bg-red rac-resizable-both:bg-red rac-sort-ascending:bg-red rac-sort-descending:bg-red group-rac-pressed:bg-red peer-rac-pressed:bg-red"></div>`;
   return run({content, options: {prefix: 'rac'}}).then((result) => {
     expect(result.css).toContain(css`
 .rac-hover\:bg-red[data-hovered] {
@@ -286,7 +286,7 @@ test('variants with prefix', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.rac-placeholder\:bg-red[data-placeholder] {
+.rac-placeholder-shown\:bg-red[data-placeholder] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }


### PR DESCRIPTION
* Added `group-` and `peer-` modifiers for each variant. Tailwind doesn't do this by default: https://tailwindcss.com/docs/plugins#parent-and-sibling-states
* Audited for missing states
* Fixed some modifiers that conflict with builtin Tailwind ones