### PR TITLE
docs: fix tanstack router useHref example

### DIFF
--- a/packages/dev/docs/pages/react-aria/routing.mdx
+++ b/packages/dev/docs/pages/react-aria/routing.mdx
@@ -288,7 +288,7 @@ function RootRoute() {
   return (
     <RouterProvider 
       navigate={(to, options) => router.navigate({to, ...options})}
-      useHref={to => router.buildLocation(to).href}>
+      useHref={to => router.buildLocation({to}).href}>
       {/* ...*/}
     </RouterProvider>
   );

--- a/packages/dev/docs/pages/react-spectrum/routing.mdx
+++ b/packages/dev/docs/pages/react-spectrum/routing.mdx
@@ -292,7 +292,7 @@ function RootRoute() {
       theme={defaultTheme}
       router={{
         navigate: (to, options) => router.navigate({to, ...options}),
-        useHref: to => router.buildLocation(to).href
+        useHref: to => router.buildLocation({to}).href
       }}>
       {/* ...*/}
     </Provider>


### PR DESCRIPTION
In the integration of the `tanstack-router` package in the docs, the `router.buildLocation` should accept an object instead in order for client-side routing to work as expected.  

Reference:
https://github.com/TanStack/router/blob/main/packages/react-router/src/RouterProvider.tsx#L49

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

## 🧢 Your Project:
