### PR TITLE
fix: S2 upgrade assistant links and install step

### DIFF
--- a/packages/dev/codemods/src/s1-to-s2/src/index.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/index.ts
@@ -53,7 +53,7 @@ export async function s1_to_s2(options: S1ToS2CodemodOptions) {
       `  - Vite: ${chalk.underline('https://github.com/adobe/react-spectrum/tree/main/examples/s2-vite-project')}\n` +
       `  - Rollup: ${chalk.underline('https://github.com/adobe/react-spectrum/tree/main/examples/s2-rollup-starter-app')}\n` +
       `  - ESBuild: ${chalk.underline('https://github.com/adobe/react-spectrum/tree/main/examples/s2-esbuild-starter-app')}\n\n` +
-      `or view documentation for the plugin here: ${chalk.underline('https://jsr.io/@unplugin/macros')}`
+      `or view documentation here: ${chalk.underline('https://react-spectrum.adobe.com/s2/index.html?path=/docs/intro--docs#configuring-your-bundler')}`
     );
   }
 
@@ -63,7 +63,7 @@ export async function s1_to_s2(options: S1ToS2CodemodOptions) {
     `${chalk.bold('TODO(S2-upgrade)')}\n\n` +
     'You should be able to search your codebase and handle these manually. \n\n' +
     'We also recommend running your project\'s code formatter (i.e. Prettier, ESLint) after the upgrade process to clean up any extraneous formatting from the codemod.\n\n' +
-    `For additional help, reference the Spectrum 2 Migration Guide: ${chalk.underline('https://github.com/adobe/react-spectrum/tree/main/packages/@react-spectrum/codemods/s1-to-s2/UPGRADE.md')}`
+    `For additional help, reference the Spectrum 2 Migration Guide: ${chalk.underline('https://react-spectrum.adobe.com/s2/index.html?path=/docs/migrating--docs')}`
   );
 
   console.log(boxen(

--- a/packages/dev/codemods/src/s1-to-s2/src/utils/installPackage.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/utils/installPackage.ts
@@ -38,7 +38,8 @@ export default async function installPackage(packageName: string, options?: {dev
   }
   try {
     logger.info(`Installing ${chalk.bold(packageName)} using ${chalk.bold(packageManager.name)}...`);
-    await execa(packageManager.name, [packageManager.installCommand, `${packageName}@latest`, options?.dev ? '-D' : undefined]);
+    const devFlag = options?.dev ? ['-D'] : [];
+    await execa(packageManager.name, [packageManager.installCommand, `${packageName}@latest`, ...devFlag]);
     logger.success(`Successfully installed ${chalk.bold(packageName)}!\n`);
     return true;
   } catch (e: any) {


### PR DESCRIPTION
- Updates two links
- Fixes package install step, where `undefined` was getting used as an argument

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. `cd packages/dev/codemods && yarn build`

2. Change directories to an example app

3. `node ../../packages/dev/codemods/dist/index.js s1-to-s2`

4. Ensure the `@react-spectrum/s2` and `unplugin-parcel-macros` packages got properly installed, and the links are correct

## 🧢 Your Project:

<!--- Company/project for pull request -->
