### PR TITLE
Do not define a default color-scheme on Provider if one is defined at the page level

### DIFF
--- a/packages/@react-spectrum/s2/src/Provider.tsx
+++ b/packages/@react-spectrum/s2/src/Provider.tsx
@@ -13,6 +13,7 @@
 import type {ColorScheme, Router} from '@react-types/provider';
 import {colorScheme, UnsafeStyles} from './style-utils' with {type: 'macro'};
 import {createContext, JSX, ReactNode, useContext} from 'react';
+import {generateDefaultColorSchemeStyles} from './page.macro' with {type: 'macro'};
 import {I18nProvider, RouterProvider, useLocale} from 'react-aria-components';
 import {mergeStyles} from '../style/runtime';
 import {style} from '../style/spectrum-theme' with {type: 'macro'};
@@ -52,7 +53,7 @@ export const ColorSchemeContext = createContext<ColorScheme | 'light dark' | nul
 export function Provider(props: ProviderProps) {
   let result = <ProviderInner {...props} />;
   let parentColorScheme = useContext(ColorSchemeContext);
-  let colorScheme = props.colorScheme || parentColorScheme || 'light dark';
+  let colorScheme = props.colorScheme || parentColorScheme;
   if (colorScheme !== parentColorScheme) {
     result = <ColorSchemeContext.Provider value={colorScheme}>{result}</ColorSchemeContext.Provider>;
   }
@@ -68,6 +69,8 @@ export function Provider(props: ProviderProps) {
   return result;
 }
 
+generateDefaultColorSchemeStyles();
+
 let providerStyles = style({
   ...colorScheme(),
   '--s2-container-bg': {
@@ -80,7 +83,14 @@ let providerStyles = style({
       }
     }
   },
-  backgroundColor: '--s2-container-bg'
+  backgroundColor: {
+    // Don't set a background unless one is requested.
+    background: {
+      base: '--s2-container-bg',
+      'layer-1': '--s2-container-bg',
+      'layer-2': '--s2-container-bg'
+    }
+  }
 });
 
 function ProviderInner(props: ProviderProps) {

--- a/packages/@react-spectrum/s2/src/page.macro.ts
+++ b/packages/@react-spectrum/s2/src/page.macro.ts
@@ -49,3 +49,27 @@ export function generatePageStyles(this: MacroContext | void) {
     });
   }
 }
+
+// This generates a low specificity rule to define default values for 
+// --lightningcss-light and --lightningcss-dark. This is used when rendering
+// a <Provider> without setting a colorScheme prop, and when page.css is not present.
+// It is equivalent to setting `color-scheme: light dark`, but without overriding
+// the browser default for content outside the provider.
+export function generateDefaultColorSchemeStyles(this: MacroContext | void) {
+  if (this && typeof this.addAsset === 'function') {
+    this.addAsset({
+      type: 'css',
+      content: `@layer _.a {
+        :where(html) {
+          --lightningcss-light: initial;
+          --lightningcss-dark: ;
+
+          @media (prefers-color-scheme: dark) {
+            --lightningcss-light: ;
+            --lightningcss-dark: initial;
+          }
+        }
+      }`
+    });
+  }
+}

--- a/packages/@react-spectrum/s2/src/style-utils.ts
+++ b/packages/@react-spectrum/s2/src/style-utils.ts
@@ -131,6 +131,8 @@ export const fieldInput = () => ({
 
 export const colorScheme = () => ({
   colorScheme: {
+    // Default to page color scheme if none is defined.
+    default: 'var(--lightningcss-light, light) var(--lightningcss-dark, dark)',
     colorScheme: {
       'light dark': 'light dark',
       light: 'light',

--- a/packages/@react-spectrum/s2/src/style-utils.ts
+++ b/packages/@react-spectrum/s2/src/style-utils.ts
@@ -132,7 +132,7 @@ export const fieldInput = () => ({
 export const colorScheme = () => ({
   colorScheme: {
     // Default to page color scheme if none is defined.
-    default: 'var(--lightningcss-light, light) var(--lightningcss-dark, dark)',
+    default: '[var(--lightningcss-light, light) var(--lightningcss-dark, dark)]',
     colorScheme: {
       'light dark': 'light dark',
       light: 'light',


### PR DESCRIPTION
A `<Provider>` with no `colorScheme` prop defined defaults to `light dark`. However, when `page.css` is imported, it defines the color scheme on the `<html>` element. In that case, the root Provider should take the color-scheme from the page rather than overriding it with `light dark`. A use case for this is when setting the locale but still using `page.css`.

This generates an additional very low specificity rule that defines default values for `--lightningcss-light` and `--lightningcss-dark`, the variables used to determine the color-scheme. When `page.css` is present, it overrides this rule. Provider does not set any color-scheme by default, and will then default to using one of these rules.

Since this is setting lightningcss variables it could affect content outside our Provider that is also compiled by lightningcss. However without any color-scheme defined this is broken, so the hope is that users will be defining their own color-scheme in that case anyway.

Once we can use `light-dark()` natively, all of this will be unnecessary.