### PR TITLE
fix: fix useButton href condition

### DIFF
--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -75,7 +75,7 @@ export function useButton(props: AriaButtonOptions<ElementType>, ref: RefObject<
     additionalProps = {
       role: 'button',
       tabIndex: isDisabled ? undefined : 0,
-      href: elementType === 'a' && isDisabled ? undefined : href,
+      href: elementType === 'a' && !isDisabled ? href : undefined,
       target: elementType === 'a' ? target : undefined,
       type: elementType === 'input' ? type : undefined,
       disabled: elementType === 'input' ? isDisabled : undefined,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7207
## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
pass `href` props to span tag which uses `useButton`
for example this codesandbox implements the span tag button (but this uses the `useButton` which is before correction)
https://codesandbox.io/p/sandbox/reverent-ives-hl88v2

## 🧢 Your Project:

<!--- Company/project for pull request -->
