### PR TITLE
Add basic docs for Accordion, DisclosureGroup, Disclosure, and Tree

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/accordion/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/accordion/index.css
@@ -43,6 +43,7 @@ governing permissions and limitations under the License.
   position: relative;
 
   display: list-item;
+  list-style: none;
   margin: 0;
 
   border-bottom: var(--spectrum-accordion-item-border-size) solid transparent;

--- a/packages/@react-spectrum/accordion/docs/Accordion.mdx
+++ b/packages/@react-spectrum/accordion/docs/Accordion.mdx
@@ -1,0 +1,61 @@
+{/* Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. */}
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-spectrum/accordion';
+import {HeaderInfo, PropTable, TypeLink, PageDescription} from '@react-spectrum/docs';
+import packageData from '@react-spectrum/accordion/package.json';
+import {InlineAlert, Content, Heading} from '@adobe/react-spectrum';
+
+---
+category: Navigation
+keywords: [disclosure, accordion, collapse, expand]
+---
+
+```jsx import
+import {Accordion, Disclosure, DisclosureHeader, DisclosurePanel} from '@react-spectrum/accordion';
+```
+
+# Accordion
+
+<PageDescription>{docs.exports.Accordion.description}</PageDescription>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['Accordion', 'Disclosure', 'DisclosureHeader', 'DisclosurePanel']} />
+
+<InlineAlert variant="notice" marginTop={60}>
+  <Heading>Under construction</Heading>
+  <Content>This component is in <strong>alpha</strong>. More documentation is coming soon!</Content>
+</InlineAlert>
+
+## Example
+
+```tsx example
+<Accordion defaultExpandedKeys={['personal']}>
+  <Disclosure id="personal">
+    <DisclosureHeader>Personal Information</DisclosureHeader>
+    <DisclosurePanel>
+      <p>Personal information form here.</p>
+    </DisclosurePanel>
+  </Disclosure>
+  <Disclosure id="billing">
+    <DisclosureHeader>Billing Address</DisclosureHeader>
+    <DisclosurePanel>
+      <p>Billing address form here.</p>
+    </DisclosurePanel>
+  </Disclosure>
+</Accordion>
+```
+
+## Props
+
+<PropTable component={docs.exports.Accordion} links={docs.links} />

--- a/packages/@react-spectrum/accordion/docs/Disclosure.mdx
+++ b/packages/@react-spectrum/accordion/docs/Disclosure.mdx
@@ -1,0 +1,63 @@
+{/* Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. */}
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-spectrum/accordion';
+import {HeaderInfo, PropTable, TypeLink, PageDescription} from '@react-spectrum/docs';
+import packageData from '@react-spectrum/accordion/package.json';
+import {InlineAlert, Content, Heading} from '@adobe/react-spectrum';
+
+---
+category: Navigation
+keywords: [disclosure, accordion, collapse, expand]
+---
+
+```jsx import
+import {Disclosure, DisclosureHeader, DisclosurePanel} from '@react-spectrum/accordion';
+```
+
+# Disclosure
+
+<PageDescription>{docs.exports.Disclosure.description}</PageDescription>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['Disclosure', 'DisclosureHeader', 'DisclosurePanel']} />
+
+<InlineAlert variant="notice" marginTop={60}>
+  <Heading>Under construction</Heading>
+  <Content>This component is in <strong>alpha</strong>. More documentation is coming soon!</Content>
+</InlineAlert>
+
+## Example
+
+```tsx example
+<Disclosure>
+  <DisclosureHeader>System Requirements</DisclosureHeader>
+  <DisclosurePanel>
+    <p>Details about system requirements here.</p>
+  </DisclosurePanel>
+</Disclosure>
+```
+
+## Props
+
+### Disclosure
+
+<PropTable component={docs.exports.Disclosure} links={docs.links} />
+
+### DisclosureHeader
+
+<PropTable component={docs.exports.DisclosureHeader} links={docs.links} />
+
+### DisclosurePanel
+
+<PropTable component={docs.exports.DisclosurePanel} links={docs.links} />

--- a/packages/@react-spectrum/accordion/src/Accordion.tsx
+++ b/packages/@react-spectrum/accordion/src/Accordion.tsx
@@ -11,16 +11,16 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, StyleProps} from '@react-types/shared';
-import {Button, DisclosureGroup, DisclosurePanelProps, DisclosureProps, Heading, Disclosure as RACDisclosure, DisclosurePanel as RACDisclosurePanel} from 'react-aria-components';
+import {Button, DisclosureGroup, DisclosureGroupProps, DisclosurePanelProps, DisclosureProps, Heading, Disclosure as RACDisclosure, DisclosurePanel as RACDisclosurePanel} from 'react-aria-components';
 import ChevronLeftMedium from '@spectrum-icons/ui/ChevronLeftMedium';
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
-import React, {forwardRef, ReactElement} from 'react';
+import React, {forwardRef} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/accordion/vars.css';
 import {useLocale} from '@react-aria/i18n';
 import {useProviderProps} from '@react-spectrum/provider';
 
-export interface SpectrumAccordionProps extends StyleProps, DOMProps, AriaLabelingProps {
+export interface SpectrumAccordionProps extends Omit<DisclosureGroupProps, 'className' | 'style' | 'children'>, StyleProps, DOMProps, AriaLabelingProps {
   /** The disclosures within the accordion group. */
   children: React.ReactNode
 }
@@ -40,9 +40,9 @@ function Accordion(props: SpectrumAccordionProps, ref: DOMRef<HTMLDivElement>) {
   );
 }
 
-export interface SpectrumDisclosureProps extends DisclosureProps, AriaLabelingProps  {
+export interface SpectrumDisclosureProps extends Omit<DisclosureProps, 'className' | 'style' | 'children'>, AriaLabelingProps  {
   /** The contents of the disclosure. The first child should be the header, and the second child should be the panel. */
-  children: [ReactElement<SpectrumDisclosureHeaderProps>, ReactElement<SpectrumDisclosurePanelProps>]
+  children: React.ReactNode
 }
 
 function Disclosure(props: SpectrumDisclosureProps, ref: DOMRef<HTMLDivElement>) {
@@ -61,7 +61,7 @@ function Disclosure(props: SpectrumDisclosureProps, ref: DOMRef<HTMLDivElement>)
   );
 }
 
-export interface SpectrumDisclosurePanelProps extends DisclosurePanelProps, DOMProps, AriaLabelingProps {
+export interface SpectrumDisclosurePanelProps extends Omit<DisclosurePanelProps, 'className' | 'style' | 'children'>, DOMProps, AriaLabelingProps {
   /** The contents of the accordion panel. */
   children: React.ReactNode
 }

--- a/packages/@react-spectrum/accordion/src/Accordion.tsx
+++ b/packages/@react-spectrum/accordion/src/Accordion.tsx
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, StyleProps} from '@react-types/shared';
-import {Button, DisclosureGroup, DisclosureGroupProps, DisclosurePanelProps, DisclosureProps, Heading, Disclosure as RACDisclosure, DisclosurePanel as RACDisclosurePanel} from 'react-aria-components';
+import {Button, UNSTABLE_DisclosureGroup as DisclosureGroup, DisclosureGroupProps, DisclosurePanelProps, DisclosureProps, Heading, UNSTABLE_Disclosure as RACDisclosure, UNSTABLE_DisclosurePanel as RACDisclosurePanel} from 'react-aria-components';
 import ChevronLeftMedium from '@spectrum-icons/ui/ChevronLeftMedium';
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';

