### PR TITLE
Ensure DismissButton has a height so it works with iOS VO

### DIFF
--- a/packages/@react-aria/overlays/src/DismissButton.tsx
+++ b/packages/@react-aria/overlays/src/DismissButton.tsx
@@ -45,7 +45,8 @@ export function DismissButton(props: DismissButtonProps) {
       <button
         {...labels}
         tabIndex={-1}
-        onClick={onClick} />
+        onClick={onClick}
+        style={{width: 1, height: 1}} />
     </VisuallyHidden>
   );
 }


### PR DESCRIPTION
Noticed that the dismiss button in popovers was not working on iOS VO on the new homepage. Looks like it was caused by Tailwind's CSS reset which removes the default padding from buttons. That caused it to be zero width/height, which iOS VO will ignore. This adds an inline width and height property to ensure it is always set. Should not affect anything because it's inside a VisuallyHidden already.