### PR TITLE
fix(#5747): [react-aira: RadioGroup]: No tabindex/Can't keyboard focus to input until value is checked

### DIFF
--- a/packages/react-aria-components/docs/RadioGroup.mdx
+++ b/packages/react-aria-components/docs/RadioGroup.mdx
@@ -261,7 +261,7 @@ The `onChange` event is fired when the user selects a radio.
 
 ```tsx example
 function Example() {
-  let [selected, setSelected] = React.useState('');
+  let [selected, setSelected] = React.useState(null);
 
   return (
     <>
@@ -269,7 +269,7 @@ function Example() {
         <Radio value="wizard">Wizard</Radio>
         <Radio value="dragon">Dragon</Radio>
       </MyRadioGroup>
-      <p>You have selected: {selected}</p>
+      <p>You have selected: {selected ?? ''}</p>
     </>
   );
 }


### PR DESCRIPTION
…
Looks like the default selected value in the example is an empty string, which is not the same as null. https://github.com/adobe/react-spectrum/pull/4985/files#diff-26ddea7c3bd0c2b48179af98635706a6391a01b59c936e8b497d1843a97ff202R71-R78

A more robust solution might be to validate whether the default value is one of the possible values within the radio group, but that's a bit more complicated.


Closes #5747 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 5747](https://github.com/adobe/react-spectrum/issue/5747).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/1c8634f70d2124e57d72b2c8b8251ac0c6c4d9ad/docs/react-aria/RadioGroup.html#controlled-value
2. Verify that pressing Tab key can focus the first RadioButton in the Controlled value story.


## 🧢 Your Project:

Adobe/Accessibility
