### PR TITLE
fix: Fix Talkback focus cursor movement when inside Dialogs

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -376,13 +376,12 @@ function useFocusContainment(scopeRef: RefObject<Element[] | null>, contain?: bo
     };
 
     let onBlur = (e) => {
-      // Firefox doesn't shift focus back to the Dialog properly without this
+      // Use raf to delay long enough that subdialogs will fully unmount and not move focus away from parent menu's hovered item that triggered the close
       if (raf.current) {
         cancelAnimationFrame(raf.current);
       }
       raf.current = requestAnimationFrame(() => {
-        // Use document.activeElement instead of e.relatedTarget so we can tell if user clicked into iframe
-        if (ownerDocument.activeElement && shouldContainFocus(scopeRef) && !isElementInChildScope(ownerDocument.activeElement, scopeRef)) {
+        if (e.relatedTarget && shouldContainFocus(scopeRef) && !isElementInChildScope(e.relatedTarget, scopeRef)) {
           activeScope = scopeRef;
           if (ownerDocument.body.contains(e.target)) {
             focusedNode.current = e.target;

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -171,7 +171,7 @@ function renderIframe({width = 'auto', isDismissable = undefined, ...props}) {
             <Header>The Header</Header>
             <Divider />
             <Content>
-              <iframe width="100%" tabIndex={-1} title="textfield iframe" src="iframe.html?providerSwitcher-express=false&providerSwitcher-toastPosition=bottom&viewMode=story&id=textfield--default" />
+              <iframe width="100%" title="textfield iframe" src="iframe.html?providerSwitcher-express=false&providerSwitcher-toastPosition=bottom&viewMode=story&id=textfield--default" />
             </Content>
             {!isDismissable &&
               <ButtonGroup>

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -171,7 +171,7 @@ function renderIframe({width = 'auto', isDismissable = undefined, ...props}) {
             <Header>The Header</Header>
             <Divider />
             <Content>
-              <iframe width="100%" title="textfield iframe" src="iframe.html?providerSwitcher-express=false&providerSwitcher-toastPosition=bottom&viewMode=story&id=textfield--default" />
+              <iframe width="100%" title="wikipedia" src="https://wikipedia.org/wiki/Main_Page" />
             </Content>
             {!isDismissable &&
               <ButtonGroup>

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -171,7 +171,7 @@ function renderIframe({width = 'auto', isDismissable = undefined, ...props}) {
             <Header>The Header</Header>
             <Divider />
             <Content>
-              <iframe width="100%" title="wikipedia" src="https://wikipedia.org/wiki/Main_Page" />
+              <iframe width="100%" tabIndex={-1} title="textfield iframe" src="iframe.html?providerSwitcher-express=false&providerSwitcher-toastPosition=bottom&viewMode=story&id=textfield--default" />
             </Content>
             {!isDismissable &&
               <ButtonGroup>

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -1123,4 +1123,3 @@ AriaMenuTests({
     )
   }
 });
-


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7471

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

 Test the RAC Modal example in the docs with Talkback and make sure you can still move focus around via swipes. Will need smoke tests in general to make sure nothing else is broken, note that anything use case that would restore focus if focus escaped focus containment won't work in Android Chrome Talkback

## 🧢 Your Project:

RSP
