### PR TITLE
feat: Add staticColor="auto" variant

### DIFF
--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -59,8 +59,9 @@ export interface ActionButtonProps extends Omit<ButtonProps, 'className' | 'styl
 
 // These styles handle both ActionButton and ToggleButton
 const iconOnly = ':has([slot=icon], [slot=avatar]):not(:has([data-rsp-slot=text]))';
-export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & ToggleButtonStyleProps & ActionGroupItemStyleProps & {isInGroup: boolean}>({
+export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & ToggleButtonStyleProps & ActionGroupItemStyleProps & {isInGroup: boolean, isStaticColor: boolean}>({
   ...focusRing(),
+  ...staticColor(),
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -98,7 +99,7 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
         isQuiet: 'transparent'
       }
     },
-    staticColor: staticColor({
+    isStaticColor: {
       ...baseColor('transparent-overlay-100'),
       default: {
         default: 'transparent-overlay-100',
@@ -111,7 +112,7 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
           isQuiet: 'transparent'
         }
       }
-    }),
+    },
     forcedColors: {
       default: 'ButtonFace',
       isSelected: {
@@ -127,11 +128,11 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
       isEmphasized: 'white'
     },
     isDisabled: 'disabled',
-    staticColor: staticColor({
+    isStaticColor: {
       default: baseColor('transparent-overlay-800'),
       isSelected: 'auto',
       isDisabled: 'transparent-overlay-400'
-    }),
+    },
     forcedColors: {
       default: 'ButtonText',
       isSelected: 'HighlightText',
@@ -146,7 +147,7 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: staticColor('transparent-overlay-1000'),
+    isStaticColor: 'transparent-overlay-1000',
     forcedColors: 'Highlight'
   },
   borderStyle: 'none',
@@ -261,6 +262,7 @@ export const ActionButton = forwardRef(function ActionButton(props: ActionButton
         // Retain hover styles when an overlay is open.
         isHovered: renderProps.isHovered || overlayTriggerState?.isOpen || false,
         staticColor,
+        isStaticColor: !!staticColor,
         size,
         isQuiet,
         density,

--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -17,7 +17,7 @@ import {ButtonProps, ButtonRenderProps, ContextValue, OverlayTriggerStateContext
 import {centerBaseline} from './CenterBaseline';
 import {createContext, forwardRef, ReactNode, useContext} from 'react';
 import {FocusableRef, FocusableRefValue} from '@react-types/shared';
-import {getAllowedOverrides, StyleProps} from './style-utils' with { type: 'macro' };
+import {getAllowedOverrides, staticColor, StyleProps} from './style-utils' with { type: 'macro' };
 import {IconContext} from './Icon';
 import {pressScale} from './pressScale';
 import {SkeletonContext} from './Skeleton';
@@ -34,7 +34,7 @@ export interface ActionButtonStyleProps {
    */
   size?: 'XS' | 'S' | 'M' | 'L' | 'XL',
   /** The static color style to apply. Useful when the ActionButton appears over a color background. */
-  staticColor?: 'black' | 'white',
+  staticColor?: 'black' | 'white' | 'auto',
   /** Whether the button should be displayed with a [quiet style](https://spectrum.adobe.com/page/action-button/#Quiet). */
   isQuiet?: boolean
 }
@@ -98,36 +98,20 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
         isQuiet: 'transparent'
       }
     },
-    staticColor: {
-      white: {
-        ...baseColor('transparent-white-100'),
-        default: {
-          default: 'transparent-white-100',
-          isQuiet: 'transparent'
-        },
-        isSelected: {
-          default: baseColor('transparent-white-800'),
-          isDisabled: {
-            default: 'transparent-white-100',
-            isQuiet: 'transparent'
-          }
-        }
+    staticColor: staticColor({
+      ...baseColor('transparent-overlay-100'),
+      default: {
+        default: 'transparent-overlay-100',
+        isQuiet: 'transparent'
       },
-      black: {
-        ...baseColor('transparent-black-100'),
-        default: {
-          default: 'transparent-black-100',
+      isSelected: {
+        default: baseColor('transparent-overlay-800'),
+        isDisabled: {
+          default: 'transparent-overlay-100',
           isQuiet: 'transparent'
-        },
-        isSelected: {
-          default: baseColor('transparent-black-800'),
-          isDisabled: {
-            default: 'transparent-black-100',
-            isQuiet: 'transparent'
-          }
         }
       }
-    },
+    }),
     forcedColors: {
       default: 'ButtonFace',
       isSelected: {
@@ -143,18 +127,11 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
       isEmphasized: 'white'
     },
     isDisabled: 'disabled',
-    staticColor: {
-      white: {
-        default: baseColor('transparent-white-800'),
-        isSelected: 'black',
-        isDisabled: 'transparent-white-400'
-      },
-      black: {
-        default: baseColor('transparent-black-800'),
-        isSelected: 'white',
-        isDisabled: 'transparent-black-400'
-      }
-    },
+    staticColor: staticColor({
+      default: baseColor('transparent-overlay-800'),
+      isSelected: 'auto',
+      isDisabled: 'transparent-overlay-400'
+    }),
     forcedColors: {
       default: 'ButtonText',
       isSelected: 'HighlightText',
@@ -169,10 +146,7 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: {
-      white: 'white',
-      black: 'black'
-    },
+    staticColor: staticColor('transparent-overlay-1000'),
     forcedColors: 'Highlight'
   },
   borderStyle: 'none',

--- a/packages/@react-spectrum/s2/src/ActionButtonGroup.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButtonGroup.tsx
@@ -36,7 +36,7 @@ export interface ActionButtonGroupProps extends UnsafeStyles, SlotProps {
   /** Whether the buttons should divide the container width equally. */
   isJustified?: boolean,
   /** Whether the button should be displayed with an [emphasized style](https://spectrum.adobe.com/page/action-button/#Emphasis). */
-  staticColor?: 'white' | 'black',
+  staticColor?: 'white' | 'black' | 'auto',
   /**
    * The axis the group should align with.
    * @default 'horizontal'

--- a/packages/@react-spectrum/s2/src/Button.tsx
+++ b/packages/@react-spectrum/s2/src/Button.tsx
@@ -65,8 +65,9 @@ export const ButtonContext = createContext<ContextValue<ButtonProps, FocusableRe
 export const LinkButtonContext = createContext<ContextValue<ButtonProps, FocusableRefValue<HTMLAnchorElement>>>(null);
 
 const iconOnly = ':has([slot=icon]):not(:has([data-rsp-slot=text]))';
-const button = style<ButtonRenderProps & ButtonStyleProps>({
+const button = style<ButtonRenderProps & ButtonStyleProps & {isStaticColor: boolean}>({
   ...focusRing(),
+  ...staticColor(),
   position: 'relative',
   display: 'flex',
   alignItems: {
@@ -120,13 +121,13 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
       secondary: baseColor('gray-300')
     },
     isDisabled: 'disabled',
-    staticColor: staticColor({
+    isStaticColor: {
       variant: {
         primary: baseColor('transparent-overlay-800'),
         secondary: baseColor('transparent-overlay-300')
       },
       isDisabled: 'transparent-overlay-300'
-    }),
+    },
     forcedColors: {
       default: 'ButtonBorder',
       isHovered: 'Highlight',
@@ -152,7 +153,7 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
         isDisabled: 'transparent'
       }
     },
-    staticColor: staticColor({
+    isStaticColor: {
       fillStyle: {
         fill: {
           variant: {
@@ -169,7 +170,7 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
           isDisabled: 'transparent'
         }
       }
-    }),
+    },
     forcedColors: {
       fillStyle: {
         fill: {
@@ -197,7 +198,7 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
         isDisabled: 'disabled'
       }
     },
-    staticColor: staticColor({
+    isStaticColor: {
       fillStyle: {
         fill: {
           variant: {
@@ -208,7 +209,7 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
         outline: baseColor('transparent-overlay-800')
       },
       isDisabled: 'transparent-overlay-400'
-    }),
+    },
     forcedColors: {
       fillStyle: {
         fill: {
@@ -228,7 +229,7 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: staticColor('transparent-overlay-1000'),
+    isStaticColor: 'transparent-overlay-1000',
     forcedColors: 'Highlight'
   },
   forcedColorAdjust: 'none',
@@ -286,7 +287,8 @@ export const Button = forwardRef(function Button(props: ButtonProps, ref: Focusa
         variant,
         fillStyle,
         size,
-        staticColor
+        staticColor,
+        isStaticColor: !!staticColor
       }, props.styles)}>
       <Provider
         values={[
@@ -373,6 +375,7 @@ export const LinkButton = forwardRef(function LinkButton(props: LinkButtonProps,
         fillStyle: props.fillStyle || 'fill',
         size: props.size || 'M',
         staticColor: props.staticColor,
+        isStaticColor: !!props.staticColor,
         isPending: false
       }, props.styles)}>
       <Provider

--- a/packages/@react-spectrum/s2/src/Button.tsx
+++ b/packages/@react-spectrum/s2/src/Button.tsx
@@ -13,7 +13,7 @@
 import {baseColor, focusRing, fontRelative, style} from '../style' with {type: 'macro'};
 import {ButtonRenderProps, ContextValue, Link, LinkProps, OverlayTriggerStateContext, Provider, Button as RACButton, ButtonProps as RACButtonProps} from 'react-aria-components';
 import {centerBaseline} from './CenterBaseline';
-import {centerPadding, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
+import {centerPadding, getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
 import {createContext, forwardRef, ReactNode, useContext, useEffect, useState} from 'react';
 import {FocusableRef, FocusableRefValue} from '@react-types/shared';
 import {IconContext} from './Icon';
@@ -48,7 +48,7 @@ interface ButtonStyleProps {
    */
   size?: 'S' | 'M' | 'L' | 'XL',
   /** The static color style to apply. Useful when the Button appears over a color background. */
-  staticColor?: 'white' | 'black'
+  staticColor?: 'white' | 'black' | 'auto'
 }
 
 export interface ButtonProps extends Omit<RACButtonProps, 'className' | 'style' | 'children' | 'onHover' | 'onHoverStart' | 'onHoverEnd' | 'onHoverChange'>, StyleProps, ButtonStyleProps {
@@ -120,22 +120,13 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
       secondary: baseColor('gray-300')
     },
     isDisabled: 'disabled',
-    staticColor: {
-      white: {
-        variant: {
-          primary: baseColor('transparent-white-800'),
-          secondary: baseColor('transparent-white-300')
-        },
-        isDisabled: 'transparent-white-300'
+    staticColor: staticColor({
+      variant: {
+        primary: baseColor('transparent-overlay-800'),
+        secondary: baseColor('transparent-overlay-300')
       },
-      black: {
-        variant: {
-          primary: baseColor('transparent-black-800'),
-          secondary: baseColor('transparent-black-300')
-        },
-        isDisabled: 'transparent-black-300'
-      }
-    },
+      isDisabled: 'transparent-overlay-300'
+    }),
     forcedColors: {
       default: 'ButtonBorder',
       isHovered: 'Highlight',
@@ -161,44 +152,24 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
         isDisabled: 'transparent'
       }
     },
-    staticColor: {
-      white: {
-        fillStyle: {
-          fill: {
-            variant: {
-              primary: baseColor('transparent-white-800'),
-              secondary: baseColor('transparent-white-100')
-            },
-            isDisabled: 'transparent-white-100'
+    staticColor: staticColor({
+      fillStyle: {
+        fill: {
+          variant: {
+            primary: baseColor('transparent-overlay-800'),
+            secondary: baseColor('transparent-overlay-100')
           },
-          outline: {
-            default: 'transparent',
-            isHovered: 'transparent-white-100',
-            isPressed: 'transparent-white-100',
-            isFocusVisible: 'transparent-white-100',
-            isDisabled: 'transparent'
-          }
-        }
-      },
-      black: {
-        fillStyle: {
-          fill: {
-            variant: {
-              primary: baseColor('transparent-black-800'),
-              secondary: baseColor('transparent-black-100')
-            },
-            isDisabled: 'transparent-black-100'
-          },
-          outline: {
-            default: 'transparent',
-            isHovered: 'transparent-black-100',
-            isPressed: 'transparent-black-100',
-            isFocusVisible: 'transparent-black-100',
-            isDisabled: 'transparent'
-          }
+          isDisabled: 'transparent-overlay-100'
+        },
+        outline: {
+          default: 'transparent',
+          isHovered: 'transparent-overlay-100',
+          isPressed: 'transparent-overlay-100',
+          isFocusVisible: 'transparent-overlay-100',
+          isDisabled: 'transparent'
         }
       }
-    },
+    }),
     forcedColors: {
       fillStyle: {
         fill: {
@@ -226,32 +197,18 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
         isDisabled: 'disabled'
       }
     },
-    staticColor: {
-      white: {
-        fillStyle: {
-          fill: {
-            variant: {
-              primary: 'black',
-              secondary: baseColor('transparent-white-800')
-            }
-          },
-          outline: baseColor('transparent-white-800')
+    staticColor: staticColor({
+      fillStyle: {
+        fill: {
+          variant: {
+            primary: 'auto',
+            secondary: baseColor('transparent-overlay-800')
+          }
         },
-        isDisabled: 'transparent-white-400'
+        outline: baseColor('transparent-overlay-800')
       },
-      black: {
-        fillStyle: {
-          fill: {
-            variant: {
-              primary: 'white',
-              secondary: baseColor('transparent-black-800')
-            }
-          },
-          outline: baseColor('transparent-black-800')
-        },
-        isDisabled: 'transparent-black-400'
-      }
-    },
+      isDisabled: 'transparent-overlay-400'
+    }),
     forcedColors: {
       fillStyle: {
         fill: {
@@ -271,10 +228,7 @@ const button = style<ButtonRenderProps & ButtonStyleProps>({
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: {
-      white: 'white',
-      black: 'black'
-    },
+    staticColor: staticColor('transparent-overlay-1000'),
     forcedColors: 'Highlight'
   },
   forcedColorAdjust: 'none',

--- a/packages/@react-spectrum/s2/src/CloseButton.tsx
+++ b/packages/@react-spectrum/s2/src/CloseButton.tsx
@@ -37,11 +37,12 @@ export interface CloseButtonProps extends Pick<ButtonProps, 'isDisabled'>, Style
 // TODO(design): this is inconsistent with ActionButton
 const hoverBackground = {
   default: 'gray-100',
-  staticColor: staticColor('transparent-overlay-100')
+  isStaticColor: 'transparent-overlay-100'
 } as const;
 
 const styles = style({
   ...focusRing(),
+  ...staticColor(),
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -62,15 +63,15 @@ const styles = style({
     value: {
       default: 'neutral',
       isDisabled: 'disabled',
-      staticColor: staticColor({
+      isStaticColor: {
         default: baseColor('transparent-overlay-800'),
         isDisabled: 'transparent-overlay-400'
-      })
+      }
     }
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: staticColor('transparent-overlay-1000'),
+    isStaticColor: 'transparent-overlay-1000',
     forcedColors: 'Highlight'
   }
 }, getAllowedOverrides());
@@ -92,7 +93,7 @@ export const CloseButton = forwardRef(function CloseButton(props: CloseButtonPro
       slot="close"
       aria-label={stringFormatter.format('dialog.dismiss')}
       style={pressScale(domRef, UNSAFE_style)}
-      className={renderProps => UNSAFE_className + styles({...renderProps, staticColor: props.staticColor}, props.styles)}>
+      className={renderProps => UNSAFE_className + styles({...renderProps, staticColor: props.staticColor, isStaticColor: !!props.staticColor}, props.styles)}>
       <CrossIcon size={({S: 'L', M: 'XL', L: 'XXL', XL: 'XXXL'} as const)[props.size || 'M']} />
     </Button>
   );

--- a/packages/@react-spectrum/s2/src/CloseButton.tsx
+++ b/packages/@react-spectrum/s2/src/CloseButton.tsx
@@ -15,7 +15,7 @@ import {Button, ButtonProps, ContextValue} from 'react-aria-components';
 import {createContext, forwardRef} from 'react';
 import CrossIcon from '../ui-icons/Cross';
 import {FocusableRef, FocusableRefValue} from '@react-types/shared';
-import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
+import {getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {pressScale} from './pressScale';
@@ -31,15 +31,13 @@ export interface CloseButtonProps extends Pick<ButtonProps, 'isDisabled'>, Style
    */
   size?: 'S' | 'M' | 'L' | 'XL',
   /** The static color style to apply. Useful when the Button appears over a color background. */
-  staticColor?: 'white' | 'black'
+  staticColor?: 'white' | 'black' | 'auto'
 }
 
+// TODO(design): this is inconsistent with ActionButton
 const hoverBackground = {
   default: 'gray-100',
-  staticColor: {
-    white: 'transparent-white-100',
-    black: 'transparent-black-100'
-  }
+  staticColor: staticColor('transparent-overlay-100')
 } as const;
 
 const styles = style({
@@ -64,24 +62,15 @@ const styles = style({
     value: {
       default: 'neutral',
       isDisabled: 'disabled',
-      staticColor: {
-        white: {
-          default: baseColor('transparent-white-800'),
-          isDisabled: 'transparent-white-400'
-        },
-        black: {
-          default: baseColor('transparent-black-800'),
-          isDisabled: 'transparent-black-400'
-        }
-      }
+      staticColor: staticColor({
+        default: baseColor('transparent-overlay-800'),
+        isDisabled: 'transparent-overlay-400'
+      })
     }
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: {
-      white: 'white',
-      black: 'black'
-    },
+    staticColor: staticColor('transparent-overlay-1000'),
     forcedColors: 'Highlight'
   }
 }, getAllowedOverrides());

--- a/packages/@react-spectrum/s2/src/Divider.tsx
+++ b/packages/@react-spectrum/s2/src/Divider.tsx
@@ -42,19 +42,20 @@ export interface DividerProps extends DividerSpectrumProps, Omit<RACSeparatorPro
 
 export const DividerContext = createContext<ContextValue<DividerProps, DOMRefValue>>(null);
 
-export const divider = style<DividerSpectrumProps>({
+export const divider = style<DividerSpectrumProps & {isStaticColor: boolean}>({
+  ...staticColor(),
   alignSelf: 'stretch',
   backgroundColor: {
     default: 'gray-200',
     size: {
       L: 'gray-800'
     },
-    staticColor: staticColor({
+    isStaticColor: {
       default: 'transparent-overlay-200',
       size: {
         L: 'transparent-overlay-800'
       }
-    }),
+    },
     forcedColors: 'ButtonBorder'
   },
   borderStyle: 'none',
@@ -101,7 +102,8 @@ export const Divider = /*#__PURE__*/ forwardRef(function Divider(props: DividerP
       className={(props.UNSAFE_className || '') + divider({
         size: props.size || 'M',
         orientation: props.orientation || 'horizontal',
-        staticColor: props.staticColor
+        staticColor: props.staticColor,
+        isStaticColor: !!props.staticColor
       }, props.styles)} />
   );
 });

--- a/packages/@react-spectrum/s2/src/Divider.tsx
+++ b/packages/@react-spectrum/s2/src/Divider.tsx
@@ -13,7 +13,7 @@
 import {ContextValue, Separator as RACSeparator, SeparatorProps as RACSeparatorProps} from 'react-aria-components';
 import {createContext, forwardRef} from 'react';
 import {DOMRef, DOMRefValue} from '@react-types/shared';
-import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
+import {getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
 import {style} from '../style' with {type: 'macro'};
 import {useDOMRef} from '@react-spectrum/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
@@ -34,7 +34,7 @@ interface DividerSpectrumProps {
    */
   orientation?: 'horizontal' | 'vertical',
   /** The static color style to apply. Useful when the Divider appears over a color background. */
-  staticColor?: 'white' | 'black'
+  staticColor?: 'white' | 'black' | 'auto'
 }
 
 // TODO: allow overriding height (only when orientation is vertical)??
@@ -49,20 +49,12 @@ export const divider = style<DividerSpectrumProps>({
     size: {
       L: 'gray-800'
     },
-    staticColor: {
-      white: {
-        default: 'transparent-white-200',
-        size: {
-          L: 'transparent-white-800'
-        }
-      },
-      black: {
-        default: 'transparent-black-200',
-        size: {
-          L: 'transparent-black-800'
-        }
+    staticColor: staticColor({
+      default: 'transparent-overlay-200',
+      size: {
+        L: 'transparent-overlay-800'
       }
-    },
+    }),
     forcedColors: 'ButtonBorder'
   },
   borderStyle: 'none',

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -36,7 +36,7 @@ interface FieldLabelProps extends Omit<LabelProps, 'className' | 'style' | 'chil
   labelAlign?: Alignment,
   labelPosition?: 'top' | 'side',
   includeNecessityIndicatorInAccessibilityName?: boolean,
-  staticColor?: 'white' | 'black',
+  staticColor?: 'white' | 'black' | 'auto',
   contextualHelp?: ReactNode,
   isQuiet?: boolean,
   children?: ReactNode

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -98,7 +98,7 @@ export const FieldLabel = forwardRef(function FieldLabel(props: FieldLabelProps,
         {...labelProps}
         ref={domRef}
         style={UNSAFE_style}
-        className={UNSAFE_className + mergeStyles(style(fieldLabel())({labelPosition, isDisabled, size, staticColor}), props.styles)}>
+        className={UNSAFE_className + mergeStyles(style(fieldLabel())({labelPosition, isDisabled, size, isStaticColor: !!staticColor}), props.styles)}>
         {props.children}
         {(isRequired || necessityIndicator === 'label') && (
           <span className={style({whiteSpace: 'nowrap'})}>

--- a/packages/@react-spectrum/s2/src/Link.tsx
+++ b/packages/@react-spectrum/s2/src/Link.tsx
@@ -40,8 +40,9 @@ export interface LinkProps extends Omit<RACLinkProps, 'isDisabled' | 'className'
 
 export const LinkContext = createContext<ContextValue<LinkProps, FocusableRefValue<HTMLAnchorElement>>>(null);
 
-const link = style<LinkRenderProps & LinkStyleProps & {isSkeleton: boolean}>({
+const link = style<LinkRenderProps & LinkStyleProps & {isSkeleton: boolean, isStaticColor: boolean}>({
   ...focusRing(),
+  ...staticColor(),
   borderRadius: 'sm',
   font: {
     isStandalone: 'ui'
@@ -51,7 +52,7 @@ const link = style<LinkRenderProps & LinkStyleProps & {isSkeleton: boolean}>({
       primary: 'accent',
       secondary: 'neutral' // TODO: should there be an option to inherit from the paragraph? What about hover states?
     },
-    staticColor: staticColor('transparent-overlay-1000'),
+    isStaticColor: 'transparent-overlay-1000',
     forcedColors: 'LinkText'
   },
   transition: 'default',
@@ -71,7 +72,7 @@ const link = style<LinkRenderProps & LinkStyleProps & {isSkeleton: boolean}>({
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: staticColor('transparent-overlay-1000'),
+    isStaticColor: 'transparent-overlay-1000',
     forcedColors: 'Highlight'
   },
   disableTapHighlight: true
@@ -101,7 +102,7 @@ export const Link = /*#__PURE__*/ forwardRef(function Link(props: LinkProps, ref
       {...props}
       ref={domRef}
       style={UNSAFE_style}
-      className={renderProps => UNSAFE_className + link({...renderProps, variant, staticColor, isQuiet, isStandalone, isSkeleton}, styles)}>
+      className={renderProps => UNSAFE_className + link({...renderProps, variant, staticColor, isStaticColor: !!staticColor, isQuiet, isStandalone, isSkeleton}, styles)}>
       {children}
     </RACLink>
   );

--- a/packages/@react-spectrum/s2/src/Link.tsx
+++ b/packages/@react-spectrum/s2/src/Link.tsx
@@ -14,7 +14,7 @@ import {ContextValue, LinkRenderProps, Link as RACLink, LinkProps as RACLinkProp
 import {createContext, forwardRef, ReactNode, useContext} from 'react';
 import {FocusableRef, FocusableRefValue} from '@react-types/shared';
 import {focusRing, style} from '../style' with {type: 'macro'};
-import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
+import {getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
 import {SkeletonContext, useSkeletonText} from './Skeleton';
 import {useFocusableRef} from '@react-spectrum/utils';
 import {useLayoutEffect} from '@react-aria/utils';
@@ -27,7 +27,7 @@ interface LinkStyleProps {
    */
   variant?: 'primary' | 'secondary',
   /** The static color style to apply. Useful when the link appears over a color background. */
-  staticColor?: 'white' | 'black',
+  staticColor?: 'white' | 'black' | 'auto',
   /** Whether the link is on its own vs inside a longer string of text. */
   isStandalone?: boolean,
   /** Whether the link should be displayed with a quiet style. */
@@ -51,10 +51,7 @@ const link = style<LinkRenderProps & LinkStyleProps & {isSkeleton: boolean}>({
       primary: 'accent',
       secondary: 'neutral' // TODO: should there be an option to inherit from the paragraph? What about hover states?
     },
-    staticColor: {
-      white: 'white',
-      black: 'black'
-    },
+    staticColor: staticColor('transparent-overlay-1000'),
     forcedColors: 'LinkText'
   },
   transition: 'default',
@@ -74,10 +71,7 @@ const link = style<LinkRenderProps & LinkStyleProps & {isSkeleton: boolean}>({
   },
   outlineColor: {
     default: 'focus-ring',
-    staticColor: {
-      white: 'white',
-      black: 'black'
-    },
+    staticColor: staticColor('transparent-overlay-1000'),
     forcedColors: 'Highlight'
   },
   disableTapHighlight: true

--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -399,7 +399,7 @@ export function Divider(props: SeparatorProps) {
         divider({
           size: 'M',
           orientation: 'horizontal',
-          staticColor: undefined
+          isStaticColor: false
         }), style({
           display: {
             default: 'grid',

--- a/packages/@react-spectrum/s2/src/Meter.tsx
+++ b/packages/@react-spectrum/s2/src/Meter.tsx
@@ -19,7 +19,7 @@ import {bar, track} from './bar-utils'  with {type: 'macro'};
 import {createContext, forwardRef, ReactNode} from 'react';
 import {DOMRef, DOMRefValue, LabelPosition} from '@react-types/shared';
 import {FieldLabel} from './Field';
-import {fieldLabel, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
+import {fieldLabel, getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
 import {lightDark, style} from '../style' with {type: 'macro'};
 import {SkeletonWrapper} from './Skeleton';
 import {Text} from './Content';
@@ -40,7 +40,7 @@ interface MeterStyleProps {
   /**
    * The static color style to apply. Useful when the button appears over a color background.
    */
-  staticColor?: 'white' | 'black',
+  staticColor?: 'white' | 'black' | 'auto',
   /**
    * The label's overall position relative to the element it is labeling.
    * @default 'top'
@@ -88,15 +88,7 @@ const fillStyles = style<MeterStyleProps>({
       notice: lightDark('notice-800', 'notice-900'), // 'notice-visual',
       negative: lightDark('negative-800', 'negative-900') // 'negative-visual'
     },
-    staticColor: {
-      white: {
-        default: 'transparent-white-900'
-      },
-      // TODO: Is there a black static color in S2?
-      black: {
-        default: 'transparent-black-900'
-      }
-    },
+    staticColor: staticColor('transparent-overlay-900'),
     forcedColors: 'ButtonText'
   }
 });

--- a/packages/@react-spectrum/s2/src/Meter.tsx
+++ b/packages/@react-spectrum/s2/src/Meter.tsx
@@ -19,7 +19,7 @@ import {bar, track} from './bar-utils'  with {type: 'macro'};
 import {createContext, forwardRef, ReactNode} from 'react';
 import {DOMRef, DOMRefValue, LabelPosition} from '@react-types/shared';
 import {FieldLabel} from './Field';
-import {fieldLabel, getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
+import {fieldLabel, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {lightDark, style} from '../style' with {type: 'macro'};
 import {SkeletonWrapper} from './Skeleton';
 import {Text} from './Content';
@@ -77,7 +77,7 @@ const trackStyles = style({
   }
 });
 
-const fillStyles = style<MeterStyleProps>({
+const fillStyles = style<MeterStyleProps & {isStaticColor: boolean}>({
   height: 'full',
   borderStyle: 'none',
   borderRadius: 'full',
@@ -88,7 +88,7 @@ const fillStyles = style<MeterStyleProps>({
       notice: lightDark('notice-800', 'notice-900'), // 'notice-visual',
       negative: lightDark('negative-800', 'negative-900') // 'negative-visual'
     },
-    staticColor: staticColor('transparent-overlay-900'),
+    isStaticColor: 'transparent-overlay-900',
     forcedColors: 'ButtonText'
   }
 });
@@ -112,6 +112,7 @@ export const Meter = forwardRef(function Meter(props: MeterProps, ref: DOMRef<HT
     labelPosition = 'top',
     ...groupProps
   } = props;
+  let isStaticColor = !!staticColor;
 
   return (
     <AriaMeter
@@ -127,10 +128,10 @@ export const Meter = forwardRef(function Meter(props: MeterProps, ref: DOMRef<HT
       {({percentage, valueText}) => (
         <>
           {label && <FieldLabel size={size} labelAlign="start" labelPosition={labelPosition} staticColor={staticColor}>{label}</FieldLabel>}
-          {label && <Text styles={valueStyles({size, labelAlign: 'end', staticColor})}>{valueText}</Text>}
+          {label && <Text styles={valueStyles({size, labelAlign: 'end', isStaticColor})}>{valueText}</Text>}
           <SkeletonWrapper>
-            <div className={trackStyles({staticColor, size})}>
-              <div className={fillStyles({staticColor, variant})} style={{width: percentage + '%'}} />
+            <div className={trackStyles({isStaticColor, size})}>
+              <div className={fillStyles({isStaticColor, variant})} style={{width: percentage + '%'}} />
             </div>
           </SkeletonWrapper>
         </>

--- a/packages/@react-spectrum/s2/src/ProgressBar.tsx
+++ b/packages/@react-spectrum/s2/src/ProgressBar.tsx
@@ -19,7 +19,7 @@ import {bar, track} from './bar-utils'  with {type: 'macro'};
 import {createContext, forwardRef, ReactNode} from 'react';
 import {DOMRef, DOMRefValue, LabelPosition} from '@react-types/shared';
 import {FieldLabel} from './Field';
-import {fieldLabel, getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
+import {fieldLabel, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {keyframes} from '../style/style-macro' with {type: 'macro'};
 import {mergeStyles} from '../style/runtime';
 import {style} from '../style' with {type: 'macro'};
@@ -135,13 +135,13 @@ const trackStyles = style({
   }
 });
 
-const fill = style<ProgressBarStyleProps>({
+const fill = style<ProgressBarStyleProps & {isStaticColor: boolean}>({
   height: 'full',
   borderStyle: 'none',
   borderRadius: 'full',
   backgroundColor: {
     default: 'accent',
-    staticColor: staticColor('transparent-overlay-900'),
+    isStaticColor: 'transparent-overlay-900',
     forcedColors: 'ButtonText'
   },
   width: {
@@ -182,20 +182,21 @@ export const ProgressBar = /*#__PURE__*/ forwardRef(function ProgressBar(props: 
   } = props;
   let domRef = useDOMRef(ref);
   let {direction} = useLocale();
+  let isStaticColor = !!staticColor;
 
   return (
     <AriaProgressBar
       {...props}
       ref={domRef}
       style={UNSAFE_style}
-      className={UNSAFE_className + wrapper({...props, size, labelPosition}, props.styles)}>
+      className={UNSAFE_className + wrapper({...props, size, labelPosition, staticColor}, props.styles)}>
       {({percentage, valueText}) => (
         <>
           {label && <FieldLabel size={size} labelAlign="start" labelPosition={labelPosition} staticColor={staticColor}>{label}</FieldLabel>}
-          {label && !isIndeterminate && <span className={valueStyles({size, labelAlign: 'end', staticColor})}>{valueText}</span>}
-          <div className={trackStyles({...props})}>
+          {label && !isIndeterminate && <span className={valueStyles({size, labelAlign: 'end', isStaticColor})}>{valueText}</span>}
+          <div className={trackStyles({isStaticColor, size})}>
             <div
-              className={mergeStyles(fill({...props, staticColor}), (isIndeterminate ? indeterminateAnimation({direction}) : null))}
+              className={mergeStyles(fill({...props, isStaticColor}), (isIndeterminate ? indeterminateAnimation({direction}) : null))}
               style={{width: isIndeterminate ? undefined : percentage + '%'}} />
           </div>
         </>

--- a/packages/@react-spectrum/s2/src/ProgressBar.tsx
+++ b/packages/@react-spectrum/s2/src/ProgressBar.tsx
@@ -19,7 +19,7 @@ import {bar, track} from './bar-utils'  with {type: 'macro'};
 import {createContext, forwardRef, ReactNode} from 'react';
 import {DOMRef, DOMRefValue, LabelPosition} from '@react-types/shared';
 import {FieldLabel} from './Field';
-import {fieldLabel, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
+import {fieldLabel, getAllowedOverrides, staticColor, StyleProps} from './style-utils' with {type: 'macro'};
 import {keyframes} from '../style/style-macro' with {type: 'macro'};
 import {mergeStyles} from '../style/runtime';
 import {style} from '../style' with {type: 'macro'};
@@ -41,7 +41,7 @@ interface ProgressBarStyleProps {
   /**
    * The static color style to apply. Useful when the button appears over a color background.
    */
-  staticColor?: 'white' | 'black',
+  staticColor?: 'white' | 'black' | 'auto',
   /**
    * The label's overall position relative to the element it is labeling.
    * @default 'top'
@@ -141,15 +141,7 @@ const fill = style<ProgressBarStyleProps>({
   borderRadius: 'full',
   backgroundColor: {
     default: 'accent',
-    staticColor: {
-      white: {
-        default: 'transparent-white-900'
-      },
-      // TODO: Is there a black static color in S2?
-      black: {
-        default: 'transparent-black-900'
-      }
-    },
+    staticColor: staticColor('transparent-overlay-900'),
     forcedColors: 'ButtonText'
   },
   width: {

--- a/packages/@react-spectrum/s2/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/s2/src/ProgressCircle.tsx
@@ -38,6 +38,7 @@ export const ProgressCircleContext = createContext<ContextValue<ProgressCirclePr
 
 // Double check the types passed to each style, may not need all for each
 const wrapper = style<ProgressCircleStyleProps>({
+  ...staticColor(),
   size: {
     default: 32,
     size: {
@@ -48,18 +49,18 @@ const wrapper = style<ProgressCircleStyleProps>({
   aspectRatio: 'square'
 }, getAllowedOverrides({height: true}));
 
-const track = style<ProgressCircleStyleProps>({
+const track = style({
   stroke: {
     default: 'gray-300',
-    staticColor: staticColor('transparent-overlay-300'),
+    isStaticColor: 'transparent-overlay-300',
     forcedColors: 'Background'
   }
 });
 
-const fill = style<ProgressCircleStyleProps>({
+const fill = style({
   stroke: {
     default: 'blue-900',
-    staticColor: staticColor('transparent-overlay-900'),
+    isStaticColor: 'transparent-overlay-900',
     forcedColors: 'Highlight'
   },
   rotate: -90,
@@ -115,6 +116,7 @@ export const ProgressCircle = /*#__PURE__*/ forwardRef(function ProgressCircle(p
 
   // SVG strokes are centered, so subtract half the stroke width from the radius to create an inner stroke.
   let radius = `calc(50% - ${strokeWidth / 2}px)`;
+  let isStaticColor = !!staticColor;
 
   return (
     <RACProgressBar
@@ -123,7 +125,8 @@ export const ProgressCircle = /*#__PURE__*/ forwardRef(function ProgressCircle(p
       style={UNSAFE_style}
       className={renderProps => UNSAFE_className + wrapper({
         ...renderProps,
-        size
+        size,
+        staticColor
       }, props.styles)}>
       {({percentage, isIndeterminate}) => (
         <svg
@@ -135,13 +138,13 @@ export const ProgressCircle = /*#__PURE__*/ forwardRef(function ProgressCircle(p
             cy="50%"
             r={radius}
             strokeWidth={strokeWidth}
-            className={track({staticColor})} />
+            className={track({isStaticColor})} />
           <circle
             cx="50%"
             cy="50%"
             r={radius}
             strokeWidth={strokeWidth}
-            className={fill({staticColor})}
+            className={fill({isStaticColor})}
             style={{
               // These cubic-bezier timing functions were derived from the previous animation keyframes
               // using a best fit algorithm, and then manually adjusted to approximate the original animation.

--- a/packages/@react-spectrum/s2/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/s2/src/ProgressCircle.tsx
@@ -13,7 +13,7 @@
 import {ContextValue, ProgressBar as RACProgressBar, ProgressBarProps as RACProgressBarProps} from 'react-aria-components';
 import {createContext, forwardRef} from 'react';
 import {DOMRef, DOMRefValue} from '@react-types/shared';
-import {getAllowedOverrides, StylesPropWithHeight, UnsafeStyles} from './style-utils' with {type: 'macro'};
+import {getAllowedOverrides, staticColor, StylesPropWithHeight, UnsafeStyles} from './style-utils' with {type: 'macro'};
 import {keyframes} from '../style/style-macro' with {type: 'macro'};
 import {style} from '../style' with {type: 'macro'};
 import {useDOMRef} from '@react-spectrum/utils';
@@ -27,7 +27,7 @@ export interface ProgressCircleStyleProps {
    */
   size?: 'S' | 'M' | 'L',
   /** The static color style to apply. Useful when the button appears over a color background. */
-  staticColor?: 'black' | 'white',
+  staticColor?: 'black' | 'white' | 'auto',
   /**
    * Whether presentation is indeterminate when progress isn't known.
    */
@@ -51,10 +51,7 @@ const wrapper = style<ProgressCircleStyleProps>({
 const track = style<ProgressCircleStyleProps>({
   stroke: {
     default: 'gray-300',
-    staticColor: {
-      white: 'transparent-white-300',
-      black: 'transparent-black-300'
-    },
+    staticColor: staticColor('transparent-overlay-300'),
     forcedColors: 'Background'
   }
 });
@@ -62,10 +59,7 @@ const track = style<ProgressCircleStyleProps>({
 const fill = style<ProgressCircleStyleProps>({
   stroke: {
     default: 'blue-900',
-    staticColor: {
-      white: 'transparent-white-900',
-      black: 'transparent-black-900'
-    },
+    staticColor: staticColor('transparent-overlay-900'),
     forcedColors: 'Highlight'
   },
   rotate: -90,

--- a/packages/@react-spectrum/s2/src/ToggleButton.tsx
+++ b/packages/@react-spectrum/s2/src/ToggleButton.tsx
@@ -65,6 +65,7 @@ export const ToggleButton = forwardRef(function ToggleButton(props: ToggleButton
       className={renderProps => (props.UNSAFE_className || '') + btnStyles({
         ...renderProps,
         staticColor,
+        isStaticColor: !!staticColor,
         size,
         isQuiet,
         isEmphasized,

--- a/packages/@react-spectrum/s2/src/bar-utils.ts
+++ b/packages/@react-spectrum/s2/src/bar-utils.ts
@@ -13,6 +13,7 @@
 import {centerPadding, fieldInput, staticColor} from './style-utils' with {type: 'macro'};
 
 export const bar = () => ({
+  ...staticColor(),
   position: 'relative',
   display: 'grid',
   gridTemplateColumns: {
@@ -64,7 +65,7 @@ export const track = () => ({
   borderRadius: 'full',
   backgroundColor: {
     default: 'gray-300',
-    staticColor: staticColor('transparent-overlay-300'),
+    isStaticColor: 'transparent-overlay-300',
     forcedColors: 'ButtonFace'
   },
   outlineWidth: {

--- a/packages/@react-spectrum/s2/src/bar-utils.ts
+++ b/packages/@react-spectrum/s2/src/bar-utils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {centerPadding, fieldInput} from './style-utils' with {type: 'macro'};
+import {centerPadding, fieldInput, staticColor} from './style-utils' with {type: 'macro'};
 
 export const bar = () => ({
   position: 'relative',
@@ -64,15 +64,7 @@ export const track = () => ({
   borderRadius: 'full',
   backgroundColor: {
     default: 'gray-300',
-    staticColor: {
-      white: {
-        default: 'transparent-white-100'
-      },
-      // TODO: Is there a black static color in S2?
-      black: {
-        default: 'transparent-black-400'
-      }
-    },
+    staticColor: staticColor('transparent-overlay-300'),
     forcedColors: 'ButtonFace'
   },
   outlineWidth: {

--- a/packages/@react-spectrum/s2/src/style-utils.ts
+++ b/packages/@react-spectrum/s2/src/style-utils.ts
@@ -83,14 +83,7 @@ export const fieldLabel = () => ({
   color: {
     default: 'neutral-subdued',
     isDisabled: 'disabled',
-    staticColor: {
-      white: {
-        default: 'transparent-white-700'
-      },
-      black: {
-        default: 'transparent-black-900'
-      }
-    },
+    staticColor: staticColor('transparent-overlay-1000'),
     forcedColors: 'ButtonText'
   }
 } as const);
@@ -130,6 +123,31 @@ export const colorScheme = () => ({
     }
   }
 } as const);
+
+/** Generates all staticColor variants from the auto definition. */
+export function staticColor<T>(auto: T): {auto: T, black: T, white: T} {
+  let process = (val: any, prefix: string) => {
+    if (typeof val === 'string' && val.startsWith('transparent-overlay-')) {
+      return prefix + val.slice('transparent-overlay-'.length);
+    }
+
+    if (typeof val === 'object' && val) {
+      let res = {};
+      for (let key in val) {
+        res[key] = process(val[key], prefix);
+      }
+      return res;
+    }
+
+    return val;
+  };
+
+  return {
+    auto,
+    black: process(auto, 'transparent-black-'),
+    white: process(auto, 'transparent-white-')
+  };
+}
 
 const allowedOverrides = [
   'margin',

--- a/packages/@react-spectrum/s2/src/style-utils.ts
+++ b/packages/@react-spectrum/s2/src/style-utils.ts
@@ -83,7 +83,7 @@ export const fieldLabel = () => ({
   color: {
     default: 'neutral-subdued',
     isDisabled: 'disabled',
-    staticColor: staticColor('transparent-overlay-1000'),
+    isStaticColor: 'transparent-overlay-1000',
     forcedColors: 'ButtonText'
   }
 } as const);
@@ -124,29 +124,18 @@ export const colorScheme = () => ({
   }
 } as const);
 
-/** Generates all staticColor variants from the auto definition. */
-export function staticColor<T>(auto: T): {auto: T, black: T, white: T} {
-  let process = (val: any, prefix: string) => {
-    if (typeof val === 'string' && val.startsWith('transparent-overlay-')) {
-      return prefix + val.slice('transparent-overlay-'.length);
-    }
-
-    if (typeof val === 'object' && val) {
-      let res = {};
-      for (let key in val) {
-        res[key] = process(val[key], prefix);
-      }
-      return res;
-    }
-
-    return val;
-  };
-
+export function staticColor() {
   return {
-    auto,
-    black: process(auto, 'transparent-black-'),
-    white: process(auto, 'transparent-white-')
-  };
+    '--s2-container-bg': {
+      type: 'backgroundColor',
+      value: {
+        staticColor: {
+          black: 'white',
+          white: 'black'
+        }
+      }
+    }
+  } as const;
 }
 
 const allowedOverrides = [

--- a/packages/@react-spectrum/s2/stories/Link.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Link.stories.tsx
@@ -40,7 +40,7 @@ export const Inline = (args: any) => (
       font: 'body',
       color: {
         default: 'body',
-        staticColor: {white: 'white', black: 'black'}
+        staticColor: {white: 'white', black: 'black', auto: 'auto'}
       }
     })({staticColor: args.staticColor})}>
     Checkbox groups should use <Link {...args}>help text</Link> for error messaging and descriptions. Descriptions are valuable for giving context.

--- a/packages/@react-spectrum/s2/stories/ProgressCircle.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ProgressCircle.stories.tsx
@@ -37,7 +37,7 @@ export const Example: Story = {
   argTypes: {
     staticColor: {
       control: 'select',
-      options: [undefined, 'white', 'black']
+      options: [undefined, 'white', 'black', 'auto']
     },
     value: {
       control: {

--- a/packages/@react-spectrum/s2/stories/utils.tsx
+++ b/packages/@react-spectrum/s2/stories/utils.tsx
@@ -11,9 +11,10 @@
  */
 
 
-import {ReactNode} from 'react';
+import {ReactNode, useState} from 'react';
+import {style} from '../style' with {type: 'macro'};
 
-type StaticColor = 'black' | 'white' | undefined;
+type StaticColor = 'black' | 'white' | 'auto' | undefined;
 
 function getBackgroundColor(staticColor: StaticColor) {
   if (staticColor === 'black') {
@@ -23,8 +24,38 @@ function getBackgroundColor(staticColor: StaticColor) {
   }
   return undefined;
 }
+
 export function StaticColorProvider(props: {children: ReactNode, staticColor?: StaticColor}) {
-  return <div style={{padding: 8, background: getBackgroundColor(props.staticColor)}}>{props.children}</div>;
+  let [autoBg, setAutoBg] = useState('#5131c4');
+  return (
+    <>
+      <div
+        style={{
+          padding: 8,
+          // @ts-ignore
+          '--s2-container-bg': props.staticColor === 'auto' ? autoBg : undefined,
+          background: props.staticColor === 'auto' ? autoBg : getBackgroundColor(props.staticColor)
+        }}>
+        {props.children}
+      </div>
+      {props.staticColor === 'auto' && (
+        <label 
+          className={style({
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginTop: 16,
+            font: 'ui'
+          })}>
+          Background:
+          <input
+            type="color"
+            value={autoBg}
+            onChange={e => setAutoBg(e.target.value)} />
+        </label>
+      )}
+    </>
+  );
 }
 
 export const StaticColorDecorator = (Story: any, {args}: any) => (

--- a/packages/@react-spectrum/s2/style/spectrum-theme.ts
+++ b/packages/@react-spectrum/s2/style/spectrum-theme.ts
@@ -11,8 +11,8 @@
  */
 
 import {ArbitraryValue, CSSValue, PropertyValueMap} from './types';
+import {autoStaticColor, colorScale, colorToken, fontSizeToken, generateOverlayColorScale, getToken, simpleColorScale, weirdColorToken} from './tokens' with {type: 'macro'};
 import {Color, createArbitraryProperty, createColorProperty, createMappedProperty, createRenamedProperty, createSizingProperty, createTheme, parseArbitraryValue} from './style-macro';
-import {colorScale, colorToken, fontSizeToken, getToken, simpleColorScale, weirdColorToken} from './tokens' with {type: 'macro'};
 import type * as CSS from 'csstype';
 
 interface MacroContext {
@@ -59,6 +59,7 @@ const color = {
 
   ...simpleColorScale('transparent-white'),
   ...simpleColorScale('transparent-black'),
+  ...generateOverlayColorScale(),
 
   // High contrast mode.
   Background: 'Background',
@@ -458,7 +459,8 @@ export const style = createTheme({
       title: colorToken('title-color'),
       body: colorToken('body-color'),
       detail: colorToken('detail-color'),
-      code: colorToken('code-color')
+      code: colorToken('code-color'),
+      auto: autoStaticColor('self(backgroundColor, var(--s2-container-bg))')
     }),
     backgroundColor: createColorProperty({
       ...color,

--- a/packages/@react-spectrum/s2/style/tokens.ts
+++ b/packages/@react-spectrum/s2/style/tokens.ts
@@ -52,6 +52,36 @@ export function simpleColorScale<S extends string>(scale: S): Record<Extract<key
   return res;
 }
 
+function extractOpacity(color: string): number {
+  return Number(color.match(/^rgba\(\d+, \d+, \d+, ([.\d]+)\)$/)?.[1] ?? 1);
+}
+
+/** 
+ * This swaps between white or black based on the background color.
+ * After testing against all RGB background colors, 49.44 minimizes the number of WCAG 4.5:1 contrast failures.
+ */
+export function autoStaticColor(bg = 'var(--s2-container-bg)', alpha = 1) {
+  return `lch(from ${bg} calc((49.44 - l) * infinity) 0 0 / ${alpha})`;
+}
+
+export function generateOverlayColorScale(bg = 'var(--s2-container-bg)') {
+  return {
+    'transparent-overlay-25': autoStaticColor(bg, extractOpacity(getToken('transparent-white-25'))),
+    'transparent-overlay-50': autoStaticColor(bg, extractOpacity(getToken('transparent-white-50'))),
+    'transparent-overlay-75': autoStaticColor(bg, extractOpacity(getToken('transparent-white-75'))),
+    'transparent-overlay-100': autoStaticColor(bg, extractOpacity(getToken('transparent-white-100'))),
+    'transparent-overlay-200': autoStaticColor(bg, extractOpacity(getToken('transparent-white-200'))),
+    'transparent-overlay-300': autoStaticColor(bg, extractOpacity(getToken('transparent-white-300'))),
+    'transparent-overlay-400': autoStaticColor(bg, extractOpacity(getToken('transparent-white-400'))),
+    'transparent-overlay-500': autoStaticColor(bg, extractOpacity(getToken('transparent-white-500'))),
+    'transparent-overlay-600': autoStaticColor(bg, extractOpacity(getToken('transparent-white-600'))),
+    'transparent-overlay-700': autoStaticColor(bg, extractOpacity(getToken('transparent-white-700'))),
+    'transparent-overlay-800': autoStaticColor(bg, extractOpacity(getToken('transparent-white-800'))),
+    'transparent-overlay-900': autoStaticColor(bg, extractOpacity(getToken('transparent-white-900'))),
+    'transparent-overlay-1000': autoStaticColor(bg, extractOpacity(getToken('transparent-white-1000')))
+  };
+}
+
 function pxToRem(px: string | number) {
   if (typeof px === 'string') {
     px = parseFloat(px);


### PR DESCRIPTION
This adds a new `staticColor="auto"` variant, alongside the existing white and black options. The auto variant automatically swaps between white and black based on the background color of the container it is placed within. The container must have the `--s2-container-bg` variable set for this to work, which we already set on the page, and in components like cards, modals, and popovers.

In the style macro theme, there is a new `transparent-overlay` series of colors at varying levels of opacity, which matches the `transparent-black` and `transparent-white` series but with a calc to automatically swap between them.

The `color` property also supports an `auto` option that does the same thing, but also includes `self(backgroundColor)` in addition to `var(--s2-container-bg)` so that it is based on the element's own background in addition to the ancestor container. We could potentially include `auto` as an alias for `transparent-overlay-1000` across all properties, but it would not make sense to include the element's own background color for most CSS properties other than `color` I think.