### PR TITLE
fix: Don't reset form fields if reset event is cancelled.

### DIFF
--- a/packages/@react-aria/utils/src/useFormReset.ts
+++ b/packages/@react-aria/utils/src/useFormReset.ts
@@ -20,8 +20,8 @@ export function useFormReset<T>(
   onReset: (value: T) => void
 ) {
   let resetValue = useRef(initialValue);
-  let handleReset = useEffectEvent(() => {
-    if (onReset) {
+  let handleReset = useEffectEvent((e: Event) => {
+    if (onReset && !e.defaultPrevented) {
       onReset(resetValue.current);
     }
   });

--- a/packages/@react-aria/utils/test/useFormReset.test.tsx
+++ b/packages/@react-aria/utils/test/useFormReset.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {fireEvent, render} from '@react-spectrum/test-utils-internal';
+import React, {useRef} from 'react';
+import {useFormReset} from '../';
+
+describe('useFormReset', () => {
+  it('should call onReset on reset', () => {
+    const onReset = jest.fn();
+    const Form = () => {
+      const ref = useRef<HTMLInputElement>(null);
+      useFormReset(ref, '', onReset);
+      return (
+        <form>
+          <input ref={ref} type="text" />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    };
+    const {getByRole} = render(<Form />);
+    const button = getByRole('button');
+    fireEvent.click(button);
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it('should not call onReset if reset is cancelled', () => {
+    const onReset = jest.fn();
+    const Form = () => {
+      const ref = useRef<HTMLInputElement>(null);
+      useFormReset(ref, '', onReset);
+      return (
+        <form onResetCapture={(e) => e.preventDefault()}>
+          <input ref={ref} type="text" />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    };
+    const {getByRole} = render(<Form />);
+    const button = getByRole('button');
+    fireEvent.click(button);
+    expect(onReset).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Native form fields don't get reset if a `reset` event is cancelled. I think it is good that React Aria components behave as the same as native form fields.

Closes #7602

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
