### PR TITLE
fixes - Accordion Chromatic and Chromatic-FC regressions

### DIFF
--- a/packages/@react-spectrum/accordion/chromatic-fc/Accordion.stories.tsx
+++ b/packages/@react-spectrum/accordion/chromatic-fc/Accordion.stories.tsx
@@ -21,5 +21,6 @@ const meta: Meta<SpectrumAccordionProps> = {
 export default meta;
 
 export const Default = {
-  render: Template
+  render: Template,
+  args: {defaultExpandedKeys: ['shared']}
 };

--- a/packages/@react-spectrum/accordion/chromatic/Accordion.stories.tsx
+++ b/packages/@react-spectrum/accordion/chromatic/Accordion.stories.tsx
@@ -55,4 +55,39 @@ export const Default = {
   render: Template
 };
 
+export const WithExpanedKeys = {
+  render: Template,
+  args: {defaultExpandedKeys: ['shared']}
+};
+
+export const WithDisabledDisclosure = {
+  render: (args) => (
+    <Accordion {...args}>
+      <Disclosure id="files">
+        <DisclosureHeader>
+          Your files
+        </DisclosureHeader>
+        <DisclosurePanel>
+          files
+        </DisclosurePanel>
+      </Disclosure>
+      <Disclosure id="shared">
+        <DisclosureHeader>
+          Shared with you
+        </DisclosureHeader>
+        <DisclosurePanel>
+          shared
+        </DisclosurePanel>
+      </Disclosure>
+      <Disclosure id="last" isDisabled>
+        <DisclosureHeader>
+          Last item
+        </DisclosureHeader>
+        <DisclosurePanel>
+          last
+        </DisclosurePanel>
+      </Disclosure>
+    </Accordion>)
+};
+
 // TODO: more stories

--- a/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
@@ -20,7 +20,8 @@ const meta: Meta<typeof Accordion> = {
   parameters: {
     layout: 'centered'
   },
-  tags: ['autodocs']
+  tags: ['autodocs'],
+  title: 'S2/Accordion'
 };
 
 export default meta;


### PR DESCRIPTION
found when running chromatic for testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run chromatic-fc and confirm the story matches the baseline, i.e. there is an expanded disclosure.
In chromatic the s1 and s2 accordion stories are separated and the s1 stories match baseline from a month ago.

## 🧢 Your Project:
RSP
<!--- Company/project for pull request -->
