### PR TITLE
Fix ComboBox quiet readonly styling and SearchField padding right specificity 

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
@@ -148,7 +148,7 @@ governing permissions and limitations under the License.
     }
   }
 
-  &.spectrum-InputGroup {
+  &.spectrum-InputGroup.spectrum-InputGroup {
     &.spectrum-InputGroup--invalid {
       .spectrum-FieldButton:before,
       .spectrum-InputGroup-input {

--- a/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
@@ -103,7 +103,7 @@ governing permissions and limitations under the License.
     specifically for readonly inputgroups that aren't disabled since the button will have the disabled class
     but we don't want the border color to be the disabled quiet one
   */
-  &:not(.is-disabled) {
+  &:not(.is-disabled):not(.is-focused) {
     .spectrum-FieldButton {
       &:disabled:before,
       &:disabled:hover:before {

--- a/packages/@adobe/spectrum-css-temp/components/search/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/search/index.css
@@ -65,7 +65,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Search-input {
+.spectrum-Search-input.spectrum-Search-input {
   display: block;
 
   /* Correct the odd appearance of input[type="search"] in Chrome and Safari.*/
@@ -98,4 +98,3 @@ governing permissions and limitations under the License.
     padding-inline-end: calc(var(--spectrum-search-padding-right) + var(--spectrum-textfield-padding-x) + var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-textfield-icon-margin-left));
   }
 }
-


### PR DESCRIPTION
Caught by Chromatic

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
