### PR TITLE
RAC select complex selected value

### DIFF
--- a/packages/react-aria-components/example/index.css
+++ b/packages/react-aria-components/example/index.css
@@ -126,6 +126,10 @@ html {
   justify-self: end;
 }
 
+.select .selected-description {
+  display: none;
+}
+
 .popover[data-trigger=SubmenuTrigger][data-placement="right"] {
   margin-left: -8px;
 }

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -243,7 +243,8 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
     values: {
       selectedItem: state.selectedItem?.value as T ?? null,
       selectedText: state.selectedItem?.textValue ?? null,
-      isPlaceholder: !selectedItem
+      isPlaceholder: !selectedItem,
+      selectedChildren: rendered
     }
   });
 

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -204,7 +204,9 @@ export interface SelectValueRenderProps<T> {
   /** The object value of the currently selected item. */
   selectedItem: T | null,
   /** The textValue of the currently selected item. */
-  selectedText: string | null
+  selectedText: string | null,
+  /** The rendered value of the currently selected item. */
+  selectedChildren: ReactNode
 }
 
 export interface SelectValueProps<T extends object> extends Omit<HTMLAttributes<HTMLElement>, keyof RenderProps<unknown>>, RenderProps<SelectValueRenderProps<T>> {}

--- a/packages/react-aria-components/stories/Select.stories.tsx
+++ b/packages/react-aria-components/stories/Select.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {
-  Button, DEFAULT_SLOT,
+  Button,
   Label,
   ListBox,
   OverlayArrow,

--- a/packages/react-aria-components/stories/Select.stories.tsx
+++ b/packages/react-aria-components/stories/Select.stories.tsx
@@ -10,7 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, Label, ListBox, OverlayArrow, Popover, Select, SelectValue} from 'react-aria-components';
+import {
+  Button, DEFAULT_SLOT,
+  Label,
+  ListBox,
+  OverlayArrow,
+  Popover,
+  Provider,
+  Select,
+  SelectValue,
+  Text, TextContext
+} from 'react-aria-components';
 import {MyListBoxItem} from './utils';
 import React from 'react';
 import styles from '../example/index.css';
@@ -77,6 +87,43 @@ export const SelectManyItems = () => (
       </OverlayArrow>
       <ListBox items={manyItems} className={styles.menu}>
         {item => <MyListBoxItem>{item.name}</MyListBoxItem>}
+      </ListBox>
+    </Popover>
+  </Select>
+);
+
+export const SelectComplexItemsExample = () => (
+  <Select className={styles.select} data-testid="select-example" id="select-example-id">
+    <Label style={{display: 'block'}}>Test</Label>
+    <Button>
+      <SelectValue>
+        {(value) => {
+          return value.isPlaceholder ? 'Select an option...' : (
+            <Provider
+              values={[
+                [TextContext, {
+                  slots: {
+                    label: {className: styles['selected-title']},
+                    description: {className: styles['selected-description']}
+                  }
+                }]
+              ]}>
+              {value.selectedChildren}
+            </Provider>
+          );
+        }}
+      </SelectValue>
+      <span aria-hidden="true" style={{paddingLeft: 5}}>▼</span>
+    </Button>
+    <Popover>
+      <OverlayArrow>
+        <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>
+      </OverlayArrow>
+      <ListBox className={styles.menu}>
+        <MyListBoxItem textValue="Foo by Dre"><Text slot="label">Foo</Text><Text slot="description">by Dre</Text></MyListBoxItem>
+        <MyListBoxItem textValue="Bar by Tiffany's"><Text slot="label">Bar</Text><Text slot="description">by Tiffany's</Text></MyListBoxItem>
+        <MyListBoxItem textValue="Baz by Mark Jacob"><Text slot="label">Baz</Text><Text slot="description">by Mark Jacob</Text></MyListBoxItem>
+        <MyListBoxItem textValue="Google by don't be evil" href="http://google.com"><Text slot="label">Google</Text><Text slot="description">by don't be evil</Text></MyListBoxItem>
       </ListBox>
     </Popover>
   </Select>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

As seen in the story I added, if you don't allow for selectedChildren, and you don't provide a render function, then you'll get the entire rendered item with no ability to access the children.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Only the title should appear in the story, not the description for the selected item

## 🧢 Your Project:

<!--- Company/project for pull request -->
