### PR TITLE
Add prop disabledBehavior to RSP TableView api

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/skin.css
@@ -180,6 +180,10 @@ tbody.spectrum-Table-body {
     background-color: var(--spectrum-table-row-background-color-down);
   }
 
+  &.is-disabled .spectrum-Table-cell.is-disabled {
+    color: var(--spectrum-alias-text-color-disabled);
+  }
+
   /* Alternative to border on rows. Using box shadow since they don't take room unlike border which would cause wiggles
    * in the highlight case and displace the sticky indicator. Also allows for a nicer bottom curved border to match the container,
    * the bottom border curved corners were cut off when using borders.

--- a/packages/@react-spectrum/table/src/TableViewWrapper.tsx
+++ b/packages/@react-spectrum/table/src/TableViewWrapper.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import type {AriaLabelingProps, DOMProps, DOMRef, Key, SpectrumSelectionProps, StyleProps} from '@react-types/shared';
+import type {AriaLabelingProps, DisabledBehavior, DOMProps, DOMRef, Key, SpectrumSelectionProps, StyleProps} from '@react-types/shared';
 import type {ColumnSize, TableProps} from '@react-types/table';
 import type {DragAndDropHooks} from '@react-spectrum/dnd';
 import React, {JSX, ReactElement} from 'react';
@@ -33,6 +33,11 @@ export interface SpectrumTableProps<T> extends TableProps<T>, SpectrumSelectionP
   isQuiet?: boolean,
   /** Sets what the TableView should render when there is no content to display. */
   renderEmptyState?: () => JSX.Element,
+  /**
+   * Whether `disabledKeys` applies to all interactions, or only selection.
+   * @default "selection"
+   */
+  disabledBehavior?: DisabledBehavior,
   /** Handler that is called when a user performs an action on a row. */
   onAction?: (key: Key) => void,
   /**

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -117,6 +117,10 @@ export default {
     },
     disallowEmptySelection: {
       control: 'boolean'
+    },
+    disabledBehavior: {
+      control: 'select',
+      options: ['all', 'selection']
     }
   }
 } as ComponentMeta<typeof TableView>;


### PR DESCRIPTION
Closes [issue](https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=37183649)

- [ ] Do we need an expandable rows with `disabledKeys` story?
- [ ] Do we need a story with `disabledKeys` and content like buttons in the cells?
- [ ] Documentation wasn't mentioned in the scoping, but the docs would be updated to match ListView, correct?
- [ ] Add or update a chromatic story?

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Added control "disabledBehavior" to TableView stories.
Easiest to test is you set `selectionMode` to "multiple" because the checkboxes will be disabled in both modes.

Test with "dynamic with disabled keys" story.

Test DnD with "Drag between tables" story.

Didn't see a story to test expandable row with.

* Confirm "selection" is the default for TableView. (Should be opposite ListView with is "all".)
* Confirm "all" shows the cell content text as disabled.
* Confirm "all" prevents DnD, focus, hover, actions, etc.

## 🧢 Your Project:
RSP