### PR TITLE
chore: add aria-label to custom popover story in s2

### DIFF
--- a/packages/@react-spectrum/s2/stories/Popover.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Popover.stories.tsx
@@ -41,7 +41,7 @@ export const HelpCenter = (args: any) => (
       <Help />
     </ActionButton>
     <Popover {...args}>
-      <Tabs density="compact">
+      <Tabs density="compact" aria-label="Support and assistance tabs">
         <TabList styles={style({marginX: 12})}>
           <Tab id="help">Help</Tab>
           <Tab id="support">Support</Tab>


### PR DESCRIPTION
just prevents the story from crashing but doesn't actually fix the layout of contents inside the popover. that probably changed with the s2 tabs refactor. noticed it while i was trying to figure some stuff out with menu item focus rings.

currently on main: https://reactspectrum.blob.core.windows.net/reactspectrum/1ba8f01cec51a965205c068b1a46c333d5cf1a1b/storybook-s2/index.html?path=/story/popover--help-center

try opening the popover and see error being thrown

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
