### PR TITLE
ActionBar expose ActionGroup's `buttonLabelBehavior` prop

### DIFF
--- a/packages/@react-spectrum/actionbar/src/ActionBar.tsx
+++ b/packages/@react-spectrum/actionbar/src/ActionBar.tsx
@@ -58,6 +58,7 @@ function ActionBarInner<T>(props: ActionBarInnerProps<T>, ref: Ref<HTMLDivElemen
     onClearSelection,
     selectedItemCount,
     isOpen,
+    buttonLabelBehavior = 'collapse',
     items
   } = props;
 
@@ -110,7 +111,7 @@ function ActionBarInner<T>(props: ActionBarInnerProps<T>, ref: Ref<HTMLDivElemen
             isQuiet
             staticColor={isEmphasized ? 'white' : undefined}
             overflowMode="collapse"
-            buttonLabelBehavior="collapse"
+            buttonLabelBehavior={buttonLabelBehavior}
             onAction={onAction}
             UNSAFE_className={classNames(styles, 'react-spectrum-ActionBar-actionGroup')}>
             {children}

--- a/packages/@react-spectrum/actionbar/stories/ActionBar.stories.tsx
+++ b/packages/@react-spectrum/actionbar/stories/ActionBar.stories.tsx
@@ -31,6 +31,10 @@ export default {
     },
     isEmphasized: {
       control: 'boolean'
+    },
+    buttonLabelBehavior: {
+      control: 'select',
+      options: ['show', 'hide', 'collapse']
     }
   }
 } as ComponentMeta<typeof ActionBar>;

--- a/packages/@react-types/actionbar/src/index.d.ts
+++ b/packages/@react-types/actionbar/src/index.d.ts
@@ -27,7 +27,15 @@ export interface ActionBarProps<T> {
   /** Whether the ActionBar should be displayed with a emphasized style. */
   isEmphasized?: boolean,
   /** Handler that is called when an ActionBar button is pressed. */
-  onAction?: (key: Key) => void
+  onAction?: (key: Key) => void,
+  /**
+   * Defines when the text within the buttons should be hidden and only the icon should be shown.
+   * When set to 'hide', the text is always shown in a tooltip. When set to 'collapse', the text is visible
+   * if space is available, and hidden when space is limited. The text is always visible when the item
+   * is collapsed into a menu.
+   * @default 'collapse'
+   */
+  buttonLabelBehavior?: 'show' | 'collapse' | 'hide'
 }
 
 export interface SpectrumActionBarProps<T> extends ActionBarProps<T>, DOMProps, StyleProps {}


### PR DESCRIPTION
Closes #6528

Note: In ActionGroup `buttonLabelBehavior` defaults to `show`. ActionBar had it hardcoded to `collapse`, so that is its default in ActionBar.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

ActionBar stories have control for `buttonLabelBehavior` to test the three states.

## 🧢 Your Project:
RSP