### PR TITLE
Update Tooltip docs to reflect correct default placement value

### DIFF
--- a/packages/@react-types/overlays/src/index.d.ts
+++ b/packages/@react-types/overlays/src/index.d.ts
@@ -25,7 +25,7 @@ export type PlacementAxis = Axis | 'center';
 export interface PositionProps {
   /**
    * The placement of the element with respect to its anchor element.
-   * @default 'top'
+   * @default 'bottom'
    */
   placement?: Placement,
   /**

--- a/packages/@react-types/overlays/src/index.d.ts
+++ b/packages/@react-types/overlays/src/index.d.ts
@@ -25,7 +25,7 @@ export type PlacementAxis = Axis | 'center';
 export interface PositionProps {
   /**
    * The placement of the element with respect to its anchor element.
-   * @default 'bottom'
+   * @default 'top'
    */
   placement?: Placement,
   /**

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, DOMProps, StyleProps} from '@react-types/shared';
-import {OverlayTriggerProps, PositionProps} from '@react-types/overlays';
+import {OverlayTriggerProps, Placement, PositionProps} from '@react-types/overlays';
 import {ReactElement, ReactNode} from 'react';
 
 export interface TooltipTriggerProps extends OverlayTriggerProps {
@@ -46,7 +46,12 @@ export interface SpectrumTooltipTriggerProps extends Omit<TooltipTriggerProps, '
    * anchor element.
    * @default 7
    */
-  offset?: number
+  offset?: number,
+  /**
+   * The placement of the popover with respect to the action button.
+   * @default 'top'
+   */
+  placement?: Placement
 }
 
 export interface TooltipProps {

--- a/packages/@react-types/tooltip/src/index.d.ts
+++ b/packages/@react-types/tooltip/src/index.d.ts
@@ -48,7 +48,7 @@ export interface SpectrumTooltipTriggerProps extends Omit<TooltipTriggerProps, '
    */
   offset?: number,
   /**
-   * The placement of the popover with respect to the action button.
+   * The placement of the tooltip with respect to the trigger.
    * @default 'top'
    */
   placement?: Placement

--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, FocusableElement, forwardRefType, RefObject} from '@react-types/shared';
-import {AriaPositionProps, mergeProps, OverlayContainer, PlacementAxis, PositionProps, useOverlayPosition, useTooltip, useTooltipTrigger} from 'react-aria';
+import {AriaPositionProps, mergeProps, OverlayContainer, Placement, PlacementAxis, PositionProps, useOverlayPosition, useTooltip, useTooltipTrigger} from 'react-aria';
 import {ContextValue, Provider, RenderProps, useContextProps, useEnterAnimation, useExitAnimation, useRenderProps} from './utils';
 import {FocusableProvider} from '@react-aria/focus';
 import {OverlayArrowContext} from './OverlayArrow';
@@ -42,7 +42,12 @@ export interface TooltipProps extends PositionProps, Pick<AriaPositionProps, 'ar
    * The container element in which the overlay portal will be placed. This may have unknown behavior depending on where it is portalled to.
    * @default document.body
    */
-  UNSTABLE_portalContainer?: Element
+  UNSTABLE_portalContainer?: Element,
+  /**
+   * The placement of the popover with respect to the action button.
+   * @default 'top'
+   */
+  placement?: Placement
 }
 
 export interface TooltipRenderProps {

--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -44,7 +44,7 @@ export interface TooltipProps extends PositionProps, Pick<AriaPositionProps, 'ar
    */
   UNSTABLE_portalContainer?: Element,
   /**
-   * The placement of the popover with respect to the action button.
+   * The placement of the tooltip with respect to the trigger.
    * @default 'top'
    */
   placement?: Placement


### PR DESCRIPTION
Closes #6713

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Make sure that RSP TooltipTrigger and RAC Tooltip have the default value 'top' for placement. 

## 🧢 Your Project:

<!--- Company/project for pull request -->
