### PR TITLE
fix: Use absolute path resolution for empty.js in locales plugin

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.js
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 const {createUnplugin} = require('unplugin');
+const path = require('path');
 
 module.exports = createUnplugin(({locales}) => {
   locales = locales.map(l => new Intl.Locale(l));
@@ -24,7 +25,7 @@ module.exports = createUnplugin(({locales}) => {
       if (match) {
         let locale = new Intl.Locale(match[0]);
         if (!locales.some(l => localeMatches(locale, l))) {
-          return __dirname + '/empty.js';
+          return path.join(__dirname, 'empty.js');
         }
       }
 


### PR DESCRIPTION
Closes #7462 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
