### PR TITLE
Fix importing CSS on forms guide in prod docs

### DIFF
--- a/packages/dev/docs/pages/react-aria/forms.mdx
+++ b/packages/dev/docs/pages/react-aria/forms.mdx
@@ -11,8 +11,8 @@ import {Layout} from '@react-spectrum/docs';
 export default Layout;
 
 ```css hidden
-@import '../../../../react-aria-components/docs/TextField.mdx';
-@import '../../../../react-aria-components/docs/Button.mdx';
+@import 'react-aria-components/docs/TextField.mdx';
+@import 'react-aria-components/docs/Button.mdx';
 ```
 
 ---

--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -19,6 +19,7 @@ const dprint = require('dprint-node');
 const t = require('@babel/types');
 const lightningcss = require('lightningcss');
 const fs = require('fs');
+const path = require('path');
 
 const IMPORT_MAPPINGS = {
   '@react-spectrum/theme-default': {
@@ -179,6 +180,14 @@ module.exports = new Transformer({
           safari: 15 << 16
         },
         resolver: {
+          resolve(specifier, parent) {
+            if (specifier.startsWith('.')) {
+              return path.resolve(path.dirname(parent), specifier);
+            }
+
+            let baseDir = process.env.DOCS_ENV === 'production' ? 'docs' : 'packages';
+            return path.resolve(options.projectRoot, baseDir, specifier);
+          },
           read(filePath) {
             if (filePath === `${asset.filePath}.lightning`) {
               return cssCode.join('\n');


### PR DESCRIPTION
The prod docs puts its files in different locations so CSS importing wasn't working in the prod docs for the react aria forms page