### PR TITLE
Fix focusVisible & calendar issue #3975

### DIFF
--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -478,6 +478,7 @@ function CalendarCell({date, ...otherProps}: CalendarCellProps, ref: ForwardedRe
 
   let {hoverProps, isHovered} = useHover({...otherProps, isDisabled: states.isDisabled});
   let {focusProps, isFocusVisible} = useFocusRing();
+  isFocusVisible &&= states.isFocused;
   let isOutsideMonth = !isSameMonth(currentMonth, date);
   let isSelectionStart = false;
   let isSelectionEnd = false;


### PR DESCRIPTION
Closes #3975

## ✅ Pull Request Checklist:

- [ x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Check the storybook link locally: http://localhost:9003/?path=/story/react-aria-components--calendar-example&providerSwitcher-express=false&strict=true, select date 2024-JAN-3, open dev toolbar and inspect the selected div element. Navigate to DEC-27 __using the "up" arrow key__. With the fix applied, the element does not have `data-focus-visible`. Without the fix, the attribute is there even if the date is disabled.

## 🧢 Your Project:

<!--- Company/project for pull request -->
