### PR TITLE
Fix incremental layout with variable heights

### DIFF
--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -237,7 +237,7 @@ export class TableLayout<T> extends ListLayout<T> {
       let rowHeight = (this.rowHeight ?? this.estimatedRowHeight) + 1;
 
       // Skip rows before the valid rectangle unless they are already cached.
-      if (y + rowHeight < this.validRect.y && !this.isValid(node, y)) {
+      if (y + rowHeight < this.requestedRect.y && !this.isValid(node, y)) {
         y += rowHeight;
         skipped++;
         continue;
@@ -250,7 +250,7 @@ export class TableLayout<T> extends ListLayout<T> {
       width = Math.max(width, layoutNode.layoutInfo.rect.width);
       children.push(layoutNode);
 
-      if (y > this.validRect.maxY) {
+      if (y > this.requestedRect.maxY) {
         // Estimate the remaining height for rows that we don't need to layout right now.
         y += (this.collection.size - (skipped + children.length)) * rowHeight;
         break;
@@ -290,7 +290,7 @@ export class TableLayout<T> extends ListLayout<T> {
     return {
       layoutInfo,
       children,
-      validRect: layoutInfo.rect.intersection(this.validRect)
+      validRect: layoutInfo.rect.intersection(this.requestedRect)
     };
   }
 
@@ -318,7 +318,7 @@ export class TableLayout<T> extends ListLayout<T> {
     let height = 0;
     for (let [i, child] of [...getChildNodes(node, this.collection)].entries()) {
       if (child.type === 'cell') {
-        if (x > this.validRect.maxX) {
+        if (x > this.requestedRect.maxX) {
           // Adjust existing cached layoutInfo to ensure that it is out of view.
           // This can happen due to column resizing.
           let layoutNode = this.layoutNodes.get(child.key);
@@ -344,7 +344,7 @@ export class TableLayout<T> extends ListLayout<T> {
     return {
       layoutInfo,
       children,
-      validRect: rect.intersection(this.validRect)
+      validRect: rect.intersection(this.requestedRect)
     };
   }
 

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -229,22 +229,35 @@ ListBoxGrid.story = {
   }
 };
 
-export function VirtualizedListBox() {
+function generateRandomString(minLength: number, maxLength: number): string {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const length = Math.floor(Math.random() * (maxLength - minLength + 1)) + minLength;
+
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+
+  return result;
+}
+
+export function VirtualizedListBox({variableHeight}) {
   let sections: {id: string, name: string, children: {id: string, name: string}[]}[] = [];
   for (let s = 0; s < 10; s++) {
     let items: {id: string, name: string}[] = [];
     for (let i = 0; i < 100; i++) {
-      items.push({id: `item_${s}_${i}`, name: `Item ${i}`});
+      const l = (s * 5) + i + 10;
+      items.push({id: `item_${s}_${i}`, name: `Section ${s}, Item ${i}${variableHeight ? ' ' + generateRandomString(l, l) : ''}`});
     }
     sections.push({id: `section_${s}`, name: `Section ${s}`, children: items});
   }
 
   let layout = useMemo(() => {
     return new ListLayout({
-      rowHeight: 25,
+      [variableHeight ? 'estimatedRowHeight' : 'rowHeight']: 25,
       estimatedHeadingHeight: 26
     });
-  }, []);
+  }, [variableHeight]);
 
   return (
     <Virtualizer layout={layout}>
@@ -261,6 +274,10 @@ export function VirtualizedListBox() {
     </Virtualizer>
   );
 }
+
+VirtualizedListBox.args = {
+  variableHeight: false
+};
 
 export function VirtualizedListBoxEmpty() {
   let layout = useMemo(() => {

--- a/packages/react-aria-components/stories/utils.tsx
+++ b/packages/react-aria-components/stories/utils.tsx
@@ -7,6 +7,7 @@ export const MyListBoxItem = (props: ListBoxItemProps) => {
   return (
     <ListBoxItem
       {...props}
+      style={{wordBreak: 'break-word'}}
       className={({isFocused, isSelected, isHovered}) => classNames(styles, 'item', {
         focused: isFocused,
         selected: isSelected,


### PR DESCRIPTION
Reported by @rostero1 in https://github.com/adobe/react-spectrum/pull/6518#issuecomment-2178438003

In ListLayout with variable row heights, sometimes a large empty space could appear at the end of the list. This was due to the `validRect` not being invalidated properly when the height of an item changed. When this occurs, all items after that item need to be repositioned.

For clarity, I've also renamed two properties:

* `lastValidRect` is now called `validRect` - this is the rectangle that is currently valid. We can reuse previously laid out items within this rectangle.
* `validRect` is now called `requestedRect` - this is the rectangle that has been requested for layout so far. After a layout pass, `validRect` will equal `requestedRect`.