### PR TITLE
fix(S2): ContextualHelp in Field wrapping to new line

### DIFF
--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -76,7 +76,6 @@ export const FieldLabel = forwardRef(function FieldLabel(props: FieldLabelProps,
       className={style({
         gridArea: 'label',
         display: 'inline',
-        whiteSpace: 'nowrap',
         textAlign: {
           labelAlign: {
             start: 'start',
@@ -128,21 +127,24 @@ export const FieldLabel = forwardRef(function FieldLabel(props: FieldLabelProps,
         )}
       </Label>
       {contextualHelp && (
-        <CenterBaseline
-          styles={style({
-            display: 'inline-flex',
-            height: 0,
-            marginStart: 4
-          })}>
-          <ContextualHelpContext.Provider
-            value={{
-              id: contextualHelpId,
-              'aria-labelledby': labelProps?.id ? `${labelProps.id} ${contextualHelpId}` : undefined,
-              size: (size === 'L' || size === 'XL') ? 'S' : 'XS'
-            }}>
-            {contextualHelp}
-          </ContextualHelpContext.Provider>
-        </CenterBaseline>
+        <span className={style({whiteSpace: 'nowrap'})}>
+          &nbsp;
+          <CenterBaseline
+            styles={style({
+              display: 'inline-flex',
+              height: 0,
+              marginStart: 4
+            })}>
+            <ContextualHelpContext.Provider
+              value={{
+                id: contextualHelpId,
+                'aria-labelledby': labelProps?.id ? `${labelProps.id} ${contextualHelpId}` : undefined,
+                size: (size === 'L' || size === 'XL') ? 'S' : 'XS'
+              }}>
+              {contextualHelp}
+            </ContextualHelpContext.Provider>
+          </CenterBaseline>
+        </span>
       )}
     </div>
   );

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -76,6 +76,7 @@ export const FieldLabel = forwardRef(function FieldLabel(props: FieldLabelProps,
       className={style({
         gridArea: 'label',
         display: 'inline',
+        whiteSpace: 'nowrap',
         textAlign: {
           labelAlign: {
             start: 'start',

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -132,8 +132,7 @@ export const FieldLabel = forwardRef(function FieldLabel(props: FieldLabelProps,
           <CenterBaseline
             styles={style({
               display: 'inline-flex',
-              height: 0,
-              marginStart: 4
+              height: 0
             })}>
             <ContextualHelpContext.Provider
               value={{


### PR DESCRIPTION
In small width fields, the ContextualHelp would wrap to a new line if the widest checkbox item was smaller than the Label + ContextualHelp. 

Before:

<img width="135" alt="Contextual help wrapping to new line" src="https://github.com/user-attachments/assets/12a08b49-94d6-407a-9597-4fa8a213cab0">

After:

<img width="157" alt="Contextual help on same line as last line for label" src="https://github.com/user-attachments/assets/404b40d0-a7fd-48be-85af-cbb55162f5a9" />




## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
