### PR TITLE
chore(codemod): handle margin/padding multi-value shorthands in style props codemod

### DIFF
--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/styleProps.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/styleProps.test.ts.snap
@@ -171,6 +171,56 @@ import { style } from "@react-spectrum/s2/style" with { type: "macro" };
   })}>Test</Button>"
 `;
 
+exports[`Handles multi-value margin/padding shorthands 1`] = `
+"import { style } from "@react-spectrum/s2/style" with { type: "macro" };
+
+<>
+  <div className={style({
+    margin: "[10px]"
+  })}>Single Value Margin</div>
+
+  <div className={style({
+    marginY: "[10px]",
+    marginX: 16
+  })}>Two Value Margin</div>
+
+  <div className={style({
+    marginTop: "[10px]",
+    marginX: 16,
+    marginBottom: 20
+  })}>Three Value Margin</div>
+
+  <div className={style({
+    marginTop: "[10px]",
+    marginRight: 16,
+    marginBottom: 20,
+    marginLeft: 24
+  })}>Four Value Margin</div>
+
+  <div className={style({
+    padding: "[10px]"
+  })}>Single Value Padding</div>
+
+  <div className={style({
+    paddingY: "[10px]",
+    paddingX: 16
+  })}>Two Value Padding</div>
+
+  <div className={style({
+    paddingTop: "[10px]",
+    paddingX: 16,
+    paddingBottom: 20
+  })}>Three Value Padding</div>
+
+  <div className={style({
+    paddingTop: "[10px]",
+    paddingRight: 16,
+    paddingBottom: 20,
+    paddingLeft: 24
+  })}>Four Value Padding</div>
+</>"
+`;
+
 exports[`Handles responsive style props 1`] = `
 "import { TextField } from "@react-spectrum/s2";
 import { style } from "@react-spectrum/s2/style" with { type: "macro" };

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/styleProps.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/styleProps.test.ts
@@ -206,3 +206,25 @@ import { style } from "@react-spectrum/s2/style" with { type: "macro" };
 
 <TextField label="Name" styles={style({width: 160})} />
 `);
+
+test('Handles multi-value margin/padding shorthands', `
+import {View} from '@adobe/react-spectrum';
+
+<>
+  <View margin="10px">Single Value Margin</View>
+
+  <View margin="10px 16px">Two Value Margin</View>
+
+  <View margin="10px 16px 20px">Three Value Margin</View>
+
+  <View margin="10px 16px 20px 24px">Four Value Margin</View>
+
+  <View padding="10px">Single Value Padding</View>
+
+  <View padding="10px 16px">Two Value Padding</View>
+
+  <View padding="10px 16px 20px">Three Value Padding</View>
+
+  <View padding="10px 16px 20px 24px">Four Value Padding</View>
+</>
+`);


### PR DESCRIPTION
Handles an issue found by @ktabors:

Previously:

```diff
-    <Flex alignItems="center" margin="10px 16px">
+    <div
+      className={style({
+        display: "flex",
+        alignItems: "center",
+        margin: "[10px]"
+      })}>
```

Now:

```diff
-    <Flex alignItems="center" margin="10px 16px">
+    <div
+      className={style({
+        display: "flex",
+        alignItems: "center",
+        marginY: "[10px]",
+        marginX: 16
+      })}>
```

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check snapshots

## 🧢 Your Project:

<!--- Company/project for pull request -->
