### PR TITLE
chore: removing s2 references to css flex shorthand, use grow, basis, and shrink

### DIFF
--- a/.storybook-s2/docs/Intro.jsx
+++ b/.storybook-s2/docs/Intro.jsx
@@ -202,7 +202,6 @@ import {ActionButton} from '@react-spectrum/s2';
           <li><Code>width</Code></li>
           <li><Code>minWidth</Code></li>
           <li><Code>maxWidth</Code></li>
-          <li><Code>flex</Code></li>
           <li><Code>flexGrow</Code></li>
           <li><Code>flexShrink</Code></li>
           <li><Code>flexBasis</Code></li>

--- a/packages/@react-spectrum/s2/src/style-utils.ts
+++ b/packages/@react-spectrum/s2/src/style-utils.ts
@@ -146,7 +146,6 @@ const allowedOverrides = [
   'marginBottom',
   'marginX',
   'marginY',
-  'flex',
   'flexGrow',
   'flexShrink',
   'flexBasis',


### PR DESCRIPTION
Do we also want it removed for s1? https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/style-macro-s1/src/spectrum-theme.ts#L754

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check the S2 docs to config css flex shorthand is no longer listed as a supported type.
When deployed confirm that flex isn't a supported type for S2 style macros.

## 🧢 Your Project:
xx xxxxxxxx