### PR TITLE
Add support for fixed week display in Calendar

### DIFF
--- a/packages/@react-types/calendar/src/index.d.ts
+++ b/packages/@react-types/calendar/src/index.d.ts
@@ -62,7 +62,12 @@ export interface CalendarPropsBase {
    * Controls the behavior of paging. Pagination either works by advancing the visible page by visibleDuration (default) or one unit of visibleDuration.
    * @default visible
    */
-  pageBehavior?: PageBehavior
+  pageBehavior?: PageBehavior,
+  /**
+   * Whether the calendar should always display 6 weeks.
+   * @default false
+   */
+  isFixedWeeks?: boolean
 }
 
 export type DateRange = RangeValue<DateValue>;

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -63,6 +63,7 @@ export interface RangeCalendarProps<T extends DateValue> extends Omit<BaseRangeC
 export const CalendarContext = createContext<ContextValue<CalendarProps<any>, HTMLDivElement>>({});
 export const RangeCalendarContext = createContext<ContextValue<RangeCalendarProps<any>, HTMLDivElement>>({});
 export const CalendarStateContext = createContext<CalendarState | null>(null);
+export const CalendarGridContext = createContext<boolean | null>(null);
 export const RangeCalendarStateContext = createContext<RangeCalendarState | null>(null);
 
 function Calendar<T extends DateValue>(props: CalendarProps<T>, ref: ForwardedRef<HTMLDivElement>) {
@@ -104,6 +105,7 @@ function Calendar<T extends DateValue>(props: CalendarProps<T>, ref: ForwardedRe
           }],
           [HeadingContext, {'aria-hidden': true, level: 2, children: title}],
           [CalendarStateContext, state],
