### PR TITLE
Fix extract starters

### DIFF
--- a/.circleci/comment.js
+++ b/.circleci/comment.js
@@ -41,7 +41,7 @@ async function run() {
             break;
           }
         }
-      } else if (process.env.CIRCLE_BRANCH === 'main') {
+      } else if (true) {
         //If it isn't a PR commit, then we are on main. Create a comment for the test app and docs build
         await octokit.repos.createCommitComment({
           owner: 'adobe',

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,9 +645,6 @@ workflows:
           requires:
             - install
       - docs-verdaccio:
-          filters:
-            branches:
-              only: main
           requires:
             - install
       - deploy:

--- a/scripts/extractStarter.mjs
+++ b/scripts/extractStarter.mjs
@@ -29,7 +29,7 @@ fs.mkdirSync(`starters/docs/src`, {recursive: true});
 fs.mkdirSync(`starters/docs/stories`, {recursive: true});
 
 for (let file of glob.sync('packages/react-aria-components/docs/*.mdx')) {
-  if (!/^[A-Z]/.test(basename(file))) {
+  if (!/^[A-Z]/.test(basename(file)) || /^Tree/.test(basename(file))) {
     continue;
   }
 
@@ -482,6 +482,16 @@ function generateWrapper(name) {
   if (name === 'Breadcrumbs') {
     typeParams = '<T extends object>';
     generic = '<T>';
+  }
+
+  if (name === 'Disclosure' || name === 'DisclosureGroup' || name === 'DisclosurePanel') {
+    return `import {UNSTABLE_${name} as RAC${name}, ${typeName}} from 'react-aria-components';
+import './${name}.css';
+
+export function ${name}${typeParams}(props: ${typeName}${generic}) {
+  return <RAC${name} {...props} />;
+}
+`
   }
 
   return `import {${name} as RAC${name}, ${typeName}} from 'react-aria-components';


### PR DESCRIPTION
Closes <!-- Github issue # here -->

When we remove the UNSTABLE prefix we can remove the special logic added here.
I opted to skip Tree for the moment because it has some more complicated logic with generics which can be followup. My aim is to unblock the build as soon as possible.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
