### PR TITLE
Fix TooltipTrigger with DialogTrigger

### DIFF
--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {DOMAttributes, FocusableElement, FocusEvents} from '@react-types/shared';
-import {getInteractionModality, HoverProps, isFocusVisible, PressProps, useHover, usePress} from '@react-aria/interactions';
+import {DOMAttributes, FocusableElement} from '@react-types/shared';
+import {getInteractionModality, isFocusVisible, useHover} from '@react-aria/interactions';
 import {mergeProps, useId} from '@react-aria/utils';
 import {RefObject, useEffect, useRef} from 'react';
 import {TooltipTriggerProps} from '@react-types/tooltip';
@@ -22,7 +22,7 @@ export interface TooltipTriggerAria {
   /**
    * Props for the trigger element.
    */
-  triggerProps: DOMAttributes & PressProps & HoverProps & FocusEvents,
+  triggerProps: DOMAttributes,
 
   /**
    * Props for the overlay container element.
@@ -129,8 +129,6 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
     onHoverEnd
   });
 
-  let {pressProps} = usePress({onPressStart});
-
   let {focusableProps} = useFocusable({
     isDisabled,
     onFocus,
@@ -140,7 +138,10 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
   return {
     triggerProps: {
       'aria-describedby': state.isOpen ? tooltipId : undefined,
-      ...mergeProps(focusableProps, hoverProps, pressProps)
+      ...mergeProps(focusableProps, hoverProps, {
+        onPointerDown: onPressStart,
+        onKeyDown: onPressStart
+      })
     },
     tooltipProps: {
       id: tooltipId

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -473,8 +473,60 @@ export const WithTooltip = () => (
 );
 
 WithTooltip.story = {
-  name: 'withTooltip'
+  name: 'with tooltip inside'
 };
+
+export const WithTooltipTrigger = () => (
+  <Flex direction="row" gap={10}>
+    <DialogTrigger>
+      <ActionButton>DialogTrigger only</ActionButton>
+      {close => <CustomDialog close={close} />}
+    </DialogTrigger>
+
+    <TooltipTrigger>
+      <ActionButton>TooltipTrigger only</ActionButton>
+      <Tooltip>This is a tooltip</Tooltip>
+    </TooltipTrigger>
+
+    <TooltipTrigger>
+      <ActionButton isDisabled>TooltipTrigger only</ActionButton>
+      <Tooltip>This is a tooltip</Tooltip>
+    </TooltipTrigger>
+
+    <DialogTrigger>
+      <TooltipTrigger>
+        <ActionButton>DialogTrigger + TooltipTrigger</ActionButton>
+        <Tooltip>This is a tooltip</Tooltip>
+      </TooltipTrigger>
+      {close => <CustomDialog close={close} />}
+    </DialogTrigger>
+
+    <DialogTrigger>
+      <TooltipTrigger>
+        <ActionButton isDisabled>DialogTrigger + TooltipTrigger</ActionButton>
+        <Tooltip>This is a tooltip</Tooltip>
+      </TooltipTrigger>
+      {close => <CustomDialog close={close} />}
+    </DialogTrigger>
+  </Flex>
+);
+
+WithTooltipTrigger.story = {
+  name: 'with tooltip wrapper'
+};
+
+function CustomDialog({close}) {
+  return (
+    <Dialog>
+      <Content>
+        Dialog content
+      </Content>
+      <ButtonGroup>
+        <Button variant="cta" onPress={close}>Close</Button>
+      </ButtonGroup>
+    </Dialog>
+  );
+}
 
 export const WithTranslations = () => <TranslateDialog />;
 

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, pointerMap, render, triggerPress} from '@react-spectrum/test-utils';
+import {act, fireEvent, pointerMap, render} from '@react-spectrum/test-utils';
 import {ActionButton} from '@react-spectrum/button';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -282,7 +282,7 @@ describe('TooltipTrigger', function () {
       expect(onOpenChange).toHaveBeenCalledWith(true);
       let tooltip = getByRole('tooltip');
       expect(tooltip).toBeVisible();
-      triggerPress(button);
+      await user.click(button);
       expect(onOpenChange).toHaveBeenCalledWith(false);
       act(() => {
         jest.advanceTimersByTime(CLOSE_TIME);


### PR DESCRIPTION
Closes #3009, closes #4195

This is an alternate fix to #4195. It uses native `onPointerDown` and `onKeyDown` to hide tooltips instead of `usePress`. This avoids the double event causing tooltips preventing dialog triggers and other press events from working. It also allows press events on elements with tooltips to propagate rather than blocking interactions which would be unexpected.

I tried to add a test but was unable to reproduce the issue in a test environment. I believe this is due to `act` batching the double press events together unlike how it works in the browser.