### PR TITLE
Fix Meter docs story so it renders with the proper width

### DIFF
--- a/packages/@react-spectrum/s2/stories/Meter.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Meter.stories.tsx
@@ -17,7 +17,7 @@ import {StaticColorDecorator} from './utils';
 const meta: Meta<typeof Meter> = {
   component: Meter,
   parameters: {
-    chromaticProvider: {disableAnimations: true}
+    layout: 'centered'
   },
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

S2 Meter docs story should have the proper width 

## 🧢 Your Project:

RSP
