### PR TITLE
Fix usePress when taps happen on Links with non plain text content

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -527,7 +527,7 @@ export function usePress(props: PressHookProps): PressResult {
       // https://github.com/facebook/react/issues/9809
       let onTouchEnd = (e: TouchEvent) => {
         // Don't preventDefault if we actually want the default (e.g. submit/link click).
-        if (shouldPreventDefaultUp(e.target as Element)) {
+        if (shouldPreventDefaultUp(e.currentTarget as Element)) {
           e.preventDefault();
         }
       };
@@ -942,7 +942,7 @@ function shouldPreventDefaultUp(target: Element) {
   if (target instanceof HTMLInputElement) {
     return false;
   }
-  
+
   if (target instanceof HTMLButtonElement) {
     return target.type !== 'submit' && target.type !== 'reset';
   }

--- a/packages/@react-aria/interactions/stories/usePress.stories.tsx
+++ b/packages/@react-aria/interactions/stories/usePress.stories.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {Link} from 'react-aria-components';
 import React from 'react';
 import styles from './usePress-stories.css';
 import {usePress} from '@react-aria/interactions';
@@ -84,3 +85,30 @@ function OnPress(props) {
     </div>
   );
 }
+
+export const linkOnPress = {
+  render: () => (
+    <div className={styles['outer-div']}>
+      {/* Note that the svg needs to not have pointer-events: none */}
+      <Link href="http://adobe.com" target="_blank">
+        <svg
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{
+            height: '2rem',
+            width: '2rem',
+            fill: 'red'
+          }}>
+          <title>Adobe</title>
+          <path d="M13.966 22.624l-1.69-4.281H8.122l3.892-9.144 5.662 13.425zM8.884 1.376H0v21.248zm15.116 0h-8.884L24 22.624Z" />
+        </svg>
+      </Link>
+    </div>
+  ),
+  parameters: {
+    description: {
+      data: 'Pressing on the link should always open a new tab. This tests specifically that usePress doesnt erroneously prevent default, especially on mobile'
+    }
+  }
+};


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7157

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the "Link on press" story in the usePress stories. Verify that tapping on the Adobe logo in the story opens a new tab on all devices 

## 🧢 Your Project:

RSP
