### PR TITLE
fix: RadioGroup controlled example

### DIFF
--- a/packages/@react-spectrum/radio/docs/RadioGroup.mdx
+++ b/packages/@react-spectrum/radio/docs/RadioGroup.mdx
@@ -133,7 +133,7 @@ The example below uses `onChange` to log how the user is interacting with the co
 
 ```tsx example
 function Example() {
-  let [selected, setSelected] = React.useState('');
+  let [selected, setSelected] = React.useState(null);
 
   return (
     <>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

reported internally

using value of an empty string makes it so you can't tab to the radiogroup at all, this is because an empty string could be a valid value for an individual radio. `null` should be used instead

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
