### PR TITLE
Do not build list of available slots when no error

### DIFF
--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -160,15 +160,12 @@ export function useSlottedContext<T>(context: Context<SlottedContextValue<T>>, s
     return null;
   }
   if (ctx && typeof ctx === 'object' && 'slots' in ctx && ctx.slots) {
-    let availableSlots = new Intl.ListFormat().format(Object.keys(ctx.slots).map(p => `"${p}"`));
-
-    if (!slot && !ctx.slots[DEFAULT_SLOT]) {
-      throw new Error(`A slot prop is required. Valid slot names are ${availableSlots}.`);
-    }
     let slotKey = slot || DEFAULT_SLOT;
     if (!ctx.slots[slotKey]) {
-      // @ts-ignore
-      throw new Error(`Invalid slot "${slot}". Valid slot names are ${availableSlots}.`);
+      let availableSlots = new Intl.ListFormat().format(Object.keys(ctx.slots).map(p => `"${p}"`));
+      let errorMessage = slot ? `Invalid slot "${slot}".` : 'A slot prop is required.';
+
+      throw new Error(`${errorMessage} Valid slot names are ${availableSlots}.`);
     }
     return ctx.slots[slotKey];
   }


### PR DESCRIPTION
An error was logged on my website because `Intl.ListFormat` was not available:

```
TypeError: undefined is not a constructor (evaluating 'new Intl.ListFormat()')
  at c(./node_modules/react-aria-components/dist/utils.mjs:76:1)
  at m(./node_modules/react-aria-components/dist/utils.mjs:87:1)
```

It seemed the site was accessed using Playwright, an automated browser. (https://github.com/microsoft/playwright, https://github.com/microsoft/playwright/issues/23978).

Out of curiousity, I checked which react-aria code was using `Intl.ListFormat` and it seemed that the code in utils that caused this should not have run, as the list is only needed in case of errors.

I refactored the code so the list of available slots is only compiled in case the requested slot is not available. This is a small speed optimization, as there is no longer a new instance of `Intl.ListFormat` on every render.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Find a browser with no support for `Intl.ListFormat`.
2. Create a component with subcomponents that use slots.
3. Use an valid slot name.
4. Notice that there is no error because missing `Intl.ListFormat`.