--- a/packages/@react-spectrum/s2/src/Accordion.tsx
+++ b/packages/@react-spectrum/s2/src/Accordion.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {ContextValue, DisclosureGroup, DisclosureGroupProps, SlotProps} from 'react-aria-components';
+import {ContextValue, UNSTABLE_DisclosureGroup as DisclosureGroup, DisclosureGroupProps, SlotProps} from 'react-aria-components';
 import {DisclosureContext} from './Disclosure';
 import {DOMProps, DOMRef, DOMRefValue} from '@react-types/shared';
 import {getAllowedOverrides, StylesPropWithHeight, UnsafeStyles} from './style-utils' with { type: 'macro' };

--- a/packages/@react-spectrum/s2/src/Accordion.tsx
+++ b/packages/@react-spectrum/s2/src/Accordion.tsx
@@ -19,7 +19,7 @@ import {style} from '../style/spectrum-theme' with { type: 'macro' };
 import {useDOMRef} from '@react-spectrum/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface AccordionProps extends DisclosureGroupProps, UnsafeStyles, DOMProps, SlotProps {
+export interface AccordionProps extends Omit<DisclosureGroupProps, 'className' | 'style' | 'children'>, UnsafeStyles, DOMProps, SlotProps {
   /** The disclosure elements in the accordion. */
   children: React.ReactNode,
   /** Spectrum-defined styles, returned by the `style()` macro. */

--- a/packages/@react-spectrum/s2/src/Disclosure.tsx
+++ b/packages/@react-spectrum/s2/src/Disclosure.tsx
@@ -21,7 +21,7 @@ import React, {createContext, forwardRef, ReactNode, useContext} from 'react';
 import {useDOMRef} from '@react-spectrum/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface DisclosureProps extends RACDisclosureProps, StyleProps {
+export interface DisclosureProps extends Omit<RACDisclosureProps, 'className' | 'style' | 'children'>, StyleProps {
   /**
    * The size of the disclosure.
    * @default "M"
@@ -231,7 +231,7 @@ function DisclosureHeader(props: DisclosureHeaderProps, ref: DOMRef<HTMLDivEleme
 let _DisclosureHeader = forwardRef(DisclosureHeader);
 export {_DisclosureHeader as DisclosureHeader};
 
-export interface DisclosurePanelProps extends RACDisclosurePanelProps, UnsafeStyles, DOMProps, AriaLabelingProps {
+export interface DisclosurePanelProps extends Omit<RACDisclosurePanelProps, 'className' | 'style' | 'children'>, UnsafeStyles, DOMProps, AriaLabelingProps {
   children: React.ReactNode
 }
 

--- a/packages/@react-spectrum/s2/src/Disclosure.tsx
+++ b/packages/@react-spectrum/s2/src/Disclosure.tsx
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, DOMRefValue} from '@react-types/shared';
-import {Button, ContextValue, DisclosureStateContext, Heading, Provider, Disclosure as RACDisclosure, DisclosurePanel as RACDisclosurePanel, DisclosurePanelProps as RACDisclosurePanelProps, DisclosureProps as RACDisclosureProps, useLocale, useSlottedContext} from 'react-aria-components';
+import {Button, ContextValue, DisclosureStateContext, Heading, Provider, UNSTABLE_Disclosure as RACDisclosure, UNSTABLE_DisclosurePanel as RACDisclosurePanel, DisclosurePanelProps as RACDisclosurePanelProps, DisclosureProps as RACDisclosureProps, useLocale, useSlottedContext} from 'react-aria-components';
 import {CenterBaseline} from './CenterBaseline';
 import {centerPadding, focusRing, getAllowedOverrides, StyleProps, UnsafeStyles} from './style-utils' with { type: 'macro' };
 import Chevron from '../ui-icons/Chevron';

--- a/packages/@react-spectrum/tree/test/TreeView.test.tsx
+++ b/packages/@react-spectrum/tree/test/TreeView.test.tsx
@@ -227,7 +227,6 @@ describe('Tree', () => {
       expect(row).toHaveAttribute('data-level');
       expect(row).toHaveAttribute('aria-posinset');
       expect(row).toHaveAttribute('aria-setsize');
-      expect(row).toHaveAttribute('data-has-child-rows');
       expect(row).toHaveAttribute('data-rac');
       expect(row).not.toHaveAttribute('data-selected');
       expect(row).not.toHaveAttribute('data-disabled');
@@ -251,7 +250,7 @@ describe('Tree', () => {
     expect(rowNoChild).toHaveAttribute('data-level', '1');
     expect(rowNoChild).toHaveAttribute('aria-posinset', '1');
     expect(rowNoChild).toHaveAttribute('aria-setsize', '2');
-    expect(rowNoChild).toHaveAttribute('data-has-child-rows', 'false');
+    expect(rowNoChild).not.toHaveAttribute('data-has-child-rows');
     expect(rowNoChild).toHaveAttribute('data-rac');
 
     let rowWithChildren = rows[1];
@@ -285,7 +284,7 @@ describe('Tree', () => {
     expect(level3ChildRow).toHaveAttribute('data-level', '3');
     expect(level3ChildRow).toHaveAttribute('aria-posinset', '1');
     expect(level3ChildRow).toHaveAttribute('aria-setsize', '1');
-    expect(level3ChildRow).toHaveAttribute('data-has-child-rows', 'false');
+    expect(level3ChildRow).not.toHaveAttribute('data-has-child-rows');
     expect(level3ChildRow).toHaveAttribute('data-rac');
 
     let level2ChildRow2 = rows[4];
@@ -296,7 +295,7 @@ describe('Tree', () => {
     expect(level2ChildRow2).toHaveAttribute('data-level', '2');
     expect(level2ChildRow2).toHaveAttribute('aria-posinset', '2');
     expect(level2ChildRow2).toHaveAttribute('aria-setsize', '3');
-    expect(level2ChildRow2).toHaveAttribute('data-has-child-rows', 'false');
+    expect(level2ChildRow2).not.toHaveAttribute('data-has-child-rows');
     expect(level2ChildRow2).toHaveAttribute('data-rac');
 
     let level2ChildRow3 = rows[5];
@@ -307,7 +306,7 @@ describe('Tree', () => {
     expect(level2ChildRow3).toHaveAttribute('data-level', '2');
     expect(level2ChildRow3).toHaveAttribute('aria-posinset', '3');
     expect(level2ChildRow3).toHaveAttribute('aria-setsize', '3');
-    expect(level2ChildRow3).toHaveAttribute('data-has-child-rows', 'false');
+    expect(level2ChildRow3).not.toHaveAttribute('data-has-child-rows');
     expect(level2ChildRow3).toHaveAttribute('data-rac');
   });
 
@@ -430,7 +429,7 @@ describe('Tree', () => {
     expect(rows[0]).toHaveAttribute('aria-label', 'Test');
     // Until the row gets children, don't mark it with the aria/data attributes.
     expect(rows[0]).not.toHaveAttribute('aria-expanded');
-    expect(rows[0]).toHaveAttribute('data-has-child-rows', 'false');
+    expect(rows[0]).not.toHaveAttribute('data-has-child-rows');
     expect(chevron).toBeTruthy();
   });
 
@@ -846,7 +845,7 @@ describe('Tree', () => {
         await trigger(rows[0], 'Enter');
         expect(document.activeElement).toBe(rows[0]);
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(rows[0]).toHaveAttribute('aria-level', '1');
         expect(rows[0]).toHaveAttribute('aria-posinset', '1');
         expect(rows[0]).toHaveAttribute('aria-setsize', '2');
@@ -884,7 +883,7 @@ describe('Tree', () => {
         await trigger(rows[2], 'ArrowLeft');
         expect(document.activeElement).toBe(rows[2]);
         expect(rows[2]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[2]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[2]).not.toHaveAttribute('data-expanded');
         expect(rows[2]).toHaveAttribute('aria-level', '2');
         expect(rows[2]).toHaveAttribute('aria-posinset', '2');
         expect(rows[2]).toHaveAttribute('aria-setsize', '5');
@@ -944,14 +943,14 @@ describe('Tree', () => {
         await user.tab();
         rows = tree.getAllByRole('row');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(rows[0]).toHaveAttribute('aria-disabled', 'true');
         expect(rows[0]).toHaveAttribute('data-disabled', 'true');
         expect(onExpandedChange).toHaveBeenCalledTimes(0);
 
         await trigger(rows[0], 'Space');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(0);
       });
 
@@ -971,7 +970,7 @@ describe('Tree', () => {
         await trigger(chevron, 'ArrowLeft');
         expect(document.activeElement).toBe(rows[0]);
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['Project-2', 'Project-5', 'Reports', 'Reports-1', 'Reports-1A', 'Reports-1AB']));
         expect(onSelectionChange).toHaveBeenCalledTimes(0);
@@ -1016,7 +1015,7 @@ describe('Tree', () => {
         let chevron = within(rows[0]).getAllByRole('button')[0];
         await trigger(chevron, 'ArrowLeft');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['Project-2', 'Project-5', 'Reports', 'Reports-1', 'Reports-1A', 'Reports-1AB']));
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
@@ -1044,7 +1043,7 @@ describe('Tree', () => {
         let chevron = within(rows[0]).getAllByRole('button')[0];
         await trigger(chevron, 'ArrowLeft');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['Project-2', 'Project-5', 'Reports', 'Reports-1', 'Reports-1A', 'Reports-1AB']));
         expect(onAction).toHaveBeenCalledTimes(1);
@@ -1075,7 +1074,7 @@ describe('Tree', () => {
         let chevron = within(rows[0]).getAllByRole('button')[0];
         await trigger(chevron, 'ArrowLeft');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['Project-2', 'Project-5', 'Reports', 'Reports-1', 'Reports-1A', 'Reports-1AB']));
       });
@@ -1097,7 +1096,7 @@ describe('Tree', () => {
       await user.tab();
       expect(document.activeElement).toBe(rows[0]);
       expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-      expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+      expect(rows[0]).not.toHaveAttribute('data-expanded');
 
       await user.click(rows[0]);
       rows = getAllByRole('row');
@@ -1105,7 +1104,7 @@ describe('Tree', () => {
 
       await user.click(rows[0]);
       expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-      expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+      expect(rows[0]).not.toHaveAttribute('data-expanded');
       rows = getAllByRole('row');
       expect(rows).toHaveLength(2);
     });

--- a/packages/react-aria-components/docs/Checkbox.mdx
+++ b/packages/react-aria-components/docs/Checkbox.mdx
@@ -166,7 +166,7 @@ This example wraps `Checkbox` and all of its children together into a single com
 ```tsx example export=true
 import type {CheckboxProps} from 'react-aria-components';
 
-function MyCheckbox({children, ...props}: CheckboxProps) {
+export function MyCheckbox({children, ...props}: CheckboxProps) {
   return (
     <Checkbox {...props}>
       {({isIndeterminate}) => <>

--- a/packages/react-aria-components/docs/Disclosure.mdx
+++ b/packages/react-aria-components/docs/Disclosure.mdx
@@ -26,7 +26,7 @@ preRelease: alpha
 
 # Disclosure
 
-<PageDescription>{docs.exports.Disclosure.description}</PageDescription>
+<PageDescription>{docs.exports.UNSTABLE_Disclosure.description}</PageDescription>
 
 <HeaderInfo
   packageData={packageData}
@@ -43,7 +43,7 @@ preRelease: alpha
 ## Example
 
 ```tsx example
-import {Disclosure, Button, DisclosurePanel} from 'react-aria-components';
+import {UNSTABLE_Disclosure as Disclosure, Button, UNSTABLE_DisclosurePanel as DisclosurePanel} from 'react-aria-components';
 
 <Disclosure>
   <h3>
@@ -107,7 +107,7 @@ import {Disclosure, Button, DisclosurePanel} from 'react-aria-components';
 
 ### Disclosure
 
-<PropTable component={docs.exports.Disclosure} links={docs.links} />
+<PropTable component={docs.exports.UNSTABLE_Disclosure} links={docs.links} />
 
 ### Button
 
@@ -123,7 +123,7 @@ import {Disclosure, Button, DisclosurePanel} from 'react-aria-components';
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
-<PropTable component={docs.exports.DisclosurePanel} links={docs.links} />
+<PropTable component={docs.exports.UNSTABLE_DisclosurePanel} links={docs.links} />
 
 </details>
 

--- a/packages/react-aria-components/docs/Disclosure.mdx
+++ b/packages/react-aria-components/docs/Disclosure.mdx
@@ -1,0 +1,178 @@
+{/* Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. */}
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:react-aria-components';
+import {PropTable, HeaderInfo, TypeLink, PageDescription, StateTable, ContextTable} from '@react-spectrum/docs';
+import styles from '@react-spectrum/docs/src/docs.css';
+import packageData from 'react-aria-components/package.json';
+import ChevronRight from '@spectrum-icons/workflow/ChevronRight';
+import {InlineAlert, Content, Heading} from '@adobe/react-spectrum';
+
+---
+category: Navigation
+keywords: [disclosure, collapse, expand, aria]
+type: component
+preRelease: alpha
+---
+
+# Disclosure
+
+<PageDescription>{docs.exports.Disclosure.description}</PageDescription>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['Disclosure']}
+  sourceData={[
+    {type: 'W3C', url: 'https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/'}
+  ]} />
+
+<InlineAlert variant="notice" marginTop={60}>
+  <Heading>Under construction</Heading>
+  <Content>This component is in <strong>alpha</strong>. More documentation is coming soon!</Content>
+</InlineAlert>
+
+## Example
+
+```tsx example
+import {Disclosure, Button, DisclosurePanel} from 'react-aria-components';
+
+<Disclosure>
+  <h3>
+    <Button slot="trigger">
+      <svg viewBox="0 0 24 24">
+        <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+      </svg>
+      System Requirements
+    </Button>
+  </h3>
+  <DisclosurePanel>
+    <p>Details about system requirements here.</p>
+  </DisclosurePanel>
+</Disclosure>
+```
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
+
+```css hidden
+@import "@react-aria/example-theme";
+@import './Button.mdx' layer(button);
+```
+
+```css
+.react-aria-Disclosure {
+  .react-aria-Button[slot=trigger] {
+    background: none;
+    border: none;
+    box-shadow: none;
+    font-weight: bold;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    svg {
+      rotate: 0deg;
+      transition: rotate 200ms;
+      width: 12px;
+      height: 12px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 3px;
+    }
+  }
+
+  &[data-expanded] .react-aria-Button[slot=trigger] svg {
+    rotate: 90deg;
+  }
+}
+
+.react-aria-DisclosurePanel {
+  margin-left: 32px;
+}
+```
+
+</details>
+
+## Props
+
+### Disclosure
+
+<PropTable component={docs.exports.Disclosure} links={docs.links} />
+
+### Button
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.Button} links={docs.links} />
+
+</details>
+
+### DisclosurePanel
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.DisclosurePanel} links={docs.links} />
+
+</details>
+
+## Styling
+
+React Aria components can be styled in many ways, including using CSS classes, inline styles, utility classes (e.g. Tailwind), CSS-in-JS (e.g. Styled Components), etc. By default, all components include a builtin `className` attribute which can be targeted using CSS selectors. These follow the `react-aria-ComponentName` naming convention.
+
+```css
+.react-aria-Disclosure {
+  /* ... */
+}
+```
+
+A custom `className` can also be specified on any component. This overrides the default `className` provided by React Aria with your own.
+
+```jsx
+<Disclosure className="my-disclosure">
+  {/* ... */}
+</Disclosure>
+```
+
+In addition, some components support multiple UI states (e.g. focused, placeholder, readonly, etc.). React Aria components expose states using data attributes, which you can target in CSS selectors. For example:
+
+```css
+.react-aria-Disclosure[data-expanded] {
+  /* ... */
+}
+```
+
+The `className` and `style` props also accept functions which receive states for styling. This lets you dynamically determine the classes or styles to apply, which is useful when using utility CSS libraries like [Tailwind](https://tailwindcss.com/).
+
+```jsx
+<Disclosure className={({isExpanded}) => isExpanded ? 'border-blue-500' : 'border-gray-600'} />
+```
+
+The states, selectors, and render props for each component used in a `Disclosure` are documented below.
+
+### Disclosure
+
+A `Disclosure` can be targeted with the `.react-aria-Disclosure` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DisclosureRenderProps.properties} />
+
+### Button
+
+A `Button` can be targeted with the `.react-aria-Button` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.ButtonRenderProps.properties} />
+
+### DisclosurePanel
+
+A `DisclosurePanel` can be targeted with the `.react-aria-DisclosurePanel` CSS selector, or by overriding with a custom `className`.

