### PR TITLE
RAC: Fix broken link in new `Autocomplete` docs

### DIFF
--- a/packages/react-aria-components/docs/Autocomplete.mdx
+++ b/packages/react-aria-components/docs/Autocomplete.mdx
@@ -105,7 +105,7 @@ function Example() {
 
 ## Anatomy
 
-`Autocomplete` is a controller for a child text input, such as a [TextField](TextField.html) or [SearchField](SearchField), and a collection component such as a [Menu](Menu.html) or [ListBox](ListBox.html). It enables the user to filter a list of items, and navigate via the arrow keys while keeping focus on the input.
+`Autocomplete` is a controller for a child text input, such as a [TextField](TextField.html) or [SearchField](SearchField.html), and a collection component such as a [Menu](Menu.html) or [ListBox](ListBox.html). It enables the user to filter a list of items, and navigate via the arrow keys while keeping focus on the input.
 
 ```tsx
 import {UNSTABLE_Autocomplete as Autocomplete, SearchField, Menu} from 'react-aria-components';


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Visit https://react-spectrum.adobe.com/react-aria/Autocomplete.html#anatomy
1. Click the `SearchField` link
