### PR TITLE
Fix tooltip stuck to screen on scroll

### DIFF
--- a/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
+++ b/packages/@react-spectrum/tooltip/src/TooltipTrigger.tsx
@@ -70,7 +70,8 @@ function TooltipTrigger(props: SpectrumTooltipTriggerProps) {
     shouldFlip: props.shouldFlip,
     containerPadding: props.containerPadding,
     arrowSize: arrowWidth,
-    arrowBoundaryOffset: borderRadius
+    arrowBoundaryOffset: borderRadius,
+    onClose: () => state.close(true)
   });
 
   return (

--- a/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
+++ b/packages/@react-spectrum/tooltip/test/TooltipTrigger.test.js
@@ -682,6 +682,43 @@ describe('TooltipTrigger', function () {
       expect(() => getByText(helpfulText)).toThrow();
       fireEvent.mouseLeave(badButton);
     });
+
+    it('should hide tooltip on scroll', () => {
+      let {getByLabelText, getByText, getByTestId} = render(
+        <Provider theme={theme}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '30px',
+              overflow: 'scroll',
+              height: '200px'
+            }}
+            data-testid="scroll-container">
+            {new Array(10).fill().map((_, idx) => (
+              <TooltipTrigger key={idx}>
+                <ActionButton aria-label={`trigger-${idx}`} />
+                <Tooltip>{`Tooltip-${idx}`}</Tooltip>
+              </TooltipTrigger>
+            ))}
+          </div>
+        </Provider>
+      );
+
+      // Tooltip should be visible on focus
+      let button1 = getByLabelText('trigger-1');
+      act(() => {
+        button1.focus();
+      });
+      let tooltip1 = getByText('Tooltip-1');
+      expect(tooltip1).toBeVisible();
+
+      // Tooltip should not be visible on scroll
+      let scrollContainer = getByTestId('scroll-container');
+      expect(scrollContainer).toBeInTheDocument();
+      fireEvent.scroll(scrollContainer, {target: {top: 100}});
+      expect(tooltip1).not.toBeVisible();
+    });
   });
 
   it('supports a ref on the Tooltip', () => {


### PR DESCRIPTION
Closes [#6546](https://github.com/adobe/react-spectrum/issues/6546)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Add multiple tooltip triggers inside a scrollable container
2. Focus on a button to make the tooltip appear
3. Scroll the container, the tooltip should not stick to the screen on scroll

## 🧢 Your Project:

Adobe - DX - Campaign
