### PR TITLE
Pass through ActionBar disabledKeys to ActionGroup

### DIFF
--- a/packages/@react-spectrum/actionbar/docs/ActionBar.mdx
+++ b/packages/@react-spectrum/actionbar/docs/ActionBar.mdx
@@ -248,3 +248,47 @@ function Example({isEmphasized}: {isEmphasized?: boolean}) {
   <Example isEmphasized />
 </Flex>
 ```
+
+### isDisabled
+To disable individual items, a list of disabledKeys can be provided.
+
+```tsx example
+import type {Selection} from '@adobe/react-spectrum';
+
+function Example() {
+  let [selectedKeys, setSelectedKeys] = React.useState<Selection>(new Set(['photoshop']));
+
+  return (
+    <ActionBarContainer height={300} width="size-5000">
+      <ListView aria-label="ListView with action bar" selectionMode="multiple" selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys}>
+        <Item key="photoshop">Adobe Photoshop</Item>
+        <Item key="illustrator">Adobe Illustrator</Item>
+        <Item key="xd">Adobe XD</Item>
+      </ListView>
+      <ActionBar
+        /*- begin highlight -*/
+        disabledKeys={['edit']}
+        /*- end highlight -*/
+        isEmphasized={true}
+        selectedItemCount={selectedKeys === 'all' ? 'all' : selectedKeys.size}
+        onAction={(key) => alert(`Performing ${key} action...`)}
+        onClearSelection={() => setSelectedKeys(new Set())}>
+        <Item key="edit">
+          <Edit />
+          <Text>Edit</Text>
+        </Item>
+        <Item key="copy">
+          <Copy />
+          <Text>Copy</Text>
+        </Item>
+        <Item key="delete">
+          <Delete />
+          <Text>Delete</Text>
+        </Item>
+      </ActionBar>
+    </ActionBarContainer>
+  );
+}
+
+<Example />
+```

--- a/packages/@react-spectrum/actionbar/src/ActionBar.tsx
+++ b/packages/@react-spectrum/actionbar/src/ActionBar.tsx
@@ -59,7 +59,8 @@ function ActionBarInner<T>(props: ActionBarInnerProps<T>, ref: Ref<HTMLDivElemen
     selectedItemCount,
     isOpen,
     buttonLabelBehavior = 'collapse',
-    items
+    items,
+    disabledKeys
   } = props;
 
   let {styleProps} = useStyleProps(props);
@@ -113,6 +114,7 @@ function ActionBarInner<T>(props: ActionBarInnerProps<T>, ref: Ref<HTMLDivElemen
             overflowMode="collapse"
             buttonLabelBehavior={buttonLabelBehavior}
             onAction={onAction}
+            disabledKeys={disabledKeys}
             UNSAFE_className={classNames(styles, 'react-spectrum-ActionBar-actionGroup')}>
             {children}
           </ActionGroup>

--- a/packages/@react-spectrum/actionbar/stories/ActionBar.stories.tsx
+++ b/packages/@react-spectrum/actionbar/stories/ActionBar.stories.tsx
@@ -66,8 +66,8 @@ function FullWidth(props) {
 export const DisabledKeysStory: ActionBarStory = {
   ...Default,
   render: (args) => <DisabledKeys {...args} />
-}
+};
 
 function DisabledKeys(props) {
-  return <Example disabledKeys={['edit']} {...props} />
+  return <Example disabledKeys={['edit']} {...props} />;
 }

--- a/packages/@react-spectrum/actionbar/stories/ActionBar.stories.tsx
+++ b/packages/@react-spectrum/actionbar/stories/ActionBar.stories.tsx
@@ -62,3 +62,12 @@ function FullWidth(props) {
   let viewport = useViewportSize();
   return <Example tableWidth="100vw" containerHeight={viewport.height} isQuiet {...props} />;
 }
+
+export const DisabledKeysStory: ActionBarStory = {
+  ...Default,
+  render: (args) => <DisabledKeys {...args} />
+}
+
+function DisabledKeys(props) {
+  return <Example disabledKeys={['edit']} {...props} />
+}

--- a/packages/@react-spectrum/actionbar/test/ActionBar.test.js
+++ b/packages/@react-spectrum/actionbar/test/ActionBar.test.js
@@ -285,4 +285,17 @@ describe('ActionBar', () => {
 
     expect(onAction).toHaveBeenCalledWith('edit');
   });
+
+  it('should respect disabledKeys when passed in', async () => {
+    let tree = render(<Provider theme={theme}><Example disabledKeys={['edit']} /></Provider>);
+    act(() => {jest.runAllTimers();});
+
+    let table = tree.getByRole('grid');
+    let rows = within(table).getAllByRole('row');
+
+    await user.click(rows[1]);
+
+    expect(within(tree.getByRole('toolbar')).getAllByRole('button')[0]).toBeDisabled();
+    expect(within(tree.getByRole('toolbar')).getAllByRole('button')[1]).not.toBeDisabled();
+  })
 });

--- a/packages/@react-spectrum/actionbar/test/ActionBar.test.js
+++ b/packages/@react-spectrum/actionbar/test/ActionBar.test.js
@@ -297,5 +297,5 @@ describe('ActionBar', () => {
 
     expect(within(tree.getByRole('toolbar')).getAllByRole('button')[0]).toBeDisabled();
     expect(within(tree.getByRole('toolbar')).getAllByRole('button')[1]).not.toBeDisabled();
-  })
+  });
 });


### PR DESCRIPTION
No associated Github issue

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:
In ActionBar/DisabledKeys story, select a table row item and see that the Edit action button in the ActionBar is disabled.
<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
