### PR TITLE
fix: SingleSelectListState.selectedItem type should be nullable

### DIFF
--- a/packages/@react-stately/list/src/useSingleSelectListState.ts
+++ b/packages/@react-stately/list/src/useSingleSelectListState.ts
@@ -30,7 +30,7 @@ export interface SingleSelectListState<T> extends ListState<T> {
   setSelectedKey(key: Key | null): void,
 
   /** The value of the currently selected item. */
-  readonly selectedItem: Node<T>
+  readonly selectedItem: Node<T> | null
 }
 
 /**


### PR DESCRIPTION
The `SingleSelectListState<T>.selectedItem` type should be nullable as the `useSingleSelectListState` is assigning it to null where there is no default `selectedKey` as seen below.

```tsx
  let selectedItem = selectedKey != null
    ? collection.getItem(selectedKey)
    : null;
```

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
