### PR TITLE
fix: Environment with no FinalizationRegistry

### DIFF
--- a/packages/@react-aria/utils/src/useId.ts
+++ b/packages/@react-aria/utils/src/useId.ts
@@ -27,7 +27,7 @@ export let idsUpdaterMap: Map<string, { current: string | null }[]> = new Map();
 // Map is a strong reference, so unused ids wouldn't be cleaned up otherwise.
 // This can happen in suspended components where mount/unmount is not called.
 let registry;
-if (typeof window !== 'undefined' && window.FinalizationRegistry) {
+if (typeof FinalizationRegistry !== 'undefined') {
   registry = new FinalizationRegistry<string>((heldValue) => {
     idsUpdaterMap.delete(heldValue);
   });

--- a/packages/@react-aria/utils/src/useId.ts
+++ b/packages/@react-aria/utils/src/useId.ts
@@ -26,9 +26,12 @@ export let idsUpdaterMap: Map<string, { current: string | null }[]> = new Map();
 // This allows us to clean up the idsUpdaterMap when the id is no longer used.
 // Map is a strong reference, so unused ids wouldn't be cleaned up otherwise.
 // This can happen in suspended components where mount/unmount is not called.
-let registry = new FinalizationRegistry<string>((heldValue) => {
-  idsUpdaterMap.delete(heldValue);
-});
+let registry;
+if (typeof window !== 'undefined' && window.FinalizationRegistry) {
+  registry = new FinalizationRegistry<string>((heldValue) => {
+    idsUpdaterMap.delete(heldValue);
+  });
+}
 
 /**
  * If a default is not provided, generate an id.
@@ -41,7 +44,9 @@ export function useId(defaultId?: string): string {
   let res = useSSRSafeId(value);
   let cleanupRef = useRef(null);
 
-  registry.register(cleanupRef, res);
+  if (registry) {
+    registry.register(cleanupRef, res);
+  }
 
   if (canUseDOM) {
     const cacheIdRef = idsUpdaterMap.get(res);
@@ -57,7 +62,9 @@ export function useId(defaultId?: string): string {
     return () => {
       // In Suspense, the cleanup function may be not called
       // when it is though, also remove it from the finalization registry.
-      registry.unregister(cleanupRef);
+      if (registry) {
+        registry.unregister(cleanupRef);
+      }
       idsUpdaterMap.delete(r);
     };
   }, [res]);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7882

We thought we could safely use this as every environment supports it
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
https://caniuse.com/?search=FinalizationRegistry

But it's not supported in CloudFlare workers. In that case though, every request should result in the complete throwing away of any previous request making the memory leak a non-issue.

If any other environments come along without this feature, they'll also have the problem, but given how long it took for it to be reported, maybe it's not that big of a deal.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
