### PR TITLE
[WIP] Tree drag and drop

### DIFF
--- a/packages/@react-spectrum/tree/src/TreeView.tsx
+++ b/packages/@react-spectrum/tree/src/TreeView.tsx
@@ -11,7 +11,7 @@
  */
 
 import {AriaTreeGridListProps} from '@react-aria/tree';
-import {ButtonContext, Collection, TreeItemContentRenderProps, TreeItemProps, TreeItemRenderProps, TreeRenderProps, UNSTABLE_Tree, UNSTABLE_TreeItem, UNSTABLE_TreeItemContent, useContextProps} from 'react-aria-components';
+import {ButtonContext, Collection, DragAndDropHooks, TreeItemContentRenderProps, TreeItemProps, TreeItemRenderProps, TreeRenderProps, UNSTABLE_Tree, UNSTABLE_TreeItem, UNSTABLE_TreeItemContent, useContextProps} from 'react-aria-components';
 import {Checkbox} from '@react-spectrum/checkbox';
 import ChevronLeftMedium from '@spectrum-icons/ui/ChevronLeftMedium';
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
@@ -24,7 +24,7 @@ import {Text} from '@react-spectrum/text';
 import {useButton} from '@react-aria/button';
 import {useLocale} from '@react-aria/i18n';
 
