### PR TITLE
Fix double filter dropshadow menu unavailable

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -35,6 +35,16 @@ governing permissions and limitations under the License.
   --spectrum-menu-max-width: 320px;
 }
 
+.spectrum-Menu-wrapper,
+.spectrum-Menu-subdialog {
+  overflow: hidden;
+  max-height: 100%;
+  display: inline-flex;
+  border-radius: var(--spectrum-alias-border-radius-regular);
+  border-style: solid;
+  border-width: var(--spectrum-popover-border-size);
+}
+
 .spectrum-Menu-popover {
   max-width: var(--spectrum-menu-max-width);
 }

--- a/packages/@adobe/spectrum-css-temp/components/menu/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/skin.css
@@ -15,6 +15,12 @@ governing permissions and limitations under the License.
   --spectrum-selectlist-divider-color: var(--spectrum-global-color-gray-300);
 }
 
+.spectrum-Menu-wrapper,
+.spectrum-Menu-subdialog {
+  border-color: var(--spectrum-popover-border-color);
+  background-color: var(--spectrum-popover-background-color);
+  filter: drop-shadow(0 var(--spectrum-popover-shadow-offset-y) var(--spectrum-popover-shadow-blur) var(--spectrum-popover-shadow-color));
+}
 
 .spectrum-Menu {
   --spectrum-heading-subtitle3-text-color: var(--spectrum-global-color-gray-900);

--- a/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
@@ -17,6 +17,7 @@ import {ItemProps} from '@react-types/shared';
 import {MenuDialogContext, useMenuStateContext} from './context';
 import {Modal, Popover} from '@react-spectrum/overlays';
 import React, {Key, ReactElement, useRef} from 'react';
+import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 
 interface MenuDialogTriggerProps {
@@ -48,7 +49,7 @@ function ContextualHelpTrigger(props: InternalMenuDialogTriggerProps): ReactElem
   let slots = {};
   if (isUnavailable) {
     slots = {
-      dialog: {UNSAFE_className: classNames(helpStyles, 'react-spectrum-ContextualHelp-dialog')},
+      dialog: {UNSAFE_className: classNames(helpStyles, 'react-spectrum-ContextualHelp-dialog', classNames(styles, 'spectrum-Menu-subdialog'))},
       content: {UNSAFE_className: helpStyles['react-spectrum-ContextualHelp-content']},
       footer: {UNSAFE_className: helpStyles['react-spectrum-ContextualHelp-footer']}
     };
@@ -86,6 +87,7 @@ function ContextualHelpTrigger(props: InternalMenuDialogTriggerProps): ReactElem
             </Modal>
           ) : (
             <Popover
+              UNSAFE_style={{clipPath: 'unset', overflow: 'visible', filter: 'unset', borderWidth: '0px'}}
               onExit={onExit}
               onBlurWithin={onBlurWithin}
               container={container.current}

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -39,7 +39,7 @@ function Menu<T extends object>(props: SpectrumMenuProps<T>, ref: DOMRef<HTMLDiv
   return (
     <MenuStateContext.Provider value={{state, container: scopedRef, menu: domRef}}>
       <FocusScope contain={state.expandedKeys.size > 0}>
-        <div style={{overflow: 'hidden', maxHeight: '100%', display: 'inline-flex', borderRadius: 'var(--spectrum-alias-border-radius-regular)'}}>
+        <div className={classNames(styles, 'spectrum-Menu-wrapper')}>
           <div
             {...menuProps}
             {...styleProps}

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -81,7 +81,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
   } else {
     overlay = (
       <Popover
-        UNSAFE_style={{clipPath: 'unset', overflow: 'visible'}}
+        UNSAFE_style={{clipPath: 'unset', overflow: 'visible', filter: 'unset', borderWidth: '0px'}}
         state={state}
         triggerRef={menuTriggerRef}
         scrollRef={menuRef}


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Pulled out from https://github.com/adobe/react-spectrum/pull/4976

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
