### PR TITLE
Add isDisabled render prop to DateSegment

### DIFF
--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -289,6 +289,11 @@ export interface DateSegmentRenderProps extends Omit<IDateSegment, 'isEditable'>
    */
   isReadOnly: boolean,
   /**
+   * Whether the date field is disabled.
+   * @selector [data-disabled]
+   */
+  isDisabled: boolean,
+  /**
    * Whether the date field is in an invalid state.
    * @selector [data-invalid]
    */
@@ -318,6 +323,7 @@ function DateSegment({segment, ...otherProps}: DateSegmentProps, ref: ForwardedR
       ...segment,
       isReadOnly: !segment.isEditable,
       isInvalid: state.isInvalid,
+      isDisabled: state.isDisabled,
       isHovered,
       isFocused,
       isFocusVisible
@@ -335,6 +341,7 @@ function DateSegment({segment, ...otherProps}: DateSegmentProps, ref: ForwardedR
       data-placeholder={segment.isPlaceholder || undefined}
       data-invalid={state.isInvalid || undefined}
       data-readonly={!segment.isEditable || undefined}
+      data-disabled={state.isDisabled || undefined}
       data-type={segment.type}
       data-hovered={isHovered || undefined}
       data-focused={isFocused || undefined}


### PR DESCRIPTION
To make it easier to style the disabled state, add `isDisabled` render prop and `data-disabled` attribute to `DateSegment`. Extracted from #5666