### PR TITLE
Expose UNSTABLE container for RSP overlays

### DIFF
--- a/packages/@react-spectrum/actionbar/src/ActionBar.tsx
+++ b/packages/@react-spectrum/actionbar/src/ActionBar.tsx
@@ -112,6 +112,7 @@ function ActionBarInner<T>(props: ActionBarInnerProps<T>, ref: Ref<HTMLDivElemen
             overflowMode="collapse"
             buttonLabelBehavior="collapse"
             onAction={onAction}
+            UNSTABLE_portalContainer={props.UNSTABLE_portalContainer}
             UNSAFE_className={classNames(styles, 'react-spectrum-ActionBar-actionGroup')}>
             {children}
           </ActionGroup>

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -375,7 +375,8 @@ interface ActionGroupMenuProps<T> extends AriaLabelingProps {
   summaryIcon?: ReactNode,
   isOnlyItem?: boolean,
   orientation?: 'horizontal' | 'vertical',
-  onAction?: (key: Key) => void
+  onAction?: (key: Key) => void,
+  UNSTABLE_portalContainer?: HTMLElement
 }
 
 function ActionGroupMenu<T>({state, isDisabled, isEmphasized, staticColor, items, onAction, summaryIcon, hideButtonText, isOnlyItem, orientation, UNSTABLE_portalContainer, ...otherProps}: ActionGroupMenuProps<T>) {

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -53,6 +53,7 @@ function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: 
     onAction,
     buttonLabelBehavior,
     summaryIcon,
+    UNSTABLE_portalContainer,
     ...otherProps
   } = props;
 
@@ -205,7 +206,8 @@ function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: 
         summaryIcon={summaryIcon}
         hideButtonText={hideButtonText}
         isOnlyItem={visibleItems === 0}
-        orientation={orientation} />
+        orientation={orientation}
+        UNSTABLE_portalContainer={UNSTABLE_portalContainer} />
     );
   }
 
@@ -247,7 +249,8 @@ function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: 
                 item={item}
                 state={state}
                 hideButtonText={hideButtonText}
-                orientation={orientation} />
+                orientation={orientation}
+                UNSTABLE_portalContainer={UNSTABLE_portalContainer} />
             ))}
             {menuItem}
           </Provider>
@@ -271,10 +274,11 @@ interface ActionGroupItemProps<T> extends DOMProps, StyleProps {
   staticColor?: 'white' | 'black',
   hideButtonText?: boolean,
   orientation?: 'horizontal' | 'vertical',
-  onAction?: (key: Key) => void
+  onAction?: (key: Key) => void,
+  UNSTABLE_portalContainer?: HTMLElement
 }
 
