### PR TITLE
refactor: No longer preventDefault in usePress and allow browser to manage focus

### DIFF
--- a/packages/@react-aria/breadcrumbs/test/useBreadcrumbItem.test.js
+++ b/packages/@react-aria/breadcrumbs/test/useBreadcrumbItem.test.js
@@ -44,7 +44,7 @@ describe('useBreadcrumbItem', function () {
 
   it('handles descendant link with href', function () {
     let {itemProps} = renderLinkHook({children: <a href="https://example.com">Breadcrumb Item</a>});
-    expect(itemProps.tabIndex).toBeUndefined();
+    expect(itemProps.tabIndex).toBe(0);
     expect(itemProps.role).toBeUndefined();
     expect(itemProps['aria-disabled']).toBeUndefined();
     expect(typeof itemProps.onKeyDown).toBe('function');

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -74,7 +74,6 @@ export function useButton(props: AriaButtonOptions<ElementType>, ref: RefObject<
   } else {
     additionalProps = {
       role: 'button',
-      tabIndex: isDisabled ? undefined : 0,
       href: elementType === 'a' && !isDisabled ? href : undefined,
       target: elementType === 'a' ? target : undefined,
       type: elementType === 'input' ? type : undefined,

--- a/packages/@react-aria/dnd/test/dnd.test.js
+++ b/packages/@react-aria/dnd/test/dnd.test.js
@@ -2466,7 +2466,7 @@ describe('useDrag and useDrop', function () {
 
       let draggable = tree.getByText('Drag me');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       fireEvent(draggable, pointerEvent('pointerdown', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0}));
       fireEvent(draggable, pointerEvent('pointerup', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0}));
       await user.click(draggable);
@@ -2496,7 +2496,7 @@ describe('useDrag and useDrop', function () {
       let draggable = tree.getByText('Drag me');
       let droppable = tree.getByText('Drop here');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       fireEvent(draggable, pointerEvent('pointerdown', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0}));
       fireEvent(draggable, pointerEvent('pointerup', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0}));
       await user.click(draggable);
@@ -2505,7 +2505,7 @@ describe('useDrag and useDrop', function () {
 
 
       // Android Talkback fires with click event of detail = 1, test that our onPointerDown listener detects that it is a virtual click
-      fireEvent.focus(droppable);
+      act(() => droppable.focus());
       fireEvent(droppable, pointerEvent('pointerdown', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0, pointerType: 'mouse'}));
       fireEvent(droppable, pointerEvent('pointerup', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0, pointerType: 'mouse'}));
       fireEvent.click(droppable, {detail: 1});
@@ -2535,7 +2535,7 @@ describe('useDrag and useDrop', function () {
 
       let draggable = tree.getByText('Drag me');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2563,7 +2563,7 @@ describe('useDrag and useDrop', function () {
 
       expect(tree.getAllByRole('textbox')).toHaveLength(1);
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       fireEvent.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2596,7 +2596,7 @@ describe('useDrag and useDrop', function () {
 
       let draggable = tree.getByText('Drag me');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2621,7 +2621,7 @@ describe('useDrag and useDrop', function () {
 
       let draggable = tree.getByText('Drag me');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2644,7 +2644,7 @@ describe('useDrag and useDrop', function () {
       let droppable = tree.getByText('Drop here');
       let input = tree.getByRole('textbox');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2664,7 +2664,7 @@ describe('useDrag and useDrop', function () {
       let draggable = tree.getByText('Drag me');
       let input = tree.getByRole('textbox');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2681,7 +2681,7 @@ describe('useDrag and useDrop', function () {
       let draggable = tree.getByText('Drag me');
       let droppable = tree.getByText('Drop here');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
 
@@ -2715,7 +2715,7 @@ describe('useDrag and useDrop', function () {
 
       let draggable = tree.getByText('Drag me');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       fireEvent.click(draggable, {detail: 1});
       act(() => jest.runAllTimers());
 
@@ -2731,7 +2731,7 @@ describe('useDrag and useDrop', function () {
       let draggable = tree.getByText('Drag me');
       let droppable = tree.getByText('Drop here');
 
-      fireEvent.focus(draggable);
+      act(() => draggable.focus());
       await user.click(draggable);
       act(() => jest.runAllTimers());
       expect(draggable).toHaveAttribute('data-dragging', 'true');

--- a/packages/@react-aria/dnd/test/useDraggableCollection.test.js
+++ b/packages/@react-aria/dnd/test/useDraggableCollection.test.js
@@ -781,7 +781,8 @@ describe('useDraggableCollection', () => {
 
       let dragButton = within(cells[1]).getByRole('button');
       expect(dragButton).toHaveAttribute('aria-label', 'Drag Bar');
-      fireEvent.focus(dragButton);
+      act(() => cells[1].focus());
+      act(() => dragButton.focus());
       fireEvent.click(dragButton);
       act(() => jest.runAllTimers());
       expect(cells[0]).not.toHaveClass('is-dragging');
@@ -852,7 +853,7 @@ describe('useDraggableCollection', () => {
       let cells = within(grid).getAllByRole('gridcell');
       expect(cells).toHaveLength(3);
 
-      fireEvent.focus(cells[0]);
+      act(() => cells[0].focus());
       fireEvent.click(cells[0]);
       expect(rows[0]).toHaveAttribute('aria-selected', 'true');
       fireEvent.click(cells[1]);
@@ -860,7 +861,7 @@ describe('useDraggableCollection', () => {
 
       let dragButton = within(cells[1]).getByRole('button');
       expect(dragButton).toHaveAttribute('aria-label', 'Drag 2 selected items');
-      fireEvent.focus(dragButton);
+      act(() => dragButton.focus());
       fireEvent.click(dragButton);
       act(() => jest.runAllTimers());
       expect(cells[0]).toHaveClass('is-dragging');
@@ -939,13 +940,13 @@ describe('useDraggableCollection', () => {
       let cells = within(grid).getAllByRole('gridcell');
       expect(cells).toHaveLength(3);
 
-      fireEvent.focus(cells[0]);
+      act(() => cells[0].focus());
       fireEvent.click(cells[0]);
       expect(rows[0]).toHaveAttribute('aria-selected', 'true');
 
       let dragButton = within(cells[1]).getByRole('button');
       expect(dragButton).toHaveAttribute('aria-label', 'Drag Bar');
-      fireEvent.focus(dragButton);
+      act(() => dragButton.focus());
       fireEvent.click(dragButton);
       act(() => jest.runAllTimers());
       expect(cells[0]).not.toHaveClass('is-dragging');

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -12,7 +12,7 @@
 
 import {FocusableElement, RefObject} from '@react-types/shared';
 import {focusSafely} from './focusSafely';
-import {getOwnerDocument, useLayoutEffect} from '@react-aria/utils';
+import {getOwnerDocument, isFocusable, isTabbable, useLayoutEffect} from '@react-aria/utils';
 import {isElementVisible} from './isElementVisible';
 import React, {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 
@@ -265,31 +265,6 @@ function createFocusManagerForScope(scopeRef: React.RefObject<Element[] | null>)
       return previousNode;
     }
   };
-}
-
-const focusableElements = [
-  'input:not([disabled]):not([type=hidden])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  'button:not([disabled])',
-  'a[href]',
-  'area[href]',
-  'summary',
-  'iframe',
-  'object',
-  'embed',
-  'audio[controls]',
-  'video[controls]',
-  '[contenteditable]:not([contenteditable^="false"])'
-];
-
-const FOCUSABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]),') + ',[tabindex]:not([disabled]):not([hidden])';
-
-focusableElements.push('[tabindex]:not([tabindex="-1"]):not([disabled])');
-const TABBABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]):not([tabindex="-1"]),');
-
-export function isFocusable(element: HTMLElement) {
-  return element.matches(FOCUSABLE_ELEMENT_SELECTOR);
 }
 
 function getScopeRoot(scope: Element[]) {
@@ -742,7 +717,7 @@ function restoreFocusToElement(node: FocusableElement) {
  * that matches all focusable/tabbable elements.
  */
 export function getFocusableTreeWalker(root: Element, opts?: FocusManagerOptions, scope?: Element[]) {
-  let selector = opts?.tabbable ? TABBABLE_ELEMENT_SELECTOR : FOCUSABLE_ELEMENT_SELECTOR;
+  let filter = opts?.tabbable ? isTabbable : isFocusable;
   let walker = getOwnerDocument(root).createTreeWalker(
     root,
     NodeFilter.SHOW_ELEMENT,
@@ -753,7 +728,7 @@ export function getFocusableTreeWalker(root: Element, opts?: FocusManagerOptions
           return NodeFilter.FILTER_REJECT;
         }
 
-        if ((node as Element).matches(selector)
+        if (filter(node as Element)
           && isElementVisible(node as Element)
           && (!scope || isElementInScope(node as Element, scope))
           && (!opts?.accept || opts.accept(node as Element))

--- a/packages/@react-aria/focus/src/index.ts
+++ b/packages/@react-aria/focus/src/index.ts
@@ -10,12 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-export {FocusScope, useFocusManager, getFocusableTreeWalker, createFocusManager, isElementInChildOfActiveScope, isFocusable} from './FocusScope';
+export {FocusScope, useFocusManager, getFocusableTreeWalker, createFocusManager, isElementInChildOfActiveScope} from './FocusScope';
 export {FocusRing} from './FocusRing';
 export {FocusableProvider, useFocusable} from './useFocusable';
 export {useFocusRing} from './useFocusRing';
 export {focusSafely} from './focusSafely';
 export {useHasTabbableChild} from './useHasTabbableChild';
+// For backward compatibility.
+export {isFocusable} from '@react-aria/utils';
 
 export type {FocusScopeProps, FocusManager, FocusManagerOptions} from './FocusScope';
 export type {FocusRingProps} from './FocusRing';

--- a/packages/@react-aria/focus/src/useFocusable.tsx
+++ b/packages/@react-aria/focus/src/useFocusable.tsx
@@ -82,11 +82,17 @@ export function useFocusable<T extends FocusableElement = FocusableElement>(prop
     autoFocusRef.current = false;
   }, [domRef]);
 
+  // Always set a tabIndex so that Safari allows focusing native buttons and inputs.
+  let tabIndex: number | undefined = props.excludeFromTabOrder ? -1 : 0;
+  if (props.isDisabled) {
+    tabIndex = undefined;
+  }
+
   return {
     focusableProps: mergeProps(
       {
         ...interactions,
-        tabIndex: props.excludeFromTabOrder && !props.isDisabled ? -1 : undefined
+        tabIndex
       },
       interactionProps
     )

--- a/packages/@react-aria/interactions/package.json
+++ b/packages/@react-aria/interactions/package.json
@@ -28,7 +28,8 @@
     "@swc/helpers": "^0.5.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -16,6 +16,7 @@
 // See https://github.com/facebook/react/tree/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions
 
 import {getOwnerDocument, getOwnerWindow, isMac, isVirtualClick} from '@react-aria/utils';
+import {ignoreFocusEvent} from './utils';
 import {useEffect, useState} from 'react';
 import {useIsSSR} from '@react-aria/ssr';
 
@@ -92,7 +93,7 @@ function handleFocusEvent(e: FocusEvent) {
   // Firefox fires two extra focus events when the user first clicks into an iframe:
   // first on the window, then on the document. We ignore these events so they don't
   // cause keyboard focus rings to appear.
-  if (e.target === window || e.target === document) {
+  if (e.target === window || e.target === document || ignoreFocusEvent) {
     return;
   }
 
@@ -108,6 +109,10 @@ function handleFocusEvent(e: FocusEvent) {
 }
 
 function handleWindowBlur() {
+  if (ignoreFocusEvent) {
+    return;
+  }
+
   // When the window is blurred, reset state. This is necessary when tabbing out of the window,
   // for example, since a subsequent focus event won't be fired.
   hasEventBeforeFocus = false;

--- a/packages/@react-aria/interactions/src/useLongPress.ts
+++ b/packages/@react-aria/interactions/src/useLongPress.ts
@@ -82,7 +82,7 @@ export function useLongPress(props: LongPressProps): LongPressResult {
           // Prevent other usePress handlers from also handling this event.
           e.target.dispatchEvent(new PointerEvent('pointercancel', {bubbles: true}));
 
-          // Ensure target is focused. On touch devices, browsers typicaly focus on pointer up.
+          // Ensure target is focused. On touch devices, browsers typically focus on pointer up.
           if (getOwnerDocument(e.target).activeElement !== e.target) {
             focusWithoutScrolling(e.target as FocusableElement);
           }

--- a/packages/@react-aria/interactions/src/useLongPress.ts
+++ b/packages/@react-aria/interactions/src/useLongPress.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {DOMAttributes, LongPressEvent} from '@react-types/shared';
-import {mergeProps, useDescription, useGlobalListeners} from '@react-aria/utils';
+import {DOMAttributes, FocusableElement, LongPressEvent} from '@react-types/shared';
+import {focusWithoutScrolling, getOwnerDocument, mergeProps, useDescription, useGlobalListeners} from '@react-aria/utils';
 import {usePress} from './usePress';
 import {useRef} from 'react';
 
@@ -81,6 +81,12 @@ export function useLongPress(props: LongPressProps): LongPressResult {
         timeRef.current = setTimeout(() => {
           // Prevent other usePress handlers from also handling this event.
           e.target.dispatchEvent(new PointerEvent('pointercancel', {bubbles: true}));
+
+          // Ensure target is focused. On touch devices, browsers typicaly focus on pointer up.
+          if (getOwnerDocument(e.target).activeElement !== e.target) {
+            focusWithoutScrolling(e.target as FocusableElement);
+          }
+
           if (onLongPress) {
             onLongPress({
               ...e,

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -344,11 +344,6 @@ export function usePress(props: PressHookProps): PressResult {
           // If triggered from a screen reader or by using element.click(),
           // trigger as if it were a keyboard click.
           if (!state.ignoreEmulatedMouseEvents && !state.isPressed && (state.pointerType === 'virtual' || isVirtualClick(e.nativeEvent))) {
-            // Ensure the element receives focus (VoiceOver on iOS does not do this)
-            if (!isDisabled && !preventFocusOnPress) {
-              focusWithoutScrolling(e.currentTarget);
-            }
-
             let stopPressStart = triggerPressStart(e, 'virtual');
             let stopPressUp = triggerPressUp(e, 'virtual');
             let stopPressEnd = triggerPressEnd(e, 'virtual');

--- a/packages/@react-aria/interactions/src/utils.ts
+++ b/packages/@react-aria/interactions/src/utils.ts
@@ -132,6 +132,11 @@ export function useSyntheticBlurEvent<Target = Element>(onBlur: (e: ReactFocusEv
 
 export let ignoreFocusEvent = false;
 
+/**
+ * This function prevents the next focus event fired on `target`, without using `event.preventDefault()`.
+ * It works by waiting for the series of focus events to occur, and reverts focus back to where it was before.
+ * It also makes these events mostly non-observable by using a capturing listener on the window and stopping propagation.
+ */
 export function preventFocus(target: FocusableElement | null) {
   // The browser will focus the nearest focusable ancestor of our target.
   while (target && !isFocusable(target)) {

--- a/packages/@react-aria/interactions/stories/usePress.stories.tsx
+++ b/packages/@react-aria/interactions/stories/usePress.stories.tsx
@@ -10,7 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-import {Link} from 'react-aria-components';
+import {
+  Button,
+  Dialog,
+  DialogTrigger,
+  Heading,
+  Link,
+  Modal,
+  ModalOverlay
+} from 'react-aria-components';
 import React from 'react';
 import styles from './usePress-stories.css';
 import {usePress} from '@react-aria/interactions';
@@ -112,3 +120,71 @@ export const linkOnPress = {
     }
   }
 };
+
+export function ClickOutsideIssue() {
+  const handleClick = () => {
+    alert('Clicked!');
+  };
+
+  return (
+    <div style={{alignSelf: 'start'}}>
+      <h2 style={{fontSize: 16}}>
+        before clicking the button please make sure 'desktop(touch)' mode is
+        active in the responsive dev tools
+      </h2>
+      <div
+        style={{
+          position: 'fixed',
+          display: 'flex',
+          backgroundColor: 'black',
+          top: 150,
+          width: '100%',
+          height: 200
+        }}>
+        {/* eslint-disable-next-line */}
+        <div
+          onClick={handleClick}
+          style={{
+            marginLeft: 'auto',
+            color: '#fff',
+            border: '1px solid #fff',
+            width: 400,
+            backgroundColor: 'red'
+          }}>
+          Help
+        </div>
+      </div>
+      <DialogTrigger>
+        <Button>Open drawer</Button>
+        <ModalOverlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(45 0 0 / 0.3)'
+          }}>
+          <Modal
+            style={{
+              position: 'fixed',
+              top: 0,
+              bottom: 0,
+              right: 0,
+              width: 300,
+              background: '#fff',
+              outline: 'none',
+              borderLeft: '1px solid gray',
+              boxShadow: '-8px 0 20px rgba(0 0 0 / 0.1)',
+              paddingTop: 50
+            }}>
+            <Dialog>
+              <Heading slot="title">Notice</Heading>
+              <p>This is a modal with a custom modal overlay.</p>
+
+              <Button slot="close">Close</Button>
+            </Dialog>
+          </Modal>
+        </ModalOverlay>
+      </DialogTrigger>
+    </div>
+  );
+}
+

--- a/packages/@react-aria/interactions/stories/usePress.stories.tsx
+++ b/packages/@react-aria/interactions/stories/usePress.stories.tsx
@@ -188,3 +188,49 @@ export function ClickOutsideIssue() {
   );
 }
 
+export function SoftwareKeyboardIssue() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        padding: '12px',
+        maxWidth: '256px',
+        height: '100vh'
+      }}>
+      <p>Focus the input to show the software keyboard, then press the buttons below.</p>
+      <input type="text" style={{fontSize: 16}} />
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+          marginTop: 'auto'
+        }}>
+        {/* eslint-disable-next-line */}
+        <a
+          onClick={() => {
+            alert('I told you not to click me');
+          }}
+          style={{fontSize: '64px'}}>
+          Don't click me
+        </a>
+
+        <div style={{display: 'flex', gap: '8px', marginTop: '110px'}}>
+          <Button
+            style={{height: '36px'}}
+            onPress={() => alert('Hello world, Aria!')}>
+            Aria press me
+          </Button>
+          <button
+            style={{height: '36px'}}
+            onClick={() => alert('Hello world, native!')}>
+            native press me
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/@react-aria/interactions/test/useFocusVisible.test.js
+++ b/packages/@react-aria/interactions/test/useFocusVisible.test.js
@@ -9,13 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import {act, fireEvent, render, renderHook, screen, waitFor} from '@react-spectrum/test-utils-internal';
+import {act, fireEvent, pointerMap, render, renderHook, screen, waitFor} from '@react-spectrum/test-utils-internal';
 import {addWindowFocusTracking, useFocusVisible, useFocusVisibleListener} from '../';
 import {hasSetupGlobalListeners} from '../src/useFocusVisible';
 import {mergeProps} from '@react-aria/utils';
 import React from 'react';
 import {useButton} from '@react-aria/button';
 import {useFocusRing} from '@react-aria/focus';
+import userEvent from '@testing-library/user-event';
 
 function Example(props) {
   const {isFocusVisible} = useFocusVisible();
@@ -59,6 +60,11 @@ function toggleBrowserWindow() {
 }
 
 describe('useFocusVisible', function () {
+  let user;
+  beforeAll(() => {
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+  
   beforeEach(() => {
     fireEvent.focus(document.body);
   });
@@ -306,10 +312,8 @@ describe('useFocusVisible', function () {
 
       const el = document.querySelector('iframe').contentWindow.document.body.querySelector('button[id="iframe-example"]');
 
-      fireEvent.mouseDown(el);
-      fireEvent.mouseUp(el);
-      fireEvent.keyDown(el, {key: 'Esc'});
-      fireEvent.keyUp(el, {key: 'Esc'});
+      await user.pointer({target: el, keys: '[MouseLeft]'});
+      await user.keyboard('{Esc}');
 
       expect(el.textContent).toBe('example-focusVisible');
     });

--- a/packages/@react-aria/interactions/test/useLongPress.test.js
+++ b/packages/@react-aria/interactions/test/useLongPress.test.js
@@ -295,6 +295,7 @@ describe('useLongPress', function () {
     fireEvent.pointerDown(el, {pointerType: 'touch'});
     act(() => jest.advanceTimersByTime(300));
     fireEvent.pointerUp(el, {pointerType: 'touch'});
+    fireEvent.click(el, {detail: 1});
 
     expect(events).toEqual([
       {

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -2891,17 +2891,6 @@ describe('usePress', function () {
     expect(document.activeElement).not.toBe(el);
   });
 
-  it('should focus the target on virtual click by default', function () {
-    let {getByText} = render(
-      <Example />
-    );
-
-    let el = getByText('test');
-    fireEvent.click(el);
-
-    expect(document.activeElement).toBe(el);
-  });
-
   describe('disable text-selection when pressed', function () {
     let handler = jest.fn();
     let mockUserSelect = 'contain';

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -68,18 +68,19 @@ describe('usePress', function () {
 
       let el = res.getByText('test');
       fireEvent(el, pointerEvent('pointerover', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
+
       let shouldFireMouseEvents = fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
-      if (shouldFireMouseEvents) {
-        let shouldFocus = fireEvent.mouseDown(el);
-        if (shouldFocus) {
-          act(() => el.focus());
-        }
-      }
+      expect(shouldFireMouseEvents).toBe(true);
+
+      let shouldFocus = fireEvent.mouseDown(el);
+      expect(shouldFocus).toBe(true);
+      act(() => el.focus());
+
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
-      if (shouldFireMouseEvents) {
-        fireEvent.mouseUp(el);
-      }
-      fireEvent.click(el);
+      fireEvent.mouseUp(el);
+
+      let shouldClick = fireEvent.click(el);
+      expect(shouldClick).toBe(true);
       fireEvent(el, pointerEvent('pointerout', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
 
       // How else to get the DOM node it renders the hook to?
@@ -156,23 +157,24 @@ describe('usePress', function () {
       // mousedown and focus is delayed until after pointerup.
       let el = res.getByText('test');
       fireEvent(el, pointerEvent('pointerover', {pointerId: 1, pointerType: 'touch', clientX: 0, clientY: 0}));
+
       let shouldFireCompatibilityEvents = fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch', clientX: 0, clientY: 0}));
+      expect(shouldFireCompatibilityEvents).toBe(true);
+
       let shouldFocus = true;
-      if (shouldFireCompatibilityEvents) {
-        shouldFocus = shouldFireCompatibilityEvents = fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
-      }
+      shouldFocus = shouldFireCompatibilityEvents = fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      expect(shouldFireCompatibilityEvents).toBe(true);
+      expect(shouldFocus).toBe(true);
+
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
       fireEvent(el, pointerEvent('pointerout', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
-      if (shouldFireCompatibilityEvents) {
-        shouldFocus = fireEvent.touchEnd(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
-        shouldFocus = fireEvent.mouseDown(el);
-      }
-      if (shouldFocus) {
-        act(() => el.focus());
-      }
-      if (shouldFireCompatibilityEvents) {
-        fireEvent.mouseUp(el);
-      }
+
+      shouldFocus = fireEvent.touchEnd(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      shouldFocus = fireEvent.mouseDown(el);
+      expect(shouldFocus).toBe(true);
+      act(() => el.focus());
+
+      fireEvent.mouseUp(el);
       fireEvent.click(el);
 
       expect(events).toEqual([
@@ -245,15 +247,19 @@ describe('usePress', function () {
 
       let el = res.getByText('test');
       fireEvent(el, pointerEvent('pointerover', {pointerId: 1, pointerType: 'touch', clientX: 0, clientY: 0}));
+
       let shouldFireCompatibilityEvents = fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch', clientX: 0, clientY: 0}));
-      if (shouldFireCompatibilityEvents) {
-        shouldFireCompatibilityEvents = fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
-      }
+      expect(shouldFireCompatibilityEvents).toBe(true);
+
+      shouldFireCompatibilityEvents = fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      expect(shouldFireCompatibilityEvents).toBe(true);
+
       fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
       fireEvent(el, pointerEvent('pointerout', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
-      if (shouldFireCompatibilityEvents) {
-        fireEvent.touchEnd(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
-      }
+
+      let shouldFocus = fireEvent.touchEnd(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      expect(shouldFocus).toBe(true);
+
       // Mouse events are not fired in this case, and the browser does not focus the element.
       act(() => jest.advanceTimersByTime(10));
       expect(document.activeElement).toBe(el);
@@ -725,58 +731,6 @@ describe('usePress', function () {
       expect(document.activeElement).not.toBe(el);
     });
 
-    it.skip('should focus the target on click by default', function () {
-      let res = render(
-        <Example />
-      );
-
-      let el = res.getByText('test');
-      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
-      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', clientX: 0, clientY: 0}));
-      expect(document.activeElement).toBe(el);
-    });
-
-    it.skip('should prevent default on pointerdown and mousedown by default', function () {
-      let res = render(
-        <Example />
-      );
-
-      let el = res.getByText('test');
-      let allowDefault = fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
-      expect(allowDefault).toBe(false);
-
-      allowDefault = fireEvent.mouseDown(el);
-      expect(allowDefault).toBe(false);
-    });
-
-    it.skip('should still prevent default when pressing on a non draggable + pressable item in a draggable container', function () {
-      let res = render(
-        <div draggable="true">
-          <Example />
-        </div>
-      );
-
-      let el = res.getByText('test');
-      let allowDefault = fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
-      expect(allowDefault).toBe(false);
-
-      allowDefault = fireEvent.mouseDown(el);
-      expect(allowDefault).toBe(false);
-    });
-
-    it.skip('should not prevent default when pressing on a draggable item', function () {
-      let res = render(
-        <Example draggable="true" />
-      );
-
-      let el = res.getByText('test');
-      let allowDefault = fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse'}));
-      expect(allowDefault).toBe(true);
-
-      allowDefault = fireEvent.mouseDown(el);
-      expect(allowDefault).toBe(true);
-    });
-
     it('should ignore virtual pointer events', function () {
       let events = [];
       let addEvent = (e) => events.push(e);
@@ -1024,61 +978,6 @@ describe('usePress', function () {
       fireEvent.click(el);
       expect(el).not.toHaveStyle('user-select: none');
     });
-
-    it.skip('should preventDefault on touchend to prevent click events on the wrong element', function () {
-      let res = render(<Example />);
-
-      let el = res.getByText('test');
-      el.ontouchend = () => {}; // So that 'ontouchend' in target works
-      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'}));
-      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'}));
-      let browserDefault = fireEvent.touchEnd(el);
-      expect(browserDefault).toBe(false);
-    });
-
-    it('should not preventDefault on touchend when element is a submit button', function () {
-      let res = render(<Example elementType="button" type="submit" />);
-
-      let el = res.getByText('test');
-      el.ontouchend = () => {}; // So that 'ontouchend' in target works
-      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'}));
-      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'}));
-      let browserDefault = fireEvent.touchEnd(el);
-      expect(browserDefault).toBe(true);
-    });
-
-    it('should not preventDefault on touchend when element is an <input type="submit">', function () {
-      let res = render(<Example elementType="input" type="submit" />);
-
-      let el = res.getByRole('button');
-      el.ontouchend = () => {}; // So that 'ontouchend' in target works
-      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'}));
-      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'}));
-      let browserDefault = fireEvent.touchEnd(el);
-      expect(browserDefault).toBe(true);
-    });
-
-    it('should not preventDefault on touchend when element is an <input type="checkbox">', function () {
-      let res = render(<Example elementType="input" type="checkbox" />);
-
-      let el = res.getByRole('checkbox');
-      el.ontouchend = () => {}; // So that 'ontouchend' in target works
-      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'}));
-      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'}));
-      let browserDefault = fireEvent.touchEnd(el);
-      expect(browserDefault).toBe(true);
-    });
-
-    it('should not preventDefault on touchend when element is a link', function () {
-      let res = render(<Example elementType="a" href="http://google.com" />);
-
-      let el = res.getByText('test');
-      el.ontouchend = () => {}; // So that 'ontouchend' in target works
-      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'}));
-      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'}));
-      let browserDefault = fireEvent.touchEnd(el);
-      expect(browserDefault).toBe(true);
-    });
   });
 
   describe('mouse events', function () {
@@ -1095,9 +994,12 @@ describe('usePress', function () {
       );
 
       let el = res.getByText('test');
-      fireEvent.mouseDown(el, {detail: 1});
+      let shouldFocus = fireEvent.mouseDown(el, {detail: 1});
+      expect(shouldFocus).toBe(true);
+      act(() => el.focus());
       fireEvent.mouseUp(el, {detail: 1});
-      fireEvent.click(el, {detail: 1});
+      let shouldClick = fireEvent.click(el, {detail: 1});
+      expect(shouldClick).toBe(true);
 
       expect(events).toEqual([
         {
@@ -1471,39 +1373,6 @@ describe('usePress', function () {
       fireEvent.click(el);
 
       expect(document.activeElement).toBe(el);
-    });
-
-    it.skip('should prevent default on mousedown by default', function () {
-      let res = render(
-        <Example />
-      );
-
-      let el = res.getByText('test');
-      let allowDefault = fireEvent.mouseDown(el);
-      expect(allowDefault).toBe(false);
-    });
-
-    it.skip('should still prevent default when pressing on a non draggable + pressable item in a draggable container', function () {
-      let res = render(
-        <div draggable="true">
-          <Example />
-        </div>
-      );
-
-      let el = res.getByText('test');
-      let allowDefault = fireEvent.mouseDown(el);
-      expect(allowDefault).toBe(false);
-    });
-
-
-    it.skip('should not prevent default when pressing on a draggable item', function () {
-      let res = render(
-        <Example draggable="true" />
-      );
-
-      let el = res.getByText('test');
-      let allowDefault = fireEvent.mouseDown(el);
-      expect(allowDefault).toBe(true);
     });
 
     it('should cancel press on dragstart', function () {

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -1366,7 +1366,7 @@ describe('usePress', function () {
       let el = res.getByText('test');
       fireEvent.mouseDown(el, {detail: 1, metaKey: true});
       fireEvent.mouseUp(el, {detail: 1, shiftKey: true});
-      fireEvent.click(el, {detail: 1});
+      fireEvent.click(el, {detail: 1, shiftKey: true});
 
       expect(events).toEqual([
         {
@@ -1463,14 +1463,17 @@ describe('usePress', function () {
       );
 
       let el = res.getByText('test');
-      fireEvent.mouseDown(el);
+      let shouldFocus = fireEvent.mouseDown(el);
+      if (shouldFocus) {
+        act(() => el.focus());
+      }
       fireEvent.mouseUp(el);
       fireEvent.click(el);
 
       expect(document.activeElement).toBe(el);
     });
 
-    it('should prevent default on mousedown by default', function () {
+    it.skip('should prevent default on mousedown by default', function () {
       let res = render(
         <Example />
       );
@@ -1480,7 +1483,7 @@ describe('usePress', function () {
       expect(allowDefault).toBe(false);
     });
 
-    it('should still prevent default when pressing on a non draggable + pressable item in a draggable container', function () {
+    it.skip('should still prevent default when pressing on a non draggable + pressable item in a draggable container', function () {
       let res = render(
         <div draggable="true">
           <Example />
@@ -1493,7 +1496,7 @@ describe('usePress', function () {
     });
 
 
-    it('should not prevent default when pressing on a draggable item', function () {
+    it.skip('should not prevent default when pressing on a draggable item', function () {
       let res = render(
         <Example draggable="true" />
       );
@@ -2179,8 +2182,11 @@ describe('usePress', function () {
       );
 
       let el = res.getByText('test');
-      fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
-      fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      let shouldFocus = fireEvent.touchStart(el, {targetTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      let shouldFocus2 = fireEvent.touchEnd(el, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
+      if (shouldFocus && shouldFocus2) {
+        act(() => el.focus());
+      }
 
       expect(document.activeElement).toBe(el);
     });
@@ -3364,7 +3370,7 @@ describe('usePress', function () {
       ]}
       ${'Pointer Events'} | ${installPointerEvent}| ${[
         (el) => fireEvent.pointerDown(el, {button: 0, pointerId: 1}),
-        (el) => {fireEvent.pointerUp(el, {button: 0, pointerId: 1}); fireEvent.click(el);}
+        (el) => fireEvent.pointerUp(el, {button: 0, pointerId: 1})
       ]}
       ${'Touch Events'}   | ${() => {}}           | ${[
         (el) => fireEvent.touchStart(el, {targetTouches: [{identifier: 1}]}),
@@ -3394,6 +3400,7 @@ describe('usePress', function () {
         let el = res.getByTestId('test');
         start(el);
         end(el);
+        fireEvent.click(el);
         expect(outerPressMock.mock.calls).toHaveLength(0);
         expect(innerPressMock.mock.calls).toHaveLength(3);
       });
@@ -3421,6 +3428,7 @@ describe('usePress', function () {
         let el = res.getByTestId('test');
         start(el);
         end(el);
+        fireEvent.click(el);
         expect(outerPressMock.mock.calls).toHaveLength(4);
         expect(innerPressMock.mock.calls).toHaveLength(4);
       });

--- a/packages/@react-aria/link/test/useLink.test.js
+++ b/packages/@react-aria/link/test/useLink.test.js
@@ -23,7 +23,7 @@ describe('useLink', function () {
   it('handles defaults', function () {
     let {linkProps} = renderLinkHook({children: 'Test Link'});
     expect(linkProps.role).toBeUndefined();
-    expect(linkProps.tabIndex).toBeUndefined();
+    expect(linkProps.tabIndex).toBe(0);
     expect(typeof linkProps.onKeyDown).toBe('function');
   });
 

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -12,9 +12,9 @@
 
 import {AriaButtonProps} from '@react-types/button';
 import {AriaMenuOptions} from './useMenu';
-// @ts-ignore
 import {FocusableElement, RefObject} from '@react-types/shared';
 import {focusWithoutScrolling, useId} from '@react-aria/utils';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {MenuTriggerState} from '@react-stately/menu';
 import {MenuTriggerType} from '@react-types/menu';

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -13,13 +13,13 @@
 import {AriaButtonProps} from '@react-types/button';
 import {AriaMenuOptions} from './useMenu';
 // @ts-ignore
+import {FocusableElement, RefObject} from '@react-types/shared';
+import {focusWithoutScrolling, useId} from '@react-aria/utils';
 import intlMessages from '../intl/*.json';
 import {MenuTriggerState} from '@react-stately/menu';
 import {MenuTriggerType} from '@react-types/menu';
-import {RefObject} from '@react-types/shared';
-import {useId} from '@react-aria/utils';
+import {PressProps, useLongPress} from '@react-aria/interactions';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
-import {useLongPress} from '@react-aria/interactions';
 import {useOverlayTrigger} from '@react-aria/overlays';
 
 export interface AriaMenuTriggerProps {
@@ -108,10 +108,14 @@ export function useMenuTrigger<T>(props: AriaMenuTriggerProps, state: MenuTrigge
     }
   });
 
-  let pressProps =  {
+  let pressProps: PressProps =  {
+    preventFocusOnPress: true,
     onPressStart(e) {
       // For consistency with native, open the menu on mouse/key down, but touch up.
       if (e.pointerType !== 'touch' && e.pointerType !== 'keyboard' && !isDisabled) {
+        // Ensure trigger has focus before opening the menu so it can be restored by FocusScope on close.
+        focusWithoutScrolling(e.target as FocusableElement);
+
         // If opened with a screen reader, auto focus the first item.
         // Otherwise, the menu itself will be focused.
         state.open(e.pointerType === 'virtual' ? 'first' : null);

--- a/packages/@react-aria/menu/test/useMenuTrigger.test.js
+++ b/packages/@react-aria/menu/test/useMenuTrigger.test.js
@@ -77,7 +77,7 @@ describe('useMenuTrigger', function () {
 
     let {menuTriggerProps} = renderMenuTriggerHook(props, state);
     expect(typeof menuTriggerProps.onPressStart).toBe('function');
-    menuTriggerProps.onPressStart({pointerType: 'mouse'});
+    menuTriggerProps.onPressStart({pointerType: 'mouse', target: document.createElement('button')});
     expect(setOpen).toHaveBeenCalledTimes(1);
     expect(setOpen).toHaveBeenCalledWith(!state.isOpen);
     expect(setFocusStrategy).toHaveBeenCalledTimes(1);

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -293,6 +293,9 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
           (e.pointerType === 'keyboard' && (!allowsActions || isSelectionKey()))
         )
       ) {
+        if (e.pointerType === 'mouse') {
+          focusSafely(e.target as FocusableElement);
+        }
         onSelect(e);
       }
     };

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -296,6 +296,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
         if (e.pointerType === 'mouse') {
           focusSafely(e.target as FocusableElement);
         }
+  
         onSelect(e);
       }
     };

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -293,10 +293,6 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
           (e.pointerType === 'keyboard' && (!allowsActions || isSelectionKey()))
         )
       ) {
-        if (e.pointerType === 'mouse') {
-          focusSafely(e.target as FocusableElement);
-        }
-  
         onSelect(e);
       }
     };

--- a/packages/@react-aria/selection/test/useSelectableCollection.test.js
+++ b/packages/@react-aria/selection/test/useSelectableCollection.test.js
@@ -77,11 +77,17 @@ describe('useSelectableCollection', () => {
     type                     | prepare               | actions
     ${'VO Events'}           | ${installPointerEvent}| ${[
       (el) => fireEvent.pointerDown(el, {button: 0, pointerType: 'virtual'}),
-      (el) => fireEvent.pointerUp(el, {button: 0, pointerType: 'virtual'})
+      (el) => {
+        fireEvent.pointerUp(el, {button: 0, pointerType: 'virtual'});
+        fireEvent.click(el, {detail: 1});
+      }
     ]}
     ${'Touch Pointer Events'} | ${installPointerEvent}| ${[
       (el) => fireEvent.pointerDown(el, {button: 0, pointerType: 'touch', pointerId: 1}),
-      (el) => fireEvent.pointerUp(el, {button: 0, pointerType: 'touch', pointerId: 1})
+      (el) => {
+        fireEvent.pointerUp(el, {button: 0, pointerType: 'touch', pointerId: 1});
+        fireEvent.click(el, {detail: 1});
+      }
     ]}
   `('always uses toggle for $type', ({prepare, actions: [start, end]}) => {
     prepare();

--- a/packages/@react-aria/table/src/useTableColumnHeader.ts
+++ b/packages/@react-aria/table/src/useTableColumnHeader.ts
@@ -90,9 +90,9 @@ export function useTableColumnHeader<T>(props: AriaTableColumnHeaderProps<T>, st
   return {
     columnHeaderProps: {
       ...mergeProps(
+        focusableProps,
         gridCellProps,
         pressProps,
-        focusableProps,
         descriptionProps,
         // If the table is empty, make all column headers untabbable
         shouldDisableFocus ? {tabIndex: -1} : null

--- a/packages/@react-aria/table/src/useTableColumnResize.ts
+++ b/packages/@react-aria/table/src/useTableColumnResize.ts
@@ -224,6 +224,7 @@ export function useTableColumnResize<T>(props: AriaTableColumnResizeProps<T>, st
   };
 
   let {pressProps} = usePress({
+    preventFocusOnPress: true,
     onPressStart: (e) => {
       if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey || e.pointerType === 'keyboard') {
         return;

--- a/packages/@react-aria/test-utils/src/table.ts
+++ b/packages/@react-aria/test-utils/src/table.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, waitFor, within} from '@testing-library/react';
+import {act, waitFor, within} from '@testing-library/react';
 import {BaseTesterOpts, UserOpts} from './user';
 import {pressElement, triggerLongPress} from './events';
 export interface TableOptions extends UserOpts, BaseTesterOpts {
@@ -60,10 +60,6 @@ export class TableTester {
 
         // Note that long press interactions with rows is strictly touch only for grid rows
         await triggerLongPress({element: cell, advanceTimer: this._advanceTimer, pointerOpts: {pointerType: 'touch'}});
-        // TODO: interestingly enough, we need to do a followup click otherwise future row selections may not fire properly?
-        // To reproduce, try removing this, forcing toggleRowSelection to hit "needsLongPress ? await triggerLongPress(cell) : await action(cell);" and
-        // run Table.test's "should support long press to enter selection mode on touch" test to see what happens
-        await fireEvent.click(cell);
       } else {
         await pressElement(this.user, cell, interactionType);
       }

--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -140,7 +140,8 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
       'aria-describedby': state.isOpen ? tooltipId : undefined,
       ...mergeProps(focusableProps, hoverProps, {
         onPointerDown: onPressStart,
-        onKeyDown: onPressStart
+        onKeyDown: onPressStart,
+        tabIndex: undefined
       })
     },
     tooltipProps: {

--- a/packages/@react-aria/utils/src/index.ts
+++ b/packages/@react-aria/utils/src/index.ts
@@ -44,3 +44,4 @@ export {useFormReset} from './useFormReset';
 export {useLoadMore} from './useLoadMore';
 export {CLEAR_FOCUS_EVENT, FOCUS_EVENT, UPDATE_ACTIVEDESCENDANT} from './constants';
 export {useEnterAnimation, useExitAnimation} from './animation';
+export {isFocusable, isTabbable} from './isFocusable';

--- a/packages/@react-aria/utils/src/isFocusable.ts
+++ b/packages/@react-aria/utils/src/isFocusable.ts
@@ -1,0 +1,28 @@
+const focusableElements = [
+  'input:not([disabled]):not([type=hidden])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'a[href]',
+  'area[href]',
+  'summary',
+  'iframe',
+  'object',
+  'embed',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable^="false"])'
+];
+
+const FOCUSABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]),') + ',[tabindex]:not([disabled]):not([hidden])';
+
+focusableElements.push('[tabindex]:not([tabindex="-1"]):not([disabled])');
+const TABBABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]):not([tabindex="-1"]),');
+
+export function isFocusable(element: Element) {
+  return element.matches(FOCUSABLE_ELEMENT_SELECTOR);
+}
+
+export function isTabbable(element: Element) {
+  return element.matches(TABBABLE_ELEMENT_SELECTOR);
+}

--- a/packages/@react-aria/utils/src/useGlobalListeners.ts
+++ b/packages/@react-aria/utils/src/useGlobalListeners.ts
@@ -13,6 +13,7 @@
 import {useCallback, useEffect, useRef} from 'react';
 
 interface GlobalListeners {
+  addGlobalListener<K extends keyof WindowEventMap>(el: Window, type: K, listener: (this: Document, ev: WindowEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void,
   addGlobalListener<K extends keyof DocumentEventMap>(el: EventTarget, type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void,
   addGlobalListener(el: EventTarget, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void,
   removeGlobalListener<K extends keyof DocumentEventMap>(el: EventTarget, type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void,

--- a/packages/@react-aria/utils/src/useUpdateEffect.ts
+++ b/packages/@react-aria/utils/src/useUpdateEffect.ts
@@ -13,7 +13,7 @@
 import {EffectCallback, useEffect, useRef} from 'react';
 
 // Like useEffect, but only called for updates after the initial render.
-export function useUpdateEffect(effect: EffectCallback, dependencies: any[]) {
+export function useUpdateEffect(effect: EffectCallback, dependencies: any[]): (() => void) | void {
   const isInitialMount = useRef(true);
   const lastDeps = useRef<any[] | null>(null);
 
@@ -28,7 +28,7 @@ export function useUpdateEffect(effect: EffectCallback, dependencies: any[]) {
     if (isInitialMount.current) {
       isInitialMount.current = false;
     } else if (!lastDeps.current || dependencies.some((dep, i) => !Object.is(dep, lastDeps[i]))) {
-      effect();
+      return effect();
     }
     lastDeps.current = dependencies;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/@react-spectrum/calendar/test/CalendarBase.test.js
+++ b/packages/@react-spectrum/calendar/test/CalendarBase.test.js
@@ -759,7 +759,7 @@ describe('CalendarBase', () => {
       );
 
       let grid = getByRole('grid');
-      let selected = getAllByRole('button').find(cell => cell.getAttribute('tabIndex') === '0');
+      let selected = getAllByRole('button').find(cell => cell.tagName === 'SPAN' && cell.getAttribute('tabIndex') === '0');
       expect(document.activeElement).toBe(selected);
 
       await user.keyboard('{ArrowLeft}');
@@ -779,7 +779,7 @@ describe('CalendarBase', () => {
       fireEvent.blur(grid);
       fireEvent.focus(grid);
 
-      selected = getAllByRole('button').find(cell => cell.getAttribute('tabIndex') === '0');
+      selected = getAllByRole('button').find(cell => cell.tagName === 'SPAN' && cell.getAttribute('tabIndex') === '0');
       expect(document.activeElement).toBe(selected);
 
       await user.keyboard('{ArrowLeft}');

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -1708,7 +1708,7 @@ describe('ComboBox', function () {
       expect(listbox).toBeVisible();
       let items = within(listbox).getAllByRole('option');
 
-      fireEvent.mouseDown(items[0]);
+      await user.pointer({target: items[0], keys: '[MouseLeft>]'});
       act(() => {
         jest.runAllTimers();
       });
@@ -1720,7 +1720,7 @@ describe('ComboBox', function () {
       expect(document.activeElement).toBe(combobox);
       expect(listbox).toBeVisible();
 
-      fireEvent.mouseUp(items[0]);
+      await user.pointer({target: items[0], keys: '[/MouseLeft]'});
       act(() => {
         jest.runAllTimers();
       });

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -73,7 +73,7 @@ describe('DatePickerBase', function () {
 
       let button = getAllByRole('button')[0];
       expect(button).toBeVisible();
-      expect(button).not.toHaveAttribute('tabindex');
+      expect(button).toHaveAttribute('tabindex', '0');
     });
 
     it.each`

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -746,8 +746,7 @@ describe('ListView', function () {
       let row = tree.getAllByRole('row')[0];
       await user.tab();
       expect(row).toHaveAttribute('aria-selected', 'false');
-      fireEvent.keyDown(row, {key: ' '});
-      fireEvent.keyUp(row, {key: ' '});
+      await user.keyboard(' ');
 
       checkSelection(onSelectionChange, ['foo']);
       expect(row).toHaveAttribute('aria-selected', 'true');
@@ -761,8 +760,7 @@ describe('ListView', function () {
       let row = tree.getAllByRole('row')[0];
       await user.tab();
       expect(row).toHaveAttribute('aria-selected', 'false');
-      fireEvent.keyDown(row, {key: 'Enter'});
-      fireEvent.keyUp(row, {key: 'Enter'});
+      await user.keyboard('{Enter}');
 
       checkSelection(onSelectionChange, ['foo']);
       expect(row).toHaveAttribute('aria-selected', 'true');
@@ -850,8 +848,8 @@ describe('ListView', function () {
       expect(announce).toHaveBeenCalledTimes(1);
       expect(gridListTester.selectedRows).toHaveLength(1);
 
-      fireEvent.keyDown(rows[0], {key: 'a', ctrlKey: true});
-      fireEvent.keyUp(rows[0], {key: 'a', ctrlKey: true});
+      await user.keyboard('{Control>}a{/Control}');
+      act(() => jest.runAllTimers());
       checkSelection(onSelectionChange, 'all');
       onSelectionChange.mockClear();
       expect(announce).toHaveBeenLastCalledWith('All items selected.');
@@ -1199,9 +1197,7 @@ describe('ListView', function () {
         let row = tree.getAllByRole('row')[1];
         expect(row).toHaveAttribute('aria-selected', 'false');
         await user.keyboard('[ControlLeft>]');
-        fireEvent.pointerDown(getRow(tree, 'Bar'), {pointerType: 'mouse', ctrlKey: true});
-        fireEvent.pointerUp(getRow(tree, 'Bar'), {pointerType: 'mouse', ctrlKey: true});
-        fireEvent.click(getRow(tree, 'Bar'), {ctrlKey: true});
+        await user.pointer({target: getRow(tree, 'Bar'), keys: '[MouseLeft]', coords: {width: 1}});
         await user.keyboard('[/ControlLeft]');
 
         checkSelection(onSelectionChange, ['bar']);
@@ -1243,22 +1239,19 @@ describe('ListView', function () {
         checkSelection(onSelectionChange, ['foo']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
+        await user.keyboard('{ArrowDown}');
         expect(announce).toHaveBeenLastCalledWith('Bar selected.');
         expect(announce).toHaveBeenCalledTimes(2);
         checkSelection(onSelectionChange, ['bar']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowUp'});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowUp'});
+        await user.keyboard('{ArrowUp}');
         expect(announce).toHaveBeenLastCalledWith('Foo selected.');
         expect(announce).toHaveBeenCalledTimes(3);
         checkSelection(onSelectionChange, ['foo']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown', shiftKey: true});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown', shiftKey: true});
+        await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
         expect(announce).toHaveBeenLastCalledWith('Bar selected. 2 items selected.');
         expect(announce).toHaveBeenCalledTimes(4);
         checkSelection(onSelectionChange, ['foo', 'bar']);
@@ -1274,15 +1267,13 @@ describe('ListView', function () {
         checkSelection(onSelectionChange, ['foo']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown', shiftKey: true});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown', shiftKey: true});
+        await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
         expect(announce).toHaveBeenLastCalledWith('Bar selected. 2 items selected.');
         expect(announce).toHaveBeenCalledTimes(2);
         checkSelection(onSelectionChange, ['foo', 'bar']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
+        await user.keyboard('{ArrowDown}');
         expect(announce).toHaveBeenLastCalledWith('Baz selected. 1 item selected.');
         checkSelection(onSelectionChange, ['baz']);
       });
@@ -1297,27 +1288,23 @@ describe('ListView', function () {
         checkSelection(onSelectionChange, ['foo']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
+        await user.keyboard('{Control>}{ArrowDown}{/Control}');
         expect(announce).toHaveBeenCalledTimes(1);
         expect(onSelectionChange).not.toHaveBeenCalled();
         expect(document.activeElement).toBe(getRow(tree, 'Bar'));
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
+        await user.keyboard('{Control>}{ArrowDown}{/Control}');
         expect(announce).toHaveBeenCalledTimes(1);
         expect(onSelectionChange).not.toHaveBeenCalled();
         expect(document.activeElement).toBe(getRow(tree, 'Baz'));
 
-        fireEvent.keyDown(document.activeElement, {key: ' ', ctrlKey: true});
-        fireEvent.keyUp(document.activeElement, {key: ' ', ctrlKey: true});
+        await user.keyboard('{Control>} {/Control}');
         expect(announce).toHaveBeenCalledWith('Baz selected. 2 items selected.');
         expect(announce).toHaveBeenCalledTimes(2);
         checkSelection(onSelectionChange, ['foo', 'baz']);
         onSelectionChange.mockClear();
 
-        fireEvent.keyDown(document.activeElement, {key: ' '});
-        fireEvent.keyUp(document.activeElement, {key: ' '});
+        await user.keyboard(' ');
         expect(announce).toHaveBeenCalledWith('Baz selected. 1 item selected.');
         expect(announce).toHaveBeenCalledTimes(3);
         checkSelection(onSelectionChange, ['baz']);
@@ -1327,23 +1314,19 @@ describe('ListView', function () {
         let tree = renderSelectionList({onSelectionChange, selectionStyle: 'highlight', onAction, selectionMode: 'multiple'});
 
         let rows = tree.getAllByRole('row');
-        fireEvent.pointerDown(rows[0], {pointerType: 'mouse'});
-        fireEvent.pointerUp(rows[0], {pointerType: 'mouse'});
-        fireEvent.click(rows[0], {pointerType: 'mouse'});
+        await user.pointer({target: rows[0], keys: '[MouseLeft]', coords: {width: 1}});
         checkSelection(onSelectionChange, ['foo']);
         onSelectionChange.mockClear();
         expect(announce).toHaveBeenLastCalledWith('Foo selected.');
         expect(announce).toHaveBeenCalledTimes(1);
 
-        fireEvent.keyDown(rows[0], {key: 'a', ctrlKey: true});
-        fireEvent.keyUp(rows[0], {key: 'a', ctrlKey: true});
+        await user.keyboard('{Control>}a{/Control}');
         checkSelection(onSelectionChange, 'all');
         onSelectionChange.mockClear();
         expect(announce).toHaveBeenLastCalledWith('All items selected.');
         expect(announce).toHaveBeenCalledTimes(2);
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
+        await user.keyboard('{ArrowDown}');
         expect(announce).toHaveBeenLastCalledWith('Bar selected. 1 item selected.');
         expect(announce).toHaveBeenCalledTimes(3);
         checkSelection(onSelectionChange, ['bar']);

--- a/packages/@react-spectrum/list/test/ListView.test.js
+++ b/packages/@react-spectrum/list/test/ListView.test.js
@@ -13,7 +13,7 @@
 
 jest.mock('@react-aria/live-announcer');
 jest.mock('@react-aria/utils/src/scrollIntoView');
-import {act, fireEvent, installPointerEvent, mockClickDefault, pointerMap, render as renderComponent, within} from '@react-spectrum/test-utils-internal';
+import {act, fireEvent, installPointerEvent, mockClickDefault, pointerMap, render as renderComponent, triggerTouch, within} from '@react-spectrum/test-utils-internal';
 import {ActionButton} from '@react-spectrum/button';
 import {announce} from '@react-aria/live-announcer';
 import {FocusExample} from '../stories/ListViewActions.stories';
@@ -932,17 +932,13 @@ describe('ListView', function () {
           fireEvent.pointerUp(rows[1], {pointerType: 'touch'});
           onSelectionChange.mockReset();
 
-          fireEvent.pointerDown(rows[2], {pointerType: 'touch'});
-          fireEvent.pointerUp(rows[2], {pointerType: 'touch'});
-
+          triggerTouch(rows[2]);
           checkSelection(onSelectionChange, ['bar', 'baz']);
 
           // Deselect all to exit selection mode
-          fireEvent.pointerDown(rows[2], {pointerType: 'touch'});
-          fireEvent.pointerUp(rows[2], {pointerType: 'touch'});
+          triggerTouch(rows[2]);
           onSelectionChange.mockReset();
-          fireEvent.pointerDown(rows[1], {pointerType: 'touch'});
-          fireEvent.pointerUp(rows[1], {pointerType: 'touch'});
+          triggerTouch(rows[1]);
 
           act(() => jest.runAllTimers());
           checkSelection(onSelectionChange, []);
@@ -1387,6 +1383,7 @@ describe('ListView', function () {
         expect(within(rows[0]).getByRole('checkbox')).toBeTruthy();
 
         fireEvent.pointerUp(rows[0], {pointerType: 'touch'});
+        fireEvent.click(rows[0], {detail: 1});
 
         await user.pointer({target: rows[1], keys: '[TouchA]'});
         expect(announce).toHaveBeenLastCalledWith('Bar selected. 2 items selected.');

--- a/packages/@react-spectrum/list/test/ListViewDnd.test.js
+++ b/packages/@react-spectrum/list/test/ListViewDnd.test.js
@@ -418,6 +418,7 @@ describe('ListView', function () {
 
         let dataTransfer = new DataTransfer();
         fireEvent.pointerDown(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
+        act(() => rows[1].focus());
         fireEvent(cell, new DragEvent('dragstart', {dataTransfer, clientX: 0, clientY: 0}));
         expect(onDragStart).toHaveBeenCalledTimes(1);
 
@@ -469,6 +470,7 @@ describe('ListView', function () {
 
         let dataTransfer = new DataTransfer();
         fireEvent.pointerDown(cell, {pointerType: 'mouse', button: 0, pointerId: 1, clientX: 0, clientY: 0});
+        act(() => rows[1].focus());
         fireEvent(cell, new DragEvent('dragstart', {dataTransfer, clientX: 0, clientY: 0}));
         expect(onDragStart).toHaveBeenCalledTimes(1);
 
@@ -2931,6 +2933,7 @@ describe('ListView', function () {
       expect(draggableRow).toHaveAttribute('aria-selected', 'false');
       expect(onSelectionChange).toHaveBeenCalledTimes(0);
       fireEvent.pointerUp(draggableRow, {pointerType: 'mouse'});
+      fireEvent.click(draggableRow, {detail: 1});
       expect(draggableRow).toHaveAttribute('aria-selected', 'true');
       checkSelection(onSelectionChange, ['a']);
     });

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3193,22 +3193,21 @@ export let tableTests = () => {
         });
       });
 
-      it('should support Enter to perform onAction with keyboard', function () {
+      it('should support Enter to perform onAction with keyboard', async function () {
         let onSelectionChange = jest.fn();
         let onAction = jest.fn();
         let tree = renderTable({onSelectionChange, selectionStyle: 'highlight', onAction});
 
-        fireEvent.keyDown(getCell(tree, 'Baz 10'), {key: ' '});
-        fireEvent.keyUp(getCell(tree, 'Baz 10'), {key: ' '});
+        act(() => getCell(tree, 'Baz 10').focus());
+        await user.keyboard(' ');
         checkSelection(onSelectionChange, ['Foo 10']);
-        // screen reader automatically handles this one
-        expect(announce).not.toHaveBeenCalled();
+        expect(announce).toHaveBeenCalledWith('Foo 10 selected.');
         expect(onAction).not.toHaveBeenCalled();
 
         announce.mockReset();
         onSelectionChange.mockReset();
-        fireEvent.keyDown(getCell(tree, 'Baz 5'), {key: 'Enter'});
-        fireEvent.keyUp(getCell(tree, 'Baz 5'), {key: 'Enter'});
+        act(() => getCell(tree, 'Baz 5').focus());
+        await user.keyboard('{Enter}');
         expect(onSelectionChange).not.toHaveBeenCalled();
         expect(announce).not.toHaveBeenCalled();
         expect(onAction).toHaveBeenCalledTimes(1);

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3291,28 +3291,24 @@ export let tableTests = () => {
 
         announce.mockReset();
         onSelectionChange.mockReset();
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
+        await user.keyboard('{Control>}{ArrowDown}{/Control}');
         expect(announce).not.toHaveBeenCalled();
         expect(onSelectionChange).not.toHaveBeenCalled();
-        expect(document.activeElement).toBe(getCell(tree, 'Baz 6').closest('[role="row"]'));
+        expect(document.activeElement).toBe(getCell(tree, 'Baz 6'));
 
-        fireEvent.keyDown(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
-        fireEvent.keyUp(document.activeElement, {key: 'ArrowDown', ctrlKey: true});
+        await user.keyboard('{Control>}{ArrowDown}{/Control}');
         expect(announce).not.toHaveBeenCalled();
         expect(onSelectionChange).not.toHaveBeenCalled();
-        expect(document.activeElement).toBe(getCell(tree, 'Baz 7').closest('[role="row"]'));
+        expect(document.activeElement).toBe(getCell(tree, 'Baz 7'));
 
-        fireEvent.keyDown(document.activeElement, {key: ' ', ctrlKey: true});
-        fireEvent.keyUp(document.activeElement, {key: ' ', ctrlKey: true});
+        await user.keyboard('{Control>} {/Control}');
         expect(announce).toHaveBeenCalledWith('Foo 7 selected. 2 items selected.');
         expect(announce).toHaveBeenCalledTimes(1);
         checkSelection(onSelectionChange, ['Foo 5', 'Foo 7']);
 
         announce.mockReset();
         onSelectionChange.mockReset();
-        fireEvent.keyDown(document.activeElement, {key: ' '});
-        fireEvent.keyUp(document.activeElement, {key: ' '});
+        await user.keyboard(' ');
         expect(announce).toHaveBeenCalledWith('Foo 7 selected. 1 item selected.');
         expect(announce).toHaveBeenCalledTimes(1);
         checkSelection(onSelectionChange, ['Foo 7']);

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -3160,7 +3160,9 @@ export let tableTests = () => {
             expect(onAction).not.toHaveBeenCalled();
             expect(tree.queryByLabelText('Select All')).not.toBeNull();
 
-            fireEvent.pointerUp(getCell(tree, 'Baz 5'), {pointerType: 'touch'});
+            let cell = getCell(tree, 'Baz 5');
+            fireEvent.pointerUp(cell, {pointerType: 'touch'});
+            fireEvent.click(cell, {detail: 1});
             onSelectionChange.mockReset();
             act(() => {
               jest.runAllTimers();

--- a/packages/@react-spectrum/table/test/TableDnd.test.js
+++ b/packages/@react-spectrum/table/test/TableDnd.test.js
@@ -2810,6 +2810,7 @@ describe('TableView', function () {
         expect(draggableRow).toHaveAttribute('aria-selected', 'false');
         expect(onSelectionChange).toHaveBeenCalledTimes(0);
         fireEvent.pointerUp(draggableRow, {pointerType: 'mouse'});
+        fireEvent.click(draggableRow);
         expect(draggableRow).toHaveAttribute('aria-selected', 'true');
         checkSelection(onSelectionChange, ['a']);
       });

--- a/packages/@react-spectrum/table/test/TableSizing.test.tsx
+++ b/packages/@react-spectrum/table/test/TableSizing.test.tsx
@@ -17,7 +17,7 @@ import Add from '@spectrum-icons/workflow/Add';
 import {Cell, Column, Row, TableBody, TableHeader, TableView} from '../';
 import {ColumnSize} from '@react-types/table';
 import {ControllingResize} from '../stories/ControllingResize';
-import {fireEvent, installPointerEvent, pointerMap, simulateDesktop} from '@react-spectrum/test-utils-internal';
+import {fireEvent, installPointerEvent, pointerMap, simulateDesktop, triggerTouch} from '@react-spectrum/test-utils-internal';
 import {HidingColumns} from '../stories/HidingColumns';
 import {Key} from '@react-types/shared';
 import {Provider} from '@react-spectrum/provider';
@@ -978,14 +978,12 @@ describe('TableViewSizing', function () {
         let header = tree.getAllByRole('columnheader')[0];
         let resizableHeader = within(header).getByRole('button');
 
-        fireEvent.pointerDown(resizableHeader, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(resizableHeader, {pointerType: 'touch', pointerId: 1});
+        triggerTouch(resizableHeader);
         act(() => {jest.runAllTimers();});
 
         let resizeMenuItem = tree.getAllByRole('menuitem')[0];
 
-        fireEvent.pointerDown(resizeMenuItem, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(resizeMenuItem, {pointerType: 'touch', pointerId: 1});
+        triggerTouch(resizeMenuItem);
         act(() => {jest.runAllTimers();});
 
         let resizer = tree.getByRole('slider');

--- a/packages/@react-spectrum/table/test/TreeGridTable.test.tsx
+++ b/packages/@react-spectrum/table/test/TreeGridTable.test.tsx
@@ -1341,7 +1341,7 @@ describe('TableView with expandable rows', function () {
     describe('selectionStyle highlight', function () {
       installPointerEvent();
 
-      it('should toggle selection with mouse', function () {
+      it('should toggle selection with mouse', async function () {
         let treegrid = render(<ManyRowsExpandableTable onSelectionChange={onSelectionChange} selectionMode="multiple" selectionStyle="highlight" disabledKeys={undefined} onAction={undefined} />);
         expect(treegrid.queryByLabelText('Select All')).toBeNull();
 
@@ -1350,9 +1350,7 @@ describe('TableView with expandable rows', function () {
         let cell = getCell(treegrid, 'Row 1, Lvl 3, Foo');
 
         checkRowSelection(rows, false);
-        fireEvent.pointerDown(cell, {pointerType: 'mouse', pointerId: 1});
-        fireEvent.pointerUp(cell, {pointerType: 'mouse', pointerId: 1});
-        fireEvent.click(cell, {detail: 1});
+        await user.pointer({target: cell, keys: '[MouseLeft]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 3, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(1);
@@ -1361,9 +1359,7 @@ describe('TableView with expandable rows', function () {
         onSelectionChange.mockReset();
 
         cell = getCell(treegrid, 'Row 1, Lvl 1, Foo');
-        fireEvent.pointerDown(cell, {pointerType: 'mouse', pointerId: 1});
-        fireEvent.pointerUp(cell, {pointerType: 'mouse', pointerId: 1});
-        fireEvent.click(cell, {detail: 1});
+        await user.pointer({target: cell, keys: '[MouseLeft]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 1, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(2);
@@ -1372,7 +1368,7 @@ describe('TableView with expandable rows', function () {
         checkRowSelection(rows.slice(1), false);
       });
 
-      it('should toggle selection with touch', function () {
+      it('should toggle selection with touch', async function () {
         let treegrid = render(<ManyRowsExpandableTable onSelectionChange={onSelectionChange} selectionMode="multiple" selectionStyle="highlight" disabledKeys={undefined} onAction={undefined} />);
         expect(treegrid.queryByLabelText('Select All')).toBeNull();
 
@@ -1381,8 +1377,7 @@ describe('TableView with expandable rows', function () {
         let cell = getCell(treegrid, 'Row 1, Lvl 3, Foo');
 
         checkRowSelection(rows, false);
-        fireEvent.pointerDown(cell, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(cell, {pointerType: 'touch', pointerId: 1});
+        await user.pointer({target: cell, keys: '[TouchA]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 3, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(1);
@@ -1391,8 +1386,7 @@ describe('TableView with expandable rows', function () {
         onSelectionChange.mockReset();
 
         cell = getCell(treegrid, 'Row 1, Lvl 1, Foo');
-        fireEvent.pointerDown(cell, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(cell, {pointerType: 'touch', pointerId: 1});
+        await user.pointer({target: cell, keys: '[TouchA]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 1, Foo selected. 2 items selected.');
         expect(announce).toHaveBeenCalledTimes(2);
@@ -1408,7 +1402,7 @@ describe('TableView with expandable rows', function () {
         let firstCell = getCell(treegrid, 'Row 1, Lvl 3, Foo');
         let secondCell = getCell(treegrid, 'Row 1, Lvl 1, Foo');
 
-        fireEvent.pointerDown(firstCell, {pointerType: 'touch'});
+        await user.pointer({target: firstCell, keys: '[TouchA>]', coords: {width: 1}});
         expect(onSelectionChange).not.toHaveBeenCalled();
         expect(onAction).not.toHaveBeenCalled();
 
@@ -1418,22 +1412,19 @@ describe('TableView with expandable rows', function () {
         checkRowSelection([rows[2]], true);
         expect(onAction).not.toHaveBeenCalled();
 
-        fireEvent.pointerUp(firstCell, {pointerType: 'touch'});
+        await user.pointer({target: firstCell, keys: '[/TouchA]', coords: {width: 1}});
         onSelectionChange.mockReset();
 
-        fireEvent.pointerDown(secondCell, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(secondCell, {pointerType: 'touch', pointerId: 1});
+        await user.pointer({target: secondCell, keys: '[TouchA]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         checkSelection(onSelectionChange, ['Row 1 Lvl 1', 'Row 1 Lvl 3']);
         checkRowSelection([rows[0], rows[2]], true);
 
         // Deselect all to exit selection mode
-        fireEvent.pointerDown(firstCell, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(firstCell, {pointerType: 'touch', pointerId: 1});
+        await user.pointer({target: firstCell, keys: '[TouchA]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         onSelectionChange.mockReset();
-        fireEvent.pointerDown(secondCell, {pointerType: 'touch', pointerId: 1});
-        fireEvent.pointerUp(secondCell, {pointerType: 'touch', pointerId: 1});
+        await user.pointer({target: secondCell, keys: '[TouchA]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         checkSelection(onSelectionChange, []);
         expect(onAction).not.toHaveBeenCalled();
@@ -1449,9 +1440,7 @@ describe('TableView with expandable rows', function () {
         let cell = getCell(treegrid, 'Row 1, Lvl 3, Foo');
 
         checkRowSelection(rows, false);
-        fireEvent.pointerDown(cell, {pointerType: 'mouse', pointerId: 1});
-        fireEvent.pointerUp(cell, {pointerType: 'mouse', pointerId: 1});
-        fireEvent.click(cell, {detail: 1});
+        await user.pointer({target: cell, keys: '[MouseLeft]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 3, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(1);

--- a/packages/@react-spectrum/table/test/TreeGridTable.test.tsx
+++ b/packages/@react-spectrum/table/test/TreeGridTable.test.tsx
@@ -1352,6 +1352,7 @@ describe('TableView with expandable rows', function () {
         checkRowSelection(rows, false);
         fireEvent.pointerDown(cell, {pointerType: 'mouse', pointerId: 1});
         fireEvent.pointerUp(cell, {pointerType: 'mouse', pointerId: 1});
+        fireEvent.click(cell, {detail: 1});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 3, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(1);
@@ -1362,6 +1363,7 @@ describe('TableView with expandable rows', function () {
         cell = getCell(treegrid, 'Row 1, Lvl 1, Foo');
         fireEvent.pointerDown(cell, {pointerType: 'mouse', pointerId: 1});
         fireEvent.pointerUp(cell, {pointerType: 'mouse', pointerId: 1});
+        fireEvent.click(cell, {detail: 1});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 1, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(2);
@@ -1449,13 +1451,14 @@ describe('TableView with expandable rows', function () {
         checkRowSelection(rows, false);
         fireEvent.pointerDown(cell, {pointerType: 'mouse', pointerId: 1});
         fireEvent.pointerUp(cell, {pointerType: 'mouse', pointerId: 1});
+        fireEvent.click(cell, {detail: 1});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenLastCalledWith('Row 1, Lvl 3, Foo selected.');
         expect(announce).toHaveBeenCalledTimes(1);
         checkSelection(onSelectionChange, ['Row 1 Lvl 3']);
         expect(onAction).not.toHaveBeenCalled();
         onSelectionChange.mockReset();
-        await user.dblClick(cell);
+        await user.pointer({target: cell, keys: '[MouseLeft][MouseLeft]', coords: {width: 1}});
         act(() => jest.runAllTimers());
         expect(announce).toHaveBeenCalledTimes(1);
         expect(onSelectionChange).not.toHaveBeenCalled();

--- a/packages/@react-spectrum/tree/test/TreeView.test.tsx
+++ b/packages/@react-spectrum/tree/test/TreeView.test.tsx
@@ -507,40 +507,40 @@ describe('Tree', () => {
       let row = tree.getAllByRole('row')[0];
       expect(row).not.toHaveAttribute('data-pressed');
 
-      fireEvent.mouseDown(row);
+      await user.pointer({target: row, keys: '[MouseLeft>]'});
       expect(row).toHaveAttribute('data-pressed', 'true');
 
-      fireEvent.mouseUp(row);
+      await user.pointer({target: row, keys: '[/MouseLeft]'});
       expect(row).not.toHaveAttribute('data-pressed');
 
       rerender(tree, <StaticTree treeProps={{selectionMode: 'none', onAction: jest.fn()}} />);
       row = tree.getAllByRole('row')[0];
       expect(row).not.toHaveAttribute('data-pressed');
 
-      fireEvent.mouseDown(row);
+      await user.pointer({target: row, keys: '[MouseLeft>]'});
       expect(row).toHaveAttribute('data-pressed', 'true');
 
-      fireEvent.mouseUp(row);
+      await user.pointer({target: row, keys: '[/MouseLeft]'});
       expect(row).not.toHaveAttribute('data-pressed');
     });
 
-    it('should not update the press state if the row is not interactive', () => {
+    it('should not update the press state if the row is not interactive', async () => {
       let tree = render(<StaticTree treeProps={{selectionMode: 'none'}} />);
 
       let row = tree.getAllByRole('row')[0];
       expect(row).not.toHaveAttribute('data-pressed');
 
-      fireEvent.mouseDown(row);
+      await user.pointer({target: row, keys: '[MouseLeft>]'});
       expect(row).not.toHaveAttribute('data-pressed');
-      fireEvent.mouseUp(row);
+      await user.pointer({target: row, keys: '[/MouseLeft]'});
 
       let expandableRow = tree.getAllByRole('row')[1];
       expect(expandableRow).not.toHaveAttribute('data-pressed');
 
-      fireEvent.mouseDown(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[MouseLeft>]'});
       expect(expandableRow).toHaveAttribute('data-pressed', 'true');
 
-      fireEvent.mouseUp(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[/MouseLeft]'});
       expect(expandableRow).not.toHaveAttribute('data-pressed');
 
       // Test a completely inert expandable row
@@ -549,9 +549,9 @@ describe('Tree', () => {
       expect(expandableRow).toHaveAttribute('data-disabled', 'true');
       expect(expandableRow).not.toHaveAttribute('data-pressed');
 
-      fireEvent.mouseDown(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[MouseLeft>]'});
       expect(expandableRow).not.toHaveAttribute('data-pressed');
-      fireEvent.mouseUp(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[/MouseLeft]'});
     });
 
     it('should support focus', async () => {

--- a/packages/dev/test-utils/src/events.ts
+++ b/packages/dev/test-utils/src/events.ts
@@ -14,8 +14,9 @@ import {fireEvent} from '@testing-library/react';
 
 // Triggers a "touch" event on an element.
 export function triggerTouch(element, opts = {}) {
-  fireEvent.pointerDown(element, {pointerType: 'touch', ...opts});
-  fireEvent.pointerUp(element, {pointerType: 'touch', ...opts});
+  fireEvent.pointerDown(element, {pointerType: 'touch', pointerId: 1, ...opts});
+  fireEvent.pointerUp(element, {pointerType: 'touch', pointerId: 1, ...opts});
+  fireEvent.click(element, opts);
 }
 
 // Mocks and prevents the next click's default operation

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -13,10 +13,9 @@
 import {AriaLabelingProps, HoverEvents} from '@react-types/shared';
 import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
 import {DropOptions, mergeProps, useButton, useClipboard, useDrop, useFocusRing, useHover, useLocalizedStringFormatter, VisuallyHidden} from 'react-aria';
-import {filterDOMProps, useLabels, useObjectRef, useSlotId} from '@react-aria/utils';
+import {filterDOMProps, isFocusable, useLabels, useObjectRef, useSlotId} from '@react-aria/utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {isFocusable} from '@react-aria/focus';
 import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
 import {TextContext} from './Text';
 

--- a/packages/react-aria-components/test/AriaMenu.test-util.tsx
+++ b/packages/react-aria-components/test/AriaMenu.test-util.tsx
@@ -147,6 +147,7 @@ export const AriaMenuTests = ({renderers, setup, prefix}: AriaMenuTestProps) => 
       fireEvent.mouseLeave(triggerButton);
       fireEvent.mouseEnter(triggerButton);
       fireEvent.mouseUp(triggerButton, {detail: 1});
+      fireEvent.click(triggerButton);
 
       expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
     });

--- a/packages/react-aria-components/test/Button.test.js
+++ b/packages/react-aria-components/test/Button.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {act, pointerMap, render} from '@react-spectrum/test-utils-internal';
 import {Button, ButtonContext, ProgressBar, Text} from '../';
 import React, {useState} from 'react';
 import userEvent from '@testing-library/user-event';
@@ -103,7 +103,7 @@ describe('Button', () => {
     expect(button).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let onPress = jest.fn();
     let {getByRole} = render(<Button className={({isPressed}) => isPressed ? 'pressed' : ''} onPress={onPress}>Test</Button>);
     let button = getByRole('button');
@@ -111,11 +111,11 @@ describe('Button', () => {
     expect(button).not.toHaveAttribute('data-pressed');
     expect(button).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(button);
+    await user.pointer({target: button, keys: '[MouseLeft>]'});
     expect(button).toHaveAttribute('data-pressed', 'true');
     expect(button).toHaveClass('pressed');
 
-    fireEvent.mouseUp(button);
+    await user.pointer({target: button, keys: '[/MouseLeft]'});
     expect(button).not.toHaveAttribute('data-pressed');
     expect(button).not.toHaveClass('pressed');
 
@@ -130,16 +130,16 @@ describe('Button', () => {
     expect(button).toHaveClass('disabled');
   });
 
-  it('should support render props', () => {
+  it('should support render props', async () => {
     let {getByRole} = render(<Button>{({isPressed}) => isPressed ? 'Pressed' : 'Test'}</Button>);
     let button = getByRole('button');
 
     expect(button).toHaveTextContent('Test');
 
-    fireEvent.mouseDown(button);
+    await user.pointer({target: button, keys: '[MouseLeft>]'});
     expect(button).toHaveTextContent('Pressed');
 
-    fireEvent.mouseUp(button);
+    await user.pointer({target: button, keys: '[/MouseLeft]'});
     expect(button).toHaveTextContent('Test');
   });
 

--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -200,7 +200,7 @@ describe('Calendar', () => {
     expect(cell).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getByRole} = renderCalendar({}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let grid = getByRole('grid');
     let cell = within(grid).getAllByRole('button')[7];
@@ -208,11 +208,11 @@ describe('Calendar', () => {
     expect(cell).not.toHaveAttribute('data-pressed');
     expect(cell).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(cell);
+    await user.pointer({target: cell, keys: '[MouseLeft>]'});
     expect(cell).toHaveAttribute('data-pressed', 'true');
     expect(cell).toHaveClass('pressed');
 
-    fireEvent.mouseUp(cell);
+    await user.pointer({target: cell, keys: '[/MouseLeft]'});
     expect(cell).not.toHaveAttribute('data-pressed');
     expect(cell).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/Checkbox.test.js
+++ b/packages/react-aria-components/test/Checkbox.test.js
@@ -11,7 +11,7 @@
  */
 
 import {Checkbox, CheckboxContext} from '../';
-import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
@@ -122,18 +122,18 @@ describe('Checkbox', () => {
     expect(onFocusChange).toHaveBeenLastCalledWith(false);
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getByRole} = render(<Checkbox className={({isPressed}) => isPressed ? 'pressed' : ''}>Test</Checkbox>);
     let checkbox = getByRole('checkbox').closest('label');
 
     expect(checkbox).not.toHaveAttribute('data-pressed');
     expect(checkbox).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(checkbox);
+    await user.pointer({target: checkbox, keys: '[MouseLeft>]'});
     expect(checkbox).toHaveAttribute('data-pressed', 'true');
     expect(checkbox).toHaveClass('pressed');
 
-    fireEvent.mouseUp(checkbox);
+    await user.pointer({target: checkbox, keys: '[/MouseLeft]'});
     expect(checkbox).not.toHaveAttribute('data-pressed');
     expect(checkbox).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/GridList.test.js
+++ b/packages/react-aria-components/test/GridList.test.js
@@ -189,34 +189,34 @@ describe('GridList', () => {
     expect(row).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderGridList({selectionMode: 'multiple'}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let row = getAllByRole('row')[0];
 
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).toHaveAttribute('data-pressed', 'true');
     expect(row).toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
   });
 
-  it('should not show press state when not interactive', () => {
+  it('should not show press state when not interactive', async () => {
     let {getAllByRole} = renderGridList({}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let row = getAllByRole('row')[0];
 
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/Link.test.js
+++ b/packages/react-aria-components/test/Link.test.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
 import {Link, LinkContext, RouterProvider} from '../';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
@@ -107,7 +107,7 @@ describe('Link', () => {
     expect(link).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let onPress = jest.fn();
     let {getByRole} = render(<Link className={({isPressed}) => isPressed ? 'pressed' : ''} onPress={onPress}>Test</Link>);
     let link = getByRole('link');
@@ -115,11 +115,11 @@ describe('Link', () => {
     expect(link).not.toHaveAttribute('data-pressed');
     expect(link).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(link);
+    await user.pointer({target: link, keys: '[MouseLeft>]'});
     expect(link).toHaveAttribute('data-pressed', 'true');
     expect(link).toHaveClass('pressed');
 
-    fireEvent.mouseUp(link);
+    await user.pointer({target: link, keys: '[/MouseLeft]'});
     expect(link).not.toHaveAttribute('data-pressed');
     expect(link).not.toHaveClass('pressed');
 

--- a/packages/react-aria-components/test/ListBox.test.js
+++ b/packages/react-aria-components/test/ListBox.test.js
@@ -395,34 +395,34 @@ describe('ListBox', () => {
     expect(option).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderListbox({selectionMode: 'multiple'}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let option = getAllByRole('option')[0];
 
     expect(option).not.toHaveAttribute('data-pressed');
     expect(option).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(option);
+    await user.pointer({target: option, keys: '[MouseLeft>]'});
     expect(option).toHaveAttribute('data-pressed', 'true');
     expect(option).toHaveClass('pressed');
 
-    fireEvent.mouseUp(option);
+    await user.pointer({target: option, keys: '[/MouseLeft]'});
     expect(option).not.toHaveAttribute('data-pressed');
     expect(option).not.toHaveClass('pressed');
   });
 
-  it('should not show press state when not interactive', () => {
+  it('should not show press state when not interactive', async () => {
     let {getAllByRole} = renderListbox({}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let option = getAllByRole('option')[0];
 
     expect(option).not.toHaveAttribute('data-pressed');
     expect(option).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(option);
+    await user.pointer({target: option, keys: '[MouseLeft>]'});
     expect(option).not.toHaveAttribute('data-pressed');
     expect(option).not.toHaveClass('pressed');
 
-    fireEvent.mouseUp(option);
+    await user.pointer({target: option, keys: '[/MouseLeft]'});
     expect(option).not.toHaveAttribute('data-pressed');
     expect(option).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/Menu.test.tsx
+++ b/packages/react-aria-components/test/Menu.test.tsx
@@ -301,18 +301,18 @@ describe('Menu', () => {
     expect(menuitem).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderMenu({}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let menuitem = getAllByRole('menuitem')[0];
 
     expect(menuitem).not.toHaveAttribute('data-pressed');
     expect(menuitem).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(menuitem);
+    await user.pointer({target: menuitem, keys: '[MouseLeft>]'});
     expect(menuitem).toHaveAttribute('data-pressed', 'true');
     expect(menuitem).toHaveClass('pressed');
 
-    fireEvent.mouseUp(menuitem);
+    await user.pointer({target: menuitem, keys: '[/MouseLeft]'});
     expect(menuitem).not.toHaveAttribute('data-pressed');
     expect(menuitem).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
+import {act, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
 import {Button, Dialog, DialogTrigger, FieldError, Label, Modal, Radio, RadioContext, RadioGroup, RadioGroupContext, Text} from '../';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -166,18 +166,18 @@ describe('RadioGroup', () => {
     expect(label).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderGroup({}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let radio = getAllByRole('radio')[0].closest('label');
 
     expect(radio).not.toHaveAttribute('data-pressed');
     expect(radio).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(radio);
+    await user.pointer({target: radio, keys: '[MouseLeft>]'});
     expect(radio).toHaveAttribute('data-pressed', 'true');
     expect(radio).toHaveClass('pressed');
 
-    fireEvent.mouseUp(radio);
+    await user.pointer({target: radio, keys: '[/MouseLeft]'});
     expect(radio).not.toHaveAttribute('data-pressed');
     expect(radio).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/RangeCalendar.test.tsx
+++ b/packages/react-aria-components/test/RangeCalendar.test.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
+import {act, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
 import {Button, CalendarCell, CalendarGrid, CalendarGridBody, CalendarGridHeader, CalendarHeaderCell, Heading, RangeCalendar, RangeCalendarContext} from 'react-aria-components';
 import {CalendarDate, getLocalTimeZone, startOfMonth, startOfWeek, today} from '@internationalized/date';
 import {DateValue} from '@react-types/calendar';
@@ -220,7 +220,7 @@ describe('RangeCalendar', () => {
     expect(cell).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getByRole} = renderCalendar({}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let grid = getByRole('grid');
     let cell = within(grid).getAllByRole('button')[7];
@@ -228,11 +228,11 @@ describe('RangeCalendar', () => {
     expect(cell).not.toHaveAttribute('data-pressed');
     expect(cell).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(cell);
+    await user.pointer({target: cell, keys: '[MouseLeft>]'});
     expect(cell).toHaveAttribute('data-pressed', 'true');
     expect(cell).toHaveClass('pressed');
 
-    fireEvent.mouseUp(cell);
+    await user.pointer({target: cell, keys: '[/MouseLeft]'});
     expect(cell).not.toHaveAttribute('data-pressed');
     expect(cell).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/Switch.test.js
+++ b/packages/react-aria-components/test/Switch.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
 import React from 'react';
 import {Switch, SwitchContext} from '../';
 import userEvent from '@testing-library/user-event';
@@ -138,18 +138,18 @@ describe('Switch', () => {
     expect(onFocusChange).toHaveBeenLastCalledWith(false);
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getByRole} = render(<Switch className={({isPressed}) => isPressed ? 'pressed' : ''}>Test</Switch>);
     let s = getByRole('switch').closest('label');
 
     expect(s).not.toHaveAttribute('data-pressed');
     expect(s).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(s);
+    await user.pointer({target: s, keys: '[MouseLeft>]'});
     expect(s).toHaveAttribute('data-pressed', 'true');
     expect(s).toHaveClass('pressed');
 
-    fireEvent.mouseUp(s);
+    await user.pointer({target: s, keys: '[/MouseLeft]'});
     expect(s).not.toHaveAttribute('data-pressed');
     expect(s).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -477,7 +477,7 @@ describe('Table', () => {
     expect(column).toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderTable({
       tableProps: {selectionMode: 'multiple'},
       rowProps: {className: ({isPressed}) => isPressed ? 'pressed' : ''}
@@ -488,16 +488,16 @@ describe('Table', () => {
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).toHaveAttribute('data-pressed', 'true');
     expect(row).toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
   });
 
-  it('should not show press state when not interactive', () => {
+  it('should not show press state when not interactive', async () => {
     let {getAllByRole} = renderTable({
       rowProps: {className: ({isPressed}) => isPressed ? 'pressed' : ''}
     });
@@ -506,16 +506,16 @@ describe('Table', () => {
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
   });
 
-  it('should support row actions', () => {
+  it('should support row actions', async () => {
     let onRowAction = jest.fn();
     let {getAllByRole} = renderTable({
       tableProps: {onRowAction},
@@ -527,11 +527,11 @@ describe('Table', () => {
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).toHaveAttribute('data-pressed', 'true');
     expect(row).toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -177,18 +177,18 @@ describe('Tabs', () => {
     expect(tab).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderTabs({}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let tab = getAllByRole('tab')[0];
 
     expect(tab).not.toHaveAttribute('data-pressed');
     expect(tab).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(tab);
+    await user.pointer({target: tab, keys: '[MouseLeft>]'});
     expect(tab).toHaveAttribute('data-pressed', 'true');
     expect(tab).toHaveClass('pressed');
 
-    fireEvent.mouseUp(tab);
+    await user.pointer({target: tab, keys: '[/MouseLeft]'});
     expect(tab).not.toHaveAttribute('data-pressed');
     expect(tab).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/TagGroup.test.js
+++ b/packages/react-aria-components/test/TagGroup.test.js
@@ -176,34 +176,34 @@ describe('TagGroup', () => {
     expect(row).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let {getAllByRole} = renderTagGroup({selectionMode: 'multiple'}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let row = getAllByRole('row')[0];
 
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).toHaveAttribute('data-pressed', 'true');
     expect(row).toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
   });
 
-  it('should not show press state when not interactive', () => {
+  it('should not show press state when not interactive', async () => {
     let {getAllByRole} = renderTagGroup({}, {}, {className: ({isPressed}) => isPressed ? 'pressed' : ''});
     let row = getAllByRole('row')[0];
 
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(row);
+    await user.pointer({target: row, keys: '[MouseLeft>]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
 
-    fireEvent.mouseUp(row);
+    await user.pointer({target: row, keys: '[/MouseLeft]'});
     expect(row).not.toHaveAttribute('data-pressed');
     expect(row).not.toHaveClass('pressed');
   });

--- a/packages/react-aria-components/test/ToggleButton.test.js
+++ b/packages/react-aria-components/test/ToggleButton.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
 import React from 'react';
 import {ToggleButton, ToggleButtonContext} from '../';
 import userEvent from '@testing-library/user-event';
@@ -93,7 +93,7 @@ describe('ToggleButton', () => {
     expect(button).not.toHaveClass('focus');
   });
 
-  it('should support press state', () => {
+  it('should support press state', async () => {
     let onPress = jest.fn();
     let {getByRole} = render(<ToggleButton className={({isPressed}) => isPressed ? 'pressed' : ''} onPress={onPress}>Test</ToggleButton>);
     let button = getByRole('button');
@@ -101,11 +101,11 @@ describe('ToggleButton', () => {
     expect(button).not.toHaveAttribute('data-pressed');
     expect(button).not.toHaveClass('pressed');
 
-    fireEvent.mouseDown(button);
+    await user.pointer({target: button, keys: '[MouseLeft>]'});
     expect(button).toHaveAttribute('data-pressed', 'true');
     expect(button).toHaveClass('pressed');
 
-    fireEvent.mouseUp(button);
+    await user.pointer({target: button, keys: '[/MouseLeft]'});
     expect(button).not.toHaveAttribute('data-pressed');
     expect(button).not.toHaveClass('pressed');
 

--- a/packages/react-aria-components/test/Tree.test.tsx
+++ b/packages/react-aria-components/test/Tree.test.tsx
@@ -526,11 +526,11 @@ describe('Tree', () => {
       expect(row).not.toHaveAttribute('data-pressed');
       expect(row).not.toHaveClass('pressed');
 
-      fireEvent.mouseDown(row);
+      await user.pointer({target: row, keys: '[MouseLeft>]'});
       expect(row).toHaveAttribute('data-pressed', 'true');
       expect(row).toHaveClass('pressed');
 
-      fireEvent.mouseUp(row);
+      await user.pointer({target: row, keys: '[/MouseLeft]'});
       expect(row).not.toHaveAttribute('data-pressed');
       expect(row).not.toHaveClass('pressed');
 
@@ -539,36 +539,36 @@ describe('Tree', () => {
       expect(row).not.toHaveAttribute('data-pressed');
       expect(row).not.toHaveClass('pressed');
 
-      fireEvent.mouseDown(row);
+      await user.pointer({target: row, keys: '[MouseLeft>]'});
       expect(row).toHaveAttribute('data-pressed', 'true');
       expect(row).toHaveClass('pressed');
 
-      fireEvent.mouseUp(row);
+      await user.pointer({target: row, keys: '[/MouseLeft]'});
       expect(row).not.toHaveAttribute('data-pressed');
       expect(row).not.toHaveClass('pressed');
     });
 
-    it('should not update the press state if the row is not interactive', () => {
+    it('should not update the press state if the row is not interactive', async () => {
       let {getAllByRole, rerender} = render(<StaticTree treeProps={{selectionMode: 'none'}} rowProps={{className: ({isPressed}) => isPressed ? 'pressed' : ''}} />);
 
       let row = getAllByRole('row')[0];
       expect(row).not.toHaveAttribute('data-pressed');
       expect(row).not.toHaveClass('pressed');
 
-      fireEvent.mouseDown(row);
+      await user.pointer({target: row, keys: '[MouseLeft>]'});
       expect(row).not.toHaveAttribute('data-pressed');
       expect(row).not.toHaveClass('pressed');
-      fireEvent.mouseUp(row);
+      await user.pointer({target: row, keys: '[/MouseLeft]'});
 
       let expandableRow = getAllByRole('row')[1];
       expect(expandableRow).not.toHaveAttribute('data-pressed');
       expect(expandableRow).not.toHaveClass('pressed');
 
-      fireEvent.mouseDown(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[MouseLeft>]'});
       expect(expandableRow).toHaveAttribute('data-pressed', 'true');
       expect(expandableRow).toHaveClass('pressed');
 
-      fireEvent.mouseUp(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[/MouseLeft]'});
       expect(expandableRow).not.toHaveAttribute('data-pressed');
       expect(expandableRow).not.toHaveClass('pressed');
 
@@ -579,10 +579,10 @@ describe('Tree', () => {
       expect(expandableRow).not.toHaveAttribute('data-pressed');
       expect(expandableRow).not.toHaveClass('pressed');
 
-      fireEvent.mouseDown(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[MouseLeft>]'});
       expect(expandableRow).not.toHaveAttribute('data-pressed');
       expect(expandableRow).not.toHaveClass('pressed');
-      fireEvent.mouseUp(expandableRow);
+      await user.pointer({target: expandableRow, keys: '[/MouseLeft]'});
     });
 
     it('should support focus', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6248,6 +6248,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Related: #1720 

This is a major refactor to `usePress` to improve compatibility with other libraries, improve the way focus is managed, and fix many issues caused by our current approach. 🎄 

This is mainly possible because of a change in Safari 17, which enabled buttons and other native inputs to be focused (both via mouse/touch and keyboard tabbing) only when they have an explicit `tabIndex` set. https://github.com/WebKit/WebKit/pull/12743 We previously worked around this by calling `preventDefault` and manually managing focus. However, because `preventDefault` is not granular this had many unintended side effects that we needed to work around.

...