### PR TITLE
Use default cursor for help text on disabled elements

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/helptext/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/helptext/index.css
@@ -48,4 +48,8 @@
     text-transform: var(--spectrum-helptext-neutral-textonly-text-transform);
     letter-spacing: var(--spectrum-helptext-neutral-textonly-text-letter-spacing);
   }
+
+  &.is-disabled {
+    cursor: default;
+  }
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the http://localhost:9003/?path=/story/textfield--with-description&args=isDisabled:true&providerSwitcher-express=false&strict=true story and disable it via controls. Hovering over the text shouldn't display the text cursor

## 🧢 Your Project:

RSP
