### PR TITLE
Trim git stdout when getting current commit hash in docs

### DIFF
--- a/packages/dev/docs/pages/react-aria/getting-started.mdx
+++ b/packages/dev/docs/pages/react-aria/getting-started.mdx
@@ -226,7 +226,7 @@ To help kick-start your project, we offer a starter kit that includes example im
 
 <ResourceCard
   type="Storybook"
-  url={`../react-aria-starter.${process.env.GIT_HASH || spawnSync('git', ['rev-parse', '--short', 'HEAD']).stdout}.zip`}
+  url={`../react-aria-starter.${process.env.GIT_HASH || spawnSync('git', ['rev-parse', '--short', 'HEAD']).stdout.toString().trim()}.zip`}
   style={{marginTop: 36}} />
 
 ## Hooks

--- a/scripts/buildWebsite.js
+++ b/scripts/buildWebsite.js
@@ -31,7 +31,7 @@ async function build() {
   console.log(`Building into ${dir}...`);
 
   // Generate a package.json containing just what we need to build the website
-  let gitHash = spawnSync('git', ['rev-parse', '--short', 'HEAD']).stdout;
+  let gitHash = spawnSync('git', ['rev-parse', '--short', 'HEAD']).stdout.toString().trim();
   let pkg = {
     name: 'rsp-website',
     version: '0.0.0',


### PR DESCRIPTION
Should fix verdaccio docs build on main. Git stdout includes a newline at the end which messed up the environment variables passed to the parcel build script meaning they were not set correctly.