### PR TITLE
FIX use early return to VisuallyHidden

### DIFF
--- a/packages/@react-aria/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/@react-aria/visually-hidden/src/VisuallyHidden.tsx
@@ -51,27 +51,27 @@ export interface VisuallyHiddenAria {
  * but keeps content visible to assistive technology.
  */
 export function useVisuallyHidden(props: VisuallyHiddenProps = {}): VisuallyHiddenAria {
-  let {
+  const {
     style,
     isFocusable
   } = props;
 
-  let [isFocused, setFocused] = useState(false);
-  let {focusWithinProps} = useFocusWithin({
+  const [isFocused, setFocused] = useState(false);
+  const {focusWithinProps} = useFocusWithin({
     isDisabled: !isFocusable,
     onFocusWithinChange: (val) => setFocused(val)
   });
 
   // If focused, don't hide the element.
-  let combinedStyles = useMemo(() => {
+  const combinedStyles = useMemo(() => {
     if (isFocused) {
       return style;
-    } else if (style) {
-      return {...styles, ...style};
-    } else {
-      return styles;
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (style) {
+      return {...styles, ...style};
+    }
+    return styles;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFocused]);
 
   return {
@@ -88,8 +88,8 @@ export function useVisuallyHidden(props: VisuallyHiddenProps = {}): VisuallyHidd
  */
 export function VisuallyHidden(props: VisuallyHiddenProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let {children, elementType: Element = 'div', isFocusable, style, ...otherProps} = props;
-  let {visuallyHiddenProps} = useVisuallyHidden(props);
+  const {children, elementType: Element = 'div', isFocusable, style, ...otherProps} = props;
+  const {visuallyHiddenProps} = useVisuallyHidden(props);
 
   return (
     <Element {...mergeProps(otherProps, visuallyHiddenProps)}>


### PR DESCRIPTION

## Before

<img width="421" alt="image" src="https://github.com/adobe/react-spectrum/assets/86355699/ad7cd067-9fd7-4470-8e05-4379c65a2490">

## After

<img width="477" alt="image" src="https://github.com/adobe/react-spectrum/assets/86355699/a23f1d99-8cb1-4926-94ee-afce90551ae6">

## What I did

1. Early-return was used to improve the readability of the if/else syntax.
2. The stability was improved by eliminating the possibility of reallocation of the let using const.

<br/>

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
