### PR TITLE
Fix RAC progressbar and meter overflow

### DIFF
--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -44,6 +44,7 @@
     "@react-aria/toolbar": "3.0.0-beta.1",
     "@react-aria/utils": "^3.23.0",
     "@react-stately/table": "^3.11.4",
+    "@react-stately/utils": "^3.9.0",
     "@react-types/form": "^3.7.1",
     "@react-types/grid": "^3.2.3",
     "@react-types/shared": "^3.22.0",

--- a/packages/react-aria-components/src/Meter.tsx
+++ b/packages/react-aria-components/src/Meter.tsx
@@ -11,6 +11,7 @@
  */
 
 import {AriaMeterProps, useMeter} from 'react-aria';
+import {clamp} from '@react-stately/utils';
 import {ContextValue, forwardRefType, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {LabelContext} from './Label';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
@@ -38,6 +39,7 @@ function Meter(props: MeterProps, ref: ForwardedRef<HTMLDivElement>) {
     minValue = 0,
     maxValue = 100
   } = props;
+  value = clamp(value, minValue, maxValue);
 
   let [labelRef, label] = useSlot();
   let {

--- a/packages/react-aria-components/src/ProgressBar.tsx
+++ b/packages/react-aria-components/src/ProgressBar.tsx
@@ -11,6 +11,7 @@
  */
 
 import {AriaProgressBarProps, useProgressBar} from 'react-aria';
+import {clamp} from '@react-stately/utils';
 import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {LabelContext} from './Label';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
@@ -44,6 +45,7 @@ function ProgressBar(props: ProgressBarProps, ref: ForwardedRef<HTMLDivElement>)
     maxValue = 100,
     isIndeterminate = false
   } = props;
+  value = clamp(value, minValue, maxValue);
 
   let [labelRef, label] = useSlot();
   let {

--- a/packages/react-aria-components/stories/Meter.stories.tsx
+++ b/packages/react-aria-components/stories/Meter.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Label, Meter} from 'react-aria-components';
+import React from 'react';
+
+export default {
+  title: 'React Aria Components',
+  component: Meter,
+  args: {
+    value: 50
+  },
+  argTypes: {
+    value: {control: 'number'},
+    minValue: {control: 'number'},
+    maxValue: {control: 'number'}
+  }
+};
+
+export const MeterExample = (args) => {
+  return (
+    <Meter {...args}>
+      {({percentage, valueText}) => (
+        <>
+          <Label>Storage space</Label>
+          <span className="value">{valueText}</span>
+          <div className="bar">
+            <div className="fill" style={{width: percentage + '%'}} />
+          </div>
+        </>
+      )}
+    </Meter>
+  );
+};

--- a/packages/react-aria-components/stories/ProgressBar.stories.tsx
+++ b/packages/react-aria-components/stories/ProgressBar.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Label, ProgressBar} from 'react-aria-components';
+import React from 'react';
+
+export default {
+  title: 'React Aria Components',
+  component: ProgressBar,
+  args: {
+    value: 50
+  },
+  argTypes: {
+    value: {control: 'number'},
+    minValue: {control: 'number'},
+    maxValue: {control: 'number'}
+  }
+};
+
+export const ProgressBarExample = (args) => {
+  return (
+    <ProgressBar {...args}>
+      {({percentage, valueText}) => (
+        <>
+          <Label>Storage space</Label>
+          <span className="value">{valueText}</span>
+          <div className="bar">
+            <div className="fill" style={{width: percentage + '%'}} />
+          </div>
+        </>
+      )}
+    </ProgressBar>
+  );
+};

--- a/packages/react-aria-components/stories/styles.css
+++ b/packages/react-aria-components/stories/styles.css
@@ -357,3 +357,32 @@
     opacity: 0.4;
   }
 }
+
+:global(.react-aria-Meter) {
+  --fill-color: forestgreen;
+
+  display: grid;
+  grid-template-areas: "label value"
+                       "bar bar";
+  grid-template-columns: 1fr auto;
+  gap: 4px;
+  width: 250px;
+  color: var(--text-color);
+
+  :global(.value) {
+    grid-area: value;
+  }
+
+  :global(.bar) {
+    grid-area: bar;
+    box-shadow: inset 0px 0px 0px 1px var(--spectrum-global-color-gray-400);
+    height: 10px;
+    border-radius: 5px;
+    overflow: hidden;
+  }
+
+  :global(.fill) {
+    background: var(--fill-color);
+    height: 100%;
+  }
+}

--- a/packages/react-aria-components/stories/styles.css
+++ b/packages/react-aria-components/stories/styles.css
@@ -358,7 +358,8 @@
   }
 }
 
-:global(.react-aria-Meter) {
+:global(.react-aria-Meter),
+:global(.react-aria-ProgressBar) {
   --fill-color: forestgreen;
 
   display: grid;


### PR DESCRIPTION
Closes Found in testing session, can set a RAC progressbar or meter to an overflowing value which can cause funny rendering in the starter kit

Note, this is the same way we solve it in RSP https://github.com/adobe/react-spectrum/blob/4ae2831f9487958511c88b9ebe672b5650042d7e/packages/%40react-spectrum/progress/src/ProgressBarBase.tsx#L47

We could have useProgressBar return the clamped value since there is no stately associated with it, but that felt a little strange.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Check in RAC starter kit using a min value larger than value.
Check in Storybook RAC stories for two new stories, Meter and ProgressBar

## 🧢 Your Project:

<!--- Company/project for pull request -->
