### PR TITLE
Add support for overriding default keyboard actions

### DIFF
--- a/packages/@react-aria/accordion/src/useAccordion.ts
+++ b/packages/@react-aria/accordion/src/useAccordion.ts
@@ -13,10 +13,10 @@
 import {AriaAccordionProps} from '@react-types/accordion';
 import {ButtonHTMLAttributes, RefObject} from 'react';
 import {DOMAttributes, Node} from '@react-types/shared';
+import {KeyboardEventHandler, useSelectableItem, useSelectableList} from '@react-aria/selection';
 import {mergeProps, useId} from '@react-aria/utils';
 import {TreeState} from '@react-stately/tree';
 import {useButton} from '@react-aria/button';
-import {useSelectableItem, useSelectableList} from '@react-aria/selection';
 
 export interface AccordionAria {
   /** Props for the accordion container element. */
@@ -32,6 +32,13 @@ export interface AccordionItemAria {
   buttonProps: ButtonHTMLAttributes<HTMLElement>,
   /** Props for the accordion item content element. */
   regionProps: DOMAttributes
+}
+
+export interface AccordionItemAriaOptions<T> extends AccordionItemAriaProps<T> {
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler
 }
 
 export function useAccordionItem<T>(props: AccordionItemAriaProps<T>, state: TreeState<T>, ref: RefObject<HTMLButtonElement>): AccordionItemAria {

--- a/packages/@react-aria/gridlist/src/useGridList.ts
+++ b/packages/@react-aria/gridlist/src/useGridList.ts
@@ -21,12 +21,12 @@ import {
   MultipleSelection
 } from '@react-types/shared';
 import {filterDOMProps, mergeProps, useId} from '@react-aria/utils';
+import {KeyboardEventHandler, useSelectableList} from '@react-aria/selection';
 import {listMap} from './utils';
 import {ListState} from '@react-stately/list';
 import {RefObject} from 'react';
 import {useGridSelectionAnnouncement, useHighlightSelectionDescription} from '@react-aria/grid';
 import {useHasTabbableChild} from '@react-aria/focus';
-import {useSelectableList} from '@react-aria/selection';
 
 export interface GridListProps<T> extends CollectionBase<T>, MultipleSelection {
   /**
@@ -48,6 +48,10 @@ export interface AriaGridListOptions<T> extends Omit<AriaGridListProps<T>, 'chil
    * to override the default.
    */
   keyboardDelegate?: KeyboardDelegate,
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler,
   /**
    * Whether focus should wrap around when the end/start is reached.
    * @default false
@@ -79,6 +83,7 @@ export function useGridList<T>(props: AriaGridListOptions<T>, state: ListState<T
   let {
     isVirtualized,
     keyboardDelegate,
+    keyboardEventHandler,
     onAction,
     linkBehavior = 'action'
   } = props;
@@ -93,6 +98,7 @@ export function useGridList<T>(props: AriaGridListOptions<T>, state: ListState<T
     disabledKeys: state.disabledKeys,
     ref,
     keyboardDelegate: keyboardDelegate,
+    keyboardEventHandler,
     isVirtualized,
     selectOnFocus: state.selectionManager.selectionBehavior === 'replace',
     shouldFocusWrap: props.shouldFocusWrap,

--- a/packages/@react-aria/listbox/src/useListBox.ts
+++ b/packages/@react-aria/listbox/src/useListBox.ts
@@ -13,12 +13,12 @@
 import {AriaListBoxProps} from '@react-types/listbox';
 import {DOMAttributes, KeyboardDelegate} from '@react-types/shared';
 import {filterDOMProps, mergeProps, useId} from '@react-aria/utils';
+import {KeyboardEventHandler, useSelectableList} from '@react-aria/selection';
 import {listData} from './utils';
 import {ListState} from '@react-stately/list';
 import {RefObject} from 'react';
 import {useFocusWithin} from '@react-aria/interactions';
 import {useLabel} from '@react-aria/label';
-import {useSelectableList} from '@react-aria/selection';
 
 export interface ListBoxAria {
   /** Props for the listbox element. */
@@ -36,6 +36,11 @@ export interface AriaListBoxOptions<T> extends Omit<AriaListBoxProps<T>, 'childr
    * to override the default.
    */
   keyboardDelegate?: KeyboardDelegate,
+
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler,
 
   /**
    * Whether the listbox items should use virtual focus instead of being focused directly.

--- a/packages/@react-aria/menu/src/useMenu.ts
+++ b/packages/@react-aria/menu/src/useMenu.ts
@@ -13,9 +13,9 @@
 import {AriaMenuProps} from '@react-types/menu';
 import {DOMAttributes, Key, KeyboardDelegate, KeyboardEvents} from '@react-types/shared';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
+import {KeyboardEventHandler, useSelectableList} from '@react-aria/selection';
 import {RefObject} from 'react';
 import {TreeState} from '@react-stately/tree';
-import {useSelectableList} from '@react-aria/selection';
 
 export interface MenuAria {
   /** Props for the menu element. */
@@ -30,7 +30,12 @@ export interface AriaMenuOptions<T> extends Omit<AriaMenuProps<T>, 'children'>, 
    * An optional keyboard delegate implementation for type to select,
    * to override the default.
    */
-  keyboardDelegate?: KeyboardDelegate
+  keyboardDelegate?: KeyboardDelegate,
+
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler
 }
 
 interface MenuData {

--- a/packages/@react-aria/selection/src/index.ts
+++ b/packages/@react-aria/selection/src/index.ts
@@ -16,7 +16,7 @@ export {useSelectableList} from './useSelectableList';
 export {ListKeyboardDelegate} from './ListKeyboardDelegate';
 export {useTypeSelect} from './useTypeSelect';
 
-export type {AriaSelectableCollectionOptions, SelectableCollectionAria} from './useSelectableCollection';
+export type {AriaSelectableCollectionOptions, SelectableCollectionAria, KeyboardAction, KeyboardEventHandler} from './useSelectableCollection';
 export type {AriaSelectableListOptions, SelectableListAria} from './useSelectableList';
 export type {SelectableItemOptions, SelectableItemStates, SelectableItemAria} from './useSelectableItem';
 export type {AriaTypeSelectOptions, TypeSelectAria} from './useTypeSelect';

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -31,7 +31,7 @@ export type KeyboardAction = 'nav-down'
   | 'nav-page-up'
   | 'select-all'
   | 'clear-selection'
-  | ''
+  | 'noop'
 
 export type KeyboardEventHandler = (e: KeyboardEvent, m: MultipleSelectionManager, d: KeyboardDelegate) => KeyboardAction | null
 
@@ -289,36 +289,37 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
       switch (action) {
         case 'nav-down':
           navDown();
-          break;
+          return;
         case 'nav-up':
           navUp();
-          break;
+          return;
         case 'nav-left':
           navLeft();
-          break;
+          return;
         case 'nav-right':
           navRight();
-          break;
+          return;
         case 'nav-start':
           navStart();
-          break;
+          return;
         case 'nav-end':
           navEnd();
-          break;
+          return;
         case 'nav-page-down':
           navPageDown();
-          break;
+          return;
         case 'nav-page-up':
           navPageUp();
-          break;
+          return;
         case 'select-all':
           selectAll();
-          break;
+          return;
         case 'clear-selection':
           clearSelection();
-          break;
+          return;
+        case 'noop':
+          return;
       }
-      return;
     }
 
     switch (e.key) {

--- a/packages/@react-aria/selection/stories/useSelectableList.stories.tsx
+++ b/packages/@react-aria/selection/stories/useSelectableList.stories.tsx
@@ -197,6 +197,10 @@ export const CustomKeyboardEventHandler = () => (
             return 'nav-up';
           }
         }
+        case 'ArrowUp': {
+          e.preventDefault();
+          return 'noop';
+        }
       }
       return null;
     }}>

