### PR TITLE
Show all toasts

### DIFF
--- a/packages/@react-spectrum/toast/docs/Toast.mdx
+++ b/packages/@react-spectrum/toast/docs/Toast.mdx
@@ -58,7 +58,7 @@ Then, queue a toast from anywhere:
 
 Toasts are triggered using one of the methods of <TypeLink links={docs.links} type={docs.exports.ToastQueue} />. A &lt;<TypeLink links={docs.links} type={docs.exports.ToastContainer} />&gt; element must be rendered at the root of your app in order to display the queued toasts.
 
-Toasts are shown according to the order they are added from the bottommost position. Since all opens Toasts are displayed until dismissed, please be mindful of how often toasts are triggered, see [Spectrum design docs](https://spectrum.corp.adobe.com/page/toast/#Too-many-toasts).
+Toasts are shown according to the order they are added, with the most recent toast appearing at the bottom of the stack. Please use Toasts sparingly, see [Spectrum design docs](https://spectrum.corp.adobe.com/page/toast/#Too-many-toasts).
 
 ```tsx example
 <ButtonGroup>

--- a/packages/@react-spectrum/toast/docs/Toast.mdx
+++ b/packages/@react-spectrum/toast/docs/Toast.mdx
@@ -58,7 +58,7 @@ Then, queue a toast from anywhere:
 
 Toasts are triggered using one of the methods of <TypeLink links={docs.links} type={docs.exports.ToastQueue} />. A &lt;<TypeLink links={docs.links} type={docs.exports.ToastContainer} />&gt; element must be rendered at the root of your app in order to display the queued toasts.
 
-Toasts are shown according to a priority queue, depending on their variant. Actionable toasts are prioritized over non-actionable toasts, and errors are prioritized over other types of notifications. Only one toast is displayed at a time. See the [Spectrum design docs](https://spectrum.adobe.com/page/toast/#Priority-queue) for full information on toast priorities.
+Toasts are shown according to the order they are added from the bottommost position. Since all opens Toasts are displayed until dismissed, please be mindful of how often toasts are triggered, see [Spectrum design docs](https://spectrum.corp.adobe.com/page/toast/#Too-many-toasts).
 
 ```tsx example
 <ButtonGroup>

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -35,7 +35,7 @@ let globalToastQueue: ToastQueue<SpectrumToastValue> | null = null;
 function getGlobalToastQueue() {
   if (!globalToastQueue) {
     globalToastQueue = new ToastQueue({
-      maxVisibleToasts: 1,
+      maxVisibleToasts: Infinity,
       hasExitAnimation: true
     });
   }
@@ -151,7 +151,7 @@ function addToast(children: string, variant: SpectrumToastValue['variant'], opti
   // It is debatable whether non-actionable toasts would also fail.
   let timeout = options.timeout && !options.onAction ? Math.max(options.timeout, 5000) : null;
   let queue = getGlobalToastQueue();
-  let key = queue.add(value, {priority: getPriority(variant, options), timeout, onClose: options.onClose});
+  let key = queue.add(value, {timeout, onClose: options.onClose});
   return () => queue.close(key);
 }
 
@@ -175,20 +175,3 @@ const SpectrumToastQueue = {
 };
 
 export {SpectrumToastQueue as ToastQueue};
-
-// https://spectrum.adobe.com/page/toast/#Priority-queue
-// TODO: if a lower priority toast comes in, no way to know until you dismiss the higher priority one.
-const VARIANT_PRIORITY = {
-  negative: 10,
-  positive: 3,
-  info: 2,
-  neutral: 1
-};
-
-function getPriority(variant: SpectrumToastValue['variant'], options: SpectrumToastOptions) {
-  let priority = VARIANT_PRIORITY[variant] || 1;
-  if (options.onAction) {
-    priority += 4;
-  }
-  return priority;
-}

--- a/packages/@react-spectrum/toast/src/toastContainer.css
+++ b/packages/@react-spectrum/toast/src/toastContainer.css
@@ -20,10 +20,10 @@
   display: flex;
   pointer-events: none;
   outline: none;
+  margin-block-end: 8px;
 
   .spectrum-Toast {
-    position: absolute;
-    margin: 16px;
+    margin: 8px;
     pointer-events: all;
   }
 

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -202,73 +202,6 @@ describe('Toast Provider and Container', function () {
     expect(queryByRole('alert')).toBeNull();
   });
 
-  it('prioritizes toasts based on variant', () => {
-    function ToastPriorites(props = {}) {
-      return (
-        <div>
-          <Button
-            onPress={() => ToastQueue.info('Info', props)}
-            variant="primary">
-            Info
-          </Button>
-          <Button
-            onPress={() => ToastQueue.negative('Error', props)}
-            variant="primary">
-            Error
-          </Button>
-        </div>
-      );
-    }
-
-    let {getByRole, getAllByRole, queryByRole} = renderComponent(<ToastPriorites />);
-    let buttons = getAllByRole('button');
-
-    // show info toast first. error toast should supersede it.
-
-    expect(queryByRole('alert')).toBeNull();
-    triggerPress(buttons[0]);
-
-    let alert = getByRole('alert');
-    expect(alert).toBeVisible();
-    expect(alert).toHaveTextContent('Info');
-
-    triggerPress(buttons[1]);
-    fireAnimationEnd(alert);
-
-    alert = getByRole('alert');
-    expect(alert).toHaveTextContent('Error');
-
-    triggerPress(within(alert).getByRole('button'));
-    fireAnimationEnd(alert);
-
-    alert = getByRole('alert');
-    expect(alert).toHaveTextContent('Info');
-
-    triggerPress(within(alert).getByRole('button'));
-    fireAnimationEnd(alert);
-    expect(queryByRole('alert')).toBeNull();
-
-    // again, but with error toast first.
-
-    triggerPress(buttons[1]);
-    alert = getByRole('alert');
-    expect(alert).toHaveTextContent('Error');
-
-    triggerPress(buttons[0]);
-    alert = getByRole('alert');
-    expect(alert).toHaveTextContent('Error');
-
-    triggerPress(within(alert).getByRole('button'));
-    fireAnimationEnd(alert);
-
-    alert = getByRole('alert');
-    expect(alert).toHaveTextContent('Info');
-
-    triggerPress(within(alert).getByRole('button'));
-    fireAnimationEnd(alert);
-    expect(queryByRole('alert')).toBeNull();
-  });
-
   it('can focus toast region using F6', () => {
     let {getByRole} = renderComponent(<RenderToastButton timeout={5000} />);
     let button = getByRole('button');
@@ -303,13 +236,13 @@ describe('Toast Provider and Container', function () {
   });
 
   it('should move focus to container when a toast exits and there are more', () => {
-    let {getByRole, queryByRole} = renderComponent(<RenderToastButton />);
+    let {getAllByRole, getByRole, queryByRole} = renderComponent(<RenderToastButton />);
     let button = getByRole('button');
 
     triggerPress(button);
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getAllByRole('alert')[0];
     let closeButton = within(toast).getByRole('button');
     triggerPress(closeButton);
     fireAnimationEnd(toast);

--- a/packages/@react-stately/toast/test/useToastState.test.js
+++ b/packages/@react-stately/toast/test/useToastState.test.js
@@ -58,8 +58,8 @@ describe('useToastState', () => {
 
     act(() => {result.current.add(secondToast.content, secondToast.props);});
     expect(result.current.visibleToasts.length).toBe(2);
-    expect(result.current.visibleToasts[0].content).toBe(newValue[0].content);
-    expect(result.current.visibleToasts[1].content).toBe(secondToast.content);
+    expect(result.current.visibleToasts[0].content).toBe(secondToast.content);
+    expect(result.current.visibleToasts[1].content).toBe(newValue[0].content);
   });
 
   it('should close a toast', () => {
@@ -91,11 +91,11 @@ describe('useToastState', () => {
 
     act(() => {result.current.add('Second Toast');});
     expect(result.current.visibleToasts.length).toBe(1);
-    expect(result.current.visibleToasts[0].content).toBe(newValue[0].content);
+    expect(result.current.visibleToasts[0].content).toBe('Second Toast');
 
     act(() => {result.current.close(result.current.visibleToasts[0].key);});
     expect(result.current.visibleToasts.length).toBe(1);
-    expect(result.current.visibleToasts[0].content).toBe('Second Toast');
+    expect(result.current.visibleToasts[0].content).toBe(newValue[0].content);
     expect(result.current.visibleToasts[0].animation).toBe('queued');
   });
 


### PR DESCRIPTION
Closes

Do we want to add additional animations to this?

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Goto a Toast story and add a Toast.
- Toast should be added from the bottom.
- Multiple toasts can be shown at the same time.
  - Toasts are sorted by order added.
- Toast has enter and exit animations.
- Toast should exit by timeout if defined or by close button (unless there is an action).

## 🧢 Your Project:
RSP