### PR TITLE
fix: S2 menu press scaling

### DIFF
--- a/packages/@react-aria/utils/src/useGlobalListeners.ts
+++ b/packages/@react-aria/utils/src/useGlobalListeners.ts
@@ -29,7 +29,7 @@ export function useGlobalListeners(): GlobalListeners {
       listener(...args);
     } : listener;
     globalListeners.current.set(listener, {type, eventTarget, fn, options});
-    eventTarget.addEventListener(type, listener, options);
+    eventTarget.addEventListener(type, fn, options);
   }, []);
   let removeGlobalListener = useCallback((eventTarget, type, listener, options) => {
     let fn = globalListeners.current.get(listener)?.fn || listener;


### PR DESCRIPTION
The refactor to usePress to remove the custom hit testing (#7427) broke S2's press scaling on menu triggers because menus open on mouse down, and when the underlay appears it covers the trigger button and the browser fires pointerleave immediately. This issue is unique to S2 because RAC already overrides `isPressed` on the trigger button to true, but in S2 we disabled that so that the press scaling doesn't get "stuck" while the menu is open. Now we can listen for pointerup on the document in onPressStart in S2 ourselves, and it should only remain scaled while the mouse is down.

One slight difference vs before is that if you mouse down on the button and drag away it remains in the scaled state instead of removing it like our other buttons. Is this ok or should we add more logic to handle that?