### PR TITLE
refactor: Use calc to implement S2 touch scale

### DIFF
--- a/packages/@react-spectrum/s2/src/page.macro.ts
+++ b/packages/@react-spectrum/s2/src/page.macro.ts
@@ -29,6 +29,11 @@ export function generatePageStyles(this: MacroContext | void) {
         color-scheme: light dark;
         --s2-container-bg: ${colorToken(tokens['background-base-color'])};
         background: var(--s2-container-bg);
+        --s2-scale: 1;
+
+        @media not ((hover: hover) and (pointer: fine)) {
+          --s2-scale: 1.25;
+        }
 
         &[data-color-scheme=light] {
           color-scheme: light;
@@ -55,6 +60,7 @@ export function generatePageStyles(this: MacroContext | void) {
 // a <Provider> without setting a colorScheme prop, and when page.css is not present.
 // It is equivalent to setting `color-scheme: light dark`, but without overriding
 // the browser default for content outside the provider.
+// Also set defaults for --s2-scale here.
 export function generateDefaultColorSchemeStyles(this: MacroContext | void) {
   if (this && typeof this.addAsset === 'function') {
     this.addAsset({
@@ -63,10 +69,15 @@ export function generateDefaultColorSchemeStyles(this: MacroContext | void) {
         :where(html) {
           --lightningcss-light: initial;
           --lightningcss-dark: ;
+          --s2-scale: 1;
 
           @media (prefers-color-scheme: dark) {
             --lightningcss-light: ;
             --lightningcss-dark: initial;
+          }
+
+          @media not ((hover: hover) and (pointer: fine)) {
+            --s2-scale: 1.25;
           }
         }
       }`

--- a/packages/@react-spectrum/s2/style/spectrum-theme.ts
+++ b/packages/@react-spectrum/s2/style/spectrum-theme.ts
@@ -222,13 +222,13 @@ const spacing = {
 };
 
 export function size(this: MacroContext | void, px: number) {
-  return {default: arbitrary(this, pxToRem(px)), touch: arbitrary(this, pxToRem(px * 1.25))};
+  return arbitrary(this, `calc(${pxToRem(px)} * var(--s2-scale))`);
 }
 
-const scaledSpacing: {[key in keyof typeof baseSpacing]: {default: string, touch: string}} =
+const scaledSpacing: {[key in keyof typeof baseSpacing]: string} =
   Object.fromEntries(Object.entries(baseSpacing).map(([k, v]) =>
-    [k, {default: v, touch: parseFloat(v) * 1.25 + v.match(/[^0-9.]+/)![0]}])
-  ) as any;
+    [k, `calc(${v} * var(--s2-scale))`]
+  )) as any;
 
 const sizing = {
   ...scaledSpacing,


### PR DESCRIPTION
This makes the S2 CSS significantly smaller by using `calc(X * var(--s2-scale))` to implement touch scaling instead of precalculating two separate rules for each value. The `--s2-scale` variable is set either when importing `page.css` or `Provider`.