### PR TITLE
Cap overlay max height to 100vh on initial render

### DIFF
--- a/packages/@react-aria/overlays/src/useOverlayPosition.ts
+++ b/packages/@react-aria/overlays/src/useOverlayPosition.ts
@@ -250,7 +250,7 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
         position: 'absolute',
         zIndex: 100000, // should match the z-index in ModalTrigger
         ...position.position,
-        maxHeight: position.maxHeight
+        maxHeight: position.maxHeight ?? '100vh'
       }
     },
     placement: position.placement,


### PR DESCRIPTION
This fixes the performance issue introduced by #6451 when opening a ComboBox or Picker (or any virtualized collection inside a popover). Since virtualizer layout occurs during render, it can now occur prior to the popover being fully positioned. Without a max-height, this resulted in all collection items being rendered to the DOM. We already cap the max-height to the size of the viewport just before positioning, but didn't have any max-height before that (in the initial render). Adding `100vh` here fixes the problem. 🤞 that it doesn't break anything else.