### PR TITLE
fix: gracefully treat locales removed by optimize-locales-plugin

### DIFF
--- a/packages/@internationalized/message/src/MessageDictionary.ts
+++ b/packages/@internationalized/message/src/MessageDictionary.ts
@@ -26,7 +26,10 @@ export class MessageDictionary {
 
   constructor(messages: LocalizedStrings, defaultLocale: string = 'en-US') {
     // Clone messages so we don't modify the original object.
-    this.messages = {...messages};
+    // Filter out entries with falsy values which may have been caused by applying optimize-locales-plugin.
+    this.messages = Object.fromEntries(
+      Object.entries(messages).filter(([, v]) => v)
+    );
     this.defaultLocale = defaultLocale;
   }
 

--- a/packages/@internationalized/message/test/MessageDictionary.test.js
+++ b/packages/@internationalized/message/test/MessageDictionary.test.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {MessageDictionary} from '..';
+
+describe('MessageDictionary', function () {
+
+  describe('getStringForLocale', function () {
+    const messages = Object.freeze({
+      'en-US': {
+        'hello': 'Hello',
+        'goodbye': 'Good bye'
+      },
+      'ja-JP': undefined,
+      'es-ES': {
+        'hello': 'Hola',
+        'goodbye': 'Adiós'
+      },
+      'it-IT': {
+        'hello': 'Ciao',
+        'goodbye': 'Arrivederci'
+      }
+    });
+
+    it('throws when attempt to get a missing message key is made', function () {
+      expect(() => {
+        const messageDictionary = new MessageDictionary(messages);
+        messageDictionary.getStringForLocale('missing.key', 'it-IT');
+      }).toThrow(/Could not find intl message/);
+    });
+
+    it('uses closest match by language when specified locale does not contain requested message key', function () {
+      const messageDictionary = new MessageDictionary(messages);
+      expect(messageDictionary.getStringForLocale('goodbye', 'es-MX')).toBe('Adiós');
+    });
+
+    it('uses default locale when specified locale is missing and there is no closest match found', function () {
+      const messageDictionary = new MessageDictionary(messages, 'it-IT');
+      expect(messageDictionary.getStringForLocale('hello', 'hy-AM')).toBe('Ciao');
+    });
+
+    it('uses default locale when specified locale key exists, but the value is falsy', function () {
+      const messageDictionary = new MessageDictionary(messages, 'es-ES');
+      expect(messageDictionary.getStringForLocale('hello', 'ja-JP')).toBe('Hola');
+    });
+  });
+});

--- a/packages/@internationalized/string/src/LocalizedStringDictionary.ts
+++ b/packages/@internationalized/string/src/LocalizedStringDictionary.ts
@@ -30,7 +30,10 @@ export class LocalizedStringDictionary<K extends string = string, T extends Loca
 
   constructor(messages: LocalizedStrings<K, T>, defaultLocale: string = 'en-US') {
     // Clone messages so we don't modify the original object.
-    this.strings = {...messages};
+    // Filter out entries with falsy values which may have been caused by applying optimize-locales-plugin.
+    this.strings = Object.fromEntries(
+      Object.entries(messages).filter(([, v]) => v)
+    );
     this.defaultLocale = defaultLocale;
   }
 

--- a/packages/@internationalized/string/test/LocalizedStringDictionary.test.js
+++ b/packages/@internationalized/string/test/LocalizedStringDictionary.test.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {LocalizedStringDictionary} from '..';
+
+describe('LocalizedStringDictionary', function () {
+
+  describe('getStringForLocale', function () {
+    const messages = Object.freeze({
+      'en-US': {
+        'hello': 'Hello',
+        'goodbye': 'Good bye'
+      },
+      'ja-JP': undefined,
+      'es-ES': {
+        'hello': 'Hola',
+        'goodbye': 'Adiós'
+      },
+      'it-IT': {
+        'hello': 'Ciao',
+        'goodbye': 'Arrivederci'
+      }
+    });
+
+    it('throws when attempt to get a missing message key is made', function () {
+      expect(() => {
+        const localizedStringDictionary = new LocalizedStringDictionary(messages);
+        localizedStringDictionary.getStringForLocale('missing.key', 'it-IT');
+      }).toThrow(/Could not find intl message/);
+    });
+
+    it('uses closest match by language when specified locale does not contain requested message key', function () {
+      const localizedStringDictionary = new LocalizedStringDictionary(messages);
+      expect(localizedStringDictionary.getStringForLocale('goodbye', 'es-MX')).toBe('Adiós');
+    });
+
+    it('uses default locale when specified locale is missing and there is no closest match found', function () {
+      const localizedStringDictionary = new LocalizedStringDictionary(messages, 'it-IT');
+      expect(localizedStringDictionary.getStringForLocale('hello', 'hy-AM')).toBe('Ciao');
+    });
+
+    it('uses default locale when specified locale key exists, but the value is falsy', function () {
+      const localizedStringDictionary = new LocalizedStringDictionary(messages, 'es-ES');
+      expect(localizedStringDictionary.getStringForLocale('hello', 'ja-JP')).toBe('Hola');
+    });
+  });
+});

--- a/packages/dev/optimize-locales-plugin/empty.js
+++ b/packages/dev/optimize-locales-plugin/empty.js
@@ -1,1 +1,2 @@
-export default {};
+const removedLocale = undefined;
+export default removedLocale;

--- a/packages/dev/parcel-resolver-optimize-locales/empty.js
+++ b/packages/dev/parcel-resolver-optimize-locales/empty.js
@@ -1,1 +1,2 @@
-export default {};
+const removedLocale = undefined;
+export default removedLocale;


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6069

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)


## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Install Spectrum changes in https://stackblitz.com/edit/stackblitz-starters-6dzpek?file=readme.md and see if issue is still there.

## 🧢 Your Project:

<!--- Company/project for pull request -->
Adobe Workfront