### PR TITLE
Fix error during SSR when first Table column is not a row header

### DIFF
--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -37,11 +37,11 @@ class TableCollection<T> extends BaseCollection<T> implements ITableCollection<T
   }
 
   commit(firstKey: Key, lastKey: Key, isSSR = false) {
-    this.updateColumns();
+    this.updateColumns(isSSR);
     super.commit(firstKey, lastKey, isSSR);
   }
 
-  private updateColumns() {
+  private updateColumns(isSSR: boolean) {
     if (!this.columnsDirty) {
       return;
     }
@@ -75,7 +75,7 @@ class TableCollection<T> extends BaseCollection<T> implements ITableCollection<T
 
     this.headerRows = buildHeaderRows(columnKeyMap, this.columns);
     this.columnsDirty = false;
-    if (this.rowHeaderColumnKeys.size === 0 && this.columns.length > 0) {
+    if (this.rowHeaderColumnKeys.size === 0 && this.columns.length > 0 && !isSSR) {
       throw new Error('A table must have at least one Column with the isRowHeader prop set to true');
     }
   }

--- a/packages/react-aria-components/test/Table.ssr.test.js
+++ b/packages/react-aria-components/test/Table.ssr.test.js
@@ -24,8 +24,8 @@ describe('Table SSR', function () {
             <button onClick={() => setShow(true)}>Show</button>
             <Table aria-label="Table">
               <TableHeader>
-                <Column isRowHeader>Foo</Column>
-                <Column>Bar</Column>
+                <Column>Foo</Column>
+                <Column isRowHeader>Bar</Column>
               </TableHeader>
               <TableBody>
                 <Row key="1">


### PR DESCRIPTION
Fixes #5140

During SSR, the collection is updated during render because effects don't run on the server. Therefore, each time a new collection node is rendered, it calls `updateCollection`. If the first column doesn't have `isRowHeader` this will result in an error. The easiest fix is just to suppress this error on the server. If none of the columns have `isRowHeader`, it will happen on the client instead.