### PR TITLE
fix(#5877): Picker in TableView creates a focus trap with arrow key navigation

### DIFF
--- a/packages/@react-aria/focus/src/isElementVisible.ts
+++ b/packages/@react-aria/focus/src/isElementVisible.ts
@@ -43,6 +43,8 @@ function isStyleVisible(element: Element) {
 function isAttributeVisible(element: Element, childElement?: Element) {
   return (
     !element.hasAttribute('hidden') &&
+    // Ignore HiddenSelect when tree walking.
+    !(element.hasAttribute('data-a11y-ignore') && element.getAttribute('aria-hidden') === 'true') &&
     (element.nodeName === 'DETAILS' &&
       childElement &&
       childElement.nodeName !== 'SUMMARY'

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1634,17 +1634,19 @@ describe('Picker', function () {
     });
 
     it('move selection on Arrow-Left/Right', async function () {
-      let {getByRole} = render(
+      let {getByRole, getByTestId} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
             <Item key="one">One</Item>
             <Item key="two">Two</Item>
             <Item key="three">Three</Item>
           </Picker>
+          <div tabIndex={-1} data-testid="after" />
         </Provider>
       );
 
       let picker = getByRole('button');
+      let after = getByTestId('after');
       await user.tab();
       expect(picker).toHaveTextContent('Select an option…');
       await user.keyboard('{ArrowLeft}');
@@ -1654,26 +1656,50 @@ describe('Picker', function () {
       expect(picker).toHaveTextContent('One');
 
       await user.keyboard('{ArrowLeft}');
+      act(() => jest.runAllTimers());
       expect(picker).toHaveTextContent('One');
 
       await user.keyboard('{ArrowRight}');
+      act(() => jest.runAllTimers());
       expect(picker).toHaveTextContent('Two');
       expect(onSelectionChange).toHaveBeenCalledTimes(2);
 
       await user.keyboard('{ArrowRight}');
+      act(() => jest.runAllTimers());
       expect(picker).toHaveTextContent('Three');
       expect(onSelectionChange).toHaveBeenCalledTimes(3);
 
       await user.keyboard('{ArrowRight}');
+      act(() => jest.runAllTimers());
       expect(picker).toHaveTextContent('Three');
       expect(onSelectionChange).toHaveBeenCalledTimes(3);
 
       await user.keyboard('{ArrowLeft}');
+      act(() => jest.runAllTimers());
       expect(picker).toHaveTextContent('Two');
       expect(onSelectionChange).toHaveBeenCalledTimes(4);
 
       await user.keyboard('{ArrowLeft}');
+      act(() => jest.runAllTimers());
       expect(picker).toHaveTextContent('One');
+      expect(onSelectionChange).toHaveBeenCalledTimes(5);
+
+
+      await user.keyboard('{ArrowLeft}');
+      act(() => {
+        after.focus();
+        jest.runAllTimers();
+      });
+      expect(picker).toHaveTextContent('One', 'Picker value should not change if focus has moved elsewhere after ArrowLeft.');
+      expect(onSelectionChange).toHaveBeenCalledTimes(5);
+
+      act(() => picker.focus());
+      await user.keyboard('{ArrowRight}');
+      act(() => {
+        after.focus();
+        jest.runAllTimers();
+      });
+      expect(picker).toHaveTextContent('One', 'Picker value should not change if focus has moved elsewhere after ArrowRight.');
       expect(onSelectionChange).toHaveBeenCalledTimes(5);
     });
   });

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -31,6 +31,7 @@ import {IllustratedMessage} from '@react-spectrum/illustratedmessage';
 import {Key, LoadingState} from '@react-types/shared';
 import {Link} from '@react-spectrum/link';
 import NoSearchResults from '@spectrum-icons/illustrations/NoSearchResults';
+import {Picker} from '@react-spectrum/picker';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
 import React, {useCallback, useState} from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
@@ -448,6 +449,17 @@ export const FocusableCells: TableStory = {
           <Row>
             <Cell><Switch aria-label="Foo" /></Cell>
             <Cell><Link><a href="https://yahoo.com" target="_blank">Yahoo</a></Link></Cell>
+            <Cell>Three</Cell>
+          </Row>
+          <Row>
+            <Cell><Switch aria-label="Foo" /></Cell>
+            <Cell>
+              <Picker aria-label="Search engine" placeholder="Search with:" width={'100%'} isQuiet>
+                <Item key="Yahoo">Yahoo</Item>
+                <Item key="Google">Google</Item>
+                <Item key="DuckDuckGo">DuckDuckGo</Item>
+              </Picker>
+            </Cell>
             <Cell>Three</Cell>
           </Row>
         </TableBody>
@@ -927,7 +939,7 @@ function AsyncLoadingExample(props) {
       let url = new URL('https://www.reddit.com/r/upliftingnews.json');
       if (cursor) {
         url.searchParams.append('after', cursor);
-      }      
+      }
       let res = await fetch(url.toString(), {signal});
       let json = await res.json();
       return {items: json.data.children, cursor: json.data.after};
@@ -1076,14 +1088,14 @@ function AsyncLoadingExampleQuarryTest(props) {
       return {
         items: items.slice().sort((a, b) => {
           let cmp = a[sortDescriptor.column] < b[sortDescriptor.column] ? -1 : 1;
-    
+
           if (sortDescriptor.direction === 'descending') {
             cmp *= -1;
           }
-    
+
           return cmp;
         })
-        
+
       };
     }
   });

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -25,6 +25,7 @@ import {Divider} from '@react-spectrum/divider';
 import {enableTableNestedRows} from '@react-stately/flags';
 import {getFocusableTreeWalker} from '@react-aria/focus';
 import {Heading} from '@react-spectrum/text';
+import {Item, Picker} from '@react-spectrum/picker';
 import {Link} from '@react-spectrum/link';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -1499,6 +1500,31 @@ export let tableTests = () => {
         </>
       );
 
+      let renderWithPicker = () => render(
+        <>
+          <TableView aria-label="Table">
+            <TableHeader>
+              <Column>Foo</Column>
+              <Column>Bar</Column>
+              <Column>baz</Column>
+            </TableHeader>
+            <TableBody>
+              <Row>
+                <Cell textValue="Foo 1"><Switch aria-label="Foo 1" /></Cell>
+                <Cell textValue="Search engine">
+                  <Picker aria-label="Search engine" placeholder="Search with:" width={'100%'} isQuiet>
+                    <Item key="Yahoo">Yahoo</Item>
+                    <Item key="Google">Google</Item>
+                    <Item key="DuckDuckGo">DuckDuckGo</Item>
+                  </Picker>
+                </Cell>
+                <Cell>Baz 1</Cell>
+              </Row>
+            </TableBody>
+          </TableView>
+        </>
+      );
+
       it('should retain focus on the pressed child', async function () {
         let tree = renderFocusable();
         let switchToPress = tree.getAllByRole('switch')[2];
@@ -1627,6 +1653,19 @@ export let tableTests = () => {
         fireEvent.keyUp(after, {key: 'Tab'});
 
         expect(document.activeElement).toBe(baz1);
+      });
+
+      it('should not trap focus when navigating through a cell with a picker using the arrow keys', function () {
+        let tree = renderWithPicker();
+        focusCell(tree, 'Baz 1');
+        moveFocus('ArrowLeft');
+        expect(document.activeElement).toBe(tree.getByRole('button'));
+        moveFocus('ArrowLeft');
+        expect(document.activeElement).toBe(tree.getByRole('switch'));
+        moveFocus('ArrowRight');
+        expect(document.activeElement).toBe(tree.getByRole('button'));
+        moveFocus('ArrowRight');
+        expect(document.activeElement).toBe(tree.getAllByRole('gridcell')[1]);
       });
 
       it('should move focus after the table when tabbing', async function () {


### PR DESCRIPTION
Closes #5877 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 5877](https://github.com/adobe/react-spectrum/issue/5877).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open the Storybook example at https://reactspectrum.blob.core.windows.net/reactspectrum/5ea877f566df0d8fbd9543963778c4c21bfa0f10/storybook/index.html?path=/story/tableview--focusable-cells&providerSwitcher-express=false&strict=true
2. The example app consists of a TableView in which the last row has a Picker in the second cell.
3. Press Tab to navigate and set focus to the first row in the TableView.
4. Press ArrowDown until the last row, containing the Picker has focus.
5. Press ArrowRight to focus the Switch in the first cell.
6. Press ArrowRight again to focus the Picker in the second cell.
7. Press ArrowRight to move focus to the next cell, containing the word "Three."
8. The value of the Picker does not change as the focus moves to the next cell.
9. Press ArrowLeft to focus the Picker in the second cell again.
10. Press ArrowLeft again to move focus to the previous cell.
11. Focus moves to the Switch in the first cell, and the value of the Picker does not change.

## 🧢 Your Project:

Adobe/Accessibility
