### PR TITLE
fix(Accordion): add box-sizing: content-box Accordion chevron

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/accordion/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/accordion/index.css
@@ -38,6 +38,7 @@ governing permissions and limitations under the License.
   padding-inline-end: var(--spectrum-accordion-icon-gap);
 
   transition: transform ease var(--spectrum-global-animation-duration-100);
+  box-sizing: content-box;
 }
 
 .spectrum-Accordion-item {
@@ -122,8 +123,6 @@ governing permissions and limitations under the License.
     > .spectrum-Accordion-itemHeading {
       > .spectrum-Accordion-itemHeader {
         > .spectrum-Accordion-itemIndicator {
-          box-sizing: content-box;
-
           [dir='ltr'] & {
             transform: rotate(90deg);
           }


### PR DESCRIPTION
Previously the style only affected the accordion when it was expanded.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
