### PR TITLE
docs: follow-up on accordion docs from testing

### DIFF
--- a/packages/@react-aria/disclosure/docs/anatomy.svg
+++ b/packages/@react-aria/disclosure/docs/anatomy.svg
@@ -1,8 +1,8 @@
-<svg style="max-height: 300px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 763 153">
-  <rect id="Rectangle_136670" data-name="Rectangle 136670" width="763" height="153" fill="var(--anatomy-gray-100)"/>
-  <path id="Path_934" data-name="Path 934" d="M6.155,5a.908.908,0,0,0-.3-.7l-4-4a.967.967,0,0,0-1.4,0,.967.967,0,0,0,0,1.4L3.655,5,.355,8.3a.972.972,0,0,0-.1,1.4.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.155,5Z" transform="matrix(0.035, 0.999, -0.999, 0.035, 308.136, 60.974)" fill="var(--anatomy-gray-600)"/>
-  <text id="Landscape" transform="translate(320.951 68.67)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Landscape</tspan></text>
-  <g id="Group_2" data-name="Group 2" transform="translate(414.002 62)">
+<svg style="max-height: 70px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 300 60">
+  <rect id="Rectangle_136670" data-name="Rectangle 136670" width="303" height="66" fill="var(--anatomy-gray-100)"/>
+  <path id="Path_934" data-name="Path 934" d="M6.155,5a.908.908,0,0,0-.3-.7l-4-4a.967.967,0,0,0-1.4,0,.967.967,0,0,0,0,1.4L3.655,5,.355,8.3a.972.972,0,0,0-.1,1.4.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.155,5Z" transform="matrix(0.035, 0.999, -0.999, 0.035, 79.136, 19.974)" fill="var(--anatomy-gray-600)"/>
+  <text id="Landscape" transform="translate(91.951 27.67)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Landscape</tspan></text>
+  <g id="Group_2" data-name="Group 2" transform="translate(185.002 21)">
     <g id="Group_1" data-name="Group 1">
       <rect id="rectangle-1" width="33" height="1" transform="translate(0.998 1)" fill="var(--anatomy-gray-500)"/>
       <g id="Ellipse_1" data-name="Ellipse 1" transform="translate(-0.002)" fill="var(--anatomy-gray-500)" stroke="var(--anatomy-gray-500)" stroke-width="1">
@@ -11,15 +11,13 @@
       </g>
     </g>
   </g>
-  <text id="Button" transform="translate(452 67)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Button</tspan></text>
-  <text id="Landscape_content" data-name="Landscape content" transform="translate(304.397 90.67)" fill="var(--anatomy-gray-900)" font-size="14" font-family="Adobe-Clean" font-weight="300"><tspan x="0" y="0">Landscape content</tspan></text>
-  <text id="Panel" transform="translate(452 90)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Panel</tspan></text>
-  <g id="Group_3" data-name="Group 3" transform="translate(418.405 76.99)">
+  <text id="Button" transform="translate(223 26)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Button</tspan></text>
+  <text id="Landscape_content" data-name="Landscape content" transform="translate(75.397 49.67)" fill="var(--anatomy-gray-900)" font-size="14" font-family="Adobe-Clean" font-weight="300"><tspan x="0" y="0">Landscape content</tspan></text>
+  <text id="Panel" transform="translate(223 49)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Panel</tspan></text>
+  <g id="Group_3" data-name="Group 3" transform="translate(189.405 35.99)">
     <rect id="rectangle-1-2" data-name="rectangle-1" width="24" height="1" transform="translate(5.595 9.01)" fill="var(--anatomy-gray-500)"/>
     <rect id="rectangle-1-3" data-name="rectangle-1" width="18.005" height="1" transform="matrix(0.017, 1, -1, 0.017, 6.125, 0)" fill="var(--anatomy-gray-500)"/>
     <rect id="rectangle-1-4" data-name="rectangle-1" width="5.782" height="1.004" transform="translate(5.782 18.02) rotate(-180)" fill="var(--anatomy-gray-500)"/>
     <rect id="rectangle-1-5" data-name="rectangle-1" width="6" height="1" transform="translate(6 1) rotate(-180)" fill="var(--anatomy-gray-500)"/>
   </g>
 </svg>
-
-

