### PR TITLE
fix: prevent focus visible on label (checkbox, switch, radio) 

### DIFF
--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -69,7 +69,11 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
 
   // Handle press state on the label.
   let {pressProps: labelProps, isPressed: isLabelPressed} = usePress({
-    isDisabled
+    isDisabled,
+    onPress() {
+      state.setSelectedValue(value);
+      ref.current?.focus();
+    }
   });
 
   let {focusableProps} = useFocusable(mergeProps(props, {
@@ -94,7 +98,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
   useFormValidation({validationBehavior}, state, ref);
 
   return {
-    labelProps,
+    labelProps: mergeProps(labelProps, {onClick: e => e.preventDefault()}),
     inputProps: mergeProps(domProps, {
       ...interactions,
       type: 'radio',

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -70,6 +70,10 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
 
   // Handle press state on the label.
   let {pressProps: labelProps, isPressed: isLabelPressed} = usePress({
+    onPress() {
+      state.toggle();
+      ref.current?.focus();
+    },
     isDisabled: isDisabled || isReadOnly
   });
 
@@ -80,7 +84,7 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
   useFormReset(ref, state.isSelected, state.setSelected);
 
   return {
-    labelProps,
+    labelProps: mergeProps(labelProps, {onClick: e => e.preventDefault()}),
     inputProps: mergeProps(domProps, {
       'aria-invalid': isInvalid || validationState === 'invalid' || undefined,
       'aria-errormessage': props['aria-errormessage'],


### PR DESCRIPTION
Closes <!-- Github issue # here -->

In https://github.com/adobe/react-spectrum/pull/7677, we removed the preventDefault on `onClick` which allowed the browser to focus the label but also caused a focus ring to appear by triggering a virtual click. This PR adds back the preventDefault but since we still need to focus the label, we do that through the ref instead

Related issues: https://github.com/adobe/react-spectrum/issues/3675
Related PRs: https://github.com/adobe/react-spectrum/pull/7542, https://github.com/adobe/react-spectrum/pull/7677, https://github.com/adobe/react-spectrum/pull/5525

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test Gridlist docs, virtualizer docs, S2 TreeView, S2 custom popover (specifically the switch in the popover) and make sure that the focus ring doesn't appear but that they are focused


## 🧢 Your Project:

<!--- Company/project for pull request -->
