### PR TITLE
chore: add isJustified to segmented control in s2 example apps

### DIFF
--- a/examples/s2-parcel-example/src/Lazy.js
+++ b/examples/s2-parcel-example/src/Lazy.js
@@ -165,7 +165,7 @@ export default function Lazy() {
           The missing link.
         </Link>
         <Link href="/foo">Foo</Link>
-        <SegmentedControl aria-label="Time granularity" styles={style({width: 384})}>
+        <SegmentedControl aria-label="Time granularity" styles={style({width: 384})} isJustified>
           <SegmentedControlItem id="day">Day</SegmentedControlItem>
           <SegmentedControlItem id="week">Week</SegmentedControlItem>
           <SegmentedControlItem id="month">Month</SegmentedControlItem>

--- a/examples/s2-webpack-5-example/src/Lazy.js
+++ b/examples/s2-webpack-5-example/src/Lazy.js
@@ -165,7 +165,7 @@ export default function Lazy() {
           The missing link.
         </Link>
         <Link href="/foo">Foo</Link>
-        <SegmentedControl aria-label="Time granularity" styles={style({width: 384})}>
+        <SegmentedControl aria-label="Time granularity" styles={style({width: 384})} isJustified>
           <SegmentedControlItem id="day">Day</SegmentedControlItem>
           <SegmentedControlItem id="week">Week</SegmentedControlItem>
           <SegmentedControlItem id="month">Month</SegmentedControlItem>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

should fix the segmented control layout issues found in the example apps by applying isJustified since there's a custom width


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
