### PR TITLE
fix: Re-show focus ring on ComboBox input when closed

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/inputgroup/skin.css
@@ -20,6 +20,10 @@ governing permissions and limitations under the License.
     }
   }
 
+  .spectrum-InputGroup-input:focus {
+    border-color: var(--spectrum-textfield-border-color);
+  }
+
   &.is-focused {
     &:not(.spectrum-InputGroup--invalid):not(.is-disabled) {
       .spectrum-InputGroup-input {
@@ -48,7 +52,8 @@ governing permissions and limitations under the License.
 
   &.spectrum-InputGroup--invalid {
     .spectrum-FieldButton:before,
-    .spectrum-InputGroup-input {
+    .spectrum-InputGroup-input,
+    .spectrum-InputGroup-input:focus {
       border-color: var(--spectrum-textfield-border-color-error);
     }
 

--- a/packages/@react-aria/combobox/package.json
+++ b/packages/@react-aria/combobox/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/adobe/react-spectrum"
   },
   "dependencies": {
+    "@react-aria/focus": "^3.19.1",
     "@react-aria/i18n": "^3.12.5",
     "@react-aria/listbox": "^3.14.0",
     "@react-aria/live-announcer": "^3.4.1",

--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -16,8 +16,9 @@ import {AriaComboBoxProps} from '@react-types/combobox';
 import {ariaHideOutside} from '@react-aria/overlays';
 import {AriaListBoxOptions, getItemId, listData} from '@react-aria/listbox';
 import {BaseEvent, DOMAttributes, KeyboardDelegate, LayoutDelegate, PressEvent, RefObject, RouterOptions, ValidationResult} from '@react-types/shared';
-import {chain, isAppleDevice, mergeProps, useLabels, useRouter} from '@react-aria/utils';
+import {chain, getActiveElement, getOwnerDocument, isAppleDevice, mergeProps, useLabels, useRouter, useUpdateEffect} from '@react-aria/utils';
 import {ComboBoxState} from '@react-stately/combobox';
+import {dispatchVirtualFocus} from '@react-aria/focus';
 import {FocusEvent, InputHTMLAttributes, KeyboardEvent, TouchEvent, useEffect, useMemo, useRef} from 'react';
 import {getChildNodes, getItemCount} from '@react-stately/collections';
 // @ts-ignore
@@ -341,6 +342,13 @@ export function useComboBox<T>(props: AriaComboBoxOptions<T>, state: ComboBoxSta
       return ariaHideOutside([inputRef.current, popoverRef.current].filter(element => element != null));
     }
   }, [state.isOpen, inputRef, popoverRef]);
+
+  useUpdateEffect(() => {
+    // Re-show focus ring when there is no virtually focused item.
+    if (!focusedItem && inputRef.current && getActiveElement(getOwnerDocument(inputRef.current)) === inputRef.current) {
+      dispatchVirtualFocus(inputRef.current, null);
+    }
+  }, [focusedItem]);
 
   return {
     labelProps,

--- a/packages/@react-aria/utils/src/useUpdateEffect.ts
+++ b/packages/@react-aria/utils/src/useUpdateEffect.ts
@@ -13,7 +13,7 @@
 import {EffectCallback, useEffect, useRef} from 'react';
 
 // Like useEffect, but only called for updates after the initial render.
-export function useUpdateEffect(effect: EffectCallback, dependencies: any[]): (() => void) | void {
+export function useUpdateEffect(effect: EffectCallback, dependencies: any[]): void {
   const isInitialMount = useRef(true);
   const lastDeps = useRef<any[] | null>(null);
 
@@ -25,10 +25,11 @@ export function useUpdateEffect(effect: EffectCallback, dependencies: any[]): ((
   }, []);
 
   useEffect(() => {
+    let prevDeps = lastDeps.current;
     if (isInitialMount.current) {
       isInitialMount.current = false;
-    } else if (!lastDeps.current || dependencies.some((dep, i) => !Object.is(dep, lastDeps[i]))) {
-      return effect();
+    } else if (!prevDeps || dependencies.some((dep, i) => !Object.is(dep, prevDeps[i]))) {
+      effect();
     }
     lastDeps.current = dependencies;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -96,9 +96,9 @@ import {ComboBox, Label, Input, Button, Popover, ListBox, ListBoxItem} from 'rea
     border-radius: 6px;
     padding: 0.286rem 2rem 0.286rem 0.571rem;
     vertical-align: middle;
+    outline: none;
 
     &[data-focused] {
-      outline: none;
       outline: 2px solid var(--focus-ring-color);
       outline-offset: -1px;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6049,6 +6049,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-aria/combobox@workspace:packages/@react-aria/combobox"
   dependencies:
+    "@react-aria/focus": "npm:^3.19.1"
     "@react-aria/i18n": "npm:^3.12.5"
     "@react-aria/listbox": "npm:^3.14.0"
     "@react-aria/live-announcer": "npm:^3.4.1"


### PR DESCRIPTION
Autocomplete introduced a change for virtual focus collections where we fire focus/blur events to move the focus ring. This also affects ComboBox - now when the virtual focus is on an item, the input loses its focus ring. However, when closing the ComboBox, the focus ring never shifted back to the input. We also need to better account for this state in the styles for the v3 ComboBox.