### PR TITLE
feat(Button): add support for `aria-current` prop

### DIFF
--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -107,6 +107,7 @@ export function useButton(props: AriaButtonOptions<ElementType>, ref: RefObject<
       'aria-expanded': props['aria-expanded'],
       'aria-controls': props['aria-controls'],
       'aria-pressed': props['aria-pressed'],
+      'aria-current': props['aria-current'],
       onClick: (e) => {
         if (deprecatedOnClick) {
           deprecatedOnClick(e);

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -55,6 +55,8 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
   'aria-controls'?: string,
   /** Indicates the current "pressed" state of toggle buttons. */
   'aria-pressed'?: boolean | 'true' | 'false' | 'mixed',
+  /** Indicates whether this element represents the current item within a container or set of related elements. */
+  'aria-current'?: boolean | 'true' | 'false' | 'page' | 'step' | 'location' | 'date' | 'time',
   /**
    * The behavior of the button when used in an HTML form.
    * @default 'button'

--- a/packages/react-aria-components/test/Button.test.js
+++ b/packages/react-aria-components/test/Button.test.js
@@ -51,6 +51,12 @@ describe('Button', () => {
     expect(button).toHaveAttribute('formMethod', 'post');
   });
 
+  it('should support accessibility props', () => {
+    let {getByRole} = render(<Button aria-current="page">Test</Button>);
+    let button = getByRole('button');
+    expect(button).toHaveAttribute('aria-current', 'page');
+  });
+
   it('should support slot', () => {
     let {getByRole} = render(
       <ButtonContext.Provider value={{slots: {test: {'aria-label': 'test'}}}}>


### PR DESCRIPTION
Closes #6159 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

1. Render a `Button`
2. Add `aria-current` prop with a valid value (e.g., `"page"`)
3. The rendered `button` element should have the `aria-current` attribute with the assigned value

## 🧢 Your Project:

<!--- Company/project for pull request -->