### PR TITLE
fix: DropZone button type

### DIFF
--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -117,6 +117,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
           </div>
           <button
             {...mergeProps(buttonProps, focusProps, clipboardProps, labelProps)}
+            type="button"
             ref={buttonRef} />
         </VisuallyHidden>
         {renderProps.children}

--- a/packages/react-aria-components/test/DropZone.test.js
+++ b/packages/react-aria-components/test/DropZone.test.js
@@ -11,7 +11,7 @@
  */
 
 import {act, fireEvent, pointerMap, render} from '@react-spectrum/test-utils';
-import {Button, DropZone, DropZoneContext, FileTrigger, Link, Text} from '../';
+import {Button, DropZone, DropZoneContext, FileTrigger, Form, Link, Text} from '../';
 import {ClipboardEvent, DataTransfer, DataTransferItem, DragEvent} from '@react-aria/dnd/test/mocks';
 import {Draggable} from '@react-aria/dnd/test/examples';
 import React from 'react';
@@ -181,6 +181,27 @@ describe('DropZone', () => {
 
     let dropzone = getByTestId('foo');
     expect(ref.current).toEqual(dropzone);
+  });
+
+  it('should not submit a parent form', async () => {
+    const submitSpy = jest.fn();
+
+    let {getByRole} = render(
+      <Form onSubmit={submitSpy}>
+        <DropZone>
+          <Text slot="label">Test</Text>
+        </DropZone>
+      </Form>
+    );
+
+    await user.tab();
+
+    let button = getByRole('button');
+    expect(document.activeElement).toBe(button);
+
+    await user.keyboard('{Enter}');
+
+    expect(submitSpy).not.toHaveBeenCalled();
   });
 
   describe('drag and drop', function () {
@@ -528,7 +549,7 @@ describe('DropZone', () => {
           </DropZone>
         </>
       );
-  
+
       let button = getByRole('button');
       await user.tab();
       expect(document.activeElement).not.toBe(button);


### PR DESCRIPTION
Closes #6230 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
