### PR TITLE
Codemod: don't affect Items in unimplemented collection components

### DIFF
--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/multi-collection.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/multi-collection.test.ts.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Does not affect unimplemented collections 1`] = `
+"import {Accordion, Item, ActionBarContainer, ActionBar, ListView, ListBox} from '@adobe/react-spectrum';
+import {SearchAutocomplete} from '@react-spectrum/autocomplete';
+import {StepList} from '@react-spectrum/steplist';
+
+<div>
+  <SearchAutocomplete>
+    <Item key="one">One</Item>
+    <Item key="two">Two</Item>
+    <Item key="three">Three</Item>
+  </SearchAutocomplete>
+  <Accordion>
+    <Item title="One" key="one">One</Item>
+    <Item title="Two" key="two">Two</Item>
+    <Item title="Three" key="three">Three</Item>
+  </Accordion>
+  <ActionBarContainer height={300} maxWidth="size-6000">
+    <ListView>
+      <Item key="photoshop">Adobe Photoshop</Item>
+      <Item key="illustrator">Adobe Illustrator</Item>
+      <Item key="xd">Adobe XD</Item>
+    </ListView>
+    <ActionBar>
+      <Item key="one">One</Item>
+      <Item key="two">Two</Item>
+      <Item key="three">Three</Item>
+    </ActionBar>
+  </ActionBarContainer>
+  <StepList>
+    <Item key="one">One</Item>
+    <Item key="two">Two</Item>
+    <Item key="three">Three</Item>
+  </StepList>
+  <ListBox>
+    <Item key="one">One</Item>
+    <Item key="two">Two</Item>
+    <Item key="three">Three</Item>
+  </ListBox>
+</div>"
+`;
+
 exports[`Static - Renames Item to Breadcrumb and adds import 1`] = `
 "import {
   Breadcrumb,

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/multi-collection.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/multi-collection.test.ts
@@ -39,3 +39,43 @@ import {Breadcrumbs, Item, Menu, MenuTrigger, SubmenuTrigger, Button, Section, H
 </div>
 `);
 
+test('Does not affect unimplemented collections', `
+import {Accordion, Item, ActionBarContainer, ActionBar, ListView, ListBox} from '@adobe/react-spectrum';
+import {SearchAutocomplete} from '@react-spectrum/autocomplete';
+import {StepList} from '@react-spectrum/steplist';
+
+<div>
+  <SearchAutocomplete>
+    <Item key="one">One</Item>
+    <Item key="two">Two</Item>
+    <Item key="three">Three</Item>
+  </SearchAutocomplete>
+  <Accordion>
+    <Item title="One" key="one">One</Item>
+    <Item title="Two" key="two">Two</Item>
+    <Item title="Three" key="three">Three</Item>
+  </Accordion>
+  <ActionBarContainer height={300} maxWidth="size-6000">
+    <ListView>
+      <Item key="photoshop">Adobe Photoshop</Item>
+      <Item key="illustrator">Adobe Illustrator</Item>
+      <Item key="xd">Adobe XD</Item>
+    </ListView>
+    <ActionBar>
+      <Item key="one">One</Item>
+      <Item key="two">Two</Item>
+      <Item key="three">Three</Item>
+    </ActionBar>
+  </ActionBarContainer>
+  <StepList>
+    <Item key="one">One</Item>
+    <Item key="two">Two</Item>
+    <Item key="three">Three</Item>
+  </StepList>
+  <ListBox>
+    <Item key="one">One</Item>
+    <Item key="two">Two</Item>
+    <Item key="three">Three</Item>
+  </ListBox>
+</div>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
@@ -509,7 +509,7 @@ function updateComponentWithinCollection(
 function commentIfParentCollectionNotDetected(
   path: NodePath<t.JSXElement>
 ) {
-  const collectionItemParents = new Set(['Menu', 'ActionMenu', 'TagGroup', 'Breadcrumbs', 'Picker', 'ComboBox', 'ListBox', 'TabList', 'TabPanels', 'ActionGroup', 'ListBox', 'ListView', 'Collection']);
+  const collectionItemParents = new Set(['Menu', 'ActionMenu', 'TagGroup', 'Breadcrumbs', 'Picker', 'ComboBox', 'ListBox', 'TabList', 'TabPanels', 'ActionGroup', 'ListBox', 'ListView', 'Collection', 'SearchAutocomplete', 'Accordion', 'ActionBar', 'StepList']);
   if (
     t.isJSXElement(path.node)
   ) {


### PR DESCRIPTION
Previously, we were only checking implemented parent collection components of Items, so you may end up with a case like this:

```
<SearchAutocomplete label="Search with Autocomplete">
  // TODO(S2-upgrade): Couldn't automatically detect what type of collection component this is rendered in. You'll need to update this manually.
  <Item>Aerospace</Item>
</SearchAutocomplete>
```

but this is a valid case where we don't want to leave a comment.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
