### PR TITLE
Fix various imports in the docs from being set to monopackage imports

### DIFF
--- a/packages/@react-spectrum/menu/docs/Menu.mdx
+++ b/packages/@react-spectrum/menu/docs/Menu.mdx
@@ -331,11 +331,9 @@ callbacks will not fire for items made unavailable by a ContextualHelpTrigger.
 
 The example below illustrates how one would setup a Menu to use ContextualHelpTrigger.
 
-```tsx example
+```tsx example keepIndividualImports
+import {Content, Dialog, Heading} from '@adobe/react-spectrum';
 import {ContextualHelpTrigger} from '@react-spectrum/menu';
-import {Dialog} from '@react-spectrum/dialog';
-import {Heading} from '@react-spectrum/text';
-import {Content} from '@react-spectrum/view';
 
 <MenuTrigger>
   <ActionButton>Edit</ActionButton>
@@ -374,7 +372,8 @@ Each submenu's Menu accepts its own set of menu props, allowing you to customize
 
 ### Static
 
-```tsx example
+```tsx example keepIndividualImports
+
 import {SubmenuTrigger} from '@react-spectrum/menu';
 
 <MenuTrigger>
@@ -406,7 +405,7 @@ import {SubmenuTrigger} from '@react-spectrum/menu';
 
 You can define a recursive function to render the nested menu items dynamically.
 
-```tsx example
+```tsx example keepIndividualImports
 import {SubmenuTrigger} from '@react-spectrum/menu';
 
 let items = [

--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -582,7 +582,7 @@ function transformExample(node, preRelease, keepIndividualImports) {
 
     traverse(ast, {
       ImportDeclaration(path) {
-        if (/^(@react-spectrum|@react-aria|@react-stately)/.test(path.node.source.value) && !keepIndividualImports) {
+        if (/^(@react-spectrum|@react-aria|@react-stately)/.test(path.node.source.value) && !/test-utils/.test(path.node.source.value) && !keepIndividualImports) {
           let lib = path.node.source.value.split('/')[0];
           let s = path.node.importKind === 'type' ? typeSpecifiers : specifiers;
           if (!s[lib]) {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
