### PR TITLE
Rename and export `defaultSlot` from RAC 

### DIFF
--- a/packages/react-aria-components/docs/advanced.mdx
+++ b/packages/react-aria-components/docs/advanced.mdx
@@ -115,6 +115,46 @@ function Stepper({children}) {
 
 The slots provided by each built-in React Aria component are shown in the Anatomy section of their documentation.
 
+#### Default slot
+
+The default slot is used to provide props to a component without specifying a slot name. This approach allows you to assign a default slot to a component for its default use case and enables you to specify a slot name for a specific use case.
+
+This example shows a custom `Button` component with slots for an icon with no slot name or an icon with a slot named "end".
+
+```tsx
+import {Button, DEFAULT_SLOT} from 'react-aria-components';
+
+function MyCustomButton({children}) {
+  return (
+    <IconContext.Provider
+      value={{
+        slots: {
+          [DEFAULT_SLOT]: {
+            className: "start-icon"
+          },
+          end: {
+            className: "end-icon"
+          }
+        }
+      }}>
+        <Button>{children}</Button>
+    </IconContext.Provider>
+  );
+}
+
+<MyCustomButton>
+  {/* Consumes the props passed to the default slot */}
+  <BellIcon />
+  <Text>Icon + Label</Text>
+</MyCustomButton>
+
+<MyCustomButton>
+  <Text>Label + Icon</Text>
+  {/* Consumes the props passed to the "end" slot */}
+  <BellIcon slot="end" />
+</MyCustomButton>
+```
+
 ### Provider
 
 In complex components, you may need to provide many contexts. The `Provider` component is a utility that makes it easier to provide multiple React contexts without manually nesting them. This can be achieved by passing pairs of contexts and values as an array to the `values` prop.

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {AriaDialogProps, useDialog, useId, useOverlayTrigger} from 'react-aria';
-import {ContextValue, defaultSlot, forwardRefType, Provider, SlotProps, StyleProps, useContextProps} from './utils';
+import {ContextValue, DEFAULT_SLOT, forwardRefType, Provider, SlotProps, StyleProps, useContextProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {HeadingContext} from './Heading';
 import {OverlayTriggerProps, OverlayTriggerState, useOverlayTriggerState} from 'react-stately';
@@ -104,7 +104,7 @@ function Dialog(props: DialogProps, ref: ForwardedRef<HTMLElement>) {
         values={[
           [HeadingContext, {
             slots: {
-              [defaultSlot]: {},
+              [DEFAULT_SLOT]: {},
               title: {...titleProps, level: 2}
             }
           }]

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -14,7 +14,7 @@ import {ButtonContext} from './Button';
 import {CheckboxContext} from './Checkbox';
 import {Collection, DraggableCollectionState, DroppableCollectionState, ListState, Node, SelectionBehavior, useListState} from 'react-stately';
 import {CollectionProps, ItemRenderProps, useCachedChildren, useCollection, useSSRCollectionNode} from './Collection';
-import {ContextValue, defaultSlot, forwardRefType, Provider, RenderProps, ScrollableProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {ContextValue, DEFAULT_SLOT, forwardRefType, Provider, RenderProps, ScrollableProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {DragAndDropContext, DragAndDropHooks, DropIndicator, DropIndicatorContext, DropIndicatorProps} from './useDragAndDrop';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {Key, LinkDOMProps} from '@react-types/shared';
@@ -348,7 +348,7 @@ function GridListRow({item}) {
               }],
               [ButtonContext, {
                 slots: {
-                  [defaultSlot]: {},
+                  [DEFAULT_SLOT]: {},
                   drag: {
                     ...draggableItem?.dragButtonProps,
                     ref: dragButtonRef,

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -4,7 +4,7 @@ import {buildHeaderRows, TableColumnResizeState} from '@react-stately/table';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './Checkbox';
 import {ColumnSize, ColumnStaticSize, TableCollection as ITableCollection, TableProps as SharedTableProps} from '@react-types/table';
-import {ContextValue, defaultSlot, DOMProps, forwardRefType, Provider, RenderProps, ScrollableProps, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {ContextValue, DEFAULT_SLOT, DOMProps, forwardRefType, Provider, RenderProps, ScrollableProps, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {DisabledBehavior, DraggableCollectionState, DroppableCollectionState, Node, SelectionBehavior, SelectionMode, SortDirection, TableState, useTableColumnResizeState, useTableState} from 'react-stately';
 import {DragAndDropContext, DragAndDropHooks, DropIndicator, DropIndicatorContext, DropIndicatorProps} from './useDragAndDrop';
 import {DraggableItemResult, DragPreviewRenderer, DropIndicatorAria, DroppableCollectionResult, FocusScope, ListKeyboardDelegate, mergeProps, useFocusRing, useHover, useLocale, useLocalizedStringFormatter, useTable, useTableCell, useTableColumnHeader, useTableColumnResize, useTableHeaderRow, useTableRow, useTableRowGroup, useTableSelectAllCheckbox, useTableSelectionCheckbox, useVisuallyHidden} from 'react-aria';
@@ -1104,7 +1104,7 @@ function TableRow<T>({item}: {item: GridNode<T>}) {
             }],
             [ButtonContext, {
               slots: {
-                [defaultSlot]: {},
+                [DEFAULT_SLOT]: {},
                 drag: {
                   ...draggableItem?.dragButtonProps,
                   ref: dragButtonRef,

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -19,7 +19,7 @@ export {Button, ButtonContext} from './Button';
 export {Calendar, CalendarGrid, CalendarGridHeader, CalendarGridBody, CalendarHeaderCell, CalendarCell, RangeCalendar, CalendarContext, RangeCalendarContext, CalendarStateContext, RangeCalendarStateContext} from './Calendar';
 export {Checkbox, CheckboxGroup, CheckboxGroupContext, CheckboxContext, CheckboxGroupStateContext} from './Checkbox';
 export {ComboBox, ComboBoxContext, ComboBoxStateContext} from './ComboBox';
-export {composeRenderProps, Provider, useContextProps, useSlottedContext} from './utils';
+export {composeRenderProps, DEFAULT_SLOT, Provider, useContextProps, useSlottedContext} from './utils';
 export {DateField, DateInput, DateSegment, TimeField, DateFieldContext, TimeFieldContext, DateFieldStateContext, TimeFieldStateContext} from './DateField';
 export {DatePicker, DateRangePicker, DatePickerContext, DateRangePickerContext, DatePickerStateContext, DateRangePickerStateContext} from './DatePicker';
 export {DialogTrigger, Dialog, DialogContext, OverlayTriggerStateContext} from './Dialog';

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -23,7 +23,7 @@ declare function forwardRef<T, P = {}>(
 
 export type forwardRefType = typeof forwardRef;
 
-export const defaultSlot = Symbol('default');
+export const DEFAULT_SLOT = Symbol('default');
 
 interface SlottedValue<T> {
   slots?: Record<string | symbol, T>
@@ -169,10 +169,10 @@ export function useSlottedContext<T>(context: Context<SlottedContextValue<T>>, s
   if (ctx && typeof ctx === 'object' && 'slots' in ctx && ctx.slots) {
     let availableSlots = new Intl.ListFormat().format(Object.keys(ctx.slots).map(p => `"${p}"`));
 
-    if (!slot && !ctx.slots[defaultSlot]) {
+    if (!slot && !ctx.slots[DEFAULT_SLOT]) {
       throw new Error(`A slot prop is required. Valid slot names are ${availableSlots}.`);
     }
-    let slotKey = slot || defaultSlot;
+    let slotKey = slot || DEFAULT_SLOT;
     if (!ctx.slots[slotKey]) {
       // @ts-ignore
       throw new Error(`Invalid slot "${slot}". Valid slot names are ${availableSlots}.`);

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -23,12 +23,10 @@ declare function forwardRef<T, P = {}>(
 
 export type forwardRefType = typeof forwardRef;
 
-export const slotCallbackSymbol = Symbol('callback');
 export const defaultSlot = Symbol('default');
 
 interface SlottedValue<T> {
-  slots?: Record<string | symbol, T>,
-  [slotCallbackSymbol]?: (value: T) => void
+  slots?: Record<string | symbol, T>
 }
 
 export type SlottedContextValue<T> = SlottedValue<T> | T | null | undefined;
@@ -188,7 +186,7 @@ export function useSlottedContext<T>(context: Context<SlottedContextValue<T>>, s
 export function useContextProps<T, U extends SlotProps, E extends Element>(props: T & SlotProps, ref: ForwardedRef<E>, context: Context<ContextValue<U, E>>): [T, RefObject<E>] {
   let ctx = useSlottedContext(context, props.slot) || {};
   // @ts-ignore - TS says "Type 'unique symbol' cannot be used as an index type." but not sure why.
-  let {ref: contextRef, [slotCallbackSymbol]: callback, ...contextProps} = ctx;
+  let {ref: contextRef, ...contextProps} = ctx;
   let mergedRef = useObjectRef(useMemo(() => mergeRefs(ref, contextRef), [ref, contextRef]));
   let mergedProps = mergeProps(contextProps, props) as unknown as T;
 
@@ -204,13 +202,6 @@ export function useContextProps<T, U extends SlotProps, E extends Element>(props
     // @ts-ignore
     mergedProps.style = {...contextProps.style, ...props.style};
   }
-
-  // A parent component might need the props from a child, so call slot callback if needed.
-  useEffect(() => {
-    if (callback) {
-      callback(props);
-    }
-  }, [callback, props]);
 
   return [mergedProps, mergedRef];
 }


### PR DESCRIPTION
Closes #5671 

- Renamed  `defaultSlot` to `DEFAULT_SLOT` to follow the naming convention used by other exported symbols.
- Exported `DEFAULT_SLOT` from `react-aria-components`
- Removed the `slotCallback` symbol as suggested by @devongovett in this comment: https://github.com/adobe/react-spectrum/issues/5671#issuecomment-1915384557
- Added documentation in the Advanced Customization part of the documentation, as suggested by @LFDanLu in this comment: https://github.com/adobe/react-spectrum/issues/5671#issuecomment-1899324835

Of course, the hardest part of this PR was the documentation, so feel free to suggest any changes, and I'll happily make them.


## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
