### PR TITLE
fix: update getSymbols in NumberParser to support roundingIncrement

### DIFF
--- a/packages/@internationalized/number/src/NumberParser.ts
+++ b/packages/@internationalized/number/src/NumberParser.ts
@@ -255,7 +255,14 @@ const pluralNumbers = [
 
 function getSymbols(locale: string, formatter: Intl.NumberFormat, intlOptions: Intl.ResolvedNumberFormatOptions, originalOptions: Intl.NumberFormatOptions): Symbols {
   // formatter needs access to all decimal places in order to generate the correct literal strings for the plural set
-  let symbolFormatter = new Intl.NumberFormat(locale, {...intlOptions, minimumSignificantDigits: 1, maximumSignificantDigits: 21});
+  let symbolFormatter = new Intl.NumberFormat(locale, {...intlOptions,
+    // Resets so we get the full range of symbols
+    minimumSignificantDigits: 1,
+    maximumSignificantDigits: 21,
+    roundingIncrement: 1,
+    roundingPriority: 'auto',
+    roundingMode: 'halfExpand'
+  });
   // Note: some locale's don't add a group symbol until there is a ten thousands place
   let allParts = symbolFormatter.formatToParts(-10000.111);
   let posAllParts = symbolFormatter.formatToParts(10000.111);

--- a/packages/@internationalized/number/test/NumberParser.test.js
+++ b/packages/@internationalized/number/test/NumberParser.test.js
@@ -165,6 +165,14 @@ describe('NumberParser', function () {
       });
     });
 
+    describe('NumberFormat options', function () {
+      it('supports roundingIncrement', function () {
+        expect(new NumberParser('en-US', {roundingIncrement: 2}).parse('10')).toBe(10);
+        // This doesn't fail in Node 18 because roundingIncrement isn't on the resolved options. Hopefully later versions of Node this test will be meaningful.
+        expect(new NumberParser('en-US', {roundingIncrement: 2, minimumFractionDigits: 2, maximumFractionDigits: 2}).parse('10.00')).toBe(10.00);
+      });
+    });
+
     describe('round trips', function () {
       // Locales have to include: 'de-DE', 'ar-EG', 'fr-FR' and possibly others
       // But for the moment they are not properly supported


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7168

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
