### PR TITLE
fix: respect padding and remove cursor in DateRangePicker

### DIFF
--- a/packages/@react-spectrum/datepicker/src/styles.css
+++ b/packages/@react-spectrum/datepicker/src/styles.css
@@ -88,7 +88,7 @@
 }
 
 .react-spectrum-Datepicker-segments {
-  display: inline;
+  display: inline-block;
   align-items: center;
 }
 


### PR DESCRIPTION
Fixes stuff from testing.

In FF, in the DateRangePicker Granularity Second story, if you tab to the DateRangePicker, a cursor will appear. 
<img width="574" alt="Screenshot 2025-02-03 at 3 43 18 PM" src="https://github.com/user-attachments/assets/d7740d09-9b42-4275-b6d3-0b053c5f0958" />


In Safari, between the dash separating the two datefields and the rightmost datefield, there's supposed to be padding but it appears to be missing. 

<img width="374" alt="Screenshot 2025-02-03 at 1 16 33 PM" src="https://github.com/user-attachments/assets/48a23147-0cbc-4ab1-85d7-a4974fa0ec5e" />

see chromatic:  https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=885

there seems to be one minor change which is the thickness of the dash in daterangepicker only in hebrew tho. i don't think that change is that bad for the tradeoffs we get. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Make sure the two issues above are fixed and that the date/time formats are still in the correct order. 

## 🧢 Your Project:

<!--- Company/project for pull request -->
