### PR TITLE
Add key attribute to each item example

### DIFF
--- a/packages/@react-spectrum/combobox/docs/ComboBox.mdx
+++ b/packages/@react-spectrum/combobox/docs/ComboBox.mdx
@@ -87,7 +87,7 @@ function Example() {
         label="Pick an engineering major"
         defaultItems={options}
         onSelectionChange={setMajorId}>
-        {item => <Item>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ComboBox>
     </>
   );
@@ -131,7 +131,7 @@ function Example() {
         label="Adobe product (Uncontrolled)"
         defaultItems={options}
         defaultInputValue="Adobe XD">
-        {item => <Item>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ComboBox>
 
       <ComboBox
@@ -139,7 +139,7 @@ function Example() {
         defaultItems={options}
         inputValue={value}
         onInputChange={setValue}>
-        {item => <Item>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ComboBox>
     </Flex>
   );
@@ -282,7 +282,7 @@ function Example() {
         label="Pick an Adobe product (uncontrolled)"
         defaultItems={options}
         defaultSelectedKey={9}>
-        {item => <Item>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ComboBox>
 
       <ComboBox
@@ -290,7 +290,7 @@ function Example() {
         defaultItems={options}
         selectedKey={productId}
         onSelectionChange={selected => setProductId(selected)}>
-        {item => <Item>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ComboBox>
     </Flex>
   );
@@ -426,7 +426,7 @@ function Example() {
         selectedKey={majorId}
         onSelectionChange={onSelectionChange}
         onInputChange={onInputChange}>
-        {item => <Item>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ComboBox>
     </>
   );
@@ -891,7 +891,7 @@ function Example() {
       items={options}
       selectedKey={animalId}
       onSelectionChange={selected => setAnimalId(selected)}>
-      {item => <Item>{item.name}</Item>}
+      {item => <Item key={item.name}>{item.name}</Item>}
     </ComboBox>
   );
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

This is a simple docs update. Without a "key" attribute added to each JSX element created from a list, React will complain about the need for a key attribute. This way people are set up for success when they copy and paste from the Combobox examples.

## 🧢 Your Project:

<!--- Company/project for pull request -->
