### PR TITLE
Fix calendar test

### DIFF
--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -328,7 +328,7 @@ describe('Calendar', () => {
     let grid = getByRole('application');
     expect(grid).toHaveAttribute('class', 'grid');
 
-    let cell = within(grid).getAllByRole('button')[7];
+    let cell = within(grid).getAllByRole('button')[8];
     expect(cell).toBeInTheDocument();
 
     await user.click(cell);

--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -304,7 +304,7 @@ describe('Calendar', () => {
     };
 
     let {getByRole} = render(
-      <Calendar aria-label="Appointment date" className="grid">
+      <Calendar aria-label="Appointment date" className="grid" defaultValue={new CalendarDate(2020, 3, 3)}>
         <header>
           <Button slot="previous">◀</Button>
           <Heading />
@@ -328,7 +328,7 @@ describe('Calendar', () => {
     let grid = getByRole('application');
     expect(grid).toHaveAttribute('class', 'grid');
 
-    let cell = within(grid).getAllByRole('button')[8];
+    let cell = within(grid).getAllByRole('button')[7];
     expect(cell).toBeInTheDocument();
 
     await user.click(cell);


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Apparently we can have 7 - 2 (prev/next) = 5 days worth of the previous month. This was only apparent today, though it also happened in Feb. I now set the test to a specific month so we have more predictability

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
