### PR TITLE
Fix extra char read by AT

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/steplist/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/steplist/index.css
@@ -218,7 +218,7 @@ governing permissions and limitations under the License.
 
     padding-inline-start: calc(var(--spectrum-steplist-chevron-gap) - var(--spectrum-steplist-marker-label-gap));
     &::before {
-      content: 'x';
+      content: ' ';
       width: 0;
       visibility: hidden;
     }
@@ -239,7 +239,7 @@ governing permissions and limitations under the License.
     display: flex;
     align-items: center;
     &::before {
-      content: 'x';
+      content: ' ';
       width: 0;
       visibility: hidden;
     }
@@ -281,7 +281,7 @@ governing permissions and limitations under the License.
     display: flex;
     align-items: center;
     &::before {
-      content: 'x';
+      content: ' ';
       width: 0;
       visibility: hidden;
     }

--- a/packages/@adobe/spectrum-css-temp/components/steplist/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/steplist/index.css
@@ -218,7 +218,8 @@ governing permissions and limitations under the License.
 
     padding-inline-start: calc(var(--spectrum-steplist-chevron-gap) - var(--spectrum-steplist-marker-label-gap));
     &::before {
-      content: ' ';
+      content: "*";
+      content: "*" / "";
       width: 0;
       visibility: hidden;
     }
@@ -239,7 +240,8 @@ governing permissions and limitations under the License.
     display: flex;
     align-items: center;
     &::before {
-      content: ' ';
+      content: "*";
+      content: "*" / "";
       width: 0;
       visibility: hidden;
     }
@@ -281,7 +283,8 @@ governing permissions and limitations under the License.
     display: flex;
     align-items: center;
     &::before {
-      content: ' ';
+      content: "*";
+      content: "*" / "";
       width: 0;
       visibility: hidden;
     }

--- a/packages/@adobe/spectrum-css-temp/components/steplist/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/steplist/index.css
@@ -219,7 +219,6 @@ governing permissions and limitations under the License.
     padding-inline-start: calc(var(--spectrum-steplist-chevron-gap) - var(--spectrum-steplist-marker-label-gap));
     &::before {
       content: "*";
-      content: "*" / "";
       width: 0;
       visibility: hidden;
     }
@@ -241,7 +240,6 @@ governing permissions and limitations under the License.
     align-items: center;
     &::before {
       content: "*";
-      content: "*" / "";
       width: 0;
       visibility: hidden;
     }
@@ -284,7 +282,6 @@ governing permissions and limitations under the License.
     align-items: center;
     &::before {
       content: "*";
-      content: "*" / "";
       width: 0;
       visibility: hidden;
     }

--- a/packages/@react-spectrum/steplist/src/StepListItem.tsx
+++ b/packages/@react-spectrum/steplist/src/StepListItem.tsx
@@ -105,8 +105,8 @@ export function StepListItem<T>(props: SpectrumStepListItemProps<T>) {
                 'is-reversed': direction === 'rtl'
               })} />
           </div>
-          <div id={markerId} aria-hidden="true" className={classNames(styles, 'spectrum-Steplist-markerWrapper')}>
-            <div  className={classNames(styles, 'spectrum-Steplist-marker')}>{numberFormatter.format((item.index || 0) + 1)}</div>
+          <div aria-hidden="true" className={classNames(styles, 'spectrum-Steplist-markerWrapper')}>
+            <div id={markerId}  className={classNames(styles, 'spectrum-Steplist-marker')}>{numberFormatter.format((item.index || 0) + 1)}</div>
           </div>
         </a>
       </FocusRing>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

~This is super dumb, but doing the space ends up with a no-height line, so alignment is wrong again.
Every other character seems to be announced. So we have to do this trick~ https://stackoverflow.com/questions/46815260/hide-a-pseudo-element-from-a-screenreader

Adjusts element we point to for announcement of marker such that it doesn't include the psuedo element

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
