### PR TITLE
fix: resizing window causes 'ResizeObserver loop completed with undelivered notifications' error

### DIFF
--- a/packages/@react-aria/utils/src/useResizeObserver.ts
+++ b/packages/@react-aria/utils/src/useResizeObserver.ts
@@ -33,7 +33,7 @@ export function useResizeObserver<T extends Element>(options: useResizeObserverO
           return;
         }
 
-        onResize();
+        requestAnimationFrame(() => onResize());
       });
       resizeObserverInstance.observe(element, {box});
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7718

The error shown is likely due to how DOM changes triggered by the resize observer cause further resize events in the same frame. We can mitigate this by waiting until the next frame to apply the updates. This one may need a decent amount of manual regression testing.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open the RAC -> Popover Example story in it's own tab
2. Open the console and resize your window rapidly to cause the popover position to be updated
3. Verify that there is no `ResizeObserver loop completed with undelivered notifications` error in the console

## 🧢 Your Project:

<!--- Company/project for pull request -->
