### PR TITLE
fix: labelable option to Tab props for aria-label support

### DIFF
--- a/packages/@react-aria/tabs/src/useTab.ts
+++ b/packages/@react-aria/tabs/src/useTab.ts
@@ -58,7 +58,7 @@ export function useTab<T>(
   let {tabIndex} = itemProps;
 
   let item = state.collection.getItem(key);
-  let domProps = filterDOMProps(item?.props, {isLink: !!item?.props?.href});
+  let domProps = filterDOMProps(item?.props, {isLink: !!item?.props?.href, labelable: true});
   delete domProps.id;
 
   return {

--- a/packages/@react-spectrum/tabs/test/Tabs.test.js
+++ b/packages/@react-spectrum/tabs/test/Tabs.test.js
@@ -782,6 +782,30 @@ describe('Tabs', function () {
     expect(tabPanelInput.value).toBe('');
   });
 
+  it('Tabs can be aria-labelled', () => {
+    let {getAllByRole, getByLabelText} = render(
+      <Provider theme={theme}>
+        <Tabs aria-label="Tab Example" maxWidth={500}>
+          <TabList>
+            <Item aria-label="Foo">Tab 1</Item>
+            <Item>Tab 2</Item>
+          </TabList>
+          <TabPanels>
+            <Item>
+              <input data-testid="panel1_input" />
+            </Item>
+            <Item>
+              <input disabled data-testid="panel2_input" />
+            </Item>
+          </TabPanels>
+        </Tabs>
+      </Provider>
+    );
+
+    let tab = getByLabelText('Foo');
+    expect(tab).toBe(getAllByRole('tab')[0]);
+  });
+
   it('supports custom props for parent tabs element', function () {
     let {getByTestId} = renderComponent({'data-testid': 'tabs1'});
     let tabs = getByTestId('tabs1');

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -313,4 +313,24 @@ describe('Tabs', () => {
     fireEvent.keyDown(tabs[1], {key: 'ArrowRight'});
     expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
   });
+
+  it('should render tab with aria-label', () => {
+    let {getAllByRole} = render(
+      <Tabs>
+        <TabList>
+          <Tab id="a" aria-label="Tab A">A</Tab>
+          <Tab id="b" aria-label="Tab B">B</Tab>
+          <Tab id="c" aria-label="Tab C">C</Tab>
+        </TabList>
+        <TabPanel id="a">A</TabPanel>
+        <TabPanel id="b">B</TabPanel>
+        <TabPanel id="c">C</TabPanel>
+      </Tabs>
+    );
+
+    let tabs = getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute('aria-label', 'Tab A');
+    expect(tabs[1]).toHaveAttribute('aria-label', 'Tab B');
+    expect(tabs[2]).toHaveAttribute('aria-label', 'Tab C');
+  });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5312

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

To test this change, please follow these steps:

- Navigate to the Tabs component in the storybook.
- Verify that each Tab component now correctly includes its specified aria-label in the DOM.

## 🧢 Your Project:

<!--- Company/project for pull request -->