--- a/packages/@react-aria/disclosure/docs/useDisclosure.mdx
+++ b/packages/@react-aria/disclosure/docs/useDisclosure.mdx
@@ -109,6 +109,8 @@ function Disclosure(props) {
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
 
 ```css
+@import "@react-aria/example-theme";
+
 .disclosure {
   .trigger {
     background: none;
@@ -120,6 +122,7 @@ function Disclosure(props) {
     align-items: center;
     gap: 8px;
     outline: none;
+    color: var(--text-color);
 
     svg {
       rotate: 0deg;

--- a/packages/@react-aria/disclosure/docs/useDisclosure.mdx
+++ b/packages/@react-aria/disclosure/docs/useDisclosure.mdx
@@ -119,6 +119,7 @@ function Disclosure(props) {
     display: flex;
     align-items: center;
     gap: 8px;
+    outline: none;
 
     svg {
       rotate: 0deg;

--- a/packages/@react-aria/disclosure/docs/useDisclosure.mdx
+++ b/packages/@react-aria/disclosure/docs/useDisclosure.mdx
@@ -187,7 +187,7 @@ A disclosure can be disabled with the `isDisabled` prop. This will disable the t
 
 A disclosure group (i.e. accordion) is a set of disclosures where only one disclosure can be expanded at a time. The following example shows how to create a `DisclosureGroup` component with the `useDisclosureGroupState` hook. We'll also create a `DisclosureItem` component that uses the `DisclosureGroupState` context for managing its state.
 
-```tsx example export=true
+```tsx example export=true render=false
 import {useDisclosureGroupState} from '@react-stately/disclosure';
 import {useId} from '@react-aria/utils';
 

--- a/packages/@react-aria/disclosure/docs/useDisclosure.mdx
+++ b/packages/@react-aria/disclosure/docs/useDisclosure.mdx
@@ -73,6 +73,7 @@ This example displays a basic disclosure with a button that toggles the visibili
 import {useDisclosureState} from '@react-stately/disclosure';
 import {useDisclosure} from '@react-aria/disclosure';
 import {useButton} from '@react-aria/button';
+import {useFocusRing} from 'react-aria';
 
 function Disclosure(props) {
   let state = useDisclosureState(props);
@@ -80,11 +81,17 @@ function Disclosure(props) {
   let triggerRef = React.useRef<HTMLButtonElement | null>(null);
   let {buttonProps: triggerProps, panelProps} = useDisclosure(props, state, panelRef);
   let {buttonProps} = useButton(triggerProps, triggerRef);
+  let {isFocusVisible, focusProps} = useFocusRing();
 
   return (
     <div className="disclosure">
       <h3>
-        <button className="trigger" ref={triggerRef} {...buttonProps}>
+        <button 
+          className="trigger" 
+          ref={triggerRef} 
+          {...buttonProps} 
+          {...focusProps} 
+          style={{outline: isFocusVisible? '2px solid dodgerblue' : 'none'}}>
           <svg viewBox="0 0 24 24">
             <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
           </svg>
@@ -121,7 +128,6 @@ function Disclosure(props) {
     display: flex;
     align-items: center;
     gap: 8px;
-    outline: none;
     color: var(--text-color);
 
     svg {

--- a/packages/@react-aria/disclosure/docs/useDisclosure.mdx
+++ b/packages/@react-aria/disclosure/docs/useDisclosure.mdx
@@ -241,11 +241,17 @@ function DisclosureItem(props) {
     isDisabled
   }, state, panelRef);
   let {buttonProps} = useButton(triggerProps, triggerRef);
+  let {isFocusVisible, focusProps} = useFocusRing();
 
   return (
     <div className="disclosure">
       <h3>
-        <button className="trigger" ref={triggerRef} {...buttonProps}>
+        <button 
+          className="trigger" 
+          ref={triggerRef} 
+          {...buttonProps}
+          {...focusProps}
+          style={{outline: isFocusVisible? '2px solid dodgerblue' : 'none'}}>
           <svg viewBox="0 0 24 24">
             <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
           </svg>

--- a/packages/@react-aria/disclosure/docs/useDisclosure.mdx
+++ b/packages/@react-aria/disclosure/docs/useDisclosure.mdx
@@ -73,7 +73,7 @@ This example displays a basic disclosure with a button that toggles the visibili
 import {useDisclosureState} from '@react-stately/disclosure';
 import {useDisclosure} from '@react-aria/disclosure';
 import {useButton} from '@react-aria/button';
-import {useFocusRing} from 'react-aria';
+import {mergeProps, useFocusRing} from 'react-aria';
 
 function Disclosure(props) {
   let state = useDisclosureState(props);
@@ -88,9 +88,8 @@ function Disclosure(props) {
       <h3>
         <button 
           className="trigger" 
-          ref={triggerRef} 
-          {...buttonProps} 
-          {...focusProps} 
+          ref={triggerRef}
+          {...mergeProps(buttonProps, focusProps)}
           style={{outline: isFocusVisible? '2px solid dodgerblue' : 'none'}}>
           <svg viewBox="0 0 24 24">
             <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
@@ -248,9 +247,8 @@ function DisclosureItem(props) {
       <h3>
         <button 
           className="trigger" 
-          ref={triggerRef} 
-          {...buttonProps}
-          {...focusProps}
+          ref={triggerRef}
+          {...mergeProps(buttonProps, focusProps)}
           style={{outline: isFocusVisible? '2px solid dodgerblue' : 'none'}}>
           <svg viewBox="0 0 24 24">
             <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />

--- a/packages/@react-spectrum/accordion/docs/Accordion.mdx
+++ b/packages/@react-spectrum/accordion/docs/Accordion.mdx
@@ -13,6 +13,7 @@ export default Layout;
 import docs from 'docs:@react-spectrum/accordion';
 import {HeaderInfo, PropTable, TypeLink, PageDescription} from '@react-spectrum/docs';
 import packageData from '@react-spectrum/accordion/package.json';
+import ChevronRight from '@spectrum-icons/workflow/ChevronRight';
 
 ---
 category: Navigation
@@ -90,7 +91,7 @@ function ControlledExpansion() {
 }
 ```
 
-## Expansion
+## Expanded
 
 By default, only one disclosure will be expanded at a time. To expand multiple disclosures, apply the `allowsMultipleExpanded` prop to Accordion.
 
@@ -112,7 +113,17 @@ By default, only one disclosure will be expanded at a time. To expand multiple d
 ```
 ## Props
 
+### Disclosure
+
 <PropTable component={docs.exports.Accordion} links={docs.links} />
+
+### Disclosure Panel
+
+<PropTable component={docs.exports.DisclosurePanel} links={docs.links} />
+
+### Disclosure Header
+
+<PropTable component={docs.exports.DisclosureHeader} links={docs.links} />
 
 ## Visual Options
 

--- a/packages/react-aria-components/docs/Disclosure.mdx
+++ b/packages/react-aria-components/docs/Disclosure.mdx
@@ -103,10 +103,11 @@ import {Disclosure, Button, DisclosurePanel, Heading} from 'react-aria-component
 
 ## Features
 
-Custom styled disclosures can be difficult to build in an accessible way with the correct ARIA pattern. When implementing, you must manually ensure that the button and panel are semantically connected via ids for accessibility. `Disclosure` helps with this and other accessibility features while allowing for custom styling.
+Disclosures can be built with the [&lt;details&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) and [&lt;summary&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) HTML element, but this can be difficult to style especially when adding adjacent interactive elements, like buttons, to the disclosure's heading. `Disclosure` helps achieve accessible disclosures implemented with the correct ARIA pattern while making custom styling easy. 
 
 * **Flexible** - Structured such that it can be used standalone or combined with other disclosures to form a `DisclosureGroup`
-* **Accessible** - When focused, a disclosure's visibility can be toggled with either the <Keyboard>Enter</Keyboard> or <Keyboard>Space</Keyboard> key, and the appropriate ARIA attributes are automatically applied.
+* **Keyboard Interaction** - When focused, a disclosure's visibility can be toggled with either the <Keyboard>Enter</Keyboard> or <Keyboard>Space</Keyboard> key, and the appropriate ARIA attributes are automatically applied.
+* **Accessible** - Uses hidden="until-found" in supported browsers, enabling find-in-page search support and improved search engine visibility for collapsed content
 * **Styleable** - Keyboard focus, disabled and expanded states are provided for easy styling. These states only apply when interacting with an appropriate input device, unlike CSS pseudo classes.
 
 ## Anatomy
@@ -201,6 +202,39 @@ A Disclosure can be disabled using the `isDisabled` prop.
   Details about knitting here
 </MyDisclosure>
 ```
+
+## Interactive elements
+
+In some use cases, you may want to add an interactive element, like an button, adjacent to the disclosure's heading.
+
+```tsx example
+<Disclosure>
+  <div style={{display: 'flex', alignItems: 'center'}}>
+    <Heading>
+      <Button slot="trigger">
+        <svg viewBox="0 0 24 24">
+          <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+        </svg>
+        System Requirements
+      </Button>
+    </Heading>
+    <Button>Click me</Button>
+  </div>
+  <DisclosurePanel>
+    <p>Details about system requirements here.</p>
+  </DisclosurePanel>
+</Disclosure>
+```
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
+
+  ```css
+  .react-aria-Button {
+    height: fit-content;
+  }
+  ```
+</details>
 
 ## Props
 

--- a/packages/react-aria-components/docs/Disclosure.mdx
+++ b/packages/react-aria-components/docs/Disclosure.mdx
@@ -205,7 +205,7 @@ A Disclosure can be disabled using the `isDisabled` prop.
 
 ## Interactive elements
 
-In some use cases, you may want to add an interactive element, like an button, adjacent to the disclosure's heading.
+In some use cases, you may want to add an interactive element, like a button, adjacent to the disclosure's heading.
 
 ```tsx example
 <Disclosure>
@@ -225,16 +225,6 @@ In some use cases, you may want to add an interactive element, like an button, a
   </DisclosurePanel>
 </Disclosure>
 ```
-
-<details>
-  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
-
-  ```css
-  .react-aria-Button {
-    height: fit-content;
-  }
-  ```
-</details>
 
 ## Props
 

--- a/packages/react-aria-components/docs/DisclosureAnatomy.svg
+++ b/packages/react-aria-components/docs/DisclosureAnatomy.svg
@@ -1,8 +1,8 @@
-<svg style="max-height: 300px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 763 153">
-  <rect id="Rectangle_136670" data-name="Rectangle 136670" width="763" height="153" fill="var(--anatomy-gray-100)"/>
-  <path id="Path_934" data-name="Path 934" d="M6.155,5a.908.908,0,0,0-.3-.7l-4-4a.967.967,0,0,0-1.4,0,.967.967,0,0,0,0,1.4L3.655,5,.355,8.3a.972.972,0,0,0-.1,1.4.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.155,5Z" transform="matrix(0.035, 0.999, -0.999, 0.035, 308.136, 60.974)" fill="var(--anatomy-gray-600)"/>
-  <text id="Landscape" transform="translate(320.951 68.67)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Landscape</tspan></text>
-  <g id="Group_2" data-name="Group 2" transform="translate(414.002 62)">
+<svg style="max-height: 70px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 300 60">
+  <rect id="Rectangle_136670" data-name="Rectangle 136670" width="303" height="66" fill="var(--anatomy-gray-100)"/>
+  <path id="Path_934" data-name="Path 934" d="M6.155,5a.908.908,0,0,0-.3-.7l-4-4a.967.967,0,0,0-1.4,0,.967.967,0,0,0,0,1.4L3.655,5,.355,8.3a.972.972,0,0,0-.1,1.4.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.155,5Z" transform="matrix(0.035, 0.999, -0.999, 0.035, 79.136, 19.974)" fill="var(--anatomy-gray-600)"/>
+  <text id="Landscape" transform="translate(91.951 27.67)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Landscape</tspan></text>
+  <g id="Group_2" data-name="Group 2" transform="translate(185.002 21)">
     <g id="Group_1" data-name="Group 1">
       <rect id="rectangle-1" width="33" height="1" transform="translate(0.998 1)" fill="var(--anatomy-gray-500)"/>
       <g id="Ellipse_1" data-name="Ellipse 1" transform="translate(-0.002)" fill="var(--anatomy-gray-500)" stroke="var(--anatomy-gray-500)" stroke-width="1">
@@ -11,15 +11,13 @@
       </g>
     </g>
   </g>
-  <text id="Button" transform="translate(452 67)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Button</tspan></text>
-  <text id="Landscape_content" data-name="Landscape content" transform="translate(304.397 90.67)" fill="var(--anatomy-gray-900)" font-size="14" font-family="Adobe-Clean" font-weight="300"><tspan x="0" y="0">Landscape content</tspan></text>
-  <text id="Panel" transform="translate(452 90)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Panel</tspan></text>
-  <g id="Group_3" data-name="Group 3" transform="translate(418.405 76.99)">
+  <text id="Button" transform="translate(223 26)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Button</tspan></text>
+  <text id="Landscape_content" data-name="Landscape content" transform="translate(75.397 49.67)" fill="var(--anatomy-gray-900)" font-size="14" font-family="Adobe-Clean" font-weight="300"><tspan x="0" y="0">Landscape content</tspan></text>
+  <text id="Panel" transform="translate(223 49)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Panel</tspan></text>
+  <g id="Group_3" data-name="Group 3" transform="translate(189.405 35.99)">
     <rect id="rectangle-1-2" data-name="rectangle-1" width="24" height="1" transform="translate(5.595 9.01)" fill="var(--anatomy-gray-500)"/>
     <rect id="rectangle-1-3" data-name="rectangle-1" width="18.005" height="1" transform="matrix(0.017, 1, -1, 0.017, 6.125, 0)" fill="var(--anatomy-gray-500)"/>
     <rect id="rectangle-1-4" data-name="rectangle-1" width="5.782" height="1.004" transform="translate(5.782 18.02) rotate(-180)" fill="var(--anatomy-gray-500)"/>
     <rect id="rectangle-1-5" data-name="rectangle-1" width="6" height="1" transform="translate(6 1) rotate(-180)" fill="var(--anatomy-gray-500)"/>
   </g>
 </svg>
-
-

--- a/packages/react-aria-components/docs/DisclosureGroup.mdx
+++ b/packages/react-aria-components/docs/DisclosureGroup.mdx
@@ -82,8 +82,7 @@ import {DisclosureGroup, Disclosure, Button, DisclosurePanel, Heading} from 'rea
 
 ## Features
 
-
-Custom styled disclosure groups can be difficult to implement in an accessible way with the correct ARIA pattern. When implementing, you must manually ensure that the button and panel are semantically connected via ids for accessibility. `DisclosureGroup` helps with this and other accessibility features while allowing for custom styling.
+Accordions can be built by combing multiple disclosures built in HTML with the [&lt;details&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) and [&lt;summary&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) HTML element, but this can be difficult to style especially when adding adjacent interactive elements, like buttons, to the disclosure's heading. `Accordion` helps achieve accessible disclosures implemented with the correct ARIA pattern while making custom styling easy. 
 
 * **Accessible** - Disclosure group is exposed to assistive technology via ARIA 
 * **Styleable** - Disclosures include builtin states for styling such as keyboard focus, disabled, and expanded states.
@@ -124,7 +123,7 @@ import {DisclosureGroup, Disclosure, Button, DisclosurePanel, Heading} from 'rea
 
 ### Default expanded
 
-An uncontrolled DisclosureGroup can be expanded by default using the `defaultExpandedKeys` prop.
+An uncontrolled DisclosureGroup can be expanded by default using the `defaultExpandedKeys` prop. The `defaultExpandedKeys` must match the `id` on the disclosure(s) component that you wish to expand.
 
 ```tsx example export=true
 import type {DisclosureProps} from 'react-aria-components';
@@ -165,7 +164,7 @@ function MyDisclosure({title, children, ...props}: MyDisclosureProps) {
 
 ### Controlled expanded
 
-A controlled DisclosureGroup can be expanded and collapsed using `expandedKeys` and `defaultExpandedKeys`
+A controlled DisclosureGroup can be expanded and collapsed using `expandedKeys` and `onExpandedChange`. The `expandedKeys` must match the `id` on the disclosure component(s) that you wish to expand.
 
 ```tsx example
 import {Key} from "@react-types/shared";
@@ -309,6 +308,8 @@ A `Button` can be targeted with the `.react-aria-Button` CSS selector, or by ove
 ### DisclosurePanel
 
 A `DisclosurePanel` can be targeted with the `.react-aria-DisclosurePanel` CSS selector, or by overriding with a custom `className`.
+
+<StateTable properties={docs.exports.DisclosurePanelRenderProps.properties} />
 
 ## Advanced Customization
 

--- a/packages/react-aria-components/docs/DisclosureGroupAnatomy.svg
+++ b/packages/react-aria-components/docs/DisclosureGroupAnatomy.svg
@@ -1,13 +1,13 @@
-<svg style="max-height: 300px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 789 205">
-  <rect id="Rectangle_136672" data-name="Rectangle 136672" width="789" height="205" fill="var(--anatomy-gray-100)"/>
-  <rect id="rectangle-34" width="164" height="1" transform="translate(307 36)" fill="var(--anatomy-gray-300)"/>
-  <rect id="rectangle-34-2" data-name="rectangle-34" width="164" height="1" transform="translate(307 129)" fill="var(--anatomy-gray-300)"/>
-  <rect id="rectangle-34-3" data-name="rectangle-34" width="164" height="1" transform="translate(307 178)" fill="var(--anatomy-gray-300)"/>
-  <path id="Path_929" data-name="Path 929" d="M6.1,5a.908.908,0,0,0-.3-.7l-4-4A.967.967,0,0,0,.4.3a.967.967,0,0,0,0,1.4L3.6,5,.3,8.3A.972.972,0,0,0,.2,9.7a.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.1,5Z" transform="matrix(0.035, 0.999, -0.999, 0.035, 332.842, 57.831)" fill="var(--anatomy-gray-600)"/>
-  <path id="Path_930" data-name="Path 930" d="M6.1,5a.908.908,0,0,0-.3-.7l-4-4A.967.967,0,0,0,.4.3a.967.967,0,0,0,0,1.4L3.6,5,.3,8.3A.972.972,0,0,0,.2,9.7a.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.1,5Z" transform="translate(324.9 149)" fill="var(--anatomy-gray-600)"/>
-  <text id="Recent" transform="translate(341 67)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Recent</tspan></text>
-  <text id="Abstract" transform="translate(341 160)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Abstract</tspan></text>
-  <g id="Group_2" data-name="Group 2" transform="translate(318.998 63) rotate(180)">
+<svg style="max-height: 200px; background: var(--anatomy-gray-100); padding: 32px; margin-bottom: 16px; width: calc(100% - 64px); border-radius: 4px;" viewBox="0 0 310 200">
+  <rect id="Rectangle_136672" data-name="Rectangle 136672" width="385" height="205" fill="var(--anatomy-gray-100)"/>
+  <rect id="rectangle-34" width="164" height="1" transform="translate(105 36)" fill="var(--anatomy-gray-300)"/>
+  <rect id="rectangle-34-2" data-name="rectangle-34" width="164" height="1" transform="translate(105 129)" fill="var(--anatomy-gray-300)"/>
+  <rect id="rectangle-34-3" data-name="rectangle-34" width="164" height="1" transform="translate(105 178)" fill="var(--anatomy-gray-300)"/>
+  <path id="Path_929" data-name="Path 929" d="M6.1,5a.908.908,0,0,0-.3-.7l-4-4A.967.967,0,0,0,.4.3a.967.967,0,0,0,0,1.4L3.6,5,.3,8.3A.972.972,0,0,0,.2,9.7a.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.1,5Z" transform="matrix(0.035, 0.999, -0.999, 0.035, 130.842, 57.831)" fill="var(--anatomy-gray-600)"/>
+  <path id="Path_930" data-name="Path 930" d="M6.1,5a.908.908,0,0,0-.3-.7l-4-4A.967.967,0,0,0,.4.3a.967.967,0,0,0,0,1.4L3.6,5,.3,8.3A.972.972,0,0,0,.2,9.7a.972.972,0,0,0,1.4.1l.1-.1,4-4A1.012,1.012,0,0,0,6.1,5Z" transform="translate(122.9 149)" fill="var(--anatomy-gray-600)"/>
+  <text id="Recent" transform="translate(139 67)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Recent</tspan></text>
+  <text id="Abstract" transform="translate(139 160)" fill="var(--anatomy-gray-900)" font-size="18" font-family="Adobe-Clean" font-weight="700"><tspan x="0" y="0">Abstract</tspan></text>
+  <g id="Group_2" data-name="Group 2" transform="translate(116.998 63) rotate(180)">
     <g id="Group_1" data-name="Group 1" transform="translate(-0.002)">
       <rect id="rectangle-1" width="53" height="1" transform="translate(1 1)" fill="var(--anatomy-gray-500)"/>
       <g id="Ellipse_1" data-name="Ellipse 1" fill="var(--anatomy-gray-500)" stroke="var(--anatomy-gray-500)" stroke-width="1">
@@ -16,17 +16,17 @@
       </g>
     </g>
   </g>
-  <text id="Button" transform="translate(230 64)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Button</tspan></text>
+  <text id="Button" transform="translate(28 64)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Button</tspan></text>
   <text id="Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit" data-name="Lorem ipsum dolor sit amet, 
-consectetur adipiscing elit" transform="translate(322.791 96)" fill="var(--anatomy-gray-900)" font-size="14" font-family="Adobe-Clean" font-weight="300"><tspan x="0" y="0">Lorem ipsum dolor sit amet, </tspan><tspan x="0" y="17">consectetur adipiscing elit</tspan></text>
-  <text id="Panel" transform="translate(235 104)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Panel</tspan></text>
-  <rect id="rectangle-1-2" data-name="rectangle-1" width="48.218" height="1" transform="translate(313.218 100.993) rotate(180)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-3" data-name="rectangle-1" width="35.013" height="1" transform="translate(312.84 118) rotate(-90)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-4" data-name="rectangle-1" width="5.782" height="1.004" transform="translate(313.218 82.987)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-5" data-name="rectangle-1" width="6" height="1" transform="translate(313 117)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-6" data-name="rectangle-1" width="4.406" height="1" transform="translate(500.873 107)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-7" data-name="rectangle-1" width="143.022" height="1" transform="translate(501.373 35.989) rotate(90)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-8" data-name="rectangle-1" width="5.782" height="1.004" transform="translate(501.373 179.011) rotate(-180)" fill="var(--anatomy-gray-500)"/>
-  <rect id="rectangle-1-9" data-name="rectangle-1" width="6" height="1" transform="translate(501 37) rotate(-180)" fill="var(--anatomy-gray-500)"/>
-  <text id="Group" transform="translate(509 111)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Group</tspan></text>
+consectetur adipiscing elit" transform="translate(120.791 96)" fill="var(--anatomy-gray-900)" font-size="14" font-family="Adobe-Clean" font-weight="300"><tspan x="0" y="0">Lorem ipsum dolor sit amet, </tspan><tspan x="0" y="17">consectetur adipiscing elit</tspan></text>
+  <text id="Panel" transform="translate(33 104)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Panel</tspan></text>
+  <rect id="rectangle-1-2" data-name="rectangle-1" width="48.218" height="1" transform="translate(111.218 100.993) rotate(180)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-3" data-name="rectangle-1" width="35.013" height="1" transform="translate(110.84 118) rotate(-90)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-4" data-name="rectangle-1" width="5.782" height="1.004" transform="translate(111.218 82.987)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-5" data-name="rectangle-1" width="6" height="1" transform="translate(111 117)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-6" data-name="rectangle-1" width="4.406" height="1" transform="translate(298.873 107)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-7" data-name="rectangle-1" width="143.022" height="1" transform="translate(299.373 35.989) rotate(90)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-8" data-name="rectangle-1" width="5.782" height="1.004" transform="translate(299.373 179.011) rotate(-180)" fill="var(--anatomy-gray-500)"/>
+  <rect id="rectangle-1-9" data-name="rectangle-1" width="6" height="1" transform="translate(299 37) rotate(-180)" fill="var(--anatomy-gray-500)"/>
+  <text id="Group" transform="translate(307 111)" fill="var(--anatomy-gray-800)" font-size="12" font-family="Adobe-Clean" font-style="italic" letter-spacing="0.003em"><tspan x="0" y="0">Group</tspan></text>
 </svg>


### PR DESCRIPTION
done:

- [x] Disclosure docs: Add render props table to DisclosurePanel in DisclosureGroup
- [x] Disclosure docs: Add example to docs showing a button adjacent to heading
- [x] Disclosure docs: mention hidden=until-found in features section like hook docs. Also mention that a disclosure can be built with the HTML `<details>` and `<summary>` elements but there are styling limitations with things like adjacent buttons
- [x] Disclosure docs: Disclosure group example didn't render? [Link](https://reactspectrum.blob.core.windows.net/reactspectrum/4f85a359f81eb4fe00ac463d76265c3cd4409096/docs/react-aria/useDisclosure.html#disclosure-group)
  - actually i don't think this is an issue. it's showing how to build reusable wrapper and then it shows how to use it right underneath where we do actually render it
- [x] v3 Accordion docs: Disclosure, DisclosurePanel, DisclosureHeading should have prop tables if they have props that users can apply
- [x] Disclosure docs: Mention that expandedKeys must match the id prop of the Disclosure component
- [x] Disclosure docs: Fix anatomy svg size on mobile
- [x] useDisclosure docs: When tapping on the disclosure headers, an outline around the header appears.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
