### PR TITLE
Fix crash in TimeField on Android

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -269,6 +269,17 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
     selection.collapse(ref.current);
   };
 
+  let documentRef = useRef(typeof document !== 'undefined' ? document : null);
+  useEvent(documentRef, 'selectionchange', () => {
+    // Enforce that the selection is collapsed when inside a date segment.
+    // Otherwise, when tapping on a segment in Android Chrome and then entering text,
+    // composition events will be fired that break the DOM structure and crash the page.
+    let selection = window.getSelection();
+    if (ref.current.contains(selection.anchorNode)) {
+      selection.collapse(ref.current);
+    }
+  });
+
   let compositionRef = useRef('');
   // @ts-ignore - TODO: possibly old TS version? doesn't fail in my editor...
   useEvent(ref, 'beforeinput', e => {


### PR DESCRIPTION
Closes https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=70985842

This could occur when tapping on an already focused date segment. This moved the cursor between letters. Then when entering a character, Chrome would fire a composition event rather than a regular text entry event. Composition events are not cancelable, so chrome would mutate the DOM. Later, React would try to update the DOM but it was no longer in the expected state and this resulted in a crash.

Fix is to always collapse the selection to the start of the segment. We already did this on initial focus, but tapping on the segment again could change the selection. Now we listen for selection change events and collapse them if they are inside the segment.