### PR TITLE
S2 Card updates

### DIFF
--- a/packages/@react-spectrum/s2/src/Card.tsx
+++ b/packages/@react-spectrum/s2/src/Card.tsx
@@ -331,6 +331,13 @@ let content = style({
   }
 });
 
+let actionMenu = style({
+  gridArea: 'menu',
+  // Don't cause the row to expand, preserve gap between title and description text.
+  // Would use -100% here but it doesn't work in Firefox.
+  marginY: '[calc(-1 * self(height))]'
+});
+
 let footer = style({
   display: 'flex',
   flexDirection: 'row',
@@ -397,7 +404,7 @@ export const Card = forwardRef(function Card(props: CardProps, ref: DOMRef<HTMLD
           isDisabled: isSkeleton,
           // @ts-ignore
           'data-slot': 'menu',
-          styles: style({gridArea: 'menu'})
+          styles: actionMenu
         }],
         [SkeletonContext, isSkeleton]
       ]}>

--- a/packages/@react-spectrum/s2/src/Card.tsx
+++ b/packages/@react-spectrum/s2/src/Card.tsx
@@ -215,7 +215,7 @@ let selectionIndicator = style({
   },
   // Quiet cards with no checkbox have an extra inner stroke
   // to distinguish the selection indicator from the preview.
-  outlineColor: 'gray-25',
+  outlineColor: lightDark('transparent-white-600', 'transparent-black-600'),
   outlineOffset: -4,
   outlineStyle: {
     default: 'none',


### PR DESCRIPTION
Three changes from conversation with design:

1. Make the white inner stroke for selected quiet cards with highlight selection more subtle, by making it partially transparent. I believe this still passes contrast, and it also matches the overlay around the checkbox when that appears.
2. Prevent the gap between the title and description from expanding when an action button is present. The action button is taller than a single line of text so it makes the grid row taller, making it appear like there's more space. Now the button overlaps the gap and doesn't change the height of the row.
3. When resizing a CardView with waterfall layout, the cards seemed to jump around since we always chose the shortest column to append to during layout and this could change due to small changes in text wrapping, etc. Now we store the current column index for each card and try to preserve that so cards don't jump around unless the number of columns changes.