### PR TITLE
Use explicit "title" slot for RAC dialogs, and improve aria labelling

### DIFF
--- a/packages/react-aria-components/docs/Dialog.mdx
+++ b/packages/react-aria-components/docs/Dialog.mdx
@@ -51,7 +51,7 @@ import {DialogTrigger, Modal, Dialog, Button, Heading, TextField, Label, Input} 
     <Dialog>
       {({close}) => (
         <form>
-          <Heading>Sign up</Heading>
+          <Heading slot="title">Sign up</Heading>
           <TextField autoFocus>
             <Label>First Name</Label>
             <Input />
@@ -123,7 +123,7 @@ import {DialogTrigger, Modal, Dialog, Button, Heading} from 'react-aria-componen
   <Button />
   <Modal>
     <Dialog>
-      <Heading />
+      <Heading slot="title" />
     </Dialog>
   </Modal>
 </DialogTrigger>
@@ -149,7 +149,7 @@ import {Popover, OverlayArrow} from 'react-aria-components';
       <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>
     </OverlayArrow>
     <Dialog>
-      <Heading>Help</Heading>
+      <Heading slot="title">Help</Heading>
       <p>For help accessing your account, please contact support.</p>
     </Dialog>
   </Popover>
@@ -167,7 +167,7 @@ Alert dialogs are a special type of dialog meant to present a prompt that the us
     <Dialog role="alertdialog">
       {({close}) => (
         <>
-          <Heading>Delete file</Heading>
+          <Heading slot="title">Delete file</Heading>
           <p>This will permanently delete the selected file. Continue?</p>
           <div>
             <Button onPress={close}>Cancel</Button>
@@ -290,7 +290,7 @@ function CloseButton() {
   <Button>About</Button>
   <Modal isDismissable>
     <Dialog>
-      <Heading>About</Heading>
+      <Heading slot="title">About</Heading>
       <p>Copyright © 2023 Adobe. All rights reserved.</p>
       {/*- begin highlight -*/}
       <CloseButton />

--- a/packages/react-aria-components/docs/Modal.mdx
+++ b/packages/react-aria-components/docs/Modal.mdx
@@ -50,7 +50,7 @@ import {DialogTrigger, Modal, Dialog, Button, Heading, TextField, Label, Input} 
     <Dialog>
       {({close}) => (
         <form>
-          <Heading>Sign up</Heading>
+          <Heading slot="title">Sign up</Heading>
           <TextField autoFocus>
             <Label>First Name: </Label>
             <Input />
@@ -186,7 +186,7 @@ on the `Modal`. This allows the user to click outside to close the dialog.
   <Button>Open dialog</Button>
   <Modal isDismissable>
     <Dialog>
-      <Heading>Notice</Heading>
+      <Heading slot="title">Notice</Heading>
       <p>Click outside to close this dialog.</p>
     </Dialog>
   </Modal>
@@ -203,7 +203,7 @@ By default, modals can be closed by pressing the <Keyboard>Escape</Keyboard> key
   <Modal isKeyboardDismissDisabled>
     <Dialog>
       {({close}) => <>
-        <Heading>Notice</Heading>
+        <Heading slot="title">Notice</Heading>
         <p>You must close this dialog using the button below.</p>
         <Button onPress={close}>Close</Button>
       </>}
@@ -225,7 +225,7 @@ import {ModalOverlay} from 'react-aria-components';
     <Modal className="my-modal">
       <Dialog>
         {({close}) => <>
-          <Heading>Notice</Heading>
+          <Heading slot="title">Notice</Heading>
           <p>This is a modal with a custom modal overlay.</p>
           <Button onPress={close}>Close</Button>
         </>}
@@ -315,7 +315,7 @@ function Example() {
       <Button onPress={() => setOpen(true)}>Open dialog</Button>
       <Modal isDismissable isOpen={isOpen} onOpenChange={setOpen}>
         <Dialog>
-          <Heading>Notice</Heading>
+          <Heading slot="title">Notice</Heading>
           <p>Click outside to close this dialog.</p>
         </Dialog>
       </Modal>
@@ -438,7 +438,7 @@ The following example uses `KeyboardModalTrigger` to show a modal when the <Keyb
 <KeyboardModalTrigger keyboardShortcut="/">
   <Modal isDismissable>
     <Dialog>
-      <Heading>Command palette</Heading>
+      <Heading slot="title">Command palette</Heading>
       <p>Your cool command palette UI here!</p>
     </Dialog>
   </Modal>

--- a/packages/react-aria-components/docs/Popover.mdx
+++ b/packages/react-aria-components/docs/Popover.mdx
@@ -42,16 +42,26 @@ type: component
 ## Example
 
 ```tsx example
-import {DialogTrigger, Popover, Dialog, Button, OverlayArrow} from 'react-aria-components';
+import {DialogTrigger, Popover, Dialog, Button, OverlayArrow, Heading, Switch} from 'react-aria-components';
 
 <DialogTrigger>
-  <Button>Open popover</Button>
+  <Button>Settings</Button>
   <Popover>
     <OverlayArrow>
       <svg width={12} height={12} viewBox="0 0 12 12"><path d="M0 0 L6 6 L12 0" /></svg>
     </OverlayArrow>
     <Dialog>
-      This is a popover.
+      <div className="flex-col">
+        <Switch defaultSelected>
+          <div className="indicator" /> Wi-Fi
+        </Switch>
+        <Switch defaultSelected>
+          <div className="indicator" /> Bluetooth
+        </Switch>
+        <Switch>
+          <div className="indicator" /> Mute
+        </Switch>
+      </div>
     </Dialog>
   </Popover>
 </DialogTrigger>
@@ -62,6 +72,13 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow} from 'react-aria-c
 ```css hidden
 @import './Button.mdx';
 @import './Dialog.mdx';
+@import './Switch.mdx';
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 ```
 
 ```css
@@ -206,8 +223,11 @@ function MyPopover({children, ...props}: MyPopoverProps) {
 }
 
 <DialogTrigger>
-  <Button>Open popover</Button>
-  <MyPopover>This is an example popover.</MyPopover>
+  <Button aria-label="Help">ⓘ</Button>
+  <MyPopover>
+    <Heading slot="title">Help</Heading>
+    <p>For help accessing your account, please contact support.</p>
+  </MyPopover>
 </DialogTrigger>
 ```
 
@@ -251,7 +271,7 @@ Below is a popover offset by an additional 50px above the trigger.
 
 ```tsx example
 <DialogTrigger>
-  <Button>Open popover</Button>
+  <Button>Offset</Button>
   <MyPopover placement="top" offset={50}>
     Offset by an additional 50px.
   </MyPopover>
@@ -262,7 +282,7 @@ Below is a popover cross offset by an additional 100px to the right of the trigg
 
 ```tsx example
 <DialogTrigger>
-  <Button>Open popover</Button>
+  <Button>Cross offset</Button>
   <MyPopover placement="top" crossOffset={100}>
     Offset by an additional 100px.
   </MyPopover>
@@ -276,19 +296,28 @@ would cause it to render out of view. This can be overridden by setting `shouldF
 To see the difference between the two options, scroll this page so that the example below is near the bottom of the window.
 
 ```tsx example
-<DialogTrigger>
-  <Button>Default</Button>
-  <MyPopover placement="bottom">
-    This is a popover that will flip if it can't fully render below the button.
-  </MyPopover>
-</DialogTrigger>
+<div className="flex-row">
+  <DialogTrigger>
+    <Button>Default</Button>
+    <MyPopover placement="bottom">
+      This is a popover that will flip if it can't fully render below the button.
+    </MyPopover>
+  </DialogTrigger>
 
-<DialogTrigger>
-  <Button>shouldFlip=false</Button>
-  <MyPopover placement="bottom" shouldFlip={false}>
-    This is a popover that won't flip if it can't fully render below the button.
-  </MyPopover>
-</DialogTrigger>
+  <DialogTrigger>
+    <Button>shouldFlip=false</Button>
+    <MyPopover placement="bottom" shouldFlip={false}>
+      This is a popover that won't flip if it can't fully render below the button.
+    </MyPopover>
+  </DialogTrigger>
+</div>
+```
+
+```css hidden
+.flex-row {
+  display: flex;
+  gap: 8px;
+}
 ```
 
 ### Container padding
@@ -301,7 +330,7 @@ The example below will maintain at least 50px between the popover and the edge o
 
 ```tsx example
 <DialogTrigger>
-  <Button>Trigger</Button>
+  <Button>Container padding</Button>
   <MyPopover placement="top" containerPadding={50}>
     This is a popover.
   </MyPopover>
@@ -324,7 +353,8 @@ function Example() {
       <Button onPress={() => setOpen(true)}>Trigger</Button>
       <span ref={triggerRef} style={{paddingLeft: 12}}>Popover will be positioned relative to me</span>
       <MyPopover triggerRef={triggerRef} isOpen={isOpen} onOpenChange={setOpen}>
-        This is a popover.
+        <Heading slot="title">Popover</Heading>
+        <div>I'm over here!</div>
       </MyPopover>
     </>
   );
@@ -445,7 +475,8 @@ function HelpTrigger({children}: HelpTriggerProps) {
 <HelpTrigger>
   <Button>Press ? for help</Button>
   <MyPopover>
-    Do you need help?
+    <Heading slot="title">Help</Heading>
+    <div>Do you need help?</div>
   </MyPopover>
 </HelpTrigger>
 ```

--- a/packages/react-aria-components/docs/examples/destructive-dialog.mdx
+++ b/packages/react-aria-components/docs/examples/destructive-dialog.mdx
@@ -56,7 +56,7 @@ function ModalExample() {
           `}>
             <Dialog role="alertdialog" className="outline-none relative">
               {({ close }) => (<>
-                <Heading className="text-xxl font-semibold leading-6 my-0 text-slate-700">Delete folder</Heading>
+                <Heading slot="title" className="text-xxl font-semibold leading-6 my-0 text-slate-700">Delete folder</Heading>
                 <div className="w-6 h-6 text-red-500 absolute right-0 top-0 stroke-2"><AlertIcon size="M" /></div>
                 <p className="mt-3 text-slate-500">
                   Are you sure you want to delete "Documents"? All contents will be permanently destroyed.

--- a/packages/react-aria-components/docs/examples/framer-modal-sheet.mdx
+++ b/packages/react-aria-components/docs/examples/framer-modal-sheet.mdx
@@ -154,7 +154,7 @@ function Sheet() {
                     Done
                   </Button>
                 </div>
-                <Heading className="text-3xl font-semibold mb-4">
+                <Heading slot="title" className="text-3xl font-semibold mb-4">
                   Modal sheet
                 </Heading>
                 <p className="text-lg mb-4">

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -9,8 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import {AriaDialogProps, useDialog, useOverlayTrigger} from 'react-aria';
-import {ContextValue, forwardRefType, Provider, SlotProps, StyleProps, useContextProps} from './utils';
+import {AriaDialogProps, useDialog, useId, useOverlayTrigger} from 'react-aria';
+import {ContextValue, defaultSlot, forwardRefType, Provider, SlotProps, StyleProps, useContextProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {HeadingContext} from './Heading';
 import {OverlayTriggerProps, OverlayTriggerState, useOverlayTriggerState} from 'react-stately';
@@ -43,6 +43,13 @@ export function DialogTrigger(props: DialogTriggerProps) {
   let buttonRef = useRef<HTMLButtonElement>(null);
   let {triggerProps, overlayProps} = useOverlayTrigger({type: 'dialog'}, state, buttonRef);
 
+  // Label dialog by the trigger as a fallback if there is no title slot.
+  // This is done in RAC instead of hooks because otherwise we cannot distinguish
+  // between context and props. Normally aria-labelledby overrides the title
+  // but when sent by context we want the title to win.
+  triggerProps.id = useId();
+  overlayProps['aria-labelledby'] = triggerProps.id;
+
   return (
     <Provider
       values={[
@@ -58,8 +65,14 @@ export function DialogTrigger(props: DialogTriggerProps) {
 }
 
 function Dialog(props: DialogProps, ref: ForwardedRef<HTMLElement>) {
+  let originalAriaLabelledby = props['aria-labelledby'];
   [props, ref] = useContextProps(props, ref, DialogContext);
-  let {dialogProps, titleProps} = useDialog(props, ref);
+  let {dialogProps, titleProps} = useDialog({
+    ...props,
+    // Only pass aria-labelledby from props, not context.
+    // Context is used as a fallback below.
+    'aria-labelledby': originalAriaLabelledby
+  }, ref);
   let state = useContext(OverlayTriggerStateContext);
 
   let children = props.children;
@@ -67,6 +80,16 @@ function Dialog(props: DialogProps, ref: ForwardedRef<HTMLElement>) {
     children = children({
       close: state?.close || (() => {})
     });
+  }
+
+  if (!dialogProps['aria-label'] && !dialogProps['aria-labelledby']) {
+    // If aria-labelledby exists on props, we know it came from context.
+    // Use that as a fallback in case there is no title slot.
+    if (props['aria-labelledby']) {
+      dialogProps['aria-labelledby'] = props['aria-labelledby'];
+    } else {
+      console.warn('If a Dialog does not contain a <Heading slot="title">, it must have an aria-label or aria-labelledby attribute for accessibility.');
+    }
   }
 
   return (
@@ -79,8 +102,12 @@ function Dialog(props: DialogProps, ref: ForwardedRef<HTMLElement>) {
       className={props.className ?? 'react-aria-Dialog'}>
       <Provider
         values={[
-          // TODO: clear context within dialog content?
-          [HeadingContext, {...titleProps, level: 2}]
+          [HeadingContext, {
+            slots: {
+              [defaultSlot]: {},
+              title: {...titleProps, level: 2}
+            }
+          }]
         ]}>
         {children}
       </Provider>

--- a/packages/react-aria-components/stories/animations.stories.tsx
+++ b/packages/react-aria-components/stories/animations.stories.tsx
@@ -26,7 +26,7 @@ export let ModalAnimation = {
               <Dialog>
                 {({close}) => (
                   <>
-                    <Heading>Notice</Heading>
+                    <Heading slot="title">Notice</Heading>
                     <p>This is a modal with a custom modal overlay.</p>
                     <Button onPress={close}>Close</Button>
                   </>

--- a/packages/react-aria-components/stories/index.stories.tsx
+++ b/packages/react-aria-components/stories/index.stories.tsx
@@ -591,6 +591,7 @@ export const PopoverExample = () => (
       <Dialog>
         {({close}) => (
           <form style={{display: 'flex', flexDirection: 'column'}}>
+            <Heading slot="title">Sign up</Heading>
             <label>
               First Name: <input placeholder="John" />
             </label>
@@ -633,7 +634,7 @@ export const ModalExample = () => (
         <Dialog>
           {({close}) => (
             <form style={{display: 'flex', flexDirection: 'column'}}>
-              <Heading style={{marginTop: 0}}>Sign up</Heading>
+              <Heading slot="title" style={{marginTop: 0}}>Sign up</Heading>
               <label>
                 First Name: <input placeholder="John" />
               </label>
@@ -839,7 +840,7 @@ export const TableExample = () => {
                       }}>
                       <Dialog>
                         {({close}) => (<>
-                          <Heading>Delete item</Heading>
+                          <Heading slot="title">Delete item</Heading>
                           <p>Are you sure?</p>
                           <Button onPress={close}>Cancel</Button>
                           <Button
@@ -1393,4 +1394,3 @@ ToolbarExample.argTypes = {
     options: ['horizontal', 'vertical']
   }
 };
-

--- a/packages/react-aria-components/test/Dialog.ssr.test.js
+++ b/packages/react-aria-components/test/Dialog.ssr.test.js
@@ -24,7 +24,7 @@ describe('Dialog SSR', function () {
             <Dialog>
               {({ close }) => (
                 <form>
-                  <Heading>Sign up</Heading>
+                  <Heading slot="title">Sign up</Heading>
                   <TextField autoFocus>
                     <Label>First Name:</Label>
                     <Input />

--- a/packages/react-aria-components/test/Dialog.test.js
+++ b/packages/react-aria-components/test/Dialog.test.js
@@ -29,7 +29,7 @@ describe('Dialog', () => {
           <Dialog role="alertdialog" data-test="dialog">
             {({close}) => (
               <>
-                <Heading>Alert</Heading>
+                <Heading slot="title">Alert</Heading>
                 <Button onPress={close}>Close</Button>
               </>
             )}
@@ -64,7 +64,7 @@ describe('Dialog', () => {
             <Dialog role="alertdialog" data-test="dialog">
               {({close}) => (
                 <>
-                  <Heading>Alert</Heading>
+                  <Heading slot="title">Alert</Heading>
                   <Button onPress={close}>Close</Button>
                 </>
               )}
@@ -99,7 +99,7 @@ describe('Dialog', () => {
           <Dialog role="alertdialog" data-test="dialog">
             {({close}) => (
               <>
-                <Heading>Alert</Heading>
+                <Heading slot="title">Alert</Heading>
                 <Button onPress={close}>Close</Button>
               </>
             )}
@@ -128,7 +128,7 @@ describe('Dialog', () => {
             <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>
           </OverlayArrow>
           <Dialog data-test="dialog">
-            <Heading>Help</Heading>
+            <Heading slot="title">Help</Heading>
             <p>For help accessing your account, please contact support.</p>
           </Dialog>
         </Popover>
@@ -160,6 +160,26 @@ describe('Dialog', () => {
     expect(dialog).not.toBeInTheDocument();
   });
 
+  it('should get default aria label from trigger', async () => {
+    let {getByRole} = render(
+      <DialogTrigger>
+        <Button>Settings</Button>
+        <Popover>
+          <Dialog>Test</Dialog>
+        </Popover>
+      </DialogTrigger>
+    );
+
+    let button = getByRole('button');
+    await user.click(button);
+
+    let dialog = getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', button.id);
+
+    await user.click(document.body);
+    expect(dialog).not.toBeInTheDocument();
+  });
+
   it('should support render props', async () => {
     let {getByRole} = render(
       <DialogTrigger>
@@ -168,7 +188,7 @@ describe('Dialog', () => {
           <Dialog>
             {({close}) => (
               <>
-                <Heading>Help</Heading>
+                <Heading slot="title">Help</Heading>
                 <p>For help accessing your account, please contact support.</p>
                 <Button onPress={() => close()}>Dismiss</Button>
               </>
@@ -196,7 +216,7 @@ describe('Dialog', () => {
     let onOpenChange = jest.fn();
     let {getByRole} = render(
       <Modal isDismissable isOpen onOpenChange={onOpenChange}>
-        <Dialog>A modal</Dialog>
+        <Dialog aria-label="Modal">A modal</Dialog>
       </Modal>
     );
 
@@ -214,7 +234,7 @@ describe('Dialog', () => {
       <DialogTrigger>
         <Button />
         <Modal isDismissable isOpen onOpenChange={onOpenChange}>
-          <Dialog>A modal</Dialog>
+          <Dialog aria-label="Modal">A modal</Dialog>
         </Modal>
       </DialogTrigger>
     </>);

--- a/packages/react-aria-components/test/Popover.test.js
+++ b/packages/react-aria-components/test/Popover.test.js
@@ -98,7 +98,7 @@ describe('Popover', () => {
     let {getByRole} = render(<>
       <span ref={triggerRef}>Trigger</span>
       <Popover isOpen triggerRef={triggerRef} onOpenChange={onOpenChange}>
-        <Dialog>A popover</Dialog>
+        <Dialog aria-label="Popover">A popover</Dialog>
       </Popover>
     </>);
 


### PR DESCRIPTION
The `<Heading>` component can be used inside a `<Dialog>` to set the aria label for the dialog. However, if you had multiple headings inside the dialog contents they would all receive the aria labelling props from the dialog. This changes the API to require an explicit `slot="title"` prop to be added to the instance of the heading you want to use as the title. In addition it adds a warning if you have a dialog with no title slot or explicit aria labelling props.

After adding the warning I found that we had a bunch of unlabeled dialogs in our examples/tests, mostly in popovers. To fix these, I made dialogs within a `<DialogTrigger>` be labeled by the trigger element as a fallback, in case no title slot or aria labelling props are provided. Standalone popovers will need to do this manually, and will get a warning.