### PR TITLE
fix: exporting types for SpectrumTextAreaProps, ItemProps, SectionProps

### DIFF
--- a/packages/@adobe/react-spectrum/src/index.ts
+++ b/packages/@adobe/react-spectrum/src/index.ts
@@ -106,7 +106,7 @@ export type {HeadingProps, KeyboardProps, TextProps} from '@react-spectrum/text'
 export type {SpectrumTableProps, SpectrumColumnProps, TableHeaderProps, TableBodyProps, RowProps, CellProps} from '@react-spectrum/table';
 export type {SpectrumTabListProps, SpectrumTabPanelsProps, SpectrumTabsProps} from '@react-spectrum/tabs';
 export type {SpectrumTagGroupProps} from '@react-spectrum/tag';
-export type {SpectrumTextFieldProps} from '@react-spectrum/textfield';
+export type {SpectrumTextFieldProps, SpectrumTextAreaProps} from '@react-spectrum/textfield';
 export type {SpectrumTooltipProps, SpectrumTooltipTriggerProps} from '@react-spectrum/tooltip';
 export type {ContentProps, FooterProps, HeaderProps, ViewProps} from '@react-spectrum/view';
 export type {SpectrumWellProps} from '@react-spectrum/well';
@@ -115,4 +115,4 @@ export type {VisuallyHiddenAria, VisuallyHiddenProps} from '@react-aria/visually
 export type {DateFormatter, DateFormatterOptions, Filter, FormatMessage, Locale, LocalizedStrings} from '@react-aria/i18n';
 export type {SSRProviderProps} from '@react-aria/ssr';
 export type {DirectoryDropItem, DragAndDropHooks, DragAndDropOptions, DraggableCollectionEndEvent, DraggableCollectionMoveEvent, DraggableCollectionStartEvent, DragPreviewRenderer, DragTypes, DropItem, DropOperation, DroppableCollectionDropEvent, DroppableCollectionEnterEvent, DroppableCollectionExitEvent, DroppableCollectionInsertDropEvent, DroppableCollectionMoveEvent, DroppableCollectionOnItemDropEvent, DroppableCollectionReorderEvent, DroppableCollectionRootDropEvent, DropPosition, DropTarget, FileDropItem, ItemDropTarget, RootDropTarget, TextDropItem} from '@react-spectrum/dnd';
-export type {Key, Selection} from '@react-types/shared';
+export type {Key, Selection, ItemProps, SectionProps} from '@react-types/shared';

--- a/packages/@react-spectrum/textfield/src/index.ts
+++ b/packages/@react-spectrum/textfield/src/index.ts
@@ -15,4 +15,4 @@
 export {TextArea} from './TextArea';
 export {TextField} from './TextField';
 export {TextFieldBase} from './TextFieldBase';
-export type {SpectrumTextFieldProps} from '@react-types/textfield';
+export type {SpectrumTextFieldProps, SpectrumTextAreaProps} from '@react-types/textfield';


### PR DESCRIPTION
Closes #6089 

`@adobe/react-spectrum` exports SpectrumTextFieldProps but not for TextArea.

Re-exports `SpectrumTextAreaProps`, `ItemProps`, `SectionProps` from `@adobe/react-spectrum`.