### PR TITLE
Ensure all refs go to the outer-most element

### DIFF
--- a/packages/react-aria-components/src/Breadcrumbs.tsx
+++ b/packages/react-aria-components/src/Breadcrumbs.tsx
@@ -107,6 +107,7 @@ function BreadcrumbItem({node, isCurrent, isDisabled, onAction}: BreadcrumbItemP
   return (
     <li
       {...filterDOMProps(node.props)}
+      ref={node.props.ref}
       style={node.props.style}
       className={node.props.className ?? 'react-aria-Breadcrumb'}>
       <LinkContext.Provider value={linkProps}>

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -15,9 +15,9 @@ import {CalendarDate, createCalendar, DateDuration, endOfMonth, getWeeksInMonth,
 import {CalendarState, RangeCalendarState, useCalendarState, useRangeCalendarState} from 'react-stately';
 import {ContextValue, DOMProps, forwardRefType, Provider, RenderProps, SlotProps, StyleProps, useContextProps, useRenderProps} from './utils';
 import {DOMAttributes, FocusableElement, HoverEvents} from '@react-types/shared';
-import {filterDOMProps, useObjectRef} from '@react-aria/utils';
+import {filterDOMProps} from '@react-aria/utils';
 import {HeadingContext} from './Heading';
-import React, {createContext, ForwardedRef, forwardRef, ReactElement, useContext} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, ReactElement, useContext, useRef} from 'react';
 import {TextContext} from './Text';
 
 export interface CalendarRenderProps {
@@ -464,16 +464,16 @@ export interface CalendarCellProps extends RenderProps<CalendarCellRenderProps>,
   date: CalendarDate
 }
 
-function CalendarCell({date, ...otherProps}: CalendarCellProps, ref: ForwardedRef<HTMLDivElement>) {
+function CalendarCell({date, ...otherProps}: CalendarCellProps, ref: ForwardedRef<HTMLTableCellElement>) {
   let calendarState = useContext(CalendarStateContext);
   let rangeCalendarState = useContext(RangeCalendarStateContext);
   let state = calendarState ?? rangeCalendarState!;
   let {startDate: currentMonth} = useContext(InternalCalendarGridContext) ?? {startDate: state.visibleRange.start};
-  let objectRef = useObjectRef(ref);
+  let buttonRef = useRef<HTMLDivElement>(null);
   let {cellProps, buttonProps, ...states} = useCalendarCell(
     {date},
     state,
-    objectRef
+    buttonRef
   );
 
   let {hoverProps, isHovered} = useHover({...otherProps, isDisabled: states.isDisabled});
@@ -517,8 +517,8 @@ function CalendarCell({date, ...otherProps}: CalendarCellProps, ref: ForwardedRe
   };
 
   return (
-    <td {...cellProps}>
-      <div {...mergeProps(filterDOMProps(otherProps as any), buttonProps, focusProps, hoverProps, dataAttrs, renderProps)} ref={objectRef} />
+    <td {...cellProps} ref={ref}>
+      <div {...mergeProps(filterDOMProps(otherProps as any), buttonProps, focusProps, hoverProps, dataAttrs, renderProps)} ref={buttonRef} />
     </td>
   );
 }

--- a/packages/react-aria-components/src/Checkbox.tsx
+++ b/packages/react-aria-components/src/Checkbox.tsx
@@ -15,7 +15,7 @@ import {ContextValue, forwardRefType, Provider, RACValidation, RenderProps, Slot
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps} from '@react-aria/utils';
 import {LabelContext} from './Label';
-import React, {createContext, ForwardedRef, forwardRef, useContext, useState} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, useContext, useRef, useState} from 'react';
 import {TextContext} from './Text';
 
 export interface CheckboxGroupProps extends Omit<AriaCheckboxGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<CheckboxGroupRenderProps>, SlotProps {}
@@ -157,10 +157,11 @@ function CheckboxGroup(props: CheckboxGroupProps, ref: ForwardedRef<HTMLDivEleme
   );
 }
 
-export const CheckboxContext = createContext<ContextValue<CheckboxProps, HTMLInputElement>>(null);
+export const CheckboxContext = createContext<ContextValue<CheckboxProps, HTMLLabelElement>>(null);
 
-function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLInputElement>) {
+function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) {
   [props, ref] = useContextProps(props, ref, CheckboxContext);
+  let inputRef = useRef<HTMLInputElement>(null);
   let groupState = useContext(CheckboxGroupStateContext);
   let {inputProps, isSelected, isDisabled, isReadOnly, isPressed: isPressedKeyboard, isInvalid} = groupState
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -172,14 +173,14 @@ function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLInputElement>) {
       value: props.value,
       // ReactNode type doesn't allow function children.
       children: typeof props.children === 'function' ? true : props.children
-    }, groupState, ref)
+    }, groupState, inputRef)
     // eslint-disable-next-line react-hooks/rules-of-hooks
     : useCheckbox({
       ...props,
       children: typeof props.children === 'function' ? true : props.children,
       validationBehavior: props.validationBehavior ?? 'native'
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    }, useToggleState(props), ref);
+    }, useToggleState(props), inputRef);
   let {isFocused, isFocusVisible, focusProps} = useFocusRing();
   let isInteractionDisabled = isDisabled || isReadOnly;
 
