### PR TITLE
fix: Tabs infinite loop

### DIFF
--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -461,6 +461,10 @@ let HiddenTabs = function (props: {
         opacity: 0
       })}>
       {items.map((item) => {
+        if (typeof item.props.className !== 'function') {
+          console.log(item.props);
+          return null;
+        }
         // pull off individual props as an allow list, don't want refs or other props getting through
         return (
           <div
@@ -543,8 +547,9 @@ function CollapsingCollection({children, containerRef}) {
       _setShowItems(value);
     }
   }, [orientation]);
+  let ctx = useMemo(() => ({containerRef, showItems: orientation === 'vertical' ? true : showItems, setShowItems}), [containerRef, showItems, setShowItems]);
   return (
-    <CollapseContext.Provider value={{containerRef, showItems: orientation === 'vertical' ? true : showItems, setShowItems}}>
+    <CollapseContext.Provider value={ctx}>
       <UNSTABLE_CollectionRendererContext.Provider value={CollapsingCollectionRenderer}>
         {children}
       </UNSTABLE_CollectionRendererContext.Provider>
@@ -605,6 +610,8 @@ let useCollectionRender = (collection: Collection<Node<unknown>>) => {
     document.fonts?.ready.then(() => updateOverflow());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  console.log('collection renderer called')
 
   return (
     <>

--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -461,10 +461,6 @@ let HiddenTabs = function (props: {
         opacity: 0
       })}>
       {items.map((item) => {
-        if (typeof item.props.className !== 'function') {
-          console.log(item.props);
-          return null;
-        }
         // pull off individual props as an allow list, don't want refs or other props getting through
         return (
           <div
@@ -547,7 +543,11 @@ function CollapsingCollection({children, containerRef}) {
       _setShowItems(value);
     }
   }, [orientation]);
-  let ctx = useMemo(() => ({containerRef, showItems: orientation === 'vertical' ? true : showItems, setShowItems}), [containerRef, showItems, setShowItems]);
+  let ctx = useMemo(() => ({
+    containerRef,
+    showItems: orientation === 'vertical' ? true : showItems,
+    setShowItems
+  }), [containerRef, showItems, setShowItems]);
   return (
     <CollapseContext.Provider value={ctx}>
       <UNSTABLE_CollectionRendererContext.Provider value={CollapsingCollectionRenderer}>
@@ -610,8 +610,6 @@ let useCollectionRender = (collection: Collection<Node<unknown>>) => {
     document.fonts?.ready.then(() => updateOverflow());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  console.log('collection renderer called')
 
   return (
     <>

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, forwardRefType, HoverEvents, Key, LinkDOMProps, RefObject} from '@react-types/shared';
 import {AriaTabListProps, AriaTabPanelProps, mergeProps, Orientation, useFocusRing, useHover, useTab, useTabList, useTabPanel} from 'react-aria';
 import {Collection, CollectionBuilder, createHideableComponent, createLeafComponent} from '@react-aria/collections';
-import {CollectionProps, CollectionRendererContext, usePersistedKeys} from './Collection';
+import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, usePersistedKeys} from './Collection';
 import {ContextValue, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlottedContext} from './utils';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {Collection as ICollection, Node, TabListState, useTabListState} from 'react-stately';
@@ -330,7 +330,9 @@ export const TabPanel = /*#__PURE__*/ createHideableComponent(function TabPanel(
           [TabsContext, null],
           [TabListStateContext, null]
         ]}>
-        {renderProps.children}
+        <CollectionRendererContext.Provider value={DefaultCollectionRenderer}>
+          {renderProps.children}
+        </CollectionRendererContext.Provider>
       </Provider>
     </div>
   );


### PR DESCRIPTION
Closes <!-- Github issue # here -->

An infinite loop and wrong items in the tablist could occur if a collection was provided as a child of the TabPanel because we provide a Custom Collection Renderer context, which was leaking down into the TabPanels children. This stops that from happening unintentionally

This could be observed in the S2 Popover story for 'control center' where a menu was used inside a tabpanel

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
