### PR TITLE
Fix useMove docs example

### DIFF
--- a/packages/@react-aria/interactions/docs/useMove.mdx
+++ b/packages/@react-aria/interactions/docs/useMove.mdx
@@ -115,6 +115,12 @@ function Example() {
       setEvents(events => [`move with pointerType = ${e.pointerType}, deltaX = ${e.deltaX}, deltaY = ${e.deltaY}`, ...events]);
     },
     onMoveEnd(e) {
+      setPosition(({x, y}) => {
+        // Clamp position on mouse up
+        x = clamp(x);
+        y = clamp(y);
+        return {x, y};
+      });
       setColor('black');
       setEvents(events => [`move end with pointerType = ${e.pointerType}`, ...events]);
     }


### PR DESCRIPTION
Closes #5189 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

In live docs, test dragging the circle to the edge of the container, continue dragging mouse past, then release the mouse. Next, try to drag the circle again in the opposite direction. You'll see that it still requires coming back by this offset despite the mouseUp. PR fixes this behavior.
