### PR TITLE
[SB7] Remove deprecated key prop in descriptionAddon

### DIFF
--- a/.storybook/custom-addons/descriptions/register.js
+++ b/.storybook/custom-addons/descriptions/register.js
@@ -19,8 +19,8 @@ addons.register(ADDON_ID, (api) => {
   addons.add(PANEL_ID, {
     type: types.PANEL,
     title: 'Description',
-    render: ({ active, key }) => (
-      <AddonPanel active={active} key={key}>
+    render: ({ active }) => (
+      <AddonPanel active={active}>
         <MyPanel />
       </AddonPanel>
     ),


### PR DESCRIPTION
Hey guys, I've noticed a warning previously not existed before SB7 is being printed when I open the browser inspector:

<img width="958" alt="Screenshot 2024-05-08 at 11 24 21 PM" src="https://github.com/adobe/react-spectrum/assets/71210554/11ef371f-267d-4b19-b53e-cd825db3ec91">

I searched around a bit, and it turned out `key` prop that had been fed into `<AddonPanel>` was now generating the warning so I removed it as recommended [here](https://github.com/storybookjs/storybook/pull/23792/files#diff-66fd0ef2f3df056f95276eb1d7f4ba662f32a1ed1a494f0b6c932ef1da9a832aR310-R314).

Releted Storybook issues:
* https://github.com/storybookjs/storybook/issues/23782
* https://github.com/storybookjs/storybook/pull/23792
* https://github.com/storybookjs/addon-designs/pull/207

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
