### PR TITLE
Add support for DropZone isDisabled prop

### DIFF
--- a/packages/@react-aria/dnd/src/useClipboard.ts
+++ b/packages/@react-aria/dnd/src/useClipboard.ts
@@ -69,7 +69,6 @@ export function useClipboard(options: ClipboardProps): ClipboardResult {
   let {isDisabled} = options;
   let isFocusedRef = useRef(false);
   let {focusProps} = useFocus({
-    isDisabled,
     onFocusChange: (isFocused) => {
       isFocusedRef.current = isFocused;
     }

--- a/packages/@react-aria/dnd/src/useClipboard.ts
+++ b/packages/@react-aria/dnd/src/useClipboard.ts
@@ -24,7 +24,9 @@ export interface ClipboardProps {
   /** Handler that is called when the user triggers a cut interaction. */
   onCut?: () => void,
   /** Handler that is called when the user triggers a paste interaction. */
-  onPaste?: (items: DropItem[]) => void
+  onPaste?: (items: DropItem[]) => void,
+  /** Whether the clipboard is disabled. */
+  isDisabled?: boolean
 }
 
 export interface ClipboardResult {
@@ -64,8 +66,10 @@ function addGlobalEventListener(event, fn) {
  * data types, and integrates with the operating system native clipboard.
  */
 export function useClipboard(options: ClipboardProps): ClipboardResult {
+  let {isDisabled} = options;
   let isFocusedRef = useRef(false);
   let {focusProps} = useFocus({
+    isDisabled,
     onFocusChange: (isFocused) => {
       isFocusedRef.current = isFocused;
     }
@@ -123,6 +127,9 @@ export function useClipboard(options: ClipboardProps): ClipboardResult {
   });
 
   useEffect(() => {
+    if (isDisabled) {
+      return;
+    }
     return chain(
       addGlobalEventListener('beforecopy', onBeforeCopy),
       addGlobalEventListener('copy', onCopy),
@@ -131,7 +138,7 @@ export function useClipboard(options: ClipboardProps): ClipboardResult {
       addGlobalEventListener('beforepaste', onBeforePaste),
       addGlobalEventListener('paste', onPaste)
     );
-  }, [onBeforeCopy, onCopy, onBeforeCut, onCut, onBeforePaste, onPaste]);
+  }, [isDisabled, onBeforeCopy, onCopy, onBeforeCut, onCut, onBeforePaste, onPaste]);
 
   return {
     clipboardProps: focusProps

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -10,8 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaButtonProps} from '@react-types/button';
-import {DragEvent, HTMLAttributes, RefObject,  useRef, useState} from 'react';
+import {ButtonHTMLAttributes, DragEvent, HTMLAttributes,  RefObject, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
 import {DragTypes, globalAllowedDropOperations, globalDndState, readFromDataTransfer, setGlobalDnDState, setGlobalDropEffect} from './utils';
 import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, DROP_OPERATION_ALLOWED, DROP_OPERATION_TO_DROP_EFFECT} from './constants';
@@ -47,7 +46,11 @@ export interface DropOptions {
    * Whether the item has an explicit focusable drop affordance to initiate accessible drag and drop mode.
    * If true, the dropProps will omit these event handlers, and they will be applied to dropButtonProps instead.
    */
-  hasDropButton?: boolean
+  hasDropButton?: boolean,
+  /**
+   * Whether the drop target is disabled. If true, the drop target will not accept any drops.
+   */
+  isDisabled?: boolean
 }
 
 export interface DropResult {
@@ -56,8 +59,7 @@ export interface DropResult {
   /** Whether the drop target is currently focused or hovered. */
   isDropTarget: boolean,
   /** Props for the explicit drop button affordance, if any. */
-  dropButtonProps?: AriaButtonProps
-  
+  dropButtonProps?: ButtonHTMLAttributes<HTMLButtonElement>
 }
 
 const DROP_ACTIVATE_TIMEOUT = 800;
@@ -67,7 +69,7 @@ const DROP_ACTIVATE_TIMEOUT = 800;
  * based drag and drop, in addition to full parity for keyboard and screen reader users.
  */
 export function useDrop(options: DropOptions): DropResult {
-  let {hasDropButton} = options;
+  let {hasDropButton, isDisabled} = options;
   let [isDropTarget, setDropTarget] = useState(false);
   let state = useRef({
     x: 0,
@@ -311,23 +313,34 @@ export function useDrop(options: DropOptions): DropResult {
   });
 
   let {ref} = options;
-  useLayoutEffect(() => DragManager.registerDropTarget({
-    element: ref.current,
-    getDropOperation: getDropOperationKeyboard,
-    onDropEnter(e) {
-      setDropTarget(true);
-      onDropEnter(e);
-    },
-    onDropExit(e) {
-      setDropTarget(false);
-      onDropExit(e);
-    },
-    onDrop: onKeyboardDrop,
-    onDropActivate
-  }), [ref, getDropOperationKeyboard, onDropEnter, onDropExit, onKeyboardDrop, onDropActivate]);
+  useLayoutEffect(() => {
+    if (isDisabled) {
+      return;
+    }
+    return DragManager.registerDropTarget({
+      element: ref.current,
+      getDropOperation: getDropOperationKeyboard,
+      onDropEnter(e) {
+        setDropTarget(true);
+        onDropEnter(e);
+      },
+      onDropExit(e) {
+        setDropTarget(false);
+        onDropExit(e);
+      },
+      onDrop: onKeyboardDrop,
+      onDropActivate
+    });
+  }, [isDisabled, ref, getDropOperationKeyboard, onDropEnter, onDropExit, onKeyboardDrop, onDropActivate]);
 
   let {dropProps} = useVirtualDrop();
-  
+  if (isDisabled) {
+    return {
+      dropProps: {},
+      dropButtonProps: {disabled: true},
+      isDropTarget: false
+    };
+  }
   return {
     dropProps: {
       ...(!hasDropButton && dropProps),

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaButtonProps} from '@react-types/button';
-import {DragEvent, HTMLAttributes,  RefObject, useRef, useState} from 'react';
+import {DragEvent, HTMLAttributes, RefObject, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
 import {DragTypes, globalAllowedDropOperations, globalDndState, readFromDataTransfer, setGlobalDnDState, setGlobalDropEffect} from './utils';
 import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, DROP_OPERATION_ALLOWED, DROP_OPERATION_TO_DROP_EFFECT} from './constants';

--- a/packages/@react-aria/dnd/src/useDrop.ts
+++ b/packages/@react-aria/dnd/src/useDrop.ts
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {ButtonHTMLAttributes, DragEvent, HTMLAttributes,  RefObject, useRef, useState} from 'react';
+import {AriaButtonProps} from '@react-types/button';
+import {DragEvent, HTMLAttributes,  RefObject, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
 import {DragTypes, globalAllowedDropOperations, globalDndState, readFromDataTransfer, setGlobalDnDState, setGlobalDropEffect} from './utils';
 import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, DROP_OPERATION_ALLOWED, DROP_OPERATION_TO_DROP_EFFECT} from './constants';
@@ -59,7 +60,7 @@ export interface DropResult {
   /** Whether the drop target is currently focused or hovered. */
   isDropTarget: boolean,
   /** Props for the explicit drop button affordance, if any. */
-  dropButtonProps?: ButtonHTMLAttributes<HTMLButtonElement>
+  dropButtonProps?: AriaButtonProps
 }
 
 const DROP_ACTIVATE_TIMEOUT = 800;
@@ -337,7 +338,7 @@ export function useDrop(options: DropOptions): DropResult {
   if (isDisabled) {
     return {
       dropProps: {},
-      dropButtonProps: {disabled: true},
+      dropButtonProps: {isDisabled: true},
       isDropTarget: false
     };
   }

--- a/packages/@react-spectrum/dropzone/src/DropZone.tsx
+++ b/packages/@react-spectrum/dropzone/src/DropZone.tsx
@@ -20,7 +20,7 @@ import React, {ReactNode} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/dropzone/vars.css';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
-export interface SpectrumDropZoneProps extends Omit<DropZoneProps, 'onHoverStart' | 'onHoverChange' | 'onHoverEnd'>, DOMProps, StyleProps, AriaLabelingProps {
+export interface SpectrumDropZoneProps extends Omit<DropZoneProps, 'onHoverStart' | 'onHoverChange' | 'onHoverEnd' | 'isDisabled'>, DOMProps, StyleProps, AriaLabelingProps {
   /** The content to display in the drop zone. */
   children: ReactNode,
   /** Whether the drop zone has been filled. */

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -42,11 +42,17 @@ export interface DropZoneRenderProps {
   isDropTarget: boolean
 }
 
-export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps {}
+export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps {
+  /**
+   * Whether the dropzone is disabled.
+   */
+  isDisabled?: boolean
+}
 
 export const DropZoneContext = createContext<ContextValue<DropZoneProps, HTMLDivElement>>(null);
 
 function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
+  let {isDisabled} = props;
   [props, ref] = useContextProps(props, ref, DropZoneContext);
   let buttonRef = useRef<HTMLButtonElement>(null);
   let {dropProps, dropButtonProps, isDropTarget} = useDrop({...props, ref: buttonRef, hasDropButton: true});
@@ -63,6 +69,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   let labelProps = useLabels({'aria-labelledby': ariaLabelledby});
 
   let {clipboardProps} = useClipboard({
+    isDisabled,
     onPaste: (items) => props.onDrop?.({
       type: 'drop',
       items,

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -56,7 +56,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, DropZoneContext);
   let buttonRef = useRef<HTMLButtonElement>(null);
   let {dropProps, dropButtonProps, isDropTarget} = useDrop({...props, ref: buttonRef, hasDropButton: true});
-  let {buttonProps} = useButton(dropButtonProps, buttonRef);
+  let {buttonProps} = useButton(dropButtonProps || {}, buttonRef);
   let {hoverProps, isHovered} = useHover(props);
   let {focusProps, isFocused, isFocusVisible} = useFocusRing();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, 'react-aria-components');

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -12,7 +12,7 @@
 
 import {AriaLabelingProps, HoverEvents} from '@react-types/shared';
 import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
-import {DropOptions, mergeProps, useClipboard, useDrop, useFocusRing, useHover, useLocalizedStringFormatter, VisuallyHidden} from 'react-aria';
+import {DropOptions, mergeProps, useButton, useClipboard, useDrop, useFocusRing, useHover, useLocalizedStringFormatter, VisuallyHidden} from 'react-aria';
 import {filterDOMProps, useLabels, useSlotId} from '@react-aria/utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -39,15 +39,15 @@ export interface DropZoneRenderProps {
    * Whether the dropzone is the drop target.
    * @selector [data-drop-target]
    */
-  isDropTarget: boolean
-}
-
-export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps {
+  isDropTarget: boolean,
   /**
    * Whether the dropzone is disabled.
+   * @selector [data-disabled]
    */
   isDisabled?: boolean
 }
+
+export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps {}
 
 export const DropZoneContext = createContext<ContextValue<DropZoneProps, HTMLDivElement>>(null);
 
@@ -56,6 +56,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, DropZoneContext);
   let buttonRef = useRef<HTMLButtonElement>(null);
   let {dropProps, dropButtonProps, isDropTarget} = useDrop({...props, ref: buttonRef, hasDropButton: true});
+  let {buttonProps} = useButton(dropButtonProps, buttonRef);
   let {hoverProps, isHovered} = useHover(props);
   let {focusProps, isFocused, isFocusVisible} = useFocusRing();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, 'react-aria-components');
@@ -107,14 +108,15 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
         data-hovered={isHovered || undefined}
         data-focused={isFocused || undefined}
         data-focus-visible={isFocusVisible || undefined}
-        data-drop-target={isDropTarget || undefined} >
+        data-drop-target={isDropTarget || undefined} 
+        data-disabled={isDisabled || undefined}>
         <VisuallyHidden>
           {/* Added as a workaround for a Chrome + VO bug where it will not announce the aria label */}
           <div id={dropzoneId} aria-hidden="true">
             {ariaLabel}
           </div>
           <button
-            {...mergeProps(dropButtonProps, focusProps, clipboardProps, labelProps)}
+            {...mergeProps(buttonProps, focusProps, clipboardProps, labelProps)}
             ref={buttonRef} />
         </VisuallyHidden>
         {renderProps.children}

--- a/packages/react-aria-components/stories/Dropzone.stories.tsx
+++ b/packages/react-aria-components/stories/Dropzone.stories.tsx
@@ -162,6 +162,18 @@ export const DropzoneWithRenderProps = (props) => (
   </div>
 );
 
+export const DropzoneWithRenderPropsExample = {
+  args: {
+    isDisabled: true
+  },
+  argTypes: {
+    isDisabled: {control: 'boolean'}
+  },
+  render: (args) => (
+    <DropzoneWithRenderProps {...args} />
+  )
+};
+
 const Draggable = () => {
   let buttonRef = useRef(null);
   let {dragProps, isDragging} = useDrag({

--- a/packages/react-aria-components/stories/Dropzone.stories.tsx
+++ b/packages/react-aria-components/stories/Dropzone.stories.tsx
@@ -136,7 +136,7 @@ export const DropzoneExampleWithCopyableObject = (props) => (
   </div>
 );
 
-export const DropzoneWithRenderProps = (props) => (
+const DropzoneWithRenderPropsExample = (props) => (
   <div>
     <Draggable />
     <Copyable />
@@ -162,15 +162,15 @@ export const DropzoneWithRenderProps = (props) => (
   </div>
 );
 
-export const DropzoneWithRenderPropsExample = {
+export const DropzoneWithRenderProps = {
   args: {
-    isDisabled: true
+    isDisabled: false
   },
   argTypes: {
     isDisabled: {control: 'boolean'}
   },
   render: (args) => (
-    <DropzoneWithRenderProps {...args} />
+    <DropzoneWithRenderPropsExample {...args} />
   )
 };
 

--- a/packages/react-aria-components/test/DropZone.test.js
+++ b/packages/react-aria-components/test/DropZone.test.js
@@ -306,6 +306,73 @@ describe('DropZone', () => {
         expect(dropzone).not.toHaveAttribute('data-drop-target');
 
       });
+
+      it('should not trigger drag events if disabled', async () => {
+        let tree = render(
+          <>
+            <Draggable onDragStart={onDragStart} onDragMove={onDragMove} onDragEnd={onDragEnd} />
+            <DropZone isDisabled data-testid="disabled" onDropEnter={onDropEnter} onDrop={onDrop} onDropMove={onDropMove}>
+              <Text slot="label">
+                Test
+              </Text>
+            </DropZone>
+          </>
+        );
+        let dropzone = tree.getByTestId('disabled');
+        let draggable = tree.getByText('Drag me');
+        expect(dropzone).toHaveClass('react-aria-DropZone');
+        expect(draggable).toHaveAttribute('draggable', 'true');
+        expect(draggable).toHaveAttribute('data-dragging', 'false');
+        expect(dropzone).not.toHaveAttribute('data-drop-target');
+
+        let dataTransfer = new DataTransfer();
+        fireEvent(draggable, new DragEvent('dragstart', {dataTransfer, clientX: 0, clientY: 0}));
+        expect(dataTransfer.dropEffect).toBe('none');
+        expect(dataTransfer.effectAllowed).toBe('all');
+        expect([...dataTransfer.items]).toEqual([new DataTransferItem('text/plain', 'hello world')]);
+        expect(dataTransfer._dragImage).toBeUndefined();
+
+        act(() => jest.runAllTimers());
+        expect(draggable).toHaveAttribute('data-dragging', 'true');
+
+        expect(onDragStart).toHaveBeenCalledTimes(1);
+        expect(onDragStart).toHaveBeenCalledWith({
+          type: 'dragstart',
+          x: 0,
+          y: 0
+        });
+
+        fireEvent(draggable, new DragEvent('drag', {dataTransfer, clientX: 1, clientY: 1}));
+        expect(onDragMove).toHaveBeenCalledTimes(1);
+        expect(onDragMove).toHaveBeenCalledWith({
+          type: 'dragmove',
+          x: 1,
+          y: 1
+        });
+
+        fireEvent(dropzone, new DragEvent('dragenter', {dataTransfer, clientX: 1, clientY: 1}));
+        expect(onDropEnter).toHaveBeenCalledTimes(0);
+
+        expect(dataTransfer.dropEffect).toBe('none');
+        expect(dropzone).not.toHaveAttribute('data-drop-target');
+
+        fireEvent(dropzone, new DragEvent('dragover', {dataTransfer, clientX: 2, clientY: 2}));
+        expect(onDropMove).toHaveBeenCalledTimes(0);
+
+        expect(dataTransfer.dropEffect).toBe('none');
+        expect(dropzone).not.toHaveAttribute('data-drop-target');
+
+        fireEvent(draggable, new DragEvent('dragend', {dataTransfer, clientX: 2, clientY: 2}));
+        expect(onDragEnd).toHaveBeenCalledTimes(1);
+        expect(onDragEnd).toHaveBeenCalledWith({
+          type: 'dragend',
+          x: 2,
+          y: 2,
+          dropOperation: 'cancel'
+        });
+
+        expect(dropzone).not.toHaveAttribute('data-drop-target');
+      });
     });
 
     describe('via keyboard', function () {
@@ -362,12 +429,56 @@ describe('DropZone', () => {
 
         expect(dropzone).not.toHaveAttribute('data-drop-target');
       });
+
+      it('should not allow drag and drop if disabled', async () => {
+        let tree = render(
+          <>
+            <Draggable onDragStart={onDragStart} onDragEnd={onDragEnd} />
+            <DropZone isDisabled data-testid="disabled" onDropEnter={onDropEnter} onDrop={onDrop} onDropMove={onDropMove}>
+              <Text slot="label">
+                Test
+              </Text>
+            </DropZone>
+          </>
+        );
+
+        let dropzone = tree.getByTestId('disabled');
+        let draggable = tree.getByText('Drag me');
+
+        expect(dropzone).toHaveClass('react-aria-DropZone');
+        expect(draggable).toHaveAttribute('draggable', 'true');
+
+        await user.tab();
+        fireEvent.keyDown(draggable, {key: 'Enter'});
+        fireEvent.keyUp(draggable, {key: 'Enter'});
+
+        expect(onDragStart).toHaveBeenCalledTimes(1);
+        expect(onDragStart).toHaveBeenCalledWith({
+          type: 'dragstart',
+          x: 50,
+          y: 25
+        });
+
+        act(() => jest.runAllTimers());
+        expect(document.activeElement).toBe(draggable);
+        fireEvent.keyDown(dropzone, {key: 'Enter'});
+        fireEvent.keyUp(dropzone, {key: 'Enter'});
+
+        expect(onDrop).toHaveBeenCalledTimes(0);
+
+        expect(onDragEnd).toHaveBeenCalledTimes(1);
+        expect(onDragEnd).toHaveBeenCalledWith({
+          type: 'dragend',
+          x: 50,
+          y: 25,
+          dropOperation: 'cancel'
+        });
+      });
     });
   });
-
   describe('useClipboard', () => {
+    let onDrop = jest.fn();
     it('should be able to paste items into the dropzone', async () => {
-      let onDrop = jest.fn();
 
       let tree = render(
         <>
@@ -404,5 +515,25 @@ describe('DropZone', () => {
 
       expect(await onDrop.mock.calls[0][0].items[0].getText('text/plain')).toBe('hello world');
     });
+
+    it('should not allow paste into the dropzone if disabled', async () => {
+      let tree = render(
+        <>
+          <DropZone isDisabled data-testid="disabled" onDrop={onDrop}>
+            <Text slot="label">
+              Cannot paste here
+            </Text>
+          </DropZone>
+        </>
+      );
+  
+      let dropzone = tree.getByTestId('disabled');
+      let clipboardData = new DataTransfer();
+      clipboardData.items.add('hello world', 'text/plain');
+
+      fireEvent.paste(dropzone, {clipboardData});
+      expect(onDrop).not.toHaveBeenCalled();
+    });
+  
   });
 });

--- a/packages/react-aria-components/test/DropZone.test.js
+++ b/packages/react-aria-components/test/DropZone.test.js
@@ -319,6 +319,8 @@ describe('DropZone', () => {
           </>
         );
         let dropzone = tree.getByTestId('disabled');
+        expect(dropzone).toHaveAttribute('data-disabled', 'true');
+
         let draggable = tree.getByText('Drag me');
         expect(dropzone).toHaveClass('react-aria-DropZone');
         expect(draggable).toHaveAttribute('draggable', 'true');


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5938

To enable the `isDisabled` prop in DropZone, I've extended `isDisabled` support to several internal hooks. This update activates `isDisabled` for React Spectrum's DropZone as well. If this implementation poses no issues, I plan to add unit tests for it in React Spectrum's DropZone. I welcome any feedback.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
1. Visit http://localhost:9003/?path=/story/react-aria-components--dropzone-with-render-props&providerSwitcher-express=false&strict=true.
2. In the Controls tab, set isDisabled to true.
3. Verify that drag-and-drop with the mouse is disabled.
4. Verify that pasting from the clipboard is not possible.
5. Verify that the DropZone cannot receive focus.


## 🧢 Your Project:

<!--- Company/project for pull request -->
