### PR TITLE
Exclude id from TextField DOMProps

### DIFF
--- a/packages/react-aria-components/src/TextField.tsx
+++ b/packages/react-aria-components/src/TextField.tsx
@@ -85,9 +85,12 @@ function TextField(props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) {
     defaultClassName: 'react-aria-TextField'
   });
 
+  let DOMProps = filterDOMProps(props);
+  delete DOMProps.id;
+
   return (
     <div
-      {...filterDOMProps(props)}
+      {...DOMProps}
       {...renderProps}
       ref={ref}
       slot={props.slot || undefined}

--- a/packages/react-aria-components/test/TextField.test.js
+++ b/packages/react-aria-components/test/TextField.test.js
@@ -226,5 +226,17 @@ describe('TextField', () => {
       await user.tab();
       expect(input).not.toHaveAttribute('aria-describedby');
     });
+
+    it('should render the id attribute only on the input element', async () => {
+      let {getAllByTestId, getByRole} = render(
+        <TestTextField id="name" input={component} />
+      );
+      let outerEl = getAllByTestId('text-field-test');
+      let input = getByRole('textbox');
+
+      expect(outerEl).toHaveLength(1);
+      expect(outerEl[0]).not.toHaveAttribute('id');
+      expect(input).toHaveAttribute('id', 'name');
+    });
   });
 });


### PR DESCRIPTION
Closes #6125

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

`yarn jest TextField`
