### PR TITLE
Increase specificity so that ActionGroup collapsed text only icons don't render extra padding

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -230,7 +230,7 @@ a.spectrum-ActionButton {
     padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
   }
 
-  .spectrum-ActionGroup-itemIcon {
+  .spectrum-ActionGroup-itemIcon.spectrum-ActionGroup-itemIcon {
     padding-inline-end: 0;
   }
 }

--- a/packages/@react-spectrum/actiongroup/chromatic/ActionGroup.chromatic.tsx
+++ b/packages/@react-spectrum/actiongroup/chromatic/ActionGroup.chromatic.tsx
@@ -314,6 +314,13 @@ DisabledKeys.story = {
   name: 'disabledKeys'
 };
 
+export const OverflowAndHide = () =>
+  render({overflowMode: 'collapse', buttonLabelBehavior: 'hide', selectionMode: 'multiple'}, dataItems);
+
+OverflowAndHide.story = {
+  name: 'overflowMode: collapse, buttonLabelBehavior: hide'
+};
+
 function render(props, items) {
   return (
     <Flex rowGap="size-300" margin="size-100" width="100%" direction="column">


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test ActionGroup stories with overflowMode="collapse" and buttonLabelBehavior="hide" and make sure the icon only buttons aren't too wide

## 🧢 Your Project:

RSP
