### PR TITLE
Fix intermittent focus ring compilation issue in docs

### DIFF
--- a/patches/@parcel+transformer-css+2.0.0-canary.1565.patch
+++ b/patches/@parcel+transformer-css+2.0.0-canary.1565.patch
@@ -7,7 +7,7 @@ index b8dd9f2..fd3c753 100644
        contents.cssModules.exclude = contents.cssModules.exclude.map(exclude => typeof exclude === 'string' ? (0, _utils().globToRegex)(exclude) : exclude);
      }
 +    if (config.searchPath.endsWith('home.global.css')) {
-+      contents.pseudoClasses = null;
++      contents = {...contents, pseudoClasses: null};
 +    }
      return contents;
    },


### PR DESCRIPTION
Fixes an intermittent issue where focus rings appeared on mouse interaction. This seemed to appear on some PR builds and not others, and resulted in `:focus-visible` and `:hover` pseudo classes not being compiled to the `.focus-ring` and `.is-hovered` classes that we apply. The native `:focus-visible` pseudo class also applies on programmatic focus, which is why we see the issue.

The problem was caused by a patch we had applied to skip this compilation on the React Aria tailwind-based homepage. Since all files load this config from the same package.json file, mutating it caused unintentional changes when compiling files other than the one we were looking for. It appeared intermittent because files are compiled in a different order on each build. The fix is to clone the config and modify that instead.