### PR TITLE
SearchField escape key propagates #5480

### DIFF
--- a/packages/@react-aria/searchfield/src/useSearchField.ts
+++ b/packages/@react-aria/searchfield/src/useSearchField.ts
@@ -57,7 +57,7 @@ export function useSearchField(
   let onKeyDown = (e) => {
     const key = e.key;
 
-    if (key === 'Enter' || key === 'Escape') {
+    if (key === 'Enter') {
       e.preventDefault();
     }
 
@@ -74,6 +74,7 @@ export function useSearchField(
       if (onClear) {
         onClear();
       }
+      e.continuePropagation();
     }
   };
 

--- a/packages/@react-spectrum/searchfield/stories/SearchField.stories.tsx
+++ b/packages/@react-spectrum/searchfield/stories/SearchField.stories.tsx
@@ -11,8 +11,10 @@
  */
 
 import {action} from '@storybook/addon-actions';
+import {ActionButton} from '@react-spectrum/button';
 import {Content} from '@react-spectrum/view';
 import {ContextualHelp} from '@react-spectrum/contextualhelp';
+import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Flex} from '@react-spectrum/layout';
 import {Heading} from '@react-spectrum/text';
 import React from 'react';
@@ -170,6 +172,25 @@ export const CustomWidthAndNarrowContainer = (args) => (
 
 CustomWidthAndNarrowContainer.story = {
   name: 'custom width and narrow container'
+};
+
+export const WithinAPopover = (args) => (
+  <DialogTrigger type="popover">
+    <ActionButton>Trigger</ActionButton>
+    <Dialog>
+      <Heading>The Heading</Heading>
+      <Content>
+        <SearchField
+          label="Search"
+          onChange={action('change')}
+          onSubmit={action('submit')} />
+      </Content>
+    </Dialog>
+  </DialogTrigger>
+);
+
+WithinAPopover.story = {
+  name: 'within a popover'
 };
 
 function renderSearchLandmark(child) {


### PR DESCRIPTION
Closes #5480

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

added new searchfield story with it in a popover

## 🧢 Your Project:
RSP