### PR TITLE
Fixing Tags so they properly truncate if wider than the container

### DIFF
--- a/packages/@react-spectrum/s2/src/TagGroup.tsx
+++ b/packages/@react-spectrum/s2/src/TagGroup.tsx
@@ -443,6 +443,8 @@ function ActionGroup(props) {
 const tagStyles = style({
   ...focusRing(),
   display: 'inline-flex',
+  boxSizing: 'border-box',
+  maxWidth: 'full',
   verticalAlign: 'middle',
   alignItems: 'center',
   justifyContent: 'center',

--- a/packages/@react-spectrum/s2/stories/TagGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TagGroup.stories.tsx
@@ -56,6 +56,7 @@ export let Example = {
       <div style={{width: 320, resize: 'horizontal', overflow: 'hidden', padding: 4}}>
         <TagGroup {...args}>
           <Tag id="chocolate">Chocolate</Tag>
+          <Tag>Very very very very very very very very very very very very very very very very long tag </Tag>
           <Tag>Mint</Tag>
           <Tag>Strawberry</Tag>
           <Tag>Vanilla</Tag>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6962

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
