### PR TITLE
fix: mobile restore focus after a Select closes

### DIFF
--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -123,6 +123,9 @@ export function useMenuTrigger<T>(props: AriaMenuTriggerProps, state: MenuTrigge
     },
     onPress(e) {
       if (e.pointerType === 'touch' && !isDisabled) {
+        // Ensure trigger has focus before opening the menu so it can be restored by FocusScope on close.
+        focusWithoutScrolling(e.target as FocusableElement);
+
         state.toggle();
       }
     }

--- a/packages/@react-spectrum/table/test/TableSizing.test.tsx
+++ b/packages/@react-spectrum/table/test/TableSizing.test.tsx
@@ -984,7 +984,8 @@ describe('TableViewSizing', function () {
         let resizeMenuItem = tree.getAllByRole('menuitem')[0];
 
         triggerTouch(resizeMenuItem);
-        act(() => {jest.runAllTimers();});
+        act(() => {jest.advanceTimersToNextTimer();});
+        act(() => {jest.advanceTimersToNextTimer();});
 
         let resizer = tree.getByRole('slider');
         expect(resizer).toBeVisible();


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Addresses an issue found while looking at https://github.com/adobe/react-spectrum/issues/7902

Ensure the Select has focus before opening the select menu so it can be restored by FocusScope on close. Note that this is the same behavior that keyboard and mouse have, for the same reason.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

To reproduce, using a touch device:
Go to https://react-spectrum.adobe.com/react-aria/index.html and open the "modal" top right of the example. Put focus in one of the textfields, then open one of the Selects. After closing the Select, focus will be restored to the textfield, not the select's trigger, as expected.

Then do the same thing but on the docs built by this PR.

## 🧢 Your Project:

<!--- Company/project for pull request -->
