### PR TITLE
3.36 audit

### DIFF
--- a/packages/@react-aria/collections/src/BaseCollection.ts
+++ b/packages/@react-aria/collections/src/BaseCollection.ts
@@ -18,7 +18,7 @@ export type Mutable<T> = {
 }
 
 /** An immutable object representing a Node in a Collection. */
-export class NodeValue<T> implements Node<T> {
+export class CollectionNode<T> implements Node<T> {
   readonly type: string;
   readonly key: Key;
   readonly value: T | null = null;
@@ -45,8 +45,8 @@ export class NodeValue<T> implements Node<T> {
     throw new Error('childNodes is not supported');
   }
 
-  clone(): NodeValue<T> {
-    let node: Mutable<NodeValue<T>> = new NodeValue(this.type, this.key);
+  clone(): CollectionNode<T> {
+    let node: Mutable<CollectionNode<T>> = new CollectionNode(this.type, this.key);
     node.value = this.value;
     node.level = this.level;
     node.hasChildNodes = this.hasChildNodes;
@@ -71,7 +71,7 @@ export class NodeValue<T> implements Node<T> {
  * custom collection behaviors.
  */
 export class BaseCollection<T> implements ICollection<Node<T>> {
-  private keyMap: Map<Key, NodeValue<T>> = new Map();
+  private keyMap: Map<Key, CollectionNode<T>> = new Map();
   private firstKey: Key | null = null;
   private lastKey: Key | null = null;
   private frozen = false;
@@ -183,7 +183,7 @@ export class BaseCollection<T> implements ICollection<Node<T>> {
     return collection;
   }
 
-  addNode(node: NodeValue<T>) {
+  addNode(node: CollectionNode<T>) {
     if (this.frozen) {
       throw new Error('Cannot add a node to a frozen collection');
     }

--- a/packages/@react-aria/collections/src/Document.ts
+++ b/packages/@react-aria/collections/src/Document.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {BaseCollection, Mutable, NodeValue} from './BaseCollection';
+import {BaseCollection, CollectionNode, Mutable} from './BaseCollection';
 import {ForwardedRef, ReactElement} from 'react';
 import {Node} from '@react-types/shared';
 
@@ -220,13 +220,13 @@ export class BaseNode<T> {
  */
 export class ElementNode<T> extends BaseNode<T> {
   nodeType = 8; // COMMENT_NODE (we'd use ELEMENT_NODE but React DevTools will fail to get its dimensions)
-  node: NodeValue<T>;
+  node: CollectionNode<T>;
   private _index: number = 0;
   hasSetProps = false;
 
   constructor(type: string, ownerDocument: Document<T, any>) {
     super(ownerDocument);
-    this.node = new NodeValue(type, `react-aria-${++ownerDocument.nodeId}`);
+    this.node = new CollectionNode(type, `react-aria-${++ownerDocument.nodeId}`);
     // Start a transaction so that no updates are emitted from the collection
     // until the props for this node are set. We don't know the real id for the
     // node until then, so we need to avoid emitting collections in an inconsistent state.
@@ -336,7 +336,7 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
    * Lazily gets a mutable instance of a Node. If the node has already
    * been cloned during this update cycle, it just returns the existing one.
    */
-  getMutableNode(element: ElementNode<T>): Mutable<NodeValue<T>> {
+  getMutableNode(element: ElementNode<T>): Mutable<CollectionNode<T>> {
     let node = element.node;
     if (!this.mutatedNodes.has(element)) {
       node = element.node.clone();

--- a/packages/@react-aria/collections/src/index.ts
+++ b/packages/@react-aria/collections/src/index.ts
@@ -13,7 +13,7 @@
 export {CollectionBuilder, Collection, createLeafComponent, createBranchComponent} from './CollectionBuilder';
 export {createHideableComponent, useIsHidden} from './Hidden';
 export {useCachedChildren} from './useCachedChildren';
-export {BaseCollection, NodeValue} from './BaseCollection';
+export {BaseCollection, CollectionNode} from './BaseCollection';
 
 export type {CollectionBuilderProps, CollectionProps} from './CollectionBuilder';
 export type {CachedChildrenOptions} from './useCachedChildren';

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -16,7 +16,6 @@ import {AriaMenuOptions} from './useMenu';
 import intlMessages from '../intl/*.json';
 import {MenuTriggerState} from '@react-stately/menu';
 import {MenuTriggerType} from '@react-types/menu';
-import {} from 'react';
 import {RefObject} from '@react-types/shared';
 import {useId} from '@react-aria/utils';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -1,5 +1,5 @@
 import {AriaLabelingProps, HoverEvents, Key, LinkDOMProps, RefObject} from '@react-types/shared';
-import {BaseCollection, Collection, CollectionBuilder, createBranchComponent, createLeafComponent, NodeValue, useCachedChildren} from '@react-aria/collections';
+import {BaseCollection, Collection, CollectionBuilder, createBranchComponent, createLeafComponent, CollectionNode, useCachedChildren} from '@react-aria/collections';
 import {buildHeaderRows, TableColumnResizeState} from '@react-stately/table';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './RSPContexts';
@@ -22,11 +22,11 @@ class TableCollection<T> extends BaseCollection<T> implements ITableCollection<T
   columns: GridNode<T>[] = [];
   rows: GridNode<T>[] = [];
   rowHeaderColumnKeys: Set<Key> = new Set();
-  head: NodeValue<T> = new NodeValue('tableheader', -1);
-  body: NodeValue<T> = new NodeValue('tablebody', -2);
+  head: CollectionNode<T> = new CollectionNode('tableheader', -1);
+  body: CollectionNode<T> = new CollectionNode('tablebody', -2);
   columnsDirty = true;
 
-  addNode(node: NodeValue<T>) {
+  addNode(node: CollectionNode<T>) {
     super.addNode(node);
 
     this.columnsDirty ||= node.type === 'column';

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -1,5 +1,5 @@
 import {AriaLabelingProps, HoverEvents, Key, LinkDOMProps, RefObject} from '@react-types/shared';
-import {BaseCollection, Collection, CollectionBuilder, createBranchComponent, createLeafComponent, CollectionNode, useCachedChildren} from '@react-aria/collections';
+import {BaseCollection, Collection, CollectionBuilder, CollectionNode, createBranchComponent, createLeafComponent, useCachedChildren} from '@react-aria/collections';
 import {buildHeaderRows, TableColumnResizeState} from '@react-stately/table';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './RSPContexts';

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -13,7 +13,7 @@
 import {AriaTreeGridListProps, useTreeGridList, useTreeGridListItem} from '@react-aria/tree';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './RSPContexts';
-import {Collection, CollectionBuilder, createBranchComponent, createLeafComponent, CollectionNode, useCachedChildren} from '@react-aria/collections';
+import {Collection, CollectionBuilder, CollectionNode, createBranchComponent, createLeafComponent, useCachedChildren} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps, usePersistedKeys} from './Collection';
 import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, ScrollableProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {DisabledBehavior, Expandable, forwardRefType, HoverEvents, Key, LinkDOMProps, RefObject} from '@react-types/shared';

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -13,7 +13,7 @@
 import {AriaTreeGridListProps, useTreeGridList, useTreeGridListItem} from '@react-aria/tree';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './RSPContexts';
-import {Collection, CollectionBuilder, createBranchComponent, createLeafComponent, NodeValue, useCachedChildren} from '@react-aria/collections';
+import {Collection, CollectionBuilder, createBranchComponent, createLeafComponent, CollectionNode, useCachedChildren} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps, usePersistedKeys} from './Collection';
 import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, ScrollableProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {DisabledBehavior, Expandable, forwardRefType, HoverEvents, Key, LinkDOMProps, RefObject} from '@react-types/shared';
@@ -25,7 +25,7 @@ import {useControlledState} from '@react-stately/utils';
 
 class TreeCollection<T> implements ICollection<Node<T>> {
   private flattenedRows: Node<T>[];
-  private keyMap: Map<Key, NodeValue<T>> = new Map();
+  private keyMap: Map<Key, CollectionNode<T>> = new Map();
 
   constructor(opts) {
     let {collection, expandedKeys} = opts;
@@ -506,14 +506,14 @@ interface TreeGridCollectionOptions {
 
 interface FlattenedTree<T> {
   flattenedRows: Node<T>[],
-  keyMap: Map<Key, NodeValue<T>>
+  keyMap: Map<Key, CollectionNode<T>>
 }
 
 function flattenTree<T>(collection: TreeCollection<T>, opts: TreeGridCollectionOptions): FlattenedTree<T> {
   let {
     expandedKeys = new Set()
   } = opts;
-  let keyMap: Map<Key, NodeValue<T>> = new Map();
+  let keyMap: Map<Key, CollectionNode<T>> = new Map();
   let flattenedRows: Node<T>[] = [];
 
   let visitNode = (node: Node<T>) => {
@@ -534,9 +534,9 @@ function flattenTree<T>(collection: TreeCollection<T>, opts: TreeGridCollectionO
           clone.level = node.level + 1;
         }
 
-        keyMap.set(clone.key, clone as NodeValue<T>);
+        keyMap.set(clone.key, clone as CollectionNode<T>);
       } else {
-        keyMap.set(node.key, node as NodeValue<T>);
+        keyMap.set(node.key, node as CollectionNode<T>);
       }
 
       if (node.level === 0 || (parentKey != null && expandedKeys.has(parentKey) && flattenedRows.find(row => row.key === parentKey))) {
@@ -544,7 +544,7 @@ function flattenTree<T>(collection: TreeCollection<T>, opts: TreeGridCollectionO
         flattenedRows.push(keyMap.get(node.key) || node);
       }
     } else if (node.type !== null) {
-      keyMap.set(node.key, node as NodeValue<T>);
+      keyMap.set(node.key, node as CollectionNode<T>);
     }
 
     for (let child of collection.getChildren(node.key)) {


### PR DESCRIPTION
* Renamed `NodeValue` to `CollectionNode` as discussed in #6640.
* Removed empty import