-function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, staticColor, onAction, hideButtonText, orientation}: ActionGroupItemProps<T>) {
+function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, staticColor, onAction, hideButtonText, orientation, UNSTABLE_portalContainer}: ActionGroupItemProps<T>) {
   let ref = useRef(null);
   let {buttonProps} = useActionGroupItem({key: item.key}, state);
   isDisabled = isDisabled || state.disabledKeys.has(item.key);
@@ -347,7 +351,7 @@ function ActionGroupItem<T>({item, state, isDisabled, isEmphasized, staticColor,
 
   if (hideButtonText && textContent) {
     button = (
-      <TooltipTrigger placement={orientation === 'vertical' ? 'end' : 'top'}>
+      <TooltipTrigger placement={orientation === 'vertical' ? 'end' : 'top'} UNSTABLE_portalContainer={UNSTABLE_portalContainer}>
         {button}
         <Tooltip>{textContent}</Tooltip>
       </TooltipTrigger>
@@ -374,7 +378,7 @@ interface ActionGroupMenuProps<T> extends AriaLabelingProps {
   onAction?: (key: Key) => void
 }
 
-function ActionGroupMenu<T>({state, isDisabled, isEmphasized, staticColor, items, onAction, summaryIcon, hideButtonText, isOnlyItem, orientation, ...otherProps}: ActionGroupMenuProps<T>) {
+function ActionGroupMenu<T>({state, isDisabled, isEmphasized, staticColor, items, onAction, summaryIcon, hideButtonText, isOnlyItem, orientation, UNSTABLE_portalContainer, ...otherProps}: ActionGroupMenuProps<T>) {
   // Use the key of the first item within the menu as the key of the button.
   // The key must actually exist in the collection for focus to work correctly.
   let key = items[0].key;
@@ -430,7 +434,7 @@ function ActionGroupMenu<T>({state, isDisabled, isEmphasized, staticColor, items
 
   return (
     // Use a PressResponder to send DOM props through.
-    <MenuTrigger align={isOnlyItem ? 'start' : 'end'} direction={orientation === 'vertical' ? 'end' : 'bottom'}>
+    <MenuTrigger align={isOnlyItem ? 'start' : 'end'} direction={orientation === 'vertical' ? 'end' : 'bottom'} UNSTABLE_portalContainer={UNSTABLE_portalContainer}>
       <SlotProvider
         slots={{
           text: {

--- a/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
@@ -63,7 +63,8 @@ function _MobileSearchAutocomplete<T extends object>(props: SpectrumSearchAutoco
     validate,
     name,
     isReadOnly,
-    onSubmit = () => {}
+    onSubmit = () => {},
+    UNSTABLE_portalContainer
   } = props;
 
   let {contains} = useFilter({sensitivity: 'base'});
@@ -156,7 +157,7 @@ function _MobileSearchAutocomplete<T extends object>(props: SpectrumSearchAutoco
         </SearchAutocompleteButton>
       </Field>
       <input {...inputProps} ref={inputRef} />
-      <Tray state={state} isFixedHeight {...overlayProps}>
+      <Tray state={state} isFixedHeight {...overlayProps} container={UNSTABLE_portalContainer}>
         <SearchAutocompleteTray
           {...props}
           onClose={state.close}

--- a/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
@@ -76,7 +76,8 @@ function _SearchAutocompleteBase<T extends object>(props: SpectrumSearchAutocomp
     loadingState,
     onLoadMore,
     onSubmit = () => {},
-    validate
+    validate,
+    UNSTABLE_portalContainer
   } = props;
 
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/autocomplete');
@@ -167,7 +168,8 @@ function _SearchAutocompleteBase<T extends object>(props: SpectrumSearchAutocomp
         placement={`${direction} ${align}`}
         hideArrow
         isNonModal
-        shouldFlip={shouldFlip}>
+        shouldFlip={shouldFlip}
+        container={UNSTABLE_portalContainer}>
         <ListBoxBase
           {...listBoxProps}
           ref={listBoxRef}

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -81,7 +81,8 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
     allowsCustomValue,
     menuWidth: customMenuWidth,
     name,
-    formValue = 'text'
+    formValue = 'text',
+    UNSTABLE_portalContainer
   } = props;
   if (allowsCustomValue) {
     formValue = 'text';
@@ -181,7 +182,8 @@ const ComboBoxBase = React.forwardRef(function ComboBoxBase<T extends object>(pr
         placement={`${direction} ${align}`}
         hideArrow
         isNonModal
-        shouldFlip={shouldFlip}>
+        shouldFlip={shouldFlip}
+        container={UNSTABLE_portalContainer}>
         <ListBoxBase
           {...listBoxProps}
           ref={listBoxRef}

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -56,7 +56,8 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
     validationBehavior,
     name,
     formValue = 'text',
-    allowsCustomValue
+    allowsCustomValue,
+    UNSTABLE_portalContainer
   } = props;
   if (allowsCustomValue) {
     formValue = 'text';
@@ -145,7 +146,7 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox<T extends
         </ComboBoxButton>
       </Field>
       <input {...inputProps} ref={inputRef} />
-      <Tray state={state} isFixedHeight {...overlayProps}>
+      <Tray state={state} isFixedHeight {...overlayProps} container={UNSTABLE_portalContainer}>
         <ComboBoxTray
           {...props}
           onClose={state.close}

--- a/packages/@react-spectrum/dialog/src/DialogContainer.tsx
+++ b/packages/@react-spectrum/dialog/src/DialogContainer.tsx
@@ -27,7 +27,8 @@ export function DialogContainer(props: SpectrumDialogContainerProps) {
     type = 'modal',
     onDismiss,
     isDismissable,
-    isKeyboardDismissDisabled
+    isKeyboardDismissDisabled,
+    UNSTABLE_portalContainer
   } = props;
 
   let childArray = React.Children.toArray(children);
@@ -67,6 +68,7 @@ export function DialogContainer(props: SpectrumDialogContainerProps) {
 
   return (
     <Modal
+      container={UNSTABLE_portalContainer}
       state={state}
       type={type}
       isDismissable={isDismissable}

--- a/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
+++ b/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
@@ -28,6 +28,7 @@ function DialogTrigger(props: SpectrumDialogTriggerProps) {
     targetRef,
     isDismissable,
     isKeyboardDismissDisabled,
+    UNSTABLE_portalContainer,
     ...positionProps
   } = props;
   if (!Array.isArray(children) || children.length > 2) {
@@ -71,6 +72,7 @@ function DialogTrigger(props: SpectrumDialogTriggerProps) {
     return (
       <PopoverTrigger
         {...positionProps}
+        UNSTABLE_portalContainer={UNSTABLE_portalContainer}
         state={state}
         targetRef={targetRef}
         trigger={trigger}
@@ -89,6 +91,7 @@ function DialogTrigger(props: SpectrumDialogTriggerProps) {
           <Modal
             state={state}
             isDismissable={type === 'modal' ? isDismissable : false}
+            container={UNSTABLE_portalContainer}
             type={type}
             isKeyboardDismissDisabled={isKeyboardDismissDisabled}
             onExiting={onExiting}
@@ -100,6 +103,7 @@ function DialogTrigger(props: SpectrumDialogTriggerProps) {
         return (
           <Tray
             state={state}
+            container={UNSTABLE_portalContainer}
             isKeyboardDismissDisabled={isKeyboardDismissDisabled}>
             {typeof content === 'function' ? content(state.close) : content}
           </Tray>
@@ -143,7 +147,7 @@ DialogTrigger.getCollectionNode = function* (props: SpectrumDialogTriggerProps) 
 let _DialogTrigger = DialogTrigger as (props: SpectrumDialogTriggerProps) => JSX.Element;
 export {_DialogTrigger as DialogTrigger};
 
-function PopoverTrigger({state, targetRef, trigger, content, hideArrow, ...props}) {
+function PopoverTrigger({state, targetRef, trigger, content, hideArrow, UNSTABLE_portalContainer, ...props}) {
   let triggerRef = useRef<HTMLElement>(null);
   let {triggerProps, overlayProps} = useOverlayTrigger({type: 'dialog'}, state, triggerRef);
 
@@ -155,6 +159,7 @@ function PopoverTrigger({state, targetRef, trigger, content, hideArrow, ...props
   let overlay = (
     <Popover
       {...props}
+      container={UNSTABLE_portalContainer}
       hideArrow={hideArrow}
       triggerRef={targetRef || triggerRef}
       state={state}>

--- a/packages/@react-spectrum/dialog/test/DialogContainer.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogContainer.test.js
@@ -10,11 +10,18 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, render, triggerPress, within} from '@react-spectrum/test-utils';
+import {act, fireEvent, pointerMap, render, triggerPress, within} from '@react-spectrum/test-utils';
+import {ActionButton, Button} from '@react-spectrum/button';
+import {ButtonGroup} from '@react-spectrum/buttongroup';
+import {Content, Header} from '@react-spectrum/view';
+import {Dialog, DialogContainer, useDialogContainer} from '../src';
 import {DialogContainerExample, MenuExample, NestedDialogContainerExample} from '../stories/DialogContainerExamples';
+import {Divider} from '@react-spectrum/divider';
+import {Heading, Text} from '@react-spectrum/text';
 import {Provider} from '@react-spectrum/provider';
-import React from 'react';
+import React, {useState} from 'react';
 import {theme} from '@react-spectrum/theme-default';
+import userEvent from '@testing-library/user-event';
 
 describe('DialogContainer', function () {
   beforeAll(() => {
@@ -206,5 +213,58 @@ describe('DialogContainer', function () {
     act(() => {jest.runAllTimers();});
 
     expect(document.activeElement).toBe(button);
+  });
+
+  describe('portalContainer', () => {
+    let user;
+    beforeAll(() => {
+      user = userEvent.setup({delay: null, pointerMap});
+      jest.useFakeTimers();
+    });
+    function ExampleDialog(props) {
+      let container = useDialogContainer();
+
+      return (
+        <Dialog>
+          <Heading>The Heading</Heading>
+          <Header>The Header</Header>
+          <Divider />
+          <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
+          {!props.isDismissable &&
+            <ButtonGroup>
+              <Button variant="secondary" onPress={container.dismiss}>Cancel</Button>
+              <Button variant="cta" onPress={container.dismiss}>Confirm</Button>
+            </ButtonGroup>
+          }
+        </Dialog>
+      );
+    }
+    function App(props) {
+      let [container, setContainer] = useState();
+      let [isOpen, setOpen] = useState(false);
+
+      return (
+        <Provider theme={theme}>
+          <ActionButton onPress={() => setOpen(true)}>Open dialog</ActionButton>
+          <DialogContainer onDismiss={() => setOpen(false)} UNSTABLE_portalContainer={container} {...props}>
+            {isOpen &&
+              <ExampleDialog {...props} />
+            }
+          </DialogContainer>
+          <div ref={setContainer} data-testid="custom-container" />
+        </Provider>
+      );
+    }
+
+    it('should render the dialog in the portal container', async () => {
+      let {getByRole, getByTestId} = render(
+        <App />
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+
+      expect(getByRole('dialog').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
+    });
   });
 });

--- a/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
@@ -1026,4 +1026,55 @@ describe('DialogTrigger', function () {
     expect(document.activeElement).toBe(innerButton);
   });
 
+  describe('portalContainer', () => {
+    function InfoDialog(props) {
+      return (
+        <Provider theme={theme}>
+          <DialogTrigger type={props.type} UNSTABLE_portalContainer={props.container}>
+            <ActionButton>Trigger</ActionButton>
+            <Dialog>contents</Dialog>
+          </DialogTrigger>
+        </Provider>
+      );
+    }
+    function App(props) {
+      let [container, setContainer] = React.useState();
+      return (
+        <>
+          <InfoDialog type={props.type} container={container} />
+          <div ref={setContainer} data-testid="custom-container" />
+        </>
+      );
+    }
+    it('should render the dialog in the portal container', async () => {
+      let {getByRole, getByTestId} = render(
+        <App />
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+
+      expect(getByRole('dialog').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
+    });
+    it('should render the tray in the portal container', async () => {
+      let {getByRole, getByTestId} = render(
+        <App type="tray" />
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+
+      expect(getByRole('dialog').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
+    });
+    it('should render the popover in the portal container', async () => {
+      let {getByRole, getByTestId} = render(
+        <App type="popover" />
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+
+      expect(getByRole('dialog').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
+    });
+  });
 });

--- a/packages/@react-spectrum/menu/src/ActionMenu.tsx
+++ b/packages/@react-spectrum/menu/src/ActionMenu.tsx
@@ -38,7 +38,8 @@ function ActionMenu<T extends object>(props: SpectrumActionMenuProps<T>, ref: Fo
       onOpenChange={props.onOpenChange}
       align={props.align}
       direction={props.direction}
-      shouldFlip={props.shouldFlip}>
+      shouldFlip={props.shouldFlip}
+      UNSTABLE_portalContainer={props.UNSTABLE_portalContainer}>
       <ActionButton
         ref={ref}
         {...props}

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -33,7 +33,8 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
     shouldFlip = true,
     direction = 'bottom',
     closeOnSelect,
-    trigger = 'press'
+    trigger = 'press',
+    UNSTABLE_portalContainer
   } = props;
 
   let [menuTrigger, menu] = React.Children.toArray(children);
@@ -74,7 +75,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
   let overlay;
   if (isMobile) {
     overlay = (
-      <Tray state={state} isFixedHeight>
+      <Tray state={state} isFixedHeight container={UNSTABLE_portalContainer}>
         {menu}
       </Tray>
     );
@@ -83,6 +84,7 @@ function MenuTrigger(props: SpectrumMenuTriggerProps, ref: DOMRef<HTMLElement>) 
       <Popover
         UNSAFE_style={{clipPath: 'unset', overflow: 'visible', filter: 'unset', borderWidth: '0px'}}
         state={state}
+        container={UNSTABLE_portalContainer}
         triggerRef={menuTriggerRef}
         scrollRef={menuRef}
         placement={initialPlacement}

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -70,6 +70,7 @@ describe('MenuTrigger', function () {
   let onSelect = jest.fn();
   let onSelectionChange = jest.fn();
   let user;
+  let windowSpy;
 
   beforeAll(function () {
     user = userEvent.setup({delay: null, pointerMap});
@@ -78,6 +79,10 @@ describe('MenuTrigger', function () {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
     jest.spyOn(window.screen, 'width', 'get').mockImplementation(() => 1024);
     jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window.screen, 'width', 'get').mockImplementation(() => 1024);
   });
 
   afterEach(() => {
@@ -1223,6 +1228,53 @@ describe('MenuTrigger', function () {
         let triggerButton = tree.getByRole('button');
         expect(document.activeElement).toBe(triggerButton);
       });
+    });
+  });
+
+  describe('portalContainer', () => {
+    function InfoMenu(props) {
+      return (
+        <Provider theme={theme}>
+          <MenuTrigger UNSTABLE_portalContainer={props.container}>
+            <ActionButton aria-label="trigger" />
+            <Menu>
+              <Item key="1">One</Item>
+              <Item key="">Two</Item>
+              <Item key="3">Three</Item>
+            </Menu>
+          </MenuTrigger>
+        </Provider>
+      );
+    }
+    function App() {
+      let [container, setContainer] = React.useState();
+      return (
+        <>
+          <InfoMenu container={container} />
+          <div ref={setContainer} data-testid="custom-container" />
+        </>
+      );
+    }
+    it('should render the menu in the portal container', async () => {
+      let {getByRole, getByTestId} = render(
+        <App />
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+
+      expect(getByRole('menu').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
+    });
+    it('should render the menu tray in the portal container', async () => {
+      windowSpy.mockImplementation(() => 700);
+      let {getByRole, getByTestId} = render(
+        <App />
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+
+      expect(getByRole('menu').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
     });
   });
 });

--- a/packages/@react-spectrum/overlays/src/Tray.tsx
+++ b/packages/@react-spectrum/overlays/src/Tray.tsx
@@ -25,7 +25,8 @@ import {useViewportSize} from '@react-aria/utils';
 interface TrayProps extends AriaModalOverlayProps, StyleProps, Omit<OverlayProps, 'nodeRef' | 'shouldContainFocus'> {
   children: ReactNode,
   state: OverlayTriggerState,
-  isFixedHeight?: boolean
+  isFixedHeight?: boolean,
+  container?: Element
 }
 
 interface TrayWrapperProps extends TrayProps {

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -58,7 +58,8 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     labelPosition = 'top' as LabelPosition,
     menuWidth,
     name,
-    autoFocus
+    autoFocus,
+    UNSTABLE_portalContainer
   } = props;
 
   let state = useSelectState(props);
@@ -125,7 +126,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
   let overlay;
   if (isMobile) {
     overlay = (
-      <Tray state={state}>
+      <Tray state={state} container={UNSTABLE_portalContainer}>
         {listbox}
       </Tray>
     );
@@ -149,7 +150,8 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         hideArrow
         state={state}
         triggerRef={unwrappedTriggerRef}
-        scrollRef={listboxRef}>
+        scrollRef={listboxRef}
+        container={UNSTABLE_portalContainer}>
         {listbox}
       </Popover>
     );

--- a/packages/@react-spectrum/table/src/TableViewBase.tsx
+++ b/packages/@react-spectrum/table/src/TableViewBase.tsx
@@ -122,7 +122,8 @@ export interface TableContextValue<T> {
   onResize: (widths: Map<Key, ColumnSize>) => void,
   onResizeEnd: (widths: Map<Key, ColumnSize>) => void,
   headerMenuOpen: boolean,
-  setHeaderMenuOpen: (val: boolean) => void
+  setHeaderMenuOpen: (val: boolean) => void,
+  UNSTABLE_portalContainer: HTMLElement
 }
 
 export const TableContext = React.createContext<TableContextValue<unknown>>(null);

--- a/packages/@react-spectrum/table/src/TableViewBase.tsx
+++ b/packages/@react-spectrum/table/src/TableViewBase.tsx
@@ -147,6 +147,7 @@ function TableViewBase<T extends object>(props: TableBaseProps<T>, ref: DOMRef<H
     onResizeStart: propsOnResizeStart,
     onResizeEnd: propsOnResizeEnd,
     dragAndDropHooks,
+    UNSTABLE_portalContainer,
     state
   } = props;
   let isTableDraggable = !!dragAndDropHooks?.useDraggableCollectionState;
@@ -489,7 +490,7 @@ function TableViewBase<T extends object>(props: TableBaseProps<T>, ref: DOMRef<H
   );
 
   return (
-    <TableContext.Provider value={{state, dragState, dropState, dragAndDropHooks, isTableDraggable, isTableDroppable, layout, onResizeStart, onResize: props.onResize, onResizeEnd, headerRowHovered, isInResizeMode, setIsInResizeMode, isEmpty, onFocusedResizer, headerMenuOpen, setHeaderMenuOpen}}>
+    <TableContext.Provider value={{state, dragState, dropState, dragAndDropHooks, isTableDraggable, isTableDroppable, layout, onResizeStart, onResize: props.onResize, onResizeEnd, headerRowHovered, isInResizeMode, setIsInResizeMode, isEmpty, onFocusedResizer, headerMenuOpen, setHeaderMenuOpen, UNSTABLE_portalContainer}}>
       <TableVirtualizer
         {...mergedProps}
         {...styleProps}
@@ -822,7 +823,8 @@ function ResizableTableColumnHeader(props) {
     isEmpty,
     isInResizeMode,
     headerMenuOpen,
-    setHeaderMenuOpen
+    setHeaderMenuOpen,
+    UNSTABLE_portalContainer
   } = useTableContext();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/table');
   let {pressProps, isPressed} = usePress({isDisabled: isEmpty});
@@ -914,7 +916,7 @@ function ResizableTableColumnHeader(props) {
             )
           )
         }>
-        <MenuTrigger onOpenChange={setHeaderMenuOpen} align={menuAlign}>
+        <MenuTrigger onOpenChange={setHeaderMenuOpen} align={menuAlign} UNSTABLE_portalContainer={UNSTABLE_portalContainer}>
           <TableColumnHeaderButton alignment={alignment} ref={triggerRef} focusProps={focusProps}>
             {columnProps.allowsSorting &&
               <ArrowDownSmall UNSAFE_className={classNames(styles, 'spectrum-Table-sortedIcon')} />

--- a/packages/@react-spectrum/table/src/TableViewWrapper.tsx
+++ b/packages/@react-spectrum/table/src/TableViewWrapper.tsx
@@ -81,7 +81,13 @@ export interface SpectrumTableProps<T> extends TableProps<T>, SpectrumSelectionP
    * @version alpha
    * @private
    */
-  UNSTABLE_onExpandedChange?: (keys: Set<Key>) => any
+  UNSTABLE_onExpandedChange?: (keys: Set<Key>) => any,
+  /**
+   * The container element in which the column header menu's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }
 
 function TableViewWrapper<T extends object>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {

--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -29,7 +29,8 @@ function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
     crossOffset = DEFAULT_CROSS_OFFSET,
     isDisabled,
     offset = DEFAULT_OFFSET,
-    trigger: triggerAction
+    trigger: triggerAction,
+    UNSTABLE_portalContainer
   } = props;
 
   let [trigger, tooltip] = React.Children.toArray(children) as [ReactElement, ReactElement];
@@ -88,7 +89,7 @@ function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
           arrowRef: arrowRef,
           ...tooltipProps
         }}>
-        <Overlay isOpen={state.isOpen} nodeRef={overlayRef}>
+        <Overlay isOpen={state.isOpen} nodeRef={overlayRef} container={UNSTABLE_portalContainer}>
           {tooltip}
         </Overlay>
       </TooltipContext.Provider>

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -961,4 +961,46 @@ describe('TooltipTrigger', function () {
       expect(queryByRole('tooltip')).toBeNull();
     });
   });
+
+  describe('portalContainer', () => {
+    function InfoTooltip(props) {
+      return (
+        <TooltipTrigger UNSTABLE_portalContainer={props.container}>
+          <ActionButton aria-label="trigger" />
+          <Tooltip>
+            <div data-testid="content">hello</div>
+          </Tooltip>
+        </TooltipTrigger>
+      );
+    }
+    function App() {
+      let [container, setContainer] = React.useState();
+      return (
+        <>
+          <InfoTooltip container={container} />
+          <div ref={setContainer} data-testid="custom-container" />
+        </>
+      );
+    }
+    it('should render the tooltip in the portal container', async () => {
+      let {getByRole, getByTestId} = render(
+        <Provider theme={theme}>
+          <App />
+        </Provider>
+      );
+
+      let button = getByRole('button');
+      act(() => {
+        button.focus();
+      });
+
+      expect(getByTestId('content').closest('[data-testid="custom-container"]')).toBe(getByTestId('custom-container'));
+      act(() => {
+        button.blur();
+      });
+      act(() => {
+        jest.advanceTimersByTime(CLOSE_TIME);
+      });
+    });
+  });
 });

--- a/packages/@react-types/actionbar/src/index.d.ts
+++ b/packages/@react-types/actionbar/src/index.d.ts
@@ -30,7 +30,14 @@ export interface ActionBarProps<T> {
   onAction?: (key: Key) => void
 }
 
-export interface SpectrumActionBarProps<T> extends ActionBarProps<T>, DOMProps, StyleProps {}
+export interface SpectrumActionBarProps<T> extends ActionBarProps<T>, DOMProps, StyleProps {
+  /**
+   * The container element in which the collapsed action menu's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
+}
 
 interface ActionBarContainerProps {
   /** The contents of the ActionBarContainer. Should include a ActionBar and the renderable content it is associated with. */

--- a/packages/@react-types/actiongroup/src/index.d.ts
+++ b/packages/@react-types/actiongroup/src/index.d.ts
@@ -70,5 +70,11 @@ export interface SpectrumActionGroupProps<T> extends AriaActionGroupProps<T>, St
    */
   buttonLabelBehavior?: 'show' | 'collapse' | 'hide',
   /** The icon displayed in the dropdown menu button when a selectable ActionGroup is collapsed. */
-  summaryIcon?: ReactElement
+  summaryIcon?: ReactElement,
+  /**
+   * The container element in which the picker's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }

--- a/packages/@react-types/autocomplete/src/index.d.ts
+++ b/packages/@react-types/autocomplete/src/index.d.ts
@@ -74,5 +74,11 @@ export interface SpectrumSearchAutocompleteProps<T> extends SpectrumTextInputBas
   menuWidth?: DimensionValue,
   onLoadMore?: () => void,
   /** An icon to display at the start of the input. */
-  icon?: ReactElement | null
+  icon?: ReactElement | null,
+  /**
+   * The container element in which the field's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }

--- a/packages/@react-types/combobox/src/index.d.ts
+++ b/packages/@react-types/combobox/src/index.d.ts
@@ -106,5 +106,11 @@ export interface SpectrumComboBoxProps<T> extends SpectrumTextInputBase, Omit<Ar
    * When `allowsCustomValue` is `true`, this option does not apply and the text is always submitted.
    * @default 'text'
    */
-  formValue?: 'text' | 'key'
+  formValue?: 'text' | 'key',
+  /**
+   * The container element in which the combobox's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -35,7 +35,13 @@ export interface SpectrumDialogTriggerProps extends OverlayTriggerProps, Positio
   /** Whether a modal type Dialog should be dismissable. */
   isDismissable?: boolean,
   /** Whether pressing the escape key to close the dialog should be disabled. */
-  isKeyboardDismissDisabled?: boolean
+  isKeyboardDismissDisabled?: boolean,
+  /**
+   * The container element in which the dialogs' overlay portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: Element
 }
 
 export interface SpectrumDialogContainerProps {
@@ -51,7 +57,13 @@ export interface SpectrumDialogContainerProps {
   /** Whether the Dialog is dismissable. See the [Dialog docs](Dialog.html#dismissable-dialogs) for more details. */
   isDismissable?: boolean,
   /** Whether pressing the escape key to close the dialog should be disabled. */
-  isKeyboardDismissDisabled?: boolean
+  isKeyboardDismissDisabled?: boolean,
+  /**
+   * The container element in which the dialogs' overlay portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: Element
 }
 
 export interface AriaDialogProps extends DOMProps, AriaLabelingProps {

--- a/packages/@react-types/menu/src/index.d.ts
+++ b/packages/@react-types/menu/src/index.d.ts
@@ -48,7 +48,13 @@ export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
    * Whether the Menu closes when a selection is made.
    * @default true
    */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean,
+  /**
+   * The container element in which the menu's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }
 
 export interface MenuProps<T> extends CollectionBase<T>, MultipleSelection {

--- a/packages/@react-types/menu/src/index.d.ts
+++ b/packages/@react-types/menu/src/index.d.ts
@@ -79,5 +79,11 @@ export interface SpectrumActionMenuProps<T> extends CollectionBase<T>, Omit<Spec
   /** Whether the element should receive focus on render. */
   autoFocus?: boolean,
   /** Handler that is called when an item is selected. */
-  onAction?: (key: Key) => void
+  onAction?: (key: Key) => void,
+  /**
+   * The container element in which the action menu's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }

--- a/packages/@react-types/select/src/index.d.ts
+++ b/packages/@react-types/select/src/index.d.ts
@@ -70,5 +70,11 @@ export interface SpectrumPickerProps<T> extends AriaSelectProps<T>, AsyncLoadabl
   /** Width of the menu. By default, matches width of the trigger. Note that the minimum width of the dropdown is always equal to the trigger's width. */
   menuWidth?: DimensionValue,
   /** Whether the element should receive focus on render. */
-  autoFocus?: boolean
+  autoFocus?: boolean,
+  /**
+   * The container element in which the picker's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: HTMLElement
 }

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -46,7 +46,13 @@ export interface SpectrumTooltipTriggerProps extends Omit<TooltipTriggerProps, '
    * anchor element.
    * @default 7
    */
-  offset?: number
+  offset?: number,
+  /**
+   * The container element in which the menu's overlay or tray portal will be placed. This may have unknown behavior depending on where it is portal-ed to.
+   * Make sure to test in mobile and desktop environments.
+   * @default document.body
+   */
+  UNSTABLE_portalContainer?: Element
 }
 
 export interface TooltipProps {


### PR DESCRIPTION
Reverts adobe/react-spectrum#5806

I've also made another commit to show how much threading through this requires. I still haven't done all the components. I think the color components, date/time pickers, every component with contextual help, and breadcrumbs, would all need to expose this prop too if we do it as it is currently setup.

I think this is a good time to consider doing a context based approach instead.