### PR TITLE
Improve German translations for React Aria tree

### DIFF
--- a/packages/@react-aria/tree/intl/de-DE.json
+++ b/packages/@react-aria/tree/intl/de-DE.json
@@ -1,4 +1,4 @@
 {
   "collapse": "Einklappen",
-  "expand": "Aufklappen"
+  "expand": "Ausklappen"
 }

--- a/packages/@react-aria/tree/intl/de-DE.json
+++ b/packages/@react-aria/tree/intl/de-DE.json
@@ -1,4 +1,4 @@
 {
-  "collapse": "Reduzieren",
-  "expand": "Erweitern"
+  "collapse": "Einklappen",
+  "expand": "Aufklappen"
 }


### PR DESCRIPTION
While the previous translations are technically correct, they do not make a lot of sense in the context they are used. I doubt that vision impaired persons will understand what is meant here when they can't see what's visually on the screen.

The new translations literally mean something like "fold up" and "fold out". Also see https://www.dict.cc/englisch-deutsch/to+expand.html and https://www.dict.cc/englisch-deutsch/to+collapse.html (translations marked with context `[in a tree view]`) as a source to back up my points.
