### PR TITLE
Fix RAC Table caching issues

### DIFF
--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -647,12 +647,16 @@ export interface CollectionProps<T> extends Omit<CollectionBase<T>, 'children'> 
 
 interface CachedChildrenOptions<T> extends CollectionProps<T> {
   idScope?: Key,
-  addIdAndValue?: boolean
+  addIdAndValue?: boolean,
+  value?: any
 }
 
 export function useCachedChildren<T extends object>(props: CachedChildrenOptions<T>): ReactNode {
-  let {children, items, idScope, addIdAndValue} = props;
-  let cache = useMemo(() => new WeakMap(), []);
+  let {children, items, idScope, addIdAndValue, value} = props;
+
+  // Invalidate the cache whenever the parent value changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  let cache = useMemo(() => new WeakMap(), [value]);
   return useMemo(() => {
     if (items && typeof children === 'function') {
       let res: ReactElement[] = [];

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -570,7 +570,6 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
 
   removeNode(node: ElementNode<T>) {
     for (let child of node) {
-      child.parentNode = null;
       this.removeNode(child);
     }
 

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -150,6 +150,10 @@ class BaseNode<T> {
     this.ownerDocument.markDirty(this);
   }
 
+  get isConnected() {
+    return this.parentNode?.isConnected || false;
+  }
+
   appendChild(child: ElementNode<T>) {
     this.ownerDocument.startTransaction();
     if (child.parentNode) {
@@ -515,6 +519,10 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
     this.collectionMutated = true;
   }
 
+  get isConnected() {
+    return true;
+  }
+
   createElement(type: string) {
     return new ElementNode(type, this);
   }
@@ -590,7 +598,7 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
 
   updateCollection() {
     for (let element of this.dirtyNodes) {
-      if (element instanceof ElementNode && element.parentNode) {
+      if (element instanceof ElementNode && element.isConnected) {
         element.updateNode();
       }
     }
@@ -600,7 +608,7 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
     if (this.mutatedNodes.size) {
       let collection = this.getMutableCollection();
       for (let element of this.mutatedNodes) {
-        if (element.parentNode) {
+        if (element.isConnected) {
           collection.addNode(element.node);
         }
       }

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -608,17 +608,20 @@ export interface RowProps<T> extends StyleRenderProps<RowRenderProps>, LinkDOMPr
   /** The cells within the row. Supports static items or a function for dynamic rendering. */
   children?: ReactNode | ((item: T) => ReactElement),
   /** A string representation of the row's contents, used for features like typeahead. */
-  textValue?: string
+  textValue?: string,
+  /** The object value that this row represents. When using dynamic collections, this is set automatically. */
+  value?: any
 }
 
 function Row<T extends object>(props: RowProps<T>, ref: ForwardedRef<HTMLTableRowElement>): React.JSX.Element | null {
   let children = useCollectionChildren({
+    value: props.value,
     children: props.children,
     items: props.columns,
     idScope: props.id
   });
 
-  let ctx = useMemo(() => ({idScope: props.id}), [props.id]);
+  let ctx = useMemo(() => ({idScope: props.id, value: props.value}), [props.id, props.value]);
 
   return useSSRCollectionNode('item', props, ref, null, (
     <CollectionContext.Provider value={ctx}>

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -684,6 +684,28 @@ describe('Table', () => {
     expect(cells[0]).toHaveTextContent('Foo (focused)');
   });
 
+  it('should support updating columns', () => {
+    let tree = render(<DynamicTable tableHeaderProps={{columns}} tableBodyProps={{dependencies: [columns]}} rowProps={{columns}} />);
+    let headers = tree.getAllByRole('columnheader');
+    expect(headers).toHaveLength(3);
+
+    let newColumns = [columns[0], columns[2]];
+    tree.rerender(<DynamicTable tableHeaderProps={{columns: newColumns}} tableBodyProps={{dependencies: [newColumns]}} rowProps={{columns: newColumns}} />);
+
+    headers = tree.getAllByRole('columnheader');
+    expect(headers).toHaveLength(2);
+  });
+
+  it('should support updating and reordering a row at the same time', () => {
+    let tree = render(<DynamicTable tableBodyProps={{items: rows}} />);
+    let rowHeaders = tree.getAllByRole('rowheader');
+    expect(rowHeaders.map(r => r.textContent)).toEqual(['Games', 'Program Files', 'bootmgr', 'log.txt']);
+
+    tree.rerender(<DynamicTable tableBodyProps={{items: [rows[1], {...rows[0], name: 'XYZ'}, ...rows.slice(2)]}} />);
+    rowHeaders = tree.getAllByRole('rowheader');
+    expect(rowHeaders.map(r => r.textContent)).toEqual(['Program Files', 'XYZ', 'bootmgr', 'log.txt']);
+  });
+
   describe('drag and drop', () => {
     it('should support drag button slot', () => {
       let {getAllByRole} = render(<DraggableTable />);


### PR DESCRIPTION
This fixes two issues:

1. When updating the list of `columns` in a dynamic collection, the Table would crash. This was due to the caching of rows in `TableBody` not knowing that the columns changed, resulting in the rows having a different number of cells than the header had columns. This is fixed by adding a `dependencies` prop to collection components which you can provide an array of values that should invalidate the cache. Not ideal but this is a good escape hatch to have anyway and we can try to simplify more in the future.

2. When updating and reordering a row at the same time (e.g. due to the update causing a sort change), the cells wouldn't update correctly. This was due to an ordering of operations issue, where React would remove the row from the tree, then update the cell, and then re-insert the row. A bug related to updating the `parentNode` property of the cell to `null` even though it was still connected to the row was the issue here. Now it is retained and we check an `isConnected` property instead.