### PR TITLE
fix package.json#types field in tailwind plugin

### DIFF
--- a/packages/tailwindcss-react-aria-components/package.json
+++ b/packages/tailwindcss-react-aria-components/package.json
@@ -4,7 +4,7 @@
   "description": "A Tailwind plugin that adds variants for data attributes in React Aria Components",
   "license": "Apache-2.0",
   "main": "src/index.js",
-  "types": "src/types.d.ts",
+  "types": "src/index.d.ts",
   "source": "src/index.js",
   "files": [
     "dist",


### PR DESCRIPTION
in the tailwind plugin package, point `package.json#types` to https://github.com/adobe/react-spectrum/blob/main/packages/tailwindcss-react-aria-components/src/index.d.ts