### PR TITLE
Fix ListBox (grid layout) keyboard navigation TypeError

### DIFF
--- a/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
+++ b/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
@@ -203,7 +203,7 @@ export class ListKeyboardDelegate<T> implements KeyboardDelegate {
   }
 
   private getItem(key: Key): HTMLElement {
-    return this.ref.current.querySelector(`[data-key="${CSS.escape(key.toString())}"]`);
+    return key !== null ? this.ref.current.querySelector(`[data-key="${CSS.escape(key.toString())}"]`) : null;
   }
 
   getKeyPageAbove(key: Key) {

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -193,19 +193,21 @@ export const ListBoxGrid = (args) => (
     className={styles.menu} 
     aria-label="test listbox"
     style={{
+      width: 300,
+      height: 300,
       display: 'grid',
-      gridTemplateColumns: 'repeat(3, 1fr)',
-      gridAutoRows: 'minmax(50px, auto)'
+      gridTemplate: 'repeat(3, 1fr) / repeat(3, 1fr)',
+      gridAutoFlow: args.orientation === 'vertical' ? 'row' : 'column'
     }}>
-    <MyListBoxItem style={{gridColumn: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,1</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 2, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,2</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 3, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,3</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,1</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 2, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,2</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 3, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,3</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,1</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 2, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,2</MyListBoxItem>
-    <MyListBoxItem style={{gridColumn: 3, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,3</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,1</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,2</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,3</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,1</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,2</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,3</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,1</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,2</MyListBoxItem>
+    <MyListBoxItem style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,3</MyListBoxItem>
   </ListBox>
 );
 

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -187,3 +187,39 @@ export const ListBoxHover = () => (
   </ListBox>
 );
 
+export const ListBoxGrid = (args) => (
+  <ListBox
+    {...args}
+    className={styles.menu} 
+    aria-label="test listbox"
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gridAutoRows: 'minmax(50px, auto)'
+    }}>
+    <MyListBoxItem style={{gridColumn: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,1</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 2, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,2</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 3, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>1,3</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,1</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 2, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,2</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 3, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>2,3</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,1</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 2, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,2</MyListBoxItem>
+    <MyListBoxItem style={{gridColumn: 3, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>3,3</MyListBoxItem>
+  </ListBox>
+);
+
+ListBoxGrid.story = {
+  args: {
+    layout: 'grid',
+    orientation: 'vertical'
+  },
+  argTypes: {
+    orientation: {
+      control: {
+        type: 'radio',
+        options: ['vertical', 'horizontal']
+      }
+    }
+  }
+};

--- a/packages/react-aria-components/test/ListBox.test.js
+++ b/packages/react-aria-components/test/ListBox.test.js
@@ -498,6 +498,63 @@ describe('ListBox', () => {
     expect(document.activeElement).toBe(options[1]);
   });
 
+  it('should not throw TypeError at boundaries of vertical grid layout when keyboard navigating (up/down)', async () => {
+    /**
+     * The following ListBox is roughly in this shape:
+     * 
+     * -------------------
+     * | 1,1 | 1,2 | 1,3 |
+     * -------------------
+     * | 2,1 | 2,2 | 2,3 |
+     * -------------------
+     * | 3,1 | 3,2 | 3,3 |
+     * -------------------
+     */
+    let {getAllByRole} = render(
+      <ListBox layout="grid" aria-label="Test">
+        <ListBoxItem>1,1</ListBoxItem>
+        <ListBoxItem>1,2</ListBoxItem>
+        <ListBoxItem>1,3</ListBoxItem>
+        <ListBoxItem>2,1</ListBoxItem>
+        <ListBoxItem>2,2</ListBoxItem>
+        <ListBoxItem>2,3</ListBoxItem>
+        <ListBoxItem>3,1</ListBoxItem>
+        <ListBoxItem>3,2</ListBoxItem>
+        <ListBoxItem>3,3</ListBoxItem>
+      </ListBox>);
+    let options = getAllByRole('option');
+
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      if (this.getAttribute('role') === 'listbox') {
+        return {top: 0, left: 0, bottom: 200, right: 300, width: 300, height: 200};
+      } else {
+        let index = [...this.parentElement.children].indexOf(this);
+        return {top: Math.floor(index / 3) * 40, left: (index % 3) * 100, bottom: Math.floor(index / 3) * 40 + 40, right: (index % 3) * 100 + 100, width: 100, height: 40};
+      }
+    });
+
+    await user.tab();
+    expect(document.activeElement).toBe(options[0]);  // 1,1
+
+    keyPress('ArrowDown');
+    expect(document.activeElement).toBe(options[3]);  // 2,1
+
+    keyPress('ArrowDown');  // the end reached
+    expect(document.activeElement).toBe(options[6]);  // 3,1
+
+    keyPress('ArrowDown');  // shouldn't throw when pressed one more time at the boundary.
+    expect(document.activeElement).toBe(options[6]);  // 3,1
+
+    keyPress('ArrowUp');
+    expect(document.activeElement).toBe(options[3]);  // 2,1
+
+    keyPress('ArrowUp');  // the end reached
+    expect(document.activeElement).toBe(options[0]);  // 1,1
+
+    keyPress('ArrowUp');  // shouldn't throw when pressed one more time at the boundary.
+    expect(document.activeElement).toBe(options[0]);  // 1,1
+  });
+
   it('should support horizontal grid layout', async () => {
     let {getAllByRole} = renderListbox({layout: 'grid', orientation: 'horizontal'});
     let options = getAllByRole('option');
@@ -527,7 +584,7 @@ describe('ListBox', () => {
     expect(document.activeElement).toBe(options[1]);
   });
 
-  it('should not throw TypeError at boundaries of grid layout', async () => {
+  it('should not throw TypeError at boundaries of horizontal grid layout when keyboard navigating (left/right)', async () => {
     /**
      * The following ListBox is roughly in this shape:
      * 
@@ -539,8 +596,8 @@ describe('ListBox', () => {
      * | 3,1 | 3,2 | 3,3 |
      * -------------------
      */
-    let {getAllByRole, rerender} = render(
-      <ListBox layout="grid" aria-label="Test">
+    let {getAllByRole} = render(
+      <ListBox layout="grid" orientation="horizontal" aria-label="Test">
         <ListBoxItem>1,1</ListBoxItem>
         <ListBoxItem>1,2</ListBoxItem>
         <ListBoxItem>1,3</ListBoxItem>
@@ -565,57 +622,22 @@ describe('ListBox', () => {
     await user.tab();
     expect(document.activeElement).toBe(options[0]);  // 1,1
 
-    keyPress('ArrowDown');
-    expect(document.activeElement).toBe(options[3]);  // 2,1
-
-    keyPress('ArrowDown');
-    expect(document.activeElement).toBe(options[6]);  // 3,1
-
-    keyPress('ArrowDown');  // shouldn't throw
-    expect(document.activeElement).toBe(options[6]);  // 3,1
-
-    keyPress('ArrowUp');
-    expect(document.activeElement).toBe(options[3]);  // 2,1
-
-    keyPress('ArrowUp');
-    expect(document.activeElement).toBe(options[0]);  // 1,1
-
-    keyPress('ArrowUp');  // shouldn't throw
-    expect(document.activeElement).toBe(options[0]);  // 1,1
-
-    // horizontal
-    rerender(
-      <ListBox layout="grid" orientation="horizontal" aria-label="Test">
-        <ListBoxItem>1,1</ListBoxItem>
-        <ListBoxItem>1,2</ListBoxItem>
-        <ListBoxItem>1,3</ListBoxItem>
-        <ListBoxItem>2,1</ListBoxItem>
-        <ListBoxItem>2,2</ListBoxItem>
-        <ListBoxItem>2,3</ListBoxItem>
-        <ListBoxItem>3,1</ListBoxItem>
-        <ListBoxItem>3,2</ListBoxItem>
-        <ListBoxItem>3,3</ListBoxItem>
-      </ListBox>
-    );
-
-    expect(document.activeElement).toBe(options[0]);  // 1,1
-    
     keyPress('ArrowRight');
     expect(document.activeElement).toBe(options[1]);  // 1,2
 
-    keyPress('ArrowRight');
+    keyPress('ArrowRight');  // the end reached
     expect(document.activeElement).toBe(options[2]);  // 1,3
 
-    keyPress('ArrowRight');  // shouldn't throw
+    keyPress('ArrowRight');  // shouldn't throw when pressed one more time at the boundary.
     expect(document.activeElement).toBe(options[2]);  // 1,3
 
     keyPress('ArrowLeft');
     expect(document.activeElement).toBe(options[1]);  // 1,2
 
-    keyPress('ArrowLeft');
+    keyPress('ArrowLeft');  // the end reached
     expect(document.activeElement).toBe(options[0]);  // 1,1
 
-    keyPress('ArrowLeft');  // shouldn't throw
+    keyPress('ArrowLeft');  // shouldn't throw when pressed one more time at the boundary.
     expect(document.activeElement).toBe(options[0]);  // 1,1
   });
 

--- a/packages/react-aria-components/test/ListBox.test.js
+++ b/packages/react-aria-components/test/ListBox.test.js
@@ -501,7 +501,7 @@ describe('ListBox', () => {
   it('should not throw TypeError at boundaries of vertical grid layout when keyboard navigating (up/down)', async () => {
     /**
      * The following ListBox is roughly in this shape:
-     * 
+     *
      * -------------------
      * | 1,1 | 1,2 | 1,3 |
      * -------------------
@@ -587,13 +587,13 @@ describe('ListBox', () => {
   it('should not throw TypeError at boundaries of horizontal grid layout when keyboard navigating (left/right)', async () => {
     /**
      * The following ListBox is roughly in this shape:
-     * 
+     *
      * -------------------
-     * | 1,1 | 1,2 | 1,3 |
+     * | 1,1 | 2,1 | 3,1 |
      * -------------------
-     * | 2,1 | 2,2 | 2,3 |
+     * | 1,2 | 2,2 | 3,2 |
      * -------------------
-     * | 3,1 | 3,2 | 3,3 |
+     * | 1,3 | 3,2 | 3,3 |
      * -------------------
      */
     let {getAllByRole} = render(
@@ -615,7 +615,7 @@ describe('ListBox', () => {
         return {top: 0, left: 0, bottom: 200, right: 300, width: 300, height: 200};
       } else {
         let index = [...this.parentElement.children].indexOf(this);
-        return {top: Math.floor(index / 3) * 40, left: (index % 3) * 100, bottom: Math.floor(index / 3) * 40 + 40, right: (index % 3) * 100 + 100, width: 100, height: 40};
+        return {top: (index % 3) * 40, left: Math.floor(index / 3) * 100, bottom: (index % 3) * 40 + 40, right: Math.floor(index / 3) * 100 + 100, width: 100, height: 40};
       }
     });
 
@@ -623,16 +623,16 @@ describe('ListBox', () => {
     expect(document.activeElement).toBe(options[0]);  // 1,1
 
     keyPress('ArrowRight');
-    expect(document.activeElement).toBe(options[1]);  // 1,2
+    expect(document.activeElement).toBe(options[3]);  // 2,1
 
     keyPress('ArrowRight');  // the end reached
-    expect(document.activeElement).toBe(options[2]);  // 1,3
+    expect(document.activeElement).toBe(options[6]);  // 3,1
 
     keyPress('ArrowRight');  // shouldn't throw when pressed one more time at the boundary.
-    expect(document.activeElement).toBe(options[2]);  // 1,3
+    expect(document.activeElement).toBe(options[6]);  // 3,1
 
     keyPress('ArrowLeft');
-    expect(document.activeElement).toBe(options[1]);  // 1,2
+    expect(document.activeElement).toBe(options[3]);  // 2,1
 
     keyPress('ArrowLeft');  // the end reached
     expect(document.activeElement).toBe(options[0]);  // 1,1


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6168

While fixing the bug, I've noticed a horizontal grid ListBox also has the same issue when navigating left and right via keyboard ('arrowLeft' and 'arrowRight'). Included unit test covers both cases.

By the way, these bugs can be seen in the docs as well
* https://react-spectrum.adobe.com/react-aria/ListBox.html#vertical-grid
* https://react-spectrum.adobe.com/react-aria/ListBox.html#horizontal-grid

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Story
* http://localhost:9003/?path=/story/react-aria-components--list-box-grid

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
