### PR TITLE
fix: In Calendar, selecting an unavailable date with keyboard should not change the current selection

### DIFF
--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -291,7 +291,9 @@ export function useCalendarState<T extends DateValue = DateValue>(props: Calenda
       }
     },
     selectFocusedDate() {
-      setValue(focusedDate);
+      if (!(isDateUnavailable && isDateUnavailable(focusedDate))) {
+        setValue(focusedDate);
+      }
     },
     selectDate(date) {
       setValue(date);

--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -342,4 +342,12 @@ describe('Calendar', () => {
     expect(cell).not.toHaveAttribute('data-selected');
     expect(cell).not.toHaveClass('selected');
   });
+
+  it('should not modify selection when trying to select an unavailable date by keyboard', async () => {
+    let calendar = renderCalendar({isDateUnavailable: d => d.day === 15});
+    let day16 = calendar.getByText('16');
+    fireEvent.click(day16);
+    await user.keyboard('[ArrowLeft][Enter]');
+    expect(calendar.getByLabelText(/selected/)).toBe(day16);
+  });
 });


### PR DESCRIPTION
In Calendar, selecting an unavailable date with keyboard selected the previous available date. Now it does not change the selection.


Closes #5692

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

The issue itself and the modification can be tested on the Spectrum Calendar story page.

## 🧢 Your Project:

<!--- Company/project for pull request -->
