### PR TITLE
Fix CardView quiet heights in Safari

### DIFF
--- a/packages/@react-spectrum/s2/src/Card.tsx
+++ b/packages/@react-spectrum/s2/src/Card.tsx
@@ -114,6 +114,7 @@ let card = style({
       quiet: 'visible'
     }
   },
+  contain: 'layout',
   disableTapHighlight: true,
   userSelect: {
     isCardView: 'none'

--- a/packages/@react-spectrum/s2/src/CardView.tsx
+++ b/packages/@react-spectrum/s2/src/CardView.tsx
@@ -551,11 +551,13 @@ function CardView<T extends object>(props: CardViewProps<T>, ref: DOMRef<HTMLDiv
     items: props.items, // TODO: ideally this would be the collection. items won't exist for static collections, or those using <Collection>
     onLoadMore: props.onLoadMore
   }, domRef);
+
+  let ctx = useMemo(() => ({size, variant}), [size, variant]);
   
   return (
     <UNSTABLE_Virtualizer layout={layout} layoutOptions={options}>
       <CardViewContext.Provider value={GridListItem}>
-        <CardContext.Provider value={{size, variant}}>
+        <CardContext.Provider value={ctx}>
           <ImageCoordinator>
             <AriaGridList
               ref={domRef}


### PR DESCRIPTION
Fixes a bug found during testing where in Safari the heights of the cards would become massive, only in the quiet variant, and this could result in a "maximum update depth exceeded" crash. That resulted from the cards getting larger and larger each render, triggering more renders, etc.

I don't quite understand the reason this happened, only in Safari, but the difference between quiet and non-quiet cards that seemed to cause it was `overflow: visible` vs `overflow: clip`. We need `visible` so the shadow on the preview shows. Adding `contain: layout` seems to fix this, but again, still not sure why exactly. I also noticed that the issue is fixed in Safari Tech Preview, even without this change. 🤷 