### PR TITLE
Add ContextualHelp example for disabled button to Tooltip docs

### DIFF
--- a/packages/@react-spectrum/tooltip/docs/Tooltip.mdx
+++ b/packages/@react-spectrum/tooltip/docs/Tooltip.mdx
@@ -194,3 +194,24 @@ A TooltipTrigger can be disabled without disabling the trigger it displays on.
   <Tooltip variant="negative" showIcon>Dangerous action.</Tooltip>
 </TooltipTrigger>
 ```
+
+## Usage on disabled or non-interactive elements
+
+Tooltips need to be accessible to keyboard and screen reader users, so we want to ensure that they are only placed on focusable and hoverable elements. For example, plain text and disabled buttons aren't focusable, so keyboard and screen reader users would be unable to access the information in that tooltip.
+
+If you need to display some additional context, consider using [ContextualHelp](ContextualHelp.html).
+
+```tsx example
+import {ContextualHelp, Flex, Heading, Content} from '@adobe/react-spectrum';
+
+<Flex gap="size-100" alignItems="center">
+  <TooltipTrigger>
+    <ActionButton isDisabled>Delete resource</ActionButton>
+    <Tooltip variant="negative" showIcon>Dangerous action.</Tooltip>
+  </TooltipTrigger>
+  <ContextualHelp variant="info">
+      <Heading>Permission required</Heading>
+      <Content>Your admin must grant you permission before your can delete resources.</Content>
+  </ContextualHelp>
+</Flex>
+```


### PR DESCRIPTION
We have this in the FAQ, but it would be nice to include in the docs for so it's more discoverable.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
