### PR TITLE
feat(radio): add aria-checked attribute for accessibility improvement

### DIFF
--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -107,6 +107,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
       checked,
       value,
       onChange,
+      'aria-checked': checked,
       'aria-describedby': [
         props['aria-describedby'],
         state.isInvalid ? errorMessageId : null,

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -137,8 +137,11 @@ describe('Radios', function () {
     expect(radios[2].value).toBe('dragons');
 
     expect(radios[0].checked).toBe(false);
+    expect(radios[0]).toHaveAttribute('aria-checked', 'false');
     expect(radios[1].checked).toBe(false);
+    expect(radios[1]).toHaveAttribute('aria-checked', 'false');
     expect(radios[2].checked).toBe(false);
+    expect(radios[2]).toHaveAttribute('aria-checked', 'false');
 
     let dogs = getByLabelText('Dogs');
     await user.click(dogs);
@@ -146,8 +149,11 @@ describe('Radios', function () {
     expect(onChangeSpy).toHaveBeenCalledWith('dogs');
 
     expect(radios[0].checked).toBe(true);
+    expect(radios[0]).toHaveAttribute('aria-checked', 'true');
     expect(radios[1].checked).toBe(false);
+    expect(radios[1]).toHaveAttribute('aria-checked', 'false');
     expect(radios[2].checked).toBe(false);
+    expect(radios[2]).toHaveAttribute('aria-checked', 'false');
   });
 
   it.each`

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -214,18 +214,21 @@ describe('RadioGroup', () => {
     let label = radios[0].closest('label');
 
     expect(radios[0]).not.toBeChecked();
+    expect(radios[0]).toHaveAttribute('aria-checked', 'false');
     expect(label).not.toHaveAttribute('data-selected');
     expect(label).not.toHaveClass('selected');
 
     await user.click(radios[0]);
     expect(onChange).toHaveBeenLastCalledWith('a');
     expect(radios[0]).toBeChecked();
+    expect(radios[0]).toHaveAttribute('aria-checked', 'true');
     expect(label).toHaveAttribute('data-selected', 'true');
     expect(label).toHaveClass('selected');
 
     await user.click(radios[1]);
     expect(onChange).toHaveBeenLastCalledWith('b');
     expect(radios[0]).not.toBeChecked();
+    expect(radios[0]).toHaveAttribute('aria-checked', 'false');
     expect(label).not.toHaveAttribute('data-selected');
     expect(label).not.toHaveClass('selected');
   });


### PR DESCRIPTION
In this PR, we update the useRadio hook to appropriately manage the aria-checked attribute for radio buttons. Following the [Aria Practices Radio Group Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/), if a radio button is checked, the radio element has aria-checked set to true. If it is not checked, it has aria-checked set to false.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
1. Visit http://localhost:9003/?path=/story/react-aria-components--radio-group-example&providerSwitcher-express=false&strict=true
2. Select a radio button and use developer tools to verify that the aria-checked attribute is set to true.
3. Select another radio button and confirm that the aria-checked of the previously selected radio button updates to false.

## 🧢 Your Project:

<!--- Company/project for pull request -->
