### PR TITLE
Fix Select keyboard focus trap

### DIFF
--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
-    "@react-aria/focus": "^3.18.2",
+    "@react-aria/focus": "^3.18.3",
     "@react-aria/form": "^3.0.9",
     "@react-aria/i18n": "^3.12.3",
     "@react-aria/interactions": "^3.22.3",

--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-aria/focus": "^3.18.2",
     "@react-aria/form": "^3.0.9",
     "@react-aria/i18n": "^3.12.3",
     "@react-aria/interactions": "^3.22.3",

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -112,8 +112,8 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
       onFocus: (e) => {
         let position = e.relatedTarget?.compareDocumentPosition(e.currentTarget);
         let walker = getFocusableTreeWalker(document.body, {tabbable: true});
-        walker.currentNode = e.relatedTarget;
-        if (position & Node.DOCUMENT_POSITION_PRECEDING ) {
+        if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+          walker.currentNode = e.relatedTarget;
           // if focus is coming from "after" this element, we know it's a shift tab
           let prevNode = walker.previousNode() as FocusableElement | null;
           if (prevNode) {
@@ -121,7 +121,8 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
           } else {
             triggerRef.current.focus();
           }
-        } else if ( position & Node.DOCUMENT_POSITION_FOLLOWING ) {
+        } else if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+          walker.currentNode = e.relatedTarget;
           // if focus is coming from "before" this element, we know it's a tab
           let nextNode = walker.nextNode() as FocusableElement | null;
           if (nextNode) {

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -283,7 +283,7 @@ describe('Select', () => {
     let state = React.useContext(SelectStateContext);
     return (
       <Button
-      data-testid="clear"
+        data-testid="clear"
         // Don't inherit behavior from Select.
         slot={null}
         style={{fontSize: 'small', marginTop: 6, padding: 4}}

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -11,7 +11,7 @@
  */
 
 import {act, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
-import {Button, FieldError, Label, ListBox, ListBoxItem, Popover, Select, SelectContext, SelectValue, Text} from '../';
+import {Button, FieldError, Label, ListBox, ListBoxItem, Popover, Select, SelectContext, SelectStateContext, SelectValue, Text} from '../';
 import React from 'react';
 import {User} from '@react-aria/test-utils';
 import userEvent from '@testing-library/user-event';
@@ -277,5 +277,79 @@ describe('Select', () => {
     await user.click(options[0]);
 
     expect(button).toHaveTextContent('0');
+  });
+
+  function SelectClearButton() {
+    let state = React.useContext(SelectStateContext);
+    return (
+      <Button
+      data-testid="clear"
+        // Don't inherit behavior from Select.
+        slot={null}
+        style={{fontSize: 'small', marginTop: 6, padding: 4}}
+        onPress={() => state?.setSelectedKey(null)}>
+        Clear
+      </Button>
+    );
+  }
+
+  it('should support extra children for use with the state', async () => {
+    let onChangeSpy = jest.fn();
+    let {getByTestId} = render(
+      <>
+        <input data-testid="before" />
+        <Select onSelectionChange={onChangeSpy}>
+          <Label>Favorite Animal</Label>
+          <Button data-testid="select">
+            <SelectValue />
+            <span aria-hidden="true">▼</span>
+          </Button>
+          <SelectClearButton />
+          <Popover>
+            <ListBox>
+              <ListBoxItem id="cat">Cat</ListBoxItem>
+              <ListBoxItem id="dog">Dog</ListBoxItem>
+              <ListBoxItem id="kangaroo">Kangaroo</ListBoxItem>
+            </ListBox>
+          </Popover>
+        </Select>
+        <input data-testid="after" />
+      </>
+    );
+
+    let beforeInput = getByTestId('before');
+    let afterInput = getByTestId('after');
+    let wrapper = getByTestId('select');
+    let clearButton = getByTestId('clear');
+    let selectTester = testUtilUser.createTester('Select', {root: wrapper});
+
+    await user.tab();
+    await user.tab();
+    expect(document.activeElement).toBe(selectTester.trigger);
+
+    await user.tab();
+    expect(document.activeElement).toBe(clearButton);
+
+    await user.tab();
+    expect(document.activeElement).toBe(afterInput);
+
+    await user.tab({shift: true});
+    expect(document.activeElement).toBe(clearButton);
+
+    await user.tab({shift: true});
+    expect(document.activeElement).toBe(selectTester.trigger);
+
+    await user.tab({shift: true});
+    expect(document.activeElement).toBe(beforeInput);
+
+    await user.tab();
+    await selectTester.selectOption({optionText: 'Dog'});
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenLastCalledWith('dog');
+
+    await user.click(clearButton);
+    expect(onChangeSpy).toHaveBeenCalledTimes(2);
+    expect(onChangeSpy).toHaveBeenLastCalledWith(null);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,7 +5841,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-aria/focus@npm:^3.18.3, @react-aria/focus@workspace:packages/@react-aria/focus":
+"@react-aria/focus@npm:^3.18.2, @react-aria/focus@npm:^3.18.3, @react-aria/focus@workspace:packages/@react-aria/focus":
   version: 0.0.0-use.local
   resolution: "@react-aria/focus@workspace:packages/@react-aria/focus"
   dependencies:
@@ -6171,6 +6171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-aria/select@workspace:packages/@react-aria/select"
   dependencies:
+    "@react-aria/focus": "npm:^3.18.2"
     "@react-aria/form": "npm:^3.0.9"
     "@react-aria/i18n": "npm:^3.12.3"
     "@react-aria/interactions": "npm:^3.22.3"
@@ -16467,9 +16468,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.28":
-  version: 1.5.31
-  resolution: "electron-to-chromium@npm:1.5.31"
-  checksum: 10c0/e8aecd88c4c6d50a9d459b4b222865b855bab8f1b52e82913804e18b7884f2887bd76c61b3aa08c2ccbdcda098dd8486443f75bf770f0138f21dd9e63548fca7
+  version: 1.5.36
+  resolution: "electron-to-chromium@npm:1.5.36"
+  checksum: 10c0/cd8d0de7801107f2b2744b5b18641c969a49b0503996cc1a586bb79d893020d0c4e916ac1935603eea65104b4fc1096bc339e0151531dca9e0f0ce0c1882e2d8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16468,9 +16468,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.28":
-  version: 1.5.36
-  resolution: "electron-to-chromium@npm:1.5.36"
-  checksum: 10c0/cd8d0de7801107f2b2744b5b18641c969a49b0503996cc1a586bb79d893020d0c4e916ac1935603eea65104b4fc1096bc339e0151531dca9e0f0ce0c1882e2d8
+  version: 1.5.31
+  resolution: "electron-to-chromium@npm:1.5.31"
+  checksum: 10c0/e8aecd88c4c6d50a9d459b4b222865b855bab8f1b52e82913804e18b7884f2887bd76c61b3aa08c2ccbdcda098dd8486443f75bf770f0138f21dd9e63548fca7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,7 +5841,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-aria/focus@npm:^3.18.2, @react-aria/focus@npm:^3.18.3, @react-aria/focus@workspace:packages/@react-aria/focus":
+"@react-aria/focus@npm:^3.18.3, @react-aria/focus@workspace:packages/@react-aria/focus":
   version: 0.0.0-use.local
   resolution: "@react-aria/focus@workspace:packages/@react-aria/focus"
   dependencies:
@@ -6171,7 +6171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-aria/select@workspace:packages/@react-aria/select"
   dependencies:
-    "@react-aria/focus": "npm:^3.18.2"
+    "@react-aria/focus": "npm:^3.18.3"
     "@react-aria/form": "npm:^3.0.9"
     "@react-aria/i18n": "npm:^3.12.3"
     "@react-aria/interactions": "npm:^3.22.3"


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7019

Couple assumptions. The only way to focus the hidden select is via keyboard tab/shift+tab. If focus is coming from the document.body (such as if the user clicks near the Select, then hits tab), then focus should just go directly to the Select, not the extra button. We can't tell what the intent was and the behavior of a click followed by tab differs across browsers anyways.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
