### PR TITLE
React 18 Support Enhancement with `use client` Directive ⚒

### DIFF
--- a/packages/@react-spectrum/accordion/src/Accordion.tsx
+++ b/packages/@react-spectrum/accordion/src/Accordion.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/actionbar/src/ActionBar.tsx
+++ b/packages/@react-spectrum/actionbar/src/ActionBar.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/avatar/src/Avatar.tsx
+++ b/packages/@react-spectrum/avatar/src/Avatar.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/badge/src/Badge.tsx
+++ b/packages/@react-spectrum/badge/src/Badge.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2022 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/breadcrumbs/src/BreadcrumbItem.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/BreadcrumbItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/button/src/ClearButton.tsx
+++ b/packages/@react-spectrum/button/src/ClearButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/button/src/LogicButton.tsx
+++ b/packages/@react-spectrum/button/src/LogicButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/button/src/ToggleButton.tsx
+++ b/packages/@react-spectrum/button/src/ToggleButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/calendar/src/Calendar.tsx
+++ b/packages/@react-spectrum/calendar/src/Calendar.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/calendar/src/CalendarCell.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/calendar/src/CalendarMonth.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarMonth.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
+++ b/packages/@react-spectrum/calendar/src/RangeCalendar.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/card/src/CardBase.tsx
+++ b/packages/@react-spectrum/card/src/CardBase.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/card/src/CardView.tsx
+++ b/packages/@react-spectrum/card/src/CardView.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/checkbox/src/CheckboxGroup.tsx
+++ b/packages/@react-spectrum/checkbox/src/CheckboxGroup.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/color/src/ColorArea.tsx
+++ b/packages/@react-spectrum/color/src/ColorArea.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/color/src/ColorField.tsx
+++ b/packages/@react-spectrum/color/src/ColorField.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/color/src/ColorWheel.tsx
+++ b/packages/@react-spectrum/color/src/ColorWheel.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/contextualhelp/src/ContextualHelp.tsx
+++ b/packages/@react-spectrum/contextualhelp/src/ContextualHelp.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/dialog/src/DialogContainer.tsx
+++ b/packages/@react-spectrum/dialog/src/DialogContainer.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
+++ b/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/dropzone/src/DropZone.tsx
+++ b/packages/@react-spectrum/dropzone/src/DropZone.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/form/src/Form.tsx
+++ b/packages/@react-spectrum/form/src/Form.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/icon/src/Icon.tsx
+++ b/packages/@react-spectrum/icon/src/Icon.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/icon/src/Illustration.tsx
+++ b/packages/@react-spectrum/icon/src/Illustration.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/icon/src/UIIcon.tsx
+++ b/packages/@react-spectrum/icon/src/UIIcon.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/label/src/Field.tsx
+++ b/packages/@react-spectrum/label/src/Field.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/label/src/Label.tsx
+++ b/packages/@react-spectrum/label/src/Label.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/link/src/Link.tsx
+++ b/packages/@react-spectrum/link/src/Link.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/list/src/InsertionIndicator.tsx
+++ b/packages/@react-spectrum/list/src/InsertionIndicator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {classNames} from '@react-spectrum/utils';
 import {ItemDropTarget} from '@react-types/shared';
 import listStyles from './styles.css';

--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/list/src/ListViewItem.tsx
+++ b/packages/@react-spectrum/list/src/ListViewItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/list/src/RootDropIndicator.tsx
+++ b/packages/@react-spectrum/list/src/RootDropIndicator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {ListViewContext} from './ListView';
 import React, {useContext, useRef} from 'react';
 import {useVisuallyHidden} from '@react-aria/visually-hidden';

