### PR TITLE
fix: Allow to configure the Toast portail container root

### DIFF
--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -45,6 +45,7 @@
     "@react-aria/focus": "^3.20.1",
     "@react-aria/interactions": "^3.24.1",
     "@react-aria/live-announcer": "^3.4.1",
+    "@react-aria/ssr": "^3.9.7",
     "@react-aria/toolbar": "3.0.0-beta.14",
     "@react-aria/utils": "^3.28.1",
     "@react-aria/virtualizer": "^4.1.3",

--- a/packages/react-aria-components/test/Toast.test.js
+++ b/packages/react-aria-components/test/Toast.test.js
@@ -322,4 +322,43 @@ describe('Toast', () => {
     let region = getByRole('region');
     expect(region).toHaveAttribute('aria-label', 'Toasts');
   });
+
+  it('should render the toast region in the portal container', async () => {
+    let queue = new ToastQueue();
+
+    function LocalToast(props) {
+      return (
+        <>
+          <ToastRegion queue={queue} portalContainer={props.container}>
+            {({toast}) => (
+              <Toast toast={toast}>
+                <ToastContent>
+                  <Text slot="title">{toast.content}</Text>
+                </ToastContent>
+                <Button slot="close">x</Button>
+              </Toast>
+            )}
+          </ToastRegion> 
+
+          <Button onPress={() => queue.add('Toast')}>Add toast</Button>
+        </>
+      );
+    }
+    function App() {
+      let [container, setContainer] = React.useState();
+      return (
+        <>
+          <LocalToast container={container} />
+          <div ref={setContainer} data-testid="custom-container" />
+        </>
+      );
+    }
+
+    let {getByRole, getByTestId} = render(<App />);
+
+    let button = getByRole('button');
+    await user.click(button);
+
+    expect(within(getByTestId('custom-container')).getByRole('alertdialog')).toBeInTheDocument();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -28997,6 +28997,7 @@ __metadata:
     "@react-aria/focus": "npm:^3.20.1"
     "@react-aria/interactions": "npm:^3.24.1"
     "@react-aria/live-announcer": "npm:^3.4.1"
+    "@react-aria/ssr": "npm:^3.9.7"
     "@react-aria/toolbar": "npm:3.0.0-beta.14"
     "@react-aria/utils": "npm:^3.28.1"
     "@react-aria/virtualizer": "npm:^4.1.3"


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7879

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Add a `portalContainer` to a `ToastReagion` and check if the toasts are renderer in it.
