### PR TITLE
Fix ComboBox async loading runtime error

### DIFF
--- a/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
+++ b/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
@@ -170,7 +170,7 @@ export class ListKeyboardDelegate<T> implements KeyboardDelegate {
     let key = this.collection.getFirstKey();
     while (key != null) {
       let item = this.collection.getItem(key);
-      if (item.type === 'item' && !this.disabledKeys.has(key)) {
+      if (item?.type === 'item' && !this.disabledKeys.has(key)) {
         return key;
       }
 

--- a/packages/react-aria-components/stories/ComboBox.stories.tsx
+++ b/packages/react-aria-components/stories/ComboBox.stories.tsx
@@ -14,6 +14,7 @@ import {Button, ComboBox, Input, Label, ListBox, Popover} from 'react-aria-compo
 import {MyListBoxItem} from './utils';
 import React from 'react';
 import styles from '../example/index.css';
+import {useAsyncList} from 'react-stately';
 
 export default {
   title: 'React Aria Components'
@@ -139,3 +140,46 @@ export const ComboBoxRenderPropsListBoxDynamic = () => (
     )}
   </ComboBox>
 );
+
+export const ComboBoxAsyncLoadingExample = () => {
+  let list = useAsyncList<ComboBoxItem>({
+    async load({filterText}) {
+      let json = await new Promise(resolve => {
+        setTimeout(() => {
+          resolve(filterText ? items.filter(item => {
+            let name = item.name.toLowerCase();
+            for (let filterChar of filterText.toLowerCase()) {
+              if (!name.includes(filterChar)) {
+                return false;
+              }
+              name = name.replace(filterChar, '');
+            }
+            return true;
+          }) : items);
+        }, 300);
+      }) as ComboBoxItem[];
+
+      return {
+        items: json
+      };
+    }
+  });
+
+  return (
+    <ComboBox items={list.items} inputValue={list.filterText} onInputChange={list.setFilterText}>
+      <Label style={{display: 'block'}}>Test</Label>
+      <div style={{display: 'flex'}}>
+        <Input />
+        <Button>
+          <span aria-hidden="true" style={{padding: '0 2px'}}>▼</span>
+        </Button>
+      </div>
+      <Popover placement="bottom end">
+        <ListBox<ComboBoxItem>
+          className={styles.menu}>
+          {item => <MyListBoxItem>{item.name}</MyListBoxItem>}
+        </ListBox>
+      </Popover>
+    </ComboBox>
+  );
+};


### PR DESCRIPTION
Closes #5680

Hello, this PR includes a minimal fix for #5680 and a ComboBox story for an async-loading example.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Visit http://localhost:9003/?path=/story/react-aria-components--combo-box-async-loading-example&providerSwitcher-express=false&strict=true
2. Test the behavior described in the issue #5680.

## 🧢 Your Project:

<!--- Company/project for pull request -->
