### PR TITLE
add onDrop to DropZone docs FileTrigger example & adjust behavior

### DIFF
--- a/packages/react-aria-components/docs/DropZone.mdx
+++ b/packages/react-aria-components/docs/DropZone.mdx
@@ -254,6 +254,7 @@ To allow the selection of files from the user's device, pass `FileTrigger` as a 
 
 ```tsx example
 import {FileTrigger, Button} from 'react-aria-components';
+import type {FileDropItem} from 'react-aria'
 
 function Example() {
   let [files, setFiles] = React.useState(null);
@@ -261,20 +262,19 @@ function Example() {
   return(
     <DropZone
       onDrop={(e) => {
-        let files = e.items;
-        let urls = files.map((file) => file.name);
-        setFiles(urls.join(', '));
+        let files = e.items.filter((file) => file.kind === 'file') as FileDropItem[];
+        let filenames = files.map((file) => file.name);
+        setFiles(filenames.join(', '));
       }}>
       <FileTrigger
         allowsMultiple
         onSelect={(e) => {
           let files = Array.from(e);
-          let urls = files.map((file) => file.name);
-          setFiles(urls.join(', '));
+          let filenames = files.map((file) => file.name);
+          setFiles(filenames.join(', '));
         }}>
         <Button>Select files</Button>
       </FileTrigger>
-      <br/>
       <Text slot="label">
         {files || 'Drop files here'}
       </Text>
@@ -338,6 +338,10 @@ function Example() {
     --text-color-disabled: GrayText;
     --focus-ring-color: Highlight;
   }
+}
+
+.react-aria-Text {
+  display: inline-block;
 }
 ```
 

--- a/packages/react-aria-components/docs/DropZone.mdx
+++ b/packages/react-aria-components/docs/DropZone.mdx
@@ -256,19 +256,28 @@ To allow the selection of files from the user's device, pass `FileTrigger` as a 
 import {FileTrigger, Button} from 'react-aria-components';
 
 function Example() {
-  let [file, setFile] = React.useState(null);
+  let [files, setFiles] = React.useState(null);
 
   return(
-    <DropZone>
+    <DropZone
+      onDrop={(e) => {
+        let files = e.items;
+        let urls = files.map((file) => file.name);
+        setFiles(urls.join(', '));
+      }}>
       <FileTrigger
+        allowsMultiple
         onSelect={(e) => {
           let files = Array.from(e);
           let urls = files.map((file) => file.name);
-          setFile(urls);
+          setFiles(urls.join(', '));
         }}>
-        <Button>Select a file</Button>
+        <Button>Select files</Button>
       </FileTrigger>
-      {file && file}
+      <br/>
+      <Text slot="label">
+        {files || 'Drop files here'}
+      </Text>
     </DropZone>
   );
 }

--- a/packages/react-aria-components/docs/FileTrigger.mdx
+++ b/packages/react-aria-components/docs/FileTrigger.mdx
@@ -50,8 +50,8 @@ function Example(){
       <FileTrigger
         onSelect={(e) => {
           let files = Array.from(e);
-          let urls = files.map((file) => file.name);
-          setFile(urls);
+          let filenames = files.map((file) => file.name);
+          setFile(filenames);
         }}>
         <Button>Select a file</Button>
       </FileTrigger>


### PR DESCRIPTION
Closes #5262 

Set FileTrigger to allow multiple files as dropZone does and adjusted surrounding text.

`<br/>` added to avoid this previous behavior with long file names and/or multiple files.
![image](https://github.com/adobe/react-spectrum/assets/34060617/e530d6f0-2395-44e4-a11d-30c206db42c0)
If anyone more familiar with the styling of the docs would like to do this in CSS please do.

Unsure if my use of `<Text slot="label">` is appropriate.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

`/react-aria/DropZone.html#filetrigger`
