### PR TITLE
Scroll into view when auto focusing regardless of modality

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -395,7 +395,6 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
         focusSafely(ref.current);
       }
     }
-    autoFocusRef.current = false;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -406,7 +405,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
     let modality = getInteractionModality();
     if (manager.isFocused && manager.focusedKey != null && scrollRef?.current) {
       let element = scrollRef.current.querySelector(`[data-key="${manager.focusedKey}"]`) as HTMLElement;
-      if (element && modality === 'keyboard') {
+      if (element && (modality === 'keyboard' || autoFocusRef.current)) {
         if (!isVirtualized) {
           scrollIntoView(scrollRef.current, element);
         }
@@ -420,6 +419,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
     }
 
     lastFocusedKey.current = manager.focusedKey;
+    autoFocusRef.current = false;
   }, [isVirtualized, scrollRef, manager.focusedKey, manager.isFocused, ref]);
 
   let handlers = {


### PR DESCRIPTION
Fixes #4974

Previously clicking on a Select with a scrolling listbox would not scroll the selected item into view if using a mouse. Can test in the docs for useSelect.

Credit to @LFDanLu who did the digging in https://github.com/adobe/react-spectrum/issues/4974#issuecomment-1693685004, I just updated our handling for non-virtualized collections to match what virtualizer does.