### PR TITLE
Tabs layout

### DIFF
--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -86,18 +86,7 @@ const tab = style({
   alignItems: 'center',
   position: 'relative',
   cursor: 'default',
-  flexGrow: {
-    orientation: {
-      default: 0,
-      vertical: 1
-    }
-  },
-  flexShrink: {
-    orientation: {
-      default: 1,
-      vertical: 0
-    }
-  }
+  flexShrink: 0
 }, getAllowedOverrides());
 
 const icon = style({

--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -44,12 +44,21 @@ interface TabPanelProps extends Omit<AriaTabPanelProps, 'children' | 'style' | '
   children?: ReactNode
 }
 
+const tabPanel = style({
+  marginTop: 4,
+  color: 'gray-800',
+  flexGrow: 1,
+  flexBasis: '[0%]',
+  minHeight: 0,
+  minWidth: 0
+}, getAllowedOverrides({height: true}));
+
 export function TabPanel(props: TabPanelProps) {
   return (
-    <AriaTabPanel 
+    <AriaTabPanel
       {...props}
       style={props.UNSAFE_style}
-      className={(props.UNSAFE_className || '') + style({marginTop: 4, color: 'gray-800'}, getAllowedOverrides())(null, props.styles)} />
+      className={(props.UNSAFE_className || '') + tabPanel(null , props.styles)} />
   );
 }
 
@@ -77,7 +86,18 @@ const tab = style({
   alignItems: 'center',
   position: 'relative',
   cursor: 'default',
-  minWidth: 'max'
+  flexGrow: {
+    orientation: {
+      default: 0,
+      vertical: 1
+    }
+  },
+  flexShrink: {
+    orientation: {
+      default: 1,
+      vertical: 0
+    }
+  }
 }, getAllowedOverrides());
 
 const icon = style({
@@ -92,7 +112,7 @@ export function Tab(props: TabProps) {
   let {density} = useContext(TabsInternalContext);
 
   return (
-    <RACTab 
+    <RACTab
       {...props}
       style={props.UNSAFE_style}
       className={renderProps => (props.UNSAFE_className || '') + tab({...renderProps, density}, props.styles)}>
@@ -104,7 +124,7 @@ export function Tab(props: TabProps) {
             styles: icon
           }]
         ]}>
-        {props.children}
+        {typeof props.children === 'string' ? <Text>{props.children}</Text> : props.children}
       </Provider>
     </RACTab>
   );
@@ -137,15 +157,17 @@ const tablist = style({
       vertical: 12
     }
   },
+  flexShrink: 0,
+  flexBasis: '[0%]'
 });
 
 export function TabList<T extends object>(props: TabListProps<T>) {
-  let {density, isDisabled, disabledKeys, orientation = 'horizontal'} = useContext(TabsInternalContext);
+  let {density, isDisabled, disabledKeys, orientation} = useContext(TabsInternalContext);
   let state = useContext(TabListStateContext);
   let [selectedTab, setSelectedTab] = useState<HTMLElement | undefined>(undefined);
   let tablistRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {    
+  useEffect(() => {
     if (tablistRef?.current) {
       let tab: HTMLElement | null = tablistRef.current.querySelector('[role=tab][data-selected=true]');
 
@@ -159,13 +181,13 @@ export function TabList<T extends object>(props: TabListProps<T>) {
     <div
       style={props.UNSAFE_style}
       className={(props.UNSAFE_className || '') + style({position: 'relative'}, getAllowedOverrides())(null, props.styles)}>
-      {orientation === 'vertical' && 
+      {orientation === 'vertical' &&
         <TabLine disabledKeys={disabledKeys} isDisabled={isDisabled} selectedTab={selectedTab} orientation={orientation} density={density}/>}
-      <RACTabList 
+      <RACTabList
         {...props}
         ref={tablistRef}
         className={renderProps => tablist({...renderProps, density})} />
-      {orientation === 'horizontal' && 
+      {orientation === 'horizontal' &&
         <TabLine disabledKeys={disabledKeys} isDisabled={isDisabled} selectedTab={selectedTab} orientation={orientation} density={density}/>}
     </div>
   );
@@ -175,7 +197,7 @@ function isAllTabsDisabled<T>(collection: Collection<Node<T>> | null, disabledKe
   let testKey: Key | null = null;
   if (collection && collection.size > 0) {
     testKey = collection.getFirstKey();
-    
+
     let index = 0;
     while (testKey && index < collection.size) {
       // We have to check if the item in the collection has a key in disabledKeys or has the isDisabled prop set directly on it
@@ -259,10 +281,10 @@ function TabLine(props: TabLineProps) {
 
   let onResize = useCallback(() => {
     if (selectedTab) {
-      let styleObj: { transform: string | undefined, width: string | undefined, height: string | undefined } = { 
-        transform: undefined, 
-        width: undefined, 
-        height: undefined 
+      let styleObj: { transform: string | undefined, width: string | undefined, height: string | undefined } = {
+        transform: undefined,
+        width: undefined,
+        height: undefined
       };
 
       // In RTL, calculate the transform from the right edge of the tablist so that resizing the window doesn't break the Tabline position due to offsetLeft changes
@@ -283,7 +305,7 @@ function TabLine(props: TabLineProps) {
   useLayoutEffect(() => {
     onResize();
   }, [onResize, state?.selectedKey, direction, orientation, density]);
-  
+
   return (
     <div style={{...style}} className={mergeStyles(selectedIndicator({isDisabled, orientation}), selectionAnimation)} />
   );
@@ -299,7 +321,7 @@ const tabs = style({
       horizontal: 'column'
     }
   }
-}, getAllowedOverrides());
+}, getAllowedOverrides({height: true}));
 
 const TabsInternalContext = createContext<TabsProps>({});
 
@@ -308,21 +330,21 @@ function Tabs(props: TabsProps, ref: DOMRef<HTMLDivElement>) {
     density = 'regular',
     isDisabled,
     disabledKeys,
-    orientation
+    orientation = 'horizontal'
   } = props
   let domRef = useDOMRef(ref);
 
   return (
-    <RACTabs 
+    <RACTabs
       {...props}
       ref={domRef}
       style={props.UNSAFE_style}
       className={renderProps => (props.UNSAFE_className || '') + tabs({...renderProps}, props.styles)}>
       <Provider
-        values={[ 
+        values={[
           [TabsInternalContext, {density, isDisabled, disabledKeys, orientation}]
         ]}>
-        {typeof props.children === 'string' ? <Text>{props.children}</Text> : props.children}
+        {props.children}
       </Provider>
     </RACTabs>
   );

--- a/packages/@react-spectrum/s2/stories/Tabs.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Tabs.stories.tsx
@@ -27,20 +27,27 @@ const meta: Meta<typeof Tabs> = {
 export default meta;
 
 export const Example = (args: any) => (
-  <Tabs {...args} styles={style({width: '[450px]', height: 144})}>
+  <Tabs {...args} styles={style({width: '[450px]', height: 256})}>
     <TabList aria-label="History of Ancient Rome">
       <Tab id="FoR"><Edit />Founding of Rome</Tab>
       <Tab id="MaR">Monarchy and Republic</Tab>
       <Tab id="Emp">Empire</Tab>
     </TabList>
-    <TabPanel id="FoR">
-      Arma virumque cano, Troiae qui primus ab oris.
+    <TabPanel id="FoR" UNSAFE_style={{display: 'flex'}}>
+      <div style={{overflow: 'auto'}}>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum non rutrum augue, a dictum est. Sed ultricies vel orci in blandit. Morbi sed tempor leo. Phasellus et sollicitudin nunc, a volutpat est. In volutpat molestie velit, nec rhoncus felis vulputate porttitor. In efficitur nibh tortor, maximus imperdiet libero sollicitudin sed. Pellentesque dictum, quam id scelerisque rutrum, lorem augue suscipit est, nec ultricies ligula lorem id dui. Cras lacus tortor, fringilla nec ligula quis, semper imperdiet ex.</p>
+    </div>
     </TabPanel>
-    <TabPanel id="MaR">
-      Senatus Populusque Romanus.
+    <TabPanel id="MaR" UNSAFE_style={{display: 'flex'}}>
+    <div style={{overflow: 'auto'}}>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut vulputate justo. Suspendisse potenti. Nunc id fringilla leo, at luctus quam. Maecenas et ipsum nisi. Curabitur in porta purus, a pretium est. Fusce eu urna diam. Sed nunc neque, consectetur ut purus nec, consequat elementum libero. Sed ut diam in quam maximus condimentum at non erat. Vestibulum sagittis rutrum velit, vitae suscipit arcu. Nulla ac feugiat ante, vitae laoreet ligula. Maecenas sed molestie ligula. Nulla sed fringilla ex. Nulla viverra tortor at enim condimentum egestas. Nulla sed tristique sapien. Integer ligula quam, vulputate eget mollis eu, interdum sit amet justo.</p>
+<p>Vivamus dignissim tortor ut sapien congue tristique. Sed ac aliquet mauris. Nulla metus dui, elementum sit amet luctus eu, condimentum id elit. Praesent id nibh sed ligula congue venenatis. Pellentesque urna turpis, eleifend id pellentesque a, auctor nec neque. Vestibulum ipsum mauris, rutrum sit amet magna et, aliquet mollis tellus. Pellentesque nec ultricies nibh, at tempus massa. Phasellus dictum turpis et interdum scelerisque. Aliquam fermentum tincidunt ipsum sit amet suscipit. Fusce non dui sed diam lacinia mattis fermentum eu urna. Cras pretium id nunc in elementum. Mauris laoreet odio vitae laoreet dictum. In non justo nec nunc vehicula posuere non non ligula. Nullam eleifend scelerisque nibh, in sollicitudin tortor ullamcorper vel. Praesent sagittis risus in erat dignissim, non lacinia elit efficitur. Quisque maximus nulla vel luctus pharetra.</p>
+    </div>
     </TabPanel>
-    <TabPanel id="Emp">
-      Alea jacta est.
+    <TabPanel id="Emp" UNSAFE_style={{display: 'flex'}}>
+    <div style={{overflow: 'auto'}}>
+      <p>Alea jacta est.</p>
+      </div>
     </TabPanel>
   </Tabs>
 );


### PR DESCRIPTION
A few things I found while reviewing the styles

Should we have some other overrides to make it easier to directly styles the tabPanel with things like `overflow` and `display`?

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
