### PR TITLE
Mask the contents of a non-selected scrolled row for a quiet table

### DIFF
--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1027,7 +1027,7 @@ const selectedActiveBackground = lightDark(colorMix('gray-25', 'informative-900'
 const rowBackgroundColor = {
   default: {
     default: 'gray-25',
-    isQuiet: 'transparent'
+    isQuiet: '--s2-container-bg'
   },
   isFocusVisibleWithin: colorMix('gray-25', 'gray-900', 7), // table-row-hover-color
   isHovered: colorMix('gray-25', 'gray-900', 7), // table-row-hover-color


### PR DESCRIPTION
Reported in slack

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to S2 table and test it when isQuiet and you scroll the row contents to the right. The text should not peek out from behind the checkbox

## 🧢 Your Project:

RSP
