### PR TITLE
fix: S2 examples Popover and add CustomDialog

### DIFF
--- a/examples/s2-parcel-example/src/App.js
+++ b/examples/s2-parcel-example/src/App.js
@@ -87,7 +87,7 @@ function App() {
         })}
       >
         <Section title="Buttons">
-          <ButtonGroup>
+          <ButtonGroup align="center" styles={style({maxWidth: '[100vh]'})}>
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <ActionButton>

--- a/examples/s2-parcel-example/src/App.js
+++ b/examples/s2-parcel-example/src/App.js
@@ -87,7 +87,7 @@ function App() {
         })}
       >
         <Section title="Buttons">
-          <ButtonGroup align="center" styles={style({maxWidth: '[100vh]'})}>
+          <ButtonGroup align="center" styles={style({maxWidth: '[100vw]'})}>
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <ActionButton>

--- a/examples/s2-parcel-example/src/Lazy.js
+++ b/examples/s2-parcel-example/src/Lazy.js
@@ -44,6 +44,7 @@ import {
   NumberField,
   Picker,
   PickerItem,
+  Popover,
   ProgressBar,
   ProgressCircle,
   Radio,
@@ -247,15 +248,15 @@ export default function Lazy() {
           </Dialog>
         </DialogTrigger>
 
-        <DialogTrigger type="popover">
+        <DialogTrigger>
           <ActionButton>Disk Status</ActionButton>
-          <Dialog>
-            <Heading>C://</Heading>
+          <Popover>
+            <Heading styles={style({font: 'heading', marginTop: 0, marginBottom: 20})}>C://</Heading>
 
-            <Content>
+            <Content styles={style({font: 'ui'})}>
               <Text>50% disk space remaining.</Text>
             </Content>
-          </Dialog>
+          </Popover>
         </DialogTrigger>
 
         <TooltipTrigger>

--- a/examples/s2-parcel-example/src/Lazy.js
+++ b/examples/s2-parcel-example/src/Lazy.js
@@ -13,6 +13,7 @@ import {
   ButtonGroup,
   Checkbox,
   CheckboxGroup,
+  CloseButton,
   ColorArea,
   ColorField,
   ColorSlider,
@@ -23,6 +24,7 @@ import {
   ComboBoxItem,
   Content,
   ContextualHelp,
+  CustomDialog,
   Dialog,
   DialogContainer,
   DialogTrigger,
@@ -68,6 +70,7 @@ import {
   Tooltip,
   TooltipTrigger,
 } from "@react-spectrum/s2";
+import Checkmark from '@react-spectrum/s2/illustrations/gradient/generic1/Checkmark';
 import Cloud from "@react-spectrum/s2/illustrations/linear/Cloud";
 import DropToUpload from "@react-spectrum/s2/illustrations/linear/DropToUpload";
 import Edit from "@react-spectrum/s2/icons/Edit";
@@ -246,6 +249,18 @@ export default function Lazy() {
               </>
             )}
           </Dialog>
+        </DialogTrigger>
+
+        <DialogTrigger>
+          <ActionButton>Illustration</ActionButton>
+          <CustomDialog size="M">
+            <div className={style({display: 'flex', flexDirection: 'column', rowGap: 8, alignItems: 'center'})}>
+              <Checkmark />
+              <Heading slot="title" styles={style({font: 'heading-lg', textAlign: 'center', marginY: 0})}>Thank you!</Heading>
+              <p className={style({font: 'body', textAlign: 'center', marginY: 0})}>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+              <CloseButton styles={style({position: 'absolute', top: 12, insetEnd: 12})} />
+            </div>
+          </CustomDialog>
         </DialogTrigger>
 
         <DialogTrigger>

--- a/examples/s2-parcel-example/src/index.html
+++ b/examples/s2-parcel-example/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Spectrum 2 + Parcel</title>
     </head>
     <body>

--- a/examples/s2-vite-project/src/App.tsx
+++ b/examples/s2-vite-project/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
         })}
       >
         <Section title="Buttons">
