### PR TITLE
Doc: collections.mdx: Remove `key` prop

### DIFF
--- a/packages/@react-stately/collections/docs/collections.mdx
+++ b/packages/@react-stately/collections/docs/collections.mdx
@@ -145,7 +145,7 @@ let [animals, setAnimals] = useState([
 ]);
 
 <ListBox items={animals}>
-  {item => <Item key={item.name}>{item.name}</Item>}
+  {item => <Item>{item.name}</Item>}
 </ListBox>
 ```
 
@@ -168,7 +168,7 @@ let [animals, setAnimals] = useState([
 
 <ListBox>
   {animals.map(item =>
-    <Item key={item.name}>{item.name}</Item>
+    <Item>{item.name}</Item>
   )}
 </ListBox>
 ```
@@ -208,7 +208,7 @@ function addAnimal(name) {
 }
 
 <ListBox items={list.items}>
-  {item => <Item key={item.name}>{item.name}</Item>}
+  {item => <Item>{item.name}</Item>}
 </ListBox>
 ```
 
@@ -240,8 +240,8 @@ let [sections, setSections] = useState([
 
 <Picker items={sections}>
   {section =>
-    <Section key={section.name} title={section.name} items={section.items}>
-      {item => <Item key={item.name}>{item.name}</Item>}
+    <Section title={section.name} items={section.items}>
+      {item => <Item>{item.name}</Item>}
     </Section>
   }
 </Picker>
@@ -339,7 +339,7 @@ let [items, setItems] = useState([
 
 <Tree items={items}>
   {item =>
-    <Item key={item.name} childItems={item.children}>{item.name}</Item>
+    <Item childItems={item.children}>{item.name}</Item>
   }
 </Tree>
 ```
@@ -374,7 +374,7 @@ let list = useAsyncList({
   label="Pick a Pokemon"
   items={list.items}
   isLoading={list.isLoading}>
-  {item => <Item key={item.name}>{item.name}</Item>}
+  {item => <Item>{item.name}</Item>}
 </Picker>
 ```
 
@@ -409,7 +409,7 @@ let list = useAsyncList({
   items={list.items}
   isLoading={list.isLoading}
   onLoadMore={list.loadMore}>
-  {item => <Item key={item.name}>{item.name}</Item>}
+  {item => <Item>{item.name}</Item>}
 </Picker>
 ```
 


### PR DESCRIPTION
My understanding from how those `{(item) => <Component>{item.name}</Component>}` work is, that the key prop is not required or recommended on this line but instead will be added automatically based on the item `key` or `id` prop or `getKey` callback.

This PR removes the key prop from the examples which makes them easier to read and understand.

See also  
- https://github.com/adobe/react-spectrum/issues/7176
- https://github.com/adobe/react-spectrum/discussions/4431#discussioncomment-5714670

---

~~Another thing I am confused about on this docs page is, what the `<Item>` component is. I assume it should be renamed, see https://github.com/adobe/react-spectrum/pull/7175~~


---

Another thing I am confused about is the mention of [`@react-stately/data`](https://www.npmjs.com/package/@react-stately/data) vs. [`react-stately`](https://www.npmjs.com/package/react-stately) especially in places like https://react-spectrum.adobe.com/react-stately/collections.html#asynchronous-loading: 
> <img width="549" alt="image" src="https://github.com/user-attachments/assets/e786cba9-4c94-4f60-8547-9a9153df8ccb">