### PR TITLE
Update TanStack Router example in docs

### DIFF
--- a/packages/dev/docs/pages/react-aria/routing.mdx
+++ b/packages/dev/docs/pages/react-aria/routing.mdx
@@ -273,13 +273,13 @@ export default function App() {
 To use [TanStack Router](https://tanstack.com/router) with React Aria, render React Aria's `RouterProvider` inside your root route. Use `router.navigate` in the `navigate` prop, and `router.buildLocation` in the `useHref` prop. You can also configure TypeScript to get autocomplete for the `href` prop by declaring the `RouterConfig` type using the types provided by TanStack Router.
 
 ```tsx
-import {useRouter, type RegisteredRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
+import {useRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
 import {RouterProvider} from 'react-aria-components';
 
 declare module 'react-aria-components' {
   interface RouterConfig {
-    href: ToPathOption<RegisteredRouter['routeTree']>;
-    routerOptions: Omit<NavigateOptions, keyof ToOptions>
+    href: ToOptions['to'];
+    routerOptions: Omit<NavigateOptions, keyof ToOptions>;
   }
 }
 

--- a/packages/dev/docs/pages/react-spectrum/routing.mdx
+++ b/packages/dev/docs/pages/react-spectrum/routing.mdx
@@ -278,7 +278,7 @@ To use [TanStack Router](https://tanstack.com/router) with React Spectrum, rende
 import {useRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
 import {Provider, defaultTheme} from '@adobe/react-spectrum';
 
-declare module 'react-aria-components' {
+declare module '@adobe/react-spectrum' {
   interface RouterConfig {
     href: ToOptions['to'];
     routerOptions: Omit<NavigateOptions, keyof ToOptions>;

--- a/packages/dev/docs/pages/react-spectrum/routing.mdx
+++ b/packages/dev/docs/pages/react-spectrum/routing.mdx
@@ -275,13 +275,13 @@ export default function App() {
 To use [TanStack Router](https://tanstack.com/router) with React Spectrum, render React Spectrum's `Provider` inside your root route. Use `router.navigate` in the `navigate` prop, and `router.buildLocation` in the `useHref` prop. You can also configure TypeScript to get autocomplete for the `href` prop by declaring the `RouterConfig` type using the types provided by TanStack Router.
 
 ```tsx
-import {useRouter, type RegisteredRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
+import {useRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
 import {Provider, defaultTheme} from '@adobe/react-spectrum';
 
-declare module '@adobe/react-spectrum' {
+declare module 'react-aria-components' {
   interface RouterConfig {
-    href: ToPathOption<RegisteredRouter['routeTree']>;
-    routerOptions: Omit<NavigateOptions, keyof ToOptions>
+    href: ToOptions['to'];
+    routerOptions: Omit<NavigateOptions, keyof ToOptions>;
   }
 }
 


### PR DESCRIPTION
Fixes #6413

The types exposed by TanStack Router have changed since the docs were originally written.

This keeps `href` as a string. We could also consider typing it as an object as shown here but not sure if everyone would want that or not? https://github.com/adobe/react-spectrum/issues/6587#issuecomment-2224235268