### PR TITLE
Allow passing inputRef to RAC `<Radio>`

### DIFF
--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -13,14 +13,19 @@
 import {AriaRadioGroupProps, AriaRadioProps, HoverEvents, Orientation, useFocusRing, useHover, useRadio, useRadioGroup, VisuallyHidden} from 'react-aria';
 import {ContextValue, forwardRefType, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {FieldErrorContext} from './FieldError';
-import {filterDOMProps, mergeProps} from '@react-aria/utils';
+import {filterDOMProps, mergeProps, mergeRefs, useObjectRef} from '@react-aria/utils';
 import {LabelContext} from './Label';
 import {RadioGroupState, useRadioGroupState} from 'react-stately';
-import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, MutableRefObject} from 'react';
 import {TextContext} from './Text';
 
 export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps {}
-export interface RadioProps extends Omit<AriaRadioProps, 'children'>, HoverEvents, RenderProps<RadioRenderProps>, SlotProps {}
+export interface RadioProps extends Omit<AriaRadioProps, 'children'>, HoverEvents, RenderProps<RadioRenderProps>, SlotProps {
+  /**
+   * A ref for the HTML input element.
+   */
+  inputRef?: MutableRefObject<HTMLInputElement>
+}
 
 export interface RadioGroupRenderProps {
   /**
@@ -163,9 +168,13 @@ function RadioGroup(props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) {
 }
 
 function Radio(props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) {
-  [props, ref] = useContextProps(props, ref, RadioContext);
+  let {
+    inputRef: userProvidedInputRef = null,
+    ...otherProps
+  } = props;
+  [props, ref] = useContextProps(otherProps, ref, RadioContext);
   let state = React.useContext(RadioGroupStateContext)!;
-  let inputRef = useRef<HTMLInputElement>(null);
+  let inputRef = useObjectRef(mergeRefs(userProvidedInputRef, props.inputRef !== undefined ? props.inputRef : null));
   let {labelProps, inputProps, isSelected, isDisabled, isPressed} = useRadio({
     ...removeDataAttributes<RadioProps>(props),
     // ReactNode type doesn't allow function children.

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -14,10 +14,9 @@ import {AriaRadioGroupProps, AriaRadioProps, HoverEvents, Orientation, useFocusR
 import {ContextValue, forwardRefType, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
-import {getFocusableTreeWalker} from '@react-aria/focus';
 import {LabelContext} from './Label';
 import {RadioGroupState, useRadioGroupState} from 'react-stately';
-import React, {createContext, ForwardedRef, forwardRef, useImperativeHandle, useRef} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
 import {TextContext} from './Text';
 
 export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps {}
@@ -109,7 +108,6 @@ export const RadioGroupStateContext = createContext<RadioGroupState | null>(null
 
 function RadioGroup(props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, RadioGroupContext);
-  let domRef = useRef<HTMLDivElement>(null);
   let state = useRadioGroupState({
     ...props,
     validationBehavior: props.validationBehavior ?? 'native'
@@ -135,25 +133,11 @@ function RadioGroup(props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) {
     defaultClassName: 'react-aria-RadioGroup'
   });
 
-  useImperativeHandle<HTMLDivElement|null, HTMLDivElement|null>(ref, () => {
-    const radioGroup = domRef.current;
-    if (radioGroup) {
-      radioGroup.focus = () => {
-        let walker = getFocusableTreeWalker(radioGroup, {
-          tabbable: true, 
-          accept: (node) => node.getAttribute('type') === 'radio'
-        });
-        (walker.firstChild() as HTMLElement).focus();
-      };
-    }
-    return radioGroup;
-  });
-
   return (
     <div
       {...radioGroupProps}
       {...renderProps}
-      ref={domRef}
+      ref={ref}
       slot={props.slot || undefined}
       data-orientation={props.orientation || 'vertical'}
       data-invalid={state.isInvalid || undefined}

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -17,7 +17,7 @@ import {filterDOMProps, mergeProps, mergeRefs, useObjectRef} from '@react-aria/u
 import {FormValidationBehaviorContext} from './Form';
 import {LabelContext} from './Label';
 import {RadioGroupState, useRadioGroupState} from 'react-stately';
-import React, {createContext, ForwardedRef, forwardRef, useContext, useRef, MutableRefObject} from 'react';
+import React, {createContext, ForwardedRef, MutableRefObject, forwardRef, useContext} from 'react';
 import {TextContext} from './Text';
 
 export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps {}

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -17,7 +17,7 @@ import {filterDOMProps, mergeProps, mergeRefs, useObjectRef} from '@react-aria/u
 import {FormValidationBehaviorContext} from './Form';
 import {LabelContext} from './Label';
 import {RadioGroupState, useRadioGroupState} from 'react-stately';
-import React, {createContext, ForwardedRef, MutableRefObject, forwardRef, useContext} from 'react';
+import React, {createContext, ForwardedRef, forwardRef, MutableRefObject, useContext} from 'react';
 import {TextContext} from './Text';
 
 export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps {}

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -136,15 +136,17 @@ function RadioGroup(props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) {
   });
 
   useImperativeHandle<HTMLDivElement|null, HTMLDivElement|null>(ref, () => {
-    if (domRef.current) {
-      domRef.current.focus = () => {
-        if (domRef.current) {
-          let walker = getFocusableTreeWalker(domRef.current, {tabbable: true});
-          (walker.firstChild() as HTMLElement).focus();
-        }
+    const radioGroup = domRef.current;
+    if (radioGroup) {
+      radioGroup.focus = () => {
+        let walker = getFocusableTreeWalker(radioGroup, {
+          tabbable: true, 
+          accept: (node) => node.getAttribute('type') === 'radio'
+        });
+        (walker.firstChild() as HTMLElement).focus();
       };
     }
-    return domRef.current;
+    return radioGroup;
   });
 
   return (

--- a/packages/react-aria-components/stories/RadioGroup.stories.tsx
+++ b/packages/react-aria-components/stories/RadioGroup.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {Button, Dialog, DialogTrigger, Label, Modal, ModalOverlay, Radio, RadioGroup} from 'react-aria-components';
-import React, {useRef, useState} from 'react';
+import React, {useState} from 'react';
 import styles from '../example/index.css';
 
 export default {
@@ -95,75 +95,4 @@ export const RadioGroupInDialogExample = () => {
       </ModalOverlay>
     </DialogTrigger>
   );
-};
-
-function RadioGroupFocusableRefComponent() {
-  let focusableRef = useRef<HTMLDivElement>(null);
-  let triggerButtonRef = useRef<HTMLButtonElement>(null);
-  let [selected, setSelected] = useState<string|null>(null);
-  
-  let onPress = () => {
-    focusableRef.current?.focus();
-    console.log(document.activeElement);
-  };
-    
-  return (
-    <>
-      <div
-        style={{
-          height: '200vh',
-          padding: '80px',
-          display: 'flex', 
-          flexDirection: 'column', 
-          justifyContent: 'space-between'
-        }}>
-        <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
-          <div style={{fontSize: 16, marginBottom: 16}}>
-            <p>
-              Use keyboard interactions for a visible focus ring or 
-              use the <a href="https://github.com/wizzyfx/nerdeFocusPlugIn" target="_blank">NerdeFocus plugin</a> to track focus.
-            </p>
-            <p>
-              Try clicking on the 'Focus radio group' button below either when no radios are selected or when any radio is selected except the first.
-            </p>
-            <p>
-              Expectation is that focus goes to the first radio in the group when none of them are selected,
-              and it goes to the selected one if it exists.
-            </p>
-          </div>
-          <Button ref={triggerButtonRef} style={{padding: 8}} onPress={onPress}>Focus radio group</Button>
-        </div>
-        <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
-          <RadioGroup
-            ref={focusableRef}
-            data-testid="radio-group-example"
-            className={styles.radiogroup}
-            value={selected}
-            onChange={setSelected}>
-            <Label>Favorite pet (focusable ref)</Label>
-            <Radio className={styles.radio} value="dogs" data-testid="radio-dog">Dog</Radio>
-            <Radio className={styles.radio} value="cats">Cat</Radio>
-            <Radio className={styles.radio} value="dragon">Dragon</Radio>
-          </RadioGroup>
-          <Button
-            style={{
-              marginTop: 40
-            }}
-            onPress={() => {
-              document.documentElement.scrollTop = 0;
-              triggerButtonRef.current?.focus();
-            }}>Scroll to top</Button>
-        </div>
-      </div>
-    </>
-  );
-}
-
-export const RadioGroupFocusableRefExample = {
-  render: RadioGroupFocusableRefComponent,
-  parameters: {description: {data: `
-  Use keyboard interactions for a visible focus ring or use the NerdeFocus plugin to track focus. 
-  Try both clicking on the extra button when no radios are selected and clicking on the extra button when any radio is selected except the first.
-  Expectation is that focus goes to the first radio is the group when none are selected, and focus goes to the selected radio if one is selected.
-  `}}
 };

--- a/packages/react-aria-components/stories/RadioGroup.stories.tsx
+++ b/packages/react-aria-components/stories/RadioGroup.stories.tsx
@@ -97,35 +97,73 @@ export const RadioGroupInDialogExample = () => {
   );
 };
 
-export const RadioGroupFocusableRefExample = () => {
-  let [selected, setSelected] = useState<string|null>(null);
+function RadioGroupFocusableRefComponent() {
   let focusableRef = useRef<HTMLDivElement>(null);
-
-  let onClick = () => {
-    focusableRef.current?.focus();
-  };
+  let triggerButtonRef = useRef<HTMLButtonElement>(null);
+  let [selected, setSelected] = useState<string|null>(null);
   
+  let onPress = () => {
+    focusableRef.current?.focus();
+    console.log(document.activeElement);
+  };
+    
   return (
-    <div
-      style={{
-        height: '200vh',
-        padding: '80px',
-        display: 'flex', 
-        flexDirection: 'column', 
-        justifyContent: 'space-between'
-      }}>
-      <button onClick={onClick}>Focus radio group</button>
-      <RadioGroup
-        ref={focusableRef}
-        data-testid="radio-group-example"
-        className={styles.radiogroup}
-        value={selected}
-        onChange={setSelected}>
-        <Label>Favorite pet (focusable ref)</Label>
-        <Radio className={styles.radio} value="dogs" data-testid="radio-dog">Dog</Radio>
-        <Radio className={styles.radio} value="cats">Cat</Radio>
-        <Radio className={styles.radio} value="dragon">Dragon</Radio>
-      </RadioGroup>
-    </div>
+    <>
+      <div
+        style={{
+          height: '200vh',
+          padding: '80px',
+          display: 'flex', 
+          flexDirection: 'column', 
+          justifyContent: 'space-between'
+        }}>
+        <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+          <div style={{fontSize: 16, marginBottom: 16}}>
+            <p>
+              Use keyboard interactions for a visible focus ring or 
+              use the <a href="https://github.com/wizzyfx/nerdeFocusPlugIn" target="_blank">NerdeFocus plugin</a> to track focus.
+            </p>
+            <p>
+              Try clicking on the 'Focus radio group' button below either when no radios are selected or when any radio is selected except the first.
+            </p>
+            <p>
+              Expectation is that focus goes to the first radio in the group when none of them are selected,
+              and it goes to the selected one if it exists.
+            </p>
+          </div>
+          <Button ref={triggerButtonRef} style={{padding: 8}} onPress={onPress}>Focus radio group</Button>
+        </div>
+        <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+          <RadioGroup
+            ref={focusableRef}
+            data-testid="radio-group-example"
+            className={styles.radiogroup}
+            value={selected}
+            onChange={setSelected}>
+            <Label>Favorite pet (focusable ref)</Label>
+            <Radio className={styles.radio} value="dogs" data-testid="radio-dog">Dog</Radio>
+            <Radio className={styles.radio} value="cats">Cat</Radio>
+            <Radio className={styles.radio} value="dragon">Dragon</Radio>
+          </RadioGroup>
+          <Button
+            style={{
+              marginTop: 40
+            }}
+            onPress={() => {
+              document.documentElement.scrollTop = 0;
+              triggerButtonRef.current?.focus();
+            }}>Scroll to top</Button>
+        </div>
+      </div>
+    </>
   );
+}
+
+export const RadioGroupFocusableRefExample = {
+  render: RadioGroupFocusableRefComponent,
+  parameters: {description: {data: `
+  Use keyboard interactions for a visible focus ring or use the NerdeFocus plugin to track focus. 
+  Try both clicking on the extra button when no radios are selected and clicking on the extra button when any radio is selected except the first.
+  Expectation is that focus goes to the first radio is the group when none are selected, and focus goes to the selected radio if one is selected.
+  `}}
 };

--- a/packages/react-aria-components/stories/RadioGroup.stories.tsx
+++ b/packages/react-aria-components/stories/RadioGroup.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {Button, Dialog, DialogTrigger, Label, Modal, ModalOverlay, Radio, RadioGroup} from 'react-aria-components';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import styles from '../example/index.css';
 
 export default {
@@ -94,5 +94,38 @@ export const RadioGroupInDialogExample = () => {
         </Modal>
       </ModalOverlay>
     </DialogTrigger>
+  );
+};
+
+export const RadioGroupFocusableRefExample = () => {
+  let [selected, setSelected] = useState<string|null>(null);
+  let focusableRef = useRef<HTMLDivElement>(null);
+
+  let onClick = () => {
+    focusableRef.current?.focus();
+  };
+  
+  return (
+    <div
+      style={{
+        height: '200vh',
+        padding: '80px',
+        display: 'flex', 
+        flexDirection: 'column', 
+        justifyContent: 'space-between'
+      }}>
+      <button onClick={onClick}>Focus radio group</button>
+      <RadioGroup
+        ref={focusableRef}
+        data-testid="radio-group-example"
+        className={styles.radiogroup}
+        value={selected}
+        onChange={setSelected}>
+        <Label>Favorite pet (focusable ref)</Label>
+        <Radio className={styles.radio} value="dogs" data-testid="radio-dog">Dog</Radio>
+        <Radio className={styles.radio} value="cats">Cat</Radio>
+        <Radio className={styles.radio} value="dragon">Dragon</Radio>
+      </RadioGroup>
+    </div>
   );
 };

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -490,4 +490,32 @@ describe('RadioGroup', () => {
     expect(groupRef.current).toBe(getByRole('radiogroup'));
     expect(radioRef.current).toBe(getByRole('radio').closest('.react-aria-Radio'));
   });
+
+  it('should support input ref', () => {
+    let inputRef = React.createRef();
+    let {getByRole} = render(
+      <RadioGroup>
+        <Label>Test</Label>
+        <Radio inputRef={inputRef} value="a">A</Radio>
+      </RadioGroup>
+    );
+    let radio = getByRole('radio');
+    expect(inputRef.current).toBe(radio);
+  });
+
+  it('should support and merge input ref on context', () => {
+    let inputRef = React.createRef();
+    let contextInputRef = React.createRef();
+    let {getByRole} = render(
+      <RadioGroup>
+        <Label>Test</Label>
+        <RadioContext.Provider value={{inputRef: contextInputRef}}>
+          <Radio inputRef={inputRef} value="a">A</Radio>
+        </RadioContext.Provider>
+      </RadioGroup>
+    );
+    let radio = getByRole('radio');
+    expect(inputRef.current).toBe(radio);
+    expect(contextInputRef.current).toBe(radio);
+  });
 });

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -490,4 +490,48 @@ describe('RadioGroup', () => {
     expect(groupRef.current).toBe(getByRole('radiogroup'));
     expect(radioRef.current).toBe(getByRole('radio').closest('.react-aria-Radio'));
   });
+
+  it('should support focusable ref that respects roving tabindex', async () => {
+    let groupRef = React.createRef();
+    let onClick = () => {
+      act(() => groupRef.current?.focus());
+    };
+         
+    let {getByRole, getAllByRole} = render(
+      <>
+        <RadioGroup ref={groupRef}>
+          <Label>Test</Label>
+          <Radio value="a">A</Radio>
+          <Radio value="b">B</Radio>
+          <Radio value="c">C</Radio>
+        </RadioGroup>
+        <button onClick={onClick}>Focus radio group</button>
+      </>
+    );
+
+    let button = getByRole('button');
+    let radios = getAllByRole('radio');
+
+    expect(document.activeElement).toBe(document.body);
+    await user.click(button);          // should focus first item when none selected
+    expect(document.activeElement).toBe(radios[0]);
+
+    await user.click(radios[1]);       // select radio
+    await user.click(document.body);   // reset focus
+    expect(document.activeElement).toBe(document.body);
+    await user.click(button);          // should focus current selected
+    expect(document.activeElement).toBe(radios[1]);
+
+    await user.click(radios[2]);       // select radio
+    await user.click(document.body);   // reset focus
+    expect(document.activeElement).toBe(document.body);
+    await user.click(button);          // should focus current selected
+    expect(document.activeElement).toBe(radios[2]);
+
+    await user.click(radios[0]);       // select radio
+    await user.click(document.body);   // reset focus
+    expect(document.activeElement).toBe(document.body);
+    await user.click(button);          // should focus current selected
+    expect(document.activeElement).toBe(radios[0]);
+  });
 });

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -490,48 +490,4 @@ describe('RadioGroup', () => {
     expect(groupRef.current).toBe(getByRole('radiogroup'));
     expect(radioRef.current).toBe(getByRole('radio').closest('.react-aria-Radio'));
   });
-
-  it('should support focusable ref that respects roving tabindex', async () => {
-    let groupRef = React.createRef();
-    let onClick = () => {
-      act(() => groupRef.current?.focus());
-    };
-         
-    let {getByRole, getAllByRole} = render(
-      <>
-        <RadioGroup ref={groupRef}>
-          <Label>Test</Label>
-          <Radio value="a">A</Radio>
-          <Radio value="b">B</Radio>
-          <Radio value="c">C</Radio>
-        </RadioGroup>
-        <button onClick={onClick}>Focus radio group</button>
-      </>
-    );
-
-    let button = getByRole('button');
-    let radios = getAllByRole('radio');
-
-    expect(document.activeElement).toBe(document.body);
-    await user.click(button);          // should focus first item when none selected
-    expect(document.activeElement).toBe(radios[0]);
-
-    await user.click(radios[1]);       // select radio
-    await user.click(document.body);   // reset focus
-    expect(document.activeElement).toBe(document.body);
-    await user.click(button);          // should focus current selected
-    expect(document.activeElement).toBe(radios[1]);
-
-    await user.click(radios[2]);       // select radio
-    await user.click(document.body);   // reset focus
-    expect(document.activeElement).toBe(document.body);
-    await user.click(button);          // should focus current selected
-    expect(document.activeElement).toBe(radios[2]);
-
-    await user.click(radios[0]);       // select radio
-    await user.click(document.body);   // reset focus
-    expect(document.activeElement).toBe(document.body);
-    await user.click(button);          // should focus current selected
-    expect(document.activeElement).toBe(radios[0]);
-  });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6054, https://github.com/adobe/react-spectrum/issues/6123

~~To implement the behavior described in https://github.com/adobe/react-spectrum/issues/6054#issuecomment-2000575049, I needed to pass `tabbable: true` to `getFocusableTreeWalker()`. This behavior is tested by the unit test, but hard to tell in the story.~~

~~Not sure if we still need to expose individual `inputRef`s for each `<Radio />` inside the group as done in https://github.com/adobe/react-spectrum/pull/5967.~~

~~Oh and should we document this behavior somewhere in the docs?~~

~~Let me know what you guys think!~~

This PR exposes `inputRef` through props in `<Radio>`, practically the same as https://github.com/adobe/react-spectrum/pull/5967.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Docs
- Visit http://localhost:1234/react-aria/RadioGroup.html#radio
- See if `inputRef` is in the prop table with the description "A ref for the HTML input element."



<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
