### PR TITLE
docs: add missing parameter to controlled Switch example

### DIFF
--- a/packages/react-aria-components/docs/Switch.mdx
+++ b/packages/react-aria-components/docs/Switch.mdx
@@ -195,7 +195,7 @@ function Example() {
 
   return (
     <>
-      <MySwitch onChange={setSelected}>Low power mode</MySwitch>
+      <MySwitch isSelected={selected} onChange={setSelected}>Low power mode</MySwitch>
       <p>{selected ? 'Low' : 'High'} power mode active.</p>
     </>
   );


### PR DESCRIPTION
No issue, sorry, just found that described prop is missing from the example

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check that docs have been updated

## 🧢 Your Project:

[Evil Martians](https://evilmartians.com) 😄 
