### PR TITLE
docs: add APG grid link to useTagGroup doc

### DIFF
--- a/packages/@react-aria/tag/docs/useTagGroup.mdx
+++ b/packages/@react-aria/tag/docs/useTagGroup.mdx
@@ -23,7 +23,7 @@ import Anatomy from './anatomy.svg';
 
 ---
 category: Collections
-keywords: [tag, aria]
+keywords: [tag, aria, grid]
 ---
 
 # useTagGroup
@@ -32,7 +32,10 @@ keywords: [tag, aria]
 
 <HeaderInfo
   packageData={packageData}
-  componentNames={['useTagGroup']} />
+  componentNames={['useTagGroup']}
+  sourceData={[
+    {type: 'W3C', url: 'https://www.w3.org/WAI/ARIA/apg/patterns/grid/'}
+  ]} />
 
 ## API
 

--- a/packages/react-aria-components/docs/TagGroup.mdx
+++ b/packages/react-aria-components/docs/TagGroup.mdx
@@ -26,7 +26,7 @@ import {StarterKits} from '@react-spectrum/docs/src/StarterKits';
 
 ---
 category: Collections
-keywords: [tag, aria]
+keywords: [tag, aria, grid]
 type: component
 ---
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

[`useTagGroup`](https://react-spectrum.adobe.com/react-aria/useTagGroup.html) page had missed APG link about grid even though [`TagGroup`](https://react-spectrum.adobe.com/react-aria/TagGroup.html) has it, so I added it.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
