### PR TITLE
(WIP) Fix overlay positioning when pinch-zooming

### DIFF
--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -23,8 +23,6 @@ interface Position {
 interface Dimensions {
   width: number,
   height: number,
-  totalWidth: number,
-  totalHeight: number,
   top: number,
   left: number,
   scroll: Position
@@ -100,19 +98,14 @@ const TOTAL_SIZE = {
 
 const PARSED_PLACEMENT_CACHE = {};
 
-// @ts-ignore
-let visualViewport = typeof document !== 'undefined' && window.visualViewport;
-
 function getContainerDimensions(containerNode: Element): Dimensions {
-  let width = 0, height = 0, totalWidth = 0, totalHeight = 0, top = 0, left = 0;
+  let width = 0, height = 0, top = 0, left = 0;
   let scroll: Position = {};
 
   if (containerNode.tagName === 'BODY') {
     let documentElement = document.documentElement;
-    totalWidth = documentElement.clientWidth;
-    totalHeight = documentElement.clientHeight;
-    width = visualViewport?.width ?? totalWidth;
-    height = visualViewport?.height ?? totalHeight;
+    width = documentElement.clientWidth;
+    height = documentElement.clientHeight;
 
     scroll.top = documentElement.scrollTop || containerNode.scrollTop;
     scroll.left = documentElement.scrollLeft || containerNode.scrollLeft;
@@ -120,11 +113,9 @@ function getContainerDimensions(containerNode: Element): Dimensions {
     ({width, height, top, left} = getOffset(containerNode));
     scroll.top = containerNode.scrollTop;
     scroll.left = containerNode.scrollLeft;
-    totalWidth = width;
-    totalHeight = height;
   }
 
-  return {width, height, totalWidth, totalHeight, scroll, top, left};
+  return {width, height, scroll, top, left};
 }
 
 function getScroll(node: Element): Offset {


### PR DESCRIPTION
Closes #2700

The decision to use visualViewport comes from https://github.com/adobe/react-spectrum/pull/1176/commits/73535b42d7cb57e133b7b02a2437c59b533ae90f#diff-f4cd45647233fa6ce298370ea0a2c8b9f3849d6ad45c45198bf8ea4427d9ad83R99 Not sure how to test keyboard functionality that the commit message is talking about.

To Dos:
- [ ] It seems the `document.body container top` story gets broken after my change.
- [ ] Also a ton of tests break, hinting that some other functionality also broke.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Run the storybook w/ `yarn start`
2. Test out overlay storybooks in their own tab, e.g.: [document-body-container-bottom](http://localhost:9003/iframe.html?providerSwitcher-express=false&strict=true&scrolling=false&providerSwitcher-locale=&providerSwitcher-theme=&providerSwitcher-scale=&args=&id=useoverlayposition--document-body-container-bottom&viewMode=story)
3. Pinch zoom with your trackpad or mobile device while the overlay is open. I'm on an M1 MacBook Pro myself.

### Before

After a certain point, the `delta` calculations (see [getDelta](https://github.com/marg0l/react-spectrum/blob/1dd4d3f18e8ce2b314ee6519aaf8728fc5818e2e/packages/%40react-aria/overlays/src/calculatePosition.ts#L139)) would result in negative values and thus the overlay would be pushed to a wrong place:

https://github.com/adobe/react-spectrum/assets/3490745/28706559-4d66-47cc-a477-9db83a5b0462

### After

https://github.com/adobe/react-spectrum/assets/3490745/32386fa4-c646-4f06-8e3c-ea7b41db4811

## 🧢 Your Project:

<!--- Company/project for pull request -->
