### PR TITLE
Add isRootDropTarget to renderEmptyState in GridList

### DIFF
--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -54,7 +54,7 @@ export interface GridListProps<T> extends Omit<AriaGridListProps<T>, 'children'>
   /** The drag and drop hooks returned by `useDragAndDrop` used to enable drag and drop behavior for the GridList. */
   dragAndDropHooks?: DragAndDropHooks,
   /** Provides content to display when there are no items in the list. */
-  renderEmptyState?: () => ReactNode
+  renderEmptyState?: (isRootDropTarget: boolean) => ReactNode
 }
 
 
@@ -176,7 +176,7 @@ function GridListInner<T extends object>({props, collection, gridListRef: ref}: 
     // they don't affect the layout of the children. However, WebKit currently has
     // a bug that makes grid elements with display: contents hidden to screen readers.
     // https://bugs.webkit.org/show_bug.cgi?id=239479
-    let content = props.renderEmptyState();
+    let content = props.renderEmptyState(isRootDropTarget);
     if (isWebKit()) {
       // For now, when in an empty state, swap the role to group in webkit.
       emptyStatePropOverrides = {


### PR DESCRIPTION
Add `isRootDropTarget` parameter to `renderEmptyState` in `GridList` component

Closes #5210

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
