### PR TITLE
Add isDisabled to RAC DropZone render props

### DIFF
--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -53,7 +53,7 @@ export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoi
 export const DropZoneContext = createContext<ContextValue<DropZoneProps, HTMLDivElement>>(null);
 
 function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
-  let {isDisabled} = props;
+  let {isDisabled = false} = props;
   [props, ref] = useContextProps(props, ref, DropZoneContext);
   let dropzoneRef = useObjectRef(ref);
   let buttonRef = useRef<HTMLButtonElement>(null);

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -45,7 +45,7 @@ export interface DropZoneRenderProps {
    * Whether the dropzone is disabled.
    * @selector [data-disabled]
    */
-  isDisabled?: boolean
+  isDisabled: boolean
 }
 
 export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps {}
@@ -83,7 +83,7 @@ function DropZone(props: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) {
 
   let renderProps = useRenderProps({
     ...props,
-    values: {isHovered, isFocused, isFocusVisible, isDropTarget},
+    values: {isHovered, isFocused, isFocusVisible, isDropTarget, isDisabled},
     defaultClassName: 'react-aria-DropZone'
   });
   let DOMProps = filterDOMProps(props);

--- a/packages/react-aria-components/stories/Dropzone.stories.tsx
+++ b/packages/react-aria-components/stories/Dropzone.stories.tsx
@@ -147,7 +147,7 @@ const DropzoneWithRenderPropsExample = (props) => (
       onDrop={action('OnDrop')}
       onDropEnter={action('OnDropEnter')}
       onDropExit={action('OnDropExit')}>
-      {({isHovered, isFocused, isFocusVisible, isDropTarget}) => (
+      {({isHovered, isFocused, isFocusVisible, isDropTarget, isDisabled}) => (
         <div>
           <Text slot="label">
             DropzoneArea
@@ -156,6 +156,7 @@ const DropzoneWithRenderPropsExample = (props) => (
           <div>isFocused: {isFocused ? 'true' : 'false'}</div>
           <div>isFocusVisible: {isFocusVisible ? 'true' : 'false'}</div>
           <div>isDropTarget: {isDropTarget ? 'true' : 'false'}</div>
+          <div>isDisabled: {isDisabled ? 'true' : 'false'}</div>
         </div>
       )}
     </DropZone>


### PR DESCRIPTION
Noticed that we added [support for isDisabled](https://github.com/adobe/react-spectrum/pull/5958
) for RAC DropZone but it wasn't added to the render props and also wasn't showing `data-disabled` in the docs as a result

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
