### PR TITLE
fix: client-navigation on MenuItem

### DIFF
--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -276,7 +276,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
       ...ariaProps,
       ...mergeProps(domProps, linkProps, isTrigger ? {onFocus: itemProps.onFocus, 'data-key': itemProps['data-key']} : itemProps, pressProps, hoverProps, keyboardProps, focusProps),
       tabIndex: itemProps.tabIndex != null ? -1 : undefined,
-      onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+      onClick: (e: React.MouseEvent<HTMLElement>) => {
         pressProps.onClick?.(e);
 
         // If a custom router is provided, prevent default and forward if this link should client navigate.


### PR DESCRIPTION
I simply copied the code from the `useLink` hook. This was enough to unblock myself for now.

I wonder if there are more similar cases across the codebase and if it would make sense to extract this to a helper.

The most important part here is that `e.preventDefault()` is getting called which is only possible by hooking into the native event. Maybe client-side router integration is also something which could be handled as part of `usePress` already but I'm not entirely sure if this makes sense.

I'm open to suggestions to better generalize this fix!

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Set `href` on a `MenuItem` wrapped inside `RouterProvider`. Full page load triggered before.

