### PR TITLE
Add support for pendingAction to AlertDialog

### DIFF
--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -49,6 +49,8 @@ function disablePendingProps(props) {
   return props;
 }
 
+export const pendingDelay = 1000;
+
 function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>, ref: FocusableRef<HTMLElement>) {
   props = useProviderProps(props);
   props = useSlotProps(props, 'button');
@@ -89,9 +91,9 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
       // Start timer when isPending is set to true.
       timeout = setTimeout(() => {
         setIsProgressVisible(true);
-      }, 1000);
+      }, pendingDelay);
     } else {
-      // Exit loading state when isPending is set to false. */
+      // Exit loading state when isPending is set to false.
       setIsProgressVisible(false);
     }
     return () => {
@@ -122,7 +124,7 @@ function Button<T extends ElementType = 'button'>(props: SpectrumButtonProps<T>,
       }
     }
   } : {
-    // no-op. 
+    // no-op.
     // Not sure why, but TypeScript wouldn't allow to have an empty object `{}`.
     onClick: () => {}
   };

--- a/packages/@react-spectrum/button/src/index.ts
+++ b/packages/@react-spectrum/button/src/index.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 /// <reference types="css-module-types" />
-export {Button} from './Button';
+export {Button, pendingDelay} from './Button';
 export {ActionButton} from './ActionButton';
 export {FieldButton} from './FieldButton';
 export {LogicButton} from './LogicButton';

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -50,6 +50,7 @@ function AlertDialog(props: SpectrumAlertDialogProps, ref: DOMRef) {
     onCancel = () => {},
     onPrimaryAction = () => {},
     onSecondaryAction = () => {},
+    pendingAction,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
@@ -91,6 +92,7 @@ function AlertDialog(props: SpectrumAlertDialogProps, ref: DOMRef) {
         }
         {secondaryActionLabel &&
           <Button
+            isPending={pendingAction === 'secondary'}
             variant="secondary"
             onPress={() => chain(onClose(), onSecondaryAction())}
             isDisabled={isSecondaryActionDisabled}
@@ -99,6 +101,7 @@ function AlertDialog(props: SpectrumAlertDialogProps, ref: DOMRef) {
           </Button>
         }
         <Button
+          isPending={pendingAction === 'primary'}
           variant={confirmVariant}
           onPress={() => chain(onClose(), onPrimaryAction())}
           isDisabled={isPrimaryActionDisabled}

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -13,7 +13,7 @@
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import {Button, pendingDelay} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
-import {chain} from '@react-aria/utils';
+import {chain, useEvent} from '@react-aria/utils';
 import {classNames, useStyleProps} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {Dialog} from './Dialog';
@@ -23,7 +23,7 @@ import {DOMRef} from '@react-types/shared';
 import {Heading} from '@react-spectrum/text';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import React, {forwardRef, useContext, useEffect, useState} from 'react';
+import React, {forwardRef, useContext, useEffect, useRef, useState} from 'react';
 import {SpectrumAlertDialogProps} from '@react-types/dialog';
 import {SpectrumButtonProps} from '@react-types/button';
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
@@ -82,6 +82,14 @@ function AlertDialog(props: SpectrumAlertDialogProps, ref: DOMRef) {
       clearTimeout(timeout);
     };
   }, [pendingAction]);
+
+  // Prevent Escape from closing the Dialog until pending action is finished
+  let windowRef = useRef(typeof window !== 'undefined' ? window : null);
+  useEvent(windowRef, 'keydown', e => {
+    if (e.key === 'Escape' && pendingAction != null) {
+      e.stopPropagation();
+    }
+  }, {capture: true});
 
   return (
     <Dialog

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -13,6 +13,7 @@ import {action} from '@storybook/addon-actions';
 import {ActionButton} from '@react-spectrum/button';
 import {AlertDialog, DialogTrigger} from '../';
 import React from 'react';
+import {SearchField} from '@adobe/react-spectrum';
 import {singleParagraph} from './Dialog.stories';
 import {SpectrumAlertDialogProps} from '@react-types/dialog';
 
@@ -158,12 +159,17 @@ function renderAlert({...props}: SpectrumAlertDialogProps) {
   );
 }
 
