### PR TITLE
Centralize S2 icon wrapper

### DIFF
--- a/packages/@react-spectrum/s2/src/Icon.tsx
+++ b/packages/@react-spectrum/s2/src/Icon.tsx
@@ -11,10 +11,12 @@
  */
 
 import {AriaLabelingProps, DOMProps} from '@react-types/shared';
+import {ComponentType, Context, createContext, FunctionComponent, ReactNode, SVGProps, useRef} from 'react';
 import {ContextValue, SlotProps} from 'react-aria-components';
-import {createContext, ReactNode} from 'react';
+import {SkeletonWrapper, useSkeletonIcon} from './Skeleton';
 import {StyleString} from '../style/types';
 import {UnsafeStyles} from './style-utils' with {type: 'macro'};
+import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 export interface IconProps extends UnsafeStyles, SlotProps, AriaLabelingProps, DOMProps {
   'aria-hidden'?: boolean | 'false' | 'true'
@@ -31,3 +33,45 @@ export interface IllustrationContextValue extends IconContextValue {
 
 export const IconContext = createContext<ContextValue<IconContextValue, SVGElement>>({});
 export const IllustrationContext = createContext<ContextValue<IllustrationContextValue, SVGElement>>({});
+
+export function createIcon(Component: ComponentType<SVGProps<SVGSVGElement>>, context: Context<ContextValue<IconContextValue, SVGElement>> = IconContext): FunctionComponent<IconProps> {
+  return (props: IconProps) => {
+    let ref = useRef<SVGElement>(null);
+    let ctx;
+    // TODO: remove this default once we release RAC and use DEFAULT_SLOT.
+    [ctx, ref] = useSpectrumContextProps({slot: props.slot || 'icon'} as IconContextValue, ref, context);
+    let {render, styles} = ctx;
+    let {
+      UNSAFE_className,
+      UNSAFE_style,
+      slot,
+      'aria-label': ariaLabel,
+      'aria-hidden': ariaHidden,
+      ...otherProps
+    } = props;
+
+    if (!ariaHidden) {
+      ariaHidden = undefined;
+    }
+
+    let svg = (
+      <SkeletonWrapper>
+        <Component
+          {...otherProps}
+          focusable={false}
+          aria-label={ariaLabel}
+          aria-hidden={ariaLabel ? (ariaHidden || undefined) : true}
+          role="img"
+          data-slot={slot}
+          className={(UNSAFE_className ?? '') + ' ' + useSkeletonIcon(styles)}
+          style={UNSAFE_style} />
+      </SkeletonWrapper>
+    );
+
+    if (render) {
+      return render(svg);
+    }
+
+    return svg;
+  };
+}

--- a/packages/@react-spectrum/s2/src/index.ts
+++ b/packages/@react-spectrum/s2/src/index.ts
@@ -40,7 +40,7 @@ export {DialogContainer, useDialogContainer} from './DialogContainer';
 export {Divider, DividerContext} from './Divider';
 export {DropZone, DropZoneContext} from './DropZone';
 export {Form} from './Form';
-export {IconContext, IllustrationContext} from './Icon';
+export {createIcon, IconContext, IllustrationContext} from './Icon';
 export {IllustratedMessage, IllustratedMessageContext} from './IllustratedMessage';
 export {Image, ImageContext} from './Image';
 export {ImageCoordinator} from './ImageCoordinator';


### PR DESCRIPTION
Realized we had a bug in the S2 icon transformer: it generated imports for SkeletonWrapper and useSkeletonIcon internal utilities that weren't exported, so couldn't be used in custom icons. Instead of exporting these, I added a single `createIcon` helper function that centralizes all of the icon logic in one place. This has the benefit that we export fewer internals, and also reduces bundle size since we aren't duplicating the same code in every icon.