--- a/packages/react-aria-components/docs/DisclosureGroup.mdx
+++ b/packages/react-aria-components/docs/DisclosureGroup.mdx
@@ -26,7 +26,7 @@ preRelease: alpha
 
 # DisclosureGroup
 
-<PageDescription>{docs.exports.DisclosureGroup.description}</PageDescription>
+<PageDescription>{docs.exports.UNSTABLE_DisclosureGroup.description}</PageDescription>
 
 <HeaderInfo
   packageData={packageData}
@@ -43,7 +43,7 @@ preRelease: alpha
 ## Example
 
 ```tsx example
-import {DisclosureGroup, Disclosure, Button, DisclosurePanel} from 'react-aria-components';
+import {UNSTABLE_DisclosureGroup as DisclosureGroup, UNSTABLE_Disclosure as Disclosure, Button, UNSTABLE_DisclosurePanel as DisclosurePanel} from 'react-aria-components';
 
 <DisclosureGroup defaultExpandedKeys={['personal']}>
   <Disclosure id="personal">
@@ -85,7 +85,7 @@ import {DisclosureGroup, Disclosure, Button, DisclosurePanel} from 'react-aria-c
 
 ### DisclosureGroup
 
-<PropTable component={docs.exports.DisclosureGroup} links={docs.links} />
+<PropTable component={docs.exports.UNSTABLE_DisclosureGroup} links={docs.links} />
 
 ### Disclosure
 
@@ -94,7 +94,7 @@ Within a `<DisclosureGroup>`, most `<Disclosure>` props are set automatically. T
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
-<PropTable component={docs.exports.Disclosure} links={docs.links} />
+<PropTable component={docs.exports.UNSTABLE_Disclosure} links={docs.links} />
 
 </details>
 
@@ -112,7 +112,7 @@ Within a `<DisclosureGroup>`, most `<Disclosure>` props are set automatically. T
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
 
-<PropTable component={docs.exports.DisclosurePanel} links={docs.links} />
+<PropTable component={docs.exports.UNSTABLE_DisclosurePanel} links={docs.links} />
 
 </details>
 

--- a/packages/react-aria-components/docs/DisclosureGroup.mdx
+++ b/packages/react-aria-components/docs/DisclosureGroup.mdx
@@ -150,9 +150,9 @@ The `className` and `style` props also accept functions which receive states for
 
 The states, selectors, and render props for each component used in a `DisclosureGroup` are documented below.
 
-### Disclosure
+### DisclosureGroup
 
-A `Disclosure` can be targeted with the `.react-aria-DisclosureGroup` CSS selector, or by overriding with a custom `className`. It supports the following states:
+A `DisclosureGroup` can be targeted with the `.react-aria-DisclosureGroup` CSS selector, or by overriding with a custom `className`. It supports the following states:
 
 <StateTable properties={docs.exports.DisclosureGroupRenderProps.properties} />
 

--- a/packages/react-aria-components/docs/DisclosureGroup.mdx
+++ b/packages/react-aria-components/docs/DisclosureGroup.mdx
@@ -1,0 +1,173 @@
+{/* Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. */}
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:react-aria-components';
+import {PropTable, HeaderInfo, TypeLink, PageDescription, StateTable, ContextTable} from '@react-spectrum/docs';
+import styles from '@react-spectrum/docs/src/docs.css';
+import packageData from 'react-aria-components/package.json';
+import ChevronRight from '@spectrum-icons/workflow/ChevronRight';
+import {InlineAlert, Content, Heading} from '@adobe/react-spectrum';
+
+---
+category: Navigation
+keywords: [disclosure, accordion, collapse, expand, aria]
+type: component
+preRelease: alpha
+---
+
+# DisclosureGroup
+
+<PageDescription>{docs.exports.DisclosureGroup.description}</PageDescription>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['DisclosureGroup']}
+  sourceData={[
+    {type: 'W3C', url: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/'}
+  ]} />
+
+<InlineAlert variant="notice" marginTop={60}>
+  <Heading>Under construction</Heading>
+  <Content>This component is in <strong>alpha</strong>. More documentation is coming soon!</Content>
+</InlineAlert>
+
+## Example
+
+```tsx example
+import {DisclosureGroup, Disclosure, Button, DisclosurePanel} from 'react-aria-components';
+
+<DisclosureGroup defaultExpandedKeys={['personal']}>
+  <Disclosure id="personal">
+    <h3>
+      <Button slot="trigger">
+        <svg viewBox="0 0 24 24">
+          <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+        </svg>
+        Personal Information
+      </Button>
+    </h3>
+    <DisclosurePanel>
+      <p>Personal information form here.</p>
+    </DisclosurePanel>
+  </Disclosure>
+  <Disclosure id="billing">
+    <h3>
+      <Button slot="trigger">
+        <svg viewBox="0 0 24 24">
+          <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+        </svg>
+        Billing Address
+      </Button>
+    </h3>
+    <DisclosurePanel>
+      <p>Billing address form here.</p>
+    </DisclosurePanel>
+  </Disclosure>
+</DisclosureGroup>
+```
+
+```css hidden
+@import "@react-aria/example-theme";
+@import './Button.mdx' layer(button);
+@import './Disclosure.mdx' layer(disclosure);
+```
+
+## Props
+
+### DisclosureGroup
+
+<PropTable component={docs.exports.DisclosureGroup} links={docs.links} />
+
+### Disclosure
+
+Within a `<DisclosureGroup>`, most `<Disclosure>` props are set automatically. The `id` prop is required to identify the disclosure within the group.
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.Disclosure} links={docs.links} />
+
+</details>
+
+### Button
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.Button} links={docs.links} />
+
+</details>
+
+### DisclosurePanel
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>
+
+<PropTable component={docs.exports.DisclosurePanel} links={docs.links} />
+
+</details>
+
+## Styling
+
+React Aria components can be styled in many ways, including using CSS classes, inline styles, utility classes (e.g. Tailwind), CSS-in-JS (e.g. Styled Components), etc. By default, all components include a builtin `className` attribute which can be targeted using CSS selectors. These follow the `react-aria-ComponentName` naming convention.
+
+```css
+.react-aria-DisclosureGroup {
+  /* ... */
+}
+```
+
+A custom `className` can also be specified on any component. This overrides the default `className` provided by React Aria with your own.
+
+```jsx
+<DisclosureGroup className="my-accordion">
+  {/* ... */}
+</DisclosureGroup>
+```
+
+In addition, some components support multiple UI states (e.g. focused, placeholder, readonly, etc.). React Aria components expose states using data attributes, which you can target in CSS selectors. For example:
+
+```css
+.react-aria-DisclosureGroup[data-disabled] {
+  /* ... */
+}
+```
+
+The `className` and `style` props also accept functions which receive states for styling. This lets you dynamically determine the classes or styles to apply, which is useful when using utility CSS libraries like [Tailwind](https://tailwindcss.com/).
+
+```jsx
+<Disclosure className={({isExpanded}) => isExpanded ? 'border-blue-500' : 'border-gray-600'} />
+```
+
+The states, selectors, and render props for each component used in a `DisclosureGroup` are documented below.
+
+### Disclosure
+
+A `Disclosure` can be targeted with the `.react-aria-DisclosureGroup` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DisclosureGroupRenderProps.properties} />
+
+### Disclosure
+
+A `Disclosure` can be targeted with the `.react-aria-Disclosure` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.DisclosureRenderProps.properties} />
+
+### Button
+
+A `Button` can be targeted with the `.react-aria-Button` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.ButtonRenderProps.properties} />
+
+### DisclosurePanel
+
+A `DisclosurePanel` can be targeted with the `.react-aria-DisclosurePanel` CSS selector, or by overriding with a custom `className`.

--- a/packages/react-aria-components/docs/GridList.mdx
+++ b/packages/react-aria-components/docs/GridList.mdx
@@ -49,6 +49,7 @@ type: component
 
 ```tsx example
 import {GridList, GridListItem, Button} from 'react-aria-components';
