### PR TITLE
Fix SelectAll logic for falsy keys

### DIFF
--- a/packages/@react-stately/selection/src/SelectionManager.ts
+++ b/packages/@react-stately/selection/src/SelectionManager.ts
@@ -376,7 +376,7 @@ export class SelectionManager implements MultipleSelectionManager {
   private getSelectAllKeys() {
     let keys: Key[] = [];
     let addKeys = (key: Key) => {
-      while (key) {
+      while (key != null) {
         if (this.canSelectItem(key)) {
           let item = this.collection.getItem(key);
           if (item.type === 'item') {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Found while testing https://github.com/adobe/react-spectrum/pull/6631 where selecting the first item in the Virtualized Table would cause the select all checkmark to render checked instead of indeterminate

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