-          <ButtonGroup>
+          <ButtonGroup align="center" styles={style({maxWidth: '[100vh]'})}>
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <ActionButton>

--- a/examples/s2-vite-project/src/App.tsx
+++ b/examples/s2-vite-project/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
         })}
       >
         <Section title="Buttons">
-          <ButtonGroup align="center" styles={style({maxWidth: '[100vh]'})}>
+          <ButtonGroup align="center" styles={style({maxWidth: '[100vw]'})}>
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <ActionButton>

--- a/examples/s2-vite-project/src/Lazy.tsx
+++ b/examples/s2-vite-project/src/Lazy.tsx
@@ -44,6 +44,7 @@ import {
   NumberField,
   Picker,
   PickerItem,
+  Popover,
   ProgressBar,
   ProgressCircle,
   Radio,
@@ -247,15 +248,15 @@ export default function Lazy() {
           </Dialog>
         </DialogTrigger>
 
-        <DialogTrigger type="popover">
+        <DialogTrigger>
           <ActionButton>Disk Status</ActionButton>
-          <Dialog>
-            <Heading>C://</Heading>
+          <Popover>
+            <Heading styles={style({font: 'heading', marginTop: 0, marginBottom: 20})}>C://</Heading>
 
-            <Content>
+            <Content styles={style({font: 'ui'})}>
               <Text>50% disk space remaining.</Text>
             </Content>
-          </Dialog>
+          </Popover>
         </DialogTrigger>
 
         <TooltipTrigger>

--- a/examples/s2-vite-project/src/Lazy.tsx
+++ b/examples/s2-vite-project/src/Lazy.tsx
@@ -13,6 +13,7 @@ import {
   ButtonGroup,
   Checkbox,
   CheckboxGroup,
+  CloseButton,
   ColorArea,
   ColorField,
   ColorSlider,
@@ -23,6 +24,7 @@ import {
   ComboBoxItem,
   Content,
   ContextualHelp,
+  CustomDialog,
   Dialog,
   DialogContainer,
   DialogTrigger,
@@ -68,6 +70,7 @@ import {
   Tooltip,
   TooltipTrigger,
 } from "@react-spectrum/s2";
+import Checkmark from '@react-spectrum/s2/illustrations/gradient/generic1/Checkmark';
 import Cloud from "@react-spectrum/s2/illustrations/linear/Cloud";
 import DropToUpload from "@react-spectrum/s2/illustrations/linear/DropToUpload";
 import Edit from "@react-spectrum/s2/icons/Edit";
@@ -246,6 +249,18 @@ export default function Lazy() {
               </>
             )}
           </Dialog>
+        </DialogTrigger>
+
+        <DialogTrigger>
+          <ActionButton>Illustration</ActionButton>
+          <CustomDialog size="M">
+            <div className={style({display: 'flex', flexDirection: 'column', rowGap: 8, alignItems: 'center'})}>
+              <Checkmark />
+              <Heading slot="title" styles={style({font: 'heading-lg', textAlign: 'center', marginY: 0})}>Thank you!</Heading>
+              <p className={style({font: 'body', textAlign: 'center', marginY: 0})}>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+              <CloseButton styles={style({position: 'absolute', top: 12, insetEnd: 12})} />
+            </div>
+          </CustomDialog>
         </DialogTrigger>
 
         <DialogTrigger>

--- a/examples/s2-webpack-5-example/src/App.js
+++ b/examples/s2-webpack-5-example/src/App.js
@@ -87,7 +87,7 @@ function App() {
         })}
       >
         <Section title="Buttons">
-          <ButtonGroup>
+          <ButtonGroup align="center" styles={style({maxWidth: '[100vh]'})}>
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <ActionButton>

--- a/examples/s2-webpack-5-example/src/App.js
+++ b/examples/s2-webpack-5-example/src/App.js
@@ -87,7 +87,7 @@ function App() {
         })}
       >
         <Section title="Buttons">
-          <ButtonGroup align="center" styles={style({maxWidth: '[100vh]'})}>
+          <ButtonGroup align="center" styles={style({maxWidth: '[100vw]'})}>
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <ActionButton>

