### PR TITLE
Fix crash in DateRangePicker when using SSR optimized localized strings

### DIFF
--- a/packages/@react-stately/datepicker/src/utils.ts
+++ b/packages/@react-stately/datepicker/src/utils.ts
@@ -105,9 +105,10 @@ export function getRangeValidationResult(
 
   let result = mergeValidation(startValidation, endValidation);
   if (value.end != null && value.start != null && value.end.compare(value.start) < 0) {
+    let strings = LocalizedStringDictionary.getGlobalDictionaryForPackage('@react-stately/datepicker') || dictionary;
     result = mergeValidation(result, {
       isInvalid: true,
-      validationErrors: [dictionary.getStringForLocale('rangeReversed', getLocale())],
+      validationErrors: [strings.getStringForLocale('rangeReversed', getLocale())],
       validationDetails: {
         ...VALID_VALIDITY_STATE,
         rangeUnderflow: true,


### PR DESCRIPTION
In our Next.js example app, when selecting a range in a DateRangePicker with reversed order, the page would crash with an error about a missing localized string. In that setup, the optimize-locales-plugin is used to remove all localized strings from the JS bundle, and they are injected into the page during SSR. However, this particular code used the dictionary imported from the JS bundle, and did not load the global dictionary from the window like other parts of the code.