### PR TITLE
fix: correct floating point of snappedValue before handling min/max behavior

### DIFF
--- a/packages/@react-stately/utils/src/number.ts
+++ b/packages/@react-stately/utils/src/number.ts
@@ -18,13 +18,25 @@ export function clamp(value: number, min: number = -Infinity, max: number = Infi
   return newValue;
 }
 
+export function roundToStepPrecision(value: number, step: number) {
+  let roundedValue = value;
+  let stepString = step.toString();
+  let pointIndex = stepString.indexOf('.');
+  let precision = pointIndex >= 0 ? stepString.length - pointIndex : 0;
+  if (precision > 0) {
+    let pow = Math.pow(10, precision);
+    roundedValue = Math.round(roundedValue * pow) / pow;
+  }
+  return roundedValue;
+}
+
 export function snapValueToStep(value: number, min: number | undefined, max: number | undefined, step: number): number {
   min = Number(min);
   max = Number(max);
   let remainder = ((value - (isNaN(min) ? 0 : min)) % step);
-  let snappedValue = Math.abs(remainder) * 2 >= step
+  let snappedValue = roundToStepPrecision(Math.abs(remainder) * 2 >= step
     ? value + Math.sign(remainder) * (step - Math.abs(remainder))
-    : value - remainder;
+    : value - remainder, step);
 
   if (!isNaN(min)) {
     if (snappedValue < min) {
@@ -37,14 +49,7 @@ export function snapValueToStep(value: number, min: number | undefined, max: num
   }
 
   // correct floating point behavior by rounding to step precision
-  let string = step.toString();
-  let index = string.indexOf('.');
-  let precision = index >= 0 ? string.length - index : 0;
-
-  if (precision > 0) {
-    let pow = Math.pow(10, precision);
-    snappedValue = Math.round(snappedValue * pow) / pow;
-  }
+  snappedValue = roundToStepPrecision(snappedValue, step);
 
   return snappedValue;
 }


### PR DESCRIPTION
## Issues

In some cases where `step`, `min` are float number, the initial `snappedValue` may have issues with "Floating Point Precision". For example, with a NumberField having props like `{ maxValue: 17, minValue: 0.1, step: 0.1 }`, when you enter `17` into the input, it will commit with a value of `16.9`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test with the same steps in the mentioned issue

## 🧢 Your Project:

https://mihi.dev/
