### PR TITLE
Fix client navigation check in Firefox

### DIFF
--- a/packages/@react-aria/utils/src/openLink.tsx
+++ b/packages/@react-aria/utils/src/openLink.tsx
@@ -69,8 +69,10 @@ interface Modifiers {
 }
 
 export function shouldClientNavigate(link: HTMLAnchorElement, modifiers: Modifiers) {
+  // Use getAttribute here instead of link.target. Firefox will default link.target to "_parent" when inside an iframe.
+  let target = link.getAttribute('target');
   return (
-    (!link.target || link.target === '_self') &&
+    (!target || target === '_self') &&
     link.origin === location.origin &&
     !link.hasAttribute('download') &&
     !modifiers.metaKey && // open in new tab (mac)


### PR DESCRIPTION
We previously checked if `link.target` was empty or equal to `_self` to determine if we should client navigate. But Firefox also defaults this to `_parent` for links inside iframes, unlike in other browsers which return an empty string. This PR switches us to use `getAttribute` instead of the property to avoid this.