### PR TITLE
Docs: useListData.mdx: Fix `ListBoxItem` name

### DIFF
--- a/packages/@react-stately/data/docs/useListData.mdx
+++ b/packages/@react-stately/data/docs/useListData.mdx
@@ -75,7 +75,7 @@ let list = useListData({
   items={list.items}
   selectedKeys={list.selectedKeys}
   onSelectionChange={list.setSelectedKeys}>
-  {item => <Item key={item.name}>{item.name}</Item>}
+  {item => <ListBoxItem key={item.name}>{item.name}</Item>}
 </ListBox>
 ```
 

--- a/packages/@react-stately/data/docs/useListData.mdx
+++ b/packages/@react-stately/data/docs/useListData.mdx
@@ -75,7 +75,7 @@ let list = useListData({
   items={list.items}
   selectedKeys={list.selectedKeys}
   onSelectionChange={list.setSelectedKeys}>
-  {item => <ListBoxItem key={item.name}>{item.name}</Item>}
+  {item => <ListBoxItem key={item.name}>{item.name}</ListBoxItem>}
 </ListBox>
 ```
 


### PR DESCRIPTION
This updates the docs which mentioned a `<List>` Component which appears to not exist. Instead it probably should be `ListBoxItem`.

I assume the Component was renamed at some point? The Docs  https://react-spectrum.adobe.com/react-aria/ListBox.html only mention `ListBoxItem`.

---

I would also recommend to add
```
import { ListBox, ListBoxItem } from 'react-aria-components';
import { useListData } from 'react-stately';
```

to the top of the code block, but since other code blocks did not have this, I left it out for now.