### PR TITLE
Revert "fix popover placement for placement="start"|"end" (#5137)"

### DIFF
--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -145,7 +145,7 @@ function getDelta(
 ) {
   let root = document.scrollingElement || document.documentElement;
   let isScrollPrevented = window.getComputedStyle(root).overflow === 'hidden';
-  let containerScroll = isScrollPrevented && (axis === 'left' || axis === 'right') ? 0 : containerDimensions.scroll[axis];
+  let containerScroll = isScrollPrevented ? 0 : containerDimensions.scroll[axis];
   let containerHeight = containerDimensions[AXIS_SIZE[axis]];
 
   let startEdgeOffset = offset - padding - containerScroll;


### PR DESCRIPTION
This reverts commit db5bb1bdc63abd6a0515591029b4120127fc6dbb.

Seems to break Menu Item Unavailable, will look for an alternate solution.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
