### PR TITLE
Backwards compatibility for Validation type

### DIFF
--- a/packages/@react-types/shared/src/inputs.d.ts
+++ b/packages/@react-types/shared/src/inputs.d.ts
@@ -18,7 +18,7 @@ export type ValidationError = string | string[];
 export type ValidationErrors = Record<string, ValidationError>;
 export type ValidationFunction<T> = (value: T) => ValidationError | true | null | undefined;
 
-export interface Validation<T> {
+export interface Validation<T = unknown> {
   /** Whether user input is required on the input before form submission. */
   isRequired?: boolean,
   /** Whether the input value is invalid. */


### PR DESCRIPTION
Fixes #5739

Adds a default to the type parameter that we added to the `Validation` type for backwards compatibility with older releases that people might have been using in custom components.