### PR TITLE
Update ARIA Practices link in PR template to the latest version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Closes <!-- Github issue # here -->
 - [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
 - [ ] Filled out test instructions.
 - [ ] Updated documentation (if it already exists for this component).
-- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
+- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
 
 ## 📝 Test Instructions:
 


### PR DESCRIPTION
This PR updates the ARIA Practices link in the Pull Request template to the latest version. The previous link still redirects to the latest page, but it is more convenient to link directly to the updated resource!

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
