### PR TITLE
Prevent flicker from all items to filtered collection when combobox is animating closed

### DIFF
--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -148,22 +148,26 @@ export function useComboBoxState<T extends object>(props: ComboBoxStateOptions<T
     toggleMenu(focusStrategy);
   };
 
+  let updateLastCollection = useCallback(() => {
+    setLastCollection(showAllItems ? originalCollection : filteredCollection);
+  }, [showAllItems, originalCollection, filteredCollection]);
+
   // If menu is going to close, save the current collection so we can freeze the displayed collection when the
   // user clicks outside the popover to close the menu. Prevents the menu contents from updating as the menu closes.
   let toggleMenu = useCallback((focusStrategy) => {
     if (triggerState.isOpen) {
-      setLastCollection(filteredCollection);
+      updateLastCollection();
     }
 
     triggerState.toggle(focusStrategy);
-  }, [triggerState, filteredCollection]);
+  }, [triggerState, updateLastCollection]);
 
   let closeMenu = useCallback(() => {
     if (triggerState.isOpen) {
-      setLastCollection(filteredCollection);
+      updateLastCollection();
       triggerState.close();
     }
-  }, [triggerState, filteredCollection]);
+  }, [triggerState, updateLastCollection]);
 
   let [lastValue, setLastValue] = useState(inputValue);
   let resetInputValue = () => {


### PR DESCRIPTION
Issue can be seen in the docs or storybook. If you select an item, and then click the button to open the listbox repeatedly, the collection changes while the menu is animating closed causing a flicker. It can even cause the popover to flip depending on the scenario. Original fix was in #4060 but this extends it to use the original collection rather than the filtered collection if `showAllItems` is true.