### PR TITLE
Decrease timeouts in test utils

### DIFF
--- a/packages/@react-aria/test-utils/src/table.ts
+++ b/packages/@react-aria/test-utils/src/table.ts
@@ -136,11 +136,11 @@ export class TableTester {
       }
 
       // Handle cases where the table may transition in response to the row selection/deselection
-      await act(async () => {
-        if (this._advanceTimer == null) {
-          throw new Error('No advanceTimers provided for table transition.');
-        }
+      if (this._advanceTimer == null) {
+        throw new Error('No advanceTimers provided for table transition.');
+      }
 
+      await act(async () => {
         await this._advanceTimer(200);
       });
 

--- a/packages/@react-aria/test-utils/src/table.ts
+++ b/packages/@react-aria/test-utils/src/table.ts
@@ -68,15 +68,6 @@ export class TableTester {
         await pressElement(this.user, cell, interactionType);
       }
     }
-
-    // Handle cases where the table may transition in response to the row selection/deselection
-    await act(async () => {
-      if (this._advanceTimer == null) {
-        throw new Error('No advanceTimers provided for table transition.');
-      }
-
-      await this._advanceTimer(200);
-    });
   };
 
   toggleSort = async (opts: {index?: number, text?: string, interactionType?: UserOpts['interactionType']} = {}) => {

--- a/packages/@react-aria/test-utils/src/table.ts
+++ b/packages/@react-aria/test-utils/src/table.ts
@@ -136,12 +136,12 @@ export class TableTester {
       }
 
       // Handle cases where the table may transition in response to the row selection/deselection
-      if (this._advanceTimer == null) {
+      if (!this._advanceTimer) {
         throw new Error('No advanceTimers provided for table transition.');
       }
 
       await act(async () => {
-        await this._advanceTimer(200);
+        await this._advanceTimer?.(200);
       });
 
       await waitFor(() => {

--- a/packages/@react-spectrum/table/test/TestTableUtils.test.js
+++ b/packages/@react-spectrum/table/test/TestTableUtils.test.js
@@ -18,7 +18,7 @@ import {theme} from '@react-spectrum/theme-default';
 import {User} from '@react-aria/test-utils';
 
 let manyItems = [];
-for (let i = 1; i <= 100; i++) {
+for (let i = 1; i <= 10; i++) {
   manyItems.push({id: i, foo: 'Foo ' + i, bar: 'Bar ' + i, baz: 'Baz ' + i});
 }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

100 items was causing multiple interactions to take almost half a second to process. This is not accurate to real life as we have no virtualization in those tests.

In addition, we no longer have transitions on tables, so can remove the timeout for that in our test util. We can add it back in conditionally if we end up needing it.



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
