### PR TITLE
Remove isCollapsed from S2 NumberField and add hideStepper

### DIFF
--- a/.storybook-s2/docs/Migrating.jsx
+++ b/.storybook-s2/docs/Migrating.jsx
@@ -209,7 +209,6 @@ export function Migrating() {
           <li className={style({lineHeight: 'body', color: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({lineHeight: 'body', color: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({lineHeight: 'body', color: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({lineHeight: 'body', color: 'body', marginY: 8})}>[PENDING] Comment out <Code>hideStepper</Code> (it has not been implemented yet)</li>
         </ul>
 
         <H3>Picker</H3>

--- a/packages/@react-spectrum/s2/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/NumberField.stories.tsx
@@ -44,12 +44,6 @@ export const Example: Story = {
   }
 };
 
-export const Collapsed: Story = {
-  render: (args) => (
-    <NumberField {...args} isCollapsed />
-  )
-};
-
 export const Validation = (args: any) => (
   <Form>
     <NumberField {...args} />

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/numberfield.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/numberfield.test.ts.snap
@@ -4,10 +4,8 @@ exports[`Comments out hideStepper 1`] = `
 "import { NumberField } from "@react-spectrum/s2";
 
 <div>
-  // TODO(S2-upgrade): hideStepper has not been implemented yet.
-  <NumberField />
-  // TODO(S2-upgrade): hideStepper has not been implemented yet.
-  <NumberField />
+  <NumberField hideStepper />
+  <NumberField hideStepper={true} />
 </div>"
 `;
 

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/changes.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/changes.ts
@@ -666,14 +666,6 @@ export const changes: ChangesJSON = {
           name: 'removeProp',
           args: {propToRemove: 'validationState', propValue: 'valid'}
         }
-      },
-      {
-        description: 'Comment out hideStepper',
-        reason: 'It has not been implemented yet',
-        function: {
-          name: 'commentOutProp',
-          args: {propToComment: 'hideStepper'}
-        }
       }
     ]
   },


### PR DESCRIPTION
The isCollapsed option was removed from the Figma designs since it is not accessible (hit targets too small). Added hideStepper option from v3 as well.