### PR TITLE
feat: support SSR when importing provider

### DIFF
--- a/packages/@react-aria/i18n/src/context.tsx
+++ b/packages/@react-aria/i18n/src/context.tsx
@@ -1,3 +1,4 @@
+"use client";
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/@react-aria/i18n/src/context.tsx
+++ b/packages/@react-aria/i18n/src/context.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Closes #7550

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] ~Added/updated unit tests and storybook for this change (for new code or code which already has tests).~
- [x] Filled out test instructions.
- [ ] ~Updated documentation (if it already exists for this component).~
- [ ] ~Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)~

## 📝 Test Instructions:

- Create a Server Rendered JS application (e.g. NextJS App Router or Tanstack Start)
- Add a component like so:
	```ts
	// page.tsx
	import { I18nProvider } from "react-aria-components";

	export async function Page() {
	  return (
	    <I18nProvider locale="en">
	      <h1>Hello World</h1>
	    </I18nProvider>
	  )
	}
	```
- run `npm dev` and load the page

## 🧢 Your Project:

[Kiddom](https://www.kiddom.co/) internal prototype (private repo sadly :()

## 🧠 Considerations

In React < 18 the `'use client';` directive should do _nothing_ as it is an unregistered string tag. In React 18/19 this directive also does not act unless rendered in a RSC context. As such this should be safe to implement and backwards compatible.

As this is a plain text and the `react-aria` library does not use RSC internally testing this is likely more of a cost than its worth.

This change is also compliant with all existing documentation on https://react-spectrum.adobe.com/react-aria/ssr.html and does not effect any ARIA recommended components directly (other than by rendering the expected internationalized version)