### PR TITLE
fix(toast): resume timers if pointer leaves region due to toast being removed

### DIFF
--- a/packages/@react-aria/toast/stories/Example.tsx
+++ b/packages/@react-aria/toast/stories/Example.tsx
@@ -32,7 +32,7 @@ function ToastRegion() {
   let ref = useRef(null);
   let {regionProps} = useToastRegion({}, state, ref);
   return (
-    <div {...regionProps} ref={ref} style={{position: 'fixed', bottom: 0, right: 0}}>
+    <div {...regionProps} ref={ref} style={{position: 'fixed', bottom: 0, right: 0, display: 'flex', flexDirection: 'column', gap: 10}}>
       {state.visibleToasts.map(toast => (
         <Toast key={toast.key} toast={toast} />
       ))}

--- a/packages/@react-aria/toast/stories/useToast.stories.tsx
+++ b/packages/@react-aria/toast/stories/useToast.stories.tsx
@@ -16,7 +16,14 @@ import {ToastContainer} from './Example';
 export default {
   title: 'useToast',
   args: {
-    maxVisibleToasts: 1
+    maxVisibleToasts: 1,
+    timeout: null
+  },
+  argTypes: {
+    timeout: {
+      control: 'radio',
+      options: [null, 5000]
+    }
   }
 };
 
@@ -25,9 +32,9 @@ let count = 0;
 export const Default = args => (
   <ToastContainer {...args}>
     {state => (<>
-      <button onClick={() => state.add('High ' + ++count, {priority: 10})}>Add high priority toast</button>
-      <button onClick={() => state.add('Medium ' + ++count, {priority: 5})}>Add medium priority toast</button>
-      <button onClick={() => state.add('Low ' + ++count, {priority: 1})}>Add low priority toast</button>
+      <button onClick={() => state.add('High ' + ++count, {priority: 10, timeout: args.timeout})}>Add high priority toast</button>
+      <button onClick={() => state.add('Medium ' + ++count, {priority: 5, timeout: args.timeout})}>Add medium priority toast</button>
+      <button onClick={() => state.add('Low ' + ++count, {priority: 1, timeout: args.timeout})}>Add low priority toast</button>
     </>)}
   </ToastContainer>
 );


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7024. Alternative to https://github.com/adobe/react-spectrum/pull/7681

After a toast has been removed, we check the pointer position on the next `pointermove` event. If it is now outside the toast region, we resume timers.

For discussion:
- The timers won't resume until the next `pointermove` after closing. This behavior seems good IMO. It gives the user time to process the new state and decide whether to move their pointer elsewhere or to the next toast (would cause another pause).
- There is some related but different behavior we may want to discuss: if you close a toast via touch, currently the next toast's remove button gets focused, causing the timer to pause. If the user scrolls or interacts with anything else outside the region, the timers resume. This behavior seems fine IMO.

Also, note that the original issue is no longer reproducible in RSP Toast after https://github.com/adobe/react-spectrum/pull/7631, so I've updated the useToast story for testing this.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

In the [useToast story](https://reactspectrum.blob.core.windows.net/reactspectrum/566eb4dd25fde26731b23e068ff5a4667b47f61e/storybook/index.html?path=/story/usetoast--default&args=maxVisibleToasts:5;timeout:5000&providerSwitcher-express=false) with a timeout enabled, open two or more toasts
Close the top one and keep your mouse where it is
Confirm that the remaining toast(s) close after a few seconds due to the timeout. Previously they would not due to the timer not resuming, due to no pointerleave event being fired in this case.


## 🧢 Your Project:

<!--- Company/project for pull request -->
