### PR TITLE
Add `--trigger-width` support for DatePicker & DateRangePicker

### DIFF
--- a/packages/react-aria-components/docs/DatePicker.mdx
+++ b/packages/react-aria-components/docs/DatePicker.mdx
@@ -954,11 +954,11 @@ The [Popover](Popover.html) component can be targeted with the `.react-aria-Popo
 
 <StateTable properties={docs.exports.PopoverRenderProps.properties} />
 
-Within a DatePicker, the popover will have the `data-trigger="DatePicker"` attribute, which can be used to define date picker-specific styles.
+Within a DatePicker, the popover will have the `data-trigger="DatePicker"` attribute, which can be used to define date picker-specific styles. In addition, the `--trigger-width` CSS custom property will be set on the popover, which you can use to make the popover match the width of the input group.
 
 ```css render=false
 .react-aria-Popover[data-trigger=DatePicker] {
-  /* ... */
+  width: var(--trigger-width);
 }
 ```
 

--- a/packages/react-aria-components/docs/DateRangePicker.mdx
+++ b/packages/react-aria-components/docs/DateRangePicker.mdx
@@ -1043,11 +1043,11 @@ The [Popover](Popover.html) component can be targeted with the `.react-aria-Popo
 
 <StateTable properties={docs.exports.PopoverRenderProps.properties} />
 
-Within a DateRangePicker, the popover will have the `data-trigger="DateRangePicker"` attribute, which can be used to define date range picker-specific styles.
+Within a DateRangePicker, the popover will have the `data-trigger="DateRangePicker"` attribute, which can be used to define date range picker-specific styles. In addition, the `--trigger-width` CSS custom property will be set on the popover, which you can use to make the popover match the width of the input group.
 
 ```css render=false
 .react-aria-Popover[data-trigger=DateRangePicker] {
-  /* ... */
+  width: var(--trigger-width);
 }
 ```
 

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -95,7 +95,7 @@ function DatePicker<T extends DateValue>(props: DatePickerProps<T>, ref: Forward
     validationBehavior: props.validationBehavior ?? 'native'
   }, state, groupRef);
 
