### PR TITLE
fix: pass aria labeling props in RAC Separator

### DIFF
--- a/packages/react-aria-components/src/Separator.tsx
+++ b/packages/react-aria-components/src/Separator.tsx
@@ -23,13 +23,14 @@ export const SeparatorContext = createContext<ContextValue<SeparatorProps, HTMLE
 export const Separator = /*#__PURE__*/ createLeafComponent('separator', function Separator(props: SeparatorProps, ref: ForwardedRef<HTMLElement>) {
   [props, ref] = useContextProps(props, ref, SeparatorContext);
 
-  let {elementType, orientation, style, className} = props;
+  let {elementType, orientation, style, className, slot, ...otherProps} = props;
   let Element = (elementType as ElementType) || 'hr';
   if (Element === 'hr' && orientation === 'vertical') {
     Element = 'div';
   }
 
   let {separatorProps} = useSeparator({
+    ...otherProps,
     elementType,
     orientation
   });
@@ -41,6 +42,6 @@ export const Separator = /*#__PURE__*/ createLeafComponent('separator', function
       style={style}
       className={className ?? 'react-aria-Separator'}
       ref={ref}
-      slot={props.slot || undefined} />
+      slot={slot || undefined} />
   );
 });

--- a/packages/react-aria-components/test/Separator.test.js
+++ b/packages/react-aria-components/test/Separator.test.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {render} from '@react-spectrum/test-utils-internal';
+import {Separator, SeparatorContext} from '../';
+
+
+describe('Separator', () => {
+  it('should render a separator with default class', () => {
+    let {getByRole} = render(<Separator />);
+    let separator = getByRole('separator');
+    expect(separator.tagName).toBe('HR');
+    expect(separator).toHaveAttribute('class', 'react-aria-Separator');
+  });
+
+  it('should render a separator with custom class', () => {
+    let {getByRole} = render(<Separator className="test"/>);
+    let separator = getByRole('separator');
+    expect(separator).toHaveAttribute('class', 'test');
+  });
+
+  it('should support DOM props', () => {
+    let {getByRole} = render(<Separator data-foo="bar" />);
+    let separator = getByRole('separator');
+    expect(separator).toHaveAttribute('data-foo', 'bar');
+  });
+
+  it('should support slot', () => {
+    let {getByRole} = render(
+      <SeparatorContext.Provider value={{slots: {test: {'aria-label': 'test'}}}}>
+        <Separator slot="test" />
+      </SeparatorContext.Provider>
+    );
+
+    let separator = getByRole('separator');
+    expect(separator).toHaveAttribute('slot', 'test');
+    expect(separator).toHaveAttribute('aria-label', 'test');
+  });
+
+  it('should support accessibility props', () => {
+    let {getByRole} = render(<Separator aria-label="label" />);
+    let separator = getByRole('separator');
+    expect(separator).toHaveAttribute('aria-label', 'label');
+  });
+});

--- a/packages/react-aria-components/test/Separator.test.js
+++ b/packages/react-aria-components/test/Separator.test.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import React from 'react';
 import {render} from '@react-spectrum/test-utils-internal';
 import {Separator, SeparatorContext} from '../';
 
@@ -23,7 +24,7 @@ describe('Separator', () => {
   });
 
   it('should render a separator with custom class', () => {
-    let {getByRole} = render(<Separator className="test"/>);
+    let {getByRole} = render(<Separator className="test" />);
     let separator = getByRole('separator');
     expect(separator).toHaveAttribute('class', 'test');
   });

--- a/packages/react-aria-components/test/Separator.test.js
+++ b/packages/react-aria-components/test/Separator.test.js
@@ -14,7 +14,6 @@ import React from 'react';
 import {render} from '@react-spectrum/test-utils-internal';
 import {Separator, SeparatorContext} from '../';
 
-
 describe('Separator', () => {
   it('should render a separator with default class', () => {
     let {getByRole} = render(<Separator />);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7860

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
