### PR TITLE
Fix circular dependency in @react-aria/i18n

### DIFF
--- a/packages/@react-aria/i18n/src/useMessageFormatter.ts
+++ b/packages/@react-aria/i18n/src/useMessageFormatter.ts
@@ -12,7 +12,7 @@
 
 import {LocalizedStrings, MessageDictionary, MessageFormatter} from '@internationalized/message';
 import {useCallback, useMemo} from 'react';
-import {useLocale} from '@react-aria/i18n';
+import {useLocale} from './context';
 
 export type FormatMessage = (key: string, variables?: {[key: string]: any}) => string;
 


### PR DESCRIPTION
Use relative import in `useMessageFormatter` instead of `@react-aria/i18n` (since it's already part of that package).

(I haven't created an issue since it's such a small fix, please let me know if you prefer it)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Shouldn't change anything since it's just changing the import.

Before this change rollup reports a circular dependency:

```
../../common/temp/node_modules/.pnpm/@react-aria+i18n@3.10.2_react@18.2.0/node_modules/@react-aria/i18n/dist/import.mjs -> ../../common/temp/node_modules/.pnpm/@react-aria+i18n@3.10.2_react@18.2.0/node_modules/@react-aria/i18n/dist/useMessageFormatter.module.mjs -> ../../common/temp/node_modules/.pnpm/@react-aria+i18n@3.10.2_react@18.2.0/node_modules/@react-aria/i18n/dist/import.mjs
```


## 🧢 Your Project:

https://github.com/dossierhq/dossierhq
