### PR TITLE
[Docs]: Add missing constants in React Aria > Examples > Contact List

### DIFF
--- a/packages/react-aria-components/docs/examples/contact-list.mdx
+++ b/packages/react-aria-components/docs/examples/contact-list.mdx
@@ -31,6 +31,10 @@ A [ListBox](../ListBox.html) styled with [Tailwind CSS](https://tailwindcss.com/
 
 ```tsx import
 import './tailwind.global.css';
+```
+
+```tsx example standalone
+import {ListBox, Item, Section, Header, Collection, Text} from 'react-aria-components';
 
 const favorites = [
   {
@@ -104,10 +108,6 @@ const people = [
     username: "@cwebb"
   }
 ];
-```
-
-```tsx example standalone
-import {ListBox, Item, Section, Header, Collection, Text} from 'react-aria-components';
 
 function ContactListExample() {
   return (


### PR DESCRIPTION
Hello, this PR is not related to any existing issue, but I was trying to use the example code presented here: [Contact List](https://react-spectrum.adobe.com/react-aria/examples/contact-list.html) and noticed that the variables `favorites` and `people` are hidden in the code snippet.

This PR is to reveal those hidden variables in the code snippet explicitly, as to avoid user confusion.

### Screenshot (before)
<img width="1468" alt="Screenshot 2023-10-25 at 10 13 32 PM" src="https://github.com/adobe/react-spectrum/assets/71210554/2c92c81b-1126-4a1e-beb3-bc5e39844f4c">

### Screenshot (after)
<img width="1917" alt="Screenshot 2023-10-25 at 10 21 25 PM" src="https://github.com/adobe/react-spectrum/assets/71210554/7b2052e1-96f5-4ded-b7e1-86e127bbb6a7">


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. `git clone <this PR>`
2. `yarn start:docs`
3. Go to http://localhost:1234/react-aria/examples/contact-list.html and check the code snippet.

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
