### PR TITLE
Fix: broken links in docs and renaming Twitter to X

### DIFF
--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -935,7 +935,7 @@ AriaMenuTests({
                   </Menu>
                 </SubmenuTrigger>
                 <Item id="sms">SMS</Item>
-                <Item id="twitter">Twitter</Item>
+                <Item id="x">X</Item>
               </Menu>
             </SubmenuTrigger>
             <Item id="delete">Delete…</Item>

--- a/packages/@react-spectrum/s2/test/Menu.test.tsx
+++ b/packages/@react-spectrum/s2/test/Menu.test.tsx
@@ -118,7 +118,7 @@ AriaMenuTests({
                     </Menu>
                   </SubmenuTrigger>
                   <MenuItem id="sms">SMS</MenuItem>
-                  <MenuItem id="twitter">Twitter</MenuItem>
+                  <MenuItem id="x">X</MenuItem>
                 </MenuSection>
               </Menu>
             </SubmenuTrigger>

--- a/packages/@react-spectrum/tree/docs/TreeView.mdx
+++ b/packages/@react-spectrum/tree/docs/TreeView.mdx
@@ -454,5 +454,5 @@ behaviors in your test suite.
 
 [Long press](./testing.html#simulating-user-long-press)
 
-Please also refer to [React Spectrum's test suite](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/tree/test/TreeView.test.js) if you find that the above
+Please also refer to [React Spectrum's test suite](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/tree/test/TreeView.test.tsx) if you find that the above
 isn't sufficient when resolving issues in your own test cases.

--- a/packages/dev/docs/pages/blog/accessible-color-descriptions.mdx
+++ b/packages/dev/docs/pages/blog/accessible-color-descriptions.mdx
@@ -23,7 +23,7 @@ import {ColorPicker} from 'react-aria-components';
 keywords: [color picker, color, internationalization, localization, components, accessibility, react spectrum, react]
 description: Recently, we released a suite of color picker components in React Aria and React Spectrum. Since colors are inherently visual, ensuring these components are accessible to users with visual impairments presented a significant challenge. In this post, we'll discuss how we developed an algorithm that generates clear color descriptions for screen readers in multiple languages, while minimizing bundle size.
 date: 2024-10-02
-author: '[Devon Govett](https://twitter.com/devongovett)'
+author: '[Devon Govett](https://x.com/devongovett)'
 ---
 
 # Accessible Color Descriptions for Improved Color Pickers

--- a/packages/dev/docs/pages/blog/building-a-button-part-1.mdx
+++ b/packages/dev/docs/pages/blog/building-a-button-part-1.mdx
@@ -19,7 +19,7 @@ export default BlogPostLayout;
 keywords: [react aria, react spectrum, react, spectrum, interactions, button, touch]
 description: Buttons seem like simple components at first, but they hide a lot of complexity under the hood. In the first part of this series, we'll look at how React Spectrum and React Aria implement adaptive press interactions that work across a wide variety of devices and interaction models.
 date: 2020-08-12
-author: '[Devon Govett](https://twitter.com/devongovett)'
+author: '[Devon Govett](https://x.com/devongovett)'
 image: ../assets/ReactAria_976x445_2x.png
 ---
 
@@ -111,6 +111,6 @@ Try a live example for yourself in our [Button](https://react-spectrum.adobe.com
 
 As you can see, buttons are deceptively complicated once you consider all of the interactions they can support. The [useButton](https://react-spectrum.adobe.com/react-aria/useButton.html) and underlying [usePress](https://react-spectrum.adobe.com/react-aria/usePress.html) hooks in React Aria handle all of this complexity, and ensure that everything works as expected across devices. If you are building your own button component, I’d highly recommend checking them out!
 
-I'd also like to acknowledge the work of the React core team, particularly [Dominic Gannaway](https://twitter.com/trueadm) and [Nicolas Gallagher](https://twitter.com/necolas), in researching some of the interactions described in this post. We learned a lot from their implementation in building React Aria's press event handling.
+I'd also like to acknowledge the work of the React core team, particularly [Dominic Gannaway](https://x.com/trueadm) and [Nicolas Gallagher](https://x.com/necolas), in researching some of the interactions described in this post. We learned a lot from their implementation in building React Aria's press event handling.
 
 In the [next part](building-a-button-part-2.html) of this series, we’ll cover how React Spectrum handles hover interactions across devices.

--- a/packages/dev/docs/pages/blog/building-a-button-part-2.mdx
+++ b/packages/dev/docs/pages/blog/building-a-button-part-2.mdx
@@ -17,7 +17,7 @@ export default BlogPostLayout;
 keywords: [react aria, react spectrum, react, interactions, button, touch, hover, web development, javascript, css]
 description: This is the second post in our three part series on building a button component. In the [first post](building-a-button-part-1.html), we covered how React Spectrum and React Aria implement adaptive press events across mouse, touch, keyboard, and screen readers. Today, we’ll cover hover interactions.
 date: 2020-08-25
-author: '[Devon Govett](https://twitter.com/devongovett)'
+author: '[Devon Govett](https://x.com/devongovett)'
 image: ../assets/ReactAria_976x445_2x.png
 ---
 

--- a/packages/dev/docs/pages/blog/building-a-button-part-3.mdx
+++ b/packages/dev/docs/pages/blog/building-a-button-part-3.mdx
@@ -18,7 +18,7 @@ export default BlogPostLayout;
 keywords: [react aria, react spectrum, react, interactions, button, keyboard, focus, web development, javascript, css]
 description: This is the last post in our three part series on building a button component. In the [first post](https://react-spectrum.adobe.com/blog/building-a-button-part-1.html), we covered how React Spectrum and React Aria implement adaptive press events across mouse, touch, keyboard, and screen readers. In the [second post](https://react-spectrum.adobe.com/blog/building-a-button-part-2.html), we covered hover interactions. Today, we’ll cover keyboard focus behavior.
 date: 2020-09-09
-author: '[Devon Govett](https://twitter.com/devongovett)'
+author: '[Devon Govett](https://x.com/devongovett)'
 image: ../assets/ReactAria_976x445_2x.png
 ---
 

--- a/packages/dev/docs/pages/blog/building-a-combobox.mdx
+++ b/packages/dev/docs/pages/blog/building-a-combobox.mdx
@@ -39,7 +39,7 @@ After many months of research, development, and extensive testing across browser
 
 For those who may be unfamiliar with a combobox (alternatively known as an "autocomplete"), it is an input field that has a popover listbox associated with it. The listbox contains
 a list of options within that a user may select as the value for the combobox and is often filtered to display possible matches to the user's current input text. Finally, there may be a button accompanying the input field used
-for toggling the open state of the popover listbox. An example of a combobox that you may be familiar with is the search bar found on Google, Youtube, or Twitter.
+for toggling the open state of the popover listbox. An example of a combobox that you may be familiar with is the search bar found on Google, Youtube, or X.
 
 <Image src={comboboxExampleImageUrl} alt="Screenshot of example ComboBox, select a major" style={{maxWidth: 'min(100%, 350px)', display: 'block', margin: '20px auto'}} />
 

--- a/packages/dev/docs/pages/blog/date-and-time-pickers-for-all.mdx
+++ b/packages/dev/docs/pages/blog/date-and-time-pickers-for-all.mdx
@@ -25,7 +25,7 @@ import {Calendar, RangeCalendar} from '@react-spectrum/calendar';
 keywords: [date picker, date, time, calendar, components, accessibility, mobile, react spectrum, react, spectrum, interactions, touch]
 description: We are very excited to announce the release of the [React Aria](../react-aria/useDatePicker.html) and [React Spectrum](../react-spectrum/DatePicker.html) date and time picker components! This includes a full suite of fully featured components and hooks including calendars, date and time fields, and range pickers, all with a focus on internationalization and accessibility. It also includes [@internationalized/date](../internationalized/date/index.html), a brand new framework-agnostic library for locale-aware date and time manipulation.
 date: 2022-06-21
-author: '[Devon Govett](https://twitter.com/devongovett)'
+author: '[Devon Govett](https://x.com/devongovett)'
 ---
 
 # Date and Time Pickers for All
@@ -263,4 +263,4 @@ See [the docs](../internationalized/date/ZonedDateTime.html#setting-fields) for 
 
 Correctly manipulating dates and times is *really hard*. Making assumptions about calendar systems, time zones, locales, date and time arithmetic, etc. is a recipe for bugs when users around the world interact with your app. [@internationalized/date](../internationalized/date/index.html) provides a library of objects and functions that help handle these differences and allow you to manipulate dates from all users consistently. It is a completely independent library, so even if you aren’t using React Aria, React Spectrum, or even React, you can still take advantage of it for all your date and time manipulation needs!
 
-In addition, React Aria hooks such as [useDatePicker](../react-aria/useDatePicker.html) and [useCalendar](../react-aria/useCalendar.html) can help you build international and accessible date and time picking components with completely customizable styles. We’ve been working on these components for a [long time](https://twitter.com/devongovett/status/1136402636754673664), and we really hope you like them!
+In addition, React Aria hooks such as [useDatePicker](../react-aria/useDatePicker.html) and [useCalendar](../react-aria/useCalendar.html) can help you build international and accessible date and time picking components with completely customizable styles. We’ve been working on these components for a [long time](https://x.com/devongovett/status/1136402636754673664), and we really hope you like them!

--- a/packages/dev/docs/pages/blog/drag-and-drop.mdx
+++ b/packages/dev/docs/pages/blog/drag-and-drop.mdx
@@ -23,7 +23,7 @@ export default BlogPostLayout;
 keywords: [drag and drop, dnd, components, accessibility, keyboard, mobile, react spectrum, react, spectrum, interactions, touch]
 description: We are excited to announce the release of drag and drop support in [React Aria](https://react-spectrum.adobe.com/react-aria/dnd.html) and [React Spectrum](https://react-spectrum.adobe.com/react-spectrum/dnd.html)! This includes a suite of hooks for implementing drag and drop interactions, with support for both mouse and touch, as well as full parity for keyboard and screen reader input.
 date: 2022-11-16
-author: '[Devon Govett](https://twitter.com/devongovett)'
+author: '[Devon Govett](https://x.com/devongovett)'
 ---
 
 # Taming the dragon: Accessible drag and drop

--- a/packages/dev/docs/pages/blog/how-we-internationalized-our-numberfield.mdx
+++ b/packages/dev/docs/pages/blog/how-we-internationalized-our-numberfield.mdx
@@ -28,7 +28,7 @@ import {Flex} from '@react-spectrum/layout';
 keywords: [react aria, react spectrum, react, spectrum, interactions, numberfield, touch, spinbutton]
 description: Number fields are commonly used form components, but are frequently not a great user experience. They often lack support for advanced formatting, such as currency and unit values, and do not provide a localized experience for users around the world. In this post, we'll discuss how we approached building our number field component with support for formatting and internationalization in mind.
 date: 2021-05-05
-author: '[Rob Snow](https://twitter.com/snowystinger)'
+author: '[Rob Snow](https://x.com/snowystinger)'
 image: ../assets/ReactAria_976x445_2x.png
 ---
 

--- a/packages/dev/docs/pages/react-aria/home/ExampleApp.tsx
+++ b/packages/dev/docs/pages/react-aria/home/ExampleApp.tsx
@@ -251,7 +251,7 @@ export function ExampleApp() {
                         Share
                       </MenuItem>
                       <Menu>
-                        <MenuItem href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(item.common_name)}`} target="blank" rel="noopener noreferrer" aria-label="Twitter"><Twitter aria-hidden className="w-4 h-4" /> Twitter…</MenuItem>
+                        <MenuItem href={`https://x.com/intent/tweet?text=${encodeURIComponent(item.common_name)}`} target="blank" rel="noopener noreferrer" aria-label="X"><Twitter aria-hidden className="w-4 h-4" /> X…</MenuItem>
                         <MenuItem href={`mailto:abc@example.com?subject=${encodeURIComponent(item.common_name)}`} target="blank" rel="noopener noreferrer" aria-label="Email"><Mail aria-hidden className="w-4 h-4" /> Email…</MenuItem>
                       </Menu>
                     </SubmenuTrigger>
@@ -311,7 +311,7 @@ export function ExampleApp() {
                                   Share
                                 </MenuItem>
                                 <Menu>
-                                  <MenuItem href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(item.common_name)}`} target="blank" rel="noopener noreferrer" aria-label="Twitter"><Twitter aria-hidden className="w-4 h-4" /> Twitter…</MenuItem>
+                                  <MenuItem href={`https://x.com/intent/tweet?text=${encodeURIComponent(item.common_name)}`} target="blank" rel="noopener noreferrer" aria-label="X"><Twitter aria-hidden className="w-4 h-4" /> X…</MenuItem>
                                   <MenuItem href={`mailto:abc@example.com?subject=${encodeURIComponent(item.common_name)}`} target="blank" rel="noopener noreferrer" aria-label="Email"><Mail aria-hidden className="w-4 h-4" /> Email…</MenuItem>
                                 </Menu>
                               </SubmenuTrigger>

--- a/packages/dev/docs/pages/releases/2020-11-30.mdx
+++ b/packages/dev/docs/pages/releases/2020-11-30.mdx
@@ -26,7 +26,7 @@ We have lots of bug fixes in this release. We have fixes for iOS 14, improved ty
 ## Fixed
 - Fixed styling of `SearchField` with `validationState` prop - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/1176)
 - Prevent iOS virtual keyboard from hiding when navigating to clear button with VoiceOver - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/1176)
-- Improve TypeScript types for `useButton` and `useToggleButton` based on `elementType` - [@toinelin](https://github.com/toinelin) - [PR](https://github.com/adobe/react-spectrum/pull/1191)
+- Improve TypeScript types for `useButton` and `useToggleButton` based on `elementType` - [@antoinelin](https://github.com/antoinelin) - [PR](https://github.com/adobe/react-spectrum/pull/1191)
 - Catch Intl.NumberFormat error for unsupported option - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/1249)
 - Fix text selection on `useInteractOutside` in Firefox - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/1240)
 - Fix value of `aria-setsize` attribute in `useOption` and `useMenuItem` - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/1176)

--- a/packages/dev/docs/pages/releases/2021-02-17.mdx
+++ b/packages/dev/docs/pages/releases/2021-02-17.mdx
@@ -62,7 +62,7 @@ After a small break, we are back with another release. This one is jam packed wi
 - Add example of passing a ref to `useButton` - [@toshi1127](https://github.com/toshi1127) - [PR](https://github.com/adobe/react-spectrum/pull/1298)
 - Improve `useCheckboxGroupItem` examples - [@stefanprobst](https://github.com/stefanprobst) - [PR](https://github.com/adobe/react-spectrum/pull/1336)
 - Update links for `TextArea` guidelines - [@matthewdeutsch](https://github.com/matthewdeutsch) - [PR](https://github.com/adobe/react-spectrum/pull/1357)
-- Fix typo in `IllustratedMessage` example - [@travigd](https://github.com/travigd) - [PR](https://github.com/adobe/react-spectrum/pull/1410)
+- Fix typo in `IllustratedMessage` example - [@twavv](https://github.com/twavv) - [PR](https://github.com/adobe/react-spectrum/pull/1410)
 - Update example in `useRadio` to include a ref - [@matamatanot](https://github.com/matamatanot) - [PR](https://github.com/adobe/react-spectrum/pull/1370)
 - Add anatomy diagrams to aria hooks - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/1452)
 - Update prop description in `useMenuSection` - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/1461)

--- a/packages/dev/docs/pages/releases/2023-08-09.mdx
+++ b/packages/dev/docs/pages/releases/2023-08-09.mdx
@@ -29,7 +29,7 @@ Thank you to our community for their support and contributions!
 - Export `fromDate` & `fromEpoch` and add to docs - [@naveen2593kumar](https://github.com/naveen2593kumar) - [PR](https://github.com/adobe/react-spectrum/pull/4732)
 - Support a null date in `DatePicker` - [@ktabors](https://github.com/ktabors) - [PR](https://github.com/adobe/react-spectrum/pull/4739)
 - Add support for continuePropagation to `usePress` - [@devongovett](https://github.com/devongovett) - [PR](https://github.com/adobe/react-spectrum/pull/4683)
-- Support a data-attribute to identify a11y false positives - [@abitbetterthanyesterday](https://github.com/abitbetterthanyesterday) - [PR](https://github.com/adobe/react-spectrum/pull/4759)
+- Support a data-attribute to identify a11y false positives - [@aloysb](https://github.com/aloysb) - [PR](https://github.com/adobe/react-spectrum/pull/4759)
 
 ## Fixes
 - Adjust `DateField` line height to prevent scroll - [@snowystinger](https://github.com/snowystinger) - [PR](https://github.com/adobe/react-spectrum/pull/4713)

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -769,7 +769,7 @@ import {Menu, Popover, SubmenuTrigger} from 'react-aria-components';
     <Popover>
       <Menu>
         <MyItem>SMS</MyItem>
-        <MyItem>Twitter</MyItem>
+        <MyItem>X</MyItem>
         <SubmenuTrigger>
           <MyItem>Email</MyItem>
           <Popover>
@@ -798,7 +798,7 @@ let items = [
   {id: 'delete', name: 'Delete'},
   {id: 'share', name: 'Share', children: [
     {id: 'sms', name: 'SMS'},
-    {id: 'twitter', name: 'Twitter'},
+    {id: 'x', name: 'X'},
     {id: 'email', name: 'Email', children: [
       {id: 'work', name: 'Work'},
       {id: 'personal', name: 'Personal'},

--- a/packages/react-aria-components/test/Menu.test.tsx
+++ b/packages/react-aria-components/test/Menu.test.tsx
@@ -540,7 +540,7 @@ describe('Menu', () => {
                   <Menu onAction={onAction}>
                     <MenuItem id="email">Email</MenuItem>
                     <MenuItem id="sms">SMS</MenuItem>
-                    <MenuItem id="twitter">Twitter</MenuItem>
+                    <MenuItem id="x">X</MenuItem>
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
@@ -613,7 +613,7 @@ describe('Menu', () => {
                       </Popover>
                     </SubmenuTrigger>
                     <MenuItem id="sms">SMS</MenuItem>
-                    <MenuItem id="twitter">Twitter</MenuItem>
+                    <MenuItem id="x">X</MenuItem>
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
@@ -706,7 +706,7 @@ describe('Menu', () => {
                       </Popover>
                     </SubmenuTrigger>
                     <MenuItem id="sms">SMS</MenuItem>
-                    <MenuItem id="twitter">Twitter</MenuItem>
+                    <MenuItem id="x">X</MenuItem>
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
@@ -793,7 +793,7 @@ describe('Menu', () => {
                   <Menu>
                     <MenuItem id="email">Email</MenuItem>
                     <MenuItem id="sms">SMS</MenuItem>
-                    <MenuItem id="twitter">Twitter</MenuItem>
+                    <MenuItem id="x">X</MenuItem>
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
@@ -870,7 +870,7 @@ describe('Menu', () => {
                       </Popover>
                     </SubmenuTrigger>
                     <MenuItem id="sms">SMS</MenuItem>
-                    <MenuItem id="twitter">Twitter</MenuItem>
+                    <MenuItem id="x">X</MenuItem>
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
@@ -957,7 +957,7 @@ describe('Menu', () => {
                       </Popover>
                     </SubmenuTrigger>
                     <MenuItem id="sms">SMS</MenuItem>
-                    <MenuItem id="twitter">Twitter</MenuItem>
+                    <MenuItem id="x">X</MenuItem>
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
@@ -1021,14 +1021,14 @@ describe('Menu', () => {
                         <Header>Work</Header>
                         <MenuItem id="email-work">Email</MenuItem>
                         <MenuItem id="sms-work">SMS</MenuItem>
-                        <MenuItem id="twitter-work">Twitter</MenuItem>
+                        <MenuItem id="x-work">X</MenuItem>
                       </MenuSection>
                       <Separator />
                       <MenuSection>
                         <Header>Personal</Header>
                         <MenuItem id="email-personal">Email</MenuItem>
                         <MenuItem id="sms-personal">SMS</MenuItem>
-                        <MenuItem id="twitter-personal">Twitter</MenuItem>
+                        <MenuItem id="x-personal">X</MenuItem>
                       </MenuSection>
                     </Menu>
                   </Popover>
@@ -1319,7 +1319,7 @@ AriaMenuTests({
                     </Popover>
                   </SubmenuTrigger>
                   <MenuItem id="sms">SMS</MenuItem>
-                  <MenuItem id="twitter">Twitter</MenuItem>
+                  <MenuItem id="x">X</MenuItem>
                 </Menu>
               </Popover>
             </SubmenuTrigger>

--- a/starters/tailwind/stories/Menu.stories.tsx
+++ b/starters/tailwind/stories/Menu.stories.tsx
@@ -79,7 +79,7 @@ export const Submenu = (args: any) => (
         <MenuItem id="share">Share</MenuItem>
         <Menu>
           <MenuItem id="sms">SMS</MenuItem>
-          <MenuItem id="twitter">Twitter</MenuItem>
+          <MenuItem id="x">X</MenuItem>
           <SubmenuTrigger>
             <MenuItem id="email">Email</MenuItem>
             <Menu>


### PR DESCRIPTION
fixit

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

check docs links
check examples where Twitter renamed to X

## 🧢 Your Project:
RSP