### PR TITLE
Temporary fix for S2 storybook crash when showing code in dark mode

### DIFF
--- a/.storybook-s2/preview.tsx
+++ b/.storybook-s2/preview.tsx
@@ -27,7 +27,8 @@ const preview = {
           channel.on(DARK_MODE_EVENT_NAME, setDark);
           return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
         }, []);
-        return <DocsContainer {...props} theme={{...(dark ? themes.dark : themes.light), appContentBg: 'var(--s2-container-bg)'}} />;
+        var style = getComputedStyle(document.body)
+        return <DocsContainer {...props} theme={{...(dark ? themes.dark : themes.light), appContentBg: style.getPropertyValue('--s2-container-bg').trim()}} />;
       },
       source: {
         // code: null, // Will disable code button, and show "No code available"
@@ -68,7 +69,7 @@ const preview = {
       storySort: {
         order: ['Intro', 'Style Macro', 'Workflow Icons', 'Illustrations', 'Migrating', 'Release Notes'],
         method: 'alphabetical'
-      }  
+      }
     }
   },
   argTypes: {


### PR DESCRIPTION
Reported in slack

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to S2 storybook, switch to dark mode, and open "show code" for any component example in the docs

## 🧢 Your Project:

RSP
