### PR TITLE
Revert fix: useSelect trigger label (#4949) and fix example story

### DIFF
--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -140,12 +140,10 @@ export function useSelect<T>(props: AriaSelectOptions<T>, state: SelectState<T>,
       isDisabled,
       onKeyDown: chain(triggerProps.onKeyDown, onKeyDown, props.onKeyDown),
       onKeyUp: props.onKeyUp,
-      'aria-label': `, ${props['aria-label'] ?? ''}`,
       'aria-labelledby': [
         valueId,
-        !(props['aria-labelledby'] && props['aria-label']) && triggerProps.id,
-        !(props['aria-labelledby'] || props['aria-label']) && labelProps.id,
-        props['aria-labelledby']
+        triggerProps['aria-labelledby'],
+        triggerProps['aria-label'] && !triggerProps['aria-labelledby'] ? triggerProps.id : null
       ].filter(Boolean).join(' '),
       onFocus(e: FocusEvent) {
         if (state.isFocused) {

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -253,8 +253,8 @@ export const LabelledBy: LabelledByStory = {
   },
   render: (args) => (
     <>
-      <div id="test label">Test label</div>
-      <Picker {...args} aria-labelledby={args['aria-labelledby'] ? 'test label' : null} items={flatOptions}>
+      <div id="test">Test label</div>
+      <Picker {...args} aria-labelledby={args['aria-labelledby'] ? 'test' : null} items={flatOptions}>
         {(item: any) => <Item>{item.name}</Item>}
       </Picker>
     </>

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -808,7 +808,7 @@ describe('Picker', function () {
       let value = getByText('Select an option…');
       expect(label).toHaveAttribute('id');
       expect(value).toHaveAttribute('id');
-      expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${picker.id} ${label.id}`);
+      expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${label.id}`);
 
       triggerPress(picker);
       act(() => jest.runAllTimers());
@@ -833,7 +833,7 @@ describe('Picker', function () {
       let value = getByText('Select an option…');
       expect(picker).toHaveAttribute('id');
       expect(value).toHaveAttribute('id');
-      expect(picker).toHaveAttribute('aria-label', ', Test');
+      expect(picker).toHaveAttribute('aria-label', 'Test');
       expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${picker.id}`);
 
       triggerPress(picker);
@@ -859,7 +859,7 @@ describe('Picker', function () {
       let value = getByText('Select an option…');
       expect(picker).toHaveAttribute('id');
       expect(value).toHaveAttribute('id');
-      expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${picker.id} foo`);
+      expect(picker).toHaveAttribute('aria-labelledby', `${value.id} foo`);
 
       triggerPress(picker);
       act(() => jest.runAllTimers());
@@ -884,8 +884,8 @@ describe('Picker', function () {
       let value = getByText('Select an option…');
       expect(picker).toHaveAttribute('id');
       expect(value).toHaveAttribute('id');
-      expect(picker).toHaveAttribute('aria-label', ', Test');
-      expect(picker).toHaveAttribute('aria-labelledby', `${value.id} foo`);
+      expect(picker).toHaveAttribute('aria-label', 'Test');
+      expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${picker.id} foo`);
 
       triggerPress(picker);
       act(() => jest.runAllTimers());
@@ -918,7 +918,7 @@ describe('Picker', function () {
         let value = getByText('Select an option…');
         expect(label).toHaveAttribute('id');
         expect(value).toHaveAttribute('id');
-        expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${picker.id} ${label.id}`);
+        expect(picker).toHaveAttribute('aria-labelledby', `${value.id} ${label.id}`);
 
         triggerPress(picker);
         act(() => jest.runAllTimers());

--- a/packages/@react-spectrum/searchwithin/test/SearchWithin.test.js
+++ b/packages/@react-spectrum/searchwithin/test/SearchWithin.test.js
@@ -187,7 +187,7 @@ describe('SearchWithin labeling', function () {
 
     expect(group).not.toHaveAttribute('aria-labelledby');
     expect(searchfield).toHaveAttribute('aria-labelledby', `${hiddenLabel.id} ${picker.id}`);
-    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${picker.id}  ${hiddenLabel.id}`);
+    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${hiddenLabel.id}`);
   });
 
   it('label = foo', function () {
@@ -203,7 +203,7 @@ describe('SearchWithin labeling', function () {
 
     expect(group).toHaveAttribute('aria-labelledby', label.id);
     expect(searchfield).toHaveAttribute('aria-labelledby', `${label.id} ${hiddenLabel.id} ${picker.id}`);
-    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${picker.id} ${label.id} ${hiddenLabel.id}`);
+    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${label.id} ${hiddenLabel.id}`);
 
     expect(label).toHaveAttribute('for', searchfield.id);
   });
@@ -220,7 +220,7 @@ describe('SearchWithin labeling', function () {
 
     expect(group).not.toHaveAttribute('aria-labelledby');
     expect(searchfield).toHaveAttribute('aria-labelledby', `${group.id} ${hiddenLabel.id} ${picker.id}`);
-    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${picker.id} ${group.id} ${hiddenLabel.id}`);
+    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${group.id} ${hiddenLabel.id}`);
   });
 
   it('aria-labelledby = {id}', function () {
@@ -251,6 +251,6 @@ describe('SearchWithin labeling', function () {
     expect(group).toHaveAttribute('aria-labelledby', 'id-foo-label');
     expect(searchfield).toHaveAttribute('aria-labelledby', `id-foo-label ${hiddenLabel.id} ${picker.id}`);
     expect(searchfield).toHaveAttribute('id', 'id-searchfield');
-    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} ${picker.id} id-foo-label ${hiddenLabel.id}`);
+    expect(picker).toHaveAttribute('aria-labelledby', `${picker.childNodes[0].id} id-foo-label ${hiddenLabel.id}`);
   });
 });

--- a/packages/@react-spectrum/tabs/test/Tabs.test.js
+++ b/packages/@react-spectrum/tabs/test/Tabs.test.js
@@ -398,8 +398,8 @@ describe('Tabs', function () {
 
     let picker = getByRole('button');
     let pickerLabel = within(picker).getByText('Tab 1');
-    expect(picker).toHaveAttribute('aria-label', ', Test Tabs');
-    expect(picker).toHaveAttribute('aria-labelledby', `${pickerLabel.id} external label`);
+    expect(picker).toHaveAttribute('aria-label', 'Test Tabs');
+    expect(picker).toHaveAttribute('aria-labelledby', `${pickerLabel.id} ${picker.id} external label`);
 
     triggerPress(picker);
     act(() => jest.runAllTimers());

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -35,7 +35,7 @@ let TestSelect = (props) => (
 
 describe('Select', () => {
   it('provides slots', () => {
-    let {getByRole, getByText} = render(<TestSelect />);
+    let {getByRole} = render(<TestSelect />);
 
     let button = getByRole('button');
     expect(button).toHaveTextContent('Select an item');
@@ -45,8 +45,9 @@ describe('Select', () => {
     expect(select).toHaveAttribute('data-foo', 'bar');
 
     expect(button).toHaveAttribute('aria-labelledby');
-    let label = getByText('Favorite Animal');
+    let label = document.getElementById(button.getAttribute('aria-labelledby').split(' ')[1]);
     expect(label).toHaveAttribute('class', 'react-aria-Label');
+    expect(label).toHaveTextContent('Favorite Animal');
 
     let valueOrPlaceholder = document.getElementById(button.getAttribute('aria-labelledby').split(' ')[0]);
     expect(valueOrPlaceholder).toHaveAttribute('class', 'react-aria-SelectValue');
@@ -79,7 +80,7 @@ describe('Select', () => {
 
     let button = getByRole('button');
     expect(button.closest('.react-aria-Select')).toHaveAttribute('slot', 'test');
-    expect(button).toHaveAttribute('aria-label', ', test');
+    expect(button).toHaveAttribute('aria-label', 'test');
   });
 
   it('supports items with render props', () => {


### PR DESCRIPTION
Reverts 50b1e19c9b9e0b9aa6e7277ca9ac0e61c5635a6f since this is a breaking change, many of our components use `useLabels` and thus expect that the aria-label and aria-labelledby will be merged and announced as such. Additionally, our RSP components differ from native implementations since we handle creating and linking the visible label and the changes from the commit mentioned above breaks when a visible label and an aria-labelledby is provided (the visible label no longer is announced, just the aria-labelledby).

Broken experience: https://reactspectrum.blob.core.windows.net/reactspectrum/d7148894b9e05acc251fc9096975cf7d9060a063/storybook/index.html?path=/story/picker--labelled-by&args=label:Visible+label&providerSwitcher-express=false

New experience 

Recommendation for how to address in applications:
See https://github.com/adobe/react-spectrum/issues/4920#issuecomment-1681476500

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the Picker -> "no visible label combination" story and make sure screen readers announce the label/aria-label/aria-labelledby combinations appropriately.

## 🧢 Your Project:

RSP
