### PR TITLE
Revert "fix #5019 Popover prevents scroll only when it's opened"

### DIFF
--- a/packages/@react-aria/overlays/src/usePopover.ts
+++ b/packages/@react-aria/overlays/src/usePopover.ts
@@ -93,7 +93,7 @@ export function usePopover(props: AriaPopoverProps, state: OverlayTriggerState):
   });
 
   usePreventScroll({
-    isDisabled: isNonModal || !state.isOpen
+    isDisabled: isNonModal
   });
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Reverts adobe/react-spectrum#5109

This caused flickering during animations on iOS, where the overlay would briefly flip to the opposite side of the trigger. This is due to the iOS-specific scroll prevention code which unfortunately can affect overlay positioning. We would really need to wait until after animations to turn off scroll prevention to avoid this. The easiest way to do that at the moment is to wait until the popover unmounts.

https://github.com/adobe/react-spectrum/assets/19409/1a5b1913-ef20-4c69-b61a-3fedb90252f1

