### PR TITLE
fix: make `a` tag link draggable with usePress

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -787,7 +787,7 @@ export function usePress(props: PressHookProps): PressResult {
   ]);
 
   // Remove user-select: none in case component unmounts immediately after pressStart
-   
+
   useEffect(() => {
     return () => {
       if (!allowTextSelectionOnPress) {
@@ -935,7 +935,15 @@ function isOverTarget(point: EventPoint, target: Element) {
 
 function shouldPreventDefaultDown(target: Element) {
   // We cannot prevent default if the target is a draggable element.
-  return !(target instanceof HTMLElement) || !target.hasAttribute('draggable');
+  if (!(target instanceof HTMLElement)) {
+    return true;
+  }
+
+  if (target.tagName === 'A' && target.getAttribute('draggable') !== 'false') {
+    return false;
+  }
+
+  return !target.hasAttribute('draggable');
 }
 
 function shouldPreventDefaultUp(target: Element) {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/6618<!-- Github issue # here -->

I'm not sure this solution is proper to solve the issue so if there is some missing consideration please let me know 🙏 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. open storybook Link Example http://localhost:9003/?path=/story/react-aria-components--link-example&providerSwitcher-express=false&strict=true
2. Attempt to drag the link with a mouse
<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
