### PR TITLE
fix: pass `loadingState` to `useAsyncList`'s `load` function

### DIFF
--- a/packages/@react-stately/data/src/useAsyncList.ts
+++ b/packages/@react-stately/data/src/useAsyncList.ts
@@ -297,7 +297,8 @@ export function useAsyncList<T, C = string>(options: AsyncListOptions<T, C>): As
         sortDescriptor: action.sortDescriptor ?? data.sortDescriptor,
         signal: abortController.signal,
         cursor: action.type === 'loadingMore' ? data.cursor : undefined,
-        filterText: previousFilterText
+        filterText: previousFilterText,
+        loadingState: data.state
       });
 
       let filterText = response.filterText ?? previousFilterText;

--- a/packages/@react-stately/data/test/useAsyncList.test.js
+++ b/packages/@react-stately/data/test/useAsyncList.test.js
@@ -45,6 +45,15 @@ describe('useAsyncList', () => {
     let {result} = renderHook(() => useAsyncList({load}));
 
     expect(load).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledWith({
+      cursor: undefined,
+      filterText: '',
+      items: [],
+      loadingState: 'idle',
+      selectedKeys: new Set(),
+      signal: expect.any(AbortSignal),
+      sortDescriptor: undefined
+    });
     let args = load.mock.calls[0][0];
     expect(args.items).toEqual([]);
     expect(args.selectedKeys).toEqual(new Set());


### PR DESCRIPTION
The `loadingState` was typed but never passed