### PR TITLE
Update aria-expanded to use true or false values

### DIFF
--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -142,7 +142,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       'aria-label': stringFormatter.format('calendar'),
       'aria-labelledby': `${buttonId} ${labelledBy}`,
       'aria-describedby': ariaDescribedBy,
-      'aria-expanded': state.isOpen || undefined,
+      'aria-expanded': state.isOpen,
       onPress: () => state.setOpen(true)
     },
     dialogProps: {

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -152,7 +152,7 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
       'aria-label': stringFormatter.format('calendar'),
       'aria-labelledby': `${buttonId} ${labelledBy}`,
       'aria-describedby': ariaDescribedBy,
-      'aria-expanded': state.isOpen || undefined,
+      'aria-expanded': state.isOpen,
       onPress: () => state.setOpen(true)
     },
     dialogProps: {


### PR DESCRIPTION
### Description:
I suggest changing aria-expanded to show state.isOpen value directly.
Right now, it's true or undefined based on if the state is open.

### Why:
The [W3C ARIA guide](https://w3c.github.io/aria/#aria-expanded) says aria-expanded can be:

- false: It means this item controls a closed group.
- true: It means this item controls an open group.
- undefined: This item doesn't control a group.

So, using true/false for aria-expanded makes things clearer.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
