### PR TITLE
Toast focus improvements

### DIFF
--- a/packages/@react-aria/toast/intl/en-US.json
+++ b/packages/@react-aria/toast/intl/en-US.json
@@ -1,4 +1,5 @@
 {
   "close": "Close",
-  "notifications": "Notifications"
+  "notifications": "Notifications",
+  "countAnnouncement": "{count, plural, one {# notification} other {# notifications}}."
 }

--- a/packages/@react-aria/toast/package.json
+++ b/packages/@react-aria/toast/package.json
@@ -22,9 +22,11 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-aria/focus": "^3.16.2",
     "@react-aria/i18n": "^3.10.2",
     "@react-aria/interactions": "^3.21.1",
     "@react-aria/landmark": "3.0.0-beta.10",
+    "@react-aria/live-announcer": "^3.3.2",
     "@react-aria/utils": "^3.23.2",
     "@react-stately/toast": "3.0.0-beta.2",
     "@react-types/button": "^3.9.2",

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -15,7 +15,7 @@ import {AriaLabelingProps, DOMAttributes, FocusableElement} from '@react-types/s
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {QueuedToast, ToastState} from '@react-stately/toast';
-import {RefObject, useEffect, useRef} from 'react';
+import {RefObject, useEffect, useRef, useState} from 'react';
 import {useFocusManager} from '@react-aria/focus';
 import {useId, useLayoutEffect, useSlotId} from '@react-aria/utils';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
@@ -78,14 +78,23 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
     };
   }, [ref, state.visibleToasts]);
 
+  const [isBusy, setIsBusy] = useState(true);
+
   // eslint-disable-next-line
   useEffect(() => {
+    let timeoutId:ReturnType<typeof setTimeout>;
+    if (isBusy) {
+      timeoutId = setTimeout(() => setIsBusy(false), 300);
+    }
     return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       if (focusOnUnmount.current) {
         focusOnUnmount.current.focus();
       }
     };
-  }, [ref]);
+  }, [ref, isBusy]);
 
   let titleId = useId();
   let descriptionId = useSlotId();
