### PR TITLE
add excludeFromTabOrder prop for Link and RadioGroup

### DIFF
--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -74,16 +74,17 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
     }
   });
 
-  let {name, descriptionId, errorMessageId, validationBehavior, excludeFromTabOrder} = radioGroupData.get(state)!;
-  let {focusableProps} = useFocusable(mergeProps({...props, excludeFromTabOrder}, {
+  let {focusableProps} = useFocusable(mergeProps(props, {
     onFocus: () => state.setLastFocusedValue(value)
   }), ref);
   let interactions = mergeProps(pressProps, focusableProps);
   let domProps = filterDOMProps(props, {labelable: true});
+  let {name, descriptionId, errorMessageId, validationBehavior, excludeFromTabOrder} = radioGroupData.get(state)!;
+
+  // A radio should only be tabbable if it's the currently selected value or if no value has been selected yet in the group.
   let tabIndex: number | undefined = -1;
-  if (interactions.tabIndex) {
-    tabIndex = interactions.tabIndex;
-  } else {
+
+  if (!excludeFromTabOrder && !isDisabled) {
     if (state.selectedValue != null) {
       if (state.selectedValue === value) {
         tabIndex = 0;
@@ -91,9 +92,8 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
     } else if (state.lastFocusedValue === value || state.lastFocusedValue == null) {
       tabIndex = 0;
     }
-    if (isDisabled) {
-      tabIndex = undefined;
-    }
+  } else if (isDisabled) {
+    tabIndex = undefined;
   }
 
   useFormReset(ref, state.selectedValue, state.setSelectedValue);

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -74,7 +74,8 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
     }
   });
 
-  let {focusableProps} = useFocusable(mergeProps(props, {
+  let {name, descriptionId, errorMessageId, validationBehavior, excludeFromTabOrder} = radioGroupData.get(state)!;
+  let {focusableProps} = useFocusable(mergeProps({...props, excludeFromTabOrder}, {
     onFocus: () => state.setLastFocusedValue(value)
   }), ref);
   let interactions = mergeProps(pressProps, focusableProps);
@@ -95,7 +96,6 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
     }
   }
 
-  let {name, descriptionId, errorMessageId, validationBehavior} = radioGroupData.get(state)!;
   useFormReset(ref, state.selectedValue, state.setSelectedValue);
   useFormValidation({validationBehavior}, state, ref);
 

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -80,15 +80,19 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
   let interactions = mergeProps(pressProps, focusableProps);
   let domProps = filterDOMProps(props, {labelable: true});
   let tabIndex: number | undefined = -1;
-  if (state.selectedValue != null) {
-    if (state.selectedValue === value) {
+  if (interactions.tabIndex) {
+    tabIndex = interactions.tabIndex;
+  } else {
+    if (state.selectedValue != null) {
+      if (state.selectedValue === value) {
+        tabIndex = 0;
+      }
+    } else if (state.lastFocusedValue === value || state.lastFocusedValue == null) {
       tabIndex = 0;
     }
-  } else if (state.lastFocusedValue === value || state.lastFocusedValue == null) {
-    tabIndex = 0;
-  }
-  if (isDisabled) {
-    tabIndex = undefined;
+    if (isDisabled) {
+      tabIndex = undefined;
+    }
   }
 
   let {name, descriptionId, errorMessageId, validationBehavior} = radioGroupData.get(state)!;

--- a/packages/@react-aria/radio/src/useRadioGroup.ts
+++ b/packages/@react-aria/radio/src/useRadioGroup.ts
@@ -44,7 +44,8 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
     isRequired,
     isDisabled,
     orientation = 'vertical',
-    validationBehavior = 'aria'
+    validationBehavior = 'aria',
+    excludeFromTabOrder
   } = props;
   let {direction} = useLocale();
 
@@ -128,7 +129,8 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
     name: groupName,
     descriptionId: descriptionProps.id,
     errorMessageId: errorMessageProps.id,
-    validationBehavior
+    validationBehavior,
+    excludeFromTabOrder: excludeFromTabOrder
   });
 
   return {

--- a/packages/@react-aria/radio/src/utils.ts
+++ b/packages/@react-aria/radio/src/utils.ts
@@ -16,7 +16,8 @@ interface RadioGroupData {
   name: string,
   descriptionId: string | undefined,
   errorMessageId: string | undefined,
-  validationBehavior: 'aria' | 'native'
+  validationBehavior: 'aria' | 'native',
+  excludeFromTabOrder?: boolean
 }
 
 export const radioGroupData = new WeakMap<RadioGroupState, RadioGroupData>();

--- a/packages/@react-stately/radio/src/useRadioGroupState.ts
+++ b/packages/@react-stately/radio/src/useRadioGroupState.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import {AriaRadioGroupProps} from '@react-types/radio';
 import {FormValidationState, useFormValidationState} from '@react-stately/form';
-import {RadioGroupProps} from '@react-types/radio';
 import {useControlledState} from '@react-stately/utils';
 import {useMemo, useState} from 'react';
 import {ValidationState} from '@react-types/shared';
@@ -52,7 +52,10 @@ export interface RadioGroupState extends FormValidationState {
   readonly lastFocusedValue: string | null,
 
   /** Sets the last focused value. */
-  setLastFocusedValue(value: string | null): void
+  setLastFocusedValue(value: string | null): void,
+
+  /** Whether the radio group is excluded from the sequential tab order. */
+  excludeFromTabOrder?: boolean
 }
 
 let instance = Math.round(Math.random() * 10000000000);
@@ -62,7 +65,7 @@ let i = 0;
  * Provides state management for a radio group component. Provides a name for the group,
  * and manages selection and focus state.
  */
-export function useRadioGroupState(props: RadioGroupProps): RadioGroupState  {
+export function useRadioGroupState(props: AriaRadioGroupProps): RadioGroupState  {
   // Preserved here for backward compatibility. React Aria now generates the name instead of stately.
   let name = useMemo(() => props.name || `radio-group-${instance}-${++i}`, [props.name]);
   let [selectedValue, setSelected] = useControlledState(props.value, props.defaultValue ?? null, props.onChange);
@@ -93,6 +96,7 @@ export function useRadioGroupState(props: RadioGroupProps): RadioGroupState  {
     isReadOnly: props.isReadOnly || false,
     isRequired: props.isRequired || false,
     validationState: props.validationState || (isInvalid ? 'invalid' : null),
-    isInvalid
+    isInvalid,
+    excludeFromTabOrder: props.excludeFromTabOrder
   };
 }

--- a/packages/@react-stately/radio/src/useRadioGroupState.ts
+++ b/packages/@react-stately/radio/src/useRadioGroupState.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaRadioGroupProps} from '@react-types/radio';
 import {FormValidationState, useFormValidationState} from '@react-stately/form';
+import {RadioGroupProps} from '@react-types/radio';
 import {useControlledState} from '@react-stately/utils';
 import {useMemo, useState} from 'react';
 import {ValidationState} from '@react-types/shared';
@@ -52,10 +52,7 @@ export interface RadioGroupState extends FormValidationState {
   readonly lastFocusedValue: string | null,
 
   /** Sets the last focused value. */
-  setLastFocusedValue(value: string | null): void,
-
-  /** Whether the radio group is excluded from the sequential tab order. */
-  excludeFromTabOrder?: boolean
+  setLastFocusedValue(value: string | null): void
 }
 
 let instance = Math.round(Math.random() * 10000000000);
@@ -65,7 +62,7 @@ let i = 0;
  * Provides state management for a radio group component. Provides a name for the group,
  * and manages selection and focus state.
  */
-export function useRadioGroupState(props: AriaRadioGroupProps): RadioGroupState  {
+export function useRadioGroupState(props: RadioGroupProps): RadioGroupState  {
   // Preserved here for backward compatibility. React Aria now generates the name instead of stately.
   let name = useMemo(() => props.name || `radio-group-${instance}-${++i}`, [props.name]);
   let [selectedValue, setSelected] = useControlledState(props.value, props.defaultValue ?? null, props.onChange);
@@ -96,7 +93,6 @@ export function useRadioGroupState(props: AriaRadioGroupProps): RadioGroupState 
     isReadOnly: props.isReadOnly || false,
     isRequired: props.isRequired || false,
     validationState: props.validationState || (isInvalid ? 'invalid' : null),
-    isInvalid,
-    excludeFromTabOrder: props.excludeFromTabOrder
+    isInvalid
   };
 }

--- a/packages/@react-types/link/src/index.d.ts
+++ b/packages/@react-types/link/src/index.d.ts
@@ -10,12 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaLabelingProps, FocusableProps, LinkDOMProps, PressEvents, StyleProps} from '@react-types/shared';
+import {AriaLabelingProps, FocusableDOMProps, FocusableProps, LinkDOMProps, PressEvents, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
 export interface LinkProps extends PressEvents, FocusableProps {}
 
-export interface AriaLinkProps extends LinkProps, LinkDOMProps, AriaLabelingProps { }
+export interface AriaLinkProps extends LinkProps, LinkDOMProps, AriaLabelingProps, FocusableDOMProps { }
 
 export interface SpectrumLinkProps extends AriaLinkProps, StyleProps {
   /** The content to display in the link. */

--- a/packages/@react-types/radio/src/index.d.ts
+++ b/packages/@react-types/radio/src/index.d.ts
@@ -68,5 +68,5 @@ export interface SpectrumRadioGroupProps extends AriaRadioGroupProps, SpectrumLa
   isEmphasized?: boolean
 }
 
-export interface AriaRadioProps extends RadioProps, DOMProps, FocusableDOMProps, AriaLabelingProps {}
+export interface AriaRadioProps extends RadioProps, DOMProps, AriaLabelingProps {}
 export interface SpectrumRadioProps extends AriaRadioProps, StyleProps {}

--- a/packages/@react-types/radio/src/index.d.ts
+++ b/packages/@react-types/radio/src/index.d.ts
@@ -14,6 +14,7 @@ import {
   AriaLabelingProps,
   AriaValidationProps,
   DOMProps,
+  FocusableDOMProps,
   FocusableProps,
   FocusEvents,
   HelpTextProps,
@@ -54,7 +55,7 @@ export interface RadioProps extends FocusableProps {
   isDisabled?: boolean
 }
 
-export interface AriaRadioGroupProps extends RadioGroupProps, DOMProps, AriaLabelingProps, AriaValidationProps {}
+export interface AriaRadioGroupProps extends RadioGroupProps, DOMProps, AriaLabelingProps, AriaValidationProps, FocusableDOMProps {}
 export interface SpectrumRadioGroupProps extends AriaRadioGroupProps, SpectrumLabelableProps, StyleProps, SpectrumHelpTextProps {
   /**
    * The Radio(s) contained within the RadioGroup.
@@ -67,5 +68,5 @@ export interface SpectrumRadioGroupProps extends AriaRadioGroupProps, SpectrumLa
   isEmphasized?: boolean
 }
 
-export interface AriaRadioProps extends RadioProps, DOMProps, AriaLabelingProps {}
+export interface AriaRadioProps extends RadioProps, DOMProps, FocusableDOMProps, AriaLabelingProps {}
 export interface SpectrumRadioProps extends AriaRadioProps, StyleProps {}

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -103,7 +103,7 @@ export interface RadioRenderProps {
    */
   isInvalid: boolean,
   /**
-   * Whether the checkbox is required.
+   * Whether the radio is required.
    * @selector [data-required]
    */
   isRequired: boolean
@@ -181,6 +181,7 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) {
   let inputRef = useObjectRef(mergeRefs(userProvidedInputRef, props.inputRef !== undefined ? props.inputRef : null));
   let {labelProps, inputProps, isSelected, isDisabled, isPressed} = useRadio({
     ...removeDataAttributes<RadioProps>(props),
+    excludeFromTabOrder: state.excludeFromTabOrder,
     // ReactNode type doesn't allow function children.
     children: typeof props.children === 'function' ? true : props.children
   }, state, inputRef);

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -181,7 +181,6 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) {
   let inputRef = useObjectRef(mergeRefs(userProvidedInputRef, props.inputRef !== undefined ? props.inputRef : null));
   let {labelProps, inputProps, isSelected, isDisabled, isPressed} = useRadio({
     ...removeDataAttributes<RadioProps>(props),
-    excludeFromTabOrder: state.excludeFromTabOrder,
     // ReactNode type doesn't allow function children.
     children: typeof props.children === 'function' ? true : props.children
   }, state, inputRef);

--- a/packages/react-aria-components/test/Link.test.js
+++ b/packages/react-aria-components/test/Link.test.js
@@ -147,4 +147,11 @@ describe('Link', () => {
     await user.click(link);
     expect(navigate).toHaveBeenCalledWith('/foo', {foo: 'bar'});
   });
+
+  it('should support excluding from tab order', () => {
+    let {getByRole} = render(<Link excludeFromTabOrder href="test">Test</Link>);
+    let link = getByRole('link');
+
+    expect(link).toHaveAttribute('tabindex', '-1');
+  });
 });

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -518,4 +518,16 @@ describe('RadioGroup', () => {
     expect(inputRef.current).toBe(radio);
     expect(contextInputRef.current).toBe(radio);
   });
+
+  it('should support excluding from tab order', () => {
+    let {getByRole} = render(
+      <RadioGroup excludeFromTabOrder>
+        <Label>Test</Label>
+        <Radio value="a">A</Radio>
+      </RadioGroup>
+    );
+    let radio = getByRole('radio');
+
+    expect(radio).toHaveAttribute('tabindex', '-1');
+  });
 });

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -530,4 +530,40 @@ describe('RadioGroup', () => {
 
     expect(radio).toHaveAttribute('tabindex', '-1');
   });
+
+  it('should unset the tabIndex for group disabled', () => {
+    let {getByRole} = render(
+      <RadioGroup isDisabled excludeFromTabOrder>
+        <Label>Test</Label>
+        <Radio value="a">A</Radio>
+      </RadioGroup>
+    );
+    let radio = getByRole('radio');
+
+    expect(radio).not.toHaveAttribute('tabindex');
+  });
+
+  it('should unset the tabIndex for radio disabled', () => {
+    let {getByRole} = render(
+      <RadioGroup excludeFromTabOrder>
+        <Label>Test</Label>
+        <Radio isDisabled value="a">A</Radio>
+      </RadioGroup>
+    );
+    let radio = getByRole('radio');
+
+    expect(radio).not.toHaveAttribute('tabindex');
+  });
+
+  it('should exclude the radio from tab order even if selected', () => {
+    let {getByRole} = render(
+      <RadioGroup excludeFromTabOrder value="a">
+        <Label>Test</Label>
+        <Radio value="a">A</Radio>
+      </RadioGroup>
+    );
+    let radio = getByRole('radio');
+
+    expect(radio).toHaveAttribute('tabindex', '-1');
+  });
 });


### PR DESCRIPTION
Closes #6569 

Add `excludeFromTabOrder` prop for Link and RadioGroup.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
