### PR TITLE
chore: correct Table/Collection array types

### DIFF
--- a/packages/@react-aria/collections/src/useCachedChildren.ts
+++ b/packages/@react-aria/collections/src/useCachedChildren.ts
@@ -19,7 +19,7 @@ export interface CachedChildrenOptions<T> {
   /** The contents of the collection. */
   children?: ReactNode | ((item: T) => ReactNode),
   /** Values that should invalidate the item cache when using dynamic collections. */
-  dependencies?: any[],
+  dependencies?: ReadonlyArray<any>,
   /** A scope to prepend to all child item ids to ensure they are unique. */
   idScope?: Key,
   /** Whether to add `id` and `value` props to all child items. */

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -19,7 +19,7 @@ export interface CollectionProps<T> extends Omit<CollectionBase<T>, 'children'> 
   /** The contents of the collection. */
   children?: ReactNode | ((item: T) => ReactNode),
   /** Values that should invalidate the item cache when using dynamic collections. */
-  dependencies?: any[]
+  dependencies?: ReadonlyArray<any>
 }
 
 export interface ItemRenderProps {
@@ -89,7 +89,7 @@ export interface SectionProps<T> extends Omit<SharedSectionProps<T>, 'children' 
   /** Static child items or a function to render children. */
   children?: ReactNode | ((item: T) => ReactElement),
   /** Values that should invalidate the item cache when using dynamic collections. */
-  dependencies?: any[]
+  dependencies?: ReadonlyArray<any>
 }
 
 interface SectionContextValue {

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -526,11 +526,11 @@ export interface TableHeaderRenderProps {
 
 export interface TableHeaderProps<T> extends StyleRenderProps<TableHeaderRenderProps>, HoverEvents {
   /** A list of table columns. */
-  columns?: T[],
+  columns?: Iterable<T>,
   /** A list of `Column(s)` or a function. If the latter, a list of columns must be provided using the `columns` prop. */
   children?: ReactNode | ((item: T) => ReactElement),
   /** Values that should invalidate the column cache when using dynamic collections. */
-  dependencies?: any[]
+  dependencies?: ReadonlyArray<any>
 }
 
 /**
@@ -989,7 +989,7 @@ export interface RowProps<T> extends StyleRenderProps<RowRenderProps>, LinkDOMPr
   /** The object value that this row represents. When using dynamic collections, this is set automatically. */
   value?: T,
   /** Values that should invalidate the cell cache when using dynamic collections. */
-  dependencies?: any[],
+  dependencies?: ReadonlyArray<any>,
   /** A string representation of the row's contents, used for features like typeahead. */
   textValue?: string,
   /** Whether the row is disabled. */


### PR DESCRIPTION
Closes #7656

I used Iterable on the columns collection. For dependencies its used in a few places that require arrays specifically, so I updated these to ReadonlyArray (which means Array or ReadonlyArray is accepted - if it is Array then only Array is accepted because you are saying you might modify the array if it is not Readonly).

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

n/a - Fixing Types.

## 🧢 Your Project:

Saxo Bank (Though this account and contribution is on my own time)