### PR TITLE
Include RAC i18n strings with RSP LocalizedStringProvider

### DIFF
--- a/examples/rsp-next-ts/next.config.mjs
+++ b/examples/rsp-next-ts/next.config.mjs
@@ -5,7 +5,7 @@ export default {
   transpilePackages: [
     '@adobe/react-spectrum',
     '@react-spectrum/*',
-    '@spectrum-icons/*',
+    '@spectrum-icons/*'
   ].flatMap(spec => glob.sync(`${spec}`, { cwd: 'node_modules/' })),
   basePath:
     process.env.VERDACCIO && process.env.CIRCLE_SHA1

--- a/examples/rsp-next-ts/pages/_app.tsx
+++ b/examples/rsp-next-ts/pages/_app.tsx
@@ -60,12 +60,6 @@ function MyApp({ Component, pageProps }: AppProps) {
           </ActionButton>
         </Flex>
         <View>
-        <ColorSwatchPicker defaultValue="#f00">
-          <ColorSwatch color="#f00" />
-          <ColorSwatch color="#0f0" />
-          <ColorSwatch color="#0ff" />
-          <ColorSwatch color="#00f" />
-        </ColorSwatchPicker>
           <Component {...pageProps} />
         </View>
       </Grid>

--- a/examples/rsp-next-ts/pages/_app.tsx
+++ b/examples/rsp-next-ts/pages/_app.tsx
@@ -15,6 +15,7 @@ import Light from "@spectrum-icons/workflow/Light";
 import { ToastContainer } from "@react-spectrum/toast";
 import {enableTableNestedRows} from '@react-stately/flags';
 import {useRouter, type NextRouter} from 'next/router';
+import {ColorSwatchPicker, ColorSwatch} from '@react-spectrum/color';
 
 declare module '@adobe/react-spectrum' {
   interface RouterConfig {
@@ -31,7 +32,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   enableTableNestedRows();
 
   return (
-    <Provider 
+    <Provider
       theme={lightTheme}
       colorScheme={theme}
       router={{
@@ -59,6 +60,12 @@ function MyApp({ Component, pageProps }: AppProps) {
           </ActionButton>
         </Flex>
         <View>
+        <ColorSwatchPicker defaultValue="#f00">
+          <ColorSwatch color="#f00" />
+          <ColorSwatch color="#0f0" />
+          <ColorSwatch color="#0ff" />
+          <ColorSwatch color="#00f" />
+        </ColorSwatchPicker>
           <Component {...pageProps} />
         </View>
       </Grid>

--- a/examples/rsp-next-ts/pages/_app.tsx
+++ b/examples/rsp-next-ts/pages/_app.tsx
@@ -15,7 +15,6 @@ import Light from "@spectrum-icons/workflow/Light";
 import { ToastContainer } from "@react-spectrum/toast";
 import {enableTableNestedRows} from '@react-stately/flags';
 import {useRouter, type NextRouter} from 'next/router';
-import {ColorSwatchPicker, ColorSwatch} from '@react-spectrum/color';
 
 declare module '@adobe/react-spectrum' {
   interface RouterConfig {

--- a/examples/rsp-next-ts/pages/index.tsx
+++ b/examples/rsp-next-ts/pages/index.tsx
@@ -77,8 +77,11 @@ import NotFound from "@spectrum-icons/illustrations/NotFound";
 import Section from "../components/Section";
 import {
   ColorArea,
+  ColorEditor,
   ColorField,
   ColorSlider,
+  ColorSwatch,
+  ColorSwatchPicker,
   ColorWheel,
 } from "@react-spectrum/color";
 import ReorderableListView from "../components/ReorderableListView";
@@ -242,6 +245,12 @@ export default function Home() {
             <ColorField label="Primary Color" />
             <ColorSlider defaultValue="#7f0000" channel="red" />
             <ColorWheel defaultValue="hsl(30, 100%, 50%)" />
+            <ColorSwatchPicker defaultValue="#f00">
+              <ColorSwatch color="#f00" />
+              <ColorSwatch color="#0f0" />
+              <ColorSwatch color="#0ff" />
+              <ColorSwatch color="#00f" />
+            </ColorSwatchPicker>
           </Section>
 
           <Section title="Date and Time">

--- a/examples/rsp-next-ts/pages/index.tsx
+++ b/examples/rsp-next-ts/pages/index.tsx
@@ -77,7 +77,6 @@ import NotFound from "@spectrum-icons/illustrations/NotFound";
 import Section from "../components/Section";
 import {
   ColorArea,
-  ColorEditor,
   ColorField,
   ColorSlider,
   ColorSwatch,

--- a/scripts/buildI18n.js
+++ b/scripts/buildI18n.js
@@ -137,6 +137,6 @@ export declare function createLocalizedStringDictionary(packages: string[]): Loc
 `);
 }
 
-build('{@react-aria,@react-stately,@react-spectrum}/*', '@adobe/react-spectrum');
+build('{@react-aria,@react-stately,@react-spectrum}/*,react-aria-components', '@adobe/react-spectrum');
 build('{@react-aria/*,@react-stately/*,react-aria-components}', 'react-aria-components');
 build('{@react-aria,@react-stately}/*', 'react-aria');

--- a/scripts/buildI18n.js
+++ b/scripts/buildI18n.js
@@ -137,6 +137,6 @@ export declare function createLocalizedStringDictionary(packages: string[]): Loc
 `);
 }
 
-build('{@react-aria,@react-stately,@react-spectrum}/*,react-aria-components', '@adobe/react-spectrum');
+build('{@react-aria/*,@react-stately/*,@react-spectrum/*,react-aria-components}', '@adobe/react-spectrum');
 build('{@react-aria/*,@react-stately/*,react-aria-components}', 'react-aria-components');
 build('{@react-aria,@react-stately}/*', 'react-aria');


### PR DESCRIPTION
RSP ColorSwatch uses RAC ColorSwatch and thus needs the i18n strings from RAC 


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run verdaccio locally and build the next app locally

## 🧢 Your Project:

RSP
