### PR TITLE
FocusScope should not scroll when containing focus

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -342,7 +342,7 @@ function useFocusContainment(scopeRef: RefObject<Element[]>, contain: boolean) {
         // If a focus event occurs outside the active scope (e.g. user tabs from browser location bar),
         // restore focus to the previously focused node or the first tabbable element in the active scope.
         if (focusedNode.current) {
-          focusedNode.current.focus();
+          focusedNode.current.focus({preventScroll: true});
         } else if (activeScope) {
           focusFirstInScope(activeScope.current);
         }
@@ -362,7 +362,7 @@ function useFocusContainment(scopeRef: RefObject<Element[]>, contain: boolean) {
           activeScope = scopeRef;
           if (document.body.contains(e.target)) {
             focusedNode.current = e.target;
-            focusedNode.current.focus();
+            focusedNode.current.focus({preventScroll: true});
           } else if (activeScope) {
             focusFirstInScope(activeScope.current);
           }


### PR DESCRIPTION
Closes #3371

I've only tested this out locally by modifying my project's node_modules so far, but it definitely works. If the maintainers agree with this change, I'll spend some more time to add tests.

The goal here is to prevent the behavior of scrolling the focused element into view. Given that the element we are focusing was already previously focused, it doesn't seem necessary to scroll (and likely feels like a bug in most instances).

In #3371, the recommended fix was to add `tabIndex={-1}` to the child element to prevent this behavior. While this works well for modal use cases, it does have the possibly undesirable side effect of making the child element focusable.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

Plasmic