### PR TITLE
Fix ActionGroup icon padding when overflow="collapse" and buttonLabelBehavior="hide"

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -54,7 +54,7 @@ governing permissions and limitations under the License.
       padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
     }
 
-    .spectrum-ActionGroup-item-icon {
+    .spectrum-ActionGroup-itemIcon {
       padding-inline-end: 0;
     }
   }

--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -49,10 +49,14 @@ governing permissions and limitations under the License.
 
   .spectrum-ActionGroup-item {
     flex-shrink: 0;
-  }
 
-  .spectrum-ActionGroup-item--iconOnly {
-    padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
+    &.spectrum-ActionGroup-item--iconOnly {
+      padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
+    }
+
+    .spectrum-ActionGroup-item-icon {
+      padding-inline-end: 0;
+    }
   }
 
   &:focus {

--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -51,6 +51,10 @@ governing permissions and limitations under the License.
     flex-shrink: 0;
   }
 
+  .spectrum-ActionGroup-item--iconOnly {
+    padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
+  }
+
   &:focus {
     outline: none;
   }
@@ -199,8 +203,4 @@ governing permissions and limitations under the License.
     align-items: center;
     justify-content: center;
   }
-}
-
-.spectrum-ActionGroup-item--iconOnly {
-  padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
 }

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -310,7 +310,7 @@ function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, staticColor,
               isHidden: hideButtonText
             },
             icon: {
-              UNSAFE_className: hideButtonText ? classNames(styles, 'spectrum-ActionGroup-item-icon') : null
+              UNSAFE_className: hideButtonText ? classNames(styles, 'spectrum-ActionGroup-itemIcon') : null
             }
           }}>
           <ActionButton

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -308,6 +308,9 @@ function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, staticColor,
             text: {
               id: hideButtonText ? textId : null,
               isHidden: hideButtonText
+            },
+            icon: {
+              UNSAFE_className: hideButtonText ? classNames(styles, 'spectrum-ActionGroup-item-icon') : null
             }
           }}>
           <ActionButton


### PR DESCRIPTION
Closes https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=46694245

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Try the actiongroup stories with overflow="collapse" and buttonLabelBehavior="hide"

## 🧢 Your Project:

RSP