+          [CalendarGridContext, props.isFixedWeeks],
           [TextContext, {
             slots: {
               errorMessage: errorMessageProps
@@ -183,6 +185,7 @@ function RangeCalendar<T extends DateValue>(props: RangeCalendarProps<T>, ref: F
           }],
           [HeadingContext, {'aria-hidden': true, level: 2, children: title}],
           [RangeCalendarStateContext, state],
+          [CalendarGridContext, props.isFixedWeeks],
           [TextContext, {
             slots: {
               errorMessage: errorMessageProps
@@ -432,7 +435,8 @@ function CalendarGridBody(props: CalendarGridBodyProps, ref: ForwardedRef<HTMLTa
   let state = calendarState ?? rangeCalendarState!;
   let {startDate} = useContext(InternalCalendarGridContext)!;
   let {locale} = useLocale();
-  let weeksInMonth = getWeeksInMonth(startDate, locale);
+  let isFixedWeeks = useContext(CalendarGridContext);
+  let weeksInMonth = isFixedWeeks ? 6 : getWeeksInMonth(startDate, locale);
 
   return (
     <tbody

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -105,7 +105,7 @@ function Calendar<T extends DateValue>(props: CalendarProps<T>, ref: ForwardedRe
           }],
           [HeadingContext, {'aria-hidden': true, level: 2, children: title}],
           [CalendarStateContext, state],
-          [CalendarGridContext, props.isFixedWeeks],
+          [CalendarGridContext, props.isFixedWeeks || false],
           [TextContext, {
             slots: {
               errorMessage: errorMessageProps
@@ -185,7 +185,7 @@ function RangeCalendar<T extends DateValue>(props: RangeCalendarProps<T>, ref: F
           }],
           [HeadingContext, {'aria-hidden': true, level: 2, children: title}],
           [RangeCalendarStateContext, state],
-          [CalendarGridContext, props.isFixedWeeks],
+          [CalendarGridContext, props.isFixedWeeks || false],
           [TextContext, {
             slots: {
               errorMessage: errorMessageProps

--- a/packages/react-aria-components/stories/DatePicker.stories.tsx
+++ b/packages/react-aria-components/stories/DatePicker.stories.tsx
@@ -16,10 +16,14 @@ import React from 'react';
 import styles from '../example/index.css';
 
 export default {
-  title: 'React Aria Components'
+  title: 'React Aria Components',
+  argTypes: {
+    isFixedWeeks: {control: 'boolean'}
+  }
 };
 
-export const DatePickerExample = () => (
+
+export const DatePickerExample = (args) => (
   <DatePicker data-testid="date-picker-example">
     <Label style={{display: 'block'}}>Date</Label>
     <Group style={{display: 'inline-flex'}}>
@@ -37,14 +41,14 @@ export const DatePickerExample = () => (
         padding: 20
       }}>
       <Dialog>
-        <Calendar style={{width: 220}}>
+        <Calendar style={{width: 220}} isFixedWeeks={args.isFixedWeeks}>
           <div style={{display: 'flex', alignItems: 'center'}}>
             <Button slot="previous">&lt;</Button>
             <Heading style={{flex: 1, textAlign: 'center'}} />
             <Button slot="next">&gt;</Button>
           </div>
           <CalendarGrid style={{width: '100%'}}>
-            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth && !args.isFixedWeeks ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
           </CalendarGrid>
         </Calendar>
       </Dialog>
@@ -52,7 +56,11 @@ export const DatePickerExample = () => (
   </DatePicker>
 );
 
-export const DateRangePickerExample = () => (
+DatePickerExample.args = {
+  isFixedWeeks: false
+};
+
+export const DateRangePickerExample = (args) => (
   <DateRangePicker data-testid="date-range-picker-example">
     <Label style={{display: 'block'}}>Date</Label>
     <Group style={{display: 'inline-flex'}}>
@@ -76,17 +84,21 @@ export const DateRangePickerExample = () => (
         padding: 20
       }}>
       <Dialog>
-        <RangeCalendar style={{width: 220}}>
+        <RangeCalendar style={{width: 220}} isFixedWeeks={args.isFixedWeeks}>
           <div style={{display: 'flex', alignItems: 'center'}}>
             <Button slot="previous">&lt;</Button>
             <Heading style={{flex: 1, textAlign: 'center'}} />
             <Button slot="next">&gt;</Button>
           </div>
           <CalendarGrid style={{width: '100%'}}>
-            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth && !args.isFixedWeeks ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
           </CalendarGrid>
         </RangeCalendar>
       </Dialog>
     </Popover>
   </DateRangePicker>
 );
+
+DateRangePickerExample.args = {
+  isFixedWeeks: false
+};

--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -284,4 +284,29 @@ describe('Calendar', () => {
     let headers = getAllByRole('columnheader', {hidden: true});
     expect(headers.map(h => h.textContent)).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
   });
+
+  it('should support fixedWeeks', async () => {
+    let {getByRole} = renderCalendar({isFixedWeeks: true, defaultValue: new CalendarDate(2024, 2, 3)});
+    let grid = getByRole('grid');
+    let rowgroups = within(grid).getAllByRole('rowgroup');
+    expect(rowgroups[0]).toHaveAttribute('class', 'react-aria-CalendarGridBody');
+
+    let calendarGridBody = rowgroups[0];
+    let rowsInCalendarGridBody = within(calendarGridBody).getAllByRole('row');
+    expect(rowsInCalendarGridBody.length).toBe(6);
+
+    let header = getByRole('banner');
+    let nextButton = within(header).getByRole('button', {name: 'Next'});
+    
+    await user.click(nextButton);
+    calendarGridBody = rowgroups[0];
+    rowsInCalendarGridBody = within(calendarGridBody).getAllByRole('row');
+    expect(rowsInCalendarGridBody.length).toBe(6);
+
+    await user.click(nextButton);
+    rowgroups = within(grid).getAllByRole('rowgroup');
+    calendarGridBody = rowgroups[0];
+    rowsInCalendarGridBody = within(calendarGridBody).getAllByRole('row');
+    expect(rowsInCalendarGridBody.length).toBe(6);
+  });
 });

--- a/packages/react-aria-components/test/RangeCalendar.test.js
+++ b/packages/react-aria-components/test/RangeCalendar.test.js
@@ -314,4 +314,31 @@ describe('RangeCalendar', () => {
     expect(cell).toHaveAttribute('aria-invalid', 'true');
     expect(cell).toHaveClass('invalid');
   });
+
+  it('should support fixedWeeks', async () => {
+    let {getByRole} = renderCalendar({isFixedWeeks: true, 
+      defaultValue: {start: new CalendarDate(2024, 2, 3), end: new CalendarDate(2024, 2, 10)}});
+
+    let grid = getByRole('grid');
+    let rowgroups = within(grid).getAllByRole('rowgroup');
+    expect(rowgroups[0]).toHaveAttribute('class', 'react-aria-CalendarGridBody');
+
+    let calendarGridBody = rowgroups[0];
+    let rowsInCalendarGridBody = within(calendarGridBody).getAllByRole('row');
+    expect(rowsInCalendarGridBody.length).toBe(6);
+
+    let header = getByRole('banner');
+    let nextButton = within(header).getByRole('button', {name: 'Next'});
+    
+    await user.click(nextButton);
+    calendarGridBody = rowgroups[0];
+    rowsInCalendarGridBody = within(calendarGridBody).getAllByRole('row');
+    expect(rowsInCalendarGridBody.length).toBe(6);
+
+    await user.click(nextButton);
+    rowgroups = within(grid).getAllByRole('rowgroup');
+    calendarGridBody = rowgroups[0];
+    rowsInCalendarGridBody = within(calendarGridBody).getAllByRole('row');
+    expect(rowsInCalendarGridBody.length).toBe(6);
+  });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/4789, https://github.com/adobe/react-spectrum/issues/5840

I added props to the Calendar to enable the selection of a fixed 6-week view.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
1. Visit the [Date Picker example](http://localhost:9003/?path=/story/react-aria-components--date-picker-example&providerSwitcher-express=false&strict=true) in your local Storybook.
2. Go to the Controls tab and set `isFixedWeeks` to true.
3. Observe that the calendar now consistently displays 6 weeks.
4. Confirm the 6-week display at the [DateRangePicker example](http://localhost:9003/?path=/story/react-aria-components--date-range-picker-example) as well.

## 🧢 Your Project:

<!--- Company/project for pull request -->
