### PR TITLE
Support null values in ColorField with channel prop

### DIFF
--- a/packages/@react-spectrum/color/docs/ColorField.mdx
+++ b/packages/@react-spectrum/color/docs/ColorField.mdx
@@ -92,7 +92,7 @@ function Example() {
         <ColorField label="Saturation" value={color} onChange={setColor} colorSpace="hsl" channel="saturation" />
         <ColorField label="Lightness" value={color} onChange={setColor} colorSpace="hsl" channel="lightness" />
       </div>
-      <p>Current color value: {color.toString('hex')}</p>
+      <p>Current color value: {color?.toString('hex')}</p>
     </>
   );
 }

--- a/packages/@react-spectrum/color/test/ColorField.test.js
+++ b/packages/@react-spectrum/color/test/ColorField.test.js
@@ -374,17 +374,45 @@ describe('ColorField', function () {
     expect(onChangeSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should support the channel prop', async function () {
-    let onChange = jest.fn();
-    let {getByRole} = renderComponent({label: null, value: '#abc', colorSpace: 'hsl', channel: 'hue', onChange});
-    let colorField = getByRole('textbox');
-    expect(colorField.value).toBe('210°');
-    expect(colorField).toHaveAttribute('aria-label', 'Hue');
+  describe('channel', function () {
+    it('should support the channel prop', async function () {
+      let onChange = jest.fn();
+      let {getByRole} = renderComponent({label: null, value: '#abc', colorSpace: 'hsl', channel: 'hue', onChange});
+      let colorField = getByRole('textbox');
+      expect(colorField.value).toBe('210°');
+      expect(colorField).toHaveAttribute('aria-label', 'Hue');
 
-    await user.tab();
-    await user.keyboard('100');
-    await user.tab();
-    expect(onChange).toHaveBeenCalledWith(parseColor('hsl(100, 25%, 73.33%)'));
+      await user.tab();
+      await user.keyboard('100');
+      await user.tab();
+      expect(onChange).toHaveBeenCalledWith(parseColor('hsl(100, 25%, 73.33%)'));
+    });
+
+    it('should default to empty', function () {
+      let {getByRole} = renderComponent({label: null, colorSpace: 'hsl', channel: 'hue'});
+      let colorField = getByRole('textbox');
+      expect(colorField).toHaveValue('');
+    });
+
+    it('should support null value', function () {
+      let {getByRole} = renderComponent({label: null, value: null, colorSpace: 'hsl', channel: 'hue'});
+      let colorField = getByRole('textbox');
+      expect(colorField).toHaveValue('');
+    });
+
+    it('should support clearing value', async function () {
+      let onChange = jest.fn();
+      let {getByRole} = renderComponent({label: null, defaultValue: '#abc', colorSpace: 'hsl', channel: 'hue', onChange});
+      let colorField = getByRole('textbox');
+      expect(colorField).toHaveValue('210°');
+
+      await user.tab();
+      await user.keyboard('{Backspace}');
+      await user.tab();
+
+      expect(colorField).toHaveValue('');
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
   });
 
   describe('validation', () => {


### PR DESCRIPTION
Fixes crash when clearing a ColorField that displays a single channel, or when passing in a `null` controlled `value` prop. The behavior now is that a `null` value causes the field to be blank, and clearing it goes back to being blank. This will emit a `null` value via `onChange`, so if multiple channel fields are synced via the same value, clearing one of them will result in all of them being cleared. When inside a `ColorPicker`, we ignore null values (or we will after #6364), so in that case, the value will be reset back to the previous value instead.