### PR TITLE
fix(Select): HiddenSelect Component Auto-Completion Issue

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -114,7 +114,6 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
   let {state, triggerRef, label, name, isDisabled} = props;
   let selectRef = useRef(null);
   let {containerProps, selectProps} = useHiddenSelect({...props, selectRef}, state, triggerRef);
-  let selectRefValue = selectRef?.current?.value;
 
   // If used in a <form>, use a hidden input so the value can be submitted to a server.
   // If the collection isn't too big, use a hidden <select> element for this so that browser
@@ -149,7 +148,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         autoComplete={selectProps.autoComplete}
         name={name}
         disabled={isDisabled}
-        value={state.selectedKey ?? (selectRefValue || '')} />
+        value={state.selectedKey ?? ''} />
     );
   }
 

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -68,7 +68,6 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
   let {autoComplete, name = data.name, isDisabled = data.isDisabled} = props;
   let {validationBehavior, isRequired} = data;
   let {visuallyHiddenProps} = useVisuallyHidden();
-  let selectRefValue = props.selectRef?.current?.value;
 
   useFormReset(props.selectRef, state.selectedKey, state.setSelectedKey);
   useFormValidation({

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -100,7 +100,7 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
       disabled: isDisabled,
       required: validationBehavior === 'native' && isRequired,
       name,
-      value: state.selectedKey ?? (selectRefValue || ''),
+      value: state.selectedKey ?? undefined,
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) => state.setSelectedKey(e.target.value)
     }
   };

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -68,6 +68,7 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
   let {autoComplete, name = data.name, isDisabled = data.isDisabled} = props;
   let {validationBehavior, isRequired} = data;
   let {visuallyHiddenProps} = useVisuallyHidden();
+  let selectRefValue = props.selectRef?.current?.value;
 
   useFormReset(props.selectRef, state.selectedKey, state.setSelectedKey);
   useFormValidation({
@@ -99,7 +100,7 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
       disabled: isDisabled,
       required: validationBehavior === 'native' && isRequired,
       name,
-      value: state.selectedKey ?? (props.selectRef?.current?.value || ''),
+      value: state.selectedKey ?? (selectRefValue || ''),
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) => state.setSelectedKey(e.target.value)
     }
   };
@@ -113,6 +114,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
   let {state, triggerRef, label, name, isDisabled} = props;
   let selectRef = useRef(null);
   let {containerProps, selectProps} = useHiddenSelect({...props, selectRef}, state, triggerRef);
+  let selectRefValue = selectRef?.current?.value;
 
   // If used in a <form>, use a hidden input so the value can be submitted to a server.
   // If the collection isn't too big, use a hidden <select> element for this so that browser
@@ -147,7 +149,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         autoComplete={selectProps.autoComplete}
         name={name}
         disabled={isDisabled}
-        value={state.selectedKey ?? (selectRef?.current?.value || '')} />
+        value={state.selectedKey ?? (selectRefValue || '')} />
     );
   }
 

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -99,7 +99,7 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
       disabled: isDisabled,
       required: validationBehavior === 'native' && isRequired,
       name,
-      value: state.selectedKey ?? '',
+      value: state.selectedKey ?? (props.selectRef?.current?.value || ''),
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) => state.setSelectedKey(e.target.value)
     }
   };
@@ -147,7 +147,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         autoComplete={selectProps.autoComplete}
         name={name}
         disabled={isDisabled}
-        value={state.selectedKey ?? ''} />
+        value={state.selectedKey ?? (selectRef?.current?.value || '')} />
     );
   }
 


### PR DESCRIPTION
Closes #7660

## Summary

This pull request addresses the issue #7660, focusing on fixing the value assignment in the `HiddenSelect` component within the `@react-aria/select` package. The changes ensure that the `value` attribute now defaults to the current value of `selectRef` when `state.selectedKey` isn't set. This should enhance the native browser autocomplete.

## Changes Made

- **File:** `packages/@react-aria/select/src/HiddenSelect.tsx`
  - Updated the `value` property in the `useHiddenSelect` function to default to `props.selectRef?.current?.value` if `state.selectedKey` is unavailable.

## Verification

- Checked that the `HiddenSelect` component now assigns the `value` attribute, and the fallback mechanism works as intended!
- Ensured that all existing functionality and behaviors are still intact and not affected by these changes.

## Additional Context

When the browser triggers autocomplete, it first fills out the hidden select component before passing the value to the visible React Aria Select component. Unfortunately, there was a hiccup where the values weren't being passed down properly, which meant the select form field wasn't being filled out correctly by the native browser autocomplete.
- @nabanitabania has shared a lot of helpful details in the links below:
  - https://github.com/adobe/react-spectrum/issues/7660
  - https://github.com/adobe/react-spectrum/issues/7447
  - https://github.com/adobe/react-spectrum/pull/7452
- Below is a demo link to see the difference before and after the fix:
  - [Demo Link](https://igorlima.github.io/unapologetic-snippets/docs/languages/js/playground/react/20250124-1451-react-aria-components-autocomplete-issue.html) - Inspired by the [sandbox](https://codesandbox.io/p/sandbox/focused-water-lhqtty) @nabanitabania shared in [ISSUE-7660](https://github.com/adobe/react-spectrum/issues/7660).

    - | Before Fix                             | After Fix                                      |
      | :---: | :---: |
      | <img width="471" alt="image" src="https://github.com/user-attachments/assets/4fc5c10b-fad6-4c45-8141-8aa135c5ae23" /> | <img width="374" alt="image" src="https://github.com/user-attachments/assets/0d9bbe24-8827-4558-b7ea-84d1ca6346a1" /> |
      | [_demo link_](https://igorlima.github.io/unapologetic-snippets/docs/languages/js/playground/react/20250124-1451-react-aria-components-autocomplete-issue.html) | [_demo link_](https://igorlima.github.io/unapologetic-snippets/docs/languages/js/playground/react/20250124-1451-react-aria-components-autocomplete-issue.html) |
      | native browser behavior wasn't working | native browser behavior works as intended |


Feel free to share thoughts!

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
There isn't a specific React Aria form story to test this issue, but I've included a [demo link](https://igorlima.github.io/unapologetic-snippets/docs/languages/js/playground/react/20250124-1451-react-aria-components-autocomplete-issue.html) to check it out. It was inspired by the [sandbox](https://codesandbox.io/p/sandbox/hungry-dan-sv87ql) that @nabanitabania shared in [a previous PR](https://github.com/adobe/react-spectrum/pull/7452).


## 🧢 Your Project:

<!--- Company/project for pull request -->
