### PR TITLE
Fix virtualizer bug when an item changes parents

### DIFF
--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -759,6 +759,60 @@ describe('ListBox', function () {
     expect(option.id).not.toEqual('Foo');
   });
 
+  it('should handle when an item changes sections', function () {
+    let sections = [
+      {
+        id: 'foo',
+        title: 'Foo',
+        children: [
+          {id: 'foo-1', title: 'Foo 1'},
+          {id: 'foo-2', title: 'Foo 2'}
+        ]
+      },
+      {
+        id: 'bar',
+        title: 'Bar',
+        children: [
+          {id: 'bar-1', title: 'Bar 1'},
+          {id: 'bar-2', title: 'Bar 2'}
+        ]
+      }
+    ];
+
+    function Example({sections}) {
+      return (
+        <Provider theme={theme}>
+          <ListBox aria-label="listbox" items={sections}>
+            {section => (
+              <Section title={section.title} items={section.children}>
+                {item => <Item>{item.title}</Item>}
+              </Section>
+            )}
+          </ListBox>
+        </Provider>
+      );
+    }
+
+    let {getByText, rerender} = render(<Example sections={sections} />);
+    let item = getByText('Foo 1');
+    expect(document.getElementById(item.closest('[role=group]').getAttribute('aria-labelledby'))).toHaveTextContent('Foo');
+
+    let sections2 = [
+      {
+        ...sections[0],
+        children: [sections[0].children[1]]
+      },
+      {
+        ...sections[1],
+        children: [...sections[1].children, sections[0].children[0]]
+      }
+    ];
+
+    rerender(<Example sections={sections2} />);
+    item = getByText('Foo 1');
+    expect(document.getElementById(item.closest('[role=group]').getAttribute('aria-labelledby'))).toHaveTextContent('Bar');
+  });
+
   describe('async loading', function () {
     it('should display a spinner while loading', async function () {
       let {getByRole, rerender} = render(

--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -101,8 +101,12 @@ export class Virtualizer<T extends object, V> {
     return false;
   }
 
+  private getParentView(layoutInfo: LayoutInfo): ReusableView<T, V> | undefined {
+    return layoutInfo.parentKey != null ? this._visibleViews.get(layoutInfo.parentKey) : this._rootView;
+  }
+
   private getReusableView(layoutInfo: LayoutInfo): ReusableView<T, V> {
-    let parentView = layoutInfo.parentKey != null ? this._visibleViews.get(layoutInfo.parentKey) : this._rootView;
+    let parentView = this.getParentView(layoutInfo)!;
     let view = parentView.getReusableView(layoutInfo.type);
     view.layoutInfo = layoutInfo;
     this._renderView(view);
@@ -195,8 +199,8 @@ export class Virtualizer<T extends object, V> {
     let removed = new Set<ReusableView<T, V>>();
     for (let [key, view] of this._visibleViews) {
       let layoutInfo = visibleLayoutInfos.get(key);
-      // If a layout info's parentKey changed, treat it as a delete and re-create in the new parent.
-      if (!layoutInfo || view.layoutInfo?.parentKey !== layoutInfo.parentKey) {
+      // If a view's parent changed, treat it as a delete and re-create in the new parent.
+      if (!layoutInfo || view.parent !== this.getParentView(layoutInfo)) {
         this._visibleViews.delete(key);
         view.parent.reuseChild(view);
         removed.add(view); // Defer removing in case we reuse this view.

--- a/packages/@react-stately/virtualizer/src/Virtualizer.ts
+++ b/packages/@react-stately/virtualizer/src/Virtualizer.ts
@@ -194,7 +194,9 @@ export class Virtualizer<T extends object, V> {
 
     let removed = new Set<ReusableView<T, V>>();
     for (let [key, view] of this._visibleViews) {
-      if (!visibleLayoutInfos.has(key)) {
+      let layoutInfo = visibleLayoutInfos.get(key);
+      // If a layout info's parentKey changed, treat it as a delete and re-create in the new parent.
+      if (!layoutInfo || view.layoutInfo?.parentKey !== layoutInfo.parentKey) {
         this._visibleViews.delete(key);
         view.parent.reuseChild(view);
         removed.add(view); // Defer removing in case we reuse this view.

--- a/packages/dev/docs/src/DocSearch.js
+++ b/packages/dev/docs/src/DocSearch.js
@@ -127,7 +127,7 @@ export default function DocSearch() {
 
       sections.push({title, items: items.map((item) => item[0])});
     }
-    let newSuggestions = sections.map((section, index) => ({key: `${index}-${section.title}`, title: section.title, children: section.items}));
+    let newSuggestions = sections.map((section) => ({key: section.title, title: section.title, children: section.items}));
     newSuggestions.push({
       key: 'algolia-footer',
       title: 'Search by',


### PR DESCRIPTION
We saw this issue in doc search due to section keys changing. Virtualizer saw the child keys as already visible even though their parents changed and didn't create new views for them. Now we treat parent key changes the same way we treat deletes. The view will then be re-created under its new parent. Added a test for this case when a listbox item changes sections.

In doc search we also make this more efficient by using only the title as the key rather than including the index, so that when sections are re-ordered the keys remain consistent and views can be reused.