### PR TITLE
feat: Add Shadow DOM support for useOverlay and improve event handling

### DIFF
--- a/packages/@react-aria/overlays/package.json
+++ b/packages/@react-aria/overlays/package.json
@@ -28,6 +28,7 @@
     "@react-aria/ssr": "^3.9.7",
     "@react-aria/utils": "^3.27.0",
     "@react-aria/visually-hidden": "^3.8.19",
+    "@react-stately/flags": "^3.0.5",
     "@react-stately/overlays": "^3.6.13",
     "@react-types/button": "^3.10.2",
     "@react-types/overlays": "^3.8.12",

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -13,6 +13,7 @@
 import {DOMAttributes, RefObject} from '@react-types/shared';
 import {isElementInChildOfActiveScope} from '@react-aria/focus';
 import {useEffect} from 'react';
+import {getEventTarget} from "@react-aria/utils"
 import {useFocusWithin, useInteractOutside} from '@react-aria/interactions';
 
 export interface AriaOverlayProps {
@@ -92,7 +93,7 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   };
 
   let onInteractOutsideStart = (e: PointerEvent) => {
-    if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as Element)) {
+    if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(getEventTarget(e))) {
       if (visibleOverlays[visibleOverlays.length - 1] === ref) {
         e.stopPropagation();
         e.preventDefault();
@@ -101,7 +102,7 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   };
 
   let onInteractOutside = (e: PointerEvent) => {
-    if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as Element)) {
+    if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(getEventTarget(e))) {
       if (visibleOverlays[visibleOverlays.length - 1] === ref) {
         e.stopPropagation();
         e.preventDefault();

--- a/packages/@react-aria/overlays/test/useOverlay.test.js
+++ b/packages/@react-aria/overlays/test/useOverlay.test.js
@@ -10,17 +10,30 @@
  * governing permissions and limitations under the License.
  */
 
-import {fireEvent, installMouseEvent, installPointerEvent, render} from '@react-spectrum/test-utils-internal';
+import {
+  createShadowRoot,
+  fireEvent,
+  installMouseEvent,
+  installPointerEvent,
+  render
+} from '@react-spectrum/test-utils-internal';
+import {enableShadowDOM} from '@react-stately/flags';
 import {mergeProps} from '@react-aria/utils';
 import React, {useRef} from 'react';
+import ReactDOM from 'react-dom';
 import {useOverlay} from '../';
 
 function Example(props) {
   let ref = useRef();
   let {overlayProps, underlayProps} = useOverlay(props, ref);
   return (
-    <div {...mergeProps(underlayProps, props.underlayProps || {})}>
-      <div ref={ref} {...overlayProps} data-testid={props['data-testid'] || 'test'}>
+    <div
+      {...mergeProps(underlayProps, props.underlayProps || {})}
+      data-testid={'underlay'}>
+      <div
+        ref={ref}
+        {...overlayProps}
+        data-testid={props['data-testid'] || 'test'}>
         {props.children}
       </div>
     </div>
@@ -29,19 +42,10 @@ function Example(props) {
 
 describe('useOverlay', function () {
   describe.each`
-    type                | prepare               | actions
-    ${'Mouse Events'}   | ${installMouseEvent}  | ${[
-      (el) => fireEvent.mouseDown(el, {button: 0}),
-      (el) => fireEvent.mouseUp(el, {button: 0})
-    ]}
-    ${'Pointer Events'} | ${installPointerEvent}| ${[
-      (el) => fireEvent.pointerDown(el, {button: 0, pointerId: 1}),
-      (el) => fireEvent.pointerUp(el, {button: 0, pointerId: 1})
-    ]}
-    ${'Touch Events'}   | ${() => {}}           | ${[
-      (el) => fireEvent.touchStart(el, {changedTouches: [{identifier: 1}]}),
-      (el) => fireEvent.touchEnd(el, {changedTouches: [{identifier: 1}]})
-    ]}
+    type                | prepare                | actions
+    ${'Mouse Events'}   | ${installMouseEvent}   | ${[(el) => fireEvent.mouseDown(el, {button: 0}), (el) => fireEvent.mouseUp(el, {button: 0})]}
+    ${'Pointer Events'} | ${installPointerEvent} | ${[(el) => fireEvent.pointerDown(el, {button: 0, pointerId: 1}), (el) => fireEvent.pointerUp(el, {button: 0, pointerId: 1})]}
+    ${'Touch Events'}   | ${() => {}}            | ${[(el) => fireEvent.touchStart(el, {changedTouches: [{identifier: 1}]}), (el) => fireEvent.touchEnd(el, {changedTouches: [{identifier: 1}]})]}
   `('$type', ({actions: [pressStart, pressEnd], prepare}) => {
     prepare();
 
@@ -56,7 +60,7 @@ describe('useOverlay', function () {
       expect(document.activeElement).toBe(input);
     });
 
-    it('should hide the overlay when clicking outside if isDismissble is true', function () {
+    it('should hide the overlay when clicking outside if isDismissable is true', function () {
       let onClose = jest.fn();
       render(<Example isOpen onClose={onClose} isDismissable />);
       pressStart(document.body);
@@ -66,7 +70,13 @@ describe('useOverlay', function () {
 
     it('should hide the overlay when clicking outside if shouldCloseOnInteractOutside returns true', function () {
       let onClose = jest.fn();
-      render(<Example isOpen onClose={onClose} isDismissable shouldCloseOnInteractOutside={target => target === document.body} />);
+      render(
+        <Example
+          isOpen
+          onClose={onClose}
+          isDismissable
+          shouldCloseOnInteractOutside={(target) => target === document.body} />
+      );
       pressStart(document.body);
       pressEnd(document.body);
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -74,7 +84,13 @@ describe('useOverlay', function () {
 
     it('should not hide the overlay when clicking outside if shouldCloseOnInteractOutside returns false', function () {
       let onClose = jest.fn();
-      render(<Example isOpen onClose={onClose} isDismissable shouldCloseOnInteractOutside={target => target !== document.body} />);
+      render(
+        <Example
+          isOpen
+          onClose={onClose}
+          isDismissable
+          shouldCloseOnInteractOutside={(target) => target !== document.body} />
+      );
       pressStart(document.body);
       pressEnd(document.body);
       expect(onClose).toHaveBeenCalledTimes(0);
@@ -92,7 +108,9 @@ describe('useOverlay', function () {
       let onCloseFirst = jest.fn();
       let onCloseSecond = jest.fn();
       render(<Example isOpen onClose={onCloseFirst} isDismissable />);
-      let second = render(<Example isOpen onClose={onCloseSecond} isDismissable />);
+      let second = render(
+        <Example isOpen onClose={onCloseSecond} isDismissable />
+      );
 
       pressStart(document.body);
       pressEnd(document.body);
@@ -117,7 +135,9 @@ describe('useOverlay', function () {
 
   it('should still hide the overlay when pressing the escape key if isDismissable is false', function () {
     let onClose = jest.fn();
-    let res = render(<Example isOpen onClose={onClose} isDismissable={false} />);
+    let res = render(
+      <Example isOpen onClose={onClose} isDismissable={false} />
+    );
     let el = res.getByTestId('test');
     fireEvent.keyDown(el, {key: 'Escape'});
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -127,10 +147,90 @@ describe('useOverlay', function () {
     installPointerEvent();
     it('should prevent default on pointer down on the underlay', function () {
       let underlayRef = React.createRef();
-      render(<Example isOpen isDismissable underlayProps={{ref: underlayRef}} />);
-      let isPrevented = fireEvent.pointerDown(underlayRef.current, {button: 0, pointerId: 1});
+      render(
+        <Example isOpen isDismissable underlayProps={{ref: underlayRef}} />
+      );
+      let isPrevented = fireEvent.pointerDown(underlayRef.current, {
+        button: 0,
+        pointerId: 1
+      });
       fireEvent.pointerUp(document.body);
       expect(isPrevented).toBeFalsy(); // meaning the event had preventDefault called
+    });
+  });
+});
+
+describe('useOverlay with shadow dom', () => {
+  beforeAll(() => {
+    enableShadowDOM();
+  });
+
+  describe.each`
+    type                | prepare                | actions
+    ${'Mouse Events'}   | ${installMouseEvent}   | ${[(el) => fireEvent.mouseDown(el, {button: 0}), (el) => fireEvent.mouseUp(el, {button: 0})]}
+    ${'Pointer Events'} | ${installPointerEvent} | ${[(el) => fireEvent.pointerDown(el, {button: 0, pointerId: 1}), (el) => fireEvent.pointerUp(el, {button: 0, pointerId: 1})]}
+    ${'Touch Events'}   | ${() => {}}            | ${[(el) => fireEvent.touchStart(el, {changedTouches: [{identifier: 1}]}), (el) => fireEvent.touchEnd(el, {changedTouches: [{identifier: 1}]})]}
+  `('$type', ({actions: [pressStart, pressEnd], prepare}) => {
+    prepare();
+
+    it('should not close the overlay when clicking outside if shouldCloseOnInteractOutside returns true', function () {
+      const {shadowRoot, shadowHost} = createShadowRoot();
+
+      let onClose = jest.fn();
+      let underlay;
+
+      const WrapperComponent = () =>
+        ReactDOM.createPortal(
+          <Example
+            isOpen
+            onClose={onClose}
+            isDismissable
+            shouldCloseOnInteractOutside={(target) => {
+              return target === underlay;
+            }} />,
+          shadowRoot
+        );
+
+      const {unmount} = render(<WrapperComponent />);
+
+      underlay = shadowRoot.querySelector("[data-testid='underlay']");
+
+      pressStart(underlay);
+      pressEnd(underlay);
+      expect(onClose).toHaveBeenCalled();
+
+      // Cleanup
+      unmount();
+      document.body.removeChild(shadowHost);
+    });
+
+    it('should not close the overlay when clicking outside if shouldCloseOnInteractOutside returns false', function () {
+      const {shadowRoot, shadowHost} = createShadowRoot();
+
+      let onClose = jest.fn();
+      let underlay;
+
+      const WrapperComponent = () =>
+        ReactDOM.createPortal(
+          <Example
+            isOpen
+            onClose={onClose}
+            isDismissable
+            shouldCloseOnInteractOutside={(target) => target !== underlay} />,
+          shadowRoot
+        );
+
+      const {unmount} = render(<WrapperComponent />);
+
+      underlay = shadowRoot.querySelector("[data-testid='underlay']");
+
+      pressStart(underlay);
+      pressEnd(underlay);
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Cleanup
+      unmount();
+      document.body.removeChild(shadowHost);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6407,6 +6407,7 @@ __metadata:
     "@react-aria/ssr": "npm:^3.9.7"
     "@react-aria/utils": "npm:^3.27.0"
     "@react-aria/visually-hidden": "npm:^3.8.19"
+    "@react-stately/flags": "npm:^3.0.5"
     "@react-stately/overlays": "npm:^3.6.13"
     "@react-types/button": "npm:^3.10.2"
     "@react-types/overlays": "npm:^3.8.12"


### PR DESCRIPTION
Followup of #6046 

This PR fixes an issue in `useOverlay` where `shouldCloseOnInteractOutside` always received the shadow root parent element as the argument whenever an element inside the shadow root was clicked.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->

Nutrient (formerly PSPDFKit)
