### PR TITLE
Fix Toolbar focus events with native elements

### DIFF
--- a/packages/@react-aria/toolbar/src/useToolbar.ts
+++ b/packages/@react-aria/toolbar/src/useToolbar.ts
@@ -12,7 +12,7 @@
 
 import {AriaLabelingProps, Orientation} from '@react-types/shared';
 import {createFocusManager} from '@react-aria/focus';
-import {HTMLAttributes, KeyboardEventHandler, RefObject, useRef, useState} from 'react';
+import {HTMLAttributes, KeyboardEventHandler, RefObject, useEffect, useRef, useState} from 'react';
 import {useLayoutEffect} from '@react-aria/utils';
 import {useLocale} from '@react-aria/i18n';
 
@@ -109,12 +109,23 @@ export function useToolbar(props: AriaToolbarProps, ref: RefObject<HTMLDivElemen
   // Restore focus to the last focused child when focus returns into the toolbar.
   // If the element was removed, do nothing, either the first item in the first group,
   // or the last item in the last group will be focused, depending on direction.
+  let timeout = useRef<number | null>(null);
   const onFocus = (e) => {
     if (lastFocused.current && !e.currentTarget.contains(e.relatedTarget) && ref.current?.contains(e.target)) {
-      lastFocused.current?.focus();
-      lastFocused.current = null;
+      timeout.current = setTimeout(() => {
+        lastFocused.current?.focus();
+        lastFocused.current = null;
+        timeout.current = null;
+      }, 0);
     }
   };
+  useEffect(() => {
+    return () => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
+    };
+  }, []);
 
   return {
     toolbarProps: {

--- a/packages/react-aria-components/stories/index.stories.tsx
+++ b/packages/react-aria-components/stories/index.stories.tsx
@@ -1415,3 +1415,27 @@ ToolbarExample.argTypes = {
     options: ['horizontal', 'vertical']
   }
 };
+
+export const ToolbarWithNativeButtons = {
+  render: (props) => (
+    <div>
+      <label htmlFor="before">Input Before Toolbar</label>
+      <input id="before" type="text" />
+      <Toolbar {...props}>
+        <div role="group" aria-label="Text style">
+          <button onFocus={action('focus B')} onBlur={action('blur B')} className={classNames(styles, 'toggleButtonExample')}><strong>B</strong></button>
+          <button onFocus={action('focus U')} onBlur={action('blur U')} className={classNames(styles, 'toggleButtonExample')}><div style={{textDecoration: 'underline'}}>U</div></button>
+          <button onFocus={action('focus I')} onBlur={action('blur I')} className={classNames(styles, 'toggleButtonExample')}><i>I</i></button>
+        </div>
+      </Toolbar>
+      <label htmlFor="after">Input After Toolbar</label>
+      <input id="after" type="text" />
+    </div>
+  ),
+  parameters: {
+    description: {
+      data: `Tab into the toolbar. Arrow key navigate to the middle button. Tab to exit, then shift tab to return. All focus actions should be in order, there should not be
+      any double blur follow by double focus.`
+    }
+  }
+};


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5457

I'm not convinced this is the correct way to handle this, or if this is even a use case we should support. Should we only be supporting components written using React Aria hooks inside of a Toolbar? This may be a slippery slope.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
