### PR TITLE
Detach React Canary development from Main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,12 +551,6 @@ workflows:
       - test-17:
           requires:
             - install-17
-      - test-ssr-canary:
-          requires:
-            - install-canary
-      - test-canary:
-          requires:
-            - install-canary
       - test-esm:
           requires:
             - install
@@ -612,9 +606,6 @@ workflows:
             - test-16
             - test-ssr-17
             - test-17
-            - test-ssr-canary
-            - test-canary
-            - test-ssr-canary
             - test-esm
             - storybook
             - storybook-16


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Unblock development on main to give us space to fix React Canary version. This should be regarded as a very temporary fix.
While looking at https://github.com/adobe/react-spectrum/pull/6144 I noticed that storybook doesn't render at all. So we'll have tests and storybook to fix at a minimum.

Looks like to fix storybook we'll need to upgrade to storybook 7 https://github.com/storybookjs/storybook/issues/18331#issuecomment-1162957861

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
