### PR TITLE
RAC: Fix Table column resizer hover events

### DIFF
--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -976,7 +976,7 @@ function ColumnResizer(props: ColumnResizerProps, ref: ForwardedRef<HTMLDivEleme
       ref={objectRef}
       role="presentation"
       {...renderProps}
-      {...mergeProps(resizerProps, {onPointerDown})}
+      {...mergeProps(resizerProps, {onPointerDown}, hoverProps)}
       data-hovered={isHovered || undefined}
       data-focused={isFocused || undefined}
       data-focus-visible={isFocusVisible || undefined}
@@ -985,7 +985,7 @@ function ColumnResizer(props: ColumnResizerProps, ref: ForwardedRef<HTMLDivEleme
       {renderProps.children}
       <input
         ref={inputRef}
-        {...mergeProps(inputProps, focusProps, hoverProps)} />
+        {...mergeProps(inputProps, focusProps)} />
       {isResizing && isMouseDown && ReactDOM.createPortal(<div style={{position: 'fixed', top: 0, left: 0, bottom: 0, right: 0, cursor}} />, document.body)}
     </div>
   );


### PR DESCRIPTION
Found by @yihuiliao in testing: `hoverProps` should go on the column resizers' outer div instead of the hidden input.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

In storybook, check that actions are fired when column resizers are hovered: https://reactspectrum.blob.core.windows.net/reactspectrum/f34fa78bc961a2c005508261219df9e772a01703/storybook/index.html?path=/story/react-aria-components--table-example&providerSwitcher-express=false

## 🧢 Your Project:

<!--- Company/project for pull request -->
