### PR TITLE
Alternative pending label approach

### DIFF
--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -113,7 +113,6 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
         data-style={style}
         data-static-color={staticColor || undefined}
         aria-disabled={isPending || undefined}
-        aria-labelledby={isPending ? undefined : `${iconId} ${textId}`}
         aria-live={isPending ? 'polite' : undefined}
         className={
           classNames(

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -22,7 +22,7 @@ import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useId} from '@react-aria/utils';
 import {ProgressCircle} from '@react-spectrum/progress';
 import React, {ElementType, ReactElement, useEffect, useState} from 'react';
 import {SpectrumButtonProps} from '@react-types/button';
@@ -72,6 +72,10 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
   let hasLabel = useHasChild(`.${styles['spectrum-Button-label']}`, domRef);
   let hasIcon = useHasChild(`.${styles['spectrum-Icon']}`, domRef);
   let [isProgressVisible, setIsProgressVisible] = useState(false);
+  let spinnerId = useId();
+  let textId = useId();
+  let iconId = useId();
+  let buttonId = useId();
 
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
@@ -98,71 +102,18 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
     staticColor = 'white';
   }
 
-  /**
-   * Parse the children of the button to determine the text to return
-   * for the pending spinner aria-label.
-   * @returns A string that ends in a "pending", localized.
-   */
-  function getLabelFromChildren(): string {
-    // Text for spinner aria-label could come from one or more of:
-    // - child string
-    // - aria-label of button props
-    // - child Text component
-    // - child icon aria-label
-    // - could be absent
-    let label: string[] = [];
-
-    // string child
-    if (typeof children === 'string') {
-      label.push(children);
-    }
-
-    // aria-label on button
-    // Todo: Test how it announces in SRs
-    if (props['aria-label']) {
-      label.push(props['aria-label']);
-    }
-
-    if (React.isValidElement(children)) {
-      // Text wrapped in an component or element
-      if (typeof children?.props?.children === 'string') {
-        label.push(children.props.children);
-      }
-      // Icon with aria-label
-      if (children?.props['aria-label']) {
-        label.push(children['props']['aria-label']);
-      }
-    }
-
-    // loop multiple children looking for text and/or aria-labels
-    if (Array.isArray(children)) {
-      children.forEach((child) => {
-        // Text component with string child
-        if (typeof child.props.children === 'string') {
-          label.push(child.props.children);
-        }
-        // Icon with aria-label
-        if (child.props['aria-label']) {
-          label.push(child.props['aria-label']);
-        }
-      });
-    }
-
-    // Append pending. If nothing matched above, will still get 'pending' as the label.
-    label.push(stringFormatter.format('pending'));
-    return label.join(' ');
-  }
-
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
       <ElementType
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}
+        id={buttonId}
         ref={domRef}
         data-variant={variant}
         data-style={style}
         data-static-color={staticColor || undefined}
         aria-disabled={isPending || undefined}
+        aria-labelledby={isPending ? undefined : `${iconId} ${textId}`}
         aria-live={isPending ? 'polite' : undefined}
         className={
           classNames(
@@ -181,22 +132,29 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
         <SlotProvider
           slots={{
             icon: {
+              id: iconId,
               size: 'S',
               UNSAFE_className: classNames(styles, 'spectrum-Icon')
             },
             text: {
+              id: textId,
               UNSAFE_className: classNames(styles, 'spectrum-Button-label')
             }
           }}>
-          {isProgressVisible && <ProgressCircle
-            aria-label={getLabelFromChildren()}
-            isIndeterminate
-            size="S"
-            UNSAFE_className={classNames(styles, 'spectrum-Button-circleLoader')}
-            staticColor={staticColor} />}
           {typeof children === 'string'
             ? <Text>{children}</Text>
             : children}
+          {isProgressVisible && <><ProgressCircle
+            aria-hidden="true"
+            isIndeterminate
+            size="S"
+            UNSAFE_className={classNames(styles, 'spectrum-Button-circleLoader')}
+            staticColor={staticColor} />
+            <div
+              id={spinnerId}
+              aria-label={stringFormatter.format('pending')}
+              aria-labelledby={`${textId} ${spinnerId}`} />
+          </>}
         </SlotProvider>
       </ElementType>
     </FocusRing>

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -75,7 +75,6 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
   let spinnerId = useId();
   let textId = useId();
   let iconId = useId();
-  let buttonId = useId();
 
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
@@ -107,7 +106,6 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
       <ElementType
         {...styleProps}
         {...mergeProps(buttonProps, hoverProps)}
-        id={buttonId}
         ref={domRef}
         data-variant={variant}
         data-style={style}

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -12,12 +12,10 @@
 
 import {act, fireEvent, render, triggerPress} from '@react-spectrum/test-utils';
 import {ActionButton, Button, ClearButton, LogicButton} from '../';
-import Bell from '@spectrum-icons/workflow/Bell';
 import {Checkbox, defaultTheme} from '@adobe/react-spectrum';
 import {Form} from '@react-spectrum/form';
 import {Provider} from '@react-spectrum/provider';
 import React, {useState} from 'react';
-import {Text} from '@react-spectrum/text';
 
 /**
  * Logic Button has no tests outside of this file because functionally it is identical

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -312,40 +312,7 @@ describe('Button', function () {
     expect(button).toHaveAttribute('aria-disabled', 'true');
     spinner = queryByRole('progressbar');
     expect(spinner).toBeVisible();
-    expect(spinner).toHaveAttribute('aria-label', 'Click me pending');
     expect(onPressSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('builds the aria-label for the isPending spinner from button children', function () {
-    function TestComponent() {
-      let pending = true;
-      return (
-        <>
-          <Button isPending={pending}>String child</Button>
-          <Button isPending={pending}><Text>Text child</Text></Button>
-          <Button isPending={pending}><Bell /></Button>
-          <Button isPending={pending}><Bell /><Text>Icon and text children</Text></Button>
-          <Button isPending={pending}><Bell aria-label="Icon only" /></Button>
-          <Button isPending={pending}><Bell aria-label="Bell" /><Text>rings</Text></Button>
-          <Button isPending={pending} aria-label="Button"><Bell /></Button>
-          {/* Unsupported by button component--including for completeness */}
-          <Button isPending={pending}><em>DOM element</em></Button>
-        </>
-      );
-    }
-    let {queryAllByRole} = render(<TestComponent />);
-    act(() => {
-      jest.advanceTimersByTime(spinnerVisibilityDelay);
-    });
-    let spinners = queryAllByRole('progressbar');
-    expect(spinners[0]).toHaveAttribute('aria-label', 'String child pending');
-    expect(spinners[1]).toHaveAttribute('aria-label', 'Text child pending');
-    expect(spinners[2]).toHaveAttribute('aria-label', 'pending');
-    expect(spinners[3]).toHaveAttribute('aria-label', 'Icon and text children pending');
-    expect(spinners[4]).toHaveAttribute('aria-label', 'Icon only pending');
-    expect(spinners[5]).toHaveAttribute('aria-label', 'Bell rings pending');
-    expect(spinners[6]).toHaveAttribute('aria-label', 'Button pending');
-    expect(spinners[7]).toHaveAttribute('aria-label', 'DOM element pending');
   });
 
   // isPending anchor element


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Needs cleanup, but check if this accomplishes what we need in terms of announcements across different AT and browser combinations.
I expect it to read the regular button label when focused. Then when it enters pending, I expect it to read the button label again, followed by the pending string (we could put a comma here to add a pause to the AT). When it exits pending, it reads the button label once more.

Might need to do some id merging to make sure we didn't clobber anything.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
