### PR TITLE
feat: implemented details prop to the getItems function in the useClipboard hook

### DIFF
--- a/packages/@react-aria/dnd/src/useClipboard.ts
+++ b/packages/@react-aria/dnd/src/useClipboard.ts
@@ -18,7 +18,7 @@ import {useFocus} from '@react-aria/interactions';
 
 export interface ClipboardProps {
   /** A function that returns the items to copy. */
-  getItems?: () => DragItem[],
+  getItems?: (details: {type: "cut" | "copy"}) => DragItem[],
   /** Handler that is called when the user triggers a copy interaction. */
   onCopy?: () => void,
   /** Handler that is called when the user triggers a cut interaction. */
@@ -88,7 +88,7 @@ export function useClipboard(options: ClipboardProps): ClipboardResult {
 
     e.preventDefault();
     if (e.clipboardData) {
-      writeToDataTransfer(e.clipboardData, options.getItems());
+      writeToDataTransfer(e.clipboardData, options.getItems({type: 'copy'}));
       options.onCopy?.();
     }
   });
@@ -106,7 +106,7 @@ export function useClipboard(options: ClipboardProps): ClipboardResult {
 
     e.preventDefault();
     if (e.clipboardData) {
-      writeToDataTransfer(e.clipboardData, options.getItems());
+      writeToDataTransfer(e.clipboardData, options.getItems({type: 'cut'}));
       options.onCut();
     }
   });

--- a/packages/@react-aria/dnd/src/useClipboard.ts
+++ b/packages/@react-aria/dnd/src/useClipboard.ts
@@ -18,7 +18,7 @@ import {useFocus} from '@react-aria/interactions';
 
 export interface ClipboardProps {
   /** A function that returns the items to copy. */
-  getItems?: (details: {type: "cut" | "copy"}) => DragItem[],
+  getItems?: (details: {type: 'cut' | 'copy'}) => DragItem[],
   /** Handler that is called when the user triggers a copy interaction. */
   onCopy?: () => void,
   /** Handler that is called when the user triggers a cut interaction. */

--- a/packages/@react-aria/dnd/test/useClipboard.test.js
+++ b/packages/@react-aria/dnd/test/useClipboard.test.js
@@ -367,10 +367,10 @@ describe('useClipboard', () => {
     it('should show the type of the clipboard event if cutting', async () => {
       let getItems = (details) => [{
         [details.type]: 'test data'
-      }]
+      }];
 
       let onCut = jest.fn();
-      let tree = render(<Copyable getItems={getItems} onCut={onCut}/>);
+      let tree = render(<Copyable getItems={getItems} onCut={onCut} />);
       let button = tree.getByRole('button');
 
       await user.tab();
@@ -380,15 +380,15 @@ describe('useClipboard', () => {
       fireEvent(button, new ClipboardEvent('cut', {clipboardData}));
       expect([...clipboardData.items]).toEqual([new DataTransferItem('cut', 'test data')]);
       expect(onCut).toHaveBeenCalledTimes(1);
-    })
+    });
 
     it('should show the type of the clipboard event if copying', async () => {
       let getItems = (details) => [{
         [details.type]: 'test data'
-      }]
+      }];
 
       let onCopy = jest.fn();
-      let tree = render(<Copyable getItems={getItems} onCopy={onCopy}/>);
+      let tree = render(<Copyable getItems={getItems} onCopy={onCopy} />);
       let button = tree.getByRole('button');
 
       await user.tab();
@@ -398,7 +398,7 @@ describe('useClipboard', () => {
       fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
       expect([...clipboardData.items]).toEqual([new DataTransferItem('copy', 'test data')]);
       expect(onCopy).toHaveBeenCalledTimes(1);
-    })
+    });
   });
 });
 

--- a/packages/@react-aria/dnd/test/useClipboard.test.js
+++ b/packages/@react-aria/dnd/test/useClipboard.test.js
@@ -363,5 +363,42 @@ describe('useClipboard', () => {
       expect(await onPaste.mock.calls[0][0][1].getText('test')).toBe('item 2');
       expect(await onPaste.mock.calls[0][0][1].getText('text/plain')).toBe('item 2');
     });
+
+    it('should show the type of the clipboard event if cutting', async () => {
+      let getItems = (details) => [{
+        [details.type]: 'test data'
+      }]
+
+      let onCut = jest.fn();
+      let tree = render(<Copyable getItems={getItems} onCut={onCut}/>);
+      let button = tree.getByRole('button');
+
+      await user.tab();
+      expect(document.activeElement).toBe(button);
+
+      let clipboardData = new DataTransfer();
+      fireEvent(button, new ClipboardEvent('cut', {clipboardData}));
+      expect([...clipboardData.items]).toEqual([new DataTransferItem('cut', 'test data')]);
+      expect(onCut).toHaveBeenCalledTimes(1);
+    })
+
+    it('should show the type of the clipboard event if copying', async () => {
+      let getItems = (details) => [{
+        [details.type]: 'test data'
+      }]
+
+      let onCopy = jest.fn();
+      let tree = render(<Copyable getItems={getItems} onCopy={onCopy}/>);
+      let button = tree.getByRole('button');
+
+      await user.tab();
+      expect(document.activeElement).toBe(button);
+
+      let clipboardData = new DataTransfer();
+      fireEvent(button, new ClipboardEvent('copy', {clipboardData}));
+      expect([...clipboardData.items]).toEqual([new DataTransferItem('copy', 'test data')]);
+      expect(onCopy).toHaveBeenCalledTimes(1);
+    })
   });
 });
+


### PR DESCRIPTION
Closes #7678

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [n/a] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

onItems change for the useClipboard hook now offers type in the onItems function this can be console.log()'d when the hook is used 

## 🧢 Your Project:

Nothing just looking to work on some open source :) 
