### PR TITLE
fix: Improve collection update performance

### DIFF
--- a/packages/react-aria-components/stories/ComboBox.stories.tsx
+++ b/packages/react-aria-components/stories/ComboBox.stories.tsx
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, ComboBox, Input, Label, ListBox, Popover} from 'react-aria-components';
+import {Button, ComboBox, Input, Label, ListBox, ListLayout, Popover, useFilter, Virtualizer} from 'react-aria-components';
 import {MyListBoxItem} from './utils';
-import React from 'react';
+import React, {useMemo, useState} from 'react';
 import styles from '../example/index.css';
 import {useAsyncList} from 'react-stately';
 
@@ -207,3 +207,32 @@ export const ComboBoxImeExample = () => (
     </Popover>
   </ComboBox>
 );
+
+let manyItems = [...Array(10000)].map((_, i) => ({id: i, name: `Item ${i}`}));
+
+export const VirtualizedComboBox = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const {contains} = useFilter({sensitivity: 'base'});
+  const filteredItems = useMemo(() => {
+    return manyItems.filter((item) => contains(item.name, searchTerm));
+  }, [searchTerm, contains]);
+
+  return (
+    <ComboBox items={filteredItems} inputValue={searchTerm} onInputChange={setSearchTerm}>
+      <Label style={{display: 'block'}}>Test</Label>
+      <div style={{display: 'flex'}}>
+        <Input />
+        <Button>
+          <span aria-hidden="true" style={{padding: '0 2px'}}>▼</span>
+        </Button>
+      </div>
+      <Popover>
+        <Virtualizer layout={ListLayout} layoutOptions={{rowHeight: 25}}>
+          <ListBox className={styles.menu}>
+            {(item: any) => <MyListBoxItem>{item.name}</MyListBoxItem>}
+          </ListBox>
+        </Virtualizer>
+      </Popover>
+    </ComboBox>
+  );
+};


### PR DESCRIPTION
Closes #7814 

When typing in a controlled `items` ComboBox with many items, updates were very slow. This was caused by collection updates. When adding/removing elements in our fake DOM, we trigger the document's `queueUpdate`. This triggers the subscription callbacks of `useSyncExternalStore`. So, for a collection with 10,000 items, this would result in 10,000 re-renders of the whole ComboBox.

The solution is to batch the updates so we only re-render once. We set a flag the first time `queueUpdate` is called, and ignore subsequent calls while it is set. React will queue a render after it's done with the current commit phase. This will trigger `getCollection` again during render (as opposed to in a subscription), and we reset the flag back to false.

Another optimization is to only update the `index` of each node once instead of looping through all the children every time an element is added/removed. Instead, track the minimum invalid child of each element, and update the subsequent children at the end.