### PR TITLE
chore: Add isRequired to NumberField RenderProps

### DIFF
--- a/packages/react-aria-components/src/NumberField.tsx
+++ b/packages/react-aria-components/src/NumberField.tsx
@@ -36,6 +36,11 @@ export interface NumberFieldRenderProps {
    */
   isInvalid: boolean,
   /**
+   * Whether the number field is required.
+   * @selector [data-required]
+   */
+  isRequired: boolean,
+  /**
    * State of the number field.
    */
   state: NumberFieldState
@@ -84,7 +89,8 @@ export const NumberField = /*#__PURE__*/ (forwardRef as forwardRefType)(function
     values: {
       state,
       isDisabled: props.isDisabled || false,
-      isInvalid: validation.isInvalid || false
+      isInvalid: validation.isInvalid || false,
+      isRequired: props.isRequired || false
     },
     defaultClassName: 'react-aria-NumberField'
   });
@@ -119,6 +125,7 @@ export const NumberField = /*#__PURE__*/ (forwardRef as forwardRefType)(function
         ref={ref}
         slot={props.slot || undefined}
         data-disabled={props.isDisabled || undefined}
+        data-required={props.isRequired || undefined}
         data-invalid={validation.isInvalid || undefined} />
       {props.name && <input type="hidden" name={props.name} value={isNaN(state.numberValue) ? '' : state.numberValue} />}
     </Provider>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

a definitely correct part of https://github.com/adobe/react-spectrum/issues/6151

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
