### PR TITLE
Make order of tailwind variants match default

### DIFF
--- a/packages/tailwindcss-react-aria-components/src/index.js
+++ b/packages/tailwindcss-react-aria-components/src/index.js
@@ -1,35 +1,45 @@
 import plugin from 'tailwindcss/plugin';
 
+// Order of these is important because it determines which states win in a conflict.
+// We mostly follow Tailwind's defaults, adding our additional states following the categories they define.
+// https://github.com/tailwindlabs/tailwindcss/blob/304c2bad6cb5fcb62754a4580b1c8f4c16b946ea/src/corePlugins.js#L83
 const attributes = {
   boolean: [
+    // Conditions
+    'allows-removing',
+    'allows-sorting',
+    'allows-dragging',
+
+    // States
+    'open',
+    'entering',
+    'exiting',
+    'indeterminate',
+    ['placeholder-shown', 'placeholder'],
+    'current',
+    'required',
+    'unavailable',
+    'invalid',
+    ['read-only', 'readonly'],
+    'outside-month',
+    'outside-visible-range',
+
+    // Content
+    'empty',
+
+    // Interactive states
+    'focus-within',
     ['hover', 'hovered'],
     ['focus', 'focused'],
     'focus-visible',
-    'focus-within',
     'pressed',
-    'disabled',
-    'drop-target',
-    'dragging',
-    'empty',
-    'allows-dragging',
-    'allows-removing',
-    'allows-sorting',
-    ['placeholder-shown', 'placeholder'],
     'selected',
-    'indeterminate',
-    ['read-only', 'readonly'],
-    'required',
-    'entering',
-    'exiting',
-    'open',
-    'unavailable',
-    'outside-month',
-    'outside-visible-range',
     'selection-start',
     'selection-end',
-    'current',
-    'invalid',
-    'resizing'
+    'dragging',
+    'drop-target',
+    'resizing',
+    'disabled'
   ],
   enum: {
     placement: ['left', 'right', 'top', 'bottom'],
@@ -100,21 +110,24 @@ let addVariants = (variantName, selectors, addVariant, matchVariant) => {
 
 module.exports = plugin.withOptions((options) => (({addVariant, matchVariant}) => {
   let prefix = options?.prefix ? `${options.prefix}-` : '';
+
+  // Enum attributes go first because currently they are all non-interactive states.
+  Object.keys(attributes.enum).forEach((attributeName) => {
+    attributes.enum[attributeName].forEach(
+      (attributeValue) => {
+        let name = shortNames[attributeName] || attributeName;
+        let variantName = `${prefix}${name}-${attributeValue}`;
+        let selectors = getSelector(prefix, attributeName, attributeValue);
+        addVariants(variantName, selectors, addVariant, matchVariant);
+      }
+    );
+  });
+
   attributes.boolean.forEach((attribute) => {
     let variantName = Array.isArray(attribute) ? attribute[0] : attribute;
     variantName = `${prefix}${variantName}`;
     let attributeName = Array.isArray(attribute) ? attribute[1] : attribute;
     let selectors = getSelector(prefix, attributeName);
     addVariants(variantName, selectors, addVariant, matchVariant);
-  });
-  Object.keys(attributes.enum).forEach((attributeName) => {
-    attributes.enum[attributeName].forEach(
-        (attributeValue) => {
-          let name = shortNames[attributeName] || attributeName;
-          let variantName = `${prefix}${name}-${attributeValue}`;
-          let selectors = getSelector(prefix, attributeName, attributeValue);
-          addVariants(variantName, selectors, addVariant, matchVariant);
-        }
-      );
   });
 }));

--- a/packages/tailwindcss-react-aria-components/src/index.test.js
+++ b/packages/tailwindcss-react-aria-components/src/index.test.js
@@ -26,194 +26,6 @@ test('variants', async () => {
   let content = html`<div data-rac className="hover:bg-red focus:bg-red focus-visible:bg-red focus-within:bg-red pressed:bg-red disabled:bg-red drop-target:bg-red dragging:bg-red empty:bg-red allows-dragging:bg-red allows-removing:bg-red allows-sorting:bg-red placeholder-shown:bg-red selected:bg-red indeterminate:bg-red read-only:bg-red required:bg-red entering:bg-red exiting:bg-red open:bg-red unavailable:bg-red outside-month:bg-red outside-visible-range:bg-red selection-start:bg-red selection-end:bg-red current:bg-red invalid:bg-red resizing:bg-red placement-left:bg-red placement-right:bg-red placement-top:bg-red placement-bottom:bg-red type-literal:bg-red type-year:bg-red type-month:bg-red type-day:bg-red layout-grid:bg-red layout-stack:bg-red orientation-horizontal:bg-red orientation-vertical:bg-red selection-single:bg-red selection-multiple:bg-red resizable-right:bg-red resizable-left:bg-red resizable-both:bg-red sort-ascending:bg-red sort-descending:bg-red group-pressed:bg-red peer-pressed:bg-red group-hover:bg-red group/custom-name group-hover/custom-name:bg-red peer-pressed/custom-name:bg-red"></div>`;
   return run({content}).then((result) => {
     expect(result.css).toContain(css`
-.hover\:bg-red:where([data-rac])[data-hovered] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.hover\:bg-red:where(:not([data-rac])):hover {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group\/custom-name:where([data-rac])[data-hovered] .group-hover\/custom-name\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group:where([data-rac])[data-hovered] .group-hover\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group\/custom-name:where(:not([data-rac])):hover .group-hover\/custom-name\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group:where(:not([data-rac])):hover .group-hover\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.focus\:bg-red:where([data-rac])[data-focused] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.focus\:bg-red:where(:not([data-rac])):focus {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.focus-visible\:bg-red:where([data-rac])[data-focus-visible] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.focus-visible\:bg-red:where(:not([data-rac])):focus-visible {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.focus-within\:bg-red:where([data-rac])[data-focus-within] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.focus-within\:bg-red:where(:not([data-rac])):focus-within {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.pressed\:bg-red[data-pressed] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group[data-pressed] .group-pressed\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.peer\/custom-name[data-pressed] ~ .peer-pressed\/custom-name\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.peer[data-pressed] ~ .peer-pressed\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.disabled\:bg-red:where([data-rac])[data-disabled] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.disabled\:bg-red:where(:not([data-rac])):disabled {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.drop-target\:bg-red[data-drop-target] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.dragging\:bg-red[data-dragging] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.empty\:bg-red:where([data-rac])[data-empty] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.empty\:bg-red:where(:not([data-rac])):empty {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.allows-dragging\:bg-red[data-allows-dragging] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.allows-removing\:bg-red[data-allows-removing] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.allows-sorting\:bg-red[data-allows-sorting] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.placeholder-shown\:bg-red:where([data-rac])[data-placeholder] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.placeholder-shown\:bg-red:where(:not([data-rac])):placeholder-shown {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.selected\:bg-red[data-selected] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.indeterminate\:bg-red:where([data-rac])[data-indeterminate] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.indeterminate\:bg-red:where(:not([data-rac])):indeterminate {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.read-only\:bg-red:where([data-rac])[data-readonly] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.read-only\:bg-red:where(:not([data-rac])):read-only {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.required\:bg-red:where([data-rac])[data-required] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.required\:bg-red:where(:not([data-rac])):required {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.entering\:bg-red[data-entering] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.exiting\:bg-red[data-exiting] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.open\:bg-red:where([data-rac])[data-open] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.open\:bg-red:where(:not([data-rac]))[open] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.unavailable\:bg-red[data-unavailable] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.outside-month\:bg-red[data-outside-month] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.outside-visible-range\:bg-red[data-outside-visible-range] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.selection-start\:bg-red[data-selection-start] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.selection-end\:bg-red[data-selection-end] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.current\:bg-red[data-current] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.invalid\:bg-red:where([data-rac])[data-invalid] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.invalid\:bg-red:where(:not([data-rac])):invalid {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.resizing\:bg-red[data-resizing] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
 .placement-left\:bg-red[data-placement="left"] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
@@ -289,6 +101,194 @@ test('variants', async () => {
 .sort-descending\:bg-red[data-sort-direction="descending"] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.allows-removing\:bg-red[data-allows-removing] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.allows-sorting\:bg-red[data-allows-sorting] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.allows-dragging\:bg-red[data-allows-dragging] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.open\:bg-red:where([data-rac])[data-open] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.open\:bg-red:where(:not([data-rac]))[open] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.entering\:bg-red[data-entering] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.exiting\:bg-red[data-exiting] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.indeterminate\:bg-red:where([data-rac])[data-indeterminate] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.indeterminate\:bg-red:where(:not([data-rac])):indeterminate {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.placeholder-shown\:bg-red:where([data-rac])[data-placeholder] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.placeholder-shown\:bg-red:where(:not([data-rac])):placeholder-shown {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.current\:bg-red[data-current] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.required\:bg-red:where([data-rac])[data-required] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.required\:bg-red:where(:not([data-rac])):required {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.unavailable\:bg-red[data-unavailable] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.invalid\:bg-red:where([data-rac])[data-invalid] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.invalid\:bg-red:where(:not([data-rac])):invalid {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.read-only\:bg-red:where([data-rac])[data-readonly] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.read-only\:bg-red:where(:not([data-rac])):read-only {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.outside-month\:bg-red[data-outside-month] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.outside-visible-range\:bg-red[data-outside-visible-range] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.empty\:bg-red:where([data-rac])[data-empty] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.empty\:bg-red:where(:not([data-rac])):empty {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.focus-within\:bg-red:where([data-rac])[data-focus-within] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.focus-within\:bg-red:where(:not([data-rac])):focus-within {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.hover\:bg-red:where([data-rac])[data-hovered] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.hover\:bg-red:where(:not([data-rac])):hover {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group\/custom-name:where([data-rac])[data-hovered] .group-hover\/custom-name\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group:where([data-rac])[data-hovered] .group-hover\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group\/custom-name:where(:not([data-rac])):hover .group-hover\/custom-name\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group:where(:not([data-rac])):hover .group-hover\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.focus\:bg-red:where([data-rac])[data-focused] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.focus\:bg-red:where(:not([data-rac])):focus {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.focus-visible\:bg-red:where([data-rac])[data-focus-visible] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.focus-visible\:bg-red:where(:not([data-rac])):focus-visible {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.pressed\:bg-red[data-pressed] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group[data-pressed] .group-pressed\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.peer\/custom-name[data-pressed] ~ .peer-pressed\/custom-name\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.peer[data-pressed] ~ .peer-pressed\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selected\:bg-red[data-selected] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selection-start\:bg-red[data-selection-start] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.selection-end\:bg-red[data-selection-end] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.dragging\:bg-red[data-dragging] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.drop-target\:bg-red[data-drop-target] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.resizing\:bg-red[data-resizing] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.disabled\:bg-red:where([data-rac])[data-disabled] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.disabled\:bg-red:where(:not([data-rac])):disabled {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }`
     );
   });
@@ -298,134 +298,6 @@ test('variants with prefix', async () => {
   let content = html`<div data-rac className="rac-hover:bg-red rac-focus:bg-red rac-focus-visible:bg-red rac-focus-within:bg-red rac-pressed:bg-red rac-disabled:bg-red rac-drop-target:bg-red rac-dragging:bg-red rac-empty:bg-red rac-allows-dragging:bg-red rac-allows-removing:bg-red rac-allows-sorting:bg-red rac-placeholder-shown:bg-red rac-selected:bg-red rac-indeterminate:bg-red rac-read-only:bg-red rac-required:bg-red rac-entering:bg-red rac-exiting:bg-red rac-open:bg-red rac-unavailable:bg-red rac-outside-month:bg-red rac-outside-visible-range:bg-red rac-selection-start:bg-red rac-selection-end:bg-red rac-current:bg-red rac-invalid:bg-red rac-resizing:bg-red rac-placement-left:bg-red rac-placement-right:bg-red rac-placement-top:bg-red rac-placement-bottom:bg-red rac-type-literal:bg-red rac-type-year:bg-red rac-type-month:bg-red rac-type-day:bg-red rac-layout-grid:bg-red rac-layout-stack:bg-red rac-orientation-horizontal:bg-red rac-orientation-vertical:bg-red rac-selection-single:bg-red rac-selection-multiple:bg-red rac-resizable-right:bg-red rac-resizable-left:bg-red rac-resizable-both:bg-red rac-sort-ascending:bg-red rac-sort-descending:bg-red group-rac-pressed:bg-red group/custom-name group-rac-hover/custom-name:bg-red peer-rac-pressed:bg-red peer-rac-pressed/custom-name:bg-red"></div>`;
   return run({content, options: {prefix: 'rac'}}).then((result) => {
     expect(result.css).toContain(css`
-.rac-hover\:bg-red[data-hovered] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group\/custom-name[data-hovered] .group-rac-hover\/custom-name\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-focus\:bg-red[data-focused] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-focus-visible\:bg-red[data-focus-visible] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-focus-within\:bg-red[data-focus-within] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-pressed\:bg-red[data-pressed] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.group[data-pressed] .group-rac-pressed\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.peer\/custom-name[data-pressed] ~ .peer-rac-pressed\/custom-name\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.peer[data-pressed] ~ .peer-rac-pressed\:bg-red {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-disabled\:bg-red[data-disabled] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-drop-target\:bg-red[data-drop-target] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-dragging\:bg-red[data-dragging] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-empty\:bg-red[data-empty] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-allows-dragging\:bg-red[data-allows-dragging] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-allows-removing\:bg-red[data-allows-removing] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-allows-sorting\:bg-red[data-allows-sorting] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-placeholder-shown\:bg-red[data-placeholder] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-selected\:bg-red[data-selected] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-indeterminate\:bg-red[data-indeterminate] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-read-only\:bg-red[data-readonly] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-required\:bg-red[data-required] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-entering\:bg-red[data-entering] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-exiting\:bg-red[data-exiting] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-open\:bg-red[data-open] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-unavailable\:bg-red[data-unavailable] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-outside-month\:bg-red[data-outside-month] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-outside-visible-range\:bg-red[data-outside-visible-range] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-selection-start\:bg-red[data-selection-start] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-selection-end\:bg-red[data-selection-end] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-current\:bg-red[data-current] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-invalid\:bg-red[data-invalid] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
-.rac-resizing\:bg-red[data-resizing] {
-    --tw-bg-opacity: 1;
-    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
-}
 .rac-placement-left\:bg-red[data-placement="left"] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
@@ -499,6 +371,134 @@ test('variants with prefix', async () => {
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
 .rac-sort-descending\:bg-red[data-sort-direction="descending"] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-allows-removing\:bg-red[data-allows-removing] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-allows-sorting\:bg-red[data-allows-sorting] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-allows-dragging\:bg-red[data-allows-dragging] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-open\:bg-red[data-open] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-entering\:bg-red[data-entering] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-exiting\:bg-red[data-exiting] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-indeterminate\:bg-red[data-indeterminate] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-placeholder-shown\:bg-red[data-placeholder] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-current\:bg-red[data-current] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-required\:bg-red[data-required] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-unavailable\:bg-red[data-unavailable] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-invalid\:bg-red[data-invalid] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-read-only\:bg-red[data-readonly] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-outside-month\:bg-red[data-outside-month] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-outside-visible-range\:bg-red[data-outside-visible-range] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-empty\:bg-red[data-empty] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-focus-within\:bg-red[data-focus-within] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-hover\:bg-red[data-hovered] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group\/custom-name[data-hovered] .group-rac-hover\/custom-name\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-focus\:bg-red[data-focused] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-focus-visible\:bg-red[data-focus-visible] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-pressed\:bg-red[data-pressed] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.group[data-pressed] .group-rac-pressed\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.peer\/custom-name[data-pressed] ~ .peer-rac-pressed\/custom-name\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.peer[data-pressed] ~ .peer-rac-pressed\:bg-red {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selected\:bg-red[data-selected] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selection-start\:bg-red[data-selection-start] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-selection-end\:bg-red[data-selection-end] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-dragging\:bg-red[data-dragging] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-drop-target\:bg-red[data-drop-target] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-resizing\:bg-red[data-resizing] {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 0 0 / var(--tw-bg-opacity))
+}
+.rac-disabled\:bg-red[data-disabled] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }`


### PR DESCRIPTION
The order that the Tailwind variants are defined in our plugin are important because Tailwind uses it to determine the order that CSS selectors are generated. For example, the `disabled` styles should usually override all of the other states (like hover/press). This PR updates the order to match the default order that Tailwind defines, with our additional states added following the general categories they define.