### PR TITLE
Release fixes

### DIFF
--- a/.parcelrc-build
+++ b/.parcelrc-build
@@ -7,6 +7,10 @@
     "packages/**/intl/*.json": ["parcel-transformer-intl"],
     "bundle-text:*.svg": ["@parcel/transformer-svg", "@parcel/transformer-inline-string"],
     "illustration:*.svg": ["@react-spectrum/parcel-transformer-s2-icon"],
+    "illustrations-module:*svg": ["@react-spectrum/parcel-transformer-s2-icon"],
+    "illustrations-main:*.svg": ["@react-spectrum/parcel-transformer-s2-icon"],
+    "illustrations-module:*": ["..."],
+    "illustrations-main:*": ["..."],
     "packages/@react-spectrum/s2/s2wf-icons/**/*.svg": ["@react-spectrum/parcel-transformer-s2-icon"],
     // Disable PostCSS from running over style macro output
     "packages/@react-spectrum/s2/**/*.css": ["@parcel/transformer-css"],

--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -126,7 +126,8 @@ const inputButton = style({
     forcedColors: {
       default: 'ButtonFace'
     }
-  }
+  },
+  cursor: 'default'
 });
 
 const iconStyles = style({

--- a/packages/dev/codemods/src/index.ts
+++ b/packages/dev/codemods/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const {parseArgs} = require('node:util');
 import {s1_to_s2} from './s1-to-s2/src';
 import {use_monopackages} from './use-monopackages/src';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/combobox.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/combobox.test.ts.snap
@@ -223,3 +223,14 @@ let props = {validationState: 'invalid'};
   </ComboBox>
 </div>"
 `;
+
+exports[`handles sections 1`] = `
+"import { ComboBoxSection, ComboBoxItem, ComboBox } from "@react-spectrum/s2";
+import { Section, Item } from '@adobe/react-spectrum';
+<ComboBox>
+  <ComboBoxSection><Header>Section title</Header>
+    <ComboBoxItem>Item one</ComboBoxItem>
+    <ComboBoxItem>Item two</ComboBoxItem>
+  </ComboBoxSection>
+</ComboBox>"
+`;

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/imports.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/imports.test.ts.snap
@@ -63,7 +63,7 @@ import { Section, Item, ListBox } from '@adobe/react-spectrum';
 
 <div>
   <Menu aria-label="Text">
-    <MenuSection title="Styles">
+    <MenuSection><Header>Styles</Header>
       <MenuItem id="bold">Bold</MenuItem>
       <MenuItem id="underline">Underline</MenuItem>
     </MenuSection>

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/menu.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/menu.test.ts.snap
@@ -180,10 +180,7 @@ import { Item, Section } from '@adobe/react-spectrum';
           <MenuItem>Email</MenuItem>
         </Menu>
       </SubmenuTrigger>
-      <MenuSection>
-        <Header>
-          <Heading>Section heading</Heading>
-        </Header>
+      <MenuSection><Header>Section heading</Header>
         <MenuItem>Save</MenuItem>
       </MenuSection>
     </Menu>
@@ -218,10 +215,7 @@ import { Item, Section } from '@adobe/react-spectrum';
           <MenuItem id="email">Email</MenuItem>
         </Menu>
       </SubmenuTrigger>
-      <MenuSection>
-        <Header>
-          <Heading>Section heading</Heading>
-        </Header>
+      <MenuSection><Header>Section heading</Header>
         <MenuItem id="save">Save</MenuItem>
       </MenuSection>
     </Menu>

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
@@ -144,3 +144,14 @@ let props = {validationState: 'invalid'};
   </Picker>
 </div>"
 `;
+
+exports[`handles sections 1`] = `
+"import { PickerSection, PickerItem, Picker } from "@react-spectrum/s2";
+import { Section, Item } from '@adobe/react-spectrum';
+<Picker>
+  <PickerSection><Header>Section title</Header>
+    <PickerItem>Item one</PickerItem>
+    <PickerItem>Item two</PickerItem>
+  </PickerSection>
+</Picker>"
+`;

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/combobox.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/combobox.test.ts
@@ -213,3 +213,13 @@ let props = {validationState: 'invalid'};
   </ComboBox>
 </div>
 `);
+
+test('handles sections', `
+import {ComboBox, Section, Item} from '@adobe/react-spectrum';
+<ComboBox>
+  <Section title="Section title">
+    <Item>Item one</Item>
+    <Item>Item two</Item>
+  </Section>
+</ComboBox>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/menu.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/menu.test.ts
@@ -22,10 +22,7 @@ import {Menu, MenuTrigger, Item, SubmenuTrigger, Button, Section, Header, Headin
           <Item>Email</Item>
         </Menu>
       </SubmenuTrigger>
-      <Section>
-        <Header>
-          <Heading>Section heading</Heading>
-        </Header>
+      <Section title="Section heading">
         <Item>Save</Item>
       </Section>
     </Menu>
@@ -49,10 +46,7 @@ import {Menu, MenuTrigger, Item, SubmenuTrigger, Button, Section, Header, Headin
           <Item key="email">Email</Item>
         </Menu>
       </SubmenuTrigger>
-      <Section>
-        <Header>
-          <Heading>Section heading</Heading>
-        </Header>
+      <Section title="Section heading">
         <Item key="save">Save</Item>
       </Section>
     </Menu>

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
@@ -138,3 +138,13 @@ let props = {validationState: 'invalid'};
   </Picker>
 </div>
 `);
+
+test('handles sections', `
+import {Picker, Section, Item} from '@adobe/react-spectrum';
+<Picker>
+  <Section title="Section title">
+    <Item>Item one</Item>
+    <Item>Item two</Item>
+  </Section>
+</Picker>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/changes.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/changes.ts
@@ -861,6 +861,28 @@ export const changes: ChangesJSON = {
         }
       },
       {
+        description: 'If within Picker, update Section to be a PickerSection',
+        reason: 'Updated component structure',
+        function: {
+          name: 'updateComponentWithinCollection',
+          args: {
+            parentComponent: 'Picker',
+            newComponent: 'PickerSection'
+          }
+        }
+      },
+      {
+        description: 'If within ComboBox, update Section to be a ComboBoxSection',
+        reason: 'Updated component structure',
+        function: {
+          name: 'updateComponentWithinCollection',
+          args: {
+            parentComponent: 'ComboBox',
+            newComponent: 'ComboBoxSection'
+          }
+        }
+      },
+      {
         description:
           'Move title prop string to be a child of new Heading within a Header',
         reason: 'Updated API',
@@ -868,7 +890,35 @@ export const changes: ChangesJSON = {
           name: 'movePropToNewChildComponent',
           args: {
             parentComponent: 'Menu',
-            childComponent: 'Section',
+            childComponent: 'MenuSection',
+            propToMove: 'title',
+            newChildComponent: 'Header'
+          }
+        }
+      },
+      {
+        description:
+          'Move title prop string to be a child of new Heading within a Header',
+        reason: 'Updated API',
+        function: {
+          name: 'movePropToNewChildComponent',
+          args: {
+            parentComponent: 'Picker',
+            childComponent: 'PickerSection',
+            propToMove: 'title',
+            newChildComponent: 'Header'
+          }
+        }
+      },
+      {
+        description:
+          'Move title prop string to be a child of new Heading within a Header',
+        reason: 'Updated API',
+        function: {
+          name: 'movePropToNewChildComponent',
+          args: {
+            parentComponent: 'ComboBox',
+            childComponent: 'ComboBoxSection',
             propToMove: 'title',
             newChildComponent: 'Header'
           }

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/codemod.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/codemod.ts
@@ -204,6 +204,7 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
         (b.path.node.imported.name === 'Item' || b.path.node.imported.name === 'Section')
       ) {
         // Keep Item and Section imports
+        // TODO: remove if they are unused
         return;
       }
       b.path.remove();

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
@@ -645,7 +645,7 @@ function movePropToNewChildComponent(
     getName(path, path.node.openingElement.name) === childComponent &&
     getName(path, path.parentPath.node.openingElement.name) === parentComponent
   ) {
-    let propValue;
+    let propValue: t.JSXAttribute['value'] | void;
     path.node.openingElement.attributes =
       path.node.openingElement.attributes.filter((attr) => {
         if (t.isJSXAttribute(attr) && attr.name.name === propToMove) {
@@ -660,9 +660,10 @@ function movePropToNewChildComponent(
         t.jsxElement(
           t.jsxOpeningElement(t.jsxIdentifier(newChildComponent), []),
           t.jsxClosingElement(t.jsxIdentifier(newChildComponent)),
-          [t.jsxText(propValue)]
+          [t.isStringLiteral(propValue) ? t.jsxText(propValue.value) : propValue]
         )
       );
+      // TODO: handle dynamic collections. Need to wrap function child in <Collection> and move `items` prop down.
     }
   }
 }

--- a/packages/dev/codemods/src/s1-to-s2/src/getComponents.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/getComponents.ts
@@ -7,7 +7,7 @@ export function getComponents(): Set<string> {
   // Determine list of available components in S2 from index.ts
   let availableComponents = new Set<string>();
   const packagePath = require.resolve('@react-spectrum/s2');
-  const indexPath = path.join(path.dirname(packagePath), process.env.NODE_ENV === 'test' ? 'src/index.ts' : '../src/index.js');
+  const indexPath = path.join(path.dirname(packagePath), process.env.NODE_ENV === 'test' ? 'src/index.ts' : '../src/index.ts');
   let index = parse(readFileSync(indexPath, 'utf8'), {sourceType: 'module', plugins: ['typescript']});
   traverse(index, {
     ExportNamedDeclaration(path) {


### PR DESCRIPTION
* Codemod needs a hashbang to specify interpreter when it is run via npx
* We need to resolve from `src/index.ts` rather than `.js`
* Convert Section to PickerSection and ComboBoxSection - this still doesn't handle dynamic collections. For that we would need to wrap the function child in `<Collection>`
* Small fix for cursor in NumberField stepper buttons
* Fix build of illustrations so that it includes our wrapper (actually processed by our Icon transformer).