@@ -119,7 +128,7 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
     contentProps: {
       role: 'alert',
       'aria-atomic': 'true',
-      'aria-relevant': 'additions'
+      'aria-busy': isBusy ?? undefined
     },
     titleProps: {
       id: titleId

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -109,7 +109,8 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
       'aria-describedby': props['aria-describedby'] || descriptionId,
       'aria-details': props['aria-details'],
       // Hide toasts that are animating out so VoiceOver doesn't announce them.
-      'aria-hidden': animation === 'exiting' ? 'true' : undefined
+      'aria-hidden': animation === 'exiting' ? 'true' : undefined,
+      tabIndex: 0
     },
     titleProps: {
       id: titleId

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -93,7 +93,7 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
     state.close(key);
     // Only move focus when there is another Toast. At this point,
     // state.visibleToasts still includes Toast being removed.
-    if (state.visibleToasts.length > 1) {
+    if (state.visibleToasts?.length > 1) {
       let nextItemFocused = focusManager.focusNext();
       if (!nextItemFocused || Object.keys(nextItemFocused).length === 0) {
         focusManager.focusPrevious();

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -16,8 +16,8 @@ import {AriaLabelingProps, DOMAttributes, FocusableElement} from '@react-types/s
 import intlMessages from '../intl/*.json';
 import {QueuedToast, ToastState} from '@react-stately/toast';
 import {RefObject, useEffect, useRef} from 'react';
-import {useId, useLayoutEffect, useSlotId} from '@react-aria/utils';
 import {useFocusManager} from '@react-aria/focus';
+import {useId, useLayoutEffect, useSlotId} from '@react-aria/utils';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 export interface AriaToastProps<T> extends AriaLabelingProps {
@@ -89,7 +89,7 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
   let descriptionId = useSlotId();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/toast');
 
-  let onClosePress = (e) => {
+  let onClosePress = () => {
     state.close(key);
     // Only move focus when there is another Toast. At this point,
     // state.visibleToasts still includes Toast being removed.
@@ -99,7 +99,7 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
         focusManager.focusPrevious();
       }
     }
-  }
+  };
 
   return {
     toastProps: {

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -66,13 +66,13 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
   useLayoutEffect(() => {
     let container = ref.current.closest('[role=region]') as HTMLElement;
     return () => {
-      if (container && container.contains(document.activeElement)) {
+      if (container && container.contains(document.activeElement) && state.visibleToasts.filter(t => t.animation !== 'exiting').length < 1) {
         // Focus must be delayed for focus ring to appear, but we can't wait
         // until useEffect cleanup to check if focus was inside the container.
         focusOnUnmount.current = container;
       }
     };
-  }, [ref]);
+  }, [ref, state.visibleToasts]);
 
   // eslint-disable-next-line
   useEffect(() => {

--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -78,20 +78,26 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
     };
   }, [ref, state.visibleToasts]);
 
-  const [isBusy, setIsBusy] = useState(true);
-
-  // eslint-disable-next-line
   useEffect(() => {
+    return () => {
+      if (focusOnUnmount.current) {
+        focusOnUnmount.current.focus();
+      }
+    };
+  }, [ref]);
+
+  // To improve screen reader announcement of the toast,
+  // we use aria-hidden="true" to hide the toast content
+  // briefly while it is animating in.
+  const [isBusy, setIsBusy] = useState(true);
+  useLayoutEffect(() => {
     let timeoutId:ReturnType<typeof setTimeout>;
-    if (isBusy) {
-      timeoutId = setTimeout(() => setIsBusy(false), 300);
+    if (isBusy && ref.current) {
+      timeoutId = setTimeout(() => setIsBusy(false), 50);
     }
     return () => {
       if (timeoutId) {
         clearTimeout(timeoutId);
-      }
-      if (focusOnUnmount.current) {
-        focusOnUnmount.current.focus();
       }
     };
   }, [ref, isBusy]);
@@ -128,7 +134,7 @@ export function useToast<T>(props: AriaToastProps<T>, state: ToastState<T>, ref:
     contentProps: {
       role: 'alert',
       'aria-atomic': 'true',
-      'aria-busy': isBusy ?? undefined
+      'aria-hidden': isBusy ?? undefined
     },
     titleProps: {
       id: titleId

--- a/packages/@react-aria/toast/src/useToastRegion.ts
+++ b/packages/@react-aria/toast/src/useToastRegion.ts
@@ -1,3 +1,4 @@
+import {announce} from '@react-aria/live-announcer';
 import {AriaLabelingProps, DOMAttributes} from '@react-types/shared';
 import {focusWithoutScrolling, mergeProps} from '@react-aria/utils';
 import {getInteractionModality, useFocusWithin, useHover} from '@react-aria/interactions';
@@ -42,6 +43,11 @@ export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState
     onFocusWithin: (e) => {
       state.pauseAll();
       lastFocused.current = e.relatedTarget;
+      if (ref.current === document.activeElement) {
+        let count: number = state.visibleToasts.length || 0;
+        let announcement = stringFormatter.format('countAnnouncement', {count});
+        announce(announcement);
+      }
     },
     onBlurWithin: () => {
       state.resumeAll();

--- a/packages/@react-aria/toast/src/useToastRegion.ts
+++ b/packages/@react-aria/toast/src/useToastRegion.ts
@@ -39,14 +39,19 @@ export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState
   });
 
   let lastFocused = useRef(null);
+  let timeoutId:ReturnType<typeof setTimeout>;
   let {focusWithinProps} = useFocusWithin({
     onFocusWithin: (e) => {
       state.pauseAll();
       lastFocused.current = e.relatedTarget;
-      if (ref.current === document.activeElement) {
+      if (ref.current?.contains(document.activeElement)) {
         let count: number = state.visibleToasts.length || 0;
         let announcement = stringFormatter.format('countAnnouncement', {count});
-        announce(announcement);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = undefined;
+        }
+        timeoutId = setTimeout(() => announce(announcement, 'polite'), 750);
       }
     },
     onBlurWithin: () => {

--- a/packages/@react-aria/toast/src/useToastRegion.ts
+++ b/packages/@react-aria/toast/src/useToastRegion.ts
@@ -39,7 +39,7 @@ export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState
   });
 
   let lastFocused = useRef(null);
-  let timeoutId:ReturnType<typeof setTimeout>;
+  const timeoutIdRef = useRef<ReturnType<typeof setTimeout>>();
   let {focusWithinProps} = useFocusWithin({
     onFocusWithin: (e) => {
       state.pauseAll();
@@ -47,11 +47,11 @@ export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState
       if (ref.current?.contains(document.activeElement)) {
         let count: number = state.visibleToasts.length || 0;
         let announcement = stringFormatter.format('countAnnouncement', {count});
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = undefined;
+        if (timeoutIdRef.current) {
+          clearTimeout(timeoutIdRef.current);
+          timeoutIdRef.current = undefined;
         }
-        timeoutId = setTimeout(() => announce(announcement, 'polite'), 750);
+        timeoutIdRef.current = setTimeout(() => announce(announcement, 'polite'), 600);
       }
     },
     onBlurWithin: () => {
@@ -66,6 +66,10 @@ export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState
   // eslint-disable-next-line arrow-body-style
   useEffect(() => {
     return () => {
+      if (timeoutIdRef.current) {
+        clearTimeout(timeoutIdRef.current);
+        timeoutIdRef.current = undefined;
+      }
       if (lastFocused.current && document.body.contains(lastFocused.current)) {
         if (getInteractionModality() === 'pointer') {
           focusWithoutScrolling(lastFocused.current);

--- a/packages/@react-aria/toast/stories/Example.tsx
+++ b/packages/@react-aria/toast/stories/Example.tsx
@@ -43,13 +43,13 @@ function ToastRegion() {
 function Toast(props) {
   let state = useContext(ToastContext);
   let ref = useRef(null);
-  let {toastProps, titleProps, closeButtonProps} = useToast(props, state, ref);
+  let {toastProps, contentProps, titleProps, closeButtonProps} = useToast(props, state, ref);
   let buttonRef = useRef();
   let {buttonProps} = useButton(closeButtonProps, buttonRef);
 
   return (
     <div {...toastProps} ref={ref} style={{margin: 20, display: 'flex', gap: 5}}>
-      <div {...titleProps}>{props.toast.content}</div>
+      <div {...contentProps} {...titleProps}>{props.toast.content}</div>
       <button {...buttonProps} ref={buttonRef}>x</button>
     </div>
   );

--- a/packages/@react-aria/toast/stories/Example.tsx
+++ b/packages/@react-aria/toast/stories/Example.tsx
@@ -49,7 +49,9 @@ function Toast(props) {
 
   return (
     <div {...toastProps} ref={ref} style={{margin: 20, display: 'flex', gap: 5}}>
-      <div {...contentProps} {...titleProps}>{props.toast.content}</div>
+      <div {...contentProps}>
+        <div {...titleProps}>{props.toast.content}</div>
+      </div>
       <button {...buttonProps} ref={buttonRef}>x</button>
     </div>
   );

--- a/packages/@react-aria/toast/test/useToast.test.js
+++ b/packages/@react-aria/toast/test/useToast.test.js
@@ -27,9 +27,10 @@ describe('useToast', () => {
   };
 
   it('handles defaults', function () {
-    let {closeButtonProps, toastProps, titleProps} = renderToastHook({}, {close});
+    let {closeButtonProps, toastProps, contentProps, titleProps} = renderToastHook({}, {close});
 
-    expect(toastProps.role).toBe('alert');
+    expect(toastProps.role).toBe('alertdialog');
+    expect(contentProps.role).toBe('alert');
     expect(closeButtonProps['aria-label']).toBe('Close');
     expect(typeof closeButtonProps.onPress).toBe('function');
     expect(titleProps.id).toEqual(toastProps['aria-labelledby']);

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -330,7 +330,7 @@ describe('Breadcrumbs', function () {
     expect(onAction).toHaveBeenCalledWith('Folder 1');
 
     // menu item
-    expect(item1[1]).not.toHaveAttribute('role');
+    expect(item1[1]).toHaveAttribute('role', 'none');
     triggerPress(item1[1]);
     expect(onAction).toHaveBeenCalledWith('Folder 1');
   });

--- a/packages/@react-spectrum/text/src/Text.tsx
+++ b/packages/@react-spectrum/text/src/Text.tsx
@@ -26,7 +26,7 @@ function Text(props: TextProps, ref: DOMRef) {
   let domRef = useDOMRef(ref);
 
   return (
-    <span {...filterDOMProps(otherProps)} {...styleProps} ref={domRef}>
+    <span role="none" {...filterDOMProps(otherProps)} {...styleProps} ref={domRef}>
       {children}
     </span>
   );

--- a/packages/@react-spectrum/toast/package.json
+++ b/packages/@react-spectrum/toast/package.json
@@ -46,6 +46,7 @@
     "@react-types/shared": "^3.22.1",
     "@spectrum-icons/ui": "^3.6.5",
     "@swc/helpers": "^0.5.0",
+    "react-aria": "^3.32.1",
     "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/toast/src/Toast.tsx
+++ b/packages/@react-spectrum/toast/src/Toast.tsx
@@ -19,11 +19,12 @@ import InfoMedium from '@spectrum-icons/ui/InfoMedium';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {QueuedToast, ToastState} from '@react-stately/toast';
-import React, {useContext} from 'react';
+import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/toast/vars.css';
 import SuccessMedium from '@spectrum-icons/ui/SuccessMedium';
 import toastContainerStyles from './toastContainer.css';
-import {ToasterContext} from './Toaster';
+import {useFocusRing} from '@react-aria/focus';
+import {useId} from '@react-aria/utils';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 import {useToast} from '@react-aria/toast';
 
@@ -66,6 +67,7 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
   let domRef = useDOMRef(ref);
   let {
     closeButtonProps,
+    contentProps,
     titleProps,
     toastProps
   } = useToast(props, state, domRef);
@@ -74,7 +76,7 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/toast');
   let iconLabel = variant && variant !== 'neutral' ? stringFormatter.format(variant) : null;
   let Icon = ICONS[variant];
-  let isFocusVisible = useContext(ToasterContext);
+  let {isFocusVisible, focusProps} = useFocusRing();
 
   const handleAction = () => {
     if (onAction) {
@@ -86,10 +88,16 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
     }
   };
 
+  const iconId = useId();
+  if (Icon) {
+    toastProps['aria-labelledby'] = `${iconId} ${titleProps.id}`;
+  }
+
   return (
     <div
       {...styleProps}
       {...toastProps}
+      {...focusProps}
       ref={domRef}
       className={classNames(styles,
         'spectrum-Toast',
@@ -98,7 +106,7 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
         classNames(
           toastContainerStyles,
           'spectrum-Toast',
-          {'focus-ring': props.toast.key === state.visibleToasts[0]?.key && isFocusVisible}
+          {'focus-ring': isFocusVisible}
         )
       )}
       style={{
@@ -111,24 +119,27 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
           state.remove(key);
         }
       }}>
-      {Icon &&
-        <Icon
-          aria-label={iconLabel}
-          UNSAFE_className={classNames(styles, 'spectrum-Toast-typeIcon')} />
-      }
-      <div className={classNames(styles, 'spectrum-Toast-body')}>
-        <div className={classNames(styles, 'spectrum-Toast-content')} {...titleProps}>{children}</div>
-        {actionLabel &&
-          <Button
-            onPress={handleAction}
-            UNSAFE_className={classNames(styles, 'spectrum-Button')}
-            variant="secondary"
-            staticColor="white">
-            {actionLabel}
-          </Button>
+      <div {...contentProps} className={classNames(toastContainerStyles, 'spectrum-Toast-contentWrapper')}>
+        {Icon &&
+          <Icon
+            id={iconId}
+            aria-label={iconLabel}
+            UNSAFE_className={classNames(styles, 'spectrum-Toast-typeIcon')} />
         }
+        <div className={classNames(styles, 'spectrum-Toast-body')} role="presentation">
+          <div className={classNames(styles, 'spectrum-Toast-content')} role="presentation" {...titleProps}>{children}</div>
+          {actionLabel &&
+            <Button
+              onPress={handleAction}
+              UNSAFE_className={classNames(styles, 'spectrum-Button')}
+              variant="secondary"
+              staticColor="white">
+              {actionLabel}
+            </Button>
+          }
+        </div>
       </div>
-      <div className={classNames(styles, 'spectrum-Toast-buttons')}>
+      <div className={classNames(styles, 'spectrum-Toast-buttons')} role="presentation">
         <ClearButton {...closeButtonProps} variant="overBackground">
           <CrossMedium />
         </ClearButton>

--- a/packages/@react-spectrum/toast/src/Toast.tsx
+++ b/packages/@react-spectrum/toast/src/Toast.tsx
@@ -14,7 +14,7 @@ import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import {Button, ClearButton} from '@react-spectrum/button';
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import CrossMedium from '@spectrum-icons/ui/CrossMedium';
-import {DOMRef} from '@react-types/shared';
+import {DOMRef, PressEvent} from '@react-types/shared';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -78,13 +78,13 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
   let Icon = ICONS[variant];
   let {isFocusVisible, focusProps} = useFocusRing();
 
-  const handleAction = () => {
+  const handleAction = (evt: PressEvent) => {
     if (onAction) {
       onAction();
     }
 
     if (shouldCloseOnAction) {
-      state.close(key);
+      closeButtonProps.onPress(evt);
     }
   };
 

--- a/packages/@react-spectrum/toast/src/Toast.tsx
+++ b/packages/@react-spectrum/toast/src/Toast.tsx
@@ -14,7 +14,7 @@ import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import {Button, ClearButton} from '@react-spectrum/button';
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import CrossMedium from '@spectrum-icons/ui/CrossMedium';
-import {DOMRef, PressEvent} from '@react-types/shared';
+import {DOMRef} from '@react-types/shared';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
 // @ts-ignore
 import intlMessages from '../intl/*.json';

--- a/packages/@react-spectrum/toast/src/Toast.tsx
+++ b/packages/@react-spectrum/toast/src/Toast.tsx
@@ -78,13 +78,13 @@ function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
   let Icon = ICONS[variant];
   let {isFocusVisible, focusProps} = useFocusRing();
 
-  const handleAction = (evt: PressEvent) => {
+  const handleAction = () => {
     if (onAction) {
       onAction();
     }
 
     if (shouldCloseOnAction) {
-      closeButtonProps.onPress(evt);
+      state.close(key);
     }
   };
 

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -120,7 +120,7 @@ export function ToastContainer(props: SpectrumToastContainerProps): ReactElement
                 state={state} />
             </li>
           ))}
-        </ol >
+        </ol>
       </Toaster>
     );
   }

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -11,8 +11,10 @@
  */
 
 import {AriaToastRegionProps} from '@react-aria/toast';
+import {classNames} from '@react-spectrum/utils';
 import React, {ReactElement, useEffect, useRef} from 'react';
 import {SpectrumToastValue, Toast} from './Toast';
+import toastContainerStyles from './toastContainer.css';
 import {Toaster} from './Toaster';
 import {ToastOptions, ToastQueue, useToastQueue} from '@react-stately/toast';
 import {useSyncExternalStore} from 'use-sync-external-store/shim/index.js';
@@ -106,12 +108,19 @@ export function ToastContainer(props: SpectrumToastContainerProps): ReactElement
   if (ref === activeToastContainer && state.visibleToasts.length > 0) {
     return (
       <Toaster state={state} {...props}>
-        {state.visibleToasts.map((toast) => (
-          <Toast
-            key={toast.key}
-            toast={toast}
-            state={state} />
-        ))}
+        <ol reversed className={classNames(toastContainerStyles, 'spectrum-Toast-list')}>
+          {state.visibleToasts.map((toast) => (
+            <li
+              key={`${toast.key}-listitem`}
+              aria-hidden={toast.animation === 'exiting' ? 'true' : undefined}
+              className={classNames(toastContainerStyles, 'spectrum-Toast-listitem')}>
+              <Toast
+                key={toast.key}
+                toast={toast}
+                state={state} />
+            </li>
+          ))}
+        </ol >
       </Toaster>
     );
   }

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -109,8 +109,10 @@ export function ToastContainer(props: SpectrumToastContainerProps): ReactElement
     return (
       <Toaster state={state} {...props}>
         <ol reversed className={classNames(toastContainerStyles, 'spectrum-Toast-list')}>
-          {state.visibleToasts.map((toast) => (
+          {state.visibleToasts.map((toast, index) => (
             <li
+              aria-posinset={state.visibleToasts.length - index}
+              aria-setsize={state.visibleToasts.length}
               key={`${toast.key}-listitem`}
               aria-hidden={toast.animation === 'exiting' ? 'true' : undefined}
               className={classNames(toastContainerStyles, 'spectrum-Toast-listitem')}>

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -18,7 +18,7 @@ import React, {createContext, ReactElement, ReactNode, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import toastContainerStyles from './toastContainer.css';
 import {ToastState} from '@react-stately/toast';
-import {useFocusRing} from '@react-aria/focus';
+import {useFocusRing, FocusScope} from '@react-aria/focus';
 
 interface ToastContainerProps extends AriaToastRegionProps {
   children: ReactNode,
@@ -40,17 +40,19 @@ export function Toaster(props: ToastContainerProps): ReactElement {
   let contents = (
     <Provider UNSAFE_style={{background: 'transparent'}}>
       <ToasterContext.Provider value={isFocusVisible}>
-        <div
-          {...mergeProps(regionProps, focusProps)}
-          ref={ref}
-          data-position="bottom"
-          data-placement="center"
-          className={classNames(
-            toastContainerStyles,
-            'react-spectrum-ToastContainer'
-          )}>
-          {children}
-        </div>
+        <FocusScope restoreFocus>
+          <div
+            {...mergeProps(regionProps, focusProps)}
+            ref={ref}
+            data-position="bottom"
+            data-placement="center"
+            className={classNames(
+              toastContainerStyles,
+              'react-spectrum-ToastContainer'
+            )}>
+            {children}
+          </div>
+        </FocusScope>
       </ToasterContext.Provider>
     </Provider>
   );

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -48,7 +48,8 @@ export function Toaster(props: ToastContainerProps): ReactElement {
             data-placement="center"
             className={classNames(
               toastContainerStyles,
-              'react-spectrum-ToastContainer'
+              'react-spectrum-ToastContainer',
+              {'focus-ring': isFocusVisible}
             )}>
             {children}
           </div>

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -12,13 +12,13 @@
 
 import {AriaToastRegionProps, useToastRegion} from '@react-aria/toast';
 import {classNames} from '@react-spectrum/utils';
+import {FocusScope, useFocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
 import {Provider} from '@react-spectrum/provider';
 import React, {createContext, ReactElement, ReactNode, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import toastContainerStyles from './toastContainer.css';
 import {ToastState} from '@react-stately/toast';
-import {useFocusRing, FocusScope} from '@react-aria/focus';
 
 interface ToastContainerProps extends AriaToastRegionProps {
   children: ReactNode,

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -19,7 +19,6 @@ import React, {createContext, ReactElement, ReactNode, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import toastContainerStyles from './toastContainer.css';
 import {ToastState} from '@react-stately/toast';
-import {useFocusRing, FocusScope} from '@react-aria/focus';
 
 interface ToastContainerProps extends AriaToastRegionProps {
   children: ReactNode,

--- a/packages/@react-spectrum/toast/src/Toaster.tsx
+++ b/packages/@react-spectrum/toast/src/Toaster.tsx
@@ -19,6 +19,7 @@ import React, {createContext, ReactElement, ReactNode, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import toastContainerStyles from './toastContainer.css';
 import {ToastState} from '@react-stately/toast';
+import {useFocusRing, FocusScope} from '@react-aria/focus';
 
 interface ToastContainerProps extends AriaToastRegionProps {
   children: ReactNode,

--- a/packages/@react-spectrum/toast/src/toastContainer.css
+++ b/packages/@react-spectrum/toast/src/toastContainer.css
@@ -72,6 +72,9 @@
   --spectrum-focus-ring-gap: var(--spectrum-alias-focus-ring-gap);
   --spectrum-focus-ring-size: var(--spectrum-alias-focus-ring-size);
 
+  position: relative;
+  outline: none;
+
   &[data-animation=entering] {
     animation: slide-in 300ms;
   }
@@ -79,6 +82,23 @@
   &[data-animation=exiting] {
     animation: fade-out 300ms forwards;
   }
+}
+.spectrum-Toast-list {
+  display: contents;
+  list-style-type: none;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 0;
+}
+
+.spectrum-Toast-listitem {
+  display: inline-block;
+}
+
+.spectrum-Toast-contentWrapper {
+  display: contents;
 }
 
 @keyframes slide-in {

--- a/packages/@react-spectrum/toast/src/toastContainer.css
+++ b/packages/@react-spectrum/toast/src/toastContainer.css
@@ -13,6 +13,11 @@
 @import "../../../@adobe/spectrum-css-temp/components/commons/focus-ring.css";
 
 .react-spectrum-ToastContainer {
+  composes: spectrum-FocusRing;
+  --spectrum-focus-ring-border-radius: var(--spectrum-toast-border-radius);
+  --spectrum-focus-ring-gap: var(--spectrum-alias-focus-ring-gap);
+  --spectrum-focus-ring-size: var(--spectrum-alias-focus-ring-size);
+
   position: fixed;
   inset-inline-start: 0;
   inset-inline-end: 0;
@@ -21,6 +26,7 @@
   pointer-events: none;
   outline: none;
   margin-block-end: 8px;
+  margin-inline: 8px;
 
   .spectrum-Toast {
     margin: 8px;
@@ -98,7 +104,7 @@
 }
 
 .spectrum-Toast-contentWrapper {
-  display: contents;
+  display: inline-flex;
 }
 
 @keyframes slide-in {

--- a/packages/@react-spectrum/toast/src/toastContainer.css
+++ b/packages/@react-spectrum/toast/src/toastContainer.css
@@ -90,7 +90,9 @@
   }
 }
 .spectrum-Toast-list {
-  display: contents;
+  display: inherit;
+  flex-direction: inherit;
+  align-items: inherit;
   list-style-type: none;
   margin-block-start: 0;
   margin-block-end: 0;

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -247,10 +247,11 @@ describe('Toast Provider and Container', function () {
     triggerPress(closeButton);
     fireAnimationEnd(toast);
 
-    expect(document.activeElement).toBe(document.body);
-
     toast = getByRole('alert');
     closeButton = within(toast).getByRole('button');
+
+    expect(document.activeElement).toBe(closeButton);
+
     triggerPress(closeButton);
     fireAnimationEnd(toast);
 

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -235,7 +235,7 @@ describe('Toast Provider and Container', function () {
     expect(document.activeElement).toBe(button);
   });
 
-  it('should move focus to body when a toast exits and there are more', () => {
+  it('should move focus to remaining toast close button when a toast exits and there are more', () => {
     let {getAllByRole, getByRole, queryByRole} = renderComponent(<RenderToastButton />);
     let button = getByRole('button');
 

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -235,7 +235,7 @@ describe('Toast Provider and Container', function () {
     expect(document.activeElement).toBe(button);
   });
 
-  it('should move focus to container when a toast exits and there are more', () => {
+  it('should move focus to body when a toast exits and there are more', () => {
     let {getAllByRole, getByRole, queryByRole} = renderComponent(<RenderToastButton />);
     let button = getByRole('button');
 
@@ -247,7 +247,7 @@ describe('Toast Provider and Container', function () {
     triggerPress(closeButton);
     fireAnimationEnd(toast);
 
-    expect(document.activeElement).toBe(getByRole('region'));
+    expect(document.activeElement).toBe(document.body);
 
     toast = getByRole('alert');
     closeButton = within(toast).getByRole('button');

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -235,7 +235,7 @@ describe('Toast Provider and Container', function () {
     expect(document.activeElement).toBe(button);
   });
 
-  it('should move focus to remaining toast close button when a toast exits and there are more', () => {
+  it('should move focus to remaining toast when a toast exits and there are more', () => {
     let {getAllByRole, getByRole, queryByRole} = renderComponent(<RenderToastButton />);
     let button = getByRole('button');
 
@@ -248,10 +248,9 @@ describe('Toast Provider and Container', function () {
     fireAnimationEnd(toast);
 
     toast = getByRole('alert');
+    expect(document.activeElement).toBe(toast);
+
     closeButton = within(toast).getByRole('button');
-
-    expect(document.activeElement).toBe(closeButton);
-
     triggerPress(closeButton);
     fireAnimationEnd(toast);
 

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -64,20 +64,24 @@ describe('Toast Provider and Container', function () {
     let {getByRole, queryByRole} = renderComponent(<RenderToastButton />);
     let button = getByRole('button');
 
+    expect(queryByRole('alertdialog')).toBeNull();
     expect(queryByRole('alert')).toBeNull();
     triggerPress(button);
 
     let region = getByRole('region');
     expect(region).toHaveAttribute('aria-label', 'Notifications');
 
-    let alert = getByRole('alert');
+    let toast = getByRole('alertdialog');
+    let alert = within(toast).getByRole('alert');
+    expect(toast).toBeVisible();
     expect(alert).toBeVisible();
 
-    button = within(alert).getByRole('button');
+    button = within(toast).getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'Close');
     triggerPress(button);
 
     fireAnimationEnd(alert);
+    expect(queryByRole('alertdialog')).toBeNull();
     expect(queryByRole('alert')).toBeNull();
   });
 
@@ -86,9 +90,12 @@ describe('Toast Provider and Container', function () {
     let button = getByRole('button');
     triggerPress(button);
 
-    let alert = getByRole('alert');
+    let toast = getByRole('alertdialog');
+    let alert = within(toast).getByRole('alert');
     let icon = within(alert).getByRole('img');
     expect(icon).toHaveAttribute('aria-label', 'Success');
+    let title = within(alert).getByText('Toast is default');
+    expect(toast).toHaveAttribute('aria-labelledby', `${icon.id} ${title.id}`);
   });
 
   it('removes a toast via timeout', () => {
@@ -97,7 +104,7 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getByRole('alertdialog');
     expect(toast).toBeVisible();
 
     act(() => jest.advanceTimersByTime(1000));
@@ -107,7 +114,7 @@ describe('Toast Provider and Container', function () {
     expect(toast).toHaveAttribute('data-animation', 'exiting');
 
     fireAnimationEnd(toast);
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
   });
 
   it('pauses timers when hovering', async () => {
@@ -116,7 +123,7 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getByRole('alertdialog');
     expect(toast).toBeVisible();
 
     act(() => jest.advanceTimersByTime(1000));
@@ -131,7 +138,7 @@ describe('Toast Provider and Container', function () {
     expect(toast).toHaveAttribute('data-animation', 'exiting');
 
     fireAnimationEnd(toast);
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
   });
 
   it('pauses timers when focusing', () => {
@@ -140,7 +147,7 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getByRole('alertdialog');
     expect(toast).toBeVisible();
 
     act(() => jest.advanceTimersByTime(1000));
@@ -155,7 +162,7 @@ describe('Toast Provider and Container', function () {
     expect(toast).toHaveAttribute('data-animation', 'exiting');
 
     fireAnimationEnd(toast);
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
   });
 
   it('renders a toast with an action', () => {
@@ -164,13 +171,15 @@ describe('Toast Provider and Container', function () {
     let {getByRole, queryByRole} = renderComponent(<RenderToastButton actionLabel="Action" onAction={onAction} onClose={onClose} />);
     let button = getByRole('button');
 
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
     triggerPress(button);
 
-    let alert = getByRole('alert');
+    let toast = getByRole('alertdialog');
+    let alert = within(toast).getByRole('alert');
+    expect(toast).toBeVisible();
     expect(alert).toBeVisible();
 
-    let buttons = within(alert).getAllByRole('button');
+    let buttons = within(toast).getAllByRole('button');
     expect(buttons[0]).toHaveTextContent('Action');
     triggerPress(buttons[0]);
 
@@ -184,22 +193,24 @@ describe('Toast Provider and Container', function () {
     let {getByRole, queryByRole} = renderComponent(<RenderToastButton actionLabel="Action" onAction={onAction} onClose={onClose} shouldCloseOnAction />);
     let button = getByRole('button');
 
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
     triggerPress(button);
 
-    let alert = getByRole('alert');
+    let toast = getByRole('alertdialog');
+    let alert = within(toast).getByRole('alert');
+    expect(toast).toBeVisible();
     expect(alert).toBeVisible();
 
-    let buttons = within(alert).getAllByRole('button');
+    let buttons = within(toast).getAllByRole('button');
     expect(buttons[0]).toHaveTextContent('Action');
     triggerPress(buttons[0]);
 
     expect(onAction).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
 
-    expect(alert).toHaveAttribute('data-animation', 'exiting');
-    fireAnimationEnd(alert);
-    expect(queryByRole('alert')).toBeNull();
+    expect(toast).toHaveAttribute('data-animation', 'exiting');
+    fireAnimationEnd(toast);
+    expect(queryByRole('alertdialog')).toBeNull();
   });
 
   it('can focus toast region using F6', () => {
@@ -208,7 +219,7 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getByRole('alertdialog');
     expect(toast).toBeVisible();
 
     expect(document.activeElement).toBe(button);
@@ -225,13 +236,13 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getByRole('alertdialog');
     let closeButton = within(toast).getByRole('button');
     act(() => closeButton.focus());
 
     triggerPress(closeButton);
     fireAnimationEnd(toast);
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
     expect(document.activeElement).toBe(button);
   });
 
@@ -242,19 +253,19 @@ describe('Toast Provider and Container', function () {
     triggerPress(button);
     triggerPress(button);
 
-    let toast = getAllByRole('alert')[0];
+    let toast = getAllByRole('alertdialog')[0];
     let closeButton = within(toast).getByRole('button');
     triggerPress(closeButton);
     fireAnimationEnd(toast);
 
-    toast = getByRole('alert');
+    toast = getByRole('alertdialog');
     expect(document.activeElement).toBe(toast);
 
     closeButton = within(toast).getByRole('button');
     triggerPress(closeButton);
     fireAnimationEnd(toast);
 
-    expect(queryByRole('alert')).toBeNull();
+    expect(queryByRole('alertdialog')).toBeNull();
     expect(document.activeElement).toBe(button);
   });
 
@@ -283,11 +294,14 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
-    let toast = getByRole('alert');
+    let toast = getByRole('alertdialog');
+    let alert = within(toast).getByRole('alert');
     expect(toast).toBeVisible();
+    expect(alert).toBeVisible();
 
     triggerPress(button);
     fireAnimationEnd(toast);
+    expect(queryByRole('alertdialog')).toBeNull();
     expect(queryByRole('alert')).toBeNull();
   });
 

--- a/packages/@react-spectrum/toast/test/ToastContainer.test.js
+++ b/packages/@react-spectrum/toast/test/ToastContainer.test.js
@@ -68,6 +68,8 @@ describe('Toast Provider and Container', function () {
     expect(queryByRole('alert')).toBeNull();
     triggerPress(button);
 
+    act(() => jest.advanceTimersByTime(100));
+
     let region = getByRole('region');
     expect(region).toHaveAttribute('aria-label', 'Notifications');
 
@@ -90,6 +92,7 @@ describe('Toast Provider and Container', function () {
     let button = getByRole('button');
     triggerPress(button);
 
+    act(() => jest.advanceTimersByTime(100));
     let toast = getByRole('alertdialog');
     let alert = within(toast).getByRole('alert');
     let icon = within(alert).getByRole('img');
@@ -174,6 +177,7 @@ describe('Toast Provider and Container', function () {
     expect(queryByRole('alertdialog')).toBeNull();
     triggerPress(button);
 
+    act(() => jest.advanceTimersByTime(100));
     let toast = getByRole('alertdialog');
     let alert = within(toast).getByRole('alert');
     expect(toast).toBeVisible();
@@ -196,6 +200,7 @@ describe('Toast Provider and Container', function () {
     expect(queryByRole('alertdialog')).toBeNull();
     triggerPress(button);
 
+    act(() => jest.advanceTimersByTime(100));
     let toast = getByRole('alertdialog');
     let alert = within(toast).getByRole('alert');
     expect(toast).toBeVisible();
@@ -294,6 +299,7 @@ describe('Toast Provider and Container', function () {
 
     triggerPress(button);
 
+    act(() => jest.advanceTimersByTime(100));
     let toast = getByRole('alertdialog');
     let alert = within(toast).getByRole('alert');
     expect(toast).toBeVisible();
@@ -317,6 +323,7 @@ describe('Toast Provider and Container', function () {
     let button = getByRole('button');
     triggerPress(button);
 
+    act(() => jest.advanceTimersByTime(100));
     expect(getAllByRole('region')).toHaveLength(1);
     expect(getAllByRole('alert')).toHaveLength(1);
 
@@ -327,6 +334,7 @@ describe('Toast Provider and Container', function () {
       </Provider>
     );
 
+    act(() => jest.advanceTimersByTime(100));
     expect(getAllByRole('region')).toHaveLength(1);
     expect(getAllByRole('alert')).toHaveLength(1);
 
@@ -337,6 +345,7 @@ describe('Toast Provider and Container', function () {
       </Provider>
     );
 
+    act(() => jest.advanceTimersByTime(100));
     expect(getAllByRole('region')).toHaveLength(1);
     expect(getAllByRole('alert')).toHaveLength(1);
 
@@ -348,6 +357,7 @@ describe('Toast Provider and Container', function () {
       </Provider>
     );
 
+    act(() => jest.advanceTimersByTime(100));
     expect(getAllByRole('region')).toHaveLength(1);
     expect(getAllByRole('alert')).toHaveLength(1);
   });


### PR DESCRIPTION
Focus issues found during testing

This behaves slightly better than v2 Toasts. When removing Toasts it behaves the same as far as not focusing another toast, but staying within the container. With the last one we now restore focus to the last focused item outside the ToastContainer.

This isn't doing what the display one Toast at a time did, which is focus Toasts loading from the queue or focusing the container when the last toast is removed.

If we like this, I'll remove all the focus code from the container and focusing an actual Toast not the close button.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Add and remove several Toasts and see where focus goes.

In Toast storybook example at: https://reactspectrum.blob.core.windows.net/reactspectrum/b849db005f61cfeed14f599878c5085e14d1d154/storybook/index.html?path=/story/toast--with-action&args=shouldCloseOnAction:true&providerSwitcher-express=false

With a screen reader running:

Toast live region announcement should include,

- The icon alt text for severity level, "Success", "Error" or "Info"
- The toast message text
- The button label for the action button, if an action button is present.

Toast live region announcement should not include the close button.

The Toast landmark region should labelled "Notification," by default and should politely announce the number of notifications when focus moves into the landmark region, “# notifications.”

Focus management use cases:

- User triggers a toast through some action
  - Toast is announced, see above. Focus remains on the trigger that caused Toast.
- User does landmark navigation (F6) to switch to Toasts landmark region.
  - Focus moves to Toast landmark and announces itself, see above.
  - Only possible if focus hasn't previous visited any of the open Toasts.
- User keyboard navigates from application to Toasts.
  - If there are more than one Toast we navigate to the bottom Toast with is the most recent Toast.
  - Toast is focused and announces, see above.
  - User can tab navigate to the toast button(s) before navigating to another Toast or to leave region.
- User is on Toast landmark region or a Toast and switches landmark regions.
  - Focus moves to the next region or returns to the last focused item prior to navigating to a Toast or Toast landmark region.
- User deletes a Toast
  - If it is the last Toast in the Toast Container, focus returns to last focused item outside of Toast landmark region.
  - If there are additional Toasts remaining in the Toast Container:
    - Focus the Toast above it.
    - If Toast being removed is the topmost toast, then move focus to the Toast below it.
  - When a Toast is removed on action, focus should be restored to an adjacent Toast as well if visible Toasts remain: (see: https://github.com/adobe/react-spectrum/pull/6011#discussion_r1536923620)
    
Toast are organized within an ordered list within the landmark region, we should not need to announce the number of notifications except when moving focus to the landmark region. Depending on the screen reader, the new count for the number of items in the list might be announced automatically when the list count changes.

Focus can move to the Notifications landmark region:

-  by using F6 or Shift+F6 to cycle into the Notifications landmark,
- by tabbing into the Notifications landmark following the DOM order,
- or by using the mouse to focus a Toast.

Regardless of how focus entered the Notifications landmark, F6 should eventually cycle back to the last focused element in the main landmark, and focus management when a Toast is removed should behave the same regardless of the manner in which the Toast received focus. For example, if I were to remove a Toast using a mouse click on the close button, focus should move to the adjacent Toast, rather than be lost to the document.body.

## 🧢 Your Project:
RSP