### PR TITLE
Add capitalization settings support for useSearchField

### DIFF
--- a/packages/@react-aria/searchfield/test/useSearchField.test.js
+++ b/packages/@react-aria/searchfield/test/useSearchField.test.js
@@ -51,6 +51,14 @@ describe('useSearchField hook', () => {
       expect(typeof inputProps.onKeyDown).toBe('function');
     });
 
+    it('with appropriate props if autoCapitalize is defined', () => {
+      let result = renderSearchHook({autoCapitalize: 'on'});
+      expect(result.inputProps.autoCapitalize).toBe('on');
+      
+      result = renderSearchHook({autoCapitalize: 'off'});
+      expect(result.inputProps.autoCapitalize).toBe('off');
+    });
+
     describe('with specific onKeyDown behavior', () => {
       let preventDefault = jest.fn();
       let stopPropagation = jest.fn();

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -79,12 +79,7 @@ export interface AriaTextFieldOptions<T extends TextFieldIntrinsicElements> exte
    * For example, [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-type).
    * @default 'input'
    */
-  inputElementType?: T,
-  /**
-   * A nonstandard attribute used by iOS Safari that controls how textual form elements should be automatically capitalized.
-   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autocapitalize).
-   */
-  autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'
+  inputElementType?: T
 }
 
 /**

--- a/packages/@react-spectrum/searchfield/stories/SearchField.stories.tsx
+++ b/packages/@react-spectrum/searchfield/stories/SearchField.stories.tsx
@@ -60,6 +60,12 @@ export default {
         type: 'radio',
         options: [null, 'valid', 'invalid']
       }
+    },
+    autoCapitalize: {
+      control: {
+        type: 'radio',
+        options: [undefined, 'off', 'none', 'on', 'sentences', 'words', 'characters']
+      }
     }
   }
 };

--- a/packages/@react-types/form/src/index.d.ts
+++ b/packages/@react-types/form/src/index.d.ts
@@ -57,8 +57,8 @@ export interface FormProps extends AriaLabelingProps {
    */
   autoComplete?: 'off' | 'on',
   /**
-   * A nonstandard attribute used by iOS Safari that controls how textual form elements should be automatically capitalized.
-   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#autocapitalize).
+   * Controls whether inputted text is automatically capitalized and, if so, in what manner. 
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize).
    */
   autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters',
   /**

--- a/packages/@react-types/shared/src/dom.d.ts
+++ b/packages/@react-types/shared/src/dom.d.ts
@@ -164,9 +164,15 @@ export interface TextInputDOMProps extends DOMProps, InputDOMProps, TextInputDOM
   type?: 'text' | 'search' | 'url' | 'tel' | 'email' | 'password' | (string & {}),
 
   /**
-   * Hints at the type of data that might be entered by the user while editing the element or its contents. See [MDN](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute).
+   * Hints at the type of data that might be entered by the user while editing the element or its contents. See [Spec](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute).
    */
   inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search'
+
+  /**
+   * A nonstandard attribute used by iOS Safari that controls how textual form elements should be automatically capitalized.
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#autocapitalize).
+   */
+  autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'
 }
 
 // Make sure to update filterDOMProps.ts when updating this.

--- a/packages/@react-types/shared/src/dom.d.ts
+++ b/packages/@react-types/shared/src/dom.d.ts
@@ -166,11 +166,11 @@ export interface TextInputDOMProps extends DOMProps, InputDOMProps, TextInputDOM
   /**
    * Hints at the type of data that might be entered by the user while editing the element or its contents. See [Spec](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute).
    */
-  inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search'
+  inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search',
 
   /**
-   * A nonstandard attribute used by iOS Safari that controls how textual form elements should be automatically capitalized.
-   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#autocapitalize).
+   * Controls whether inputted text is automatically capitalized and, if so, in what manner. 
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize).
    */
   autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'
 }


### PR DESCRIPTION
I've made some updates to allow setting autoCapitalize in useSearchField as well.

This is a follow-up to the following PR

- https://github.com/adobe/react-spectrum/pull/5472
 
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
A Storybook example has been added, so you can switch the property from the RadioButton.

## 🧢 Your Project:

<!--- Company/project for pull request -->
