### PR TITLE
Improve shift selection and responsive layout in S2 CardView

### DIFF
--- a/packages/@react-spectrum/s2/src/CardView.tsx
+++ b/packages/@react-spectrum/s2/src/CardView.tsx
@@ -71,7 +71,7 @@ class FlexibleGridLayout<T extends object> extends Layout<Node<T>, GridLayoutOpt
       maxItemSize = new Size(Infinity, Infinity),
       minSpace = new Size(18, 18),
       maxColumns = Infinity
-    } = invalidationContext.layoutOptions;
+    } = invalidationContext.layoutOptions || {};
     let visibleWidth = this.virtualizer.visibleRect.width;
 
     // The max item width is always the entire viewport.
@@ -204,7 +204,7 @@ class WaterfallLayout<T extends object> extends Layout<Node<T>, GridLayoutOption
       maxItemSize = new Size(Infinity, Infinity),
       minSpace = new Size(18, 18),
       maxColumns = Infinity
-    } = invalidationContext.layoutOptions;
+    } = invalidationContext.layoutOptions || {};
     let visibleWidth = this.virtualizer.visibleRect.width;
 
     // The max item width is always the entire viewport.
@@ -520,7 +520,7 @@ function CardView<T extends object>(props: CardViewProps<T>, ref: DOMRef<HTMLDiv
   // This calculates the maximum t-shirt size where at least two columns fit in the available width.
   let [maxSizeIndex, setMaxSizeIndex] = useState(SIZES.length - 1);
   let updateSize = useEffectEvent(() => {
-    let w = domRef.current.clientWidth;
+    let w = domRef.current?.clientWidth ?? 0;
     let i = SIZES.length - 1;
     while (i > 0) {
       let opts = layoutOptions[SIZES[i]][density];

--- a/packages/@react-spectrum/s2/src/CardView.tsx
+++ b/packages/@react-spectrum/s2/src/CardView.tsx
@@ -391,6 +391,27 @@ class WaterfallLayout<T extends object, O> extends Layout<Node<T>, O> {
 
     return bestKey;
   }
+
+  // This overrides the default behavior of shift selection to work spacially
+  // rather than following the order of the items in the collection (which may appear unpredictable).
+  getKeyRange(from: Key, to: Key): Key[] {
+    let fromLayoutInfo = this.getLayoutInfo(from);
+    let toLayoutInfo = this.getLayoutInfo(to);
+    if (!fromLayoutInfo || !toLayoutInfo) {
+      return [];
+    }
+
+    // Find items where half of the area intersects the rectangle 
+    // formed from the first item to the last item in the range.
+    let rect = fromLayoutInfo.rect.union(toLayoutInfo.rect);
+    let keys: Key[] = [];
+    for (let layoutInfo of this.layoutInfos.values()) {
+      if (rect.intersection(layoutInfo.rect).area > layoutInfo.rect.area / 2) {
+        keys.push(layoutInfo.key);
+      }
+    }
+    return keys;
+  }
 }
 
 const layoutOptions = {

--- a/packages/@react-spectrum/s2/stories/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CardView.stories.tsx
@@ -56,37 +56,47 @@ type Item = {
   height: number
 };
 
+const avatarSize = {
+  XS: 16,
+  S: 20,
+  M: 24,
+  L: 28,
+  XL: 32
+} as const;
+
 function PhotoCard({item, layout}: {item: Item, layout: string}) {
   return (
     <Card id={item.id} textValue={item.description || item.alt_description}>
-      <CardPreview>
-        <Image 
-          src={item.urls.regular}
-          styles={style({
-            width: 'full',
-            pointerEvents: 'none'
-          })}
-          // TODO - should we have a safe `dynamicStyles` or something for this?
-          UNSAFE_style={{
-            aspectRatio: layout === 'waterfall' ? `${item.width} / ${item.height}` : '4/3',
-            objectFit: layout === 'waterfall' ? 'contain' : 'cover'
-          }}
-          renderError={() => (
-            <div className={style({display: 'flex', alignItems: 'center', justifyContent: 'center', size: 'full'})}>
-              <ErrorIcon size="S" />
-            </div>
-          )} />
-      </CardPreview>
-      <Content>
-        <Text slot="title">{item.description || item.alt_description}</Text>
-        <ActionMenu>
-          <MenuItem>Test</MenuItem>
-        </ActionMenu>
-        <div className={style({display: 'flex', alignItems: 'center', gap: 8, gridArea: 'description'})}>
-          <Avatar src={item.user.profile_image.small} />
-          <Text slot="description">{item.user.name}</Text>
-        </div>
-      </Content>
+      {({size}) => (<>
+        <CardPreview>
+          <Image 
+            src={item.urls.regular}
+            styles={style({
+              width: 'full',
+              pointerEvents: 'none'
+            })}
+            // TODO - should we have a safe `dynamicStyles` or something for this?
+            UNSAFE_style={{
+              aspectRatio: layout === 'waterfall' ? `${item.width} / ${item.height}` : '4/3',
+              objectFit: layout === 'waterfall' ? 'contain' : 'cover'
+            }}
+            renderError={() => (
+              <div className={style({display: 'flex', alignItems: 'center', justifyContent: 'center', size: 'full'})}>
+                <ErrorIcon size="S" />
+              </div>
+            )} />
+        </CardPreview>
+        <Content>
+          <Text slot="title">{item.description || item.alt_description}</Text>
+          {size !== 'XS' && <ActionMenu>
+            <MenuItem>Test</MenuItem>
+          </ActionMenu>}
+          <div className={style({display: 'flex', alignItems: 'center', gap: 8, gridArea: 'description'})}>
+            <Avatar src={item.user.profile_image.small} size={avatarSize[size]} />
+            <Text slot="description">{item.user.name}</Text>
+          </div>
+        </Content>
+      </>)}
     </Card>
   );
 }

--- a/packages/@react-stately/list/src/useListState.ts
+++ b/packages/@react-stately/list/src/useListState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, CollectionStateBase, Key, Node} from '@react-types/shared';
+import {Collection, CollectionStateBase, Key, LayoutDelegate, Node} from '@react-types/shared';
 import {ListCollection} from './ListCollection';
 import {MultipleSelectionStateProps, SelectionManager, useMultipleSelectionState} from '@react-stately/selection';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
@@ -20,7 +20,12 @@ export interface ListProps<T> extends CollectionStateBase<T>, MultipleSelectionS
   /** Filter function to generate a filtered list of nodes. */
   filter?: (nodes: Iterable<Node<T>>) => Iterable<Node<T>>,
   /** @private */
-  suppressTextValueWarning?: boolean
+  suppressTextValueWarning?: boolean,
+  /**
+   * A delegate object that provides layout information for items in the collection.
+   * This can be used to override the behavior of shift selection.
+   */
+  layoutDelegate?: LayoutDelegate
 }
 
 export interface ListState<T> {
@@ -39,7 +44,7 @@ export interface ListState<T> {
  * of items from props, and manages multiple selection state.
  */
 export function useListState<T extends object>(props: ListProps<T>): ListState<T>  {
-  let {filter} = props;
+  let {filter, layoutDelegate} = props;
 
   let selectionState = useMultipleSelectionState(props);
   let disabledKeys = useMemo(() =>
@@ -52,8 +57,8 @@ export function useListState<T extends object>(props: ListProps<T>): ListState<T
   let collection = useCollection(props, factory, context);
 
   let selectionManager = useMemo(() =>
-    new SelectionManager(collection, selectionState)
-    , [collection, selectionState]
+    new SelectionManager(collection, selectionState, {layoutDelegate})
+    , [collection, selectionState, layoutDelegate]
   );
 
   // Reset focused key if that item is deleted from the collection.

--- a/packages/@react-stately/selection/src/SelectionManager.ts
+++ b/packages/@react-stately/selection/src/SelectionManager.ts
@@ -15,6 +15,7 @@ import {
   FocusStrategy,
   Selection as ISelection,
   Key,
+  LayoutDelegate,
   LongPressEvent,
   Node,
   PressEvent,
@@ -26,7 +27,8 @@ import {MultipleSelectionManager, MultipleSelectionState} from './types';
 import {Selection} from './Selection';
 
 interface SelectionManagerOptions {
-  allowsCellSelection?: boolean
+  allowsCellSelection?: boolean,
+  layoutDelegate?: LayoutDelegate
 }
 
 /**
@@ -37,12 +39,14 @@ export class SelectionManager implements MultipleSelectionManager {
   private state: MultipleSelectionState;
   private allowsCellSelection: boolean;
   private _isSelectAll: boolean;
+  private layoutDelegate: LayoutDelegate | null;
 
   constructor(collection: Collection<Node<unknown>>, state: MultipleSelectionState, options?: SelectionManagerOptions) {
     this.collection = collection;
     this.state = state;
     this.allowsCellSelection = options?.allowsCellSelection ?? false;
     this._isSelectAll = null;
+    this.layoutDelegate = options?.layoutDelegate || null;
   }
 
   /**
@@ -253,6 +257,10 @@ export class SelectionManager implements MultipleSelectionManager {
   }
 
   private getKeyRangeInternal(from: Key, to: Key) {
+    if (this.layoutDelegate?.getKeyRange) {
+      return this.layoutDelegate.getKeyRange(from, to);
+    }
+
     let keys: Key[] = [];
     let key = from;
     while (key) {

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -142,7 +142,9 @@ export interface LayoutDelegate {
   /** Returns the visible rectangle of the collection. */
   getVisibleRect(): Rect,
   /** Returns the size of the scrollable content in the collection. */
-  getContentSize(): Size
+  getContentSize(): Size,
+  /** Returns a list of keys between `from` and `to`. */
+  getKeyRange?(from: Key, to: Key): Key[]
 }
 
 /**

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -96,7 +96,8 @@ function GridListInner<T extends object>({props, collection, gridListRef: ref}: 
   let state = useListState({
     ...props,
     collection,
-    children: undefined
+    children: undefined,
+    layoutDelegate
   });
 
   let collator = useCollator({usage: 'search', sensitivity: 'base'});

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -102,7 +102,8 @@ function ListBox<T extends object>(props: ListBoxProps<T>, ref: ForwardedRef<HTM
 
 function StandaloneListBox({props, listBoxRef, collection}) {
   props = {...props, collection, children: null, items: null};
-  let state = useListState(props);
+  let {layoutDelegate} = useContext(CollectionRendererContext);
+  let state = useListState({...props, layoutDelegate});
   return <ListBoxInner state={state} props={props} listBoxRef={listBoxRef} />;
 }
 

--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -34,7 +34,7 @@ export interface VirtualizerProps<O> {
 }
 
 const VirtualizerContext = createContext<VirtualizerState<any, any> | null>(null);
-const LayoutContext = createContext(null);
+const LayoutContext = createContext<Pick<VirtualizerProps<any>, 'layout' | 'layoutOptions'> | null>(null);
 
 export function Virtualizer<O>(props: VirtualizerProps<O>) {
   let {children, layout, layoutOptions} = props;

--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionRenderer, CollectionRendererContext} from './Collection';
+import {CollectionBranchProps, CollectionRenderer, CollectionRendererContext, CollectionRootProps} from './Collection';
 import {DropPosition, DropTarget, DropTargetDelegate, ItemDropTarget, Node} from '@react-types/shared';
 import {Layout, ReusableView, useVirtualizerState, VirtualizerState} from '@react-stately/virtualizer';
 import React, {createContext, ReactElement, ReactNode, useContext, useMemo} from 'react';
@@ -24,71 +24,86 @@ export interface LayoutOptionsDelegate<O> {
 
 interface ILayout<O> extends Layout<Node<unknown>, O>, Partial<DropTargetDelegate>, LayoutOptionsDelegate<O> {}
 
-export interface VirtualizerProps {
+export interface VirtualizerProps<O> {
   /** The child collection to virtualize (e.g. ListBox, GridList, or Table). */
   children: ReactNode,
   /** The layout object that determines the position and size of the visible elements. */
-  layout: ILayout<any>
+  layout: ILayout<O>,
+  /** Options for the layout. */
+  layoutOptions?: O
 }
 
 const VirtualizerContext = createContext<VirtualizerState<any, any> | null>(null);
+const LayoutContext = createContext(null);
 
-export function Virtualizer(props: VirtualizerProps) {
-  let {children, layout} = props;
+export function Virtualizer<O>(props: VirtualizerProps<O>) {
+  let {children, layout, layoutOptions} = props;
   let renderer: CollectionRenderer = useMemo(() => ({
     isVirtualized: true,
     layoutDelegate: layout,
     dropTargetDelegate: layout.getDropTargetFromPoint ? layout as DropTargetDelegate : undefined,
-    CollectionRoot({collection, persistedKeys, scrollRef, renderDropIndicator}) {
-      let layoutOptions = layout.useLayoutOptions?.();
-      let state = useVirtualizerState({
-        layout,
-        collection,
-        renderView: (type, item) => {
-          return item?.render?.(item);
-        },
-        onVisibleRectChange(rect) {
-          let element = scrollRef?.current;
-          if (element) {
-            element.scrollLeft = rect.x;
-            element.scrollTop = rect.y;
-          }
-        },
-        persistedKeys,
-        layoutOptions
-      });
-
-      let {contentProps} = useScrollView({
-        onVisibleRectChange: state.setVisibleRect,
-        contentSize: state.contentSize,
-        onScrollStart: state.startScrolling,
-        onScrollEnd: state.endScrolling
-      }, scrollRef!);
-
-      if (state.contentSize.area === 0) {
-        return null;
-      }
-
-      return (
-        <div {...contentProps}>
-          <VirtualizerContext.Provider value={state}>
-            {renderChildren(null, state.visibleViews, renderDropIndicator)}
-          </VirtualizerContext.Provider>
-        </div>
-      );
-    },
-    CollectionBranch({parent, renderDropIndicator}) {
-      let virtualizer = useContext(VirtualizerContext);
-      let parentView = virtualizer!.virtualizer.getVisibleView(parent.key)!;
-      return renderChildren(parentView, Array.from(parentView.children), renderDropIndicator);
-    }
+    CollectionRoot,
+    CollectionBranch
   }), [layout]);
 
   return (
     <CollectionRendererContext.Provider value={renderer}>
-      {children}
+      <LayoutContext.Provider value={{layout, layoutOptions}}>
+        {children}
+      </LayoutContext.Provider>
     </CollectionRendererContext.Provider>
   );
+}
+
+function CollectionRoot({collection, persistedKeys, scrollRef, renderDropIndicator}: CollectionRootProps) {
+  let {layout, layoutOptions} = useContext(LayoutContext)!;
+  let layoutOptions2 = layout.useLayoutOptions?.();
+  let state = useVirtualizerState({
+    layout,
+    collection,
+    renderView: (type, item) => {
+      return item?.render?.(item);
+    },
+    onVisibleRectChange(rect) {
+      let element = scrollRef?.current;
+      if (element) {
+        element.scrollLeft = rect.x;
+        element.scrollTop = rect.y;
+      }
+    },
+    persistedKeys,
+    layoutOptions: useMemo(() => {
+      if (layoutOptions && layoutOptions2) {
+        return {...layoutOptions, ...layoutOptions2};
+      }
+      return layoutOptions || layoutOptions2;
+    }, [layoutOptions, layoutOptions2])
+  });
+
+  let {contentProps} = useScrollView({
+    onVisibleRectChange: state.setVisibleRect,
+    contentSize: state.contentSize,
+    onScrollStart: state.startScrolling,
+    onScrollEnd: state.endScrolling
+  }, scrollRef!);
+
+  if (state.contentSize.area === 0) {
+    return null;
+  }
+
+  return (
+    <div {...contentProps}>
+      <VirtualizerContext.Provider value={state}>
+        {renderChildren(null, state.visibleViews, renderDropIndicator)}
+      </VirtualizerContext.Provider>
+    </div>
+  );
+}
+
+function CollectionBranch({parent, renderDropIndicator}: CollectionBranchProps) {
+  let virtualizer = useContext(VirtualizerContext);
+  let parentView = virtualizer!.virtualizer.getVisibleView(parent.key)!;
+  return renderChildren(parentView, Array.from(parentView.children), renderDropIndicator);
 }
 
 function renderChildren(parent: View | null, children: View[], renderDropIndicator?: (target: ItemDropTarget) => ReactNode) {


### PR DESCRIPTION
Three updates for S2 CardView:

1. The previous behavior when using the `Shift` key to select multiple items in Waterfall layout was a bit unpredictable. Shift selection normally adds all items in collection order between the first and last item you clicked on. With waterfall layout, this doesn't make sense because the items may be rendered out of order (according to the shortest column). Now the `LayoutDelegate` interface supports overriding the `getKeyRange` behavior of `SelectionManager`. WaterfallLayout uses this to implement a spacial algorithm that selects items contained by the rectangle formed between the first and last item you shift clicked on.

2. When switching layout options like t-shirt size and density, the entire CardView would be unmounted and re-mounted. This was due to Virtualizer in RAC returning a new `CollectionRoot` component each time the layout changed (due to `useMemo`). Now Virtualizer passes the layout via a context and always uses the same component. We also avoid changing the layout entirely by using the `layoutOptions` object to pass info to the existing layout.

3. On small screens, small areas (e.g. resizable rails), or high zoom levels, the larger card sizes may no longer fit in the available space. We now treat the CardView `size` prop more like a maximum size. If at last two columns do not fit, we will reduce the t-shirt size until we find a size that does fit. This enables CardView to be more responsive out of the box. I also added render props support to `Card` so its contents can respond to the currently rendered `size`, e.g. change the size of an Avatar or hide an ActionMenu.

Question: Is this a good default? Do we need a way to set a minimum t-shirt size that a card could go down to, or a way to disable this behavior entirely? Rename `size` to `maxSize` (not sure I like this)?