-export interface SpectrumTreeViewProps<T> extends Omit<AriaTreeGridListProps<T>, 'children'>, StyleProps, SpectrumSelectionProps, Expandable {
+export interface SpectrumTreeViewProps<T> extends Omit<AriaTreeGridListProps<T>, 'children'>, StyleProps,  SpectrumSelectionProps, Expandable {
   /** Provides content to display when there are no items in the tree. */
   renderEmptyState?: () => JSX.Element,
   /**
@@ -35,7 +35,10 @@ export interface SpectrumTreeViewProps<T> extends Omit<AriaTreeGridListProps<T>,
   /**
    * The contents of the tree.
    */
-  children?: ReactNode | ((item: T) => ReactNode)
+  children?: ReactNode | ((item: T) => ReactNode),
+
+  /** The drag and drop hooks returned by `useDragAndDrop` used to enable drag and drop behavior for the ListBox. */
+  dragAndDropHooks?: DragAndDropHooks
 }
 
 export interface SpectrumTreeViewItemProps<T extends object = object> extends Omit<TreeItemProps, 'className' | 'style' | 'value' | 'onHoverStart' | 'onHoverEnd' | 'onHoverChange'> {

--- a/packages/@react-stately/data/docs/useTreeData.mdx
+++ b/packages/@react-stately/data/docs/useTreeData.mdx
@@ -182,6 +182,33 @@ tree.move('Sam', 'Animals', 1);
 tree.move('Sam', null, 1);
 ```
 
+### Move before
+An alias to move
+
+```tsx
+// Move an item within the same parent
+tree.moveBefore('Sam', 'People', 0);
+
+// Move an item to a different parent
+tree.moveBefore('Sam', 'Animals', 1);
+
+// Move an item to the root
+tree.moveBefore('Sam', null, 1);
+```
+
+### Move after
+
+```tsx
+// Move an item within the same parent
+tree.moveAfter('Sam', 'People', 0);
+
+// Move an item to a different parent
+tree.moveAfter('Sam', 'Animals', 1);
+
+// Move an item to the root
+tree.moveAfter('Sam', null, 1);
+```
+
 ### Updating items
 
 ```tsx

--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -116,10 +116,10 @@ export interface TreeData<T extends object> {
   moveBefore(key: Key, toParentKey: Key | null, index: number): void,
 
   /**
-   * Moves an item aftera node within the tree.
+   * Moves an item after ia node within the tree.
    * @param key - The key of the item to move.
    * @param toParentKey - The key of the new parent to insert into. `null` for the root.
-   * @param index - The index within the new parent to insert before.
+   * @param index - The index within the new parent to insert after.
    */
   moveAfter(key: Key, toParentKey: Key | null, index: number): void,
 

--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -116,7 +116,7 @@ export interface TreeData<T extends object> {
   moveBefore(key: Key, toParentKey: Key | null, index: number): void,
 
   /**
-   * Moves an item after ia node within the tree.
+   * Moves an item after a node within the tree.
    * @param key - The key of the item to move.
    * @param toParentKey - The key of the new parent to insert into. `null` for the root.
    * @param index - The index within the new parent to insert after.
@@ -419,7 +419,6 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
 
         // Otherwise, update the parent node and its ancestors.
         return updateTree(newItems, toParentKey, parentNode => {
-          console.log('parent node children ', parentNode.children);
           const c = [
             ...parentNode.children!.slice(0, afterIndex),
             movedNode,

--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -108,6 +108,22 @@ export interface TreeData<T extends object> {
   move(key: Key, toParentKey: Key | null, index: number): void,
 
   /**
+   * Moves an item before a node within the tree.
+   * @param key - The key of the item to move.
+   * @param toParentKey - The key of the new parent to insert into. `null` for the root.
+   * @param index - The index within the new parent to insert before.
+   */
+  moveBefore(key: Key, toParentKey: Key | null, index: number): void,
+
+  /**
+   * Moves an item aftera node within the tree.
+   * @param key - The key of the item to move.
+   * @param toParentKey - The key of the new parent to insert into. `null` for the root.
+   * @param index - The index within the new parent to insert before.
+   */
+  moveAfter(key: Key, toParentKey: Key | null, index: number): void,
+
+  /**
    * Updates an item in the tree.
    * @param key - The key of the item to update.
    * @param newValue - The new value for the item.
@@ -371,6 +387,51 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
             ...parentNode.children!.slice(index)
           ]
         }), newMap);
+      });
+    },
+    moveBefore(key: Key, toParentKey: Key | null, index: number) {
+      this.move(key, toParentKey, index);
+    },
+    moveAfter(key: Key, toParentKey: Key | null, index: number) {
+      setItems(({items, nodeMap: originalMap}) => {
+        let node = originalMap.get(key);
+        if (!node) {
+          return {items, nodeMap: originalMap};
+        }
+
+        let {items: newItems, nodeMap: newMap} = updateTree(items, key, () => null, originalMap);
+
+        const movedNode = {
+          ...node,
+          parentKey: toParentKey
+        };
+
+        const afterIndex = items.length === index ? index : index + 1;
+        // If parentKey is null, insert into the root.
+        if (toParentKey == null) {
+          newMap.set(movedNode.key, movedNode);
+          return {items: [
+            ...newItems.slice(0, afterIndex),
+            movedNode,
+            ...newItems.slice(afterIndex)
+          ], nodeMap: newMap};
+        }
+
+        // Otherwise, update the parent node and its ancestors.
+        return updateTree(newItems, toParentKey, parentNode => {
+          console.log('parent node children ', parentNode.children);
+          const c = [
+            ...parentNode.children!.slice(0, afterIndex),
+            movedNode,
+            ...parentNode.children!.slice(afterIndex)
+          ];
+          return {
+            key: parentNode.key,
+            parentKey: parentNode.parentKey,
+            value: parentNode.value,
+            children: c
+          };
+        }, newMap);
       });
     },
     update(oldKey: Key, newValue: T) {

--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -729,7 +729,6 @@ describe('useTreeData', function () {
 
   it('should move an item to a different level at the end when the index is greater than the node list length', function () {
     const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
-    console.log('initialItems', initialItems[0]);
     let {result} = renderHook(() =>
       useTreeData({initialItems, getChildren, getKey})
     );

--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -709,7 +709,7 @@ describe('useTreeData', function () {
     expect(result.current.items.length).toEqual(2);
   });
 
-  it.only('should move an item to a different level after the target', function () {
+  it('should move an item to a different level after the target', function () {
     const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
     let {result} = renderHook(() =>
       useTreeData({initialItems, getChildren, getKey})
@@ -727,7 +727,7 @@ describe('useTreeData', function () {
     expect(result.current.items.length).toEqual(2);
   });
 
-  it.only('should move an item to a different level at the end when the index is greater than the node list length', function () {
+  it('should move an item to a different level at the end when the index is greater than the node list length', function () {
     const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
     console.log('initialItems', initialItems[0]);
     let {result} = renderHook(() =>

--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -676,4 +676,74 @@ describe('useTreeData', function () {
     expect(result.current.items[1].value).toEqual(initialResult.items[2].value);
     expect(result.current.items[2]).toEqual(initialResult.items[1]);
   });
+
+
+  it('should move an item within its same level before the target', function () {
+    const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+
+    let {result} = renderHook(() =>
+      useTreeData({initialItems, getChildren, getKey})
+    );
+    act(() => {
+      result.current.moveBefore('Eli', null, 0);
+    });
+    expect(result.current.items[0].key).toEqual('Eli');
+    expect(result.current.items[1].key).toEqual('David');
+    expect(result.current.items[2].key).toEqual('Emily');
+    expect(result.current.items.length).toEqual(initialItems.length);
+  });
+
+  it('should move an item to a different level before the target', function () {
+    const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+
+    let {result} = renderHook(() =>
+      useTreeData({initialItems, getChildren, getKey})
+    );
+    act(() => {
+      result.current.moveBefore('Eli', 'David', 1);
+    });
+    expect(result.current.items[0].key).toEqual('David');
+    expect(result.current.items[0].children[0].key).toEqual('John');
+    expect(result.current.items[0].children[1].key).toEqual('Eli');
+    expect(result.current.items[1].key).toEqual('Emily');
+    expect(result.current.items.length).toEqual(2);
+  });
+
+  it.only('should move an item to a different level after the target', function () {
+    const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+    let {result} = renderHook(() =>
+      useTreeData({initialItems, getChildren, getKey})
+    );
+
+    act(() => {
+      result.current.moveAfter('Eli', 'David', 1);
+    });
+    expect(result.current.items[0].key).toEqual('David');
+
+    expect(result.current.items[0].children[0].key).toEqual('John');
+    expect(result.current.items[0].children[1].key).toEqual('Sam');
+    expect(result.current.items[0].children[2].key).toEqual('Eli');
+    expect(result.current.items[1].key).toEqual('Emily');
+    expect(result.current.items.length).toEqual(2);
+  });
+
+  it.only('should move an item to a different level at the end when the index is greater than the node list length', function () {
+    const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+    console.log('initialItems', initialItems[0]);
+    let {result} = renderHook(() =>
+      useTreeData({initialItems, getChildren, getKey})
+    );
+
+    act(() => {
+      result.current.moveAfter('Eli', 'David', 100);
+    });
+    expect(result.current.items[0].key).toEqual('David');
+
+    expect(result.current.items[0].children[0].key).toEqual('John');
+    expect(result.current.items[0].children[1].key).toEqual('Sam');
+    expect(result.current.items[0].children[2].key).toEqual('Jane');
+    expect(result.current.items[0].children[3].key).toEqual('Eli');
+    expect(result.current.items[1].key).toEqual('Emily');
+    expect(result.current.items.length).toEqual(2);
+  });
 });

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@adobe/spectrum-css-temp": "3.0.0-alpha.1",
     "@internationalized/date": "^3.7.0",
     "@internationalized/string": "^3.2.5",
     "@react-aria/autocomplete": "3.0.0-alpha.37",
@@ -52,6 +53,8 @@
     "@react-aria/tree": "3.0.0-beta.3",
     "@react-aria/utils": "^3.27.0",
     "@react-aria/virtualizer": "^4.1.1",
+    "@react-spectrum/dnd": "^3.5.1",
+    "@react-spectrum/utils": "^3.12.1",
     "@react-stately/autocomplete": "3.0.0-alpha.0",
     "@react-stately/color": "^3.8.2",
     "@react-stately/disclosure": "^3.0.1",

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -16,10 +16,12 @@ import {CheckboxContext} from './RSPContexts';
 import {Collection, CollectionBuilder, CollectionNode, createBranchComponent, createLeafComponent, useCachedChildren} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps, usePersistedKeys} from './Collection';
 import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, ScrollableProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
-import {DisabledBehavior, Expandable, forwardRefType, HoverEvents, Key, LinkDOMProps, RefObject} from '@react-types/shared';
+import {DisabledBehavior, DragPreviewRenderer, Expandable, forwardRefType, HoverEvents, Key, KeyboardDelegate, LinkDOMProps, RefObject} from '@react-types/shared';
+import {DragAndDropContext, DropIndicatorContext, DropIndicatorProps, useRenderDropIndicator} from './DragAndDrop';
+import {DragAndDropHooks} from './useDragAndDrop';
+import {DraggableCollectionState, DroppableCollectionState, Collection as ICollection, Node, SelectionBehavior, TreeState, useTreeState} from 'react-stately';
+import {DraggableItemResult, DroppableCollectionResult, DroppableItemResult, FocusScope,  ListKeyboardDelegate,  mergeProps, useCollator, useFocusRing, useGridListSelectionCheckbox, useHover, useLocale} from 'react-aria';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
-import {FocusScope,  mergeProps, useFocusRing, useGridListSelectionCheckbox, useHover} from 'react-aria';
-import {Collection as ICollection, Node, SelectionBehavior, TreeState, useTreeState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import {useControlledState} from '@react-stately/utils';
 
@@ -129,7 +131,14 @@ export interface TreeProps<T> extends Omit<AriaTreeGridListProps<T>, 'children'>
    * Whether `disabledKeys` applies to all interactions, or only selection.
    * @default 'selection'
    */
-  disabledBehavior?: DisabledBehavior
+  disabledBehavior?: DisabledBehavior,
+  dragAndDropHooks?: DragAndDropHooks,
+
+  /**
+   * An optional keyboard delegate implementation for type to select,
+   * to override the default.
+   */
+  keyboardDelegate?: KeyboardDelegate
 }
 
 
@@ -158,6 +167,11 @@ interface TreeInnerProps<T extends object> {
 }
 
 function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInnerProps<T>) {
+  const {dragAndDropHooks} = props;
+  let {direction} = useLocale();
+  let collator = useCollator({usage: 'search', sensitivity: 'base'});
+  let isListDraggable = !!dragAndDropHooks?.useDraggableCollectionState;
+  let isListDroppable = !!dragAndDropHooks?.useDroppableCollectionState;
   let {
     selectionMode = 'none',
     expandedKeys: propExpandedKeys,
@@ -188,6 +202,22 @@ function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInne
     children: undefined,
     disabledBehavior
   });
+
+  let keyboardDelegate = useMemo(
+    () =>
+      props.keyboardDelegate ||
+      new ListKeyboardDelegate({
+        collection: state.collection,
+        collator,
+        ref,
+        disabledKeys: state.selectionManager.disabledKeys,
+        disabledBehavior: state.selectionManager.disabledBehavior,
+        layout: 'stack',
+        direction,
+        layoutDelegate
+      }),
+    [collator, ref, state.selectionManager.disabledKeys, direction, state.collection, state.selectionManager.disabledBehavior, props.keyboardDelegate, layoutDelegate]
+  );
 
   let {gridProps} = useTreeGridList({
     ...props,
@@ -230,13 +260,49 @@ function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInne
       </div>
     );
   }
+  let dragState: DraggableCollectionState | undefined = undefined;
+  let dropState: DroppableCollectionState | undefined = undefined;
+  let droppableCollection: DroppableCollectionResult | undefined = undefined;
+  let preview = useRef<DragPreviewRenderer>(null);
 
+  if (isListDraggable && dragAndDropHooks) {
+    dragState = dragAndDropHooks.useDraggableCollectionState!({
+      collection: state.collection,
+      selectionManager: state.selectionManager,
+      preview: dragAndDropHooks.renderDragPreview ? preview : undefined
+    });
+    dragAndDropHooks.useDraggableCollection!({}, dragState, ref);
+  }
+
+  if (isListDroppable && dragAndDropHooks) {
+    dropState = dragAndDropHooks.useDroppableCollectionState!({
+      collection: state.collection,
+      selectionManager: state.selectionManager
+    });
+
+    let dropTargetDelegate = new dragAndDropHooks.ListDropTargetDelegate(
+      state.collection,
+      ref,
+      {layout: 'stack', direction}
+    );
+
+    droppableCollection = dragAndDropHooks.useDroppableCollection!(
+      {keyboardDelegate, dropTargetDelegate},
+      dropState,
+      ref
+    );
+  }
   return (
     <FocusScope>
       <div
         {...filterDOMProps(props)}
         {...renderProps}
-        {...mergeProps(gridProps, focusProps, emptyStatePropOverrides)}
+        {...mergeProps(
+          gridProps,
+          focusProps,
+          emptyStatePropOverrides,
+          droppableCollection?.collectionProps
+        )}
         ref={ref}
         slot={props.slot || undefined}
         onScroll={props.onScroll}
@@ -245,12 +311,15 @@ function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInne
         data-focus-visible={isFocusVisible || undefined}>
         <Provider
           values={[
-            [UNSTABLE_TreeStateContext, state]
+            [UNSTABLE_TreeStateContext, state],
+            [DragAndDropContext, {dragAndDropHooks, dragState, dropState}],
+            [DropIndicatorContext, {render: TreeDropIndicatorWrapper}]
           ]}>
           <CollectionRoot
             collection={state.collection}
             persistedKeys={usePersistedKeys(state.selectionManager.focusedKey)}
-            scrollRef={ref} />
+            scrollRef={ref}
+            renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState)} />
         </Provider>
         {emptyState}
       </div>
@@ -341,6 +410,18 @@ export const UNSTABLE_TreeItem = /*#__PURE__*/ createBranchComponent('item', <T 
     state
   );
 
+  let {dragAndDropHooks, dragState, dropState} = useContext(DragAndDropContext)!;
+
+  let draggableItem: DraggableItemResult | null = null;
+  if (dragState && dragAndDropHooks) {
+    draggableItem = dragAndDropHooks.useDraggableItem!({key: item.key}, dragState);
+  }
+
+  let droppableItem: DroppableItemResult | null = null;
+  if (dropState && dragAndDropHooks) {
+    droppableItem = dragAndDropHooks.useDroppableItem!({target: {type: 'item', key: item.key, dropPosition: 'on'}}, dropState, ref);
+  }
+
   let renderPropValues = React.useMemo<TreeItemContentRenderProps>(() => ({
     ...states,
     isHovered,
@@ -400,7 +481,15 @@ export const UNSTABLE_TreeItem = /*#__PURE__*/ createBranchComponent('item', <T 
   return (
     <>
       <div
-        {...mergeProps(filterDOMProps(props as any), rowProps, focusProps, hoverProps, focusWithinProps)}
+        {...mergeProps(
+          filterDOMProps(props as any),
+          rowProps,
+          focusProps,
+          hoverProps,
+          focusWithinProps,
+          draggableItem?.dragProps,
+          droppableItem?.dropProps
+        )}
         {...renderProps}
         ref={ref}
         // TODO: missing selectionBehavior, hasAction and allowsSelection data attribute equivalents (available in renderProps). Do we want those?
@@ -564,3 +653,51 @@ function flattenTree<T>(collection: TreeCollection<T>, opts: TreeGridCollectionO
     keyMap
   };
 }
+
+export function TreeDropIndicatorWrapper(props: DropIndicatorProps, ref: ForwardedRef<HTMLElement>) {
+  ref = useObjectRef(ref);
+  let {dragAndDropHooks, dropState} = useContext(DragAndDropContext)!;
+  let {dropIndicatorProps, isHidden, isDropTarget} = dragAndDropHooks!.useDropIndicator!(
+    props,
+    dropState!,
+    ref
+  );
+
+  if (isHidden) {
+    return null;
+  }
+  return (
+    <TreeDropIndicatorForwardRef {...props} dropIndicatorProps={dropIndicatorProps} isDropTarget={isDropTarget} ref={ref} />
+  );
+}
+
+interface TreeDropIndicatorProps extends DropIndicatorProps {
+  dropIndicatorProps: React.HTMLAttributes<HTMLElement>,
+  isDropTarget: boolean
+}
+
+function TreeDropIndicator(props: TreeDropIndicatorProps, ref: ForwardedRef<HTMLElement>) {
+  let {
+    dropIndicatorProps,
+    isDropTarget,
+    ...otherProps
+  } = props;
+  let renderProps = useRenderProps({
+    ...otherProps,
+    defaultClassName: 'react-aria-DropIndicator',
+    values: {
+      isDropTarget
+    }
+  });
+  return (
+    <div
+      {...dropIndicatorProps}
+      {...renderProps}
+      // eslint-disable-next-line
+      role="option"
+      ref={ref as RefObject<HTMLDivElement | null>}
+      data-drop-target={isDropTarget || undefined} />
+  );
+}
+
+const TreeDropIndicatorForwardRef = forwardRef(TreeDropIndicator);


### PR DESCRIPTION
I'm looking to get some feedback on this PR to add drag and drop to the Tree.

I am really really new to this codebase, and there are probably a ton of things I've not understood and have messed up

I've mainly just copied the logic from the listbox and applied it to the tree component.

There's a storybook story which I've added at http://localhost:9003/?path=/story/treeview--tree-example-dynamic-drag-n-drop&providerSwitcher-express=false&strict=true

Some things that would be great to get some feedback/help on are:

* I'm unclear as to whether the dragAndDropHooks should be created by the user each time (e.g. in the story). Some things i can see being useful, but it feels like the reorder function shouldn't have to be implemented here. Is there a better place to put this?

* Re-ordering works, but at some point it stops working. I can't seem to find a repeatable pattern of drag / drops to consistently replicate this though.

* In storybook the hot reload gives an error: 
![image](https://github.com/user-attachments/assets/2f1df73e-13c2-4282-9ccc-8f1319721243)

* Although I've added the keyboard code - I've not yet tested that - was hoping to get the other issues ironed out first. 
* The way I've implemented the drop insert indicator causes the tree items to move which in turn can cause the drop to switch from before to after. The droppable listbox story renders items with a gap in between but I'm not sure if that is what is wanted in a tree view.