--- a/examples/s2-webpack-5-example/src/Lazy.js
+++ b/examples/s2-webpack-5-example/src/Lazy.js
@@ -44,6 +44,7 @@ import {
   NumberField,
   Picker,
   PickerItem,
+  Popover,
   ProgressBar,
   ProgressCircle,
   Radio,
@@ -247,15 +248,15 @@ export default function Lazy() {
           </Dialog>
         </DialogTrigger>
 
-        <DialogTrigger type="popover">
+        <DialogTrigger>
           <ActionButton>Disk Status</ActionButton>
-          <Dialog>
-            <Heading>C://</Heading>
+          <Popover>
+            <Heading styles={style({font: 'heading', marginTop: 0, marginBottom: 20})}>C://</Heading>
 
-            <Content>
+            <Content styles={style({font: 'ui'})}>
               <Text>50% disk space remaining.</Text>
             </Content>
-          </Dialog>
+          </Popover>
         </DialogTrigger>
 
         <TooltipTrigger>

--- a/examples/s2-webpack-5-example/src/Lazy.js
+++ b/examples/s2-webpack-5-example/src/Lazy.js
@@ -13,6 +13,7 @@ import {
   ButtonGroup,
   Checkbox,
   CheckboxGroup,
+  CloseButton,
   ColorArea,
   ColorField,
   ColorSlider,
@@ -23,6 +24,7 @@ import {
   ComboBoxItem,
   Content,
   ContextualHelp,
+  CustomDialog,
   Dialog,
   DialogContainer,
   DialogTrigger,
@@ -68,6 +70,7 @@ import {
   Tooltip,
   TooltipTrigger,
 } from "@react-spectrum/s2";
+import Checkmark from '@react-spectrum/s2/illustrations/gradient/generic1/Checkmark';
 import Cloud from "@react-spectrum/s2/illustrations/linear/Cloud";
 import DropToUpload from "@react-spectrum/s2/illustrations/linear/DropToUpload";
 import Edit from "@react-spectrum/s2/icons/Edit";
@@ -246,6 +249,18 @@ export default function Lazy() {
               </>
             )}
           </Dialog>
+        </DialogTrigger>
+
+        <DialogTrigger>
+          <ActionButton>Illustration</ActionButton>
+          <CustomDialog size="M">
+            <div className={style({display: 'flex', flexDirection: 'column', rowGap: 8, alignItems: 'center'})}>
+              <Checkmark />
+              <Heading slot="title" styles={style({font: 'heading-lg', textAlign: 'center', marginY: 0})}>Thank you!</Heading>
+              <p className={style({font: 'body', textAlign: 'center', marginY: 0})}>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+              <CloseButton styles={style({position: 'absolute', top: 12, insetEnd: 12})} />
+            </div>
+          </CustomDialog>
         </DialogTrigger>
 
         <DialogTrigger>


### PR DESCRIPTION
from testing

Changes:
- Updated popover example to use Popover. Do we want it styled like S1 popovers? The implemented minimal changes,
![image](https://github.com/user-attachments/assets/9cf008d4-e8d6-4db1-a05b-ff9bd87910f5)
- Added an example of CustomDialog
- Changed ButtonGroup to have a maxWidth of the view width so the buttons will wrap on mobile.
- Added viewport metadata to the parcel example app

**Possible Bug**: If we don't define `size` on CustomDialog it takes the full screen width.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

For the Popover and CustomDialog dialog changes those can be tested on desktop.
For the parcel example app please test on mobile for the viewport and ButtonGroup changes. The viewport test is pickers open below the trigger.

When testing the webpack app, is there a ResizeObserver error on scroll down? I thought it was related to the ButtonGroup change, but I removed the change and it persisted. I'm hoping it's a local build issue. That's the only change in that file and I wouldn't expect changes to Lazy.jsx to impact this. 

Speaking of local build issue, my parcel build is refusing to import Popover and CustomDialog. I'm assuming it's a local issue and no one else will see it.

## 🧢 Your Project:
RSP