### PR TITLE
Remove box-sizing: border-box from Next.js example apps

### DIFF
--- a/examples/rsp-next-ts-17/styles/globals.css
+++ b/examples/rsp-next-ts-17/styles/globals.css
@@ -11,6 +11,3 @@ a {
   text-decoration: none;
 }
 
-* {
-  box-sizing: border-box;
-}

--- a/examples/rsp-next-ts/styles/globals.css
+++ b/examples/rsp-next-ts/styles/globals.css
@@ -11,6 +11,3 @@ a {
   text-decoration: none;
 }
 
-* {
-  box-sizing: border-box;
-}


### PR DESCRIPTION
This was making the Submenu chevrons hidden.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
