### PR TITLE
fix: DatePicker.test fails with daylight savings change (#7399)

### DIFF
--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -12,7 +12,7 @@
 
 import {act, fireEvent, pointerMap, render as render_, waitFor, within} from '@react-spectrum/test-utils-internal';
 import {Button} from '@react-spectrum/button';
-import {CalendarDate, CalendarDateTime, EthiopicCalendar, getLocalTimeZone, JapaneseCalendar, parseZonedDateTime, toCalendarDateTime, today} from '@internationalized/date';
+import {CalendarDate, CalendarDateTime, DateFormatter, EthiopicCalendar, getLocalTimeZone, JapaneseCalendar, parseZonedDateTime, toCalendarDateTime, today} from '@internationalized/date';
 import {DatePicker} from '../';
 import {Form} from '@react-spectrum/form';
 import {Provider} from '@react-spectrum/provider';
@@ -584,7 +584,7 @@ describe('DatePicker', function () {
       let month = parts.find(p => p.type === 'month').value;
       let day = parts.find(p => p.type === 'day').value;
       let year = parts.find(p => p.type === 'year').value;
-       
+
       expectPlaceholder(combobox, `${month}/${day}/${year}, 12:00 AM`);
 
       await user.keyboard('{ArrowRight}');
@@ -1928,7 +1928,17 @@ describe('DatePicker', function () {
       await user.tab();
       await user.keyboard('{Backspace}');
 
-      expectPlaceholder(combobox, 'mm/dd/yyyy, ––:–– AM PDT');
+      let timeZoneName =
+        new DateFormatter('en-US',
+          {
+            timeZone: 'America/Los_Angeles',
+            timeZoneName: 'short'
+          })
+          .formatToParts(new Date())
+          .find(p => p.type === 'timeZoneName')
+          .value;
+
+      expectPlaceholder(combobox, `mm/dd/yyyy, ––:–– AM ${timeZoneName}`);
     });
 
     it('should keep timeZone from defaultValue when date and time are cleared then set', async function () {


### PR DESCRIPTION
If the defaultValue is on daylight savings time and the user clears the value while in a time zone on standard time, the DatePicker's time zone will change to standard time. I think this is the correct behavior, however, the test is written to always expect "PDT" Pacific Daylight Savings Time, which means it will fail when we're on standard time.


Closes #7399 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run `yarn test packages/@react-spectrum/datepicker/test/DatePicker.test.js` from the first Sunday in November to the second Sunday in March, and all tests should pass.

## 🧢 Your Project:

Adobe/Accessibility