--- a/packages/@react-aria/selection/stories/useSelectableList.stories.tsx
+++ b/packages/@react-aria/selection/stories/useSelectableList.stories.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {AriaSelectableCollectionOptions, useSelectableItem, useSelectableList} from '../src';
 import {CollectionBase, Node} from '@react-types/shared';
 import {Item} from '@react-spectrum/actiongroup';
 import {List} from './List';
@@ -17,15 +18,16 @@ import {ListState, useListState} from '@react-stately/list';
 import * as React from 'react';
 import {Section} from '@react-spectrum/menu';
 import styles from './styles.css';
-import {useSelectableItem, useSelectableList} from '../src';
 
 function SelectableList(props: CollectionBase<any> & {
   isSubUlRelativelyPositioned: boolean,
-  isUlRelativelyPositioned: boolean
+  isUlRelativelyPositioned: boolean,
+  keyboardEventHandler?: AriaSelectableCollectionOptions['keyboardEventHandler']
 }) {
   const state = useListState(props);
   const listRef = React.useRef<HTMLUListElement>(null);
   const {listProps} = useSelectableList({
+    keyboardEventHandler: props.keyboardEventHandler,
     ref: listRef,
     selectionManager: state.selectionManager,
     collection: state.collection,
@@ -177,6 +179,33 @@ export const RelativeUlRelativeSubUl = () => (
 
 RelativeUlRelativeSubUl.story = {
   name: 'Relative ul, relative sub ul'
+};
+
+export const CustomKeyboardEventHandler = () => (
+  <SelectableList
+    isSubUlRelativelyPositioned
+    isUlRelativelyPositioned
+    keyboardEventHandler={(e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'j': {
+          if (e.ctrlKey) {
+            return 'nav-down';
+          }
+        }
+        case 'k': {
+          if (e.ctrlKey) {
+            return 'nav-up';
+          }
+        }
+      }
+      return null;
+    }}>
+    {options}
+  </SelectableList>
+);
+
+CustomKeyboardEventHandler.story = {
+  name: 'Custom keyboard event handler'
 };
 
 export const SingleSelectAllowEmptySelectOnFocus = () => (

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import {AriaGridListProps, DraggableItemResult, DragPreviewRenderer, DropIndicatorAria, DroppableCollectionResult, FocusScope, ListKeyboardDelegate, mergeProps, useFocusRing, useGridList, useGridListItem, useGridListSelectionCheckbox, useHover, useVisuallyHidden} from 'react-aria';
+import {AriaGridListProps, DraggableItemResult, DragPreviewRenderer, DropIndicatorAria, DroppableCollectionResult, FocusScope, KeyboardEventHandler, ListKeyboardDelegate, mergeProps, useFocusRing, useGridList, useGridListItem, useGridListSelectionCheckbox, useHover, useVisuallyHidden} from 'react-aria';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './Checkbox';
 import {Collection, DraggableCollectionState, DroppableCollectionState, ListState, Node, SelectionBehavior, useListState} from 'react-stately';
@@ -50,6 +50,10 @@ export interface GridListRenderProps {
 }
 
 export interface GridListProps<T> extends Omit<AriaGridListProps<T>, 'children'>, CollectionProps<T>, StyleRenderProps<GridListRenderProps>, SlotProps, ScrollableProps<HTMLDivElement> {
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler,
   /** How multiple selection should behave in the collection. */
   selectionBehavior?: SelectionBehavior,
   /** The drag and drop hooks returned by `useDragAndDrop` used to enable drag and drop behavior for the GridList. */

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaListBoxOptions, AriaListBoxProps, DraggableItemResult, DragPreviewRenderer, DroppableCollectionResult, DroppableItemResult, FocusScope, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing, useHover, useListBox, useListBoxSection, useLocale, useOption} from 'react-aria';
+import {AriaListBoxOptions, AriaListBoxProps, DraggableItemResult, DragPreviewRenderer, DroppableCollectionResult, DroppableItemResult, FocusScope, KeyboardEventHandler, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing, useHover, useListBox, useListBoxSection, useLocale, useOption} from 'react-aria';
 import {CollectionDocumentContext, CollectionPortal, CollectionProps, ItemRenderProps, useCachedChildren, useCollection, useSSRCollectionNode} from './Collection';
 import {ContextValue, forwardRefType, HiddenContext, Provider, RenderProps, ScrollableProps, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {DragAndDropContext, DragAndDropHooks, DropIndicator, DropIndicatorContext, DropIndicatorProps} from './useDragAndDrop';
@@ -55,6 +55,10 @@ export interface ListBoxRenderProps {
 }
 
 export interface ListBoxProps<T> extends Omit<AriaListBoxProps<T>, 'children' | 'label'>, CollectionProps<T>, StyleRenderProps<ListBoxRenderProps>, SlotProps, ScrollableProps<HTMLDivElement> {
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler,
   /** How multiple selection should behave in the collection. */
   selectionBehavior?: SelectionBehavior,
   /** The drag and drop hooks returned by `useDragAndDrop` used to enable drag and drop behavior for the ListBox. */

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -11,7 +11,7 @@
  */
 
 
-import {AriaMenuProps, FocusScope, mergeProps, useFocusRing, useMenu, useMenuItem, useMenuSection, useMenuTrigger} from 'react-aria';
+import {AriaMenuProps, FocusScope, KeyboardEventHandler, mergeProps, useFocusRing, useMenu, useMenuItem, useMenuSection, useMenuTrigger} from 'react-aria';
 import {BaseCollection, CollectionProps, ItemRenderProps, useCachedChildren, useCollection, useSSRCollectionNode} from './Collection';
 import {MenuTriggerProps as BaseMenuTriggerProps, Node, TreeState, useMenuTriggerState, useTreeState} from 'react-stately';
 import {ContextValue, forwardRefType, Provider, RenderProps, ScrollableProps, SlotProps, StyleProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
@@ -118,7 +118,12 @@ function SubmenuTriggerInner(props) {
 }
 
 
-export interface MenuProps<T> extends Omit<AriaMenuProps<T>, 'children'>, CollectionProps<T>, StyleProps, SlotProps, ScrollableProps<HTMLDivElement> {}
+export interface MenuProps<T> extends Omit<AriaMenuProps<T>, 'children'>, CollectionProps<T>, StyleProps, SlotProps, ScrollableProps<HTMLDivElement> {
+  /**
+   * An optional keyboard event handler to override default keyboard actions.
+   */
+  keyboardEventHandler?: KeyboardEventHandler
+}
 
 function Menu<T extends object>(props: MenuProps<T>, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, MenuContext);

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -57,6 +57,57 @@ ListBoxExample.story = {
   }
 };
 
+export const ListBoxCustomKeyboardHandler = (args) => (
+  <ListBox className={styles.menu} {...args} aria-label="test listbox">
+    <MyListBoxItem>Foo</MyListBoxItem>
+    <MyListBoxItem>Bar</MyListBoxItem>
+    <MyListBoxItem>Baz</MyListBoxItem>
+    <MyListBoxItem href="http://google.com">Google</MyListBoxItem>
+  </ListBox>
+);
+
+ListBoxCustomKeyboardHandler.story = {
+  args: {
+    keyboardEventHandler: (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'j': {
+          if (e.ctrlKey) {
+            return 'nav-down';
+          }
+        }
+        case 'k': {
+          if (e.ctrlKey) {
+            return 'nav-up';
+          }
+        }
+      }
+      return null;
+    },
+    selectionMode: 'single',
+    selectionBehavior: 'toggle',
+    shouldFocusOnHover: false
+  },
+  argTypes: {
+    selectionMode: {
+      control: {
+        type: 'radio',
+        options: ['none', 'single', 'multiple']
+      }
+    },
+    selectionBehavior: {
+      control: {
+        type: 'radio',
+        options: ['toggle', 'replace']
+      }
+    }
+  },
+  parameters: {
+    description: {
+      data: 'Hover styles should have higher specificity than focus style for testing purposes. Hover style should not be applied on keyboard focus even if shouldFocusOnHover is true'
+    }
+  }
+};
+
 // Known accessibility false positive: https://github.com/adobe/react-spectrum/wiki/Known-accessibility-false-positives#listbox
 // also has a aXe landmark error, not sure what it means
 export const ListBoxSections = () => (

--- a/packages/react-aria-components/stories/Menu.stories.tsx
+++ b/packages/react-aria-components/stories/Menu.stories.tsx
@@ -44,6 +44,47 @@ export const MenuExample = () => (
   </MenuTrigger>
 );
 
+export const MenuCustomKeyboardHandler = () => (
+  <MenuTrigger>
+    <Button aria-label="Menu">☰</Button>
+    <Popover>
+      <Menu
+        keyboardEventHandler={(e: React.KeyboardEvent) => {
+          switch (e.key) {
+            case 'j': {
+              if (e.ctrlKey) {
+                return 'nav-down';
+              }
+            }
+            case 'k': {
+              if (e.ctrlKey) {
+                return 'nav-up';
+              }
+            }
+          }
+          return null;
+        }}
+        className={styles.menu}
+        onAction={action('onAction')}>
+        <Section className={styles.group}>
+          <Header style={{fontSize: '1.2em'}}>Section 1</Header>
+          <MyMenuItem>Foo</MyMenuItem>
+          <MyMenuItem>Bar</MyMenuItem>
+          <MyMenuItem>Baz</MyMenuItem>
+          <MyMenuItem href="https://google.com">Google</MyMenuItem>
+        </Section>
+        <Separator style={{borderTop: '1px solid gray', margin: '2px 5px'}} />
+        <Section className={styles.group}>
+          <Header style={{fontSize: '1.2em'}}>Section 2</Header>
+          <MyMenuItem>Foo</MyMenuItem>
+          <MyMenuItem>Bar</MyMenuItem>
+          <MyMenuItem>Baz</MyMenuItem>
+        </Section>
+      </Menu>
+    </Popover>
+  </MenuTrigger>
+);
+
 export const MenuComplex = () => (
   <MenuTrigger>
     <Button aria-label="Menu">☰</Button>

--- a/packages/react-aria/src/index.ts
+++ b/packages/react-aria/src/index.ts
@@ -79,4 +79,5 @@ export type {AriaTagGroupProps, AriaTagProps, TagAria, TagGroupAria} from '@reac
 export type {AriaTextFieldOptions, AriaTextFieldProps, TextFieldAria} from '@react-aria/textfield';
 export type {AriaTooltipProps, TooltipAria, TooltipTriggerAria, TooltipTriggerProps} from '@react-aria/tooltip';
 export type {VisuallyHiddenAria, VisuallyHiddenProps} from '@react-aria/visually-hidden';
+export type {KeyboardEventHandler, KeyboardAction} from '@react-aria/selection';
 export type {Key, Orientation} from '@react-types/shared';


### PR DESCRIPTION
The keyboard navigation implementation in react-aria is excellently designed, but it lacks customization options. This limitation makes it challenging for me to utilize the existing logic of react-aria in my keyboard-first application. Moreover, the keyboard logic is embedded deeply within the hooks, making alterations difficult.

In my pull request, I have introduced a KeyboardEventHandler that allows users to choose whether to override the default keyboard operation logic. It provides two levels of customization:

1. Adding only navigation triggering keys while still utilizing the default navigation logic, such as returning the built-in KeyboardAction: `'nav-down'`.
2. Full customization of the keyboard logic, for example, by returning an empty string `''`.

This second level of customization has proven to be incredibly useful in scenarios where I use react-window for virtual scrolling. In such cases, the pagination logic, among other things, deviates from the default, rendering it unusable without extensive customization.