### PR TITLE
fix: Support range selection with grid/table checkboxes

### DIFF
--- a/packages/@react-aria/grid/src/useGridSelectionCheckbox.ts
+++ b/packages/@react-aria/grid/src/useGridSelectionCheckbox.ts
@@ -4,6 +4,7 @@ import {GridState} from '@react-stately/grid';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
+import {useEffect, useRef} from 'react';
 import {useId} from '@react-aria/utils';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
@@ -31,8 +32,30 @@ export function useGridSelectionCheckbox<T, C extends GridCollection<T>>(props: 
   let isDisabled = !state.selectionManager.canSelectItem(key);
   let isSelected = state.selectionManager.isSelected(key);
 
+  let isShiftDown = useRef(false);
+  useEffect(() => {
+    let trackKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        isShiftDown.current = true;
+      }
+    };
+    let trackKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        isShiftDown.current = false;
+      }
+    };
+
+    document.addEventListener('keydown', trackKeyDown);
+    document.addEventListener('keyup', trackKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', trackKeyDown);
+      document.removeEventListener('keyup', trackKeyUp);
+    };
+  });
+
   // Checkbox should always toggle selection, regardless of selectionBehavior.
-  let onChange = () => manager.toggleSelection(key);
+  let onChange = () => isShiftDown.current ? manager.extendSelection(key) : manager.toggleSelection(key);
 
   const stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/grid');
 


### PR DESCRIPTION
Upstreaming a fix that I made for the product I'm working on. Please let me know if you require an issue to be created and I'll create one.

I'm not particulary happy with the fix but making `e.shiftKey` flag available in `onChange` of `useCheckbox`, which goes down quite deep through other hooks, probably does not make a lot of sense.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Use a table with `slot="selection"` checkboxes and try to do a range selection by holding `Shift` key.

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
