### PR TITLE
Fix divide by zero in GridLayout

### DIFF
--- a/packages/@react-stately/layout/src/GridLayout.ts
+++ b/packages/@react-stately/layout/src/GridLayout.ts
@@ -83,7 +83,7 @@ export class GridLayout<T, O = any> extends Layout<Node<T>, O> implements DropTa
     itemWidth = Math.max(this.minItemSize.width, Math.min(maxItemWidth, itemWidth));
 
     // Compute the item height, which is proportional to the item width
-    let t = ((itemWidth - this.minItemSize.width) / (maxItemWidth - this.minItemSize.width));
+    let t = ((itemWidth - this.minItemSize.width) / Math.max(1, maxItemWidth - this.minItemSize.width));
     let itemHeight = this.minItemSize.height +  Math.floor((maxItemHeight - this.minItemSize.height) * t);
     itemHeight = Math.max(this.minItemSize.height, Math.min(maxItemHeight, itemHeight));
     this.itemSize = new Size(itemWidth, itemHeight);

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -344,7 +344,7 @@ export function VirtualizedListBoxDnd() {
   );
 }
 
-export function VirtualizedListBoxGrid() {
+export function VirtualizedListBoxGrid({minSize, maxSize}) {
   let items: {id: number, name: string}[] = [];
   for (let i = 0; i < 10000; i++) {
     items.push({id: i, name: `Item ${i}`});
@@ -352,10 +352,10 @@ export function VirtualizedListBoxGrid() {
 
   let layout = useMemo(() => {
     return new GridLayout({
-      minItemSize: new Size(80, 80),
-      maxItemSize: new Size(100, 100)
+      minItemSize: new Size(minSize, minSize),
+      maxItemSize: new Size(maxSize, maxSize)
     });
-  }, []);
+  }, [minSize, maxSize]);
 
   let list = useListData({
     initialItems: items
@@ -395,3 +395,8 @@ export function VirtualizedListBoxGrid() {
     </div>
   );
 }
+
+VirtualizedListBoxGrid.args = {
+  minSize: 80,
+  maxSize: 100
+};


### PR DESCRIPTION
If `minItemSize` and `maxItemSize` were the same, no items would appear due to a divide by zero error.