### PR TITLE
Allowing native <video> controls to be focusable

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -328,7 +328,7 @@ function useFocusContainment(scopeRef: RefObject<Element[] | null>, contain?: bo
 
     // Handle the Tab key to contain focus within the scope
     let onKeyDown = (e) => {
-      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || !shouldContainFocus(scopeRef) || e.isComposing) {
+      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || e.target.tagName === 'VIDEO' || !shouldContainFocus(scopeRef) || e.isComposing) {
         return;
       }
 


### PR DESCRIPTION
Closes [Issue 6729](https://github.com/adobe/react-spectrum/issues/6729).

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
    - I have not added a unit test for this functionality but I am happy to add one in. I just need guidance for where to put a dummy video for the test, and what kind of file size limitations exist. Please let me know your thoughts.
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Wrap a`<FocusScope>` element (with `contains={true}`) around a valid HTML `<video>` element (with the `controls` property set) . Try to tab to any of the video's controls like Fullscreen mode, volume control, CC, etc while it is wrapped by `FocusScope`.

```
<FocusScope contain={true}>
    <video src={myVideoSource} controls></video>
</FocusScope>
```

_Before the changes:_
Expected: I am able to tab into these controls
Actual: The focus stays at the top-level video item and never moves inside of the element, meaning the controls are never tabbable.

_After the changes:_
Expected: I am able to tab into these controls
Actual: I am able to tab into these controls

## 🧢 Your Project:

N/A
