### PR TITLE
fix: tailwind starter submenu story

### DIFF
--- a/starters/tailwind/stories/Menu.stories.tsx
+++ b/starters/tailwind/stories/Menu.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from '@storybook/react';
 import { MoreHorizontal } from 'lucide-react';
 import React from 'react';
-import { MenuTrigger, Popover, SubmenuTrigger } from 'react-aria-components';
+import { MenuTrigger, SubmenuTrigger } from 'react-aria-components';
 import { Button } from '../src/Button';
 import { Menu, MenuItem, MenuSection, MenuSeparator } from '../src/Menu';
 
@@ -68,32 +68,26 @@ export const Submenu = (args: any) => (
       <MenuItem id="new">New…</MenuItem>
       <SubmenuTrigger>
         <MenuItem id="open">Open</MenuItem>
-        <Popover>
-          <Menu>
-            <MenuItem id="open-new">Open in New Window</MenuItem>
-            <MenuItem id="open-current">Open in Current Window</MenuItem>
-          </Menu>
-        </Popover>
+        <Menu>
+          <MenuItem id="open-new">Open in New Window</MenuItem>
+          <MenuItem id="open-current">Open in Current Window</MenuItem>
+        </Menu>
       </SubmenuTrigger>
       <MenuSeparator />
       <MenuItem id="print">Print…</MenuItem>
       <SubmenuTrigger>
         <MenuItem id="share">Share</MenuItem>
-        <Popover>
-          <Menu>
-            <MenuItem id="sms">SMS</MenuItem>
-            <MenuItem id="twitter">Twitter</MenuItem>
-            <SubmenuTrigger>
-              <MenuItem id="email">Email</MenuItem>
-              <Popover>
-                <Menu>
-                  <MenuItem id="work">Work</MenuItem>
-                  <MenuItem id="personal">Personal</MenuItem>
-                </Menu>
-              </Popover>
-            </SubmenuTrigger>
-          </Menu>
-        </Popover>
+        <Menu>
+          <MenuItem id="sms">SMS</MenuItem>
+          <MenuItem id="twitter">Twitter</MenuItem>
+          <SubmenuTrigger>
+            <MenuItem id="email">Email</MenuItem>
+            <Menu>
+              <MenuItem id="work">Work</MenuItem>
+              <MenuItem id="personal">Personal</MenuItem>
+            </Menu>
+          </SubmenuTrigger>
+        </Menu>
       </SubmenuTrigger>
     </Menu>
   </MenuTrigger>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7242

Our tailwind starter 'Menu' component already renders a Popover:

https://github.com/adobe/react-spectrum/blob/37fbf024aa8483106b97b3f8a857bc74bfc58664/starters/tailwind/src/Menu.tsx#L19-L25

so we don't need to render a RAC popover in the submenu story. This was causing useSafelyMouseToSubmenu to not work properly.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test moving mouse to submenu in tailwind starter storybook,

## 🧢 Your Project:

<!--- Company/project for pull request -->
