### PR TITLE
Add RouterProvider tests and update RSP Link API

### DIFF
--- a/packages/@react-aria/link/docs/useLink.mdx
+++ b/packages/@react-aria/link/docs/useLink.mdx
@@ -76,8 +76,6 @@ function Link(props) {
     <a
       {...linkProps}
       ref={ref}
-      href={props.href}
-      target={props.target}
       style={{color: 'var(--blue)'}}>
       {props.children}
     </a>
@@ -136,8 +134,6 @@ function Link(props) {
     <a
       {...linkProps}
       ref={ref}
-      href={props.href}
-      target={props.target}
       style={{
         color: props.isDisabled ? 'var(--gray)' : 'var(--blue)',
         cursor: props.isDisabled ? 'default' : 'pointer'

--- a/packages/@react-aria/utils/src/index.ts
+++ b/packages/@react-aria/utils/src/index.ts
@@ -16,7 +16,7 @@ export {mergeRefs} from './mergeRefs';
 export {filterDOMProps} from './filterDOMProps';
 export {focusWithoutScrolling} from './focusWithoutScrolling';
 export {getOffset} from './getOffset';
-export {openLink, getSyntheticLinkProps, RouterProvider, useRouter} from './openLink';
+export {openLink, getSyntheticLinkProps, RouterProvider, shouldClientNavigate, useRouter} from './openLink';
 export {runAfterTransition} from './runAfterTransition';
 export {useDrag1D} from './useDrag1D';
 export {useGlobalListeners} from './useGlobalListeners';

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -440,4 +440,33 @@ describe('Breadcrumbs', function () {
     expect(items[0].tagName).toBe('A');
     expect(items[0]).toHaveAttribute('href', 'https://example.com');
   });
+
+  it('should support RouterProvider', () => {
+    let navigate = jest.fn();
+    let {getByRole, getAllByRole} = render(
+      <Provider theme={theme} router={{navigate}}>
+        <Breadcrumbs>
+          <Item href="/">Example.com</Item>
+          <Item href="/foo">Foo</Item>
+          <Item href="/foo/bar">Bar</Item>
+          <Item href="/foo/bar/baz">Baz</Item>
+          <Item href="/foo/bar/baz/qux">Qux</Item>
+        </Breadcrumbs>
+      </Provider>
+    );
+
+    let links = getAllByRole('link');
+    triggerPress(links[0]);
+    expect(navigate).toHaveBeenCalledWith('/foo/bar');
+    navigate.mockReset();
+
+    let menuButton = getByRole('button');
+    triggerPress(menuButton);
+    act(() => {jest.runAllTimers();});
+
+    let menu = getByRole('menu');
+    let items = within(menu).getAllByRole('menuitemradio');
+    triggerPress(items[1]);
+    expect(navigate).toHaveBeenCalledWith('/foo');
+  });
 });

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -5469,5 +5469,56 @@ describe('ComboBox', function () {
       expect(combobox).toHaveValue('');
       expect(listbox).not.toBeInTheDocument();
     });
+
+    it('supports RouterProvider', async () => {
+      let navigate = jest.fn();
+      let tree = render(
+        <Provider theme={theme} router={{navigate}}>
+          <ComboBox label="ComboBox with links">
+            <Item href="/one">One</Item>
+            <Item href="https://adobe.com">Two</Item>
+          </ComboBox>
+        </Provider>
+      );
+
+      let combobox = tree.getByRole('combobox');
+      let button = tree.getByRole('button');
+      triggerPress(button);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      let listbox = tree.getByRole('listbox');
+      let items = within(listbox).getAllByRole('option');
+      triggerPress(items[0]);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(navigate).toHaveBeenCalledWith('/one');
+      expect(combobox).toHaveValue('');
+      expect(listbox).not.toBeInTheDocument();
+
+      navigate.mockReset();
+
+      triggerPress(button);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      listbox = tree.getByRole('listbox');
+      items = within(listbox).getAllByRole('option');
+      triggerPress(items[1]);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      // Not called for external links.
+      expect(navigate).not.toHaveBeenCalled();
+      expect(combobox).toHaveValue('');
+      expect(listbox).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/@react-spectrum/link/docs/Link.mdx
+++ b/packages/@react-spectrum/link/docs/Link.mdx
@@ -36,36 +36,31 @@ category: Navigation
 ## Example
 
 ```tsx example
-<Link><a href="https://www.imdb.com/title/tt6348138/" target="_blank">The missing link.</a></Link>
+<Link href="https://www.imdb.com/title/tt6348138/" target="_blank">The missing link.</Link>
 ```
 
 ## Content
 
-Links accept content as children.
-If the child is a native anchor element, or a link component used with a client side router, the Link component will add spectrum styles and event handlers to that element.
-Actual navigation will be handled by the wrapped element.
+
+Links accept content as children. If the link has an href prop, it will be rendered as an `<a>` element.
 
 ```tsx example
-<Link><a href="https://www.adobe.com" target="_blank">Adobe.com</a></Link>
+<Link href="https://adobe.com" target="_blank">Adobe.com</Link>
 ```
 
-To use in [React Router](https://reactrouter.com/en/main)
+### JavaScript handled links
 
-```tsx
-import {Link} from '@react-spectrum/link';
-import {Link as RouterLink} from 'react-router-dom';
+When a `<Link`> does not have an `href` prop, it is rendered as a `<span role="link">` instead of an `<a>`. Events will need to be handled in JavaScript with the `onPress` prop.
 
-<Link><RouterLink to="/next-page">Next Page</RouterLink></Link>
-```
-
-If the content is plain text, it will be styled and exposed to assistive technologies as a link.
-Events will need to be handled in JavaScript with the `onPress` prop.
 Note: this will not behave like a native link. Browser features like context menus and open in new tab will not apply.
 
 ```tsx example
-<Link onPress={() => alert('pressed!')}>A label</Link>
+<Link onPress={() => alert('Pressed link')}>Adobe</Link>
 ```
 
+### Client side routing
+
+The `<Link>` component works with frameworks and client side routers like [Next.js](https://nextjs.org/) and [React Router](https://reactrouter.com/en/main). As with other React Spectrum components that support links, this works via the [Provider](Provider.html) component at the root of your app. See the [client side routing guide](routing.html) to learn how to set this up.
 
 ### Internationalization
 
@@ -73,15 +68,13 @@ In order to internationalize a link, a localized string should be passed to the 
 
 ### Accessibility
 
-For string-typed `children`, the link component will expose the accessible role to assistive technology as a "link".
+When an `href` is not provided, the link component will expose the accessible role to assistive technology as a "link".
 
 ```tsx example
 <Link onPress={e => alert(`clicked "${e.target.textContent}" Link`)}>
   I forgot my password
 </Link>
 ```
-
-For other children, use an element of semantic meaning, or use a [role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) where appropriate.
 
 Be mindful of what the experience is for users navigating with screen readers. Make sure to give enough context about where the link will take the user.
 

--- a/packages/@react-spectrum/link/src/Link.tsx
+++ b/packages/@react-spectrum/link/src/Link.tsx
@@ -37,39 +37,45 @@ export function Link(props: SpectrumLinkProps) {
   let {styleProps} = useStyleProps(props);
   let {hoverProps, isHovered} = useHover({});
 
-  if (href) {
-    console.warn('href is deprecated, please use an anchor element as children');
-  }
-
   let ref = useRef();
   let {linkProps} = useLink({
     ...props,
-    elementType: typeof children === 'string' ? 'span' : 'a'
+    elementType: !href && typeof children === 'string' ? 'span' : 'a'
   }, ref);
 
-  let wrappedChild = getWrappedElement(children);
+  let domProps = {
+    ...styleProps,
+    ...mergeProps(linkProps, hoverProps),
+    ref,
+    className: classNames(
+      styles,
+      'spectrum-Link',
+      {
+        'spectrum-Link--quiet': isQuiet,
+        [`spectrum-Link--${variant}`]: variant,
+        'is-hovered': isHovered
+      },
+      styleProps.className
+    )
+  };
+
+  let link: JSX.Element;
+  if (href) {
+    link = <a {...domProps}>{children}</a>;
+  } else {
+    // Backward compatibility.
+    let wrappedChild = getWrappedElement(children);
+    link = React.cloneElement(wrappedChild, {
+      ...mergeProps(wrappedChild.props, domProps),
+      // @ts-ignore https://github.com/facebook/react/issues/8873
+      ref: wrappedChild.ref ? mergeRefs(ref, wrappedChild.ref) : ref
+    });
+  }
+
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
-      {React.cloneElement(
-        wrappedChild,
-        {
-          ...styleProps,
-          ...mergeProps(wrappedChild.props, linkProps, hoverProps),
-          // @ts-ignore https://github.com/facebook/react/issues/8873
-          ref: wrappedChild.ref ? mergeRefs(ref, wrappedChild.ref) : ref,
-          className: classNames(
-            styles,
-            'spectrum-Link',
-            {
-              'spectrum-Link--quiet': isQuiet,
-              [`spectrum-Link--${variant}`]: variant,
-              'is-hovered': isHovered
-            },
-            styleProps.className
-          )
-        }
-      )}
+      {link}
     </FocusRing>
   );
 }

--- a/packages/@react-spectrum/link/stories/Link.stories.tsx
+++ b/packages/@react-spectrum/link/stories/Link.stories.tsx
@@ -68,6 +68,12 @@ export let IsQuietSecondary: LinkStory = {
   name: 'isQuiet: true, variant: secondary'
 };
 
+export let WithHref: LinkStory = {
+  ...Default,
+  args: {...Default.args, href: '//example.com'},
+  name: 'href'
+};
+
 export let WithChildren: LinkStory = {
   ...Default,
   args: {children: <a href="//example.com" target="_self">This is a React Spectrum Link</a>},

--- a/packages/@react-spectrum/link/test/Link.test.js
+++ b/packages/@react-spectrum/link/test/Link.test.js
@@ -68,6 +68,14 @@ describe('Link', function () {
     expect(link).toHaveAttribute('tabIndex', '0');
   });
 
+  it('supports href', () => {
+    let {getByRole} = render(<Link href="https://adobe.com">Click me</Link>);
+    let link = getByRole('link');
+    expect(link).toBeDefined();
+    expect(link.nodeName).toBe('A');
+    expect(link.href).toBe('https://adobe.com/');
+  });
+
   it('Wraps custom child element', () => {
     let ref = React.createRef();
     let {getByRole} = render(
@@ -137,5 +145,13 @@ describe('Link', function () {
     });
     expect(onOpenChange).toHaveBeenCalledTimes(2);
     expect(tooltip).not.toBeInTheDocument();
+  });
+
+  it('supports RouterProvider', () => {
+    let navigate = jest.fn();
+    let {getByRole} = render(<Provider theme={theme} router={{navigate}}><Link href="/foo">Click me</Link></Provider>);
+    let link = getByRole('link');
+    triggerPress(link);
+    expect(navigate).toHaveBeenCalledWith('/foo');
   });
 });

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -1616,6 +1616,30 @@ describe('ListView', function () {
         expect(onClick.mock.calls[0][0].target).toBeInstanceOf(HTMLAnchorElement);
         expect(onClick.mock.calls[0][0].target.href).toBe('https://google.com/');
       });
+
+      it('works with RouterProvider', async () => {
+        let navigate = jest.fn();
+        let {getAllByRole} = render(
+          <Provider theme={theme} router={{navigate}}>
+            <ListView aria-label="listview">
+              <Item href="/one">One</Item>
+              <Item href="https://adobe.com">Two</Item>
+            </ListView>
+          </Provider>
+        );
+
+        let items = getAllByRole('row');
+        trigger(items[0]);
+        expect(navigate).toHaveBeenCalledWith('/one');
+
+        navigate.mockReset();
+        let onClick = jest.fn().mockImplementation(e => e.preventDefault());
+        window.addEventListener('click', onClick, {once: true});
+
+        trigger(items[1]);
+        expect(navigate).not.toHaveBeenCalled();
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -1015,6 +1015,30 @@ describe('ListBox', function () {
         expect(onClick.mock.calls[0][0].target.href).toBe('https://adobe.com/');
         expect(items[1]).not.toHaveAttribute('aria-selected', 'true');
       });
+
+      it('works with RouterProvider', async () => {
+        let navigate = jest.fn();
+        let {getAllByRole} = render(
+          <Provider theme={theme} router={{navigate}}>
+            <ListBox aria-label="listbox">
+              <Item href="/one">One</Item>
+              <Item href="https://adobe.com">Two</Item>
+            </ListBox>
+          </Provider>
+        );
+
+        let items = getAllByRole('option');
+        trigger(items[0]);
+        expect(navigate).toHaveBeenCalledWith('/one');
+
+        navigate.mockReset();
+        let onClick = jest.fn().mockImplementation(e => e.preventDefault());
+        window.addEventListener('click', onClick, {once: true});
+
+        trigger(items[1]);
+        expect(navigate).not.toHaveBeenCalled();
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -2272,5 +2272,28 @@ describe('Picker', function () {
       expect(button).toHaveTextContent('Select an option…');
       expect(listbox).not.toBeInTheDocument();
     });
+
+    it('works with RouterProvider', async () => {
+      let navigate = jest.fn();
+      let tree = render(
+        <Provider theme={theme} router={{navigate}}>
+          <Picker label="Picker with links">
+            <Item href="/one">One</Item>
+            <Item href="https://adobe.com">Two</Item>
+          </Picker>
+        </Provider>
+      );
+
+      let button = tree.getByRole('button');
+      triggerPress(button);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      let listbox = tree.getByRole('listbox');
+      let items = within(listbox).getAllByRole('option');
+      triggerPress(items[0]);
+      expect(navigate).toHaveBeenCalledWith('/one');
+    });
   });
 });

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -4780,6 +4780,45 @@ export let tableTests = () => {
         expect(onClick.mock.calls[0][0].target).toBeInstanceOf(HTMLAnchorElement);
         expect(onClick.mock.calls[0][0].target.href).toBe('https://google.com/');
       });
+
+      it('should work with RouterProvider', async () => {
+        let navigate = jest.fn();
+        let {getAllByRole} = render(
+          <Provider theme={theme} router={{navigate}}>
+            <TableView aria-label="Table">
+              <TableHeader>
+                <Column>Foo</Column>
+                <Column>Bar</Column>
+                <Column>Baz</Column>
+              </TableHeader>
+              <TableBody>
+                <Row href="/one">
+                  <Cell>Foo 1</Cell>
+                  <Cell>Bar 1</Cell>
+                  <Cell>Baz 1</Cell>
+                </Row>
+                <Row href="https://adobe.com">
+                  <Cell>Foo 2</Cell>
+                  <Cell>Bar 2</Cell>
+                  <Cell>Baz 2</Cell>
+                </Row>
+              </TableBody>
+            </TableView>
+          </Provider>
+        );
+
+        let items = getAllByRole('row').slice(1);
+        await trigger(items[0]);
+        expect(navigate).toHaveBeenCalledWith('/one');
+
+        navigate.mockReset();
+        let onClick = jest.fn().mockImplementation(e => e.preventDefault());
+        window.addEventListener('click', onClick, {once: true});
+
+        await trigger(items[1]);
+        expect(navigate).not.toHaveBeenCalled();
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
     });
   });
 };

--- a/packages/@react-types/link/src/index.d.ts
+++ b/packages/@react-types/link/src/index.d.ts
@@ -10,12 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaLabelingProps, FocusableProps, PressEvents, StyleProps} from '@react-types/shared';
+import {AriaLabelingProps, FocusableProps, LinkDOMProps, PressEvents, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
 export interface LinkProps extends PressEvents, FocusableProps {}
 
-export interface AriaLinkProps extends LinkProps, AriaLabelingProps { }
+export interface AriaLinkProps extends LinkProps, LinkDOMProps, AriaLabelingProps { }
 
 export interface SpectrumLinkProps extends AriaLinkProps, StyleProps {
   /** The content to display in the link. */

--- a/packages/react-aria-components/docs/Link.mdx
+++ b/packages/react-aria-components/docs/Link.mdx
@@ -120,11 +120,13 @@ keyboard users may activate links using the <Keyboard>Enter</Keyboard> key.
 If a visual label is not provided (e.g. an icon or image only link), then an `aria-label` or
 `aria-labelledby` prop must be passed to identify the link to assistive technology.
 
-## Events
+## Content
 
-### Client side routing
+Links accept content as children. If the link has an href prop, it will be rendered as an `<a>` element.
 
-The `<Link>` component works with frameworks and client side routers like [Next.js](https://nextjs.org/) and [React Router](https://reactrouter.com/en/main). As with other React Aria components that support links, this works via the <TypeLink links={docs.links} type={docs.exports.RouterProvider} /> component at the root of your app. See the [client side routing guide](routing.html) to learn how to set this up.
+```tsx example
+<Link href="https://adobe.com" target="_blank">Adobe.com</Link>
+```
 
 ### JavaScript handled links
 
@@ -158,6 +160,10 @@ function Example() {
   )
 }
 ```
+
+### Client side routing
+
+The `<Link>` component works with frameworks and client side routers like [Next.js](https://nextjs.org/) and [React Router](https://reactrouter.com/en/main). As with other React Aria components that support links, this works via the <TypeLink links={docs.links} type={docs.exports.RouterProvider} /> component at the root of your app. See the [client side routing guide](routing.html) to learn how to set this up.
 
 ## Disabled
 

--- a/packages/react-aria-components/src/Link.tsx
+++ b/packages/react-aria-components/src/Link.tsx
@@ -12,10 +12,9 @@
 
 import {AriaLinkOptions, mergeProps, useFocusRing, useHover, useLink} from 'react-aria';
 import {ContextValue, forwardRefType, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
-import {LinkDOMProps} from '@react-types/shared';
 import React, {createContext, ElementType, ForwardedRef, forwardRef} from 'react';
 
-export interface LinkProps extends Omit<AriaLinkOptions, 'elementType'>, LinkDOMProps, RenderProps<LinkRenderProps>, SlotProps {}
+export interface LinkProps extends Omit<AriaLinkOptions, 'elementType'>, RenderProps<LinkRenderProps>, SlotProps {}
 
 export interface LinkRenderProps {
   /**

--- a/packages/react-aria-components/stories/index.stories.tsx
+++ b/packages/react-aria-components/stories/index.stories.tsx
@@ -1239,10 +1239,8 @@ export const TextfieldExample = () => {
 
 export const LinkExample = () => {
   return (
-    <Link data-testid="link-example">
-      <a href="https://www.imdb.com/title/tt6348138/" target="_blank">
-        The missing link
-      </a>
+    <Link data-testid="link-example"href="https://www.imdb.com/title/tt6348138/" target="_blank">
+      The missing link
     </Link>
   );
 };

--- a/packages/react-aria-components/test/Link.test.js
+++ b/packages/react-aria-components/test/Link.test.js
@@ -11,7 +11,7 @@
  */
 
 import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils';
-import {Link, LinkContext} from '../';
+import {Link, LinkContext, RouterProvider} from '../';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
@@ -125,5 +125,13 @@ describe('Link', () => {
 
     expect(link).toHaveAttribute('aria-disabled', 'true');
     expect(link).toHaveClass('disabled');
+  });
+
+  it('should work with RouterProvider', async () => {
+    let navigate = jest.fn();
+    let {getByRole} = render(<RouterProvider navigate={navigate}><Link href="/foo">Test</Link></RouterProvider>);
+    let link = getByRole('link');
+    await user.click(link);
+    expect(navigate).toHaveBeenCalledWith('/foo');
   });
 });


### PR DESCRIPTION
Depends on #5078 

This updates the RSP `Link` API to match RAC. It accepts an `href` prop and uses the router passed to the `Provider` to handle client side routing instead of wrapping a native/custom link component. The old API is still supported for backward compatibility if no `href` prop is provided.

This also adds tests for `RouterProvider` in components that support it, and updates the `useLink` hook to support custom routers.