### PR TITLE
Fix DropZone hover event props

### DIFF
--- a/packages/@react-spectrum/dropzone/src/DropZone.tsx
+++ b/packages/@react-spectrum/dropzone/src/DropZone.tsx
@@ -20,7 +20,7 @@ import React, {ReactNode} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/dropzone/vars.css';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
-export interface SpectrumDropZoneProps extends DropZoneProps, DOMProps, StyleProps, AriaLabelingProps {
+export interface SpectrumDropZoneProps extends Omit<DropZoneProps, 'onHoverStart' | 'onHoverChange' | 'onHoverEnd'>, DOMProps, StyleProps, AriaLabelingProps {
   /** The content to display in the drop zone. */
   children: ReactNode,
   /** Whether the drop zone has been filled. */
@@ -28,6 +28,13 @@ export interface SpectrumDropZoneProps extends DropZoneProps, DOMProps, StylePro
   /** The message to replace the default banner message that is shown when the drop zone is filled. */
   replaceMessage?: string
 }
+
+// Filter out props used by RAC DropZone that we don't want in RSP DropZone for now.
+let filterProps = (props) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let {onHoverStart, onHoverChange, onHoverEnd, ...otherProps} = props;
+  return otherProps;
+};
 
 function DropZone(props: SpectrumDropZoneProps, ref: DOMRef<HTMLDivElement>) {
   let {children, isFilled, replaceMessage, ...otherProps} = props;
@@ -38,7 +45,7 @@ function DropZone(props: SpectrumDropZoneProps, ref: DOMRef<HTMLDivElement>) {
 
   return (
     <RACDropZone
-      {...mergeProps(otherProps)}
+      {...mergeProps(filterProps(otherProps))}
       {...styleProps as Omit<React.HTMLAttributes<HTMLElement>, 'onDrop'>}
       aria-labelledby={isFilled && messageId}
       className={


### PR DESCRIPTION
Hover event props are available to RAC DropZone, but we don't necessarily want them in RSP DropZone at this time. Since `SpectrumDropZoneProps` extends `DropZoneProps`, we need to omit them from the prop types, and filter them out of the props.

We may want to add these back later, but this should be a larger discussion as more RSP components begin wrapping RAC components.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
