### PR TITLE
Respect Tailwind hoverOnlyWhenSupported, and fix placeholder-shown with Input

### DIFF
--- a/packages/tailwindcss-react-aria-components/src/index.js
+++ b/packages/tailwindcss-react-aria-components/src/index.js
@@ -66,7 +66,11 @@ const nativeVariantSelectors = new Map([
   ['hovered', ':hover'],
   ['focused', ':focus'],
   ['readonly', ':read-only'],
-  ['open', '[open]'],
+  ['open', '[open]']
+]);
+
+// Variants where both native and RAC attributes should apply. We don't override these.
+const nativeMergeSelectors = new Map([
   ['placeholder', ':placeholder-shown']
 ]);
 
@@ -75,6 +79,8 @@ let getSelector = (prefix, attributeName, attributeValue) => {
   let baseSelector = attributeValue ? `[data-${attributeName}="${attributeValue}"]` : `[data-${attributeName}]`;
   if (prefix === '' && nativeVariantSelectors.has(attributeName)) {
     return [`&:where([data-rac])${baseSelector}`, `&:where(:not([data-rac]))${nativeVariantSelectors.get(attributeName)}`];
+  } else if (nativeMergeSelectors.has(attributeName)) {
+    return [`&${baseSelector}`, `&${nativeMergeSelectors.get(attributeName)}`];
   } else {
     return `&${baseSelector}`;
   }

--- a/packages/tailwindcss-react-aria-components/src/index.js
+++ b/packages/tailwindcss-react-aria-components/src/index.js
@@ -75,10 +75,16 @@ const nativeMergeSelectors = new Map([
 ]);
 
 // If no prefix is specified, we want to avoid overriding native variants on non-RAC components, so we only target elements with the data-rac attribute for those variants.
-let getSelector = (prefix, attributeName, attributeValue) => {
+let getSelector = (prefix, attributeName, attributeValue, hoverOnlyWhenSupported) => {
   let baseSelector = attributeValue ? `[data-${attributeName}="${attributeValue}"]` : `[data-${attributeName}]`;
-  if (prefix === '' && nativeVariantSelectors.has(attributeName)) {
-    return [`&:where([data-rac])${baseSelector}`, `&:where(:not([data-rac]))${nativeVariantSelectors.get(attributeName)}`];
+  let nativeSelector = nativeVariantSelectors.get(attributeName);
+  if (prefix === '' && nativeSelector) {
+    let wrappedNativeSelector = `&:where(:not([data-rac]))${nativeSelector}`;
+    let nativeSelectorGenerator = wrappedNativeSelector;
+    if (nativeSelector === ':hover' && hoverOnlyWhenSupported) {
+      nativeSelectorGenerator = wrap => `@media (hover: hover) and (pointer: fine) { ${wrap(wrappedNativeSelector)} }`;
+    }
+    return [`&:where([data-rac])${baseSelector}`, nativeSelectorGenerator];
   } else if (prefix === '' && nativeMergeSelectors.has(attributeName)) {
     return [`&${baseSelector}`, `&${nativeMergeSelectors.get(attributeName)}`];
   } else {
@@ -94,28 +100,38 @@ let mapSelector = (selector, fn) => {
   }
 };
 
+let wrapSelector = (selector, wrap) => {
+  if (typeof selector === 'function') {
+    return selector(wrap);
+  } else {
+    return wrap(selector);
+  }
+};
+
 let addVariants = (variantName, selectors, addVariant, matchVariant) => {
-  addVariant(variantName, selectors);
+  addVariant(variantName, mapSelector(selectors, selector => wrapSelector(selector, s => s)));
   matchVariant(
     'group',
     (_, {modifier}) =>
       modifier
-        ? mapSelector(selectors, selector => `:merge(.group\\/${modifier})${selector.slice(1)} &`)
-        : mapSelector(selectors, selector => `:merge(.group)${selector.slice(1)} &`),
+        ? mapSelector(selectors, selector => wrapSelector(selector, s => `:merge(.group\\/${modifier})${s.slice(1)} &`))
+        : mapSelector(selectors, selector => wrapSelector(selector, s => `:merge(.group)${s.slice(1)} &`)),
     {values: {[variantName]: variantName}}
   );
   matchVariant(
     'peer',
     (_, {modifier}) =>
       modifier
-        ? mapSelector(selectors, selector => `:merge(.peer\\/${modifier})${selector.slice(1)} ~ &`)
-        : mapSelector(selectors, selector => `:merge(.peer)${selector.slice(1)} ~ &`),
+        ? mapSelector(selectors, selector => wrapSelector(selector, s => `:merge(.peer\\/${modifier})${s.slice(1)} ~ &`))
+        : mapSelector(selectors, selector => wrapSelector(selector, s => `:merge(.peer)${s.slice(1)} ~ &`)),
     {values: {[variantName]: variantName}}
   );
 };
 
-module.exports = plugin.withOptions((options) => (({addVariant, matchVariant}) => {
+module.exports = plugin.withOptions((options) => (({addVariant, matchVariant, config}) => {
   let prefix = options?.prefix ? `${options.prefix}-` : '';
+  let future = config().future;
+  let hoverOnlyWhenSupported = future === 'all' || future?.hoverOnlyWhenSupported;
 
   // Enum attributes go first because currently they are all non-interactive states.
   Object.keys(attributes.enum).forEach((attributeName) => {
@@ -123,7 +139,7 @@ module.exports = plugin.withOptions((options) => (({addVariant, matchVariant}) =
       (attributeValue) => {
         let name = shortNames[attributeName] || attributeName;
         let variantName = `${prefix}${name}-${attributeValue}`;
-        let selectors = getSelector(prefix, attributeName, attributeValue);
+        let selectors = getSelector(prefix, attributeName, attributeValue, hoverOnlyWhenSupported);
         addVariants(variantName, selectors, addVariant, matchVariant);
       }
     );
@@ -133,7 +149,7 @@ module.exports = plugin.withOptions((options) => (({addVariant, matchVariant}) =
     let variantName = Array.isArray(attribute) ? attribute[0] : attribute;
     variantName = `${prefix}${variantName}`;
     let attributeName = Array.isArray(attribute) ? attribute[1] : attribute;
-    let selectors = getSelector(prefix, attributeName);
+    let selectors = getSelector(prefix, attributeName, null, hoverOnlyWhenSupported);
     addVariants(variantName, selectors, addVariant, matchVariant);
   });
 }));

--- a/packages/tailwindcss-react-aria-components/src/index.js
+++ b/packages/tailwindcss-react-aria-components/src/index.js
@@ -79,7 +79,7 @@ let getSelector = (prefix, attributeName, attributeValue) => {
   let baseSelector = attributeValue ? `[data-${attributeName}="${attributeValue}"]` : `[data-${attributeName}]`;
   if (prefix === '' && nativeVariantSelectors.has(attributeName)) {
     return [`&:where([data-rac])${baseSelector}`, `&:where(:not([data-rac]))${nativeVariantSelectors.get(attributeName)}`];
-  } else if (nativeMergeSelectors.has(attributeName)) {
+  } else if (prefix === '' && nativeMergeSelectors.has(attributeName)) {
     return [`&${baseSelector}`, `&${nativeMergeSelectors.get(attributeName)}`];
   } else {
     return `&${baseSelector}`;

--- a/packages/tailwindcss-react-aria-components/src/index.test.js
+++ b/packages/tailwindcss-react-aria-components/src/index.test.js
@@ -138,11 +138,11 @@ test('variants', async () => {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.placeholder-shown\:bg-red:where([data-rac])[data-placeholder] {
+.placeholder-shown\:bg-red[data-placeholder] {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }
-.placeholder-shown\:bg-red:where(:not([data-rac])):placeholder-shown {
+.placeholder-shown\:bg-red:placeholder-shown {
     --tw-bg-opacity: 1;
     background-color: rgb(255 0 0 / var(--tw-bg-opacity))
 }


### PR DESCRIPTION
Two fixes for tailwindcss-react-aria-components:

1. Respect the `hoverOnlyWhenSupported` option in the tailwind config, which wraps native `:hover` selectors with a `@media (hover: hover)` media query so they don't apply on touch devices.
2. Make the `placeholder-shown:` variant work with the RAC `Input` component, which has `data-rac` but doesn't apply `data-placeholder`. In this case, we want both the native and the RAC version to apply without the `data-rac` check because they never overlap on the same elements.