### PR TITLE
Fix portal container assignment from context

### DIFF
--- a/packages/@react-spectrum/overlays/src/Overlay.tsx
+++ b/packages/@react-spectrum/overlays/src/Overlay.tsx
@@ -33,7 +33,9 @@ function Overlay(props: OverlayProps, ref: DOMRef<HTMLDivElement>) {
   } = props;
 
   let {getContainer} = useUNSTABLE_PortalContext();
-  container = container || getContainer?.();
+  if  (!container && getContainer) {
+    container = getContainer();
+  }
 
   let [exited, setExited] = useState(!isOpen);
 


### PR DESCRIPTION
Fixes an issue found in testing yesterday where when closing a submenu while keyboard focused, the page would get scrolled to the bottom.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Open an RSP Submenu and navigate via keyboard, then close the submenu. You should no longer get scrolled to the bottom of the page.

## 🧢 Your Project:

<!--- Company/project for pull request -->
