### PR TITLE
for react 19

### DIFF
--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -70,7 +70,7 @@
     "client-only": "^0.0.1",
     "react-aria": "^3.36.0",
     "react-stately": "^3.34.0",
-    "use-sync-external-store": "^1.2.0"
+    "use-sync-external-store": "^1.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",


### PR DESCRIPTION
the peerDependencies of use-sync-external-store 1.4.0 is "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
