### PR TITLE
fix(Toast): update toast placement options

### DIFF
--- a/packages/@react-spectrum/toast/docs/Toast.mdx
+++ b/packages/@react-spectrum/toast/docs/Toast.mdx
@@ -167,7 +167,7 @@ function Example() {
 
 ## Placement
 
-By default, toasts are displayed at the bottom center of the screen. This can be changed by setting the `placement` prop on the `ToastContainer` to `'top start'`, `'top'`, `'top end'`, `'bottom start'`, `'bottom'`, or `'bottom end'`.
+By default, toasts are displayed at the bottom center of the screen. This can be changed by setting the `placement` prop on the `ToastContainer` to `'top'`, `'top end'`, `'bottom'`, or `'bottom end'`.
 
 ```tsx example render=false hidden
 <ToastContainer placement="bottom end" />

--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -21,7 +21,7 @@ import {Toaster} from './Toaster';
 import {ToastOptions, ToastQueue, useToastQueue} from '@react-stately/toast';
 import {useSyncExternalStore} from 'use-sync-external-store/shim/index.js';
 
-export type ToastPlacement = 'top start' | 'top' | 'top end' | 'bottom start' | 'bottom' | 'bottom end';
+export type ToastPlacement = 'top' | 'top end' | 'bottom' | 'bottom end';
 
 export interface SpectrumToastContainerProps extends AriaToastRegionProps {
   placement?: ToastPlacement

--- a/packages/@react-spectrum/toast/stories/Toast.stories.tsx
+++ b/packages/@react-spectrum/toast/stories/Toast.stories.tsx
@@ -46,7 +46,7 @@ export default {
     },
     placement: {
       control: 'select',
-      options: [undefined, 'top start', 'top', 'top end', 'bottom start', 'bottom', 'bottom end']
+      options: [undefined, 'top', 'top end', 'bottom', 'bottom end']
     }
   }
 };


### PR DESCRIPTION
Removed 'start' options to be in line with Spectrum guidelines.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
