### PR TITLE
feat: useTreeData add replaceAll

### DIFF
--- a/packages/@react-stately/data/docs/useListData.mdx
+++ b/packages/@react-stately/data/docs/useListData.mdx
@@ -150,3 +150,9 @@ list.move('Snake', 0);
 ```tsx
 list.update('Snake', {name: 'Rattle Snake'});
 ```
+
+### Replacing the tree
+
+```
+list.replaceAll([{name: 'Fox', children: [{name: 'Rabbit'}]}])
+```

--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -50,7 +50,12 @@ export interface TreeData<T extends object> {
    * @param key - The key of the item to retrieve.
    */
   getItem(key: Key): TreeNode<T> | undefined,
-
+  
+  /** 
+   * Replace the whole tree.
+   * @param newItems - The new items to replace the tree with.
+   */
+  replaceAll(newItems: T[]): void,
   /**
    * Inserts an item into a parent node as a child.
    * @param parentKey - The key of the parent item to insert into. `null` for the root.
@@ -256,6 +261,9 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
     setSelectedKeys,
     getItem(key: Key) {
       return nodeMap.get(key);
+    },
+    replaceAll(newItems: T[]) {
+      setItems(buildTree(newItems, new Map()));
     },
     insert(parentKey: Key | null, index: number, ...values: T[]) {
       setItems(({items, nodeMap: originalMap}) => {

--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -745,4 +745,19 @@ describe('useTreeData', function () {
     expect(result.current.items[1].key).toEqual('Emily');
     expect(result.current.items.length).toEqual(2);
   });
+
+  it('Should replace the tree with new nodes', function () {
+    const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+    let {result} = renderHook(() =>
+      useTreeData({initialItems, getChildren, getKey})
+    );
+    act(() => {
+      result.current.replaceAll([{name: 'Robert', children: [{name: 'Linh'}]}, {name: 'Stanley'}]); 
+    });
+    expect(result.current.items[0].key).toEqual('Robert');
+
+    expect(result.current.items[0].children[0].key).toEqual('Linh');
+    expect(result.current.items[1].key).toEqual('Stanley');
+    expect(result.current.items.length).toEqual(2);
+  });
 });


### PR DESCRIPTION
The immutable nature of the useTreeData's items means I couldn't find a way to re-initialise a list with new data returned from a subsequent API call.

This PR adds a new method to  the list called `replaceAll` which will replace all items from the tree with those specified in the function call.

## ✅ Pull Request Checklist:

- [ n/a ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ✅ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ✅ ] Updated documentation (if it already exists for this component).
- [ n/a ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

The tests cover how it works, if you need to test in a component then I'm using it as :
```

// Data is the result of a fetch query to the backend which is re-run when a tree node is deleted, added etc.
export const MyTree = ({ data }) => {
  const list = useTreeData({
    initialItems: nodeTree,
  });

  useEffect(() => {
    list.replaceAll(nodeTree);
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [nodeTree]);

return <Tree items={list.items>....</Tree>
};

## 🧢 Your Project:

<!--- Company/project for pull request -->
