### PR TITLE
allow passing readonly array to LocalesPlugin

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.d.ts
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.d.ts
@@ -1,7 +1,7 @@
 import {UnpluginInstance} from 'unplugin';
 
 type Options = {
-  locales: string[]
+  locales: readonly string[]
 };
 
 declare const plugin: UnpluginInstance<Options, boolean>;


### PR DESCRIPTION
this pr updates types to allow passing a readonly array to the optimize-locales plugin options, e.g.:

```ts
const locales = ["de", "en"] as const
// ...
optimizeLocales.webpack({ locales })
```

