### PR TITLE
Add readonly & required data attributes to `<TextField />`

### DIFF
--- a/packages/react-aria-components/src/TextField.tsx
+++ b/packages/react-aria-components/src/TextField.tsx
@@ -30,7 +30,17 @@ export interface TextFieldRenderProps {
    * Whether the value is invalid.
    * @selector [data-invalid]
    */
-  isInvalid: boolean
+  isInvalid: boolean,
+  /**
+   * Whether the text field is read only.
+   * @selector [data-readonly]
+   */
+  isReadOnly: boolean,
+  /**
+   * Whether the text field is required.
+   * @selector [data-required]
+   */
+  isRequired: boolean
 }
 
 export interface TextFieldProps extends Omit<AriaTextFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, Omit<DOMProps, 'style' | 'className' | 'children'>, SlotProps, RenderProps<TextFieldRenderProps> {
@@ -65,7 +75,9 @@ function TextField(props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) {
     ...props,
     values: {
       isDisabled: props.isDisabled || false,
-      isInvalid: validation.isInvalid
+      isInvalid: validation.isInvalid,
+      isReadOnly: props.isReadOnly || false,
+      isRequired: props.isRequired || false
     },
     defaultClassName: 'react-aria-TextField'
   });
@@ -77,7 +89,9 @@ function TextField(props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) {
       ref={ref}
       slot={props.slot || undefined}
       data-disabled={props.isDisabled || undefined}
-      data-invalid={validation.isInvalid || undefined}>
+      data-invalid={validation.isInvalid || undefined}
+      data-readonly={props.isReadOnly || undefined}
+      data-required={props.isRequired || undefined}>
       <Provider
         values={[
           [LabelContext, {...labelProps, ref: labelRef}],

--- a/packages/react-aria-components/test/TextField.test.js
+++ b/packages/react-aria-components/test/TextField.test.js
@@ -110,6 +110,30 @@ describe('TextField', () => {
       expect(input).not.toHaveClass('focus');
     });
 
+    it('should support read-only state', async () => {
+      let {getByRole, rerender} = render(
+        <TestTextField input={component} />
+      );
+
+      let input = getByRole('textbox');
+      
+      expect(input.closest('.react-aria-TextField')).not.toHaveAttribute('data-readonly');
+      rerender(<TestTextField input={component} isReadOnly />);
+      expect(input.closest('.react-aria-TextField')).toHaveAttribute('data-readonly');
+    });
+
+    it('should support required state', async () => {
+      let {getByRole, rerender} = render(
+        <TestTextField input={component} />
+      );
+
+      let input = getByRole('textbox');
+      
+      expect(input.closest('.react-aria-TextField')).not.toHaveAttribute('data-required');
+      rerender(<TestTextField input={component} isRequired />);
+      expect(input.closest('.react-aria-TextField')).toHaveAttribute('data-required');
+    });
+
     it('should render data- attributes only on the outer element', () => {
       let {getAllByTestId} = render(<TestTextField input={component} />);
       let outerEl = getAllByTestId('text-field-test');


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5930

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Docs
http://localhost:1234/react-aria/TextField.html#textfield-2

## 🧢 Your Project:

<!--- Company/project for pull request -->
