### PR TITLE
react-aria-components: Expose missing RenderProps types

### DIFF
--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -25,7 +25,7 @@ export interface DialogTriggerProps extends OverlayTriggerProps {
   children: ReactNode
 }
 
-interface DialogRenderProps {
+export interface DialogRenderProps {
   close: () => void
 }
 

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -99,7 +99,7 @@ export type {ColorWheelProps, ColorWheelRenderProps, ColorWheelTrackProps, Color
 export type {ComboBoxProps, ComboBoxRenderProps} from './ComboBox';
 export type {DateFieldProps, DateFieldRenderProps, DateInputProps, DateInputRenderProps, DateSegmentProps, DateSegmentRenderProps, TimeFieldProps} from './DateField';
 export type {DatePickerProps, DatePickerRenderProps, DateRangePickerProps, DateRangePickerRenderProps} from './DatePicker';
-export type {DialogProps, DialogTriggerProps} from './Dialog';
+export type {DialogProps, DialogTriggerProps, DialogRenderProps} from './Dialog';
 export type {DisclosureProps, DisclosureRenderProps, DisclosurePanelProps, DisclosurePanelRenderProps, DisclosureGroupProps, DisclosureGroupRenderProps} from './Disclosure';
 export type {DropZoneProps, DropZoneRenderProps} from './DropZone';
 export type {FieldErrorProps, FieldErrorRenderProps} from './FieldError';
@@ -111,8 +111,7 @@ export type {HeadingProps} from './Heading';
 export type {InputProps, InputRenderProps} from './Input';
 export type {SectionProps, CollectionRenderer} from './Collection';
 export type {LabelProps} from './Label';
-export type {LinkProps} from './Link';
-export type {LinkRenderProps} from './Link';
+export type {LinkProps, LinkRenderProps} from './Link';
 export type {ListBoxProps, ListBoxRenderProps, ListBoxItemProps, ListBoxItemRenderProps, ListBoxSectionProps} from './ListBox';
 export type {MenuProps, MenuItemProps, MenuItemRenderProps, MenuTriggerProps, SubmenuTriggerProps, MenuSectionProps} from './Menu';
 export type {MeterProps, MeterRenderProps} from './Meter';
@@ -139,7 +138,7 @@ export type {ToolbarProps, ToolbarRenderProps} from './Toolbar';
 export type {TooltipProps, TooltipRenderProps, TooltipTriggerComponentProps} from './Tooltip';
 export type {TreeProps, TreeRenderProps, TreeItemProps, TreeItemRenderProps, TreeItemContentProps, TreeItemContentRenderProps} from './Tree';
 export type {DragAndDropHooks, DragAndDropOptions} from './useDragAndDrop';
-export type {DropIndicatorProps} from './DragAndDrop';
+export type {DropIndicatorProps, DropIndicatorRenderProps} from './DragAndDrop';
 export type {ContextValue, SlotProps} from './utils';
 export type {VirtualizerProps} from './Virtualizer';
 


### PR DESCRIPTION
Some RenderProps types weren't being exported properly from the react-aria-components library.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
