### PR TITLE
Remove erroneous accessibility color contrast ignore rule

### DIFF
--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -21,10 +21,6 @@ module.exports = {
       // TODO: Ideally would have a selector target for the storybook's sb main body element
       rules: [
         {
-          id: 'color-contrast',
-          selector: 'body *:not([data-a11y-ignore="color-contrast"])'
-        },
-        {
           id: 'aria-hidden-focus',
           selector: 'body *:not([data-a11y-ignore="aria-hidden-focus"])',
         },

--- a/packages/@react-spectrum/datepicker/src/DatePickerSegment.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerSegment.tsx
@@ -65,8 +65,7 @@ function EditableSegment({segment, state}: DatePickerSegmentProps) {
         minWidth: segment.maxValue != null ? String(segment.maxValue).length + 'ch' : null
       }}
       data-testid={segment.type}>
-      {/* TODO: double check this, color contrast issue with quiet placeholder */}
-      <span data-a11y-ignore="color-contrast" aria-hidden="true" className={classNames(styles, 'react-spectrum-DatePicker-placeholder')}>{segment.placeholder}</span>
+      <span aria-hidden="true" className={classNames(styles, 'react-spectrum-DatePicker-placeholder')}>{segment.placeholder}</span>
       {segment.isPlaceholder ? '' : segment.text}
     </div>
   );


### PR DESCRIPTION
investigated, turns out it is a legitimate color contrast problem: https://github.com/orgs/adobe/projects/19/views/39?pane=issue&itemId=37780001


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
