### PR TITLE
FIX- #7447: Passing autoComplete prop from Select to underlying child component

### DIFF
--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -202,6 +202,7 @@ function SelectInner<T extends object>({props, selectRef: ref, collection}: Sele
         data-invalid={validation.isInvalid || undefined}
         data-required={props.isRequired || undefined} />
       <HiddenSelect
+        autoComplete={props.autoComplete}
         state={state}
         triggerRef={buttonRef}
         label={label}


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7447

`Select` Component is not allowing to browser autofill to fill saved user values in the dropdowns. 
Issue - `autoComplete` property is not being passed by `Select` to child component `HiddenSelect`.
Ref - The same thing is done by [Picker](https://github.com/adobe/react-spectrum/blob/b0f15697245de74ebc99ab3d687f5eb3733d3a34/packages/%40react-spectrum/picker/src/Picker.tsx#L182C9-L182C21)
This PR fixes this bug.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/7447).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

There is no react aria form stories to test out the issue. But I have added a [sandbox link ](https://codesandbox.io/p/sandbox/hungry-dan-sv87ql) to check the issue.

## 🧢 Your Project:

<!--- Company/project for pull request -->
