### PR TITLE
fix: enhance FocusScope to support tab completion for IMEs

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -314,7 +314,7 @@ function useFocusContainment(scopeRef: RefObject<Element[]>, contain?: boolean) 
 
     // Handle the Tab key to contain focus within the scope
     let onKeyDown = (e) => {
-      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || !shouldContainFocus(scopeRef)) {
+      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || !shouldContainFocus(scopeRef) || e.isComposing) {
         return;
       }
 

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -585,7 +585,7 @@ function useRestoreFocus(scopeRef: RefObject<Element[]>, restoreFocus?: boolean,
     // using portals for overlays, so that focus goes to the expected element when
     // tabbing out of the overlay.
     let onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || !shouldContainFocus(scopeRef)) {
+      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || !shouldContainFocus(scopeRef) || e.isComposing) {
         return;
       }
 

--- a/packages/@react-aria/focus/stories/FocusScope.stories.tsx
+++ b/packages/@react-aria/focus/stories/FocusScope.stories.tsx
@@ -258,5 +258,19 @@ export const FocusableInputForm = {
     autoFocus: {
       control: 'boolean'
     }
+  },
+  parameters: {
+    description: {
+      data: `
+1. Open OS keyboard settings
+2. Add Chinese Pinyin - Simplified
+3. Go to the third input
+4. Type "ni", a set of suggestions should appear
+5. Press Tab 3x and see how it shows different suggestions
+6. Go to the first input
+7. Repeat steps 4&5
+8. See how it leaves the suggestions and jumps to the form button
+`
+    }
   }
 };

--- a/packages/@react-aria/focus/stories/FocusScope.stories.tsx
+++ b/packages/@react-aria/focus/stories/FocusScope.stories.tsx
@@ -211,13 +211,52 @@ export const FocusableFirstInScope = {
   render: () => <FocusableFirstInScopeExample />
 };
 
+
+function FocusableInputFormExample(args) {
+  let [isOpen, setOpen] = React.useState(false);
+  let {contain, restoreFocus, autoFocus} = args;
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open</button>
+      {isOpen && (
+        <>
+          <div style={{display: 'flex', flexDirection: 'column', marginBottom: '10px'}}>
+            <FocusScope contain={contain} restoreFocus={restoreFocus} autoFocus={autoFocus}>
+              <label htmlFor="first-input">First Input</label>
+              <input id="first-input" />
+              <label htmlFor="second-input">Second Input</label>
+              <input id="second-input" />
+            </FocusScope>
+          </div>
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+            <label htmlFor="third-input">Third Input</label>
+            <input id="third-input" />
+          </div>
+          <button onClick={() => setOpen(false)}>Close</button>
+        </>
+      )}
+    </>
+  );
+}
+
 export const FocusableInputForm = {
-  render: () => (
-    <FocusScope contain>
-      <form>
-        <input type="search" />
-        <button type="submit">Submit</button>
-      </form>
-    </FocusScope>
-  )
+  name: 'FocusableInputForm',
+  render: (args) => <FocusableInputFormExample {...args} />,
+  args: {
+    contain: true,
+    restoreFocus: true,
+    autoFocus: true
+  },
+  argTypes: {
+    contain: {
+      control: 'boolean'
+    },
+    restoreFocus: {
+      control: 'boolean'
+    },
+    autoFocus: {
+      control: 'boolean'
+    }
+  }
 };

--- a/packages/@react-aria/focus/stories/FocusScope.stories.tsx
+++ b/packages/@react-aria/focus/stories/FocusScope.stories.tsx
@@ -210,3 +210,14 @@ export const IgnoreRestoreFocus = {
 export const FocusableFirstInScope = {
   render: () => <FocusableFirstInScopeExample />
 };
+
+export const FocusableInputForm = {
+  render: () => (
+    <FocusScope contain>
+      <form>
+        <input type="search" />
+        <button type="submit">Submit</button>
+      </form>
+    </FocusScope>
+  )
+};


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5904

I've tested with several languages, but found that not many languages present completion with the Tab key. Therefore, I have confirmed the behavior only with "Chinese Pinyin - Simplified", "Japanese - Kana", and Google IME - Japanese.



## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Setup for MacOS:

1. Open OS keyboard settings.
2. Add "Chinese Pinyin - Simplified", "Japanese - Kana", and [Google IME - Japanese](https://www.google.co.jp/ime/).

### Testing Steps:

1. Navigate to the [MDN input search example](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search).
2. In the second input field, type "a" to trigger a set of suggestions.
3. Press the Tab key three times to cycle through different suggestions.
4. Now, visit the [FocusScope Storybook example](http://localhost:9003/?path=/story/focusscope--focusable-input-form&providerSwitcher-express=false&strict=true).
5. Repeat steps 2 and 3 in the Storybook example's input field.
6. Confirm that the behavior in the MDN example and the Storybook example is consistent, particularly in how suggestions are cycled through with the Tab key.

## 🧢 Your Project:

<!--- Company/project for pull request -->
