### PR TITLE
chore: Add colSpan examples to docs

### DIFF
--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -91,7 +91,7 @@ const StaticTable = (args: any) => (
         <Cell>Long long long long long long long cell</Cell>
       </Row>
       <Row id="4">
-        <Cell colSpan={4}>Total size: 75.4 GB</Cell>
+        <Cell colSpan={5}>Total size: 75.4 GB</Cell>
       </Row>
     </TableBody>
   </TableView>

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -65,7 +65,7 @@ const StaticTable = (args: any) => (
       <Column isRowHeader>Name</Column>
       <Column>Type</Column>
       <Column>Date Modified</Column>
-      <Column>A</Column>
+      <Column>Size</Column>
       <Column>B</Column>
     </TableHeader>
     <TableBody>
@@ -73,22 +73,25 @@ const StaticTable = (args: any) => (
         <Cell>Games</Cell>
         <Cell>File folder</Cell>
         <Cell>6/7/2020</Cell>
-        <Cell>Dummy content</Cell>
+        <Cell>74 GB</Cell>
         <Cell>Long long long long long long long cell</Cell>
       </Row>
       <Row id="2">
         <Cell>Program Files</Cell>
         <Cell>File folder</Cell>
         <Cell>4/7/2021</Cell>
-        <Cell>Dummy content</Cell>
+        <Cell>1.2 GB</Cell>
         <Cell>Long long long long long long long cell</Cell>
       </Row>
       <Row id="3">
         <Cell>bootmgr</Cell>
         <Cell>System file</Cell>
         <Cell>11/20/2010</Cell>
-        <Cell>Dummy content</Cell>
+        <Cell>0.2 GB</Cell>
         <Cell>Long long long long long long long cell</Cell>
+      </Row>
+      <Row id="4">
+        <Cell colSpan={4}>Total size: 75.4 GB</Cell>
       </Row>
     </TableBody>
   </TableView>

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -90,9 +90,6 @@ const StaticTable = (args: any) => (
         <Cell>0.2 GB</Cell>
         <Cell>Long long long long long long long cell</Cell>
       </Row>
-      <Row id="4">
-        <Cell colSpan={5}>Total size: 75.4 GB</Cell>
-      </Row>
     </TableBody>
   </TableView>
 );
@@ -711,4 +708,51 @@ export const FlexWidth = {
     }
   },
   name: 'flex calculated height, flex direction row'
+};
+
+
+export const ColSpan = {
+  render: (args: any) => (
+    <TableView aria-label="Files" {...args} styles={style({width: 320, height: 320})}>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Type</Column>
+        <Column>Date Modified</Column>
+        <Column>Size</Column>
+      </TableHeader>
+      <TableBody>
+        <Row id="1">
+          <Cell>Games</Cell>
+          <Cell>File folder</Cell>
+          <Cell>6/7/2020</Cell>
+          <Cell>74 GB</Cell>
+        </Row>
+        <Row id="2">
+          <Cell>Program Files</Cell>
+          <Cell>File folder</Cell>
+          <Cell>4/7/2021</Cell>
+          <Cell>1.2 GB</Cell>
+        </Row>
+        <Row id="3">
+          <Cell>bootmgr</Cell>
+          <Cell>System file</Cell>
+          <Cell>11/20/2010</Cell>
+          <Cell>0.2 GB</Cell>
+        </Row>
+        <Row id="4">
+          <Cell colSpan={4}>Total size: 75.4 GB</Cell>
+        </Row>
+      </TableBody>
+    </TableView>
+  ),
+  parameters: {
+    docs: {
+      disable: true
+    }
+  },
+  argTypes: {
+    selectionMode: {
+      control: false
+    }
+  }
 };

--- a/packages/@react-spectrum/table/docs/TableView.mdx
+++ b/packages/@react-spectrum/table/docs/TableView.mdx
@@ -675,7 +675,7 @@ The example below illustrates how each of the column width props affects their r
 <TableView
   aria-label="TableView with resizable columns"
   maxWidth={320}
-  height={200} >
+  height={210} >
   <TableHeader>
     {/*- begin highlight -*/}
     <Column key="file" allowsResizing maxWidth={500}>File Name</Column>

--- a/packages/@react-spectrum/table/docs/TableView.mdx
+++ b/packages/@react-spectrum/table/docs/TableView.mdx
@@ -694,6 +694,9 @@ The example below illustrates how each of the column width props affects their r
       <Cell>120 KB</Cell>
       <Cell>January 27, 2021 at 1:56AM</Cell>
     </Row>
+    <Row>
+      <Cell colSpan={3}>Total space: 334 KB</Cell>
+    </Row>
   </TableBody>
 </TableView>
 ```

--- a/packages/react-aria-components/docs/Tree.mdx
+++ b/packages/react-aria-components/docs/Tree.mdx
@@ -149,8 +149,8 @@ import {
       visibility: hidden;
       align-items: center;
       justify-content: center;
-      width: 1.143rem;
-      height: 1.143rem;
+      width: 1.3rem;
+      height: 100%;
       padding-left: calc((var(--tree-item-level) - 1) * var(--padding));
 
       svg {

--- a/packages/react-aria-components/stories/Tree.stories.tsx
+++ b/packages/react-aria-components/stories/Tree.stories.tsx
@@ -65,7 +65,15 @@ const StaticTreeItem = (props: StaticTreeItemProps) => {
             <div
               className={classNames(styles, 'content-wrapper')}
               style={{marginInlineStart: `${(!hasChildItems ? 20 : 0) + (level - 1) * 15}px`}}>
-              {hasChildItems && <Button className={styles.chevron} slot="chevron">{isExpanded ? '⏷' : '⏵'}</Button>}
+              {hasChildItems && (
+                <Button className={styles.chevron} slot="chevron">
+                  <div style={{transform: `rotate(${isExpanded ? 90 : 0}deg)`, width: '16px', height: '16px'}}>
+                    <svg viewBox="0 0 24 24" style={{width: '16px', height: '16px'}}>
+                      <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                    </svg>
+                  </div>
+                </Button>
+                )}
               <Text className={styles.title}>{props.title || props.children}</Text>
               <Button className={styles.button} aria-label="Info" onPress={action('Info press')}>ⓘ</Button>
               <MenuTrigger>
@@ -236,7 +244,15 @@ const DynamicTreeItem = (props: DynamicTreeItemProps) => {
                 <MyCheckbox slot="selection" />
               )}
               <div className={styles['content-wrapper']} style={{marginInlineStart: `${(!hasChildItems ? 20 : 0) + (level - 1) * 15}px`}}>
-                {hasChildItems && <Button slot="chevron">{isExpanded ? '⏷' : '⏵'}</Button>}
+                {hasChildItems && (
+                <Button className={styles.chevron} slot="chevron">
+                  <div style={{transform: `rotate(${isExpanded ? 90 : 0}deg)`, width: '16px', height: '16px'}}>
+                    <svg viewBox="0 0 24 24" style={{width: '16px', height: '16px'}}>
+                      <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                    </svg>
+                  </div>
+                </Button>
+                )}
                 <Text>{props.children}</Text>
                 <Button className={styles.button} aria-label="Info" onPress={action('Info press')}>ⓘ</Button>
                 <MenuTrigger>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

also fixes Tree chevron hit area in RAC docs and fixes rendering in Android RAC storybook

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
