### PR TITLE
Rough fix to make RSP Sections still render a divider if no title is provided

### DIFF
--- a/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
@@ -55,7 +55,7 @@ export function ListBoxSection<T>(props: ListBoxSectionProps<T>) {
               'spectrum-Menu-divider'
             )} />
         }
-        {item.rendered &&
+        {item.rendered && item.rendered !== true &&
           <div
             {...headingProps}
             className={

--- a/packages/@react-stately/collections/src/Section.ts
+++ b/packages/@react-stately/collections/src/Section.ts
@@ -24,7 +24,7 @@ Section.getCollectionNode = function* getCollectionNode<T>(props: SectionProps<T
     type: 'section',
     props: props,
     hasChildNodes: true,
-    rendered: title,
+    rendered: title || true,
     'aria-label': props['aria-label'],
     *childNodes() {
       if (typeof children === 'function') {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
