### PR TITLE
Fix <Switch> focus events

### DIFF
--- a/packages/react-aria-components/src/Switch.tsx
+++ b/packages/react-aria-components/src/Switch.tsx
@@ -110,7 +110,7 @@ function Switch(props: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) {
       data-disabled={isDisabled || undefined}
       data-readonly={isReadOnly || undefined}>
       <VisuallyHidden elementType="span">
-        <input {...inputProps} {...focusProps} ref={inputRef} />
+        <input {...mergeProps(inputProps, focusProps)} ref={inputRef} />
       </VisuallyHidden>
       {renderProps.children}
     </label>

--- a/packages/react-aria-components/test/Checkbox.test.js
+++ b/packages/react-aria-components/test/Checkbox.test.js
@@ -110,13 +110,15 @@ describe('Checkbox', () => {
     expect(document.activeElement).toBe(checkbox);
     expect(onBlur).not.toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalledTimes(1);
-    expect(onFocusChange).toHaveBeenCalledTimes(1);
+    expect(onFocusChange).toHaveBeenCalledTimes(1);  // triggered by onFocus
+    expect(onFocusChange).toHaveBeenLastCalledWith(true);
 
     await user.tab();
     expect(document.activeElement).toBe(button);
     expect(onBlur).toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalledTimes(1);
-    expect(onFocusChange).toHaveBeenCalledTimes(2);
+    expect(onFocusChange).toHaveBeenCalledTimes(2);  // triggered by onBlur
+    expect(onFocusChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should support press state', () => {

--- a/packages/react-aria-components/test/CheckboxGroup.test.js
+++ b/packages/react-aria-components/test/CheckboxGroup.test.js
@@ -262,7 +262,8 @@ describe('CheckboxGroup', () => {
     expect(document.activeElement).toBe(checkboxes[0]);
     expect(onBlur).not.toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalledTimes(1);
-    expect(onFocusChange).toHaveBeenCalledTimes(1);
+    expect(onFocusChange).toHaveBeenCalledTimes(1);  // triggered by onFocus
+    expect(onFocusChange).toHaveBeenLastCalledWith(true);
 
     // inner focus changes shouldn't call the callbacks.
     await user.tab();
@@ -270,12 +271,14 @@ describe('CheckboxGroup', () => {
     expect(onBlur).not.toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalledTimes(1);
     expect(onFocusChange).toHaveBeenCalledTimes(1);
+    expect(onFocusChange).toHaveBeenLastCalledWith(true);
 
     // `onBlur` and the following `onFocusChange` only should be called when losing focus to an outer element.
     await user.click(button);
     expect(document.activeElement).toBe(button);
     expect(onBlur).toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalledTimes(1);
-    expect(onFocusChange).toHaveBeenCalledTimes(2);
+    expect(onFocusChange).toHaveBeenCalledTimes(2);  // triggered by onBlur
+    expect(onFocusChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/packages/react-aria-components/test/Switch.test.js
+++ b/packages/react-aria-components/test/Switch.test.js
@@ -108,6 +108,36 @@ describe('Switch', () => {
     expect(label).not.toHaveClass('focus');
   });
 
+  it('should support focus events', async () => {
+    let onBlur = jest.fn();
+    let onFocus = jest.fn();
+    let onFocusChange = jest.fn();
+    
+    let {getByRole, getByText} = render(
+      <>
+        <Switch onBlur={onBlur} onFocus={onFocus} onFocusChange={onFocusChange}>Test</Switch>
+        <button>Steal focus</button>
+      </>
+    );
+
+    let s = getByRole('switch');
+    let button = getByText('Steal focus');
+
+    await user.tab();
+    expect(document.activeElement).toBe(s);
+    expect(onBlur).not.toHaveBeenCalled();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onFocusChange).toHaveBeenCalledTimes(1);  // triggered by onFocus
+    expect(onFocusChange).toHaveBeenLastCalledWith(true);
+
+    await user.tab();
+    expect(document.activeElement).toBe(button);
+    expect(onBlur).toHaveBeenCalled();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onFocusChange).toHaveBeenCalledTimes(2);  // triggered by onBlur
+    expect(onFocusChange).toHaveBeenLastCalledWith(false);
+  });
+
   it('should support press state', () => {
     let {getByRole} = render(<Switch className={({isPressed}) => isPressed ? 'pressed' : ''}>Test</Switch>);
     let s = getByRole('switch').closest('label');


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5822

This fix is very similar to the one that I did for `Checkbox` and `CheckboxGroup` a few days ago: https://github.com/adobe/react-spectrum/pull/5801.

In addition to the fix, I use this PR as a chance to add some additional test assertions to `Checkbox` and `CheckboxGroup` as well.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