+import {MyCheckbox} from './Checkbox';
 
 <GridList aria-label="Favorite pokemon" selectionMode="multiple">
   <GridListItem textValue="Charizard">
@@ -305,8 +306,7 @@ If you will use a GridList in multiple places in your app, you can wrap all of t
 This example wraps `GridList` and all of its children together into a single component which accepts a `label` prop and `children`, which are passed through to the right places. The `GridListItem` component is also wrapped to include a custom [checkbox](Checkbox.html) component automatically when the item is multi-selectable, and a drag handle when [drag and drop](#drag-and-drop) is enabled.
 
 ```tsx example export=true
-import type {GridListProps, GridListItemProps, CheckboxProps} from 'react-aria-components';
-import {Button, Checkbox} from 'react-aria-components';
+import type {GridListProps, GridListItemProps} from 'react-aria-components';
 
 function MyGridList<T extends object>({children, ...props}: GridListProps<T>) {
   return (
@@ -327,24 +327,6 @@ function MyItem({children, ...props}: GridListItemProps) {
         {children}
       </>}
     </GridListItem>
-  );
-}
-
-function MyCheckbox({children, ...props}: CheckboxProps) {
-  return (
-    <Checkbox {...props}>
-      {({isIndeterminate}) => <>
-        <div className="checkbox">
-          <svg viewBox="0 0 18 18" aria-hidden="true">
-            {isIndeterminate
-              ? <rect x={1} y={7.5} width={15} height={3} />
-              : <polyline points="1 9 7 14 15 4" />
-            }
-          </svg>
-        </div>
-        {children}
-      </>}
-    </Checkbox>
   );
 }
 

--- a/packages/react-aria-components/docs/Table.mdx
+++ b/packages/react-aria-components/docs/Table.mdx
@@ -49,6 +49,7 @@ type: component
 
 ```tsx example
 import {Table, TableHeader, TableBody, Column, Row, Cell} from 'react-aria-components';
+import {MyCheckbox} from './Checkbox';
 
 <Table aria-label="Files" selectionMode="multiple">
   <TableHeader>
@@ -362,8 +363,8 @@ function MyColumn(props: ColumnProps) {
 The TableHeader and Row components can also be wrapped to automatically include [checkboxes](Checkbox.html) for selection, and a drag handle when [drag and drop](#drag-and-drop) is enabled, allowing consumers to avoid repeating them in each row. In this example, the select all checkbox is displayed when [multiple selection](#multiple-selection) is enabled and the [selection behavior](#selection-behavior) is "toggle". These options can be retrieved from the table using the <TypeLink links={docs.links} type={docs.exports.useTableOptions} /> hook. We also use the <TypeLink links={docs.links} type={docs.exports.Collection} /> component to generate children from either static or [dynamic collections](#dynamic-collections) the same way as the default TableHeader and Row components.
 
 ```tsx example export=true render=false
-import type {TableHeaderProps, RowProps, CheckboxProps} from 'react-aria-components';
-import {Checkbox, Collection, useTableOptions} from 'react-aria-components';
+import type {TableHeaderProps, RowProps} from 'react-aria-components';
+import {Collection, useTableOptions} from 'react-aria-components';
 
 function MyTableHeader<T extends object>({columns, children}: TableHeaderProps<T>) {
   let {selectionBehavior, selectionMode, allowsDragging} = useTableOptions();
@@ -391,24 +392,6 @@ function MyRow<T extends object>({id, columns, children, ...otherProps}: RowProp
         {children}
       </Collection>
     </Row>
-  );
-}
-
-function MyCheckbox({children, ...props}: CheckboxProps) {
-  return (
-    <Checkbox {...props}>
-      {({isIndeterminate}) => <>
-        <div className="checkbox">
-          <svg viewBox="0 0 18 18" aria-hidden="true">
-            {isIndeterminate
-              ? <rect x={1} y={7.5} width={15} height={3} />
-              : <polyline points="1 9 7 14 15 4" />
-            }
-          </svg>
-        </div>
-        {children}
-      </>}
-    </Checkbox>
   );
 }
 ```

--- a/packages/react-aria-components/docs/Tree.mdx
+++ b/packages/react-aria-components/docs/Tree.mdx
@@ -37,7 +37,7 @@ preRelease: beta
 
 <InlineAlert variant="notice" marginTop={60}>
   <Heading>Under construction</Heading>
-  <Content>This component is in <strong>alpha</strong>. More documentation is coming soon!</Content>
+  <Content>This component is in <strong>beta</strong>. More documentation is coming soon!</Content>
 </InlineAlert>
 
 ## Example

--- a/packages/react-aria-components/docs/Tree.mdx
+++ b/packages/react-aria-components/docs/Tree.mdx
@@ -1,0 +1,314 @@
+{/* Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. */}
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:react-aria-components';
+import {PropTable, HeaderInfo, TypeLink, PageDescription, StateTable, ContextTable} from '@react-spectrum/docs';
+import styles from '@react-spectrum/docs/src/docs.css';
+import packageData from 'react-aria-components/package.json';
+import ChevronRight from '@spectrum-icons/workflow/ChevronRight';
+import {InlineAlert, Content, Heading} from '@adobe/react-spectrum';
+
+---
+category: Collections
+keywords: [disclosure, collapse, expand, aria]
+type: component
+preRelease: beta
+---
+
+# Tree
+
+<PageDescription>{docs.exports.UNSTABLE_Tree.description}</PageDescription>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['UNSTABLE_Tree']}
+  sourceData={[
+    {type: 'W3C', url: 'https://www.w3.org/WAI/ARIA/apg/patterns/treeview/'}
+  ]} />
+
+<InlineAlert variant="notice" marginTop={60}>
+  <Heading>Under construction</Heading>
+  <Content>This component is in <strong>alpha</strong>. More documentation is coming soon!</Content>
+</InlineAlert>
+
+## Example
+
+```tsx example
+import {
+  UNSTABLE_Tree as Tree,
+  UNSTABLE_TreeItem as TreeItem,
+  UNSTABLE_TreeItemContent as TreeItemContent,
+  Button,
+  Collection
+} from 'react-aria-components';
+import {MyCheckbox} from './Checkbox';
+
+let items = [
+  {id: 1, title: 'Documents', children: [
+    {id: 2, title: 'Project', children: [
+      {id: 3, title: 'Weekly Report', children: []}
+    ]}
+  ]},
+  {id: 4, title: 'Photos', children: [
+    {id: 5, title: 'Image 1', children: []},
+    {id: 6, title: 'Image 2', children: []}
+  ]}
+];
+
+<Tree aria-label="Files" selectionMode="multiple" items={items}>
+  {function renderItem(item) {
+    return (
+      <TreeItem textValue={item.title}>
+        <TreeItemContent>
+          {item.children.length ? <Button slot="chevron">
+            <svg viewBox="0 0 24 24">
+              <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+            </svg>
+          </Button> : null}
+          <MyCheckbox slot="selection" />
+          {item.title}
+          <Button aria-label="Info">ⓘ</Button>
+        </TreeItemContent>
+        <Collection items={item.children}>
+          {renderItem}
+        </Collection>
+      </TreeItem>
+    );
+  }}
+</Tree>
+```
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
+
+```css hidden
+@import "@react-aria/example-theme";
+@import './Button.mdx' layer(button);
+@import './Checkbox.mdx' layer(checkbox);
+```
+
+```css
+.react-aria-Tree {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: auto;
+  padding: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--overlay-background);
+  forced-color-adjust: none;
+  outline: none;
+  width: 250px;
+  max-height: 300px;
+  box-sizing: border-box;
+
+  &[data-focus-visible] {
+    outline: 2px solid var(--focus-ring-color);
+    outline-offset: -1px;
+  }
+
+  .react-aria-TreeItem {
+    display: flex;
+    align-items: center;
+    gap: 0.571rem;
+    min-height: 28px;
+    padding: 0.286rem 0.286rem 0.286rem 0.571rem;
+    --padding: 20px;
+    padding-left: calc((var(--tree-item-level) - 1) * 20px + 0.571rem + var(--padding));
+    border-radius: 6px;
+    outline: none;
+    cursor: default;
+    color: var(--text-color);
+    font-size: 1.072rem;
+    position: relative;
+    transform: translateZ(0);
+
+    &[data-has-child-rows] {
+      --padding: 0px;
+    }
+
+    .react-aria-Button[slot=chevron] {
+      all: unset;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.143rem;
+      height: 1.143rem;
+
+      svg {
+        rotate: 0deg;
+        transition: rotate 200ms;
+        width: 12px;
+        height: 12px;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 3px;
+      }
+    }
+
+    &[data-expanded] .react-aria-Button[slot=chevron] svg {
+      rotate: 90deg;
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--focus-ring-color);
+      outline-offset: -2px;
+    }
+
+    &[data-pressed] {
+      background: var(--gray-100);
+    }
+
+    &[data-selected] {
+      background: var(--highlight-background);
+      color: var(--highlight-foreground);
+      --focus-ring-color: var(--highlight-foreground);
+
+      &[data-focus-visible] {
+        outline-color: var(--highlight-foreground);
+        outline-offset: -4px;
+      }
+
+      .react-aria-Button {
+        color: var(--highlight-foreground);
+        --highlight-hover: rgb(255 255 255 / 0.1);
+        --highlight-pressed: rgb(255 255 255 / 0.2);
+      }
+    }
+
+    &[data-disabled] {
+      color: var(--text-color-disabled);
+    }
+
+    .react-aria-Button:not([slot]) {
+      margin-left: auto;
+      background: transparent;
+      border: none;
+      font-size: 1.2rem;
+      line-height: 1.2em;
+      padding: 0.286rem 0.429rem;
+      transition: background 200ms;
+
+      &[data-hovered] {
+        background: var(--highlight-hover);
+      }
+
+      &[data-pressed] {
+        background: var(--highlight-pressed);
+        box-shadow: none;
+      }
+    }
+  }
+
+  /* join selected items if :has selector is supported */
+  @supports selector(:has(.foo)) {
+    gap: 0;
+
+    .react-aria-TreeItem[data-selected]:has(+ [data-selected]) {
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
+    }
+
+    .react-aria-TreeItem[data-selected] + [data-selected] {
+      border-start-start-radius: 0;
+      border-start-end-radius: 0;
+    }
+  }
+
+  :where(.react-aria-TreeItem) .react-aria-Checkbox {
+    --selected-color: var(--highlight-foreground);
+    --selected-color-pressed: var(--highlight-foreground-pressed);
+    --checkmark-color: var(--highlight-background);
+    --background-color: var(--highlight-background);
+  }
+}
+```
+
+</details>
+
+## Props
+
+### Tree
+
+<PropTable component={docs.exports.UNSTABLE_Tree} links={docs.links} />
+
+### TreeItem
+
+<PropTable component={docs.exports.UNSTABLE_TreeItem} links={docs.links} />
+
+### TreeItemContent
+
+<PropTable component={docs.exports.UNSTABLE_TreeItemContent} links={docs.links} />
+
+## Styling
+
+React Aria components can be styled in many ways, including using CSS classes, inline styles, utility classes (e.g. Tailwind), CSS-in-JS (e.g. Styled Components), etc. By default, all components include a builtin `className` attribute which can be targeted using CSS selectors. These follow the `react-aria-ComponentName` naming convention.
+
+```css
+.react-aria-Tree {
+  /* ... */
+}
+```
+
+A custom `className` can also be specified on any component. This overrides the default `className` provided by React Aria with your own.
+
+```jsx
+<TreeItem className="my-tree-item">
+  {/* ... */}
+</TreeItem>
+```
+
+In addition, some components support multiple UI states (e.g. focused, placeholder, readonly, etc.). React Aria components expose states using data attributes, which you can target in CSS selectors. For example:
+
+```css
+.react-aria-TreeItem[data-expanded] {
+  /* ... */
+}
+
+.react-aria-TreeItem[data-selected] {
+  /* ... */
+}
+```
+
+The `className` and `style` props also accept functions which receive states for styling. This lets you dynamically determine the classes or styles to apply, which is useful when using utility CSS libraries like [Tailwind](https://tailwindcss.com/).
+
+```jsx
+<TreeItem className={({ isSelected }) => isSelected ? 'bg-blue-400' : 'bg-gray-100'} />
+```
+
+Render props may also be used as children to alter what elements are rendered based on the current state. For example, you could render a checkbox only when selection is enabled.
+
+```jsx
+<TreeItem>
+  {({selectionMode}) => (
+    <>
+      {selectionMode !== 'none' && <Checkbox />}
+      Item
+    </>
+  )}
+</TreeItem>
+```
+
+The states, selectors, and render props for each component used in a `Tree` are documented below.
+
+### Tree
+
+A `Tree` can be targeted with the `.react-aria-Tree` CSS selector, or by overriding with a custom `className`. It supports the following states:
+
+<StateTable properties={docs.exports.TreeRenderProps.properties} />
+
+### TreeItem
+
+A `TreeItem` can be targeted with the `.react-aria-TreeItem` CSS selector, or by overriding with a custom `className`. It supports the following states and render props:
+
+<StateTable properties={docs.exports.TreeItemRenderProps.properties} showOptional />

--- a/packages/react-aria-components/src/Disclosure.tsx
+++ b/packages/react-aria-components/src/Disclosure.tsx
@@ -16,8 +16,8 @@ import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, useContext
 import {DisclosureGroupState, DisclosureState, DisclosureGroupProps as StatelyDisclosureGroupProps, useDisclosureGroupState, useDisclosureState} from '@react-stately/disclosure';
 import {DOMProps, forwardRefType, Key} from '@react-types/shared';
 import {filterDOMProps, mergeProps, mergeRefs, useId} from '@react-aria/utils';
-import {HoverEvents, useFocusRing} from 'react-aria';
 import React, {createContext, DOMAttributes, ForwardedRef, forwardRef, ReactNode, useContext} from 'react';
+import {useFocusRing} from 'react-aria';
 
 export interface DisclosureGroupProps extends StatelyDisclosureGroupProps, RenderProps<DisclosureGroupRenderProps>, DOMProps {}
 
@@ -69,7 +69,7 @@ function DisclosureGroup(props: DisclosureGroupProps, ref: ForwardedRef<HTMLDivE
 const _DisclosureGroup = forwardRef(DisclosureGroup);
 export {_DisclosureGroup as DisclosureGroup};
 
-export interface DisclosureProps extends Omit<AriaDisclosureProps, 'children'>, HoverEvents, RenderProps<DisclosureRenderProps>, SlotProps {
+export interface DisclosureProps extends Omit<AriaDisclosureProps, 'children'>, RenderProps<DisclosureRenderProps>, SlotProps {
   /** An id for the disclosure when used within a DisclosureGroup, matching the id used in `expandedKeys`. */
   id?: Key
 }

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -118,11 +118,13 @@ export interface TreeRenderProps {
   state: TreeState<unknown>
 }
 
+export interface TreeEmptyStateRenderProps extends Omit<TreeRenderProps, 'isEmpty'> {}
+
 export interface TreeProps<T> extends Omit<AriaTreeGridListProps<T>, 'children'>, CollectionProps<T>, StyleRenderProps<TreeRenderProps>, SlotProps, ScrollableProps<HTMLDivElement>, Expandable {
   /** How multiple selection should behave in the tree. */
   selectionBehavior?: SelectionBehavior,
   /** Provides content to display when there are no items in the list. */
-  renderEmptyState?: (props: Omit<TreeRenderProps, 'isEmpty'>) => ReactNode,
+  renderEmptyState?: (props: TreeEmptyStateRenderProps) => ReactNode,
   /**
    * Whether `disabledKeys` applies to all interactions, or only selection.
    * @default 'selection'
@@ -359,6 +361,10 @@ export const UNSTABLE_TreeItem = /*#__PURE__*/ createBranchComponent('item', <T 
     id: undefined,
     children: item.rendered,
     defaultClassName: 'react-aria-TreeItem',
+    defaultStyle: {
+      // @ts-ignore
+      '--tree-item-level': level
+    },
     values: renderPropValues
   });
 
@@ -401,8 +407,8 @@ export const UNSTABLE_TreeItem = /*#__PURE__*/ createBranchComponent('item', <T 
         {...renderProps}
         ref={ref}
         // TODO: missing selectionBehavior, hasAction and allowsSelection data attribute equivalents (available in renderProps). Do we want those?
-        data-expanded={hasChildRows ? isExpanded : undefined}
-        data-has-child-rows={hasChildRows}
+        data-expanded={(hasChildRows && isExpanded) || undefined}
+        data-has-child-rows={hasChildRows || undefined}
         data-level={level}
         data-selected={states.isSelected || undefined}
         data-disabled={states.isDisabled || undefined}

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -33,7 +33,7 @@ export {composeRenderProps, DEFAULT_SLOT, Provider, useContextProps, useSlottedC
 export {DateField, DateInput, DateSegment, TimeField, DateFieldContext, TimeFieldContext, DateFieldStateContext, TimeFieldStateContext} from './DateField';
 export {DatePicker, DateRangePicker, DatePickerContext, DateRangePickerContext, DatePickerStateContext, DateRangePickerStateContext} from './DatePicker';
 export {DialogTrigger, Dialog, DialogContext, OverlayTriggerStateContext} from './Dialog';
-export {Disclosure, DisclosureGroup, DisclosureGroupStateContext, DisclosurePanel, DisclosureStateContext, DisclosureContext} from './Disclosure';
+export {Disclosure as UNSTABLE_Disclosure, DisclosureGroup as UNSTABLE_DisclosureGroup, DisclosureGroupStateContext, DisclosurePanel as UNSTABLE_DisclosurePanel, DisclosureStateContext, DisclosureContext} from './Disclosure';
 export {DropZone, DropZoneContext} from './DropZone';
 export {FieldError, FieldErrorContext} from './FieldError';
 export {FileTrigger} from './FileTrigger';

--- a/packages/react-aria-components/stories/Disclosure.stories.tsx
+++ b/packages/react-aria-components/stories/Disclosure.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {Button, Heading} from 'react-aria-components';
-import {Disclosure, DisclosurePanel} from '../src';
+import {Disclosure, DisclosurePanel} from '../src/Disclosure';
 import React from 'react';
 import './styles.css';
 

--- a/packages/react-aria-components/test/Tree.test.tsx
+++ b/packages/react-aria-components/test/Tree.test.tsx
@@ -201,7 +201,6 @@ describe('Tree', () => {
       expect(row).toHaveAttribute('data-level');
       expect(row).toHaveAttribute('aria-posinset');
       expect(row).toHaveAttribute('aria-setsize');
-      expect(row).toHaveAttribute('data-has-child-rows');
       expect(row).toHaveAttribute('data-rac');
       expect(row).not.toHaveAttribute('data-selected');
       expect(row).not.toHaveAttribute('data-disabled');
@@ -225,7 +224,7 @@ describe('Tree', () => {
     expect(rowNoChild).toHaveAttribute('data-level', '1');
     expect(rowNoChild).toHaveAttribute('aria-posinset', '1');
     expect(rowNoChild).toHaveAttribute('aria-setsize', '2');
-    expect(rowNoChild).toHaveAttribute('data-has-child-rows', 'false');
+    expect(rowNoChild).not.toHaveAttribute('data-has-child-rows');
     expect(rowNoChild).toHaveAttribute('data-rac');
 
     let rowWithChildren = rows[1];
@@ -259,7 +258,7 @@ describe('Tree', () => {
     expect(level3ChildRow).toHaveAttribute('data-level', '3');
     expect(level3ChildRow).toHaveAttribute('aria-posinset', '1');
     expect(level3ChildRow).toHaveAttribute('aria-setsize', '1');
-    expect(level3ChildRow).toHaveAttribute('data-has-child-rows', 'false');
+    expect(level3ChildRow).not.toHaveAttribute('data-has-child-rows');
     expect(level3ChildRow).toHaveAttribute('data-rac');
 
     let level2ChildRow2 = rows[4];
@@ -270,7 +269,7 @@ describe('Tree', () => {
     expect(level2ChildRow2).toHaveAttribute('data-level', '2');
     expect(level2ChildRow2).toHaveAttribute('aria-posinset', '2');
     expect(level2ChildRow2).toHaveAttribute('aria-setsize', '3');
-    expect(level2ChildRow2).toHaveAttribute('data-has-child-rows', 'false');
+    expect(level2ChildRow2).not.toHaveAttribute('data-has-child-rows');
     expect(level2ChildRow2).toHaveAttribute('data-rac');
 
     let level2ChildRow3 = rows[5];
@@ -281,7 +280,7 @@ describe('Tree', () => {
     expect(level2ChildRow3).toHaveAttribute('data-level', '2');
     expect(level2ChildRow3).toHaveAttribute('aria-posinset', '3');
     expect(level2ChildRow3).toHaveAttribute('aria-setsize', '3');
-    expect(level2ChildRow3).toHaveAttribute('data-has-child-rows', 'false');
+    expect(level2ChildRow3).not.toHaveAttribute('data-has-child-rows');
     expect(level2ChildRow3).toHaveAttribute('data-rac');
   });
 
@@ -884,7 +883,7 @@ describe('Tree', () => {
         await trigger(rows[0], 'Enter');
         expect(document.activeElement).toBe(rows[0]);
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(rows[0]).toHaveAttribute('aria-level', '1');
         expect(rows[0]).toHaveAttribute('aria-posinset', '1');
         expect(rows[0]).toHaveAttribute('aria-setsize', '2');
@@ -922,7 +921,7 @@ describe('Tree', () => {
         await trigger(rows[2], 'ArrowLeft');
         expect(document.activeElement).toBe(rows[2]);
         expect(rows[2]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[2]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[2]).not.toHaveAttribute('data-expanded');
         expect(rows[2]).toHaveAttribute('aria-level', '2');
         expect(rows[2]).toHaveAttribute('aria-posinset', '2');
         expect(rows[2]).toHaveAttribute('aria-setsize', '5');
@@ -982,14 +981,14 @@ describe('Tree', () => {
         await user.tab();
         rows = getAllByRole('row');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(rows[0]).toHaveAttribute('aria-disabled', 'true');
         expect(rows[0]).toHaveAttribute('data-disabled', 'true');
         expect(onExpandedChange).toHaveBeenCalledTimes(0);
 
         await trigger(rows[0], 'Space');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(0);
       });
 
@@ -1010,7 +1009,7 @@ describe('Tree', () => {
         // TODO: reenable this when we make it so the chevron button isn't focusable via click
         // expect(document.activeElement).toBe(rows[0]);
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['project-2', 'project-5', 'reports', 'reports-1', 'reports-1A', 'reports-1AB']));
         expect(onSelectionChange).toHaveBeenCalledTimes(0);
@@ -1055,7 +1054,7 @@ describe('Tree', () => {
         let chevron = within(rows[0]).getAllByRole('button')[0];
         await trigger(chevron, 'ArrowLeft');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['project-2', 'project-5', 'reports', 'reports-1', 'reports-1A', 'reports-1AB']));
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
@@ -1083,7 +1082,7 @@ describe('Tree', () => {
         let chevron = within(rows[0]).getAllByRole('button')[0];
         await trigger(chevron, 'ArrowLeft');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['project-2', 'project-5', 'reports', 'reports-1', 'reports-1A', 'reports-1AB']));
         expect(onAction).toHaveBeenCalledTimes(1);
@@ -1114,7 +1113,7 @@ describe('Tree', () => {
         let chevron = within(rows[0]).getAllByRole('button')[0];
         await trigger(chevron, 'ArrowLeft');
         expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-        expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+        expect(rows[0]).not.toHaveAttribute('data-expanded');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
         expect(new Set(onExpandedChange.mock.calls[0][0])).toEqual(new Set(['project-2', 'project-5', 'reports', 'reports-1', 'reports-1A', 'reports-1AB']));
       });
@@ -1136,7 +1135,7 @@ describe('Tree', () => {
       await user.tab();
       expect(document.activeElement).toBe(rows[0]);
       expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-      expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+      expect(rows[0]).not.toHaveAttribute('data-expanded');
 
       await user.click(rows[0]);
       rows = getAllByRole('row');
@@ -1144,7 +1143,7 @@ describe('Tree', () => {
 
       await user.click(rows[0]);
       expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
-      expect(rows[0]).toHaveAttribute('data-expanded', 'false');
+      expect(rows[0]).not.toHaveAttribute('data-expanded');
       rows = getAllByRole('row');
       expect(rows).toHaveLength(2);
     });


### PR DESCRIPTION
Basic docs just including a single example and props table for now. To be expanded later.