### PR TITLE
fix(#6109): SpectrumFieldProps should return labelProps that can be spread on a label or React-Spectrum Label

### DIFF
--- a/packages/@react-types/label/src/index.d.ts
+++ b/packages/@react-types/label/src/index.d.ts
@@ -11,7 +11,7 @@
  */
 
 import {Alignment, DOMProps, LabelPosition, NecessityIndicator, SpectrumFieldValidation, SpectrumHelpTextProps, StyleProps, Validation, ValidationResult} from '@react-types/shared';
-import {ElementType, HTMLAttributes, ReactElement, ReactNode} from 'react';
+import {ElementType, HTMLAttributes, LabelHTMLAttributes, ReactElement, ReactNode} from 'react';
 
 export interface LabelProps {
   children?: ReactNode,
@@ -34,7 +34,7 @@ export interface SpectrumFieldProps extends SpectrumLabelPropsBase, SpectrumHelp
   children: ReactElement,
   label?: ReactNode,
   contextualHelp?: ReactNode,
-  labelProps?: HTMLAttributes<HTMLElement>,
+  labelProps?: LabelHTMLAttributes<HTMLLabelElement>,
   descriptionProps?: HTMLAttributes<HTMLElement>,
   errorMessageProps?: HTMLAttributes<HTMLElement>,
   wrapperClassName?: string,


### PR DESCRIPTION
Closes #6109 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue #6109](https://github.com/adobe/react-spectrum/issues/6109).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

Adobe/Accessibility
