### PR TITLE
fix(Toast): catch startViewTransition error thrown for multiple transitions

### DIFF
--- a/packages/@react-spectrum/toast/src/ToastContainer.tsx
+++ b/packages/@react-spectrum/toast/src/ToastContainer.tsx
@@ -47,7 +47,7 @@ function wrapInViewTransition<R>(fn: () => R): R {
       flushSync(() => {
         result = fn();
       });
-    });
+    }).ready.catch(() => {});
     // @ts-ignore
     return result;
   } else {


### PR DESCRIPTION
Prevents throwing this error: `Unhandled Rejection (AbortError): Old view transition aborted by new view transition`, which could be produced by rapidly opening and closing toasts. I could only reproduce this in iOS Safari.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

On iOS Safari, try rapidly opening new toasts and closing existing toasts.

## 🧢 Your Project:

<!--- Company/project for pull request -->
