### PR TITLE
fix: Prevent submenus from closing on scroll

### DIFF
--- a/packages/@react-aria/overlays/src/usePopover.ts
+++ b/packages/@react-aria/overlays/src/usePopover.ts
@@ -106,7 +106,7 @@ export function usePopover(props: AriaPopoverProps, state: OverlayTriggerState):
     targetRef: triggerRef,
     overlayRef: popoverRef,
     isOpen: state.isOpen,
-    onClose: isNonModal ? state.close : null
+    onClose: isNonModal && !isSubmenu ? state.close : null
   });
 
   usePreventScroll({

--- a/packages/react-aria-components/docs/SearchField.mdx
+++ b/packages/react-aria-components/docs/SearchField.mdx
@@ -78,6 +78,7 @@ import {SearchField, Label, Input, Button} from 'react-aria-components';
 
   .react-aria-Input {
     grid-area: input;
+    width: 100%;
     padding: 0.286rem 1.714rem 0.286rem 0.286rem;
     margin: 0;
     border: 1px solid var(--border-color);


### PR DESCRIPTION
Fixes the "Complex content" submenu example in the docs on iPad. This was closing due to a scroll event when the virtual keyboard appeared. Close on scroll is enabled for `isNonModal` popovers, but we should exclude submenus from this. Another reason to eventually split up `isNonModal` into multiple props.

Also fixed the search field overflowing the popover on iPad in that example.