### PR TITLE
Fix prod docs build

### DIFF
--- a/packages/dev/parcel-packager-ssg/SSGPackager.js
+++ b/packages/dev/parcel-packager-ssg/SSGPackager.js
@@ -76,7 +76,11 @@ module.exports = new Packager({
 
         let resolved = bundleGraph.getResolvedAsset(dep, bundle);
         if (resolved) {
-          deps.set(getSpecifier(dep), {id: resolved.id});
+          if (resolved.type !== 'js') {
+            deps.set(getSpecifier(dep), {skipped: true});
+          } else {
+            deps.set(getSpecifier(dep), {id: resolved.id});
+          }
         } else {
           deps.set(getSpecifier(dep), {specifier: dep.specifier});
         }


### PR DESCRIPTION
A CSS dependency was causing the build to fail. Now we just ignore them inside the SSG packager (we only need to run JS there).