### PR TITLE
Fix Illustrated Message Colors

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/illustratedmessage/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/illustratedmessage/skin.css
@@ -19,11 +19,11 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-IllustratedMessage-heading {
-  color: var(--spectrum-heading-page-title-text-color);
+  color: var(--spectrum-heading-3-text-color);
 }
 
 .spectrum-IllustratedMessage-description {
-  color: var(--spectrum-body-secondary-text-color);
+  color: var(--spectrum-body-text-color);
 }
 
 @media (forced-colors: active) {


### PR DESCRIPTION
Updates the colors to match the figma design. 

Turns out the XD design is outdated and uses v5 colors so when reviewing, please look at the S1 figma designs instead


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
