### PR TITLE
Update cursor style to default for Tabs in docs

### DIFF
--- a/packages/@react-aria/tabs/docs/useTabList.mdx
+++ b/packages/@react-aria/tabs/docs/useTabList.mdx
@@ -167,6 +167,7 @@ function TabPanel({state, ...props}) {
 
 [role=tab] {
   padding: 10px;
+  cursor: default;
 }
 
 [role=tablist][aria-orientation=horizontal] [role=tab] {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5972

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
1. Open the `useTabList` documentation page.
2. Hover over any tab in the examples.
3. Verify the cursor is now the default style, not text.

## 🧢 Your Project:

<!--- Company/project for pull request -->
