### PR TITLE
Fix selected checkbox fill color when checkbox group is disabled

### DIFF
--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -32,13 +32,11 @@ function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelEleme
   let {
     isIndeterminate = false,
     isEmphasized = false,
-    isDisabled = false,
     autoFocus,
     children,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
-  let {hoverProps, isHovered} = useHover({isDisabled});
 
   let inputRef = useRef<HTMLInputElement>(null);
   let domRef = useFocusableRef(ref, inputRef);
@@ -47,7 +45,7 @@ function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelEleme
   // This is a bit unorthodox. Typically, hooks cannot be called in a conditional,
   // but since the checkbox won't move in and out of a group, it should be safe.
   let groupState = useContext(CheckboxGroupContext);
-  let {inputProps, isInvalid} = groupState
+  let {inputProps, isInvalid, isDisabled} = groupState
     // eslint-disable-next-line react-hooks/rules-of-hooks
     ? useCheckboxGroupItem({
       ...props,
@@ -63,6 +61,8 @@ function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelEleme
     }, groupState, inputRef)
     // eslint-disable-next-line react-hooks/rules-of-hooks
     : useCheckbox(props, useToggleState(props), inputRef);
+
+  let {hoverProps, isHovered} = useHover({isDisabled});
 
   let markIcon = isIndeterminate
     ? <DashSmall UNSAFE_className={classNames(styles, 'spectrum-Checkbox-partialCheckmark')} />

--- a/packages/@react-spectrum/checkbox/src/CheckboxGroup.tsx
+++ b/packages/@react-spectrum/checkbox/src/CheckboxGroup.tsx
@@ -27,7 +27,6 @@ function CheckboxGroup(props: SpectrumCheckboxGroupProps, ref: DOMRef<HTMLDivEle
   props = useFormProps(props);
   let {
     isEmphasized,
-    isDisabled,
     children,
     orientation = 'vertical'
   } = props;
@@ -54,7 +53,7 @@ function CheckboxGroup(props: SpectrumCheckboxGroupProps, ref: DOMRef<HTMLDivEle
             }
           )
         }>
-        <Provider isEmphasized={isEmphasized} isDisabled={isDisabled}>
+        <Provider isEmphasized={isEmphasized}>
           <CheckboxGroupContext.Provider value={state}>
             {children}
           </CheckboxGroupContext.Provider>

--- a/packages/@react-spectrum/checkbox/src/CheckboxGroup.tsx
+++ b/packages/@react-spectrum/checkbox/src/CheckboxGroup.tsx
@@ -27,6 +27,7 @@ function CheckboxGroup(props: SpectrumCheckboxGroupProps, ref: DOMRef<HTMLDivEle
   props = useFormProps(props);
   let {
     isEmphasized,
+    isDisabled,
     children,
     orientation = 'vertical'
   } = props;
@@ -53,7 +54,7 @@ function CheckboxGroup(props: SpectrumCheckboxGroupProps, ref: DOMRef<HTMLDivEle
             }
           )
         }>
-        <Provider isEmphasized={isEmphasized}>
+        <Provider isEmphasized={isEmphasized} isDisabled={isDisabled}>
           <CheckboxGroupContext.Provider value={state}>
             {children}
           </CheckboxGroupContext.Provider>


### PR DESCRIPTION
Closes #5378 

After investigating this a bit more, I don't think this is a css specificity issue. It seemed that when the `isDisabled` prop was provided to`<CheckboxGroup>`, that value was not passed to the individual `<Checkbox>` components, resulting in the absence of the `is-disabled` class in their classnames. Therefore, if you wanted to the disabled styles to be applied to a selected checkbox in a checkbox group, you would also have to directly pass `isDisabled` to that specific checkbox. 

Looking back at the commit history, it appears that this "broke" with this PR (https://github.com/adobe/react-spectrum/pull/3827). However, if you go commit before it (which is https://github.com/adobe/react-spectrum/pull/3962), you'll notice that the styling might be correct, but the `is-disabled` class still isn't a part of the classname even though it should be. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Go to the CheckboxGroup in storybook
2. Use the controls and play around the different states when isDisabled is true
3. It should have the correct fill color when it is disabled

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
