### PR TITLE
(WIP) Fix RSP DropZone’s filled message announcement on different platforms

### DIFF
--- a/packages/@react-spectrum/dropzone/src/DropZone.tsx
+++ b/packages/@react-spectrum/dropzone/src/DropZone.tsx
@@ -41,6 +41,7 @@ function DropZone(props: SpectrumDropZoneProps, ref: DOMRef<HTMLDivElement>) {
       {...mergeProps(otherProps)}
       {...styleProps as Omit<React.HTMLAttributes<HTMLElement>, 'onDrop'>}
       aria-labelledby={isFilled ? messageId : null}
+      aria-describedby={isFilled ? messageId : null}
       className={
       classNames(
         styles,

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -60,6 +60,8 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   let ariaLabelledby = [textId, messageId].filter(Boolean).join(' ');
   let labelProps = useLabels({'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby});
 
+  let ariaDescribedby = props['aria-describedby'];
+
   let {clipboardProps} = useClipboard({
     onPaste: (items) => props.onDrop?.({
       type: 'drop',
@@ -97,6 +99,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
         <VisuallyHidden>
           <button
             {...mergeProps(dropButtonProps, focusProps, clipboardProps, labelProps)}
+            aria-describedby={ariaDescribedby}
             ref={buttonRef} />
         </VisuallyHidden>
         {renderProps.children}

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -55,12 +55,13 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   let stringFormatter = useLocalizedStringFormatter(intlMessages);
 
   let textId = useSlotId();
+  let dropzoneId = useSlotId();
   let ariaLabel = props['aria-label'] || stringFormatter.format('dropzoneLabel');
   let messageId = (isDropTarget && props['aria-labelledby']) ? props['aria-labelledby'] : null;
-  let ariaLabelledby = [textId, messageId].filter(Boolean).join(' ');
-  let labelProps = useLabels({'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby});
-
-  let ariaDescribedby = props['aria-describedby'];
+  // Chrome + VO will not announce the drop zone's accessible name if useLabels combines an aria-label and aria-labelledby
+  let ariaLabelledby = [dropzoneId, textId, messageId].filter(Boolean).join(' ');
+  let labelProps = useLabels({
+    'aria-labelledby': ariaLabelledby});
 
   let {clipboardProps} = useClipboard({
     onPaste: (items) => props.onDrop?.({
@@ -97,9 +98,12 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
         data-focus-visible={isFocusVisible || undefined}
         data-drop-target={isDropTarget || undefined} >
         <VisuallyHidden>
+          {/* Added as a workaround for a Chrome + VO bug where it will not announce the aria label */}
+          <div id={dropzoneId}>
+            {ariaLabel}
+          </div>
           <button
             {...mergeProps(dropButtonProps, focusProps, clipboardProps, labelProps)}
-            aria-describedby={ariaDescribedby}
             ref={buttonRef} />
         </VisuallyHidden>
         {renderProps.children}


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
