### PR TITLE
Add DisclosureGroup component to RAC

### DIFF
--- a/packages/@react-aria/disclosure/src/useDisclosure.ts
+++ b/packages/@react-aria/disclosure/src/useDisclosure.ts
@@ -30,8 +30,8 @@ export interface AriaDisclosureProps {
 export interface DisclosureAria {
   /** Props for the disclosure button. */
   buttonProps: AriaButtonProps,
-  /** Props for the content element. */
-  contentProps: HTMLAttributes<HTMLElement>
+  /** Props for the disclosure panel. */
+  panelProps: HTMLAttributes<HTMLElement>
 }
 
 /**
@@ -84,8 +84,10 @@ export function useDisclosure(props: AriaDisclosureProps, state: DisclosureState
         }
       }
     },
-    contentProps: {
+    panelProps: {
       id: contentId,
+      // This can be overridden at the panel element level.
+      role: 'group',
       'aria-labelledby': triggerId,
       hidden: (!supportsBeforeMatch || isControlled) ? !state.isExpanded : true
     }

--- a/packages/@react-spectrum/accordion/chromatic/Accordion.stories.tsx
+++ b/packages/@react-spectrum/accordion/chromatic/Accordion.stories.tsx
@@ -24,7 +24,7 @@ export default meta;
 
 export const Template = (args) => (
   <Accordion {...args}>
-    <Disclosure key="files">
+    <Disclosure id="files">
       <DisclosureHeader>
         Your files
       </DisclosureHeader>
@@ -32,7 +32,7 @@ export const Template = (args) => (
         files
       </DisclosurePanel>
     </Disclosure>
-    <Disclosure key="shared">
+    <Disclosure id="shared">
       <DisclosureHeader>
         Shared with you
       </DisclosureHeader>
@@ -40,7 +40,7 @@ export const Template = (args) => (
         shared
       </DisclosurePanel>
     </Disclosure>
-    <Disclosure key="last">
+    <Disclosure id="last">
       <DisclosureHeader>
         Last item
       </DisclosureHeader>

--- a/packages/@react-spectrum/accordion/src/Accordion.tsx
+++ b/packages/@react-spectrum/accordion/src/Accordion.tsx
@@ -11,11 +11,10 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, StyleProps} from '@react-types/shared';
-import {Button, DisclosurePanelProps, DisclosureProps, Heading, Disclosure as RACDisclosure, DisclosurePanel as RACDisclosurePanel} from 'react-aria-components';
+import {Button, DisclosureGroup, DisclosurePanelProps, DisclosureProps, Heading, Disclosure as RACDisclosure, DisclosurePanel as RACDisclosurePanel} from 'react-aria-components';
 import ChevronLeftMedium from '@spectrum-icons/ui/ChevronLeftMedium';
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
-import {filterDOMProps} from '@react-aria/utils';
 import React, {forwardRef, ReactElement} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/accordion/vars.css';
 import {useLocale} from '@react-aria/i18n';
@@ -31,17 +30,17 @@ function Accordion(props: SpectrumAccordionProps, ref: DOMRef<HTMLDivElement>) {
   let {styleProps} = useStyleProps(props);
   let domRef = useDOMRef(ref);
   return (
-    <div
-      {...filterDOMProps(props)}
+    <DisclosureGroup
+      {...props}
       {...styleProps}
       ref={domRef}
       className={classNames(styles, 'spectrum-Accordion', styleProps.className)}>
       {props.children}
-    </div>
+    </DisclosureGroup>
   );
 }
 
-export interface SpectrumDisclosureProps extends DisclosureProps, DOMProps, AriaLabelingProps  {
+export interface SpectrumDisclosureProps extends DisclosureProps, AriaLabelingProps  {
   /** The contents of the disclosure. The first child should be the header, and the second child should be the panel. */
   children: [ReactElement<SpectrumDisclosureHeaderProps>, ReactElement<SpectrumDisclosurePanelProps>]
 }
