### PR TITLE
Fix Persian/Gregorian calendar conversion

### DIFF
--- a/packages/@internationalized/date/tests/conversion.test.js
+++ b/packages/@internationalized/date/tests/conversion.test.js
@@ -348,9 +348,24 @@ describe('CalendarDate conversion', function () {
         expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate(2020, 9, 2));
       });
 
+      it('persian to gregorian for months greater than 6', function () {
+        let date = new CalendarDate(new PersianCalendar(), 1403, 12, 1);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate(2025, 2, 19));
+      });
+
       it('gregorian to persian', function () {
         let date = new CalendarDate(2020, 9, 2);
         expect(toCalendar(date, new PersianCalendar())).toEqual(new CalendarDate(new PersianCalendar(), 1399, 6, 12));
+      });
+
+      it('gregorian to persian for months lower than 6', function () {
+        let date = new CalendarDate(2025, 3, 21);
+        expect(toCalendar(date, new PersianCalendar())).toEqual(new CalendarDate(new PersianCalendar(), 1404, 1, 1));
+      });
+
+      it('persian to gregorian in leap years', function () {
+        let date = new CalendarDate(new PersianCalendar(), 1403, 12, 30);
+        expect(toCalendar(date, new GregorianCalendar())).toEqual(new CalendarDate(2025, 3, 20));
       });
     });
 

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -30,6 +30,7 @@ import {
   JapaneseCalendar,
   maxDate,
   minDate,
+  PersianCalendar,
   startOfMonth,
   startOfWeek,
   startOfYear,
@@ -55,6 +56,13 @@ describe('queries', function () {
       expect(isSameDay(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 10, 4))).toBe(false);
       expect(isSameDay(new CalendarDate(2021, 4, 17), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 4))).toBe(false);
       expect(isSameDay(new CalendarDate(2021, 4, 16), new CalendarDate(new IslamicUmalquraCalendar(), 1442, 9, 3))).toBe(false);
+    });
+
+    it('works in Persian calendar', function () {
+      const persian = new CalendarDate(new PersianCalendar(), 1401, 12, 8);
+      const gregorian = new CalendarDate(2023, 2, 27);
+      expect(isSameDay(gregorian, persian)).toBe(true);
+      expect(isSameDay(persian, gregorian)).toBe(true);
     });
   });
 


### PR DESCRIPTION
Closes #5960, closes #3757, closes #6077, closes #5946, closes #5062.

This fixes two issues with the Persian to Gregorian and Gregorian to Persian date conversion.

1. Dates were sometimes off by one in months greater than 6, which resulted in 30 being displayed as the first day of the month.
2. The leap year calculation wasn't quite right, resulting in an incorrect number of days in the month.

This ports the code from [ICU](https://github.com/unicode-org/icu/blob/main/icu4j/main/core/src/main/java/com/ibm/icu/util/PersianCalendar.java) to perform the conversion and adds tests from all of the issues/PRs that have been raised for this issue.

## Test instructions

1. Open calendar stories
2. Change calendar system to Persian
3. Navigate forward/backward by month and verify that months always start with 1, not 30 or 31.
4. Navigate to "Farvardin 1404 AP", and verify that the month starts on a Friday.