### PR TITLE
#5519 [a11y] Button announces multiple times when status changes to isPending

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -167,7 +167,7 @@ governing permissions and limitations under the License.
 
     .spectrum-Button-label,
     .spectrum-Icon {
-      visibility: hidden;
+      opacity: 0;
     }
   }
 }

--- a/packages/@react-aria/utils/src/index.ts
+++ b/packages/@react-aria/utils/src/index.ts
@@ -30,7 +30,7 @@ export {useSyncRef} from './useSyncRef';
 export {getScrollParent, isScrollable} from './getScrollParent';
 export {useViewportSize} from './useViewportSize';
 export {useDescription} from './useDescription';
-export {isMac, isIPhone, isIPad, isIOS, isAppleDevice, isWebKit, isChrome, isAndroid} from './platform';
+export {isMac, isIPhone, isIPad, isIOS, isAppleDevice, isWebKit, isChrome, isAndroid, isFirefox} from './platform';
 export {useEvent} from './useEvent';
 export {useValueEffect} from './useValueEffect';
 export {scrollIntoView, scrollIntoViewport} from './scrollIntoView';


### PR DESCRIPTION
Closes #5519

## ✅ Pull Request Checklist:

- [x] Included link to corresponding React Spectrum GitHub Issue #5519.
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/399b9f9af6f93a7b8f93327aa70aa7d31d9a4fd5/storybook/iframe.html?providerSwitcher-express=false&scrolling=false&providerSwitcher-locale=&providerSwitcher-theme=&providerSwitcher-scale=&args=isPending:true&id=button--pending-spinner&viewMode=story in Firefox on Windows using NVDA or JAWS.
2. Verify that clicking each of the buttons in the example announces using the buttons accessibility name and "pending" once when the `isProgressVisible` state enters.
3. Verify that the Controlled example is named "Controlled pending" when `isPending` is set to `true` in the Actions panel 
4. Repeat using Chrome and Microsoft Edge on Windows, and using Chrome and Safari with VoiceOver on macOS.
5. Note that using Safari with VoiceOver, you can use Control + Option + Space to trigger a virtual click with the screen reader. This seems to make VoiceOver announce the "pending" state more consistently than pressing Enter or Space on their own.

## 🧢 Your Project:

Adobe/Accessibility
