### PR TITLE
RAC: Support removing data-rac attribute

### DIFF
--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -93,7 +93,8 @@ interface RenderPropsHookOptions<T> extends RenderProps<T>, SharedDOMProps, Aria
   values: T,
   defaultChildren?: ReactNode,
   defaultClassName?: string,
-  defaultStyle?: CSSProperties
+  defaultStyle?: CSSProperties,
+  'data-rac'?: string
 }
 
 export function useRenderProps<T>(props: RenderPropsHookOptions<T>) {
@@ -104,7 +105,8 @@ export function useRenderProps<T>(props: RenderPropsHookOptions<T>) {
     defaultClassName = undefined,
     defaultChildren = undefined,
     defaultStyle,
-    values
+    values,
+    'data-rac': dataRAC
   } = props;
 
   return useMemo(() => {
@@ -136,9 +138,9 @@ export function useRenderProps<T>(props: RenderPropsHookOptions<T>) {
       className: computedClassName ?? defaultClassName,
       style: (computedStyle || defaultStyle) ? {...defaultStyle, ...computedStyle} : undefined,
       children: computedChildren ?? defaultChildren,
-      'data-rac': props['data-rac'] === undefined ? '' : props['data-rac']
+      'data-rac': dataRAC === undefined ? '' : dataRAC
     };
-  }, [className, style, children, defaultClassName, defaultStyle, defaultChildren, props, values]);
+  }, [className, style, children, defaultClassName, defaultStyle, defaultChildren, dataRAC, values]);
 }
 
 /**

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -136,9 +136,9 @@ export function useRenderProps<T>(props: RenderPropsHookOptions<T>) {
       className: computedClassName ?? defaultClassName,
       style: (computedStyle || defaultStyle) ? {...defaultStyle, ...computedStyle} : undefined,
       children: computedChildren ?? defaultChildren,
-      'data-rac': ''
+      'data-rac': props['data-rac'] === undefined ? '' : props['data-rac']
     };
-  }, [className, style, children, defaultClassName, defaultChildren, defaultStyle, values]);
+  }, [className, style, children, defaultClassName, defaultStyle, defaultChildren, props, values]);
 }
 
 /**

--- a/packages/react-aria-components/test/Button.test.js
+++ b/packages/react-aria-components/test/Button.test.js
@@ -39,6 +39,12 @@ describe('Button', () => {
     expect(button).toHaveAttribute('data-foo', 'bar');
   });
 
+  it('should support removing data-rac attribute', () => {
+    let {getByRole} = render(<Button data-rac={null}>Test</Button>);
+    let button = getByRole('button');
+    expect(button).not.toHaveAttribute('data-rac');
+  });
+
   it('should support form props', () => {
     let {getByRole} = render(<form id="foo"><Button form="foo" formMethod="post">Test</Button></form>);
     let button = getByRole('button');


### PR DESCRIPTION
For discussion:

This provides a way to remove the data-rac attribute from elements by passing in `null`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
