### PR TITLE
fix: useSliderState return values + RangeValue<NumberValue> test

### DIFF
--- a/packages/@react-spectrum/labeledvalue/test/LabeledValue.test.js
+++ b/packages/@react-spectrum/labeledvalue/test/LabeledValue.test.js
@@ -272,7 +272,7 @@ describe('LabeledValue', function () {
 
     let staticField = getByTestId('test-id');
     expect(staticField).toBeInTheDocument();
-    expect(staticField).toHaveTextContent('10 – 20');
+    expect(staticField).toHaveTextContent('10–20');
   });
 
   it('attaches a user provided ref to the outer div', function () {

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -177,8 +177,8 @@ export function useSliderState<T extends number | number[]>(props: SliderStateOp
   }, [step, maxValue, minValue]);
 
   let restrictValues = useCallback((values: number[]) => values?.map((val, idx) => {
-    let min = idx === 0 ? minValue : val[idx - 1];
-    let max = idx === values.length - 1 ? maxValue : val[idx + 1];
+    let min = idx === 0 ? minValue : values[idx - 1];
+    let max = idx === values.length - 1 ? maxValue : values[idx + 1];
     return snapValueToStep(val, min, max, step);
   }), [minValue, maxValue, step]);
 


### PR DESCRIPTION
Closes #7279

Also, There was a test failure during the yarn test, so we fixed that as well.

```
  it('renders correctly with RangeValue<NumberValue>', function () {
    let {getByTestId} = render(
      <LabeledValue
        data-testid="test-id"
        label="Field label"
       value={{start: 10, end: 20}} />
    );

    let staticField = getByTestId('test-id');
    expect(staticField).toBeInTheDocument();
-   expect(staticField).toHaveTextContent('10 – 20');
+   expect(staticField).toHaveTextContent('10–20');
  });
```


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:


## 🧢 Your Project:

