### PR TITLE
Add null type to Radiogroup `value` prop.

### DIFF
--- a/packages/@react-types/radio/src/index.d.ts
+++ b/packages/@react-types/radio/src/index.d.ts
@@ -29,7 +29,7 @@ import {
 } from '@react-types/shared';
 import {ReactElement, ReactNode} from 'react';
 
-export interface RadioGroupProps extends ValueBase<string>, InputBase, InputDOMProps, Validation<string | null>, LabelableProps, HelpTextProps, FocusEvents {
+export interface RadioGroupProps extends ValueBase<string|null, string>, InputBase, InputDOMProps, Validation<string | null>, LabelableProps, HelpTextProps, FocusEvents {
   /**
    * The axis the Radio Button(s) should align with.
    * @default 'vertical'

--- a/packages/react-aria-components/stories/RadioGroup.stories.tsx
+++ b/packages/react-aria-components/stories/RadioGroup.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {Button, Dialog, DialogTrigger, Label, Modal, ModalOverlay, Radio, RadioGroup} from 'react-aria-components';
-import React from 'react';
+import React, {useState} from 'react';
 import styles from '../example/index.css';
 
 export default {
@@ -24,6 +24,23 @@ export const RadioGroupExample = () => {
       data-testid="radio-group-example"
       className={styles.radiogroup}>
       <Label>Favorite pet</Label>
+      <Radio className={styles.radio} value="dogs" data-testid="radio-dog">Dog</Radio>
+      <Radio className={styles.radio} value="cats">Cat</Radio>
+      <Radio className={styles.radio} value="dragon">Dragon</Radio>
+    </RadioGroup>
+  );
+};
+
+export const RadioGroupControlledExample = () => {
+  let [selected, setSelected] = useState<string|null>(null);
+  
+  return (
+    <RadioGroup
+      data-testid="radio-group-example"
+      className={styles.radiogroup}
+      value={selected}
+      onChange={setSelected}>
+      <Label>Favorite pet (controlled)</Label>
       <Radio className={styles.radio} value="dogs" data-testid="radio-dog">Dog</Radio>
       <Radio className={styles.radio} value="cats">Cat</Radio>
       <Radio className={styles.radio} value="dragon">Dragon</Radio>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5871

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Story
#### Controlled RadioGroup
http://localhost:9003/?path=/story/react-aria-components--radio-group-controlled-example&providerSwitcher-express=false&strict=true

## 🧢 Your Project:

<!--- Company/project for pull request -->
