### PR TITLE
fix: prevent menu item focus ring from exceeding popover boundaries

### DIFF
--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -103,6 +103,7 @@ export let menu = style({
   gridTemplateColumns: menuItemGrid,
   boxSizing: 'border-box',
   maxHeight: '[inherit]',
+  width: 'full',
   overflow: {
     isPopover: 'auto'
   },
@@ -186,6 +187,7 @@ export let menuitem = style({
   },
   alignItems: 'baseline',
   minHeight: 'control',
+  height: 'min',
   textDecoration: 'none',
   cursor: {
     default: 'default',

--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -176,6 +176,7 @@ const quietFocusLine = style({
 export let menu = style({
   outlineStyle: 'none',
   display: 'grid',
+  width: 'full',
   gridTemplateColumns: {
     size: {
       S: [edgeToText(24), 'auto', 'auto', 'minmax(0, 1fr)', 'auto', 'auto', 'auto', edgeToText(24)],

--- a/packages/@react-spectrum/s2/src/Popover.tsx
+++ b/packages/@react-spectrum/s2/src/Popover.tsx
@@ -78,7 +78,6 @@ let popover = style({
   },
   // Don't be larger than full screen minus 2 * containerPadding
   maxWidth: '[calc(100vw - 24px)]',
-  boxSizing: 'border-box',
   opacity: {
     isEntering: 0,
     isExiting: 0

--- a/packages/@react-spectrum/s2/src/Popover.tsx
+++ b/packages/@react-spectrum/s2/src/Popover.tsx
@@ -78,6 +78,8 @@ let popover = style({
   },
   // Don't be larger than full screen minus 2 * containerPadding
   maxWidth: '[calc(100vw - 24px)]',
+  boxSizing: 'border-box',
+  display: 'flex',
   opacity: {
     isEntering: 0,
     isExiting: 0
@@ -225,7 +227,7 @@ const dialogStyle = style({
   borderRadius: '[inherit]',
   overflow: 'auto',
   position: 'relative',
-  size: 'full',
+  width: 'full',
   maxSize: '[inherit]'
 }, getAllowedOverrides({height: true}));
 


### PR DESCRIPTION
See https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=90609300 for an example

This happens not just with focus rings. Try with any component that uses a popover on main, make sure that scrolling appears by adjusting the height of the viewable area, and then see how items on the bottom will appear before they're actually on the popover. 

chromatic: https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=882

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Try components like S2 Menu, Picker, Popover, Combobox, to make sure items and focus rings do not exceed the popover's borders. 

## 🧢 Your Project:

<!--- Company/project for pull request -->
