### PR TITLE
[Docs] Fix the controlled RadioGroup example

### DIFF
--- a/packages/@react-aria/radio/docs/useRadioGroup.mdx
+++ b/packages/@react-aria/radio/docs/useRadioGroup.mdx
@@ -268,7 +268,7 @@ The `onChange` event is fired when the user selects a radio.
 
 ```tsx example
 function Example() {
-  let [selected, setSelected] = React.useState('');
+  let [selected, setSelected] = React.useState(null);
 
   return (
     <>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6056

Hey guys I have one question.

Would it be better to just add the empty string (`''`) check over here?

https://github.com/adobe/react-spectrum/blob/9390151edf56eefcec0aa5635f34643affe10640/packages/%40react-aria/radio/src/useRadio.ts#L82-L92

to something like this?

```diff
let tabIndex: number | undefined = -1;
- if (state.selectedValue != null) {
+ if (state.selectedValue != null && state.selectedValue !== '') {
  if (state.selectedValue === value) {
    tabIndex = 0;
  }
} else if (state.lastFocusedValue === value || state.lastFocusedValue == null) {
  tabIndex = 0;
}
if (isDisabled) {
  tabIndex = undefined;
}
```

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Docs
http://localhost:1234/react-aria/useRadioGroup.html#controlled-value


https://github.com/adobe/react-spectrum/assets/71210554/74f3d7c9-4e63-464b-b1d1-a184919930ce



## 🧢 Your Project:

<!--- Company/project for pull request -->
