### PR TITLE
fix(#4967): useNumberField mutates number so screenreader users won’t know that their value has changed

### DIFF
--- a/packages/@react-aria/numberfield/intl/ar-AE.json
+++ b/packages/@react-aria/numberfield/intl/ar-AE.json
@@ -1,5 +1,6 @@
 {
   "decrease": "خفض {fieldLabel}",
   "increase": "زيادة {fieldLabel}",
-  "numberField": "حقل رقمي"
+  "numberField": "حقل رقمي",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/bg-BG.json
+++ b/packages/@react-aria/numberfield/intl/bg-BG.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Намаляване {fieldLabel}",
   "increase": "Усилване {fieldLabel}",
-  "numberField": "Номер на полето"
+  "numberField": "Номер на полето",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/cs-CZ.json
+++ b/packages/@react-aria/numberfield/intl/cs-CZ.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Snížit {fieldLabel}",
   "increase": "Zvýšit {fieldLabel}",
-  "numberField": "Číselné pole"
+  "numberField": "Číselné pole",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/da-DK.json
+++ b/packages/@react-aria/numberfield/intl/da-DK.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Reducer {fieldLabel}",
   "increase": "Øg {fieldLabel}",
-  "numberField": "Talfelt"
+  "numberField": "Talfelt",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/de-DE.json
+++ b/packages/@react-aria/numberfield/intl/de-DE.json
@@ -1,5 +1,6 @@
 {
   "decrease": "{fieldLabel} verringern",
   "increase": "{fieldLabel} erhöhen",
-  "numberField": "Nummernfeld"
+  "numberField": "Nummernfeld",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/el-GR.json
+++ b/packages/@react-aria/numberfield/intl/el-GR.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Μείωση {fieldLabel}",
   "increase": "Αύξηση {fieldLabel}",
-  "numberField": "Πεδίο αριθμού"
+  "numberField": "Πεδίο αριθμού",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/en-US.json
+++ b/packages/@react-aria/numberfield/intl/en-US.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Decrease {fieldLabel}",
   "increase": "Increase {fieldLabel}",
-  "numberField": "Number field"
+  "numberField": "Number field",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/es-ES.json
+++ b/packages/@react-aria/numberfield/intl/es-ES.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Reducir {fieldLabel}",
   "increase": "Aumentar {fieldLabel}",
-  "numberField": "Campo de número"
+  "numberField": "Campo de número",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/et-EE.json
+++ b/packages/@react-aria/numberfield/intl/et-EE.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Vähenda {fieldLabel}",
   "increase": "Suurenda {fieldLabel}",
-  "numberField": "Numbri väli"
+  "numberField": "Numbri väli",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/fi-FI.json
+++ b/packages/@react-aria/numberfield/intl/fi-FI.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Vähennä {fieldLabel}",
   "increase": "Lisää {fieldLabel}",
-  "numberField": "Numerokenttä"
+  "numberField": "Numerokenttä",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/fr-FR.json
+++ b/packages/@react-aria/numberfield/intl/fr-FR.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Diminuer {fieldLabel}",
   "increase": "Augmenter {fieldLabel}",
-  "numberField": "Champ de nombre"
+  "numberField": "Champ de nombre",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/he-IL.json
+++ b/packages/@react-aria/numberfield/intl/he-IL.json
@@ -1,5 +1,6 @@
 {
   "decrease": "הקטן {fieldLabel}",
   "increase": "הגדל {fieldLabel}",
-  "numberField": "שדה מספר"
+  "numberField": "שדה מספר",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/hr-HR.json
+++ b/packages/@react-aria/numberfield/intl/hr-HR.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Smanji {fieldLabel}",
   "increase": "Povećaj {fieldLabel}",
-  "numberField": "Polje broja"
+  "numberField": "Polje broja",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/hu-HU.json
+++ b/packages/@react-aria/numberfield/intl/hu-HU.json
@@ -1,5 +1,6 @@
 {
   "decrease": "{fieldLabel} csökkentése",
   "increase": "{fieldLabel} növelése",
-  "numberField": "Számmező"
+  "numberField": "Számmező",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/it-IT.json
+++ b/packages/@react-aria/numberfield/intl/it-IT.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Riduci {fieldLabel}",
   "increase": "Aumenta {fieldLabel}",
-  "numberField": "Campo numero"
+  "numberField": "Campo numero",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/ja-JP.json
+++ b/packages/@react-aria/numberfield/intl/ja-JP.json
@@ -1,5 +1,6 @@
 {
   "decrease": "{fieldLabel}を縮小",
   "increase": "{fieldLabel}を拡大",
-  "numberField": "数値フィールド"
+  "numberField": "数値フィールド",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/ko-KR.json
+++ b/packages/@react-aria/numberfield/intl/ko-KR.json
@@ -1,5 +1,6 @@
 {
   "decrease": "{fieldLabel} 감소",
   "increase": "{fieldLabel} 증가",
-  "numberField": "번호 필드"
+  "numberField": "번호 필드",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/lt-LT.json
+++ b/packages/@react-aria/numberfield/intl/lt-LT.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Sumažinti {fieldLabel}",
   "increase": "Padidinti {fieldLabel}",
-  "numberField": "Numerio laukas"
+  "numberField": "Numerio laukas",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/lv-LV.json
+++ b/packages/@react-aria/numberfield/intl/lv-LV.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Samazināšana {fieldLabel}",
   "increase": "Palielināšana {fieldLabel}",
-  "numberField": "Skaitļu lauks"
+  "numberField": "Skaitļu lauks",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/nb-NO.json
+++ b/packages/@react-aria/numberfield/intl/nb-NO.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Reduser {fieldLabel}",
   "increase": "Øk {fieldLabel}",
-  "numberField": "Tallfelt"
+  "numberField": "Tallfelt",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/nl-NL.json
+++ b/packages/@react-aria/numberfield/intl/nl-NL.json
@@ -1,5 +1,6 @@
 {
   "decrease": "{fieldLabel} verlagen",
   "increase": "{fieldLabel} verhogen",
-  "numberField": "Getalveld"
+  "numberField": "Getalveld",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/pl-PL.json
+++ b/packages/@react-aria/numberfield/intl/pl-PL.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Zmniejsz {fieldLabel}",
   "increase": "Zwiększ {fieldLabel}",
-  "numberField": "Pole numeru"
+  "numberField": "Pole numeru",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/pt-BR.json
+++ b/packages/@react-aria/numberfield/intl/pt-BR.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Diminuir {fieldLabel}",
   "increase": "Aumentar {fieldLabel}",
-  "numberField": "Campo de número"
+  "numberField": "Campo de número",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/pt-PT.json
+++ b/packages/@react-aria/numberfield/intl/pt-PT.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Diminuir {fieldLabel}",
   "increase": "Aumentar {fieldLabel}",
-  "numberField": "Campo numérico"
+  "numberField": "Campo numérico",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/ro-RO.json
+++ b/packages/@react-aria/numberfield/intl/ro-RO.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Scădere {fieldLabel}",
   "increase": "Creștere {fieldLabel}",
-  "numberField": "Câmp numeric"
+  "numberField": "Câmp numeric",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/ru-RU.json
+++ b/packages/@react-aria/numberfield/intl/ru-RU.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Уменьшение {fieldLabel}",
   "increase": "Увеличение {fieldLabel}",
-  "numberField": "Числовое поле"
+  "numberField": "Числовое поле",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/sk-SK.json
+++ b/packages/@react-aria/numberfield/intl/sk-SK.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Znížiť {fieldLabel}",
   "increase": "Zvýšiť {fieldLabel}",
-  "numberField": "Číselné pole"
+  "numberField": "Číselné pole",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/sl-SI.json
+++ b/packages/@react-aria/numberfield/intl/sl-SI.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Upadati {fieldLabel}",
   "increase": "Povečajte {fieldLabel}",
-  "numberField": "Številčno polje"
+  "numberField": "Številčno polje",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/sr-SP.json
+++ b/packages/@react-aria/numberfield/intl/sr-SP.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Smanji {fieldLabel}",
   "increase": "Povećaj {fieldLabel}",
-  "numberField": "Polje broja"
+  "numberField": "Polje broja",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/sv-SE.json
+++ b/packages/@react-aria/numberfield/intl/sv-SE.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Minska {fieldLabel}",
   "increase": "Öka {fieldLabel}",
-  "numberField": "Nummerfält"
+  "numberField": "Nummerfält",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/tr-TR.json
+++ b/packages/@react-aria/numberfield/intl/tr-TR.json
@@ -1,5 +1,6 @@
 {
   "decrease": "{fieldLabel} azalt",
   "increase": "{fieldLabel} arttır",
-  "numberField": "Sayı alanı"
+  "numberField": "Sayı alanı",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/uk-UA.json
+++ b/packages/@react-aria/numberfield/intl/uk-UA.json
@@ -1,5 +1,6 @@
 {
   "decrease": "Зменшити {fieldLabel}",
   "increase": "Збільшити {fieldLabel}",
-  "numberField": "Поле номера"
+  "numberField": "Поле номера",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/zh-CN.json
+++ b/packages/@react-aria/numberfield/intl/zh-CN.json
@@ -1,5 +1,6 @@
 {
   "decrease": "降低 {fieldLabel}",
   "increase": "提高 {fieldLabel}",
-  "numberField": "数字字段"
+  "numberField": "数字字段",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/intl/zh-TW.json
+++ b/packages/@react-aria/numberfield/intl/zh-TW.json
@@ -1,5 +1,6 @@
 {
   "decrease": "縮小 {fieldLabel}",
   "increase": "放大 {fieldLabel}",
-  "numberField": "數字欄位"
+  "numberField": "數字欄位",
+  "pastedValue": "Pasted value: {value}"
 }

--- a/packages/@react-aria/numberfield/package.json
+++ b/packages/@react-aria/numberfield/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@react-aria/i18n": "^3.11.1",
     "@react-aria/interactions": "^3.21.3",
+    "@react-aria/live-announcer": "^3.3.4",
     "@react-aria/spinbutton": "^3.6.5",
     "@react-aria/textfield": "^3.14.5",
     "@react-aria/utils": "^3.24.1",

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -10,11 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+import { announce } from '@react-aria/live-announcer';
 import {AriaButtonProps} from '@react-types/button';
 import {AriaNumberFieldProps} from '@react-types/numberfield';
 import {chain, filterDOMProps, isAndroid, isIOS, isIPhone, mergeProps, useFormReset, useId} from '@react-aria/utils';
-import {DOMAttributes, GroupDOMAttributes, TextInputDOMProps, ValidationResult} from '@react-types/shared';
 import {
+  type ClipboardEvent,
+  type ClipboardEventHandler,
   InputHTMLAttributes,
   LabelHTMLAttributes,
   RefObject,
@@ -22,6 +24,7 @@ import {
   useMemo,
   useState
 } from 'react';
+import {DOMAttributes, GroupDOMAttributes, TextInputDOMProps, ValidationResult} from '@react-types/shared';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {NumberFieldState} from '@react-stately/numberfield';
@@ -181,6 +184,25 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
     }
   };
 
+  let onPaste: ClipboardEventHandler<HTMLInputElement> = (e: ClipboardEvent<HTMLInputElement>) => {
+    props.onPaste?.(e);
+    let inputElement = e.target as HTMLInputElement;
+    if (inputElement && (inputElement.selectionEnd - inputElement.selectionStart) === inputElement.value.length) {
+      e.preventDefault();
+      let pastedText = e.clipboardData?.getData?.('text/plain')?.trim() ?? '';
+      let value = state.parseValueInAnySupportedLocale(pastedText);
+      if (!isNaN(value)) {
+        let reformattedValue = numberFormatter.format(value);
+        if (state.validate(reformattedValue)) {
+          state.setInputValue(reformattedValue);
+          if (reformattedValue !== pastedText) {
+            announce(stringFormatter.format('pastedValue', {value: reformattedValue}), 'polite');
+          }
+        }
+      }
+    }
+  };
+
   let domProps = filterDOMProps(props);
   let onKeyDownEnter = useCallback((e) => {
     if (e.key === 'Enter') {
@@ -217,6 +239,7 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
     onFocusChange,
     onKeyDown: useMemo(() => chain(onKeyDownEnter, onKeyDown), [onKeyDownEnter, onKeyDown]),
     onKeyUp,
+    onPaste,
     description,
     errorMessage
   }, state, inputRef);

--- a/packages/@react-stately/numberfield/package.json
+++ b/packages/@react-stately/numberfield/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@internationalized/number": "^3.5.3",
+    "@react-aria/live-announcer": "^3.3.4",
     "@react-stately/form": "^3.0.3",
     "@react-stately/utils": "^3.10.1",
     "@react-types/numberfield": "^3.8.3",

--- a/packages/@react-stately/numberfield/src/useNumberFieldState.ts
+++ b/packages/@react-stately/numberfield/src/useNumberFieldState.ts
@@ -15,6 +15,45 @@ import {FormValidationState, useFormValidationState} from '@react-stately/form';
 import {NumberFieldProps} from '@react-types/numberfield';
 import {NumberFormatter, NumberParser} from '@internationalized/number';
 import {useCallback, useMemo, useState} from 'react';
+import { parse } from 'yargs';
+
+let supportedLocales: string[] = [
+  'ar-AE', // Arabic (United Arab Emirates)
+  'bg-BG', // Bulgarian (Bulgaria)
+  'zh-CN', // Chinese (Simplified)
+  'zh-TW', // Chinese (Traditional)
+  'hr-HR', // Croatian (Croatia)
+  'cs-CZ', // Czech (Czech Republic)
+  'da-DK', // Danish (Denmark)
+  'nl-NL', // Dutch (Netherlands)
+  'en-GB', // English (Great Britain)
+  'en-US', // English (United States)
+  'et-EE', // Estonian (Estonia)
+  'fi-FI', // Finnish (Finland)
+  'fr-CA', // French (Canada)
+  'fr-FR', // French (France)
+  'de-DE', // German (Germany)
+  'el-GR', // Greek (Greece)
+  'he-IL', // Hebrew (Israel)
+  'hu-HU', // Hungarian (Hungary)
+  'it-IT', // Italian (Italy)
+  'ja-JP', // Japanese (Japan)
+  'ko-KR', // Korean (Korea)
+  'lv-LV', // Latvian (Latvia)
+  'lt-LT', // Lithuanian (Lithuania)
+  'no-NO', // Norwegian (Norway)
+  'pl-PL', // Polish (Poland)
+  'pt-BR', // Portuguese (Brazil)
+  'ro-RO', // Romanian (Romania)
+  'ru-RU', // Russian (Russia)
+  'sr-RS', // Serbian (Serbia)
+  'sk-SK', // Slovakian (Slovakia)
+  'sl-SI', // Slovenian (Slovenia)
+  'es-ES', // Spanish (Spain)
+  'sv-SE', // Swedish (Sweden)
+  'tr-TR', // Turkish (Turkey)
+  'uk-UA'  // Ukrainian (Ukraine)
+];
 
 export interface NumberFieldState extends FormValidationState {
   /**
@@ -59,7 +98,12 @@ export interface NumberFieldState extends FormValidationState {
   /** Sets the current value to the `maxValue` if any, and fires `onChange`. */
   incrementToMax(): void,
   /** Sets the current value to the `minValue` if any, and fires `onChange`. */
-  decrementToMin(): void
+  decrementToMin(): void,
+  /**
+   * Parses a string value in any supported locale to a number.
+   * This is useful when the user pastes a value that may be in a different locale.
+   */
+  parseValueInAnySupportedLocale(value: string): number
 }
 
 export interface NumberFieldStateOptions extends NumberFieldProps {
@@ -261,6 +305,44 @@ export function useNumberFieldState(
 
   let validate = (value: string) => numberParser.isValidPartialNumber(value, minValue, maxValue);
 
+  let parseValueInAnySupportedLocale = (value: string) => {
+    let locales = supportedLocales.filter(localeCode => localeCode !== locale);
+    locales.unshift(locale);
+    let localeCodes = locales.map(localeCode => {
+      let numberFormatter = new NumberFormatter(localeCode, formatOptions);
+      return {
+        locale: localeCode,
+        groupSeparator: numberFormatter.formatToParts(1111).find(part => part.type === 'group')?.value,
+        decimalSeparator: numberFormatter.formatToParts(1.1).find(part => part.type === 'decimal')?.value
+      };
+    });
+
+    let _parsedValue = NaN;
+    for (let localeCode of localeCodes) {
+      let _numberParser = new NumberParser(localeCode.locale, formatOptions);
+      if (
+        (
+          value.includes(localeCode.groupSeparator) ||
+          value.includes(localeCode.decimalSeparator)
+        ) &&
+        value.lastIndexOf(localeCode.groupSeparator) > value.lastIndexOf(localeCode.decimalSeparator)
+      ) {
+        if (value.lastIndexOf(localeCode.decimalSeparator) === -1) {
+          let pv = _numberParser.parse(value.replaceAll(localeCode.groupSeparator, ''));
+          if (!isNaN(pv) && parseFloat(value.replaceAll(localeCode.groupSeparator, '')) === pv) {
+            return pv;
+          }
+        }
+        continue;
+      }
+      _parsedValue = _numberParser.parse(value.replaceAll(localeCode.groupSeparator, ''));
+      if (!isNaN(_parsedValue)) {
+        return _parsedValue;
+      }
+    }
+    return _parsedValue;
+  };
+
   return {
     ...validation,
     validate,
@@ -276,7 +358,8 @@ export function useNumberFieldState(
     setNumberValue,
     setInputValue,
     inputValue,
-    commit
+    commit,
+    parseValueInAnySupportedLocale
   };
 }
 

--- a/packages/react-aria-components/test/NumberField.test.js
+++ b/packages/react-aria-components/test/NumberField.test.js
@@ -182,4 +182,44 @@ describe('NumberField', () => {
     expect(input).not.toHaveAttribute('aria-describedby');
     expect(numberfield).not.toHaveAttribute('data-invalid');
   });
+
+  it('supports pasting value in another format', async () => {
+    let {getByRole, rerender} = render(<TestNumberField />);
+    let input = getByRole('textbox');
+    act(() => {
+      input.focus();
+      input.setSelectionRange(0, input.value.length);
+    });
+    await userEvent.paste('3.000.000,25');
+    expect(input).toHaveValue('3,000,000.25');
+
+    act(() => {
+      input.setSelectionRange(0, input.value.length);
+    });
+    await userEvent.paste('3 000 000,25');
+    expect(input).toHaveValue('3,000,000.25');
+
+    rerender(<TestNumberField formatOptions={{style: 'currency', currency: 'USD'}} />);
+    act(() => {
+      input.setSelectionRange(0, input.value.length);
+    });
+    await userEvent.paste('3 000 000,256789');
+    expect(input).toHaveValue('$3,000,000.26');
+
+    act(() => {
+      input.setSelectionRange(0, input.value.length);
+    });
+    await userEvent.paste('1 000');
+    expect(input).toHaveValue('$1,000.00');
+
+    act(() => {
+      input.setSelectionRange(0, input.value.length);
+    });
+
+    await userEvent.paste('1,000');
+    expect(input).toHaveValue('$1,000.00', 'Ambiguous value should be parsed using the current locale');
+
+    await userEvent.paste('1.000');
+    expect(input).toHaveValue('$1.00', 'Ambiguous value should be parsed using the current locale');
+  });
 });


### PR DESCRIPTION
Closes #4967

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue #4967](https://github.com/adobe/react-spectrum/issue/4967).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Improves behavior when pasting a value from a different locale into a NumberField.

A pasted string containing groups and a decimal, like "3 000 000.25", "3,000,000.25" or "3.000.000,25", will now attempt to parse using supported locales rather than only parsing using the current locale.

Where there is ambiguity, as with "1,000" or "1.000", the pasted value will be parsed using the current locale. For example, "1.000" will be interpreted as "1" in en-US, and "1,000" will be "1" in de-DE.

If the pasted text is different from the resulting input text, the screen reader should announce "Pasted value: {value}" politely, so that the user hears the new value.

## 🧢 Your Project:

Adobe/Accessibility