### PR TITLE
Patch fixes

### DIFF
--- a/packages/@react-aria/collections/src/Hidden.tsx
+++ b/packages/@react-aria/collections/src/Hidden.tsx
@@ -12,7 +12,7 @@
 
 import {createPortal} from 'react-dom';
 import {forwardRefType} from '@react-types/shared';
-import React, {createContext, forwardRef, ReactNode, useContext} from 'react';
+import React, {createContext, forwardRef, ReactElement, ReactNode, useContext} from 'react';
 import {useIsSSR} from '@react-aria/ssr';
 
 // React doesn't understand the <template> element, which doesn't have children like a normal element.
@@ -64,7 +64,7 @@ export function Hidden(props: {children: ReactNode}) {
 
 /** Creates a component that forwards its ref and returns null if it is in a hidden subtree. */
 // Note: this function is handled specially in the documentation generator. If you change it, you'll need to update DocsTransformer as well.
-export function createHideableComponent<T, P = {}>(fn: (props: P, ref: React.Ref<T>) => ReactNode | null): (props: P & React.RefAttributes<T>) => ReactNode | null {
+export function createHideableComponent<T, P = {}>(fn: (props: P, ref: React.Ref<T>) => ReactElement | null): (props: P & React.RefAttributes<T>) => ReactElement | null {
   let Wrapper = (props: P, ref: React.Ref<T>) => {
     let isHidden = useContext(HiddenContext);
     if (isHidden) {

--- a/packages/@react-aria/utils/src/index.ts
+++ b/packages/@react-aria/utils/src/index.ts
@@ -17,7 +17,7 @@ export {mergeRefs} from './mergeRefs';
 export {filterDOMProps} from './filterDOMProps';
 export {focusWithoutScrolling} from './focusWithoutScrolling';
 export {getOffset} from './getOffset';
-export {openLink, useSyntheticLinkProps, RouterProvider, shouldClientNavigate, useRouter, useLinkProps} from './openLink';
+export {openLink, getSyntheticLinkProps, useSyntheticLinkProps, RouterProvider, shouldClientNavigate, useRouter, useLinkProps} from './openLink';
 export {runAfterTransition} from './runAfterTransition';
 export {useDrag1D} from './useDrag1D';
 export {useGlobalListeners} from './useGlobalListeners';

--- a/packages/@react-aria/utils/src/openLink.tsx
+++ b/packages/@react-aria/utils/src/openLink.tsx
@@ -158,6 +158,18 @@ export function useSyntheticLinkProps(props: LinkDOMProps) {
   };
 }
 
+/** @deprecated - For backward compatibility. */
+export function getSyntheticLinkProps(props: LinkDOMProps) {
+  return {
+    'data-href': props.href,
+    'data-target': props.target,
+    'data-rel': props.rel,
+    'data-download': props.download,
+    'data-ping': props.ping,
+    'data-referrer-policy': props.referrerPolicy
+  };
+}
+
 export function useLinkProps(props: LinkDOMProps) {
   let router = useRouter();
   return {

--- a/packages/@react-types/shared/src/refs.d.ts
+++ b/packages/@react-types/shared/src/refs.d.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {ReactNode, Ref, RefAttributes} from 'react';
+import {ReactElement, Ref, RefAttributes} from 'react';
 
 export interface DOMRefValue<T extends HTMLElement = HTMLElement> {
   UNSAFE_getDOMNode(): T
@@ -29,7 +29,7 @@ export interface RefObject<T> {
 
 // Override forwardRef types so generics work.
 declare function forwardRef<T, P = {}>(
-  render: (props: P, ref: Ref<T>) => ReactNode | null
-): (props: P & RefAttributes<T>) => ReactNode | null;
+  render: (props: P, ref: Ref<T>) => ReactElement | null
+): (props: P & RefAttributes<T>) => ReactElement | null;
 
 export type forwardRefType = typeof forwardRef;

--- a/packages/@react-types/sidenav/package.json
+++ b/packages/@react-types/sidenav/package.json
@@ -10,8 +10,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
-    "@react-types/shared": "^3.1.0",
-    "@react-stately/virtualizer": "^3.1.7"
+    "@react-types/shared": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"

--- a/packages/@react-types/sidenav/src/index.d.ts
+++ b/packages/@react-types/sidenav/src/index.d.ts
@@ -10,9 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaLabelingProps, CollectionBase, DOMProps, Expandable, Key, MultipleSelection, Node, StyleProps} from '@react-types/shared';
+import {AriaLabelingProps, CollectionBase, DOMProps, Expandable, MultipleSelection, Node, StyleProps} from '@react-types/shared';
 import {HTMLAttributes, ReactNode} from 'react';
-import {LayoutInfo, Size} from '@react-stately/virtualizer';
 
 export interface SideNavProps<T> extends CollectionBase<T>, Expandable, MultipleSelection {
   shouldFocusWrap?: boolean
@@ -27,14 +26,10 @@ export interface SpectrumSideNavItemProps<T> extends HTMLAttributes<HTMLElement>
   item: Node<T>
 }
 
-interface IVirtualizer {
-  updateItemSize(key: Key, size: Size): void
-}
-
 export interface SideNavSectionProps<T> {
-  layoutInfo: LayoutInfo,
-  headerLayoutInfo: LayoutInfo,
-  virtualizer: IVirtualizer,
+  layoutInfo: any,
+  headerLayoutInfo: any,
+  virtualizer: any,
   item: Node<T>,
   children?: ReactNode
 }

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -321,7 +321,15 @@ function TabPanel(props: TabPanelProps, forwardedRef: ForwardedRef<HTMLDivElemen
       data-focus-visible={isFocusVisible || undefined}
       // @ts-ignore
       inert={!isSelected ? 'true' : undefined}
-      data-inert={!isSelected ? 'true' : undefined} />
+      data-inert={!isSelected ? 'true' : undefined}>
+      <Provider
+        values={[
+          [TabsContext, null],
+          [TabListStateContext, null]
+        ]}>
+        {renderProps.children}
+      </Provider>
+    </div>
   );
 }
 

--- a/packages/react-aria-components/stories/Tabs.stories.tsx
+++ b/packages/react-aria-components/stories/Tabs.stories.tsx
@@ -89,3 +89,23 @@ const CustomTab = (props: TabProps) => {
       })} />
   );
 };
+
+export const NestedTabs = () => (
+  <Tabs>
+    <TabList style={{display: 'flex', gap: 8}}>
+      <CustomTab id="foo">Foo</CustomTab>
+      <CustomTab id="bar">Bar</CustomTab>
+    </TabList>
+    <TabPanel id="foo">
+      <Tabs>
+        <TabList style={{display: 'flex', gap: 8}}>
+          <CustomTab id="one">One</CustomTab>
+          <CustomTab id="two">Two</CustomTab>
+        </TabList>
+        <TabPanel id="one">One</TabPanel>
+        <TabPanel id="two">Two</TabPanel>
+      </Tabs>
+    </TabPanel>
+    <TabPanel id="bar">Bar</TabPanel>
+  </Tabs>
+);

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
+import {act, fireEvent, pointerMap, render, waitFor, within} from '@react-spectrum/test-utils-internal';
 import React from 'react';
 import {Tab, TabList, TabPanel, Tabs} from '../';
 import {TabsExample} from '../stories/Tabs.stories';
@@ -409,5 +409,41 @@ describe('Tabs', () => {
     expect(tabs[0]).toHaveAttribute('aria-label', 'Tab A');
     expect(tabs[1]).toHaveAttribute('aria-label', 'Tab B');
     expect(tabs[2]).toHaveAttribute('aria-label', 'Tab C');
+  });
+
+  it('supports nested tabs', async () => {
+    let {getAllByRole} = render(
+      <Tabs>
+        <TabList>
+          <Tab id="foo">Foo</Tab>
+          <Tab id="bar">Bar</Tab>
+        </TabList>
+        <TabPanel id="foo">
+          <Tabs>
+            <TabList>
+              <Tab id="one">One</Tab>
+              <Tab id="two">Two</Tab>
+            </TabList>
+            <TabPanel id="one">One</TabPanel>
+            <TabPanel id="two">Two</TabPanel>
+          </Tabs>
+        </TabPanel>
+        <TabPanel id="bar">Bar</TabPanel>
+      </Tabs>
+    );
+
+    // Wait a tick for MutationObserver in useHasTabbableChild to fire.
+    // This avoids React's "update not wrapped in act" warning.
+    await waitFor(() => Promise.resolve());
+
+    let rootTabs = within(getAllByRole('tablist')[0]).getAllByRole('tab');
+    expect(rootTabs).toHaveLength(2);
+    expect(rootTabs[0]).toHaveTextContent('Foo');
+    expect(rootTabs[1]).toHaveTextContent('Bar');
+
+    let innerTabs = within(getAllByRole('tabpanel')[0]).getAllByRole('tab');
+    expect(innerTabs).toHaveLength(2);
+    expect(innerTabs[0]).toHaveTextContent('One');
+    expect(innerTabs[1]).toHaveTextContent('Two');
   });
 });


### PR DESCRIPTION
* Fixes #6750 by bringing back `getSyntheticLinkProps` alongside the new `useSyntheticLinkProps`. This way if someone pins to an older version of an upstream package like `@react-aria/table`, but the caret dependency on `@react-aria/utils` resolves to a newer version, the packages are still compatible.
* Fixes #6752. We must always use `ReactElement` as the return type of components rather than `ReactNode`. Support for returning types other than JSX elements existed in React since 16 but not in the types until 18. TypeScript will complain that a component can't be rendered as a JSX element at the usage site if a function component returns anything other than an element with old react versions. See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544.
* Fixes #6753. We must clear `TabListStateContext` in `TabPanel` so that nested tabs work and don't connect to the wrong state object. Added test and story.
* Removed dependency on old version of `@react-stately/virtualizer` from `@react-types/sidenav`. Not sure why it was even there and that package is unused, but it caused multiple versions to be installed in our mono repo.