-  // Allows calander width to match input group
+  // Allows calendar width to match input group
   let [groupWidth, setGroupWidth] = useState<string | null>(null);
   let onResize = useCallback(() => {
     if (groupRef.current) {
@@ -197,7 +197,7 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
     validationBehavior: props.validationBehavior ?? 'native'
   }, state, groupRef);
 
-  // Allows calander width to match input group
+  // Allows calendar width to match input group
   let [groupWidth, setGroupWidth] = useState<string | null>(null);
   let onResize = useCallback(() => {
     if (groupRef.current) {

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -17,11 +17,11 @@ import {DateFieldContext} from './DateField';
 import {DatePickerState, DatePickerStateOptions, DateRangePickerState, DateRangePickerStateOptions, useDatePickerState, useDateRangePickerState} from 'react-stately';
 import {DialogContext, OverlayTriggerStateContext} from './Dialog';
 import {FieldErrorContext} from './FieldError';
-import {filterDOMProps} from '@react-aria/utils';
+import {filterDOMProps, useResizeObserver} from '@react-aria/utils';
 import {GroupContext} from './Group';
 import {LabelContext} from './Label';
 import {PopoverContext} from './Popover';
-import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, useCallback, useRef, useState} from 'react';
 import {TextContext} from './Text';
 
 export interface DatePickerRenderProps {
@@ -95,6 +95,19 @@ function DatePicker<T extends DateValue>(props: DatePickerProps<T>, ref: Forward
     validationBehavior: props.validationBehavior ?? 'native'
   }, state, groupRef);
 
+  // Allows calander width to match input group
+  let [groupWidth, setGroupWidth] = useState<string | null>(null);
+  let onResize = useCallback(() => {
+    if (groupRef.current) {
+      setGroupWidth(groupRef.current.offsetWidth + 'px');
+    }
+  }, []);
+
+  useResizeObserver({
+    ref: groupRef,
+    onResize: onResize
+  });
+
   let {focusProps, isFocused, isFocusVisible} = useFocusRing({within: true});
   let renderProps = useRenderProps({
     ...props,
@@ -122,7 +135,12 @@ function DatePicker<T extends DateValue>(props: DatePickerProps<T>, ref: Forward
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [CalendarContext, calendarProps],
         [OverlayTriggerStateContext, state],
-        [PopoverContext, {trigger: 'DatePicker', triggerRef: groupRef, placement: 'bottom start'}],
+        [PopoverContext, {
+          trigger: 'DatePicker', 
+          triggerRef: groupRef, 
+          placement: 'bottom start', 
+          style: {'--trigger-width': groupWidth} as React.CSSProperties
+        }],
         [DialogContext, dialogProps],
         [TextContext, {
           slots: {
@@ -179,6 +197,19 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
     validationBehavior: props.validationBehavior ?? 'native'
   }, state, groupRef);
 
+  // Allows calander width to match input group
+  let [groupWidth, setGroupWidth] = useState<string | null>(null);
+  let onResize = useCallback(() => {
+    if (groupRef.current) {
+      setGroupWidth(groupRef.current.offsetWidth + 'px');
+    }
+  }, []);
+
+  useResizeObserver({
+    ref: groupRef,
+    onResize: onResize
+  });
+
   let {focusProps, isFocused, isFocusVisible} = useFocusRing({within: true});
   let renderProps = useRenderProps({
     ...props,
@@ -205,7 +236,12 @@ function DateRangePicker<T extends DateValue>(props: DateRangePickerProps<T>, re
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [RangeCalendarContext, calendarProps],
         [OverlayTriggerStateContext, state],
-        [PopoverContext, {trigger: 'DateRangePicker', triggerRef: groupRef, placement: 'bottom start'}],
+        [PopoverContext, {
+          trigger: 'DateRangePicker', 
+          triggerRef: groupRef, 
+          placement: 'bottom start',
+          style: {'--trigger-width': groupWidth} as React.CSSProperties
+        }],
         [DialogContext, dialogProps],
         [DateFieldContext, {
           slots: {

--- a/packages/react-aria-components/stories/DatePicker.stories.tsx
+++ b/packages/react-aria-components/stories/DatePicker.stories.tsx
@@ -148,7 +148,8 @@ export const DateRangePickerTriggerWidthExample = () => (
         color: 'CanvasText',
         border: '1px solid gray',
         padding: 20,
-        width: 'calc(var(--trigger-width) - 20px * 2 - 1px * 2)'
+        boxSizing: 'border-box',
+        width: 'var(--trigger-width)'
       }}>
       <Dialog>
         <RangeCalendar>

--- a/packages/react-aria-components/stories/DatePicker.stories.tsx
+++ b/packages/react-aria-components/stories/DatePicker.stories.tsx
@@ -68,7 +68,8 @@ export const DatePickerTriggerWidthExample = () => (
         color: 'CanvasText',
         border: '1px solid gray',
         padding: 20,
-        width: 'calc(var(--trigger-width) - 20px * 2 - 1px * 2)'
+        boxSizing: 'border-box',
+        width: 'var(--trigger-width)'
       }}>
       <Dialog>
         <Calendar>

--- a/packages/react-aria-components/stories/DatePicker.stories.tsx
+++ b/packages/react-aria-components/stories/DatePicker.stories.tsx
@@ -52,6 +52,40 @@ export const DatePickerExample = () => (
   </DatePicker>
 );
 
+export const DatePickerTriggerWidthExample = () => (
+  <DatePicker data-testid="date-picker-example">
+    <Label style={{display: 'block'}}>Date</Label>
+    <Group style={{display: 'inline-flex', width: 300}}>
+      <DateInput className={styles.field} style={{flex: 1}}>
+        {segment => <DateSegment segment={segment} className={clsx(styles.segment, {[styles.placeholder]: segment.isPlaceholder})} />}
+      </DateInput>
+      <Button>🗓</Button>
+    </Group>
+    <Popover
+      placement="bottom start"
+      style={{
+        background: 'Canvas',
+        color: 'CanvasText',
+        border: '1px solid gray',
+        padding: 20,
+        width: 'calc(var(--trigger-width) - 20px * 2 - 1px * 2)'
+      }}>
+      <Dialog>
+        <Calendar>
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            <Button slot="previous">&lt;</Button>
+            <Heading style={{flex: 1, textAlign: 'center'}} />
+            <Button slot="next">&gt;</Button>
+          </div>
+          <CalendarGrid style={{width: '100%'}}>
+            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+          </CalendarGrid>
+        </Calendar>
+      </Dialog>
+    </Popover>
+  </DatePicker>
+);
+
 export const DateRangePickerExample = () => (
   <DateRangePicker data-testid="date-range-picker-example">
     <Label style={{display: 'block'}}>Date</Label>
@@ -77,6 +111,46 @@ export const DateRangePickerExample = () => (
       }}>
       <Dialog>
         <RangeCalendar style={{width: 220}}>
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            <Button slot="previous">&lt;</Button>
+            <Heading style={{flex: 1, textAlign: 'center'}} />
+            <Button slot="next">&gt;</Button>
+          </div>
+          <CalendarGrid style={{width: '100%'}}>
+            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+          </CalendarGrid>
+        </RangeCalendar>
+      </Dialog>
+    </Popover>
+  </DateRangePicker>
+);
+
+export const DateRangePickerTriggerWidthExample = () => (
+  <DateRangePicker data-testid="date-range-picker-example">
+    <Label style={{display: 'block'}}>Date</Label>
+    <Group style={{display: 'inline-flex', width: 300}}>
+      <div className={styles.field} style={{flex: 1}}>
+        <DateInput data-testid="date-range-picker-date-input" slot="start" style={{display: 'inline-flex'}}>
+          {segment => <DateSegment segment={segment} className={clsx(styles.segment, {[styles.placeholder]: segment.isPlaceholder})} />}
+        </DateInput>
+        <span aria-hidden="true" style={{padding: '0 4px'}}>–</span>
+        <DateInput slot="end" style={{display: 'inline-flex'}}>
+          {segment => <DateSegment segment={segment} className={clsx(styles.segment, {[styles.placeholder]: segment.isPlaceholder})} />}
+        </DateInput>
+      </div>
+      <Button>🗓</Button>
+    </Group>
+    <Popover
+      placement="bottom start"
+      style={{
+        background: 'Canvas',
+        color: 'CanvasText',
+        border: '1px solid gray',
+        padding: 20,
+        width: 'calc(var(--trigger-width) - 20px * 2 - 1px * 2)'
+      }}>
+      <Dialog>
+        <RangeCalendar>
           <div style={{display: 'flex', alignItems: 'center'}}>
             <Button slot="previous">&lt;</Button>
             <Heading style={{flex: 1, textAlign: 'center'}} />


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5883

Hello, this PR adds `--trigger-width` CSS variable as a popover inline style, so that users can match the width of the popover containing the calendar to that of the input group with said variable. 

The changes contained in this PR make direct references to those components already well supporting the `--trigger-width` such as [Select](https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/Select.tsx#L96-L107), [Menu](https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/Menu.tsx#L48-L58), and [Combobox](https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/ComboBox.tsx#L149-L164).

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Stories
#### DatePicker
http://localhost:9003/?path=/story/react-aria-components--date-picker-trigger-width-example&providerSwitcher-express=false&strict=true
#### DateRangePicker
http://localhost:9003/?path=/story/react-aria-components--date-range-picker-trigger-width-example&providerSwitcher-express=false&strict=true

## 🧢 Your Project:

<!--- Company/project for pull request -->
