### PR TITLE
Fix tree shaking of TextField component

### DIFF
--- a/packages/react-aria-components/src/TextField.tsx
+++ b/packages/react-aria-components/src/TextField.tsx
@@ -100,5 +100,5 @@ function TextField(props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) {
 /**
  * A text field allows a user to enter a plain text value with a keyboard.
  */
-const _TextField = (forwardRef as forwardRefType)(TextField);
+const _TextField = /*#__PURE__*/ (forwardRef as forwardRefType)(TextField);
 export {_TextField as TextField};


### PR DESCRIPTION
Was missing a `/*#__PURE__*/` comment on the forwardRef call, causing it to never be tree-shaken.