@@ -231,6 +232,7 @@ function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLInputElement>) {
   return (
     <label
       {...mergeProps(DOMProps, pressProps, hoverProps, renderProps)}
+      ref={ref}
       slot={props.slot || undefined}
       data-selected={isSelected || undefined}
       data-indeterminate={props.isIndeterminate || undefined}
@@ -243,7 +245,7 @@ function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLInputElement>) {
       data-invalid={isInvalid || undefined}
       data-required={props.isRequired || undefined}>
       <VisuallyHidden elementType="span">
-        <input {...inputProps} {...focusProps} ref={ref} />
+        <input {...inputProps} {...focusProps} ref={inputRef} />
       </VisuallyHidden>
       {renderProps.children}
     </label>

--- a/packages/react-aria-components/src/Heading.tsx
+++ b/packages/react-aria-components/src/Heading.tsx
@@ -25,7 +25,7 @@ function Heading(props: HeadingProps, ref: ForwardedRef<HTMLHeadingElement>) {
   let Element = `h${level}` as ElementType;
 
   return (
-    <Element {...domProps} className={className ?? 'react-aria-Heading'}>
+    <Element {...domProps} ref={ref} className={className ?? 'react-aria-Heading'}>
       {children}
     </Element>
   );

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -13,10 +13,10 @@
 import {AriaRadioGroupProps, AriaRadioProps, HoverEvents, Orientation, useFocusRing, useHover, usePress, useRadio, useRadioGroup, VisuallyHidden} from 'react-aria';
 import {ContextValue, forwardRefType, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {FieldErrorContext} from './FieldError';
-import {filterDOMProps, mergeProps, useObjectRef} from '@react-aria/utils';
+import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {LabelContext} from './Label';
 import {RadioGroupState, useRadioGroupState} from 'react-stately';
-import React, {createContext, ForwardedRef, forwardRef, useState} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, useRef, useState} from 'react';
 import {TextContext} from './Text';
 
 export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps {}
@@ -103,7 +103,7 @@ export interface RadioRenderProps {
 }
 
 export const RadioGroupContext = createContext<ContextValue<RadioGroupProps, HTMLDivElement>>(null);
-export const RadioContext = createContext<ContextValue<Partial<RadioProps>, HTMLInputElement>>(null);
+export const RadioContext = createContext<ContextValue<Partial<RadioProps>, HTMLLabelElement>>(null);
 export const RadioGroupStateContext = createContext<RadioGroupState | null>(null);
 
 function RadioGroup(props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) {
@@ -162,15 +162,15 @@ function RadioGroup(props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) {
   );
 }
 
-function Radio(props: RadioProps, ref: ForwardedRef<HTMLInputElement>) {
+function Radio(props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) {
   [props, ref] = useContextProps(props, ref, RadioContext);
   let state = React.useContext(RadioGroupStateContext)!;
-  let domRef = useObjectRef(ref);
+  let inputRef = useRef<HTMLInputElement>(null);
   let {inputProps, isSelected, isDisabled, isPressed: isPressedKeyboard} = useRadio({
     ...removeDataAttributes<RadioProps>(props),
     // ReactNode type doesn't allow function children.
     children: typeof props.children === 'function' ? true : props.children
-  }, state, domRef);
+  }, state, inputRef);
   let {isFocused, isFocusVisible, focusProps} = useFocusRing();
   let interactionDisabled = isDisabled || state.isReadOnly;
 
@@ -220,6 +220,7 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLInputElement>) {
   return (
     <label
       {...mergeProps(DOMProps, pressProps, hoverProps, renderProps)}
+      ref={ref}
       data-selected={isSelected || undefined}
       data-pressed={pressed || undefined}
       data-hovered={isHovered || undefined}
@@ -230,7 +231,7 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLInputElement>) {
       data-invalid={state.isInvalid || undefined}
       data-required={state.isRequired || undefined}>
       <VisuallyHidden elementType="span">
-        <input {...mergeProps(inputProps, focusProps)} ref={domRef} />
+        <input {...mergeProps(inputProps, focusProps)} ref={inputRef} />
       </VisuallyHidden>
       {renderProps.children}
     </label>

--- a/packages/react-aria-components/src/Switch.tsx
+++ b/packages/react-aria-components/src/Switch.tsx
@@ -60,7 +60,7 @@ export interface SwitchRenderProps {
   state: ToggleState
 }
 
-export const SwitchContext = createContext<ContextValue<SwitchProps, HTMLInputElement>>(null);
+export const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>(null);
 
 function Switch(props: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) {
   [props, ref] = useContextProps(props, ref, SwitchContext);

--- a/packages/react-aria-components/src/Switch.tsx
+++ b/packages/react-aria-components/src/Switch.tsx
@@ -13,7 +13,7 @@
 import {AriaSwitchProps, HoverEvents, mergeProps, useFocusRing, useHover, usePress, useSwitch, VisuallyHidden} from 'react-aria';
 import {ContextValue, forwardRefType, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
-import React, {createContext, ForwardedRef, forwardRef, useState} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, useRef, useState} from 'react';
 import {ToggleState, useToggleState} from 'react-stately';
 
 export interface SwitchProps extends Omit<AriaSwitchProps, 'children'>, HoverEvents, RenderProps<SwitchRenderProps>, SlotProps {}
@@ -62,14 +62,15 @@ export interface SwitchRenderProps {
 
 export const SwitchContext = createContext<ContextValue<SwitchProps, HTMLInputElement>>(null);
 
-function Switch(props: SwitchProps, ref: ForwardedRef<HTMLInputElement>) {
+function Switch(props: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) {
   [props, ref] = useContextProps(props, ref, SwitchContext);
+  let inputRef = useRef<HTMLInputElement>(null);
   let state = useToggleState(props);
   let {inputProps, isSelected, isDisabled, isReadOnly, isPressed: isPressedKeyboard} = useSwitch({
     ...removeDataAttributes(props),
     // ReactNode type doesn't allow function children.
     children: typeof props.children === 'function' ? true : props.children
-  }, state, ref);
+  }, state, inputRef);
   let {isFocused, isFocusVisible, focusProps} = useFocusRing();
   let isInteractionDisabled = props.isDisabled || props.isReadOnly;
 
@@ -118,6 +119,7 @@ function Switch(props: SwitchProps, ref: ForwardedRef<HTMLInputElement>) {
   return (
     <label
       {...mergeProps(DOMProps, pressProps, hoverProps, renderProps)}
+      ref={ref}
       slot={props.slot || undefined}
       data-selected={isSelected || undefined}
       data-pressed={pressed || undefined}
@@ -127,7 +129,7 @@ function Switch(props: SwitchProps, ref: ForwardedRef<HTMLInputElement>) {
       data-disabled={isDisabled || undefined}
       data-readonly={isReadOnly || undefined}>
       <VisuallyHidden elementType="span">
-        <input {...inputProps} {...focusProps} ref={ref} />
+        <input {...inputProps} {...focusProps} ref={inputRef} />
       </VisuallyHidden>
       {renderProps.children}
     </label>

--- a/packages/react-aria-components/test/Breadcrumbs.test.js
+++ b/packages/react-aria-components/test/Breadcrumbs.test.js
@@ -87,4 +87,20 @@ describe('Breadcrumbs', () => {
 
     expect(getAllByRole('listitem').map((it) => it.textContent)).toEqual(['Item 1', 'Item 2', 'Item 3']);
   });
+
+  it('should support refs', () => {
+    let breadcrumbsRef = React.createRef();
+    let breadcrumbRef = React.createRef();
+    let {getByRole} = render(
+      <Breadcrumbs ref={breadcrumbsRef}>
+        <Breadcrumb ref={breadcrumbRef}><Link>Test</Link></Breadcrumb>
+      </Breadcrumbs>
+    );
+
+    let breadcrumbs = getByRole('list');
+    expect(breadcrumbsRef.current).toBe(breadcrumbs);
+
+    let item = getByRole('listitem');
+    expect(breadcrumbRef.current).toBe(item);
+  });
 });

--- a/packages/react-aria-components/test/Checkbox.test.js
+++ b/packages/react-aria-components/test/Checkbox.test.js
@@ -190,4 +190,10 @@ describe('Checkbox', () => {
     await user.click(checkbox);
     expect(checkbox).toHaveTextContent('Selected');
   });
+
+  it('should support refs', () => {
+    let ref = React.createRef();
+    let {getByRole} = render(<Checkbox ref={ref}>Test</Checkbox>);
+    expect(ref.current).toBe(getByRole('checkbox').closest('.react-aria-Checkbox'));
+  });
 });

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -452,4 +452,17 @@ describe('RadioGroup', () => {
     expect(group).not.toHaveAttribute('aria-describedby');
     expect(group).not.toHaveAttribute('data-invalid');
   });
+
+  it('should support refs', () => {
+    let groupRef = React.createRef();
+    let radioRef = React.createRef();
+    let {getByRole} = render(
+      <RadioGroup ref={groupRef}>
+        <Label>Test</Label>
+        <Radio ref={radioRef} value="a">A</Radio>
+      </RadioGroup>
+    );
+    expect(groupRef.current).toBe(getByRole('radiogroup'));
+    expect(radioRef.current).toBe(getByRole('radio').closest('.react-aria-Radio'));
+  });
 });

--- a/packages/react-aria-components/test/Switch.test.js
+++ b/packages/react-aria-components/test/Switch.test.js
@@ -175,4 +175,10 @@ describe('Switch', () => {
     expect(outerEl).toHaveLength(1);
     expect(outerEl[0]).toHaveClass('react-aria-Switch');
   });
+
+  it('should support refs', () => {
+    let ref = React.createRef();
+    let {getByRole} = render(<Switch ref={ref}>Test</Switch>);
+    expect(ref.current).toBe(getByRole('switch').closest('.react-aria-Switch'));
+  });
 });


### PR DESCRIPTION
Found this with Switch when I wanted to use an IntersectionObserver with it but it didn't work because of the VisuallyHidden. But for consistency we should make all refs in RAC components go to the outer-most element.