### PR TITLE
fix: ToggleButton Props should not include aria-current

### DIFF
--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -20,7 +20,7 @@ interface ButtonProps extends PressEvents, FocusableProps {
   children?: ReactNode
 }
 
-interface ToggleButtonProps extends ButtonProps {
+interface ToggleButtonProps extends Omit<ButtonProps, 'aria-current'> {
   /** Whether the element should be selected (controlled). */
   isSelected?: boolean,
   /** Whether the element should be selected (uncontrolled). */

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -20,7 +20,7 @@ interface ButtonProps extends PressEvents, FocusableProps {
   children?: ReactNode
 }
 
-interface ToggleButtonProps extends Omit<ButtonProps, 'aria-current'> {
+interface ToggleButtonProps extends ButtonProps {
   /** Whether the element should be selected (controlled). */
   isSelected?: boolean,
   /** Whether the element should be selected (uncontrolled). */
@@ -72,7 +72,7 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
 }
 
 export interface AriaButtonProps<T extends ElementType = 'button'> extends ButtonProps, LinkButtonProps<T>, AriaBaseButtonProps {}
-export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, AriaBaseButtonProps, AriaButtonElementTypeProps<T> {}
+export interface AriaToggleButtonProps<T extends ElementType = 'button'> extends ToggleButtonProps, Omit<AriaBaseButtonProps, 'aria-current'>, AriaButtonElementTypeProps<T> {}
 export interface AriaToggleButtonGroupItemProps<E extends ElementType = 'button'> extends Omit<AriaToggleButtonProps<E>, 'id' | 'isSelected' | 'defaultSelected' | 'onChange'> {
   /** An identifier for the item in the `selectedKeys` of a ToggleButtonGroup. */
   id: Key
@@ -110,7 +110,7 @@ export interface SpectrumLogicButtonProps extends AriaBaseButtonProps, ButtonPro
   variant: 'and' | 'or'
 }
 
-export interface SpectrumToggleButtonProps extends ToggleButtonProps, SpectrumActionButtonProps {
+export interface SpectrumToggleButtonProps extends ToggleButtonProps, Omit<SpectrumActionButtonProps, 'aria-current'> {
   /** Whether the button should be displayed with an [emphasized style](https://spectrum.adobe.com/page/action-button/#Emphasis). */
   isEmphasized?: boolean
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

found in API review

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