--- a/packages/@react-spectrum/listbox/src/ListBox.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBox.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/menu/src/ActionMenu.tsx
+++ b/packages/@react-spectrum/menu/src/ActionMenu.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/ContextualHelpTrigger.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/menu/src/MenuSection.tsx
+++ b/packages/@react-spectrum/menu/src/MenuSection.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/meter/src/Meter.tsx
+++ b/packages/@react-spectrum/meter/src/Meter.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/numberfield/src/NumberField.tsx
+++ b/packages/@react-spectrum/numberfield/src/NumberField.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/numberfield/src/StepButton.tsx
+++ b/packages/@react-spectrum/numberfield/src/StepButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/overlays/src/Modal.tsx
+++ b/packages/@react-spectrum/overlays/src/Modal.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/overlays/src/OpenTransition.tsx
+++ b/packages/@react-spectrum/overlays/src/OpenTransition.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/overlays/src/Overlay.tsx
+++ b/packages/@react-spectrum/overlays/src/Overlay.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/overlays/src/Tray.tsx
+++ b/packages/@react-spectrum/overlays/src/Tray.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/pagination/src/Pagination.tsx
+++ b/packages/@react-spectrum/pagination/src/Pagination.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/progress/src/ProgressBar.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressBar.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/progress/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressCircle.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/radio/src/Radio.tsx
+++ b/packages/@react-spectrum/radio/src/Radio.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/radio/src/RadioGroup.tsx
+++ b/packages/@react-spectrum/radio/src/RadioGroup.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/searchfield/src/SearchField.tsx
+++ b/packages/@react-spectrum/searchfield/src/SearchField.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
+++ b/packages/@react-spectrum/searchwithin/src/SearchWithin.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/sidenav/src/SideNavSection.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNavSection.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/slider/src/Slider.tsx
+++ b/packages/@react-spectrum/slider/src/Slider.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/slider/src/SliderThumb.tsx
+++ b/packages/@react-spectrum/slider/src/SliderThumb.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/statuslight/src/StatusLight.tsx
+++ b/packages/@react-spectrum/statuslight/src/StatusLight.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/steplist/src/StepList.tsx
+++ b/packages/@react-spectrum/steplist/src/StepList.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/steplist/src/StepListItem.tsx
+++ b/packages/@react-spectrum/steplist/src/StepListItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/switch/src/Switch.tsx
+++ b/packages/@react-spectrum/switch/src/Switch.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/table/src/InsertionIndicator.tsx
+++ b/packages/@react-spectrum/table/src/InsertionIndicator.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/table/src/TableView.tsx
+++ b/packages/@react-spectrum/table/src/TableView.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/table/src/TableViewBase.tsx
+++ b/packages/@react-spectrum/table/src/TableViewBase.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/table/src/TreeGridTableView.tsx
+++ b/packages/@react-spectrum/table/src/TreeGridTableView.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/tag/src/TagGroup.tsx
+++ b/packages/@react-spectrum/tag/src/TagGroup.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/text/src/Heading.tsx
+++ b/packages/@react-spectrum/text/src/Heading.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/text/src/Keyboard.tsx
+++ b/packages/@react-spectrum/text/src/Keyboard.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/text/src/Text.tsx
+++ b/packages/@react-spectrum/text/src/Text.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/textfield/src/TextArea.tsx
+++ b/packages/@react-spectrum/textfield/src/TextArea.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/textfield/src/TextField.tsx
+++ b/packages/@react-spectrum/textfield/src/TextField.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/toast/src/Toast.tsx
+++ b/packages/@react-spectrum/toast/src/Toast.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/tooltip/src/Tooltip.tsx
+++ b/packages/@react-spectrum/tooltip/src/Tooltip.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-spectrum/tree/src/Tree.tsx
+++ b/packages/@react-spectrum/tree/src/Tree.tsx
@@ -1,3 +1,4 @@
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Hi, this PR enhances support for React 18-based applications, especially those utilizing server components, by adding the `"use client";` directive. This PR was inspired by the following reference: https://github.com/mui/material-ui/pull/37656.

For more information about client components, please refer to: https://nextjs.org/docs/app/building-your-application/rendering/client-components#using-client-components-in-nextjs.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)