@@ -78,11 +77,11 @@ function DisclosurePanel(props: SpectrumDisclosurePanelProps, ref: DOMRef<HTMLDi
 
 export interface SpectrumDisclosureHeaderProps extends DOMProps, AriaLabelingProps {
   /** 
-   * The heading level of the accordion header.
+   * The heading level of the disclosure header.
    * @default 3
    */
   level?: number,
-  /** The contents of the accordion header. */
+  /** The contents of the disclosure header. */
   children: React.ReactNode
 }
 

--- a/packages/@react-spectrum/accordion/stories/Accordion.stories.tsx
+++ b/packages/@react-spectrum/accordion/stories/Accordion.stories.tsx
@@ -25,7 +25,7 @@ export type AccordionStory = ComponentStoryObj<typeof Accordion>;
 export const Default: AccordionStory = {
   render: (args) => (
     <Accordion {...args}>
-      <Disclosure key="files">
+      <Disclosure id="files">
         <DisclosureHeader>
           Files
         </DisclosureHeader>
@@ -33,7 +33,7 @@ export const Default: AccordionStory = {
           <p>Files content</p>
         </DisclosurePanel>
       </Disclosure>
-      <Disclosure key="people">
+      <Disclosure id="people">
         <DisclosureHeader>
           People
         </DisclosureHeader>

--- a/packages/@react-spectrum/s2/src/Accordion.tsx
+++ b/packages/@react-spectrum/s2/src/Accordion.tsx
@@ -10,17 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import {ContextValue, Provider, SlotProps} from 'react-aria-components';
+import {ContextValue, DisclosureGroup, DisclosureGroupProps, SlotProps} from 'react-aria-components';
 import {DisclosureContext} from './Disclosure';
-import {DOMProps, DOMRef, DOMRefValue, forwardRefType} from '@react-types/shared';
-import {filterDOMProps} from '@react-aria/utils';
+import {DOMProps, DOMRef, DOMRefValue} from '@react-types/shared';
 import {getAllowedOverrides, StylesPropWithHeight, UnsafeStyles} from './style-utils' with { type: 'macro' };
 import React, {createContext, forwardRef} from 'react';
 import {style} from '../style/spectrum-theme' with { type: 'macro' };
 import {useDOMRef} from '@react-spectrum/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface AccordionProps extends UnsafeStyles, DOMProps, SlotProps {
+export interface AccordionProps extends DisclosureGroupProps, UnsafeStyles, DOMProps, SlotProps {
   /** The disclosure elements in the accordion. */
   children: React.ReactNode,
   /** Spectrum-defined styles, returned by the `style()` macro. */
@@ -36,9 +35,7 @@ export interface AccordionProps extends UnsafeStyles, DOMProps, SlotProps {
    */
   density?: 'compact' | 'regular' | 'spacious',
   /** Whether the accordion should be displayed with a quiet style. */
-  isQuiet?: boolean,
-  /** Whether the accordion should be disabled. */
-  isDisabled?: boolean
+  isQuiet?: boolean
 }
 
 const accordion = style({
@@ -56,29 +53,23 @@ function Accordion(props: AccordionProps, ref: DOMRef<HTMLDivElement>) {
     UNSAFE_className = '',
     size = 'M',
     density = 'regular',
-    isQuiet,
-    isDisabled,
-    ...otherProps
+    isQuiet
   } = props;
-  const domProps = filterDOMProps(otherProps);
   return (
-    <Provider
-      values={[
-        [DisclosureContext, {size, isQuiet, density, isDisabled}]
-      ]}>
-      <div
-        {...domProps}
+    <DisclosureContext.Provider value={{size, isQuiet, density}}>
+      <DisclosureGroup
+        {...props}
         ref={domRef}
         style={UNSAFE_style}
         className={(UNSAFE_className ?? '') + accordion(null, props.styles)}>
         {props.children}
-      </div>
-    </Provider>
+      </DisclosureGroup>
+    </DisclosureContext.Provider>
   );
 }
 
 /**
  * An accordion is a container for multiple disclosures.
  */
-let _Accordion = /*#__PURE__*/ (forwardRef as forwardRefType)(Accordion);
+let _Accordion = forwardRef(Accordion);
 export {_Accordion as Accordion};

--- a/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
@@ -20,23 +20,7 @@ const meta: Meta<typeof Accordion> = {
   parameters: {
     layout: 'centered'
   },
-  tags: ['autodocs'],
-  argTypes: {
-    size: {
-      control: 'radio',
-      options: ['S', 'M', 'L', 'XL']
-    },
-    isQuiet: {
-      control: {type: 'boolean'}
-    },
-    density: {
-      control: 'radio',
-      options: ['compact', 'regular', 'spacious']
-    },
-    isDisabled: {
-      control: {type: 'boolean'}
-    }
-  }
+  tags: ['autodocs']
 };
 
 export default meta;
@@ -47,7 +31,7 @@ export const Example: Story = {
     return (
       <div className={style({minHeight: 240})}>
         <Accordion {...args}>
-          <Disclosure key="files">
+          <Disclosure id="files">
             <DisclosureHeader>
               Files
             </DisclosureHeader>
@@ -55,7 +39,7 @@ export const Example: Story = {
               Files content
             </DisclosurePanel>
           </Disclosure>
-          <Disclosure key="people">
+          <Disclosure id="people">
             <DisclosureHeader>
               People
             </DisclosureHeader>
@@ -74,7 +58,7 @@ export const WithLongTitle: Story = {
     return (
       <div className={style({minHeight: 224})}>
         <Accordion styles={style({maxWidth: 224})} {...args}>
-          <Disclosure key="files">
+          <Disclosure>
             <DisclosureHeader>
               Files
             </DisclosureHeader>
@@ -82,7 +66,7 @@ export const WithLongTitle: Story = {
               Files content
             </DisclosurePanel>
           </Disclosure>
-          <Disclosure key="people">
+          <Disclosure>
             <DisclosureHeader>
               People
             </DisclosureHeader>
@@ -90,7 +74,7 @@ export const WithLongTitle: Story = {
               People content
             </DisclosurePanel>
           </Disclosure>
-          <Disclosure key="long-title">
+          <Disclosure>
             <DisclosureHeader>
               Very very very very very long title that wraps
             </DisclosureHeader>
@@ -109,7 +93,7 @@ export const WithDisabledDisclosure: Story = {
     return (
       <div className={style({minHeight: 240})}>
         <Accordion {...args}>
-          <Disclosure key="files">
+          <Disclosure>
             <DisclosureHeader>
               Files
             </DisclosureHeader>
@@ -117,7 +101,7 @@ export const WithDisabledDisclosure: Story = {
               Files content
             </DisclosurePanel>
           </Disclosure>
-          <Disclosure isDisabled key="people">
+          <Disclosure isDisabled>
             <DisclosureHeader>
               People
             </DisclosureHeader>

--- a/packages/@react-stately/disclosure/src/index.ts
+++ b/packages/@react-stately/disclosure/src/index.ts
@@ -11,5 +11,7 @@
  */
 
 export {useDisclosureState} from './useDisclosureState';
+export {useDisclosureGroupState} from './useDisclosureGroupState';
 
 export type {DisclosureState, DisclosureProps} from './useDisclosureState';
+export type {DisclosureGroupState, DisclosureGroupProps} from './useDisclosureGroupState';

--- a/packages/@react-stately/disclosure/src/useDisclosureGroupState.ts
+++ b/packages/@react-stately/disclosure/src/useDisclosureGroupState.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Expandable, Key} from '@react-types/shared';
+import {useControlledState} from '@react-stately/utils';
+import {useEffect, useMemo} from 'react';
+
+export interface DisclosureGroupProps extends Expandable {
+  /** Whether multiple items can be expanded at the same time. */
+  allowsMultipleExpanded?: boolean,
+  /** Whether all items are disabled. */
+  isDisabled?: boolean
+}
+
+export interface DisclosureGroupState {
+  /** Whether multiple items can be expanded at the same time. */
+  readonly allowsMultipleExpanded: boolean,
+
+  /** Whether all items are disabled. */
+  readonly isDisabled: boolean,
+  
+  /** A set of keys for items that are expanded. */
+  readonly expandedKeys: Set<Key>,
+
+  /** Toggles the expanded state for an item by its key. */
+  toggleKey(key: Key): void,
+
+  /** Replaces the set of expanded keys. */
+  setExpandedKeys(keys: Set<Key>): void
+}
+
+export function useDisclosureGroupState(props: DisclosureGroupProps): DisclosureGroupState {
+  let {allowsMultipleExpanded = false, isDisabled = false} = props;
+  let [expandedKeys, setExpandedKeys] = useControlledState(
+    useMemo(() => props.expandedKeys ? new Set(props.expandedKeys) : undefined, [props.expandedKeys]),
+    useMemo(() => props.defaultExpandedKeys ? new Set(props.defaultExpandedKeys) : new Set(), [props.defaultExpandedKeys]),
+    props.onExpandedChange
+  );
+  
+  useEffect(() => {
+    // Ensure only one item is expanded if allowsMultipleExpanded is false.
+    if (!allowsMultipleExpanded && expandedKeys.size > 1) {
+      setExpandedKeys(new Set([expandedKeys.values().next().value]));
+    }
+  });
+
+  return {
+    allowsMultipleExpanded,
+    isDisabled,
+    expandedKeys,
+    setExpandedKeys,
+    toggleKey(key) {
+      let keys: Set<Key>;
+      if (allowsMultipleExpanded) {
+        keys = new Set(expandedKeys);
+        if (keys.has(key)) {
+          keys.delete(key);
+        } else {
+          keys.add(key);
+        }
+      } else {
+        keys = new Set(expandedKeys.has(key) ? [] : [key]);
+      }
+  
+      setExpandedKeys(keys);
+    }
+  };
+}

--- a/packages/react-aria-components/src/Disclosure.tsx
+++ b/packages/react-aria-components/src/Disclosure.tsx
@@ -13,13 +13,66 @@
 import {AriaDisclosureProps, useDisclosure} from '@react-aria/disclosure';
 import {ButtonContext} from './Button';
 import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
-import {DisclosureState, useDisclosureState} from '@react-stately/disclosure';
-import {forwardRefType} from '@react-types/shared';
+import {DisclosureGroupState, DisclosureState, DisclosureGroupProps as StatelyDisclosureGroupProps, useDisclosureGroupState, useDisclosureState} from '@react-stately/disclosure';
+import {DOMProps, forwardRefType, Key} from '@react-types/shared';
+import {filterDOMProps, mergeProps, mergeRefs, useId} from '@react-aria/utils';
 import {HoverEvents, useFocusRing} from 'react-aria';
-import {mergeProps, mergeRefs} from '@react-aria/utils';
 import React, {createContext, DOMAttributes, ForwardedRef, forwardRef, ReactNode, useContext} from 'react';
 
-export interface DisclosureProps extends Omit<AriaDisclosureProps, 'children'>, HoverEvents, RenderProps<DisclosureRenderProps>, SlotProps {}
+export interface DisclosureGroupProps extends StatelyDisclosureGroupProps, RenderProps<DisclosureGroupRenderProps>, DOMProps {}
+
+export interface DisclosureGroupRenderProps {
+  /**
+   * Whether the disclosure group is disabled.
+   * @selector [data-disabled]
+   */
+  isDisabled: boolean,
+  /**
+   * State of the disclosure group.
+   */
+  state: DisclosureGroupState
+}
+
+export const DisclosureGroupStateContext = createContext<DisclosureGroupState | null>(null);
+
+function DisclosureGroup(props: DisclosureGroupProps, ref: ForwardedRef<HTMLDivElement>) {
+  let state = useDisclosureGroupState(props);
+
+  let renderProps = useRenderProps({
+    ...props,
+    defaultClassName: 'react-aria-DisclosureGroup',
+    values: {
+      isDisabled: state.isDisabled,
+      state
+    }
+  });
+
+  let domProps = filterDOMProps(props);
+
+  return (
+    <div
+      {...domProps}
+      {...renderProps}
+      ref={ref}
+      data-disabled={props.isDisabled || undefined}>
+      <DisclosureGroupStateContext.Provider value={state}>
+        {renderProps.children}
+      </DisclosureGroupStateContext.Provider>
+    </div>
+  );
+}
+
+/**
+ * A DisclosureGroup is a grouping of related disclosures, sometimes called an Accordion.
+ * It supports both single and multiple expanded items.
+ */
+const _DisclosureGroup = forwardRef(DisclosureGroup);
+export {_DisclosureGroup as DisclosureGroup};
+
+export interface DisclosureProps extends Omit<AriaDisclosureProps, 'children'>, HoverEvents, RenderProps<DisclosureRenderProps>, SlotProps {
+  /** An id for the disclosure when used within a DisclosureGroup, matching the id used in `expandedKeys`. */
+  id?: Key
+}
 
 export interface DisclosureRenderProps {
   /**
@@ -47,17 +100,40 @@ export const DisclosureContext = createContext<ContextValue<DisclosureProps, HTM
 export const DisclosureStateContext = createContext<DisclosureState | null>(null);
 
 interface InternalDisclosureContextValue {
-  contentProps: DOMAttributes<HTMLElement>,
-  contentRef: React.RefObject<HTMLElement | null>
+  panelProps: DOMAttributes<HTMLElement>,
+  panelRef: React.RefObject<HTMLDivElement | null>
 }
 
 const InternalDisclosureContext = createContext<InternalDisclosureContextValue | null>(null);
 
 function Disclosure(props: DisclosureProps, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, DisclosureContext);
-  let state = useDisclosureState(props);
-  let contentRef = React.useRef<HTMLElement | null>(null);
-  let {buttonProps, contentProps} = useDisclosure(props, state, contentRef);
+  let groupState = useContext(DisclosureGroupStateContext);
+  let {id, ...otherProps} = props;
+
+  // Generate an id if one wasn't provided.
+  // (can't pass id into useId since it can also be a number)
+  let defaultId = useId();
+  id ||= defaultId;
+
+  let state = useDisclosureState({
+    ...props,
+    isExpanded: groupState ? groupState.expandedKeys.has(id) : props.isExpanded,
+    onExpandedChange(isExpanded) {
+      if (groupState) {
+        groupState.toggleKey(id);
+      }
+
+      props.onExpandedChange?.(isExpanded);
+    }
+  });
+
+  let panelRef = React.useRef<HTMLDivElement | null>(null);
+  let isDisabled = props.isDisabled || groupState?.isDisabled || false;
+  let {buttonProps, panelProps} = useDisclosure({
+    ...props,
+    isDisabled
+  }, state, panelRef);
   let {
     isFocusVisible: isFocusVisibleWithin,
     focusProps: focusWithinProps
@@ -65,14 +141,17 @@ function Disclosure(props: DisclosureProps, ref: ForwardedRef<HTMLDivElement>) {
 
   let renderProps = useRenderProps({
     ...props,
+    id: undefined,
     defaultClassName: 'react-aria-Disclosure',
     values: {
       isExpanded: state.isExpanded,
-      isDisabled: props.isDisabled || false,
+      isDisabled,
       isFocusVisibleWithin,
       state
     }
   });
+
+  let domProps = filterDOMProps(otherProps as any);
 
   return (
     <Provider
@@ -83,14 +162,15 @@ function Disclosure(props: DisclosureProps, ref: ForwardedRef<HTMLDivElement>) {
             trigger: buttonProps
           }
         }],
-        [InternalDisclosureContext, {contentProps, contentRef}],
+        [InternalDisclosureContext, {panelProps, panelRef}],
         [DisclosureStateContext, state]
       ]}>
       <div
         ref={ref}
         data-expanded={state.isExpanded || undefined}
-        data-disabled={props.isDisabled || undefined}
+        data-disabled={isDisabled || undefined}
         data-focus-visible-within={isFocusVisibleWithin || undefined}
+        {...domProps}
         {...focusWithinProps}
         {...renderProps}>
         {renderProps.children}
@@ -108,9 +188,9 @@ export interface DisclosurePanelProps extends RenderProps<{}> {
   children: ReactNode
 }
 
-function DisclosurePanel(props: DisclosurePanelProps, ref: ForwardedRef<HTMLElement>) {
+function DisclosurePanel(props: DisclosurePanelProps, ref: ForwardedRef<HTMLDivElement>) {
   let {role = 'group'} = props;
-  let {contentProps, contentRef} = useContext(InternalDisclosureContext)!;
+  let {panelProps, panelRef} = useContext(InternalDisclosureContext)!;
   let {
     isFocusVisible: isFocusVisibleWithin,
     focusProps: focusWithinProps
@@ -124,11 +204,10 @@ function DisclosurePanel(props: DisclosurePanelProps, ref: ForwardedRef<HTMLElem
   });
   return (
     <div
-      role={role}
-      // @ts-ignore
-      ref={mergeRefs(ref, contentRef)}
-      {...mergeProps(contentProps, focusWithinProps)}
+      ref={mergeRefs(ref, panelRef)}
+      {...mergeProps(panelProps, focusWithinProps)}
       {...renderProps}
+      role={role}
       data-focus-visible-within={isFocusVisibleWithin || undefined}>
       <Provider
         values={[

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -16,7 +16,6 @@ import 'client-only';
 
 export {CheckboxContext, ColorAreaContext, ColorFieldContext, ColorSliderContext, ColorWheelContext, HeadingContext} from './RSPContexts';
 
-export {Disclosure, DisclosurePanel, DisclosureStateContext, DisclosureContext} from './Disclosure';
 export {Breadcrumbs, BreadcrumbsContext, Breadcrumb} from './Breadcrumbs';
 export {Button, ButtonContext} from './Button';
 export {Calendar, CalendarGrid, CalendarGridHeader, CalendarGridBody, CalendarHeaderCell, CalendarCell, RangeCalendar, CalendarContext, RangeCalendarContext, CalendarStateContext, RangeCalendarStateContext} from './Calendar';
@@ -34,6 +33,7 @@ export {composeRenderProps, DEFAULT_SLOT, Provider, useContextProps, useSlottedC
 export {DateField, DateInput, DateSegment, TimeField, DateFieldContext, TimeFieldContext, DateFieldStateContext, TimeFieldStateContext} from './DateField';
 export {DatePicker, DateRangePicker, DatePickerContext, DateRangePickerContext, DatePickerStateContext, DateRangePickerStateContext} from './DatePicker';
 export {DialogTrigger, Dialog, DialogContext, OverlayTriggerStateContext} from './Dialog';
+export {Disclosure, DisclosureGroup, DisclosureGroupStateContext, DisclosurePanel, DisclosureStateContext, DisclosureContext} from './Disclosure';
 export {DropZone, DropZoneContext} from './DropZone';
 export {FieldError, FieldErrorContext} from './FieldError';
 export {FileTrigger} from './FileTrigger';
@@ -81,7 +81,6 @@ export {FormValidationContext} from 'react-stately';
 export {parseColor, getColorChannels} from '@react-stately/color';
 export {ListLayout as UNSTABLE_ListLayout, GridLayout as UNSTABLE_GridLayout} from '@react-stately/layout';
 
-export type {DisclosureProps, DisclosurePanelProps} from './Disclosure';
 export type {BreadcrumbsProps, BreadcrumbProps, BreadcrumbRenderProps} from './Breadcrumbs';
 export type {ButtonProps, ButtonRenderProps} from './Button';
 export type {CalendarCellProps, CalendarProps, CalendarRenderProps, CalendarGridProps, CalendarGridHeaderProps, CalendarGridBodyProps, CalendarHeaderCellProps, CalendarCellRenderProps, RangeCalendarProps, RangeCalendarRenderProps} from './Calendar';
@@ -98,6 +97,7 @@ export type {ComboBoxProps, ComboBoxRenderProps} from './ComboBox';
 export type {DateFieldProps, DateFieldRenderProps, DateInputProps, DateInputRenderProps, DateSegmentProps, DateSegmentRenderProps, TimeFieldProps} from './DateField';
 export type {DatePickerProps, DatePickerRenderProps, DateRangePickerProps, DateRangePickerRenderProps} from './DatePicker';
 export type {DialogProps, DialogTriggerProps} from './Dialog';
+export type {DisclosureProps, DisclosureRenderProps, DisclosurePanelProps, DisclosureGroupProps, DisclosureGroupRenderProps} from './Disclosure';
 export type {DropZoneProps, DropZoneRenderProps} from './DropZone';
 export type {FieldErrorProps, FieldErrorRenderProps} from './FieldError';
 export type {FileTriggerProps} from './FileTrigger';


### PR DESCRIPTION
This adds a DisclosureGroup (aka Accordion) component to RAC. It allows a single Disclosure to be expanded by default, and an `allowsMultipleExpanded` prop to allow multiple. You can also control the `expandedKeys` similar to our other collection components. This brings parity with the existing Accordion alpha in S1.

(We discussed only supporting `expandedKey`, non-plural, but I thought of a use case for controlling multiple - e.g. if you have a multi-step process that starts all expanded and collapses each step after you completed it. This also matches the previous Accordion API in S1, and is more consistent with our other components. The downside is that it's slightly more annoying for single select usecases.)

Ideally there'd also be a `disallowCollapseAll` prop to force at least one to always be expanded but this was a bit more challenging to implement so I punted for now.

Adding some issues that should be closed by this and the previous accordion PR:

Fixes #1989, fixes #2801, fixes #3882, fixes #1891

TODO: verify #1726