### PR TITLE
Fix clipping on last table resize nubbin

### DIFF
--- a/packages/@react-spectrum/table/src/TableViewBase.tsx
+++ b/packages/@react-spectrum/table/src/TableViewBase.tsx
@@ -695,7 +695,7 @@ function TableVirtualizer<T>(props: TableVirtualizerProps<T>) {
 function useStyle(layoutInfo: LayoutInfo, parent: LayoutInfo | null) {
   let {direction} = useLocale();
   let style = layoutInfoToStyle(layoutInfo, direction, parent);
-  if (style.overflow === 'hidden') {
+  if (style.overflow === 'clip') {
     style.overflow = 'visible'; // needed to support position: sticky
   }
   return style;

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -45,7 +45,7 @@ export class TableLayout<T> extends ListLayout<T> {
   }
 
   private columnsChanged(newCollection: TableCollection<T>, oldCollection: TableCollection<T> | null) {
-    return !oldCollection || 
+    return !oldCollection ||
       newCollection.columns !== oldCollection.columns &&
       newCollection.columns.length !== oldCollection.columns.length ||
       newCollection.columns.some((c, i) =>
@@ -152,7 +152,7 @@ export class TableLayout<T> extends ListLayout<T> {
     this.setChildHeights(columns, height);
 
     rect.height = height;
-    rect.width = x;
+    rect.width = Math.max(this.virtualizer.visibleRect.width, x);
 
     return {
       layoutInfo: row,

--- a/packages/@react-stately/layout/src/TableLayout.ts
+++ b/packages/@react-stately/layout/src/TableLayout.ts
@@ -152,7 +152,7 @@ export class TableLayout<T> extends ListLayout<T> {
     this.setChildHeights(columns, height);
 
     rect.height = height;
-    rect.width = Math.max(this.virtualizer.visibleRect.width, x);
+    rect.width = x;
 
     return {
       layoutInfo: row,


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Found in testing

The way I fixed this actually has an interesting side effect. Now when you shrink the entire table to be less than the width, the horizontal dividers don't end early. This have been asked for before, so I'm putting up this as a solution.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
