### PR TITLE
fix(taggroup): add isDisabled to compoundVariants

### DIFF
--- a/starters/tailwind/src/TagGroup.tsx
+++ b/starters/tailwind/src/TagGroup.tsx
@@ -48,6 +48,7 @@ const tagStyles = tv({
   },
   compoundVariants: (Object.keys(colors) as Color[]).map((color) => ({
     isSelected: false,
+    isDisabled: false,
     color,
     class: colors[color]
   }))

--- a/starters/tailwind/stories/TagGroup.stories.tsx
+++ b/starters/tailwind/stories/TagGroup.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 export const Example = (args: any) => (
   <TagGroup {...args}>
     <Tag>Chocolate</Tag>
-    <Tag>Mint</Tag>
+    <Tag isDisabled>Mint</Tag>
     <Tag>Strawberry</Tag>
     <Tag>Vanilla</Tag>
   </TagGroup>


### PR DESCRIPTION
this allows the styles defined in isDisabled to be appliedCloses <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [x] Included link to corresponding 
   - https://github.com/adobe/react-spectrum/issues/7245
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

View the taggroup story for the tailwind starter project

## 🧢 Your Project:

UGRC
