### PR TITLE
Remove extra closing span tag

### DIFF
--- a/packages/dev/docs/pages/react-aria/index.mdx
+++ b/packages/dev/docs/pages/react-aria/index.mdx
@@ -190,7 +190,7 @@ ReactDOM.createRoot(document.getElementById('example-app')).render(<ExampleApp /
           {/* Use render props to customize children based on state. */}
           {({ isSelected }) => <>
             <img alt="" src={item.avatar} />
-            <span className="... font-normal group-selected:font-semibold">{item.name}</span></span>
+            <span className="... font-normal group-selected:font-semibold">{item.name}</span>
             {isSelected &&
               <CheckIcon />
             }


### PR DESCRIPTION
There's an extra closing span tag in the Tailwind tab of https://react-spectrum.adobe.com/react-aria/#example-1:
![image](https://github.com/adobe/react-spectrum/assets/39754176/a23aa81a-de4b-4ac9-a64e-f0c9306b4b15)

I took the screenshots with the code element zoomed out to show all of the arrow function's code.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Run `yarn start:docs`, and go to http://localhost:1234/react-aria/index.html#example-1. Click the `Tailwind` tab, and you shouldn't see the extra closing span tag anymore.

![image](https://github.com/adobe/react-spectrum/assets/39754176/1a0fbbbf-b843-4d0d-ab5c-2fefe8baa054)
