### PR TITLE
Fix Virtualizer infinite loop for height 0

### DIFF
--- a/packages/@react-spectrum/list/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListView.stories.tsx
@@ -517,3 +517,33 @@ function Demo(props) {
     </ListView>
   );
 }
+
+const manyItems = [];
+for (let i = 0; i < 500; i++) {manyItems.push({key: i, name: `item ${i}`});}
+
+function DisplayNoneComponent(args) {
+  const [isDisplay, setIsDisplay] = useState(false);
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsDisplay(true), 10000);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return (
+    <div style={!isDisplay ? {display: 'none'} : null}>
+      <ListView aria-label="Many items" items={manyItems} width="300px" height="200px" {...args}>
+        {(item: any) => (
+          <Item key={item.key} textValue={item.name}>
+            <Text>
+              {item.name}
+            </Text>
+          </Item>
+        )}
+      </ListView>
+    </div>
+  );
+}
+
+export const DisplayNone: ListViewStory = {
+  render: (args) => <DisplayNoneComponent {...args} />,
+  name: 'display: none with many items'
+};

--- a/packages/@react-stately/virtualizer/src/OverscanManager.ts
+++ b/packages/@react-stately/virtualizer/src/OverscanManager.ts
@@ -17,7 +17,7 @@ export class OverscanManager {
   private startTime = 0;
   private velocity = new Point(0, 0);
   private visibleRect = new Rect();
-  
+
   setVisibleRect(rect: Rect) {
     let time = performance.now() - this.startTime;
     if (time < 500) {
@@ -36,6 +36,9 @@ export class OverscanManager {
 
   getOverscannedRect() {
     let overscanned = this.visibleRect.copy();
+    if (this.visibleRect.height === 0) {
+      return overscanned;
+    }
 
     let overscanY = this.visibleRect.height / 3;
     overscanned.height += overscanY;

--- a/packages/@react-stately/virtualizer/src/OverscanManager.ts
+++ b/packages/@react-stately/virtualizer/src/OverscanManager.ts
@@ -36,9 +36,6 @@ export class OverscanManager {
 
   getOverscannedRect() {
     let overscanned = this.visibleRect.copy();
-    if (this.visibleRect.height === 0) {
-      return overscanned;
-    }
 
     let overscanY = this.visibleRect.height / 3;
     overscanned.height += overscanY;

--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -23,8 +23,8 @@ import {Size} from './Size';
 
 /**
  * The Virtualizer class renders a scrollable collection of data using customizable layouts.
- * It supports very large collections by only rendering visible views to the DOM, reusing 
- * them as you scroll. Virtualizer can present any type of view, including non-item views 
+ * It supports very large collections by only rendering visible views to the DOM, reusing
+ * them as you scroll. Virtualizer can present any type of view, including non-item views
  * such as section headers and footers.
  *
  * Virtualizer uses {@link Layout} objects to compute what views should be visible, and how
@@ -133,7 +133,7 @@ export class Virtualizer<T extends object, V, W> {
    */
   keyAtPoint(point: Point): Key | null {
     let rect = new Rect(point.x, point.y, 1, 1);
-    let layoutInfos = this.layout.getVisibleLayoutInfos(rect);
+    let layoutInfos = rect.height === 0 ? [] : this.layout.getVisibleLayoutInfos(rect);
 
     // Layout may return multiple layout infos in the case of
     // persisted keys, so find the first one that actually intersects.
@@ -180,7 +180,7 @@ export class Virtualizer<T extends object, V, W> {
       rect = this._overscanManager.getOverscannedRect();
     }
 
-    let layoutInfos = this.layout.getVisibleLayoutInfos(rect);
+    let layoutInfos = rect.height === 0 ? [] : this.layout.getVisibleLayoutInfos(rect);
     let map = new Map;
     for (let layoutInfo of layoutInfos) {
       map.set(layoutInfo.key, layoutInfo);
@@ -273,7 +273,7 @@ export class Virtualizer<T extends object, V, W> {
     if (!this.visibleRect.equals(opts.visibleRect)) {
       this._overscanManager.setVisibleRect(opts.visibleRect);
       let shouldInvalidate = this.layout.shouldInvalidate(opts.visibleRect, this.visibleRect);
-  
+
       if (shouldInvalidate) {
         offsetChanged = !opts.visibleRect.pointEquals(this.visibleRect);
         sizeChanged = !opts.visibleRect.sizeEquals(this.visibleRect);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6298
Alternative to https://github.com/adobe/react-spectrum/pull/6357
I believe the issue is that in our layouts, we were calling `isVisible` which checked if the layoutInfo intersects with the visible rect. This always came back as true when the height was 0 because with the display hidden, everything was 0,0. I could fix it in `isVisible`, but then we have to remember it for all other layouts. Instead, in Virtualizer, we just don't fetch any layout infos or do any detection if the height is 0. I don't think we'll want to render anything if the height is 0 anyways, so this should be fine.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
