### PR TITLE
Fix story's svgs in FF

### DIFF
--- a/packages/react-aria-components/stories/Popover.stories.tsx
+++ b/packages/react-aria-components/stories/Popover.stories.tsx
@@ -115,7 +115,7 @@ export const PopoverArrowBoundaryOffsetExample = {
         max: 100
       }
     }
-  }, 
+  },
   render: ({topLeft, topRight, leftTop, leftBotton, rightTop, rightBottom, bottomLeft, bottomRight}: any) => {
     return (
       <div style={{display: 'flex', flexDirection: 'column'}}>
@@ -125,6 +125,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Top left</Button>
               <Popover
                 placement="top left"
+                shouldFlip={false}
                 arrowBoundaryOffset={topLeft}
                 style={{
                   background: 'Canvas',
@@ -136,7 +137,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -150,6 +151,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Top right</Button>
               <Popover
                 placement="top right"
+                shouldFlip={false}
                 arrowBoundaryOffset={topRight}
                 style={{
                   background: 'Canvas',
@@ -161,7 +163,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -177,6 +179,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Left top</Button>
               <Popover
                 placement="left top"
+                shouldFlip={false}
                 arrowBoundaryOffset={leftTop}
                 style={{
                   background: 'Canvas',
@@ -188,7 +191,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block', transform: 'rotate(-90deg)'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -202,6 +205,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Left bottom</Button>
               <Popover
                 placement="left bottom"
+                shouldFlip={false}
                 arrowBoundaryOffset={leftBotton}
                 style={{
                   background: 'Canvas',
@@ -213,7 +217,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block', transform: 'rotate(-90deg)'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -229,6 +233,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Right top</Button>
               <Popover
                 placement="right top"
+                shouldFlip={false}
                 arrowBoundaryOffset={rightTop}
                 style={{
                   background: 'Canvas',
@@ -240,7 +245,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block', transform: 'rotate(90deg)'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -254,6 +259,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Right bottom</Button>
               <Popover
                 placement="right bottom"
+                shouldFlip={false}
                 arrowBoundaryOffset={rightBottom}
                 style={{
                   background: 'Canvas',
@@ -265,7 +271,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block', transform: 'rotate(90deg)'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -281,6 +287,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Bottom left</Button>
               <Popover
                 placement="bottom left"
+                shouldFlip={false}
                 arrowBoundaryOffset={bottomLeft}
                 style={{
                   background: 'Canvas',
@@ -292,7 +299,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block', transform: 'rotate(180deg)'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>
@@ -306,6 +313,7 @@ export const PopoverArrowBoundaryOffsetExample = {
               <Button style={{width: 200, height: 100}}>Bottom right</Button>
               <Popover
                 placement="bottom right"
+                shouldFlip={false}
                 arrowBoundaryOffset={bottomRight}
                 style={{
                   background: 'Canvas',
@@ -317,7 +325,7 @@ export const PopoverArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow style={{display: 'flex'}}>
                   <svg width="12" height="12" viewBox="0 0 12 12" style={{display: 'block', transform: 'rotate(180deg)'}}>
-                    <path d="M0 0,L6 6,L12 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L6 6L12 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 <Dialog style={{outline: 'none'}}>

--- a/packages/react-aria-components/stories/Tooltip.stories.tsx
+++ b/packages/react-aria-components/stories/Tooltip.stories.tsx
@@ -31,7 +31,7 @@ export const TooltipExample = () => (
       }}>
       <OverlayArrow style={{transform: 'translateX(-50%)'}}>
         <svg width="8" height="8" style={{display: 'block'}}>
-          <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+          <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
         </svg>
       </OverlayArrow>
       I am a tooltip
@@ -105,7 +105,7 @@ export const TooltipArrowBoundaryOffsetExample = {
         max: 100
       }
     }
-  }, 
+  },
   render: ({topLeft, topRight, leftTop, leftBotton, rightTop, rightBottom, bottomLeft, bottomRight}: any) => {
     return (
       <div style={{display: 'flex', flexDirection: 'column'}}>
@@ -126,7 +126,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Top left
@@ -149,7 +149,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Top right
@@ -174,7 +174,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block', transform: 'rotate(-90deg)'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Left top
@@ -197,7 +197,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block', transform: 'rotate(-90deg)'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Left bottom
@@ -222,7 +222,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block', transform: 'rotate(90deg)'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Right top
@@ -245,7 +245,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block', transform: 'rotate(90deg)'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Right bottom
@@ -270,7 +270,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block', transform: 'rotate(180deg)'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Bottom left
@@ -293,7 +293,7 @@ export const TooltipArrowBoundaryOffsetExample = {
                 }}>
                 <OverlayArrow>
                   <svg width="8" height="8" style={{display: 'block', transform: 'rotate(180deg)'}}>
-                    <path d="M0 0,L4 4,L8 0" fill="white" strokeWidth={1} stroke="gray" />
+                    <path d="M0 0L4 4L8 0" fill="white" strokeWidth={1} stroke="gray" />
                   </svg>
                 </OverlayArrow>
                 Bottom right


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Found in testing, popover and tooltip RAC stories for arrow boundary offset were not displaying the overlay arrow

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
