### PR TITLE
fix(s2): update button gradients to use static colors

### DIFF
--- a/packages/@react-spectrum/s2/src/Button.tsx
+++ b/packages/@react-spectrum/s2/src/Button.tsx
@@ -141,16 +141,48 @@ const button = style<ButtonRenderProps & ButtonStyleProps & {isStaticColor: bool
   backgroundImage: {
     variant: {
       premium: {
-        default: linearGradient('96deg', ['fuchsia-900', 0], ['indigo-900', 66], ['blue-900', 100]),
-        isHovered: linearGradient('96deg', ['fuchsia-1000', 0], ['indigo-1000', 66], ['blue-1000', 100]),
-        isPressed: linearGradient('96deg', ['fuchsia-1000', 0], ['indigo-1000', 66], ['blue-1000', 100]),
-        isFocusVisible: linearGradient('96deg', ['fuchsia-1000', 0], ['indigo-1000', 66], ['blue-1000', 100])
+        default: linearGradient('96deg',
+          ['static-fuchsia-900', 'gradient-stop-1-premium'],
+          ['static-indigo-900', 'gradient-stop-2-premium'],
+          ['static-blue-900', 'gradient-stop-3-premium']
+        ),
+        isHovered: linearGradient('96deg',
+          ['static-fuchsia-1000', 'gradient-stop-1-premium'],
+          ['static-indigo-1000', 'gradient-stop-2-premium'],
+          ['static-blue-1000', 'gradient-stop-3-premium']
+        ),
+        isPressed: linearGradient('96deg',
+          ['static-fuchsia-1000', 'gradient-stop-1-premium'],
+          ['static-indigo-1000', 'gradient-stop-2-premium'],
+          ['static-blue-1000', 'gradient-stop-3-premium']
+        ),
+        isFocusVisible: linearGradient('96deg',
+          ['static-fuchsia-1000', 'gradient-stop-1-premium'],
+          ['static-indigo-1000', 'gradient-stop-2-premium'],
+          ['static-blue-1000', 'gradient-stop-3-premium']
+        )
       },
       genai: {
-        default: linearGradient('96deg', ['red-900', 0], ['magenta-900', 33], ['indigo-900', 100]),
-        isHovered: linearGradient('96deg', ['red-1000', 0], ['magenta-1000', 33], ['indigo-1000', 100]),
-        isPressed: linearGradient('96deg', ['red-1000', 0], ['magenta-1000', 33], ['indigo-1000', 100]),
-        isFocusVisible: linearGradient('96deg', ['red-1000', 0], ['magenta-1000', 33], ['indigo-1000', 100])
+        default: linearGradient('96deg',
+          ['static-red-900', 'gradient-stop-1-genai'],
+          ['static-magenta-900', 'gradient-stop-2-genai'],
+          ['static-indigo-900', 'gradient-stop-3-genai']
+        ),
+        isHovered: linearGradient('96deg',
+          ['static-red-1000', 'gradient-stop-1-genai'],
+          ['static-magenta-1000', 'gradient-stop-2-genai'],
+          ['static-indigo-1000', 'gradient-stop-3-genai']
+        ),
+        isPressed: linearGradient('96deg',
+          ['static-red-1000', 'gradient-stop-1-genai'],
+          ['static-magenta-1000', 'gradient-stop-2-genai'],
+          ['static-indigo-1000', 'gradient-stop-3-genai']
+        ),
+        isFocusVisible: linearGradient('96deg',
+          ['static-red-1000', 'gradient-stop-1-genai'],
+          ['static-magenta-1000', 'gradient-stop-2-genai'],
+          ['static-indigo-1000', 'gradient-stop-3-genai']
+        )
       }
     },
     isDisabled: 'none',

--- a/packages/@react-spectrum/s2/style/spectrum-theme.ts
+++ b/packages/@react-spectrum/s2/style/spectrum-theme.ts
@@ -11,7 +11,7 @@
  */
 
 import {ArbitraryValue, CSSValue, PropertyValueMap} from './types';
-import {autoStaticColor, colorScale, colorToken, fontSizeToken, generateOverlayColorScale, getToken, simpleColorScale, weirdColorToken} from './tokens' with {type: 'macro'};
+import {autoStaticColor, colorScale, colorToken, fontSizeToken, generateOverlayColorScale, simpleColorScale, weirdColorToken} from './tokens' with {type: 'macro'};
 import {Color, createArbitraryProperty, createColorProperty, createMappedProperty, createRenamedProperty, createSizingProperty, createTheme, parseArbitraryValue} from './style-macro';
 import type * as CSS from 'csstype';
 // eslint-disable-next-line rulesdir/imports
@@ -111,6 +111,10 @@ export function lightDark(light: SpectrumColor, dark: SpectrumColor): `[${string
 
 export function colorMix(a: SpectrumColor, b: SpectrumColor, percent: number): `[${string}]` {
   return `[color-mix(in srgb, ${parseColor(a)}, ${parseColor(b)} ${percent}%)]`;
+}
+
+function getToken(name: keyof typeof tokens): string {
+  return (tokens[name] as any).value;
 }
 
 export function linearGradient(angle: string, ...gradientTokens: [(keyof typeof tokens), (keyof typeof tokens)][]): string {

--- a/packages/@react-spectrum/s2/style/spectrum-theme.ts
+++ b/packages/@react-spectrum/s2/style/spectrum-theme.ts
@@ -114,7 +114,7 @@ export function colorMix(a: SpectrumColor, b: SpectrumColor, percent: number): `
 }
 
 export function linearGradient(angle: string, ...gradientTokens: [(keyof typeof tokens), (keyof typeof tokens)][]): string {
-  return `linear-gradient(${angle}, ${gradientTokens.map(([color, stop]) => `${getToken(color)} ${parseFloat(getToken(stop)) * 100}%`)})`;
+  return `linear-gradient(${angle}, ${gradientTokens.map(([color, stop]) => `${getToken(color as keyof typeof tokens)} ${parseFloat(getToken(stop as keyof typeof tokens)) * 100}%`)})`;
 }
 
 function generateSpacing<K extends number[]>(px: K): {[P in K[number]]: string} {

--- a/packages/@react-spectrum/s2/style/spectrum-theme.ts
+++ b/packages/@react-spectrum/s2/style/spectrum-theme.ts
@@ -14,6 +14,8 @@ import {ArbitraryValue, CSSValue, PropertyValueMap} from './types';
 import {autoStaticColor, colorScale, colorToken, fontSizeToken, generateOverlayColorScale, getToken, simpleColorScale, weirdColorToken} from './tokens' with {type: 'macro'};
 import {Color, createArbitraryProperty, createColorProperty, createMappedProperty, createRenamedProperty, createSizingProperty, createTheme, parseArbitraryValue} from './style-macro';
 import type * as CSS from 'csstype';
+// eslint-disable-next-line rulesdir/imports
+import * as tokens from '@adobe/spectrum-tokens/dist/json/variables.json';
 
 interface MacroContext {
   addAsset(asset: {type: string, content: string}): void
@@ -111,8 +113,8 @@ export function colorMix(a: SpectrumColor, b: SpectrumColor, percent: number): `
   return `[color-mix(in srgb, ${parseColor(a)}, ${parseColor(b)} ${percent}%)]`;
 }
 
-export function linearGradient(angle: string, ...tokens: [SpectrumColor, number][]): string {
-  return `linear-gradient(${angle}, ${tokens.map(([color, stop]) => `${parseColor(color)} ${stop}%`)})`;
+export function linearGradient(angle: string, ...gradientTokens: [(keyof typeof tokens), (keyof typeof tokens)][]): string {
+  return `linear-gradient(${angle}, ${gradientTokens.map(([color, stop]) => `${getToken(color)} ${parseFloat(getToken(stop)) * 100}%`)})`;
 }
 
 function generateSpacing<K extends number[]>(px: K): {[P in K[number]]: string} {


### PR DESCRIPTION
update Button gradients (genai & premium) to use static colors as to not change for light/dark theme

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
