### PR TITLE
Additionally pass `routerOptions` to `useHref`

### DIFF
--- a/packages/@react-aria/utils/src/openLink.tsx
+++ b/packages/@react-aria/utils/src/openLink.tsx
@@ -18,7 +18,7 @@ import React, {createContext, ReactNode, useContext, useMemo} from 'react';
 interface Router {
   isNative: boolean,
   open: (target: Element, modifiers: Modifiers, href: Href, routerOptions: RouterOptions | undefined) => void,
-  useHref: (href: Href) => string
+  useHref: (href: Href, routerOptions: RouterOptions | undefined) => string
 }
 
 const RouterContext = createContext<Router>({
@@ -29,7 +29,7 @@ const RouterContext = createContext<Router>({
 
 interface RouterProviderProps {
   navigate: (path: Href, routerOptions: RouterOptions | undefined) => void,
-  useHref?: (href: Href) => string,
+  useHref?: (href: Href, routerOptions: RouterOptions | undefined) => string,
   children: ReactNode
 }
 
@@ -149,7 +149,7 @@ function openSyntheticLink(target: Element, modifiers: Modifiers) {
 export function useSyntheticLinkProps(props: LinkDOMProps) {
   let router = useRouter();
   return {
-    'data-href': props.href ? router.useHref(props.href) : undefined,
+    'data-href': props.href ? router.useHref(props.href, props.routerOptions) : undefined,
     'data-target': props.target,
     'data-rel': props.rel,
     'data-download': props.download,
@@ -161,7 +161,7 @@ export function useSyntheticLinkProps(props: LinkDOMProps) {
 export function useLinkProps(props: LinkDOMProps) {
   let router = useRouter();
   return {
-    href: props?.href ? router.useHref(props?.href) : undefined,
+    href: props?.href ? router.useHref(props?.href, props?.routerOptions) : undefined,
     target: props?.target,
     rel: props?.rel,
     download: props?.download,

--- a/packages/@react-types/provider/src/index.d.ts
+++ b/packages/@react-types/provider/src/index.d.ts
@@ -58,7 +58,7 @@ interface ContextProps {
 
 interface Router {
   navigate: (path: string, routerOptions: RouterOptions | undefined) => void,
-  useHref?: (href: Href) => string
+  useHref?: (href: Href, routerOptions: RouterOptions | undefined) => string
 }
 
 export interface ProviderProps extends ContextProps, DOMProps, StyleProps {

--- a/packages/dev/docs/pages/react-aria/routing.mdx
+++ b/packages/dev/docs/pages/react-aria/routing.mdx
@@ -288,7 +288,7 @@ function RootRoute() {
   return (
     <RouterProvider 
       navigate={(to, options) => router.navigate({to, ...options})}
-      useHref={to => router.buildLocation(to).href}>
+      useHref={(to, options) => router.buildLocation({to, ...options}).href}>
       {/* ...*/}
     </RouterProvider>
   );

--- a/packages/dev/docs/pages/react-spectrum/routing.mdx
+++ b/packages/dev/docs/pages/react-spectrum/routing.mdx
@@ -292,7 +292,7 @@ function RootRoute() {
       theme={defaultTheme}
       router={{
         navigate: (to, options) => router.navigate({to, ...options}),
-        useHref: to => router.buildLocation(to).href
+        useHref: (to, options) => router.buildLocation({to, ...options}).href
       }}>
       {/* ...*/}
     </Provider>


### PR DESCRIPTION
Closes #6587

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Add `console.log(to, options)` inside `useHref`

