### PR TITLE
fix(#6130): Ignore HiddenSelect when tree walking

### DIFF
--- a/packages/@react-aria/focus/src/isElementVisible.ts
+++ b/packages/@react-aria/focus/src/isElementVisible.ts
@@ -44,7 +44,7 @@ function isAttributeVisible(element: Element, childElement?: Element) {
   return (
     !element.hasAttribute('hidden') &&
     // Ignore HiddenSelect when tree walking.
-    !(element.hasAttribute('data-a11y-ignore') && element.getAttribute('aria-hidden') === 'true') &&
+    !(element.hasAttribute('data-hidden-select-ignore') && element.getAttribute('aria-hidden') === 'true') &&
     (element.nodeName === 'DETAILS' &&
       childElement &&
       childElement.nodeName !== 'SUMMARY'

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -88,6 +88,7 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
     containerProps: {
       ...visuallyHiddenProps,
       'aria-hidden': true,
+      ['data-hidden-select-ignore']: true,
       ['data-a11y-ignore']: 'aria-hidden-focus'
     },
     inputProps: {

--- a/packages/@react-aria/select/test/HiddenSelect.test.tsx
+++ b/packages/@react-aria/select/test/HiddenSelect.test.tsx
@@ -74,4 +74,12 @@ describe('<HiddenSelect />', () => {
 
     expect(screen.getByTestId('hidden-select-container')).toHaveAttribute('data-a11y-ignore', 'aria-hidden-focus');
   });
+
+  it('should always add a data attribute data-hidden-select-ignore', () => {
+    render(
+      <HiddenSelectExample items={makeItems(5)} />
+    );
+
+    expect(screen.getByTestId('hidden-select-container')).toHaveAttribute('data-hidden-select-ignore');
+  });
 });


### PR DESCRIPTION
We should skip HiddenSelect element in Picker when tree walking to determine the next or previous focusable element. However, we should not use [data-a11y-ignore], which is used to exclude elements from aXe automated accessibility tests.

Per comments: https://github.com/adobe/react-spectrum/pull/6116#discussion_r1544017444

Closes #6130 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 6130](https://github.com/adobe/react-spectrum/issues/6130).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open TableView focusable cells example: https://reactspectrum.blob.core.windows.net/reactspectrum/b783832dd2ff7bf0a85ee30f1233ef9ce370b661/storybook/iframe.html?scrolling=false&providerSwitcher-locale=&providerSwitcher-theme=&providerSwitcher-scale=&providerSwitcher-express=false&args=&id=tableview--focusable-cells&viewMode=story
2. The example app consists of a TableView in which the last row has a Picker in the second cell.
3. Press Tab to navigate and set focus to the first row in the TableView.
4. Press ArrowDown until the last row, containing the Picker has focus.
5. Press ArrowRight to focus the Switch in the first cell.
6. Press ArrowRight again to focus the Picker in the second cell.
7. Press ArrowRight to move focus to the next cell, containing the word "Three."
8. The value of the Picker does not change as the focus moves to the next cell.
9. Press ArrowLeft to focus the Picker in the second cell again.
10. Press ArrowLeft again to move focus to the previous cell.
11. Focus moves to the Switch in the first cell, and the value of the Picker does not change.

Related Issue and PR: #5877, #5878, #6116

## 🧢 Your Project:

Adobe/Accessibility
