### PR TITLE
iFrame focus tracking setup rename

### DIFF
--- a/packages/@react-aria/interactions/src/index.ts
+++ b/packages/@react-aria/interactions/src/index.ts
@@ -17,7 +17,7 @@ export {
   isFocusVisible,
   getInteractionModality,
   setInteractionModality,
-  setupFocus,
+  addWindowFocusTracking,
   useInteractionModality,
   useFocusVisible,
   useFocusVisibleListener

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -171,7 +171,7 @@ const tearDownWindowFocusTracking = (element, loadListener?: () => void) => {
   if (!hasSetupGlobalListeners.has(windowObject)) {
     return;
   }
-  windowObject.HTMLElement.prototype.focus = hasSetupGlobalListeners.get(windowObject).focus;
+  windowObject.HTMLElement.prototype.focus = hasSetupGlobalListeners.get(windowObject)!.focus;
 
   documentObject.removeEventListener('keydown', handleKeyboardEvent, true);
   documentObject.removeEventListener('keyup', handleKeyboardEvent, true);

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -159,7 +159,7 @@ function setupGlobalFocusEvents(element?: HTMLElement | null) {
   hasSetupGlobalListeners.set(windowObject, {focus});
 }
 
-const tearDownWindowFocusTracking = (element, loadListener) => {
+const tearDownWindowFocusTracking = (element, loadListener?: () => void) => {
   const windowObject = getOwnerWindow(element);
   const documentObject = getOwnerDocument(element);
   if (loadListener) {

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -37,7 +37,10 @@ export interface FocusVisibleResult {
 
 let currentModality: null | Modality = null;
 let changeHandlers = new Set<Handler>();
-export let hasSetupGlobalListeners = new Map<Window, boolean>(); // We use a map here to support setting event listeners across multiple document objects.
+interface GlobalListenerData {
+  focus: () => void
+}
+export let hasSetupGlobalListeners = new Map<Window, GlobalListenerData>(); // We use a map here to support setting event listeners across multiple document objects.
 let hasEventBeforeFocus = false;
 let hasBlurredWindowRecently = false;
 

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -153,45 +153,65 @@ function setupGlobalFocusEvents(element?: HTMLElement | null) {
 
   // Add unmount handler
   windowObject.addEventListener('beforeunload', () => {
-    documentObject.removeEventListener('keydown', handleKeyboardEvent, true);
-    documentObject.removeEventListener('keyup', handleKeyboardEvent, true);
-    documentObject.removeEventListener('click', handleClickEvent, true);
-    windowObject.removeEventListener('focus', handleFocusEvent, true);
-    windowObject.removeEventListener('blur', handleWindowBlur, false);
-
-    if (typeof PointerEvent !== 'undefined') {
-      documentObject.removeEventListener('pointerdown', handlePointerEvent, true);
-      documentObject.removeEventListener('pointermove', handlePointerEvent, true);
-      documentObject.removeEventListener('pointerup', handlePointerEvent, true);
-    } else {
-      documentObject.removeEventListener('mousedown', handlePointerEvent, true);
-      documentObject.removeEventListener('mousemove', handlePointerEvent, true);
-      documentObject.removeEventListener('mouseup', handlePointerEvent, true);
-    }
-
-    if (hasSetupGlobalListeners.has(windowObject)) {
-      hasSetupGlobalListeners.delete(windowObject);
-    }
+    tearDownWindowFocusTracking(element);
   }, {once: true});
 
-  hasSetupGlobalListeners.set(windowObject, true);
+  hasSetupGlobalListeners.set(windowObject, {focus});
 }
 
-export const setupFocus = (element?: HTMLElement | null) => {
+const tearDownWindowFocusTracking = (element, loadListener) => {
+  const windowObject = getOwnerWindow(element);
   const documentObject = getOwnerDocument(element);
+  if (loadListener) {
+    documentObject.removeEventListener('DOMContentLoaded', loadListener);
+  }
+  if (!hasSetupGlobalListeners.has(windowObject)) {
+    return;
+  }
+  windowObject.HTMLElement.prototype.focus = hasSetupGlobalListeners.get(windowObject).focus;
+
+  documentObject.removeEventListener('keydown', handleKeyboardEvent, true);
+  documentObject.removeEventListener('keyup', handleKeyboardEvent, true);
+  documentObject.removeEventListener('click', handleClickEvent, true);
+  windowObject.removeEventListener('focus', handleFocusEvent, true);
+  windowObject.removeEventListener('blur', handleWindowBlur, false);
+
+  if (typeof PointerEvent !== 'undefined') {
+    documentObject.removeEventListener('pointerdown', handlePointerEvent, true);
+    documentObject.removeEventListener('pointermove', handlePointerEvent, true);
+    documentObject.removeEventListener('pointerup', handlePointerEvent, true);
+  } else {
+    documentObject.removeEventListener('mousedown', handlePointerEvent, true);
+    documentObject.removeEventListener('mousemove', handlePointerEvent, true);
+    documentObject.removeEventListener('mouseup', handlePointerEvent, true);
+  }
+
+  hasSetupGlobalListeners.delete(windowObject);
+};
+
+/**
+ * Adds a window (ie iframe) to the list of windows that are being tracked for focus visible.
+ * @param element @default document.body - The element provided will be used to get the window to add.
+ */
+export const addWindowFocusTracking = (element?: HTMLElement | null) => {
+  const documentObject = getOwnerDocument(element);
+  let loadListener;
   if (documentObject.readyState !== 'loading') {
     setupGlobalFocusEvents(element);
   } else {
-    documentObject.addEventListener('DOMContentLoaded', () =>
-      setupGlobalFocusEvents(element)
-    );
+    loadListener = () => {
+      setupGlobalFocusEvents(element);
+    };
+    documentObject.addEventListener('DOMContentLoaded', loadListener);
   }
+
+  return () => tearDownWindowFocusTracking(element, loadListener);
 };
 
 // Server-side rendering does not have the document object defined
 // eslint-disable-next-line no-restricted-globals
 if (typeof document !== 'undefined') {
-  setupFocus();
+  addWindowFocusTracking();
 }
 
 /**


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Discussed in testing
Renamed function to be clearer about what its purpose is. Also return a new clean up function allowing people to disconnect an iframe whenever they like without needing to unmount it

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
