### PR TITLE
fix(#5931): TextField/TextArea: fix outline thickness with forced-colors: active

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/commons/focus-ring.css
+++ b/packages/@adobe/spectrum-css-temp/components/commons/focus-ring.css
@@ -45,3 +45,14 @@
     }
   }
 }
+
+@media (forced-colors: active) {
+  .spectrum-FocusRing,
+  .spectrum-FocusRing-ring,
+  .spectrum-FocusRing--quiet {
+    --spectrum-high-contrast-focus-ring-color: xvar(--spectrum-high-contrast-focus-ring-color, Highlight);
+    &:after {
+      forced-color-adjust: none;
+    }
+  }
+}

--- a/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/textfield/skin.css
@@ -180,9 +180,10 @@ governing permissions and limitations under the License.
     --spectrum-textfield-border-color-key-focus: Highlight;
     --spectrum-textfield-placeholder-text-color: GrayText;
     --spectrum-textfield-placeholder-text-color-hover: GrayText;
+    --spectrum-high-contrast-focus-ring-color: Highlight;
     &.focus-ring,
     &:focus-visible {
-      outline: 2px solid Highlight;
+      outline: 2px solid var(--spectrum-high-contrast-focus-ring-color);
     }
     .spectrum-Textfield--quiet & {
       &.focus-ring,


### PR DESCRIPTION
Closes #5931 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 5931](https://github.com/adobe/react-spectrum/issue/5931).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open https://reactspectrum.blob.core.windows.net/reactspectrum/47d523e79482bdf96c426b1f55813d624021c431/storybook/iframe.html?scrolling=false&providerSwitcher-locale=&providerSwitcher-theme=&providerSwitcher-scale=&providerSwitcher-express=false&args=&id=textfield--default&viewMode=story in Google Chrome or Microsoft Edge
2. Using DevTools, set Rendering > Emulate CSS media feature forced-colors to forced-colors: active. It may also be helpful to set Rendering > Emulate CSS media feature prefers-color-scheme to prefers-color-scheme: dark, which will make the Highlight color a more pronounced cyan, instead than the purple that renders with forced-colors: active and prefers-color-scheme: light.
3. Set keyboard focus to the TextField input.
4. Notice that when the input border-color changes to use the Highlight color, the box-shadow that is usually added to make the border thicker is rendered with forced-colors: active, and the border appears to be 2px wide.

## 🧢 Your Project:

Adobe/Accessibility
