### PR TITLE
fix: Improve colSpan performance

### DIFF
--- a/packages/@react-aria/collections/src/BaseCollection.ts
+++ b/packages/@react-aria/collections/src/BaseCollection.ts
@@ -35,6 +35,8 @@ export class CollectionNode<T> implements Node<T> {
   readonly lastChildKey: Key | null = null;
   readonly props: any = {};
   readonly render?: (node: Node<any>) => ReactElement;
+  readonly colSpan: number | null = null;
+  readonly colIndex: number | null = null;
 
   constructor(type: string, key: Key) {
     this.type = type;
@@ -61,6 +63,8 @@ export class CollectionNode<T> implements Node<T> {
     node.lastChildKey = this.lastChildKey;
     node.props = this.props;
     node.render = this.render;
+    node.colSpan = this.colSpan;
+    node.colIndex = this.colIndex;
     return node;
   }
 }

--- a/packages/@react-types/grid/src/index.d.ts
+++ b/packages/@react-types/grid/src/index.d.ts
@@ -33,9 +33,9 @@ export interface GridNode<T> extends Node<T> {
    */
   colspan?: number,
   /** The number of columns spanned by this cell.  */
-  colSpan?: number,
+  colSpan?: number | null,
   /** The column index of this cell, accounting for any colSpans. */
-  colIndex?: number,
+  colIndex?: number | null,
   /** The index of this node within its parent, ignoring sibling nodes that aren't of the same type. */
   indexOfType?: number
 }

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -41,51 +41,21 @@ class TableCollection<T> extends BaseCollection<T> implements ITableCollection<T
 
   commit(firstKey: Key, lastKey: Key, isSSR = false) {
     this.updateColumns(isSSR);
-    this.updateRows(isSSR);
-    super.commit(firstKey, lastKey, isSSR);
-  }
 
-  private updateRows(isSSR: boolean) {
     this.rows = [];
-    let visit = (node: Node<T>) => {
-      if (node.hasChildNodes) {
-        let rowHasCellWithColSpan = false;
-        let childNodes: Iterable<GridNode<T>> = this.getChildren(node.key);
-        for (let child of childNodes) {
-          if (child.type === 'cell' && child.props?.colSpan !== undefined) {
-            rowHasCellWithColSpan = true;
-            break;
-          }
-        }
-
-        if (rowHasCellWithColSpan) {
-          let last: GridNode<T> | null = null;
-          for (let child of childNodes) {
-            child.colSpan = child.props?.colSpan;
-            child.colspan = child.props?.colSpan;
-            child.colIndex = !last ? child.index : (last.colIndex ?? last.index) + (last.colSpan ?? 1);
-            last = child;
-          }
-
-          let lastColIndex = last?.colIndex ?? 0 + 1; // internally colIndex is 0 based
-          let lastColSpan = last?.colSpan ?? 1;
-          let numberOfCellsInRow = lastColIndex + lastColSpan;
-
-          if (numberOfCellsInRow !== this.columns.length && !isSSR) {
-            throw new Error(`Cell count must match column count. Found ${numberOfCellsInRow} cells and ${this.columns.length} columns.`);
-          }
-        } else {
-          let numberOfCellsInRow = [...childNodes].length;
-          if (numberOfCellsInRow !== this.columns.length && !isSSR) {
-            throw new Error(`Cell count must match column count. Found ${numberOfCellsInRow} cells and ${this.columns.length} columns.`);
-          }
+    for (let row of this.getChildren(this.body.key)) {
+      let lastChildKey = (row as CollectionNode<T>).lastChildKey;
+      if (lastChildKey != null) {
+        let lastCell = this.getItem(lastChildKey) as GridNode<T>;
+        let numberOfCellsInRow = (lastCell.colIndex ?? lastCell.index) + (lastCell.colSpan ?? 1);
+        if (numberOfCellsInRow !== this.columns.length && !isSSR) {
+          throw new Error(`Cell count must match column count. Found ${numberOfCellsInRow} cells and ${this.columns.length} columns.`);
         }
       }
-      this.rows.push(node);
-    };
-    for (let child of this.getChildren(this.body.key)) {
-      visit(child);
+      this.rows.push(row);
     }
+
+    super.commit(firstKey, lastKey, isSSR);
   }
 
   private updateColumns(isSSR: boolean) {

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -903,8 +903,8 @@ describe('Table', () => {
 
       let cells1 = [...within(rows[1]).getAllByRole('rowheader'), ...within(rows[1]).getAllByRole('gridcell')];
       expect(cells1).toHaveLength(3);
-      expect(cells1[0]).toHaveAttribute('aria-colindex', '1');
-      expect(cells1[1]).toHaveAttribute('aria-colindex', '2');
+      expect(cells1[0]).not.toHaveAttribute('aria-colindex');
+      expect(cells1[1]).not.toHaveAttribute('aria-colindex');
       expect(cells1[1]).toHaveAttribute('colspan', '2');
       expect(cells1[2]).toHaveAttribute('aria-colindex', '4');
 
@@ -917,12 +917,12 @@ describe('Table', () => {
 
       let cells3 = within(rows[3]).getAllByRole('rowheader');
       expect(cells3).toHaveLength(1);
-      expect(cells3[0]).toHaveAttribute('aria-colindex', '1');
+      expect(cells3[0]).not.toHaveAttribute('aria-colindex');
       expect(cells3[0]).toHaveAttribute('colspan', '4');
 
       let cells5 = [...within(rows[5]).getAllByRole('rowheader'), ...within(rows[5]).getAllByRole('gridcell')];
       expect(cells5).toHaveLength(2);
-      expect(cells5[0]).toHaveAttribute('aria-colindex', '1');
+      expect(cells5[0]).not.toHaveAttribute('aria-colindex');
       expect(cells5[0]).toHaveAttribute('colspan', '3');
       expect(cells5[1]).toHaveAttribute('aria-colindex', '4');
     });
@@ -982,6 +982,7 @@ describe('Table', () => {
 
     it('should throw error if number of cells do not match column count', () => {
       jest.spyOn(console, 'error').mockImplementation(() => {});
+      let error;
       try {
         render(
           <Table aria-label="Col Span Table with wrong number of cells">
@@ -1005,10 +1006,11 @@ describe('Table', () => {
               </Row>
             </TableBody>
           </Table>
-          );
+        );
       } catch (e) {
-        expect(e.message).toEqual('Cell count must match column count. Found 5 cells and 4 columns.');
+        error = e;
       }
+      expect(error?.message).toEqual('Cell count must match column count. Found 5 cells and 4 columns.');
       try {
         render(
           <Table aria-label="Col Span Table with wrong number of cells">
@@ -1024,8 +1026,9 @@ describe('Table', () => {
           </Table>
         );
       } catch (e) {
-        expect(e.message).toEqual('Cell count must match column count. Found 1 cells and 2 columns.');
+        error = e;
       }
+      expect(error?.message).toEqual('Cell count must match column count. Found 1 cells and 2 columns.');
     });
   });
 


### PR DESCRIPTION
In collaboration with @snowystinger 😄 

The extra traversal over all rows and cells introduced in #7638 caused a performance regression for large tables. Our S2 many rows and cells story took an extra ~20ms per collection update, and a table with 10,000 rows took an extra ~250ms per update.

We can avoid the extra traversal by computing `colIndex` and `colSpan` while building the document rather than as a separate pass. The downside is that this is done on all collections and not just tables but it's probably fine for now.