### PR TITLE
fix: the way to pass the input default value in useTextField story

### DIFF
--- a/packages/@react-aria/textfield/stories/useTextField.stories.tsx
+++ b/packages/@react-aria/textfield/stories/useTextField.stories.tsx
@@ -45,7 +45,7 @@ export const WithHTMLInputElement = {
   render: TextInputFieldTemplate,
   args: {
     label: 'Test label',
-    value: 'Test value'
+    defaultValue: 'Test value'
   }
 };
 
@@ -54,7 +54,7 @@ export const WithHTMLTextAreaElement = {
   args: {
     inputElementType: 'textarea',
     label: 'Test label',
-    value: 'Test value'
+    defaultValue: 'Test value'
   }
 };
 


### PR DESCRIPTION
On storybook, we were not able to change the input value in `useTextField.stories.tsx` because `value` was passed to `useTextField` as props so I changed to use `defaultValue` props instead of it.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Confirm we can edit input content in `useTextField.stories.tsx` on storybook
<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