-// TODO: should the button be immediately pending? Right now there is a delay
 export const WithPending = {
   render: renderAlert,
   args: {
     ...Confirmation.args,
-    secondaryActionLabel: 'Secondary button'
+    secondaryActionLabel: 'Secondary button',
+    children: (
+      <>
+        {singleParagraph()}
+        <SearchField label="Search" />
+      </>
+    )
   },
   argTypes: {
     pendingAction: {

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -17,175 +17,158 @@ import {singleParagraph} from './Dialog.stories';
 import {SpectrumAlertDialogProps} from '@react-types/dialog';
 
 export default {
-  title: 'Dialog/Alert'
+  title: 'Dialog/Alert',
+  argTypes: {
+    children: {
+      table: {
+        disable: true
+      }
+    },
+    onPrimaryAction: {
+      table: {
+        disable: true
+      }
+    },
+    onSecondaryAction: {
+      table: {
+        disable: true
+      }
+    },
+    onCancel: {
+      table: {
+        disable: true
+      }
+    }
+  }
 };
 
-export const Destructive = () => renderAlert({
-  variant: 'destructive',
-  title: 'Warning Destructive',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel')
-});
-
-Destructive.story = {
+export const Destructive = {
+  render: renderAlert,
+  args: {
+    variant: 'destructive',
+    title: 'Warning Destructive',
+    children: singleParagraph(),
+    primaryActionLabel: 'Accept',
+    cancelLabel: 'Cancel',
+    onPrimaryAction: action('primary'),
+    onSecondaryAction: action('secondary'),
+    onCancel: action('cancel')
+  },
   name: 'destructive'
 };
 
-export const Confirmation = () => renderAlert({
-  variant: 'confirmation',
-  title: 'Confirmation Required',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel')
-});
-
-Confirmation.story = {
+export const Confirmation = {
+  render: renderAlert,
+  args: {
+    ...Destructive.args,
+    variant: 'confirmation',
+    title: 'Confirmation Required'
+  },
   name: 'confirmation'
 };
 
-export const Information = () => renderAlert({
-  variant: 'information',
-  title: 'Informative Alert',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel')
-});
-
-Information.story = {
+export const Information = {
+  render: renderAlert,
+  args: {
+    ...Destructive.args,
+    variant: 'information',
+    title: 'Informative Alert'
+  },
   name: 'information'
 };
 
-export const Error = () => renderAlert({
-  variant: 'error',
-  title: 'Error: Danger Will Robinson',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel')
-});
-
-Error.story = {
+export const Error = {
+  render: renderAlert,
+  args: {
+    ...Destructive.args,
+    variant: 'error',
+    title: 'Error: Danger Will Robinson'
+  },
   name: 'error'
 };
 
-export const Warning = () => renderAlert({
-  variant: 'warning',
-  title: 'This is a warning',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel')
-});
-
-Warning.story = {
+export const Warning = {
+  render: renderAlert,
+  args: {
+    ...Destructive.args,
+    variant: 'warning',
+    title: 'This is a warning'
+  },
   name: 'warning'
 };
 
-export const PrimaryDisabled = () => renderAlert({
-  variant: 'error',
-  title: 'Error: Danger Will Robinson',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel'),
-  isPrimaryActionDisabled: true
-});
-
-PrimaryDisabled.story = {
+export const PrimaryDisabled = {
+  render: renderAlert,
+  args: {
+    ...Error.args,
+    secondaryActionLabel: 'Secondary button',
+    isPrimaryActionDisabled: true
+  },
   name: 'primary disabled'
 };
 
-export const AutoFocusPrimary = () => renderAlert({
-  variant: 'error',
-  title: 'Error: Danger Will Robinson',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  secondaryActionLabel: 'Secondary button',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel'),
-  autoFocusButton: 'primary'
-});
-
-AutoFocusPrimary.story = {
+export const AutoFocusPrimary = {
+  render: renderAlert,
+  args: {
+    ...Error.args,
+    secondaryActionLabel: 'Secondary button',
+    autoFocusButton: 'primary'
+  },
   name: 'autoFocus primary'
 };
 
-export const SecondaryDisabled = () => renderAlert({
-  variant: 'error',
-  title: 'Error: Danger Will Robinson',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  secondaryActionLabel: 'Secondary button',
-  cancelLabel: 'Cancel',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel'),
-  isSecondaryActionDisabled: true
-});
-
-SecondaryDisabled.story = {
+export const SecondaryDisabled = {
+  render: renderAlert,
+  args: {
+    ...Error.args,
+    secondaryActionLabel: 'Secondary button',
+    isSecondaryActionDisabled: true
+  },
   name: 'secondary disabled'
 };
 
-export const AutoFocusSecondary = () => renderAlert({
-  variant: 'error',
-  title: 'Error: Danger Will Robinson',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  secondaryActionLabel: 'Secondary button',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel'),
-  autoFocusButton: 'secondary'
-});
-
-AutoFocusSecondary.story = {
+export const AutoFocusSecondary = {
+  render: renderAlert,
+  args: {
+    ...Error.args,
+    secondaryActionLabel: 'Secondary button',
+    autoFocusButton: 'secondary'
+  },
   name: 'autoFocus secondary'
 };
 
-export const AutoFocusCancel = () => renderAlert({
-  variant: 'error',
-  title: 'Error: Danger Will Robinson',
-  children: singleParagraph(),
-  primaryActionLabel: 'Accept',
-  cancelLabel: 'Cancel',
-  secondaryActionLabel: 'Secondary button',
-  onPrimaryAction: action('primary'),
-  onSecondaryAction: action('secondary'),
-  onCancel: action('cancel'),
-  autoFocusButton: 'cancel'
-});
-
-AutoFocusCancel.story = {
+export const AutoFocusCancel = {
+  render: renderAlert,
+  args: {
+    ...Error.args,
+    secondaryActionLabel: 'Secondary button',
+    autoFocusButton: 'cancel'
+  },
   name: 'autoFocus cancel'
 };
 
 function renderAlert({...props}: SpectrumAlertDialogProps) {
   return (
     <div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>
-      <DialogTrigger defaultOpen>
+      <DialogTrigger>
         <ActionButton>Trigger</ActionButton>
         <AlertDialog {...props} onPrimaryAction={action('primary')} onSecondaryAction={action('secondary')} onCancel={props.onCancel} />
       </DialogTrigger>
     </div>
   );
 }
+
+// TODO: should the button be immediately pending? Right now there is a delay
+export const WithPending = {
+  render: renderAlert,
+  args: {
+    ...Confirmation.args,
+    secondaryActionLabel: 'Secondary button'
+  },
+  argTypes: {
+    pendingAction: {
+      control: 'radio',
+      options: ['primary', 'secondary', 'none']
+    }
+  }
+};

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -168,7 +168,7 @@ export const WithPending = {
   argTypes: {
     pendingAction: {
       control: 'radio',
-      options: ['primary', 'secondary', 'none']
+      options: ['primary', 'secondary', undefined]
     }
   }
 };

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -253,6 +253,12 @@ describe('AlertDialog', function () {
     let spinner = within(pendingButton).queryByRole('progressbar', {hidden: true});
     expect(spinner).toBeVisible();
 
+    await user.keyboard('{Escape}');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).toBeVisible();
+
     rerender(
       <Provider theme={theme}>
         <PendingAlert />
@@ -278,6 +284,12 @@ describe('AlertDialog', function () {
     pendingButton = buttons[2];
     expect(pendingButton).not.toHaveAttribute('aria-disabled', 'true');
     expect(within(pendingButton).queryByRole('progressbar', {hidden: true})).toBeFalsy();
+
+    await user.keyboard('{Escape}');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).not.toBeVisible();
   });
 
   it('render the secondary button as pending', async function () {
@@ -318,6 +330,11 @@ describe('AlertDialog', function () {
     expect(pendingButton).toHaveAttribute('aria-disabled', 'true');
     let spinner = within(pendingButton).queryByRole('progressbar', {hidden: true});
     expect(spinner).toBeVisible();
+    await user.keyboard('{Escape}');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).toBeVisible();
 
     rerender(
       <Provider theme={theme}>
@@ -344,5 +361,11 @@ describe('AlertDialog', function () {
     pendingButton = buttons[1];
     expect(pendingButton).not.toHaveAttribute('aria-disabled', 'true');
     expect(within(pendingButton).queryByRole('progressbar', {hidden: true})).toBeFalsy();
+
+    await user.keyboard('{Escape}');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).not.toBeVisible();
   });
 });

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -225,27 +225,33 @@ describe('AlertDialog', function () {
     let triggerButton = getByRole('button');
     await user.click(triggerButton);
     act(() => {
-      jest.runAllTimers();
+      jest.advanceTimersToNextTimer();
     });
 
     let dialog = getByRole('alertdialog');
     expect(document.activeElement).toBe(dialog);
 
     let buttons = getAllByRole('button');
-    expect(buttons).toHaveLength(3);
-
     let pendingButton = buttons[2];
-    expect(pendingButton).toHaveTextContent('Accept');
-    expect(pendingButton).toHaveAttribute('aria-disabled', 'true');
-    let spinner = within(pendingButton).queryByRole('progressbar', {hidden: true});
-    expect(spinner).toBeVisible();
+    expect(buttons).toHaveLength(3);
+    for (let button of buttons) {
+      expect(button).not.toBeDisabled();
+    }
 
-    await user.click(buttons[0]);
     act(() => {
       jest.runAllTimers();
     });
 
-    expect(dialog).not.toBeVisible();
+    for (let button of buttons) {
+      if (button !== pendingButton) {
+        expect(button).toBeDisabled();
+      }
+    }
+
+    expect(pendingButton).toHaveTextContent('Accept');
+    expect(pendingButton).toHaveAttribute('aria-disabled', 'true');
+    let spinner = within(pendingButton).queryByRole('progressbar', {hidden: true});
+    expect(spinner).toBeVisible();
 
     rerender(
       <Provider theme={theme}>
@@ -253,7 +259,12 @@ describe('AlertDialog', function () {
       </Provider>
     );
 
-    expect(queryByRole('dialog')).toBeNull();
+    await user.click(buttons[0]);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(dialog).not.toBeVisible();
     triggerButton = getByRole('button');
     await user.click(triggerButton);
     act(() => {
@@ -280,27 +291,33 @@ describe('AlertDialog', function () {
     let triggerButton = getByRole('button');
     await user.click(triggerButton);
     act(() => {
-      jest.runAllTimers();
+      jest.advanceTimersToNextTimer();
     });
 
     let dialog = getByRole('alertdialog');
     expect(document.activeElement).toBe(dialog);
 
     let buttons = getAllByRole('button');
-    expect(buttons).toHaveLength(3);
-
     let pendingButton = buttons[1];
-    expect(pendingButton).toHaveTextContent('Secondary');
-    expect(pendingButton).toHaveAttribute('aria-disabled', 'true');
-    let spinner = within(pendingButton).queryByRole('progressbar', {hidden: true});
-    expect(spinner).toBeVisible();
+    expect(buttons).toHaveLength(3);
+    for (let button of buttons) {
+      expect(button).not.toBeDisabled();
+    }
 
-    await user.click(buttons[0]);
     act(() => {
       jest.runAllTimers();
     });
 
-    expect(dialog).not.toBeVisible();
+    for (let button of buttons) {
+      if (button !== pendingButton) {
+        expect(button).toBeDisabled();
+      }
+    }
+
+    expect(pendingButton).toHaveTextContent('Secondary');
+    expect(pendingButton).toHaveAttribute('aria-disabled', 'true');
+    let spinner = within(pendingButton).queryByRole('progressbar', {hidden: true});
+    expect(spinner).toBeVisible();
 
     rerender(
       <Provider theme={theme}>
@@ -308,7 +325,12 @@ describe('AlertDialog', function () {
       </Provider>
     );
 
-    expect(queryByRole('dialog')).toBeNull();
+    await user.click(buttons[0]);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(dialog).not.toBeVisible();
     triggerButton = getByRole('button');
     await user.click(triggerButton);
     act(() => {

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -97,6 +97,8 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   /** Handler that is called when the secondary button is pressed. */
   onSecondaryAction?: () => void,
   /** Button to focus by default when the dialog opens. */
-  autoFocusButton?: 'cancel' | 'primary' | 'secondary'
+  autoFocusButton?: 'cancel' | 'primary' | 'secondary',
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
+  /** Which dialog button to set as "pending" if any.  */
+  pendingAction?: 'primary' | 'secondary'
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the Dialog/Alert With pending story and test the pending behavior with the controls. You shouldn't be able to close the Dialog as long as there is a pending button set. All other AlertDialog buttons should not trigger any actions when pending is true and should look visually disabled when the pending button spinner shows up. 

## 🧢 Your Project:

RSP
