### PR TITLE
Get rid of sizeToFit to fix cases where listbox rect wasn't updating properly

### DIFF
--- a/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
+++ b/packages/@react-aria/dnd/stories/VirtualizedListBox.tsx
@@ -168,7 +168,6 @@ export const VirtualizedListBox = React.forwardRef(function (props: any, ref) {
         {...mergeProps(collectionProps, listBoxProps)}
         ref={domRef}
         className={classNames(dndStyles, 'droppable-collection', 'is-virtualized', {'is-drop-target': isDropTarget})}
-        sizeToFit="height"
         scrollDirection="vertical"
         layout={layout}
         collection={state.collection}

--- a/packages/@react-aria/virtualizer/src/ScrollView.tsx
+++ b/packages/@react-aria/virtualizer/src/ScrollView.tsx
@@ -33,7 +33,6 @@ interface ScrollViewProps extends HTMLAttributes<HTMLElement> {
   onVisibleRectChange: (rect: Rect) => void,
   children?: ReactNode,
   innerStyle?: CSSProperties,
-  sizeToFit?: 'width' | 'height',
   onScrollStart?: () => void,
   onScrollEnd?: () => void,
   scrollDirection?: 'horizontal' | 'vertical' | 'both'
@@ -60,7 +59,6 @@ export function useScrollView(props: ScrollViewProps, ref: RefObject<HTMLElement
     contentSize,
     onVisibleRectChange,
     innerStyle,
-    sizeToFit,
     onScrollStart,
     onScrollEnd,
     scrollDirection = 'both',
@@ -158,14 +156,6 @@ export function useScrollView(props: ScrollViewProps, ref: RefObject<HTMLElement
     let clientHeight = dom.clientHeight;
     let w = isTestEnv && !isClientWidthMocked ? Infinity : clientWidth;
     let h = isTestEnv && !isClientHeightMocked ? Infinity : clientHeight;
-
-    if (sizeToFit && contentSize.width > 0 && contentSize.height > 0) {
-      if (sizeToFit === 'width') {
-        w = Math.min(w, contentSize.width);
-      } else if (sizeToFit === 'height') {
-        h = Math.min(h, contentSize.height);
-      }
-    }
 
     if (state.width !== w || state.height !== h) {
       state.width = w;

--- a/packages/@react-aria/virtualizer/src/Virtualizer.tsx
+++ b/packages/@react-aria/virtualizer/src/Virtualizer.tsx
@@ -30,7 +30,6 @@ interface VirtualizerProps<T extends object, V, O> extends Omit<HTMLAttributes<H
   layout: Layout<T, O>,
   collection: Collection<T>,
   persistedKeys?: Set<Key> | null,
-  sizeToFit?: 'width' | 'height',
   scrollDirection?: 'horizontal' | 'vertical' | 'both',
   isLoading?: boolean,
   onLoadMore?: () => void,
@@ -43,7 +42,6 @@ function Virtualizer<T extends object, V extends ReactNode, O>(props: Virtualize
     renderWrapper,
     layout,
     collection,
-    sizeToFit,
     scrollDirection,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isLoading,
@@ -81,7 +79,6 @@ function Virtualizer<T extends object, V extends ReactNode, O>(props: Virtualize
       contentSize={state.contentSize}
       onScrollStart={state.startScrolling}
       onScrollEnd={state.endScrolling}
-      sizeToFit={sizeToFit}
       scrollDirection={scrollDirection}>
       {renderChildren(null, state.visibleViews, renderWrapper || defaultRenderWrapper)}
     </ScrollView>

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -112,7 +112,6 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
           ref={ref}
           persistedKeys={persistedKeys}
           autoFocus={!!props.autoFocus || undefined}
-          sizeToFit="height"
           scrollDirection="vertical"
           className={
             classNames(


### PR DESCRIPTION
The listbox in the async case and the Docs search on mobile were rendering with very small scroll rects, causing only a couple of items to be visible at a time even though there was actually more vertical real estate available. This was because of the `sizeToFit` logic [here](https://github.com/adobe/react-spectrum/blob/9b48ec5d528adeba1a96592945459726def7ba56/packages/%40react-aria/virtualizer/src/ScrollView.tsx#L166) being called by the ResizeObserver that would then set the height of the scroll rect to the content size at the time (placeholder height). Before the changes made in https://github.com/adobe/react-spectrum/pull/6508, `updateSize` would be called much more frequently when `contentSize` changed hence why this wasn't a problem before. We think that we actually don't need `sizeToFit` anymore since the browser should handle updating the height of the scrollview when more content loads async so cases where a dropdown goes from having a single placeholder row to having loaded items should still work

To be tested further, if it breaks stuff we can fallback to calling `updateSize` if `contentSize` changes in scrollView

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test anything with a ListBox (Listbox, Combobox, Picker, tray versions of those, docs search)

## 🧢 Your Project:

RSP
