### PR TITLE
fix: make empty SlotsProvider context stable

### DIFF
--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -67,7 +67,6 @@ export function ClearSlots(props) {
       content = React.cloneElement(React.Children.only(children), otherProps);
     }
   }
-
   return (
     <SlotContext.Provider value={emptyObj}>
       {content}

--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -61,16 +61,12 @@ export function ClearSlots(props) {
 
   const emptyObj = useMemo(() => ({}), []);
 
-  const content = useMemo(() => {
-    let content = children;
-    if (React.Children.toArray(children).length <= 1) {
-      if (typeof children === 'function') { // need to know if the node is a string or something else that react can render that doesn't get props
-        content = React.cloneElement(React.Children.only(children), otherProps);
-      }
+  let content = children;
+  if (React.Children.toArray(children).length <= 1) {
+    if (typeof children === 'function') { // need to know if the node is a string or something else that react can render that doesn't get props
+      content = React.cloneElement(React.Children.only(children), otherProps);
     }
-
-    return content;
-  }, [children, otherProps]);
+  }
 
   return (
     <SlotContext.Provider value={emptyObj}>

--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -34,10 +34,11 @@ export function cssModuleToSlots(cssModule) {
   }, {});
 }
 
+const emptyObj = {};
 export function SlotProvider(props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  let parentSlots = useContext(SlotContext) || {};
-  let {slots = {}, children} = props;
+  let parentSlots = useContext(SlotContext) || emptyObj;
+  let {slots = emptyObj, children} = props;
 
   // Merge props for each slot from parent context and props
   let value = useMemo(() =>
@@ -57,14 +58,20 @@ export function SlotProvider(props) {
 
 export function ClearSlots(props) {
   let {children, ...otherProps} = props;
-  let content = children;
-  if (React.Children.toArray(children).length <= 1) {
-    if (typeof children === 'function') { // need to know if the node is a string or something else that react can render that doesn't get props
-      content = React.cloneElement(React.Children.only(children), otherProps);
+
+  const content = useMemo(() => {
+    let content = children;
+    if (React.Children.toArray(children).length <= 1) {
+      if (typeof children === 'function') { // need to know if the node is a string or something else that react can render that doesn't get props
+        content = React.cloneElement(React.Children.only(children), otherProps);
+      }
     }
-  }
+
+    return content;
+  }, [children, otherProps]);
+
   return (
-    <SlotContext.Provider value={{}}>
+    <SlotContext.Provider value={emptyObj}>
       {content}
     </SlotContext.Provider>
   );

--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -34,8 +34,8 @@ export function cssModuleToSlots(cssModule) {
   }, {});
 }
 
-const emptyObj = {};
 export function SlotProvider(props) {
+  const emptyObj = useMemo(() => ({}), []);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   let parentSlots = useContext(SlotContext) || emptyObj;
   let {slots = emptyObj, children} = props;
@@ -58,6 +58,8 @@ export function SlotProvider(props) {
 
 export function ClearSlots(props) {
   let {children, ...otherProps} = props;
+
+  const emptyObj = useMemo(() => ({}), []);
 
   const content = useMemo(() => {
     let content = children;

--- a/packages/@react-spectrum/utils/test/Slots.test.js
+++ b/packages/@react-spectrum/utils/test/Slots.test.js
@@ -11,8 +11,8 @@
  */
 
 import {pointerMap, render} from '@react-spectrum/test-utils-internal';
-import React, {useRef} from 'react';
-import {SlotProvider, useSlotProps} from '../';
+import React, {useEffect, useRef} from 'react';
+import {ClearSlots, SlotProvider, useSlotProps} from '../';
 import {useId, useSlotId} from '@react-aria/utils';
 import {usePress} from '@react-aria/interactions';
 import userEvent from '@testing-library/user-event';
@@ -190,4 +190,92 @@ describe('Slots', function () {
     expect(getByRole('presentation')).toHaveAttribute('aria-controls', id);
   });
 
+
+  it("does not rerender slots consumers when the slot provider rerenders with stable values", function () {
+    let slots = {
+      slotname: {label: 'foo'}
+    };
+    let renderCount = 0;
+
+    const TestComponent = (props) => {
+      useSlotProps(props, "slotname")
+      React.useEffect(() => {
+        renderCount++;
+      });
+
+      return <p>test component</p>;
+    };
+
+    const MemoizedComponent = React.memo(function MemoizedComponent(props) {
+      return props.children;
+    });
+
+    const FullComponentTree = () => {
+      const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, [])
+
+      return (
+        <SlotProvider>
+          <MemoizedComponent>
+            {StableTestComponent}
+          </MemoizedComponent>
+        </SlotProvider>
+      );
+    }
+
+    const { rerender } = render(
+      <FullComponentTree slots={slots} />
+    );
+    
+    // Trigger a rerender with the same stable props
+    rerender(
+     <FullComponentTree slots={slots} />
+    );
+    
+    expect(renderCount).toBe(1);
+  });
+
+  it("does not rerender slots consumers when <ClearSlot /> wrapper is placed between SlotProvider and Consumer", function () {
+    let slots = {
+      slotname: {label: 'foo'}
+    };
+    let renderCount = 0;
+
+    const TestComponent = (props) => {
+      useSlotProps(props, "slotname")
+      React.useEffect(() => {
+        renderCount++;
+      });
+
+      return <p>test component</p>;
+    };
+
+    const MemoizedComponent = React.memo(function MemoizedComponent(props) {
+      return props.children;
+    });
+
+    const FullComponentTree = () => {
+      const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, [])
+
+      return (
+        <SlotProvider>
+          <MemoizedComponent>
+            <ClearSlots>
+              {StableTestComponent}
+            </ClearSlots>
+          </MemoizedComponent>
+        </SlotProvider>
+      );
+    }
+
+    const { rerender } = render(
+      <FullComponentTree slots={slots} />
+    );
+    
+    // Trigger a rerender with the same stable props
+    rerender(
+     <FullComponentTree slots={slots} />
+    );
+    
+    expect(renderCount).toBe(1);
+  });
 });

--- a/packages/@react-spectrum/utils/test/Slots.test.js
+++ b/packages/@react-spectrum/utils/test/Slots.test.js
@@ -17,7 +17,6 @@ import {useId, useSlotId} from '@react-aria/utils';
 import {usePress} from '@react-aria/interactions';
 import userEvent from '@testing-library/user-event';
 
-
 describe('Slots', function () {
   let results = {};
 

--- a/packages/@react-spectrum/utils/test/Slots.test.js
+++ b/packages/@react-spectrum/utils/test/Slots.test.js
@@ -12,10 +12,11 @@
 
 import {ClearSlots, SlotProvider, useSlotProps} from '../';
 import {pointerMap, render} from '@react-spectrum/test-utils-internal';
-import React, {useRef} from 'react';
+import React, {StrictMode, useRef} from 'react';
 import {useId, useSlotId} from '@react-aria/utils';
 import {usePress} from '@react-aria/interactions';
 import userEvent from '@testing-library/user-event';
+
 
 describe('Slots', function () {
   let results = {};
@@ -190,7 +191,8 @@ describe('Slots', function () {
     expect(getByRole('presentation')).toHaveAttribute('aria-controls', id);
   });
 
-
+  // tests are wrapped in strict mode so renders are double what you'd typically expect
+  const STRICT_MODE_RENDER_MULTIPLIER = 2;
   it('does not rerender slots consumers when the slot provider rerenders with stable values', function () {
     let slots = {
       slotname: {label: 'foo'}
@@ -214,11 +216,13 @@ describe('Slots', function () {
       const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, []);
 
       return (
-        <SlotProvider>
-          <MemoizedComponent>
-            {StableTestComponent}
-          </MemoizedComponent>
-        </SlotProvider>
+        <StrictMode>
+          <SlotProvider>
+            <MemoizedComponent>
+              {StableTestComponent}
+            </MemoizedComponent>
+          </SlotProvider>
+        </StrictMode>
       );
     };
 
@@ -231,7 +235,7 @@ describe('Slots', function () {
       <FullComponentTree slots={slots} />
     );
     
-    expect(renderCount).toBe(1);
+    expect(renderCount).toBe(1 * STRICT_MODE_RENDER_MULTIPLIER);
   });
 
   it('does not rerender slots consumers when <ClearSlot /> wrapper is placed between SlotProvider and Consumer', function () {
@@ -257,13 +261,15 @@ describe('Slots', function () {
       const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, []);
 
       return (
-        <SlotProvider>
-          <MemoizedComponent>
-            <ClearSlots>
-              {StableTestComponent}
-            </ClearSlots>
-          </MemoizedComponent>
-        </SlotProvider>
+        <StrictMode>
+          <SlotProvider>
+            <MemoizedComponent>
+              <ClearSlots>
+                {StableTestComponent}
+              </ClearSlots>
+            </MemoizedComponent>
+          </SlotProvider>
+        </StrictMode>
       );
     };
 
@@ -276,6 +282,6 @@ describe('Slots', function () {
       <FullComponentTree slots={slots} />
     );
     
-    expect(renderCount).toBe(1);
+    expect(renderCount).toBe(1 * STRICT_MODE_RENDER_MULTIPLIER);
   });
 });

--- a/packages/@react-spectrum/utils/test/Slots.test.js
+++ b/packages/@react-spectrum/utils/test/Slots.test.js
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {pointerMap, render} from '@react-spectrum/test-utils-internal';
-import React, {useEffect, useRef} from 'react';
 import {ClearSlots, SlotProvider, useSlotProps} from '../';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
+import React, {useRef} from 'react';
 import {useId, useSlotId} from '@react-aria/utils';
 import {usePress} from '@react-aria/interactions';
 import userEvent from '@testing-library/user-event';
@@ -191,14 +191,14 @@ describe('Slots', function () {
   });
 
 
-  it("does not rerender slots consumers when the slot provider rerenders with stable values", function () {
+  it('does not rerender slots consumers when the slot provider rerenders with stable values', function () {
     let slots = {
       slotname: {label: 'foo'}
     };
     let renderCount = 0;
 
     const TestComponent = (props) => {
-      useSlotProps(props, "slotname")
+      useSlotProps(props, 'slotname');
       React.useEffect(() => {
         renderCount++;
       });
@@ -211,7 +211,7 @@ describe('Slots', function () {
     });
 
     const FullComponentTree = () => {
-      const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, [])
+      const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, []);
 
       return (
         <SlotProvider>
@@ -220,28 +220,28 @@ describe('Slots', function () {
           </MemoizedComponent>
         </SlotProvider>
       );
-    }
+    };
 
-    const { rerender } = render(
+    const {rerender} = render(
       <FullComponentTree slots={slots} />
     );
     
     // Trigger a rerender with the same stable props
     rerender(
-     <FullComponentTree slots={slots} />
+      <FullComponentTree slots={slots} />
     );
     
     expect(renderCount).toBe(1);
   });
 
-  it("does not rerender slots consumers when <ClearSlot /> wrapper is placed between SlotProvider and Consumer", function () {
+  it('does not rerender slots consumers when <ClearSlot /> wrapper is placed between SlotProvider and Consumer', function () {
     let slots = {
       slotname: {label: 'foo'}
     };
     let renderCount = 0;
 
     const TestComponent = (props) => {
-      useSlotProps(props, "slotname")
+      useSlotProps(props, 'slotname');
       React.useEffect(() => {
         renderCount++;
       });
@@ -254,7 +254,7 @@ describe('Slots', function () {
     });
 
     const FullComponentTree = () => {
-      const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, [])
+      const StableTestComponent = React.useMemo(() => <TestComponent prop1="value1" />, []);
 
       return (
         <SlotProvider>
@@ -265,15 +265,15 @@ describe('Slots', function () {
           </MemoizedComponent>
         </SlotProvider>
       );
-    }
+    };
 
-    const { rerender } = render(
+    const {rerender} = render(
       <FullComponentTree slots={slots} />
     );
     
     // Trigger a rerender with the same stable props
     rerender(
-     <FullComponentTree slots={slots} />
+      <FullComponentTree slots={slots} />
     );
     
     expect(renderCount).toBe(1);

--- a/packages/@react-spectrum/utils/test/Slots.test.js
+++ b/packages/@react-spectrum/utils/test/Slots.test.js
@@ -190,8 +190,6 @@ describe('Slots', function () {
     expect(getByRole('presentation')).toHaveAttribute('aria-controls', id);
   });
 
-  // tests are wrapped in strict mode so renders are double what you'd typically expect
-  const STRICT_MODE_RENDER_MULTIPLIER = 2;
   it('does not rerender slots consumers when the slot provider rerenders with stable values', function () {
     let slots = {
       slotname: {label: 'foo'}
@@ -228,13 +226,15 @@ describe('Slots', function () {
     const {rerender} = render(
       <FullComponentTree slots={slots} />
     );
+
+    let renderCountBeforeRerender = renderCount;
     
     // Trigger a rerender with the same stable props
     rerender(
       <FullComponentTree slots={slots} />
     );
     
-    expect(renderCount).toBe(1 * STRICT_MODE_RENDER_MULTIPLIER);
+    expect(renderCount).toEqual(renderCountBeforeRerender);
   });
 
   it('does not rerender slots consumers when <ClearSlot /> wrapper is placed between SlotProvider and Consumer', function () {
@@ -275,12 +275,14 @@ describe('Slots', function () {
     const {rerender} = render(
       <FullComponentTree slots={slots} />
     );
+
+    let renderCountBeforeRerender = renderCount;
     
     // Trigger a rerender with the same stable props
     rerender(
       <FullComponentTree slots={slots} />
     );
     
-    expect(renderCount).toBe(1 * STRICT_MODE_RENDER_MULTIPLIER);
+    expect(renderCount).toEqual(renderCountBeforeRerender);
   });
 });


### PR DESCRIPTION
In many cases when SlotsProvider rerenders it triggers all context consumers in its subtree to rerender too even when the context value hasn't changed.

We have a drag to resize type interaction that was triggering all View and ActionGroup components to rerender on each update. I tracked it down to these two components using useSlotProps which reads from context. SlotsProvider rerendering doesn't keep a stable context value because it creates a new empty object each time.

I verified that this change stopped triggering these renders and reduced render time from 28ms to .5ms with 30-40 SlotsConsumers (through useSlotProps hook) in subtree. Exact savings will depend entirely on how many slot consumers are in the subtree and how expensive they are to render.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

New unit tests will fail against main branch

## 🧢 Your Project:
