### PR TITLE
Handle left click + ctrl key in usePress

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -372,7 +372,7 @@ export function usePress(props: PressHookProps): PressResult {
     if (typeof PointerEvent !== 'undefined') {
       pressProps.onPointerDown = (e) => {
         // Only handle left clicks, and ignore events that bubbled through portals.
-        if (e.button !== 0 || !e.currentTarget.contains(e.target as Element)) {
+        if (e.button !== 0  || (e.button === 0 && e.ctrlKey) || !e.currentTarget.contains(e.target as Element)) {
           return;
         }
 


### PR DESCRIPTION
To trigger context menus you can either

- right click
- hold ctrl and click

The usePress hook wasn't handling the second case.