### PR TITLE
[WIP]: Tooltips in collection components

### DIFF
--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -105,7 +105,7 @@ export const Section = /*#__PURE__*/ createBranchComponent('section', <T extends
 
 export interface CollectionBranchProps {
   /** The collection of items to render. */
-  collection: ICollection<Node<unknown>>,
+  collection?: ICollection<Node<unknown>>,
   /** The parent node of the items to render. */
   parent: Node<unknown>,
   /** A function that renders a drop indicator between items. */
@@ -136,11 +136,18 @@ export interface CollectionRenderer {
   CollectionBranch: React.ComponentType<CollectionBranchProps>
 }
 
+let CollectionStateContext = createContext(null);
+
 export const DefaultCollectionRenderer: CollectionRenderer = {
   CollectionRoot({collection, renderDropIndicator}) {
-    return useCollectionRender(collection, null, renderDropIndicator);
+    let result = useCollectionRender(collection, null, renderDropIndicator);
+    return <CollectionStateContext.Provider value={collection}>{result}</CollectionStateContext.Provider>;
   },
   CollectionBranch({collection, parent, renderDropIndicator}) {
+    let parentCollection = useContext(CollectionStateContext);
+    if (collection == null) {
+      collection = parentCollection;
+    }
     return useCollectionRender(collection, parent, renderDropIndicator);
   }
 };

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -18,7 +18,7 @@ import {ContextValue, Provider, RenderProps, SlotProps, StyleRenderProps, useCon
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {Collection as ICollection, Node, TabListState, useTabListState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, JSX, useContext, useMemo} from 'react';
-import { useFocusable } from '@react-aria/focus';
+import {useFocusable} from '@react-aria/focus';
 
 export interface TabsProps extends Omit<AriaTabListProps<any>, 'items' | 'children'>, RenderProps<TabsRenderProps>, SlotProps {}
 

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -18,6 +18,7 @@ import {ContextValue, Provider, RenderProps, SlotProps, StyleRenderProps, useCon
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {Collection as ICollection, Node, TabListState, useTabListState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, JSX, useContext, useMemo} from 'react';
+import { useFocusable } from '@react-aria/focus';
 
 export interface TabsProps extends Omit<AriaTabListProps<any>, 'items' | 'children'>, RenderProps<TabsRenderProps>, SlotProps {}
 
@@ -251,6 +252,7 @@ export const Tab = /*#__PURE__*/ createLeafComponent('item', (props: TabProps, f
   let ref = useObjectRef<any>(forwardedRef);
   let {tabProps, isSelected, isDisabled, isPressed} = useTab({key: item.key, ...props}, state, ref);
   let {focusProps, isFocused, isFocusVisible} = useFocusRing();
+  let {focusableProps} = useFocusable(props, ref);
   let {hoverProps, isHovered} = useHover({
     isDisabled,
     onHoverStart: props.onHoverStart,
@@ -276,7 +278,7 @@ export const Tab = /*#__PURE__*/ createLeafComponent('item', (props: TabProps, f
 
   return (
     <ElementType
-      {...mergeProps(tabProps, focusProps, hoverProps, renderProps)}
+      {...mergeProps(tabProps, focusableProps, focusProps, hoverProps, renderProps)}
       ref={ref}
       data-selected={isSelected || undefined}
       data-disabled={isDisabled || undefined}

--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -20,7 +20,7 @@ import {OverlayArrowContext} from './OverlayArrow';
 import {OverlayTriggerProps, TooltipTriggerProps, TooltipTriggerState, useTooltipTriggerState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, ReactNode, useContext, useRef, useState} from 'react';
 import {useLayoutEffect} from '@react-aria/utils';
-import { useObjectRef } from '../../@react-aria/utils';
+import {useObjectRef} from '../../@react-aria/utils';
 
 export interface TooltipTriggerComponentProps extends TooltipTriggerProps {
   children: ReactNode

--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -19,8 +19,7 @@ import {FocusableProvider} from '@react-aria/focus';
 import {OverlayArrowContext} from './OverlayArrow';
 import {OverlayTriggerProps, TooltipTriggerProps, TooltipTriggerState, useTooltipTriggerState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, ReactNode, useContext, useRef, useState} from 'react';
-import {useLayoutEffect} from '@react-aria/utils';
-import {useObjectRef} from '../../@react-aria/utils';
+import {useLayoutEffect, useObjectRef} from '@react-aria/utils';
 
 export interface TooltipTriggerComponentProps extends TooltipTriggerProps {
   children: ReactNode

--- a/packages/react-aria-components/stories/Tabs.stories.tsx
+++ b/packages/react-aria-components/stories/Tabs.stories.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, Tab, TabList, TabPanel, TabProps, Tabs, TabsProps} from 'react-aria-components';
+import {Button, Tab, TabList, TabPanel, TabProps, Tabs, TabsProps, Tooltip, TooltipTrigger} from 'react-aria-components';
 import React, {useState} from 'react';
 import {RouterProvider} from '@react-aria/utils';
 
@@ -27,7 +27,7 @@ export const TabsExample = () => {
         <TabList aria-label="History of Ancient Rome" style={{display: 'flex', gap: 8}}>
           <CustomTab id="/FoR" href="/FoR">Founding of Rome</CustomTab>
           <CustomTab id="/MaR" href="/MaR">Monarchy and Republic</CustomTab>
-          <CustomTab id="/Emp" href="/Emp">Empire</CustomTab>
+          <TooltipTrigger><CustomTab id="/Emp" href="/Emp">Empire</CustomTab><Tooltip>This is a tooltip</Tooltip></TooltipTrigger>
         </TabList>
         <TabPanel id="/FoR">
           Arma virumque cano, Troiae qui primus ab oris.
@@ -61,7 +61,7 @@ export const TabsRenderProps = () => {
                 style={{display: 'flex', flexDirection: orientation === 'vertical' ? 'column' : 'row', gap: 8}}>
                 <CustomTab id="FoR">Founding of Rome</CustomTab>
                 <CustomTab id="MaR">Monarchy and Republic</CustomTab>
-                <CustomTab id="Emp">Empire</CustomTab>
+                <TooltipTrigger><CustomTab id="Emp">Empire</CustomTab><Tooltip>This is a tooltip</Tooltip></TooltipTrigger>
               </TabList>
               <TabPanel id="FoR">
                 Arma virumque cano, Troiae qui primus ab oris.


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6800

Request initially for Tooltips on Tabs, especially when we implement collapse behaviour if we want to go from a long label to icon only before collapsing further into a Picker. This has been requested in Issues before as well.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
