### PR TITLE
Make react-aria-components README match the docs

### DIFF
--- a/packages/react-aria-components/README.md
+++ b/packages/react-aria-components/README.md
@@ -13,7 +13,7 @@ Compared with the React Aria hooks, React Aria Components provides a default DOM
 
 ## Status
 
-React Aria Components is currently in **alpha**. This means APIs will likely change in future updates as we discover the best ways to use it, and there are some known bugs and limitations. That said, it is based on a solid and battle-tested foundation in React Aria, and we would love for you to try it out and give us feedback! This will directly help us shape the APIs and make it the best library it can be. Please report issues and feature requests [on GitHub](https://github.com/adobe/react-spectrum/issues).
+React Aria Components is currently in **beta**. This means most APIs are stable but some changes may still occur, and there are some known bugs. That said, it is based on a solid and battle-tested foundation in React Aria, and we would love for you to try it out and give us feedback! Please report issues and feature requests [on GitHub](https://github.com/adobe/react-spectrum/issues).
 
 ## Documentation
 


### PR DESCRIPTION
Status paragraph was copied over from the docs (which were updated in 4e5128368f305fe8c6670642ca5ffdf06a7c458f) to README for them to match. Most importantly, to highlight React Aria Components is in **beta**, not **alpha**.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
