### PR TITLE
chore: more s2 bug fixes

### DIFF
--- a/packages/@react-spectrum/s2/src/ContextualHelp.tsx
+++ b/packages/@react-spectrum/s2/src/ContextualHelp.tsx
@@ -101,7 +101,7 @@ function ContextualHelp(props: ContextualHelpProps, ref: FocusableRef<HTMLButton
         crossOffset={crossOffset}
         hideArrow
         UNSAFE_className={popover}>
-        <RACDialog className={mergeStyles(dialogInner, style({borderRadius: 'none'}))}>
+        <RACDialog className={mergeStyles(dialogInner, style({borderRadius: 'none', margin: -24, padding: 24}))}>
           <Provider
             values={[
               [TextContext, {

--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -127,7 +127,10 @@ const inputButton = style<PickerButtonProps | AriaSelectRenderProps>({
     forcedColors: 'solid'
   },
   borderColor: {
-    forcedColors: 'ButtonText'
+    forcedColors: {
+      default: 'ButtonText',
+      isDisabled: 'GrayText'
+    }
   },
   borderRadius: 'control',
   alignItems: 'center',

--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -122,7 +122,13 @@ const inputButton = style<PickerButtonProps | AriaSelectRenderProps>({
   font: 'control',
   display: 'flex',
   textAlign: 'start',
-  borderStyle: 'none',
+  borderStyle: {
+    default: 'none',
+    forcedColors: 'solid'
+  },
+  borderColor: {
+    forcedColors: 'ButtonText'
+  },
   borderRadius: 'control',
   alignItems: 'center',
   height: 'control',

--- a/packages/@react-spectrum/s2/src/ProgressBar.tsx
+++ b/packages/@react-spectrum/s2/src/ProgressBar.tsx
@@ -24,6 +24,7 @@ import {keyframes} from '../style/style-macro' with {type: 'macro'};
 import {mergeStyles} from '../style/runtime';
 import {size, style} from '../style' with {type: 'macro'};
 import {useDOMRef} from '@react-spectrum/utils';
+import {useLocale} from '@react-aria/i18n';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 interface ProgressBarStyleProps {
@@ -56,12 +57,21 @@ export interface ProgressBarProps extends Omit<AriaProgressBarProps, 'children' 
 
 export const ProgressBarContext = createContext<ContextValue<ProgressBarProps, DOMRefValue<HTMLDivElement>>>(null);
 
-const indeterminate = keyframes(`
+const indeterminateLTR = keyframes(`
   0% {
     transform:  translateX(-70%) scaleX(0.7);
   }
   100% {
     transform:  translateX(100%) scaleX(0.7);
+  }
+`);
+
+const indeterminateRTL = keyframes(`
+  0% {
+    transform:  translateX(100%) scaleX(0.7);
+  }
+  100% {
+    transform:  translateX(-70%) scaleX(0.7);
   }
 `);
 
@@ -151,7 +161,12 @@ const fill = style<ProgressBarStyleProps>({
 });
 
 const indeterminateAnimation = style({
-  animation: indeterminate,
+  animation: {
+    direction: {
+      ltr: indeterminateLTR,
+      rtl: indeterminateRTL
+    }
+  },
   animationDuration: 1000,
   animationIterationCount: 'infinite',
   animationTimingFunction: 'in-out',
@@ -170,6 +185,8 @@ function ProgressBar(props: ProgressBarProps, ref: DOMRef<HTMLDivElement>) {
     UNSAFE_className = ''
   } = props;
   let domRef = useDOMRef(ref);
+  let {direction} = useLocale();
+
   return (
     <AriaProgressBar
       {...props}
@@ -182,7 +199,7 @@ function ProgressBar(props: ProgressBarProps, ref: DOMRef<HTMLDivElement>) {
           {label && !isIndeterminate && <span className={valueStyles({size, labelAlign: 'end', staticColor})}>{valueText}</span>}
           <div className={trackStyles({...props})}>
             <div
-              className={mergeStyles(fill({...props, staticColor}), (isIndeterminate ? indeterminateAnimation : null))}
+              className={mergeStyles(fill({...props, staticColor}), (isIndeterminate ? indeterminateAnimation({direction}) : null))}
               style={{width: isIndeterminate ? undefined : percentage + '%'}} />
           </div>
         </>


### PR DESCRIPTION
- prevent the focus ring around links from getting cut off in contextual help
- add outline to the picker button in hcm
- indeterminate progress bar loads from right to left in RTL

see tickets:
- https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=75558862
- https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=77272909
- https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=52424970


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
