### PR TITLE
Add Separator to MenuSections

### DIFF
--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -224,9 +224,14 @@ function MenuSection<T>({section, className, style, parentMenuRef, ...otherProps
 
   // determine if the separator is the last key in the entire collection
   let lastKey = state.collection.getLastKey();
-  let lastItem = state.collection.getItem(lastKey);
-  let parentKey = lastItem.parentKey;
-  let isLast = parentKey === section.key;
+  let isLast = false;
+  if (lastKey) {
+    let lastItem = state.collection.getItem(lastKey);
+    if (lastItem) {
+      let parentKey = lastItem.parentKey;
+      isLast = parentKey === section.key;
+    }
+  }
 
   let children = useCachedChildren({
     items: state.collection.getChildren!(section.key),

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -222,6 +222,12 @@ function MenuSection<T>({section, className, style, parentMenuRef, ...otherProps
     'aria-label': section['aria-label'] ?? undefined
   });
 
+  // determine if the separator is the last key in the entire collection
+  let lastKey = state.collection.getLastKey();
+  let lastItem = state.collection.getItem(lastKey);
+  let parentKey = lastItem.parentKey;
+  let isLast = parentKey === section.key;
+
   let children = useCachedChildren({
     items: state.collection.getChildren!(section.key),
     children: item => {
@@ -241,6 +247,8 @@ function MenuSection<T>({section, className, style, parentMenuRef, ...otherProps
           return <MenuItemInner item={item} />;
         case 'submenutrigger':
           return <SubmenuTriggerInner item={item} parentMenuRef={parentMenuRef} />;
+        case 'separator':
+          return isLast ? <></> : <Separator {...item.props} />;
         default:
           throw new Error('Unsupported element type in Section: ' + item.type);
       }

--- a/packages/react-aria-components/stories/Menu.stories.tsx
+++ b/packages/react-aria-components/stories/Menu.stories.tsx
@@ -232,6 +232,53 @@ export const SubmenuSectionsExample = (args) => (
   </MenuTrigger>
 );
 
+export const SubmenuCustomSectionsExample = (args) => (
+  <MenuTrigger>
+    <Button aria-label="Menu">☰</Button>
+    <Popover>
+      <Menu className={styles.menu} onAction={action('onAction')}>
+        <CustomSection className={styles.group} title="Section 1">
+          <MyMenuItem>Foo</MyMenuItem>
+          <SubmenuTrigger {...args}>
+            <MyMenuItem id="Bar">Bar</MyMenuItem>
+            <Popover className={styles.popover}>
+              <Menu className={styles.menu} onAction={action('onAction')}>
+                <CustomSection className={styles.group} title="Submenu Section 1">
+                  <MyMenuItem id="Submenu Foo">Submenu Foo</MyMenuItem>
+                  <MyMenuItem id="Submenu Bar">Submenu Bar</MyMenuItem>
+                  <MyMenuItem id="Submenu Baz">Submenu Baz</MyMenuItem>
+                  <MyMenuItem href="https://google.com">Google</MyMenuItem>
+                </CustomSection>
+                <CustomSection className={styles.group} title="Submenu Section 2">
+                  <MyMenuItem id="Submenu Foo 2">Submenu Foo</MyMenuItem>
+                  <MyMenuItem id="Submenu Bar 2">Submenu Bar</MyMenuItem>
+                  <MyMenuItem id="Submenu Baz 2">Submenu Baz</MyMenuItem>
+                </CustomSection>
+              </Menu>
+            </Popover>
+          </SubmenuTrigger>
+          <MyMenuItem>Baz</MyMenuItem>
+          <MyMenuItem href="https://google.com">Google</MyMenuItem>
+        </CustomSection>
+        <CustomSection className={styles.group} title="Section 2">
+          <MyMenuItem>Foo</MyMenuItem>
+          <MyMenuItem>Bar</MyMenuItem>
+          <MyMenuItem>Baz</MyMenuItem>
+        </CustomSection>
+      </Menu>
+    </Popover>
+  </MenuTrigger>
+);
+let CustomSection = (props) => {
+  return (
+    <Section className={styles.group}>
+      <Header style={{fontSize: '1.2em'}}>{props.title}</Header>
+      {props.children}
+      <Separator style={{borderTop: '1px solid gray', margin: '2px 5px'}} />
+    </Section>
+  );
+};
+
 let submenuArgs = {
   args: {
     delay: 200
@@ -247,3 +294,4 @@ SubmenuExample.story = {...submenuArgs};
 SubmenuNestedExample.story = {...submenuArgs};
 SubmenuManyItemsExample.story = {...submenuArgs};
 SubmenuDisabledExample.story = {...submenuArgs};
+SubmenuCustomSectionsExample.story = {...submenuArgs};


### PR DESCRIPTION
Closes <!-- Github issue # here -->

This is more of a discussion PR.

I want to be able to create Sections in menus which already have a Separator inside of it. I'd also like for the last Section, if trailed by nothing else, not to display the separator.

I contemplated adding renderProps to Sections in order to handle the isLast. I ran into some issues with that, it wouldn't render the entire menu, but no warnings or errors. Instead, I've opted for the moment to force the issue and render nothing in place of the separator if the Section is the last thing in the Menu.

I could add them in an implementation by doing something like
```
    <>
      <AriaSection>
          {props.children}
      </AriaSection>
      <Divider />
    </>
```
and then make use of the `:last-child` psuedo selector



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
