### PR TITLE
fix(TagGroup): ensure Tags with and without icons are aligned vertically

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tags/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tags/index.css
@@ -46,6 +46,7 @@ governing permissions and limitations under the License.
 
   display: inline-grid;
   align-items: center;
+  vertical-align: middle;
   box-sizing: border-box;
   position: relative;
   cursor: default;

--- a/packages/@react-spectrum/tag/chromatic/TagGroup.stories.tsx
+++ b/packages/@react-spectrum/tag/chromatic/TagGroup.stories.tsx
@@ -72,23 +72,7 @@ export const WithIcon: TagGroupStory = {
     <TagGroup {...args} aria-label="Tag group">
       {(item: any) => (
         <Item key={item.key} textValue={item.label}>
-          <Audio />
-          <Text>{item.label}</Text>
-        </Item>
-      )}
-    </TagGroup>
-  ),
-  args: {
-    items: defaultItems
-  }
-};
-
-export const WithSomeIcons: TagGroupStory = {
-  render: (args) => (
-    <TagGroup aria-label="Tag group with some icons" {...args}>
-      {(item: any) => (
-        <Item key={item.key} textValue={item.label}>
-          {parseInt(item.id, 10) % 2 === 0 && <Audio />}
+          {item.id !== 1 && <Audio />}
           <Text>{item.label}</Text>
         </Item>
       )}

--- a/packages/@react-spectrum/tag/chromatic/TagGroup.stories.tsx
+++ b/packages/@react-spectrum/tag/chromatic/TagGroup.stories.tsx
@@ -83,6 +83,22 @@ export const WithIcon: TagGroupStory = {
   }
 };
 
+export const WithSomeIcons: TagGroupStory = {
+  render: (args) => (
+    <TagGroup aria-label="Tag group with some icons" {...args}>
+      {(item: any) => (
+        <Item key={item.key} textValue={item.label}>
+          {parseInt(item.id, 10) % 2 === 0 && <Audio />}
+          <Text>{item.label}</Text>
+        </Item>
+      )}
+    </TagGroup>
+  ),
+  args: {
+    items: defaultItems
+  }
+};
+
 export const LabelWrapping: TagGroupStory = {
   ...Default,
   decorators: [

--- a/packages/@react-spectrum/tag/stories/TagGroup.stories.tsx
+++ b/packages/@react-spectrum/tag/stories/TagGroup.stories.tsx
@@ -122,20 +122,6 @@ export const WithIcons: TagGroupStory = {
   )
 };
 
-export const WithSomeIcons: TagGroupStory = {
-  args: {items: [{key: '1', label: 'Cool Tag 1'}, {key: '2', label: 'Cool Tag 2'}, {key: '3', label: 'Cool Tag 3'}, {key: '4', label: 'Cool Tag 4'}]},
-  render: (args) => (
-    <TagGroup aria-label="Tag group with some icons" {...args}>
-      {(item: any) => (
-        <Item key={item.key} textValue={item.label}>
-          {parseInt(item.key, 10) % 2 === 0 && <Audio />}
-          <Text>{item.label}</Text>
-        </Item>
-      )}
-    </TagGroup>
-  )
-};
-
 export const OnRemove: TagGroupStory = {
   render: (args) => <OnRemoveExample {...args} />,
   name: 'onRemove'
@@ -189,7 +175,7 @@ export const WithAvatar: TagGroupStory = {
     <TagGroup aria-label="Tag group with avatars" {...args}>
       {(item: any) => (
         <Item key={item.key} textValue={item.label}>
-          <Avatar src="https://i.imgur.com/kJOwAdv.png" alt="default Adobe avatar" />
+          {item.key === '1' && <Avatar src="https://i.imgur.com/kJOwAdv.png" alt="default Adobe avatar" />}
           <Text>{item.label}</Text>
         </Item>
       )}

--- a/packages/@react-spectrum/tag/stories/TagGroup.stories.tsx
+++ b/packages/@react-spectrum/tag/stories/TagGroup.stories.tsx
@@ -122,6 +122,20 @@ export const WithIcons: TagGroupStory = {
   )
 };
 
+export const WithSomeIcons: TagGroupStory = {
+  args: {items: [{key: '1', label: 'Cool Tag 1'}, {key: '2', label: 'Cool Tag 2'}, {key: '3', label: 'Cool Tag 3'}, {key: '4', label: 'Cool Tag 4'}]},
+  render: (args) => (
+    <TagGroup aria-label="Tag group with some icons" {...args}>
+      {(item: any) => (
+        <Item key={item.key} textValue={item.label}>
+          {parseInt(item.key, 10) % 2 === 0 && <Audio />}
+          <Text>{item.label}</Text>
+        </Item>
+      )}
+    </TagGroup>
+  )
+};
+
 export const OnRemove: TagGroupStory = {
   render: (args) => <OnRemoveExample {...args} />,
   name: 'onRemove'


### PR DESCRIPTION
Previously if you tried to use Tags with icons and without icons in the same TagGroup, they would not be vertically aligned. This seems to be a valid use case within Spectrum guidelines, so we want to ensure they can be used together without being misaligned.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check new story and chromatic.

## 🧢 Your Project:

<!--- Company/project for pull request -->
