### PR TITLE
[Docs] Fix <Popover> offset prop default value

### DIFF
--- a/packages/react-aria-components/src/Popover.tsx
+++ b/packages/react-aria-components/src/Popover.tsx
@@ -18,7 +18,7 @@ import {OverlayTriggerProps, OverlayTriggerState, useOverlayTriggerState} from '
 import {OverlayTriggerStateContext} from './Dialog';
 import React, {createContext, ForwardedRef, forwardRef, RefObject, useContext} from 'react';
 
-export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPopoverProps, 'popoverRef' | 'triggerRef'>, OverlayTriggerProps, RenderProps<PopoverRenderProps>, SlotProps {
+export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPopoverProps, 'popoverRef' | 'triggerRef' | 'offset'>, OverlayTriggerProps, RenderProps<PopoverRenderProps>, SlotProps {
   /**
    * The name of the component that triggered the popover. This is reflected on the element
    * as the `data-trigger` attribute, and can be used to provide specific
@@ -44,7 +44,13 @@ export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPo
    * The container element in which the overlay portal will be placed. This may have unknown behavior depending on where it is portalled to.
    * @default document.body
    */
-  UNSTABLE_portalContainer?: Element
+  UNSTABLE_portalContainer?: Element,
+  /**
+   * The additional offset applied along the main axis between the element and its
+   * anchor element.
+   * @default 8
+   */
+  offset?: number
 }
 
 export interface PopoverRenderProps {


### PR DESCRIPTION
Hello, I've noticed that the default value of `props.offset` for `<Popover>` component is actually `8` not `0` as [the current docs states](https://react-spectrum.adobe.com/react-aria/Popover.html#props).

https://github.com/adobe/react-spectrum/blob/80fcbf54206ca1ffb011f28fabcfc982d97bca5f/packages/react-aria-components/src/Popover.tsx#L126-L130

This PR corrects the default value of `props.offset` to 8 by re-defining the `offset` prop and omitting the originally inherited one from `PositionProps` (as a minor consequence of this, the order of the prop table in the docs is a little different)

I'm not sure if this is the best way to override the default value of some inherited props, so let me know if there's a better way.

Thanks.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:
1. Visit http://localhost:1234/react-aria/Popover.html#props
2. Check if the default value of the prop `offset` is `8`.

## 🧢 Your Project:

<!--- Company/project for pull request -->
