### PR TITLE
fix: Remove extra class from style macro

### DIFF
--- a/packages/@react-spectrum/s2/style/__tests__/style-macro.test.js
+++ b/packages/@react-spectrum/s2/style/__tests__/style-macro.test.js
@@ -59,7 +59,7 @@ describe('style-macro', () => {
 
       "
     `);
-    expect(js).toMatchInlineSnapshot('" . A-13alit4c A-13alit4ed"');
+    expect(js).toMatchInlineSnapshot('" A-13alit4c A-13alit4ed"');
   });
 
   it('should support self references', () => {

--- a/packages/@react-spectrum/s2/style/style-macro.ts
+++ b/packages/@react-spectrum/s2/style/style-macro.ts
@@ -268,7 +268,7 @@ export function createTheme<T extends Theme>(theme: T): StyleFunction<ThemePrope
 
     // Generate JS and CSS for each rule.
     let isStatic = !(hasConditions || allowedOverrides);
-    let className = ' .';
+    let className = '';
     let rulesByLayer = new Map<string, string[]>();
     for (let [property, propertyRules] of rules) {
       if (isStatic) {


### PR DESCRIPTION
Extra `.` class left over from the `all: revert-layer` change. Now unused.