### PR TITLE
feat: Add codemod for ActionGroup

### DIFF
--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/actiongroup.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/actiongroup.test.ts.snap
@@ -34,15 +34,15 @@ function Example({disabledKeys}) {
       <ActionButton
         key="add"
         onPress={() => onAction("add")}
-        isDisabled={_disabledKeys?.has("add")}>Add</Item>
+        isDisabled={_disabledKeys.has("add")}>Add</Item>
       <ActionButton
         key="delete"
         onPress={() => onAction("delete")}
-        isDisabled={_disabledKeys?.has("delete")}>Delete</Item>
+        isDisabled={_disabledKeys.has("delete")}>Delete</Item>
       <ActionButton
         key="edit"
         onPress={() => onAction("edit")}
-        isDisabled={_disabledKeys?.has("edit")}>Edit</Item>
+        isDisabled={_disabledKeys.has("edit")}>Edit</Item>
     </ActionButtonGroup>)
   );
 }"
@@ -86,9 +86,9 @@ function Example({disabledKeys}) {
   let _disabledKeys = new Set(disabledKeys);
   return (
     (<ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
-      <ToggleButton id="add" isDisabled={_disabledKeys?.has("add")}>Add</Item>
-      <ToggleButton id="delete" isDisabled={_disabledKeys?.has("delete")}>Delete</Item>
-      <ToggleButton id="edit" isDisabled={_disabledKeys?.has("edit")}>Edit</Item>
+      <ToggleButton id="add" isDisabled={_disabledKeys.has("add")}>Add</Item>
+      <ToggleButton id="delete" isDisabled={_disabledKeys.has("delete")}>Delete</Item>
+      <ToggleButton id="edit" isDisabled={_disabledKeys.has("edit")}>Edit</Item>
     </ToggleButtonGroup>)
   );
 }"

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/actiongroup.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/actiongroup.test.ts.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Comments out unsupported props 1`] = `
+"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
+import { Item } from '@adobe/react-spectrum';
+// TODO(S2-upgrade): overflowMode has not been implemented yet.
+// TODO(S2-upgrade): buttonLabelBehavior has not been implemented yet.
+// TODO(S2-upgrade): summaryIcon has not been implemented yet.
+<ActionButtonGroup>
+  <ActionButton key="add">Add</Item>
+  <ActionButton key="delete">Delete</Item>
+  <ActionButton key="edit">Edit</Item>
+</ActionButtonGroup>"
+`;
+
+exports[`Converts ActionGroup to ActionButtonGroup 1`] = `
+"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
+import { Item } from '@adobe/react-spectrum';
+<ActionButtonGroup>
+  <ActionButton key="add" onPress={() => onAction("add")}>Add</Item>
+  <ActionButton key="delete" onPress={() => onAction("delete")}>Delete</Item>
+  <ActionButton key="edit" onPress={() => onAction("edit")}>Edit</Item>
+</ActionButtonGroup>"
+`;
+
+exports[`Converts ActionGroup to ActionButtonGroup with disabledKeys 1`] = `
+"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
+import { Item } from '@adobe/react-spectrum';
+
+function Example({disabledKeys}) {
+  let _disabledKeys = new Set(disabledKeys);
+  return (
+    (<ActionButtonGroup>
+      <ActionButton
+        key="add"
+        onPress={() => onAction("add")}
+        isDisabled={_disabledKeys?.has("add")}>Add</Item>
+      <ActionButton
+        key="delete"
+        onPress={() => onAction("delete")}
+        isDisabled={_disabledKeys?.has("delete")}>Delete</Item>
+      <ActionButton
+        key="edit"
+        onPress={() => onAction("edit")}
+        isDisabled={_disabledKeys?.has("edit")}>Edit</Item>
+    </ActionButtonGroup>)
+  );
+}"
+`;
+
+exports[`Converts ActionGroup to ActionButtonGroup with dynamic collections 1`] = `
+"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
+import { Item } from '@adobe/react-spectrum';
+<ActionButtonGroup>
+  {items.map(
+    item => <ActionButton key={item.key ?? item.id} onPress={() => onAction(item.key ?? item.id)}>{item.name}</Item>
+  )}
+</ActionButtonGroup>"
+`;
+
+exports[`Converts ActionGroup to ActionButtonGroup with dynamic collections and custom key 1`] = `
+"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
+import { Item } from '@adobe/react-spectrum';
+<ActionButtonGroup>
+  {items.map(
+    item => <ActionButton key={item._id} onPress={() => onAction(item._id)}>{item.name}</Item>
+  )}
+</ActionButtonGroup>"
+`;
+
+exports[`Converts ActionGroup to ToggleButtonGroup 1`] = `
+"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
+  import { Item } from '@adobe/react-spectrum';
+  <ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+    <ToggleButton id="add">Add</Item>
+    <ToggleButton id="delete">Delete</Item>
+    <ToggleButton id="edit">Edit</Item>
+  </ToggleButtonGroup>"
+`;
+
+exports[`Converts ActionGroup to ToggleButtonGroup with disabledKeys 1`] = `
+"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
+import { Item } from '@adobe/react-spectrum';
+
+function Example({disabledKeys}) {
+  let _disabledKeys = new Set(disabledKeys);
+  return (
+    (<ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+      <ToggleButton id="add" isDisabled={_disabledKeys?.has("add")}>Add</Item>
+      <ToggleButton id="delete" isDisabled={_disabledKeys?.has("delete")}>Delete</Item>
+      <ToggleButton id="edit" isDisabled={_disabledKeys?.has("edit")}>Edit</Item>
+    </ToggleButtonGroup>)
+  );
+}"
+`;
+
+exports[`Converts ActionGroup to ToggleButtonGroup with dynamic collections 1`] = `
+"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
+  import { Item } from '@adobe/react-spectrum';
+  <ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+    {items.map(
+      item => <ToggleButton key={item.key ?? item.id} id={item.key ?? item.id}>{item.name}</Item>
+    )}
+  </ToggleButtonGroup>"
+`;
+
+exports[`Converts ActionGroup to ToggleButtonGroup with dynamic collections and custom key 1`] = `
+"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
+  import { Item } from '@adobe/react-spectrum';
+  <ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+    {items.map(item => <ToggleButton key={item._id} id={item._id}>{item.name}</Item>)}
+  </ToggleButtonGroup>"
+`;

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/actiongroup.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/actiongroup.test.ts.snap
@@ -1,31 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Comments out unsupported props 1`] = `
-"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
-import { Item } from '@adobe/react-spectrum';
+"import { ActionButtonGroup, ActionButton } from "@react-spectrum/s2";
 // TODO(S2-upgrade): overflowMode has not been implemented yet.
 // TODO(S2-upgrade): buttonLabelBehavior has not been implemented yet.
 // TODO(S2-upgrade): summaryIcon has not been implemented yet.
 <ActionButtonGroup>
-  <ActionButton key="add">Add</Item>
-  <ActionButton key="delete">Delete</Item>
-  <ActionButton key="edit">Edit</Item>
+  <ActionButton key="add">Add</ActionButton>
+  <ActionButton key="delete">Delete</ActionButton>
+  <ActionButton key="edit">Edit</ActionButton>
 </ActionButtonGroup>"
 `;
 
 exports[`Converts ActionGroup to ActionButtonGroup 1`] = `
-"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
-import { Item } from '@adobe/react-spectrum';
+"import { ActionButtonGroup, ActionButton } from "@react-spectrum/s2";
 <ActionButtonGroup>
-  <ActionButton key="add" onPress={() => onAction("add")}>Add</Item>
-  <ActionButton key="delete" onPress={() => onAction("delete")}>Delete</Item>
-  <ActionButton key="edit" onPress={() => onAction("edit")}>Edit</Item>
+  <ActionButton key="add" onPress={() => onAction("add")}>Add</ActionButton>
+  <ActionButton key="delete" onPress={() => onAction("delete")}>Delete</ActionButton>
+  <ActionButton key="edit" onPress={() => onAction("edit")}>Edit</ActionButton>
 </ActionButtonGroup>"
 `;
 
 exports[`Converts ActionGroup to ActionButtonGroup with disabledKeys 1`] = `
-"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
-import { Item } from '@adobe/react-spectrum';
+"import { ActionButtonGroup, ActionButton } from "@react-spectrum/s2";
 
 function Example({disabledKeys}) {
   let _disabledKeys = new Set(disabledKeys);
@@ -34,80 +31,76 @@ function Example({disabledKeys}) {
       <ActionButton
         key="add"
         onPress={() => onAction("add")}
-        isDisabled={_disabledKeys.has("add")}>Add</Item>
+        isDisabled={_disabledKeys.has("add")}>Add</ActionButton>
       <ActionButton
         key="delete"
         onPress={() => onAction("delete")}
-        isDisabled={_disabledKeys.has("delete")}>Delete</Item>
+        isDisabled={_disabledKeys.has("delete")}>Delete</ActionButton>
       <ActionButton
         key="edit"
         onPress={() => onAction("edit")}
-        isDisabled={_disabledKeys.has("edit")}>Edit</Item>
+        isDisabled={_disabledKeys.has("edit")}>Edit</ActionButton>
     </ActionButtonGroup>)
   );
 }"
 `;
 
 exports[`Converts ActionGroup to ActionButtonGroup with dynamic collections 1`] = `
-"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
-import { Item } from '@adobe/react-spectrum';
+"import { ActionButtonGroup, ActionButton } from "@react-spectrum/s2";
 <ActionButtonGroup>
   {items.map(
-    item => <ActionButton key={item.key ?? item.id} onPress={() => onAction(item.key ?? item.id)}>{item.name}</Item>
+    item => <ActionButton key={item.key ?? item.id} onPress={() => onAction(item.key ?? item.id)}>{item.name}</ActionButton>
   )}
 </ActionButtonGroup>"
 `;
 
 exports[`Converts ActionGroup to ActionButtonGroup with dynamic collections and custom key 1`] = `
-"import { ActionButtonGroup, ActionButton, ActionGroup } from "@react-spectrum/s2";
-import { Item } from '@adobe/react-spectrum';
+"import { ActionButtonGroup, ActionButton } from "@react-spectrum/s2";
 <ActionButtonGroup>
   {items.map(
-    item => <ActionButton key={item._id} onPress={() => onAction(item._id)}>{item.name}</Item>
+    item => <ActionButton key={item._id} onPress={() => onAction(item._id)}>{item.name}</ActionButton>
   )}
 </ActionButtonGroup>"
 `;
 
 exports[`Converts ActionGroup to ToggleButtonGroup 1`] = `
-"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
-  import { Item } from '@adobe/react-spectrum';
-  <ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
-    <ToggleButton id="add">Add</Item>
-    <ToggleButton id="delete">Delete</Item>
-    <ToggleButton id="edit">Edit</Item>
-  </ToggleButtonGroup>"
+"import { ToggleButtonGroup, ToggleButton } from "@react-spectrum/s2";
+<ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+  <ToggleButton id="add">Add</ToggleButton>
+  <ToggleButton id="delete">Delete</ToggleButton>
+  <ToggleButton id="edit">Edit</ToggleButton>
+</ToggleButtonGroup>"
 `;
 
 exports[`Converts ActionGroup to ToggleButtonGroup with disabledKeys 1`] = `
-"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
-import { Item } from '@adobe/react-spectrum';
+"import { ToggleButtonGroup, ToggleButton } from "@react-spectrum/s2";
 
 function Example({disabledKeys}) {
   let _disabledKeys = new Set(disabledKeys);
   return (
     (<ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
-      <ToggleButton id="add" isDisabled={_disabledKeys.has("add")}>Add</Item>
-      <ToggleButton id="delete" isDisabled={_disabledKeys.has("delete")}>Delete</Item>
-      <ToggleButton id="edit" isDisabled={_disabledKeys.has("edit")}>Edit</Item>
+      <ToggleButton id="add" isDisabled={_disabledKeys.has("add")}>Add</ToggleButton>
+      <ToggleButton id="delete" isDisabled={_disabledKeys.has("delete")}>Delete</ToggleButton>
+      <ToggleButton id="edit" isDisabled={_disabledKeys.has("edit")}>Edit</ToggleButton>
     </ToggleButtonGroup>)
   );
 }"
 `;
 
 exports[`Converts ActionGroup to ToggleButtonGroup with dynamic collections 1`] = `
-"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
-  import { Item } from '@adobe/react-spectrum';
-  <ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
-    {items.map(
-      item => <ToggleButton key={item.key ?? item.id} id={item.key ?? item.id}>{item.name}</Item>
-    )}
-  </ToggleButtonGroup>"
+"import { ToggleButtonGroup, ToggleButton } from "@react-spectrum/s2";
+<ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+  {items.map(
+    item => <ToggleButton key={item.key ?? item.id} id={item.key ?? item.id}>{item.name}</ToggleButton>
+  )}
+</ToggleButtonGroup>"
 `;
 
 exports[`Converts ActionGroup to ToggleButtonGroup with dynamic collections and custom key 1`] = `
-"import { ToggleButtonGroup, ToggleButton, ActionGroup } from "@react-spectrum/s2";
-  import { Item } from '@adobe/react-spectrum';
-  <ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
-    {items.map(item => <ToggleButton key={item._id} id={item._id}>{item.name}</Item>)}
-  </ToggleButtonGroup>"
+"import { ToggleButtonGroup, ToggleButton } from "@react-spectrum/s2";
+<ToggleButtonGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+  {items.map(
+    item => <ToggleButton key={item._id} id={item._id}>{item.name}</ToggleButton>
+  )}
+</ToggleButtonGroup>"
 `;

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/actiongroup.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/actiongroup.test.ts
@@ -1,0 +1,90 @@
+// @ts-ignore
+import {defineSnapshotTest} from 'jscodeshift/dist/testUtils';
+import transform from '../src/codemods/codemod';
+
+const test = (name: string, input: string) => {
+  defineSnapshotTest(transform, {}, input, name);
+};
+
+test('Converts ActionGroup to ActionButtonGroup', `
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup onAction={onAction}>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
+</ActionGroup>
+`);
+
+test('Converts ActionGroup to ActionButtonGroup with disabledKeys', `
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+
+function Example({disabledKeys}) {
+  return (
+    <ActionGroup onAction={onAction} disabledKeys={disabledKeys}>
+      <Item key="add">Add</Item>
+      <Item key="delete">Delete</Item>
+      <Item key="edit">Edit</Item>
+    </ActionGroup>
+  );
+}
+`);
+
+test('Converts ActionGroup to ActionButtonGroup with dynamic collections', `
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup onAction={onAction} items={items}>
+  {item => <Item>{item.name}</Item>}
+</ActionGroup>
+`);
+
+test('Converts ActionGroup to ActionButtonGroup with dynamic collections and custom key', `
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup onAction={onAction} items={items}>
+  {item => <Item key={item._id}>{item.name}</Item>}
+</ActionGroup>
+`);
+
+test('Converts ActionGroup to ToggleButtonGroup', `
+  import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup selectionMode="single" onSelectionChange={onSelectionChange}>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
+</ActionGroup>
+`);
+
+test('Converts ActionGroup to ToggleButtonGroup with disabledKeys', `
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+
+function Example({disabledKeys}) {
+  return (
+    <ActionGroup selectionMode="single" onSelectionChange={onSelectionChange} disabledKeys={disabledKeys}>
+      <Item key="add">Add</Item>
+      <Item key="delete">Delete</Item>
+      <Item key="edit">Edit</Item>
+    </ActionGroup>
+  );
+}
+`);
+
+test('Converts ActionGroup to ToggleButtonGroup with dynamic collections', `
+  import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup selectionMode="single" onSelectionChange={onSelectionChange} items={items}>
+  {item => <Item>{item.name}</Item>}
+</ActionGroup>
+`);
+
+test('Converts ActionGroup to ToggleButtonGroup with dynamic collections and custom key', `
+  import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup selectionMode="single" onSelectionChange={onSelectionChange} items={items}>
+  {item => <Item key={item._id}>{item.name}</Item>}
+</ActionGroup>
+`);
+
+test('Comments out unsupported props', `
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+<ActionGroup overflowMode="collapse" buttonLabelBehavior="collapse" summaryIcon={<Icon />}>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
+</ActionGroup>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/changes.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/changes.ts
@@ -75,6 +75,10 @@ type FunctionInfo =
   | {
     name: 'updateLegacyLink',
     args: {}
+  }
+  | {
+    name: 'updateActionGroup',
+    args: {}
   };
 
 type Change = {
@@ -109,6 +113,39 @@ export const changes: ChangesJSON = {
           name: 'updateAvatarSize',
           args: {}
         }
+      }
+    ]
+  },
+  ActionGroup: {
+    changes: [
+      {
+        description: 'Comment out overflowMode',
+        reason: 'It has not been implemented yet',
+        function: {
+          name: 'commentOutProp',
+          args: {propToComment: 'overflowMode'}
+        }
+      },
+      {
+        description: 'Comment out buttonLabelBehavior',
+        reason: 'It has not been implemented yet',
+        function: {
+          name: 'commentOutProp',
+          args: {propToComment: 'buttonLabelBehavior'}
+        }
+      },
+      {
+        description: 'Comment out summaryIcon',
+        reason: 'It has not been implemented yet',
+        function: {
+          name: 'commentOutProp',
+          args: {propToComment: 'summaryIcon'}
+        }
+      },
+      {
+        description: 'Replace with ActionButtonGroup or ToggleButtonGroup',
+        reason: 'The API has changed',
+        function: {name: 'updateActionGroup', args: {}}
       }
     ]
   },

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/codemod.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/codemod.ts
@@ -229,7 +229,7 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
   if (importedComponents.size) {
     // Add imports to existing @react-spectrum/s2 import if it exists, otherwise add a new one.
     let importSpecifiers = new Set([...importedComponents]
-      .filter(([c]) => c !== 'Flex' && c !== 'Grid' && c !== 'View' && c !== 'Item' && c !== 'Section')
+      .filter(([c]) => c !== 'Flex' && c !== 'Grid' && c !== 'View' && c !== 'Item' && c !== 'Section' && c !== 'ActionGroup')
       .map(([, specifier]) => specifier));
 
     let existingImport = root.find(j.ImportDeclaration, {

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/codemod.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/codemod.ts
@@ -26,6 +26,9 @@ availableComponents.add('Section');
 // Don't update v3 Provider
 availableComponents.delete('Provider');
 
+// Replaced by ActionButtonGroup and ToggleButtonGroup
+availableComponents.add('ActionGroup');
+
 
 interface Options {
   /** Comma separated list of components to transform. If not specified, all available components will be transformed. */

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
@@ -1098,9 +1098,7 @@ function updateActionGroup(
                 t.callExpression(
                   t.memberExpression(
                     disabledKeys,
-                    t.identifier('has'),
-                    false,
-                    true
+                    t.identifier('has')
                   ),
                   [keyValue]
                 )

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/transforms.ts
@@ -523,7 +523,7 @@ function updateComponentWithinCollection(
 function commentIfParentCollectionNotDetected(
   path: NodePath<t.JSXElement>
 ) {
-  const collectionItemParents = new Set(['Menu', 'ActionMenu', 'TagGroup', 'Breadcrumbs', 'Picker', 'ComboBox', 'ListBox', 'TabList', 'TabPanels', 'ActionGroup', 'ListBox', 'ListView', 'Collection', 'SearchAutocomplete', 'Accordion', 'ActionBar', 'StepList']);
+  const collectionItemParents = new Set(['Menu', 'ActionMenu', 'TagGroup', 'Breadcrumbs', 'Picker', 'ComboBox', 'ListBox', 'TabList', 'TabPanels', 'ActionGroup', 'ActionButtonGroup', 'ToggleButtonGroup', 'ListBox', 'ListView', 'Collection', 'SearchAutocomplete', 'Accordion', 'ActionBar', 'StepList']);
   if (
     t.isJSXElement(path.node)
   ) {
@@ -960,6 +960,166 @@ function updateLegacyLink(
   }
 }
 
+function updateActionGroup(
+  path: NodePath<t.JSXElement>
+) {
+  let selectionModePath = path.get('openingElement').get('attributes').find((attr) => t.isJSXAttribute(attr.node) && attr.node.name.name === 'selectionMode') as NodePath<t.JSXAttribute> | undefined;
+  let selectionMode = t.isStringLiteral(selectionModePath?.node.value) ? selectionModePath.node.value.value : 'none';
+  let newComponent, childComponent;
+  if (selectionMode === 'none') {
+    newComponent = 'ActionButtonGroup';
+    childComponent = 'ActionButton';
+    selectionModePath?.remove();
+  } else {
+    newComponent = 'ToggleButtonGroup';
+    childComponent = 'ToggleButton';
+  }
+
+  let localName = newComponent;
+  if (availableComponents.has(newComponent)) {
+    let program = path.findParent((p) => t.isProgram(p.node)) as NodePath<t.Program>;
+    localName = addComponentImport(program, newComponent);
+  }
+
+  let localChildName = childComponent;
+  if (availableComponents.has(childComponent)) {
+    let program = path.findParent((p) => t.isProgram(p.node)) as NodePath<t.Program>;
+    localChildName = addComponentImport(program, childComponent);
+  }
+
+
+  // Convert dynamic collection to an array.map.
+  let items = path.get('openingElement').get('attributes').find((attr) => t.isJSXAttribute(attr.node) && attr.node.name.name === 'items') as NodePath<t.JSXAttribute> | undefined;
+  let itemArg: t.Identifier | undefined;
+  if (items && t.isJSXExpressionContainer(items.node.value) && t.isExpression(items.node.value.expression)) {
+    let child = path.get('children').find(c => c.isJSXExpressionContainer());
+    if (child && child.isJSXExpressionContainer() && t.isFunction(child.node.expression)) {
+      let arg = child.node.expression.params[0];
+      if (t.isIdentifier(arg)) {
+        itemArg = arg;
+      }
+
+      child.replaceWith(
+        t.jsxExpressionContainer(
+          t.callExpression(
+            t.memberExpression(
+              items.node.value.expression,
+              t.identifier('map')
+            ),
+            [child.node.expression]
+          )
+        )
+      );
+    }
+  }
+  items?.remove();
+
+  let onAction = path.get('openingElement').get('attributes').find((attr) => t.isJSXAttribute(attr.node) && attr.node.name.name === 'onAction') as NodePath<t.JSXAttribute> | undefined;
+  
+  // Pull disabledKeys prop out into a variable, converted to a Set.
+  // Then we can check it in the isDisabled prop of each item.
+  let disabledKeysPath = path.get('openingElement').get('attributes').find((attr) => t.isJSXAttribute(attr.node) && attr.node.name.name === 'disabledKeys') as NodePath<t.JSXAttribute> | undefined;
+  let disabledKeys: t.Identifier | undefined;
+  if (disabledKeysPath && t.isJSXExpressionContainer(disabledKeysPath.node.value) && t.isExpression(disabledKeysPath.node.value.expression)) {
+    disabledKeys = path.scope.generateUidIdentifier('disabledKeys');
+    path.scope.push({
+      id: disabledKeys,
+      init: t.newExpression(t.identifier('Set'), [disabledKeysPath.node.value.expression]),
+      kind: 'let'
+    });
+    disabledKeysPath.remove();
+  }
+
+  path.traverse({
+    JSXElement(child) {
+      if (t.isJSXIdentifier(child.node.openingElement.name) && child.node.openingElement.name.name === 'Item') {
+        // Replace Item with ActionButton or ToggleButton.
+        child.node.openingElement.name = t.jsxIdentifier(localChildName);
+        if (path.node.closingElement) {
+          path.node.closingElement.name = t.jsxIdentifier(localChildName);
+        }
+
+        // If there is no key prop and we are using dynamic collections, add a default computed from item.key ?? item.id.
+        let key = child.node.openingElement.attributes.find(attr => t.isJSXAttribute(attr) && attr.name.name === 'key') as t.JSXAttribute | undefined;
+        if (!key && itemArg) {
+          let id = t.jsxExpressionContainer(
+            t.logicalExpression(
+              '??',
+              t.memberExpression(itemArg, t.identifier('key')),
+              t.memberExpression(itemArg, t.identifier('id'))
+            )
+          );
+
+          key = t.jsxAttribute(
+            t.jsxIdentifier('key'),
+            id
+          );
+
+          child.node.openingElement.attributes.push(key);
+        }
+
+        // If this is a ToggleButtonGroup, add an id prop in addition to key when needed.
+        if (key && newComponent === 'ToggleButtonGroup') {
+          // If we are in an array.map we need both key and id. Otherwise, we only need id.
+          if (itemArg) {
+            child.node.openingElement.attributes.push(t.jsxAttribute(t.jsxIdentifier('id'), key.value));
+          } else {
+            key.name.name = 'id';
+          }
+        }
+
+        let keyValue: t.Expression | undefined = undefined;
+        if (key && t.isJSXExpressionContainer(key.value) && t.isExpression(key.value.expression)) {
+          keyValue = key.value.expression;
+        } else if (key && t.isStringLiteral(key.value)) {
+          keyValue = key.value;
+        }
+
+        // Add an onPress to each item that calls the previous onAction, passing in the key.
+        if (onAction && t.isJSXExpressionContainer(onAction.node.value) && t.isExpression(onAction.node.value.expression)) {
+          child.node.openingElement.attributes.push(
+            t.jsxAttribute(
+              t.jsxIdentifier('onPress'),
+              t.jsxExpressionContainer(
+                keyValue 
+                  ? t.arrowFunctionExpression([], t.callExpression(onAction.node.value.expression, [keyValue]))
+                  : onAction.node.value.expression
+              )
+            )
+          );
+        }
+
+        // Add an isDisabled prop to each item, testing whether it is in disabledKeys.
+        if (disabledKeys && keyValue) {
+          child.node.openingElement.attributes.push(
+            t.jsxAttribute(
+              t.jsxIdentifier('isDisabled'),
+              t.jsxExpressionContainer(
+                t.callExpression(
+                  t.memberExpression(
+                    disabledKeys,
+                    t.identifier('has'),
+                    false,
+                    true
+                  ),
+                  [keyValue]
+                )
+              )
+            )
+          );
+        }
+      }
+    }
+  });
+
+  onAction?.remove();
+
+  path.node.openingElement.name = t.jsxIdentifier(localName);
+  if (path.node.closingElement) {
+    path.node.closingElement.name = t.jsxIdentifier(localName);
+  }
+}
+
 export const functionMap = {
   updatePropNameAndValue,
   updatePropValueAndAddNewProp,
@@ -979,5 +1139,6 @@ export const functionMap = {
   updatePlacementToSingleValue,
   removeComponentIfWithinParent,
   updateAvatarSize,
-  updateLegacyLink
+  updateLegacyLink,
+  updateActionGroup
 };


### PR DESCRIPTION
* Converts `<ActionGroup selectionMode="none">` to `<ActionButtonGroup>`
* Converts `<ActionGroup selectionMode="single | multiple">` to `<ToggleButtonGroup>`
* Converts `key` to `id` where needed
* Converts dynamic collections (with `items` prop and function child) to `items.map`, adding implicit `key` and `id` props where needed
* Converts `onAction` on root to `onPress` function on each item that calls the original `onAction` with the key
* Converts `disabledKeys` on the root to `isDisabled` prop on each item
* Comments out props that aren't supported yet, related to collapse behavior