### PR TITLE
Typescript: Update RAC DOMProps to extend SharedDOMProps

### DIFF
--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -69,7 +69,7 @@ export interface StyleProps {
   style?: CSSProperties
 }
 
-export interface DOMProps extends StyleProps {
+export interface DOMProps extends StyleProps, SharedDOMProps {
   /** The children of the component. */
   children?: ReactNode
 }


### PR DESCRIPTION
Closes #5764
For Form components, the property "id", was missing, so had to extend the DOMProps with SharedDOMProps.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
