### PR TITLE
fix: Canceling text selection in Safari broken after usePress refactor

### DIFF
--- a/packages/@react-aria/interactions/src/textSelection.ts
+++ b/packages/@react-aria/interactions/src/textSelection.ts
@@ -46,8 +46,9 @@ export function disableTextSelection(target?: Element) {
   } else if (target instanceof HTMLElement || target instanceof SVGElement) {
     // If not iOS, store the target's original user-select and change to user-select: none
     // Ignore state since it doesn't apply for non iOS
-    modifiedElementMap.set(target, target.style.userSelect);
-    target.style.userSelect = 'none';
+    let property = 'userSelect' in target.style ? 'userSelect' : 'webkitUserSelect';
+    modifiedElementMap.set(target, target.style[property]);
+    target.style[property] = 'none';
   }
 }
 
@@ -85,9 +86,10 @@ export function restoreTextSelection(target?: Element) {
     // Ignore state since it doesn't apply for non iOS
     if (target && modifiedElementMap.has(target)) {
       let targetOldUserSelect = modifiedElementMap.get(target) as string;
+      let property = 'userSelect' in target.style ? 'userSelect' : 'webkitUserSelect';
 
-      if (target.style.userSelect === 'none') {
-        target.style.userSelect = targetOldUserSelect;
+      if (target.style[property] === 'none') {
+        target.style[property] = targetOldUserSelect;
       }
 
       if (target.getAttribute('style') === '') {


### PR DESCRIPTION
Noticed a small regression from the `usePress` refactor: text selection was no longer being canceled in Safari on desktop. For example when clicking quickly on an item in a GridList in the docs the text would be selected. This previously worked because `preventDefault` stops text selection, but after removing that we rely on setting `user-event` on pointer down. This worked in Chrome and Firefox, but Safari still doesn't support `user-select` and requires a prefixed `-webkit-user-select` property instead. Updated the code to detect the correct property to use.