### PR TITLE
fix: French number parsing ambiguity

### DIFF
--- a/packages/@internationalized/number/src/NumberParser.ts
+++ b/packages/@internationalized/number/src/NumberParser.ts
@@ -203,9 +203,9 @@ class NumberParserImpl {
 
     // fr-FR group character is narrow non-breaking space, char code 8239 (U+202F), but that's not a key on the french keyboard,
     // so allow space and non-breaking space as a group char as well
-    if (this.options.locale === 'fr-FR') {
-      value = replaceAll(value, ' ', String.fromCharCode(8239));
-      value = replaceAll(value, /\u00A0/g, String.fromCharCode(8239));
+    if (this.options.locale === 'fr-FR' && this.symbols.group) {
+      value = replaceAll(value, ' ', this.symbols.group);
+      value = replaceAll(value, /\u00A0/g, this.symbols.group);
     }
 
     return value;

--- a/packages/@internationalized/number/src/NumberParser.ts
+++ b/packages/@internationalized/number/src/NumberParser.ts
@@ -201,10 +201,11 @@ class NumberParserImpl {
       }
     }
 
-    // fr-FR group character is char code 8239, but that's not a key on the french keyboard,
-    // so allow 'period' as a group char and replace it with a space
+    // fr-FR group character is narrow non-breaking space, char code 8239 (U+202F), but that's not a key on the french keyboard,
+    // so allow space and non-breaking space as a group char as well
     if (this.options.locale === 'fr-FR') {
-      value = replaceAll(value, '.', String.fromCharCode(8239));
+      value = replaceAll(value, ' ', String.fromCharCode(8239));
+      value = replaceAll(value, /\u00A0/g, String.fromCharCode(8239));
     }
 
     return value;
@@ -303,7 +304,7 @@ function getSymbols(locale: string, formatter: Intl.NumberFormat, intlOptions: I
   return {minusSign, plusSign, decimal, group, literals, numeral, index};
 }
 
-function replaceAll(str: string, find: string, replace: string) {
+function replaceAll(str: string, find: string | RegExp, replace: string) {
   if (str.replaceAll) {
     return str.replaceAll(find, replace);
   }

--- a/scripts/checkGroupSeparators.mjs
+++ b/scripts/checkGroupSeparators.mjs
@@ -1,0 +1,74 @@
+// This script is to run over all of our supported locales and numbering systems
+// and check for the decimal and group separators so we can find
+// non-standard keyboard characters such as the French group separator, narrow non-breaking whitespace.
+// This way we can special case to be more permissive in NumberParser.
+
+
+const NUMBERING_SYSTEMS = ['latn', 'arab', 'hanidec', 'deva', 'beng'];
+let locales = [
+  {label: 'French (France)', value: 'fr-FR'},
+  {label: 'French (Canada)', value: 'fr-CA'},
+  {label: 'German (Germany)', value: 'de-DE'},
+  {label: 'English (Great Britain)', value: 'en-GB'},
+  {label: 'English (United States)', value: 'en-US'},
+  {label: 'Japanese (Japan)', value: 'ja-JP'},
+  {label: 'Danish (Denmark)', value: 'da-DK'},
+  {label: 'Dutch (Netherlands)', value: 'nl-NL'},
+  {label: 'Finnish (Finland)', value: 'fi-FI'},
+  {label: 'Italian (Italy)', value: 'it-IT'},
+  {label: 'Norwegian (Norway)', value: 'nb-NO'},
+  {label: 'Spanish (Spain)', value: 'es-ES'},
+  {label: 'Swedish (Sweden)', value: 'sv-SE'},
+  {label: 'Portuguese (Brazil)', value: 'pt-BR'},
+  {label: 'Chinese (Simplified)', value: 'zh-CN'},
+  {label: 'Chinese (Traditional)', value: 'zh-TW'},
+  {label: 'Korean (Korea)', value: 'ko-KR'},
+  {label: 'Bulgarian (Bulgaria)', value: 'bg-BG'},
+  {label: 'Croatian (Croatia)', value: 'hr-HR'},
+  {label: 'Czech (Czech Republic)', value: 'cs-CZ'},
+  {label: 'Estonian (Estonia)', value: 'et-EE'},
+  {label: 'Hungarian (Hungary)', value: 'hu-HU'},
+  {label: 'Latvian (Latvia)', value: 'lv-LV'},
+  {label: 'Lithuanian (Lithuania)', value: 'lt-LT'},
+  {label: 'Polish (Poland)', value: 'pl-PL'},
+  {label: 'Romanian (Romania)', value: 'ro-RO'},
+  {label: 'Russian (Russia)', value: 'ru-RU'},
+  {label: 'Serbian (Serbia)', value: 'sr-SP'},
+  {label: 'Slovakian (Slovakia)', value: 'sk-SK'},
+  {label: 'Slovenian (Slovenia)', value: 'sl-SI'},
+  {label: 'Turkish (Turkey)', value: 'tr-TR'},
+  {label: 'Ukrainian (Ukraine)', value: 'uk-UA'},
+  {label: 'Arabic (United Arab Emirates)', value: 'ar-AE'}, // ar-SA??
+  {label: 'Greek (Greece)', value: 'el-GR'},
+  {label: 'Hebrew (Israel)', value: 'he-IL'}
+];
+
+let separators = new Map();
+for (let nums of NUMBERING_SYSTEMS) {
+  for (let locale of locales) {
+    let formatter = new Intl.NumberFormat(locale.value + '-u-nu-' + nums, {});
+    let parts = formatter.formatToParts(10000000000);
+    let separator = parts.find(p => p.type === 'group')?.value;
+    if (separators.has(separator)) {
+      separators.set(separator, [...separators.get(separator), locale.value + '-u-nu-' + nums])
+    } else {
+      separators.set(separator, [separator.charCodeAt(0), locale.value + '-u-nu-' + nums]);
+    }
+  }
+}
+console.log(separators);
+
+let decimals = new Map();
+for (let nums of NUMBERING_SYSTEMS) {
+  for (let locale of locales) {
+    let formatter = new Intl.NumberFormat(locale.value + '-u-nu-' + nums, {minimumFractionDigits: 2});
+    let parts = formatter.formatToParts(10000.0000001);
+    let decimal = parts.find(p => p.type === 'decimal')?.value;
+    if (decimals.has(decimal)) {
+      decimals.set(decimal, [...decimals.get(decimal), locale.value + '-u-nu-' + nums])
+    } else {
+      decimals.set(decimal, [decimal.charCodeAt(0), locale.value + '-u-nu-' + nums]);
+    }
+  }
+}
+console.log(decimals);


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/7866

Discussed with Adobe's globalization team and french CLDR contributor. The consensus was that periods are ambiguous. France started to have recommendations against using periods as group separators [in 1948](https://www.bipm.org/fr/committees/cg/cgpm/9-1948/resolution-7), however, it was still taught in schools for a long time. As a result, depending on age or where someone went to school, they may expect it to be the decimal or they may expect it to be the group separator. To get rid of the ambiguity, it was recommended that we remove period as an allowed character and expand the group separator characters to allow all kinds of spaces so that they can easily be typed out on a standard keyboard.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
