### PR TITLE
chore: Reduce production bundle sizes

### DIFF
--- a/packages/@react-aria/interactions/src/PressResponder.tsx
+++ b/packages/@react-aria/interactions/src/PressResponder.tsx
@@ -39,10 +39,12 @@ export const PressResponder = React.forwardRef(({children, ...props}: PressRespo
 
   useEffect(() => {
     if (!isRegistered.current) {
-      console.warn(
-        'A PressResponder was rendered without a pressable child. ' +
-        'Either call the usePress hook, or wrap your DOM node with <Pressable> component.'
-      );
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'A PressResponder was rendered without a pressable child. ' +
+          'Either call the usePress hook, or wrap your DOM node with <Pressable> component.'
+        );
+      }
       isRegistered.current = true; // only warn once in strict mode.
     }
   }, []);

--- a/packages/@react-aria/interactions/src/Pressable.tsx
+++ b/packages/@react-aria/interactions/src/Pressable.tsx
@@ -27,6 +27,10 @@ export const Pressable = React.forwardRef(({children, ...props}: PressableProps,
   let child = React.Children.only(children);
 
   useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+    
     let el = ref.current;
     if (!el || !(el instanceof getOwnerWindow(el).Element)) {
       console.error('<Pressable> child must forward its ref to a DOM element.');

--- a/packages/@react-aria/interactions/src/createEventHandler.ts
+++ b/packages/@react-aria/interactions/src/createEventHandler.ts
@@ -32,7 +32,7 @@ export function createEventHandler<T extends SyntheticEvent>(handler?: (e: BaseE
         return e.isDefaultPrevented();
       },
       stopPropagation() {
-        if (shouldStopPropagation) {
+        if (shouldStopPropagation && process.env.NODE_ENV !== 'production') {
           console.error('stopPropagation is now the default behavior for events in React Spectrum. You can use continuePropagation() to revert this behavior.');
         } else {
           shouldStopPropagation = true;

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -153,7 +153,7 @@ function setupGlobalFocusEvents(element?: HTMLElement | null) {
     documentObject.addEventListener('pointerdown', handlePointerEvent, true);
     documentObject.addEventListener('pointermove', handlePointerEvent, true);
     documentObject.addEventListener('pointerup', handlePointerEvent, true);
-  } else {
+  } else if (process.env.NODE_ENV === 'test') {
     documentObject.addEventListener('mousedown', handlePointerEvent, true);
     documentObject.addEventListener('mousemove', handlePointerEvent, true);
     documentObject.addEventListener('mouseup', handlePointerEvent, true);
@@ -189,7 +189,7 @@ const tearDownWindowFocusTracking = (element, loadListener?: () => void) => {
     documentObject.removeEventListener('pointerdown', handlePointerEvent, true);
     documentObject.removeEventListener('pointermove', handlePointerEvent, true);
     documentObject.removeEventListener('pointerup', handlePointerEvent, true);
-  } else {
+  } else if (process.env.NODE_ENV === 'test') {
     documentObject.removeEventListener('mousedown', handlePointerEvent, true);
     documentObject.removeEventListener('mousemove', handlePointerEvent, true);
     documentObject.removeEventListener('mouseup', handlePointerEvent, true);

--- a/packages/@react-aria/interactions/src/useFocusable.tsx
+++ b/packages/@react-aria/interactions/src/useFocusable.tsx
@@ -112,6 +112,10 @@ export const Focusable = forwardRef(({children, ...props}: FocusableComponentPro
   let child = React.Children.only(children);
 
   useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+
     let el = ref.current;
     if (!el || !(el instanceof getOwnerWindow(el).Element)) {
       console.error('<Focusable> child must forward its ref to a DOM element.');

--- a/packages/@react-aria/interactions/src/useHover.ts
+++ b/packages/@react-aria/interactions/src/useHover.ts
@@ -61,7 +61,7 @@ function setupGlobalTouchEvents() {
 
   if (typeof PointerEvent !== 'undefined') {
     document.addEventListener('pointerup', handleGlobalPointerEvent);
-  } else {
+  } else if (process.env.NODE_ENV === 'test') {
     document.addEventListener('touchend', setGlobalIgnoreEmulatedMouseEvents);
   }
 
@@ -74,7 +74,7 @@ function setupGlobalTouchEvents() {
 
     if (typeof PointerEvent !== 'undefined') {
       document.removeEventListener('pointerup', handleGlobalPointerEvent);
-    } else {
+    } else if (process.env.NODE_ENV === 'test') {
       document.removeEventListener('touchend', setGlobalIgnoreEmulatedMouseEvents);
     }
   };
@@ -182,7 +182,7 @@ export function useHover(props: HoverProps): HoverResult {
           triggerHoverEnd(e, e.pointerType);
         }
       };
-    } else {
+    } else if (process.env.NODE_ENV === 'test') {
       hoverProps.onTouchStart = () => {
         state.ignoreEmulatedMouseEvents = true;
       };

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -79,7 +79,7 @@ export function useInteractOutside(props: InteractOutsideProps): void {
         documentObject.removeEventListener('pointerdown', onPointerDown, true);
         documentObject.removeEventListener('pointerup', onPointerUp, true);
       };
-    } else {
+    } else if (process.env.NODE_ENV === 'test') {
       let onMouseUp = (e) => {
         if (state.ignoreEmulatedMouseEvents) {
           state.ignoreEmulatedMouseEvents = false;

--- a/packages/@react-aria/interactions/src/useMove.ts
+++ b/packages/@react-aria/interactions/src/useMove.ts
@@ -151,7 +151,7 @@ export function useMove(props: MoveEvents): MoveResult {
         addGlobalListener(window, 'touchend', onTouchEnd, false);
         addGlobalListener(window, 'touchcancel', onTouchEnd, false);
       };
-    } else {
+    } else if (process.env.NODE_ENV === 'test') {
       let onPointerMove = (e: PointerEvent) => {
         if (e.pointerId === state.current.id) {
           let pointerType = (e.pointerType || 'mouse') as PointerType;

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -552,8 +552,8 @@ export function usePress(props: PressHookProps): PressResult {
         // Safari does not call onPointerCancel when a drag starts, whereas Chrome and Firefox do.
         cancel(e);
       };
-    } else {
-      // NOTE: this fallback branch is almost entirely used by unit tests.
+    } else if (process.env.NODE_ENV === 'test') {
+      // NOTE: this fallback branch is entirely used by unit tests.
       // All browsers now support pointer events, but JSDOM still does not.
 
       pressProps.onMouseDown = (e) => {

--- a/packages/@react-aria/label/src/useLabel.ts
+++ b/packages/@react-aria/label/src/useLabel.ts
@@ -52,7 +52,7 @@ export function useLabel(props: LabelAriaProps): LabelAria {
       id: labelId,
       htmlFor: labelElementType === 'label' ? id : undefined
     };
-  } else if (!ariaLabelledby && !ariaLabel) {
+  } else if (!ariaLabelledby && !ariaLabel && process.env.NODE_ENV !== 'production') {
     console.warn('If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility');
   }
 

--- a/packages/@react-aria/landmark/src/useLandmark.ts
+++ b/packages/@react-aria/landmark/src/useLandmark.ts
@@ -164,7 +164,7 @@ class LandmarkManager implements LandmarkManagerApi {
       return;
     }
 
-    if (this.landmarks.filter(landmark => landmark.role === 'main').length > 1) {
+    if (this.landmarks.filter(landmark => landmark.role === 'main').length > 1 && process.env.NODE_ENV !== 'production') {
       console.error('Page can contain no more than one landmark with the role "main".');
     }
 
@@ -218,12 +218,12 @@ class LandmarkManager implements LandmarkManagerApi {
     let landmarksWithRole = this.getLandmarksByRole(role);
     if (landmarksWithRole.size > 1) {
       let duplicatesWithoutLabel = [...landmarksWithRole].filter(landmark => !landmark.label);
-      if (duplicatesWithoutLabel.length > 0) {
+      if (duplicatesWithoutLabel.length > 0 && process.env.NODE_ENV !== 'production') {
         console.warn(
           `Page contains more than one landmark with the '${role}' role. If two or more landmarks on a page share the same role, all must be labeled with an aria-label or aria-labelledby attribute: `,
           duplicatesWithoutLabel.map(landmark => landmark.ref.current)
         );
-      } else {
+      } else if (process.env.NODE_ENV !== 'production') {
         let labels = [...landmarksWithRole].map(landmark => landmark.label);
         let duplicateLabels = labels.filter((item, index) => labels.indexOf(item) !== index);
 

--- a/packages/@react-aria/menu/src/useMenu.ts
+++ b/packages/@react-aria/menu/src/useMenu.ts
@@ -50,7 +50,7 @@ export function useMenu<T>(props: AriaMenuOptions<T>, state: TreeState<T>, ref: 
     ...otherProps
   } = props;
 
-  if (!props['aria-label'] && !props['aria-labelledby']) {
+  if (!props['aria-label'] && !props['aria-labelledby'] && process.env.NODE_ENV !== 'production') {
     console.warn('An aria-label or aria-labelledby prop is required for accessibility.');
   }
 

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -51,7 +51,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
 
   let hasChildren = children != null;
   let hasAriaLabel = ariaLabel != null || ariaLabelledby != null;
-  if (!hasChildren && !hasAriaLabel) {
+  if (!hasChildren && !hasAriaLabel && process.env.NODE_ENV !== 'production') {
     console.warn('If you do not provide children, you must specify an aria-label for accessibility');
   }
 

--- a/packages/@react-aria/ssr/src/SSRProvider.tsx
+++ b/packages/@react-aria/ssr/src/SSRProvider.tsx
@@ -84,7 +84,7 @@ let warnedAboutSSRProvider = false;
  */
 export function SSRProvider(props: SSRProviderProps): JSX.Element {
   if (typeof React['useId'] === 'function') {
-    if (process.env.NODE_ENV !== 'test' && !warnedAboutSSRProvider) {
+    if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'production' && !warnedAboutSSRProvider) {
       console.warn('In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.');
       warnedAboutSSRProvider = true;
     }
@@ -147,7 +147,7 @@ function useLegacySSRSafeId(defaultId?: string): string {
 
   // If we are rendering in a non-DOM environment, and there's no SSRProvider,
   // provide a warning to hint to the developer to add one.
-  if (ctx === defaultContext && !canUseDOM) {
+  if (ctx === defaultContext && !canUseDOM && process.env.NODE_ENV !== 'production') {
     console.warn('When server rendering, you must wrap your application in an <SSRProvider> to ensure consistent ids are generated between the client and server.');
   }
 

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -59,7 +59,7 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
 
   let hasChildren = children != null;
   let hasAriaLabel = ariaLabel != null || ariaLabelledby != null;
-  if (!hasChildren && !hasAriaLabel) {
+  if (!hasChildren && !hasAriaLabel && process.env.NODE_ENV !== 'production') {
     console.warn('If you do not provide children, you must specify an aria-label for accessibility');
   }
 

--- a/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/SearchAutocomplete.tsx
@@ -50,7 +50,7 @@ function SearchAutocomplete<T extends object>(props: SpectrumSearchAutocompleteP
   props = useProviderProps(props);
   props = useFormProps(props);
 
-  if (props.placeholder) {
+  if (props.placeholder && process.env.NODE_ENV !== 'production') {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead.');
   }
 

--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -74,7 +74,7 @@ export const Checkbox = forwardRef(function Checkbox(props: SpectrumCheckboxProp
     ? <DashSmall UNSAFE_className={classNames(styles, 'spectrum-Checkbox-partialCheckmark')} />
     : <CheckmarkSmall UNSAFE_className={classNames(styles, 'spectrum-Checkbox-checkmark')} />;
 
-  if (groupState) {
+  if (groupState && process.env.NODE_ENV !== 'production') {
     for (let key of ['isSelected', 'defaultSelected', 'isEmphasized']) {
       if (originalProps[key] != null) {
         console.warn(`${key} is unsupported on individual <Checkbox> elements within a <CheckboxGroup>. Please apply these props to the group instead.`);

--- a/packages/@react-spectrum/color/src/ColorField.tsx
+++ b/packages/@react-spectrum/color/src/ColorField.tsx
@@ -30,7 +30,7 @@ export const ColorField = React.forwardRef(function ColorField(props: SpectrumCo
   props = useProviderProps(props);
   props = useFormProps(props);
   [props] = useContextProps(props, null, ColorFieldContext);
-  if (props.placeholder) {
+  if (props.placeholder && process.env.NODE_ENV !== 'production') {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead. See the docs for details: https://react-spectrum.adobe.com/react-spectrum/ColorField.html#help-text');
   }
 

--- a/packages/@react-spectrum/combobox/src/ComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/ComboBox.tsx
@@ -60,7 +60,7 @@ export const ComboBox = React.forwardRef(function ComboBox<T extends object>(pro
   props = useProviderProps(props);
   props = useFormProps(props);
 
-  if (props.placeholder) {
+  if (props.placeholder && process.env.NODE_ENV !== 'production') {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead. See the docs for details: https://react-spectrum.adobe.com/react-spectrum/ComboBox.html#help-text');
   }
 

--- a/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
+++ b/packages/@react-spectrum/dialog/src/DialogTrigger.tsx
@@ -60,7 +60,7 @@ function DialogTrigger(props: SpectrumDialogTriggerProps) {
    
   useEffect(() => {
     return () => {
-      if ((wasOpen.current || isExiting.current) && type !== 'popover' && type !== 'tray') {
+      if ((wasOpen.current || isExiting.current) && type !== 'popover' && type !== 'tray' && process.env.NODE_ENV !== 'production') {
         console.warn('A DialogTrigger unmounted while open. This is likely due to being placed within a trigger that unmounts or inside a conditional. Consider using a DialogContainer instead.');
       }
     };

--- a/packages/@react-spectrum/image/src/Image.tsx
+++ b/packages/@react-spectrum/image/src/Image.tsx
@@ -37,7 +37,7 @@ function Image(props: SpectrumImageProps, ref: DOMRef<HTMLDivElement>) {
   let {styleProps} = useStyleProps(otherProps);
   let domRef = useDOMRef(ref);
 
-  if (alt == null) {
+  if (alt == null && process.env.NODE_ENV !== 'production') {
     console.warn(
       'The `alt` prop was not provided to an image. ' +
       'Add `alt` text for screen readers, or set `alt=""` prop to indicate that the image ' +

--- a/packages/@react-spectrum/list/src/ListView.tsx
+++ b/packages/@react-spectrum/list/src/ListView.tsx
@@ -124,10 +124,10 @@ export const ListView = React.forwardRef(function ListView<T extends object>(pro
   let dragHooksProvided = useRef(isListDraggable);
   let dropHooksProvided = useRef(isListDroppable);
   useEffect(() => {
-    if (dragHooksProvided.current !== isListDraggable) {
+    if (dragHooksProvided.current !== isListDraggable && process.env.NODE_ENV !== 'production') {
       console.warn('Drag hooks were provided during one render, but not another. This should be avoided as it may produce unexpected behavior.');
     }
-    if (dropHooksProvided.current !== isListDroppable) {
+    if (dropHooksProvided.current !== isListDroppable && process.env.NODE_ENV !== 'production') {
       console.warn('Drop hooks were provided during one render, but not another. This should be avoided as it may produce unexpected behavior.');
     }
   }, [isListDraggable, isListDroppable]);

--- a/packages/@react-spectrum/progress/src/ProgressBarBase.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressBarBase.tsx
@@ -54,7 +54,7 @@ export const ProgressBarBase = React.forwardRef(function ProgressBarBase(props: 
 
   // Ideally this should be in useProgressBar, but children
   // are not supported in ProgressCircle which shares that hook...
-  if (!label && !ariaLabel && !ariaLabelledby) {
+  if (!label && !ariaLabel && !ariaLabelledby && process.env.NODE_ENV !== 'production') {
     console.warn('If you do not provide a visible label via children, you must specify an aria-label or aria-labelledby attribute for accessibility');
   }
   // use inline style for fit-content because cssnano is too smart for us and will strip out the -moz prefix in css files

--- a/packages/@react-spectrum/progress/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressCircle.tsx
@@ -58,7 +58,7 @@ export const ProgressCircle = React.forwardRef(function ProgressCircle(props: Sp
     }
   }
 
-  if (!ariaLabel && !ariaLabelledby) {
+  if (!ariaLabel && !ariaLabelledby && process.env.NODE_ENV !== 'production') {
     console.warn('ProgressCircle requires an aria-label or aria-labelledby attribute for accessibility');
   }
 

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -165,7 +165,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: Provide
     if (direction && domRef.current) {
       let closestDir = domRef.current?.parentElement?.closest('[dir]');
       let dir = closestDir && closestDir.getAttribute('dir');
-      if (dir && dir !== direction && !hasWarned.current) {
+      if (dir && dir !== direction && !hasWarned.current && process.env.NODE_ENV !== 'production') {
         console.warn(`Language directions cannot be nested. ${direction} inside ${dir}.`);
         hasWarned.current = true;
       }

--- a/packages/@react-spectrum/s2/src/Image.tsx
+++ b/packages/@react-spectrum/s2/src/Image.tsx
@@ -207,7 +207,7 @@ export const Image = forwardRef(function Image(props: ImageProps, domRef: Forwar
     animation(domRef.current);
   });
 
-  if (props.alt == null) {
+  if (props.alt == null && process.env.NODE_ENV !== 'production') {
     console.warn(
       'The `alt` prop was not provided to an image. ' +
       'Add `alt` text for screen readers, or set `alt=""` prop to indicate that the image ' +

--- a/packages/@react-spectrum/s2/src/StatusLight.tsx
+++ b/packages/@react-spectrum/s2/src/StatusLight.tsx
@@ -112,11 +112,11 @@ export const StatusLight = /*#__PURE__*/ forwardRef(function StatusLight(props: 
   let domRef = useDOMRef(ref);
   let isSkeleton = useIsSkeleton();
 
-  if (!children && !props['aria-label']) {
+  if (!children && !props['aria-label'] && process.env.NODE_ENV !== 'production') {
     console.warn('If no children are provided, an aria-label must be specified');
   }
 
-  if (!role && (props['aria-label'] || props['aria-labelledby'])) {
+  if (!role && (props['aria-label'] || props['aria-labelledby']) && process.env.NODE_ENV !== 'production') {
     console.warn('A labelled StatusLight must have a role.');
   }
 

--- a/packages/@react-spectrum/searchfield/src/SearchField.tsx
+++ b/packages/@react-spectrum/searchfield/src/SearchField.tsx
@@ -42,7 +42,7 @@ export const SearchField = forwardRef(function SearchField(props: SpectrumSearch
     ...otherProps
   } = props;
 
-  if (placeholder) {
+  if (placeholder && process.env.NODE_ENV !== 'production') {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead. See the docs for details: https://react-spectrum.adobe.com/react-spectrum/SearchField.html#help-text');
   }
 

--- a/packages/@react-spectrum/statuslight/src/StatusLight.tsx
+++ b/packages/@react-spectrum/statuslight/src/StatusLight.tsx
@@ -33,11 +33,11 @@ export const StatusLight = forwardRef(function StatusLight(props: SpectrumStatus
   let domRef = useDOMRef(ref);
   let {styleProps} = useStyleProps(otherProps);
 
-  if (!children && !props['aria-label']) {
+  if (!children && !props['aria-label'] && process.env.NODE_ENV !== 'production') {
     console.warn('If no children are provided, an aria-label must be specified');
   }
 
-  if (!role && (props['aria-label'] || props['aria-labelledby'])) {
+  if (!role && (props['aria-label'] || props['aria-labelledby']) && process.env.NODE_ENV !== 'production') {
     console.warn('A labelled StatusLight must have a role.');
   }
 

--- a/packages/@react-spectrum/table/src/TableViewBase.tsx
+++ b/packages/@react-spectrum/table/src/TableViewBase.tsx
@@ -161,6 +161,9 @@ function TableViewBase<T extends object>(props: TableBaseProps<T>, ref: DOMRef<H
   let dragHooksProvided = useRef(isTableDraggable);
   let dropHooksProvided = useRef(isTableDroppable);
   useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
     if (dragHooksProvided.current !== isTableDraggable) {
       console.warn('Drag hooks were provided during one render, but not another. This should be avoided as it may produce unexpected behavior.');
     }
@@ -751,7 +754,7 @@ function TableColumnHeader(props) {
   let {pressProps, isPressed} = usePress({isDisabled: isEmpty});
   let columnProps = column.props as SpectrumColumnProps<unknown>;
   useEffect(() => {
-    if (column.hasChildNodes && columnProps.allowsResizing) {
+    if (column.hasChildNodes && columnProps.allowsResizing && process.env.NODE_ENV !== 'production') {
       console.warn(`Column key: ${column.key}. Columns with child columns don't allow resizing.`);
     }
   }, [column.hasChildNodes, column.key, columnProps.allowsResizing]);

--- a/packages/@react-spectrum/textfield/src/TextArea.tsx
+++ b/packages/@react-spectrum/textfield/src/TextArea.tsx
@@ -69,7 +69,7 @@ export const TextArea = React.forwardRef(function TextArea(props: SpectrumTextAr
     }
   }, [onHeightChange, inputValue, inputRef]);
 
-  if (props.placeholder) {
+  if (props.placeholder && process.env.NODE_ENV !== 'production') {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead. See the docs for details: https://react-spectrum.adobe.com/react-spectrum/TextArea.html#help-text');
   }
 

--- a/packages/@react-spectrum/textfield/src/TextField.tsx
+++ b/packages/@react-spectrum/textfield/src/TextField.tsx
@@ -29,7 +29,7 @@ export const TextField = forwardRef(function TextField(props: SpectrumTextFieldP
   let inputRef = useRef<HTMLInputElement>(null);
   let result = useTextField(props, inputRef);
 
-  if (props.placeholder) {
+  if (props.placeholder && process.env.NODE_ENV !== 'production') {
     console.warn('Placeholders are deprecated due to accessibility issues. Please use help text instead. See the docs for details: https://react-spectrum.adobe.com/react-spectrum/TextField.html#help-text');
   }
 

--- a/packages/@react-spectrum/utils/src/classNames.ts
+++ b/packages/@react-spectrum/utils/src/classNames.ts
@@ -16,11 +16,13 @@ export let shouldKeepSpectrumClassNames = false;
 
 export function keepSpectrumClassNames(): void {
   shouldKeepSpectrumClassNames = true;
-  console.warn(
-    'Legacy spectrum-prefixed class names enabled for backward compatibility. ' +
-    'We recommend replacing instances of CSS overrides targeting spectrum selectors ' +
-    'in your app with custom class names of your own, and disabling this flag.'
-  );
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      'Legacy spectrum-prefixed class names enabled for backward compatibility. ' +
+      'We recommend replacing instances of CSS overrides targeting spectrum selectors ' +
+      'in your app with custom class names of your own, and disabling this flag.'
+    );
+  }
 }
 
 export function classNames(cssModule: {[key: string]: string}, ...values: Array<string | Object | undefined>): string {

--- a/packages/@react-spectrum/utils/src/styleProps.ts
+++ b/packages/@react-spectrum/utils/src/styleProps.ts
@@ -266,7 +266,7 @@ export function useStyleProps<T extends StyleProps>(
   let style = {...UNSAFE_style, ...styles};
 
   // @ts-ignore
-  if (otherProps.className) {
+  if (otherProps.className && process.env.NODE_ENV !== 'production') {
     console.warn(
       'The className prop is unsafe and is unsupported in React Spectrum v3. ' +
       'Please use style props with Spectrum variables, or UNSAFE_className if you absolutely must do something custom. ' +
@@ -275,7 +275,7 @@ export function useStyleProps<T extends StyleProps>(
   }
 
   // @ts-ignore
-  if (otherProps.style) {
+  if (otherProps.style && process.env.NODE_ENV !== 'production') {
     console.warn(
       'The style prop is unsafe and is unsupported in React Spectrum v3. ' +
       'Please use style props with Spectrum variables, or UNSAFE_style if you absolutely must do something custom. ' +

--- a/packages/@react-spectrum/well/src/Well.tsx
+++ b/packages/@react-spectrum/well/src/Well.tsx
@@ -30,7 +30,7 @@ export const Well = forwardRef(function Well(props: SpectrumWellProps, ref: DOMR
   let domRef = useDOMRef(ref);
   let {styleProps} = useStyleProps(otherProps);
 
-  if (!role && (props['aria-label'] || props['aria-labelledby'])) {
+  if (!role && (props['aria-label'] || props['aria-labelledby']) && process.env.NODE_ENV !== 'production') {
     console.warn('A labelled Well must have a role.');
   }
 

--- a/packages/@react-stately/collections/src/Item.ts
+++ b/packages/@react-stately/collections/src/Item.ts
@@ -25,7 +25,7 @@ Item.getCollectionNode = function* getCollectionNode<T>(props: ItemProps<T>, con
   let textValue = props.textValue || (typeof rendered === 'string' ? rendered : '') || props['aria-label'] || '';
 
   // suppressTextValueWarning is used in components like Tabs, which don't have type to select support.
-  if (!textValue && !context?.suppressTextValueWarning) {
+  if (!textValue && !context?.suppressTextValueWarning && process.env.NODE_ENV !== 'production') {
     console.warn('<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.');
   }
 

--- a/packages/@react-stately/table/src/TableUtils.ts
+++ b/packages/@react-stately/table/src/TableUtils.ts
@@ -25,8 +25,10 @@ export function parseFractionalUnit(width?: ColumnSize | null): number {
   let match = width.match(/^(.+)(?=fr$)/);
   // if width is the incorrect format, just default it to a 1fr
   if (!match) {
-    console.warn(`width: ${width} is not a supported format, width should be a number (ex. 150), percentage (ex. '50%') or fr unit (ex. '2fr')`,
-      'defaulting to \'1fr\'');
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`width: ${width} is not a supported format, width should be a number (ex. 150), percentage (ex. '50%') or fr unit (ex. '2fr')`,
+        'defaulting to \'1fr\'');
+    }
     return 1;
   }
   return parseFloat(match[0]);

--- a/packages/@react-stately/utils/src/useControlledState.ts
+++ b/packages/@react-stately/utils/src/useControlledState.ts
@@ -21,7 +21,7 @@ export function useControlledState<T, C = T>(value: T, defaultValue: T, onChange
   let isControlled = value !== undefined;
   useEffect(() => {
     let wasControlled = isControlledRef.current;
-    if (wasControlled !== isControlled) {
+    if (wasControlled !== isControlled && process.env.NODE_ENV !== 'production') {
       console.warn(`WARN: A component changed from ${wasControlled ? 'controlled' : 'uncontrolled'} to ${isControlled ? 'controlled' : 'uncontrolled'}.`);
     }
     isControlledRef.current = isControlled;
@@ -46,7 +46,9 @@ export function useControlledState<T, C = T>(value: T, defaultValue: T, onChange
     };
 
     if (typeof value === 'function') {
-      console.warn('We can not support a function callback. See Github Issues for details https://github.com/adobe/react-spectrum/issues/2320');
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('We can not support a function callback. See Github Issues for details https://github.com/adobe/react-spectrum/issues/2320');
+      }
       // this supports functional updates https://reactjs.org/docs/hooks-reference.html#functional-updates
       // when someone using useControlledState calls setControlledState(myFunc)
       // this will call our useState setState with a function as well which invokes myFunc and calls onChange with the value from myFunc

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -102,7 +102,9 @@ export const SectionContext = createContext<SectionContextValue | null>(null);
 /** @deprecated */
 export const Section = /*#__PURE__*/ createBranchComponent('section', <T extends object>(props: SectionProps<T>, ref: ForwardedRef<HTMLElement>, section: Node<T>): JSX.Element => {
   let {name, render} = useContext(SectionContext)!;
-  console.warn(`<Section> is deprecated. Please use <${name}> instead.`);
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`<Section> is deprecated. Please use <${name}> instead.`);
+  }
   return render(props, ref, section, 'react-aria-Section');
 });
 

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -93,7 +93,7 @@ export const Dialog = /*#__PURE__*/ (forwardRef as forwardRefType)(function Dial
     // Use that as a fallback in case there is no title slot.
     if (props['aria-labelledby']) {
       dialogProps['aria-labelledby'] = props['aria-labelledby'];
-    } else {
+    } else if (process.env.NODE_ENV !== 'production') {
       console.warn('If a Dialog does not contain a <Heading slot="title">, it must have an aria-label or aria-labelledby attribute for accessibility.');
     }
   }

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -139,6 +139,9 @@ function GridListInner<T extends object>({props, collection, gridListRef: ref}: 
   let dragHooksProvided = useRef(isListDraggable);
   let dropHooksProvided = useRef(isListDroppable);
   useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
     if (dragHooksProvided.current !== isListDraggable) {
       console.warn('Drag hooks were provided during one render, but not another. This should be avoided as it may produce unexpected behavior.');
     }
@@ -344,7 +347,7 @@ export const GridListItem = /*#__PURE__*/ createLeafComponent('item', function G
   }, []);
 
   useEffect(() => {
-    if (!item.textValue) {
+    if (!item.textValue && process.env.NODE_ENV !== 'production') {
       console.warn('A `textValue` prop is required for <GridListItem> elements with non-plain text children in order to support accessibility features such as type to select.');
     }
   }, [item.textValue]);

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -155,6 +155,9 @@ function ListBoxInner<T extends object>({state: inputState, props, listBoxRef}: 
   let dragHooksProvided = useRef(isListDraggable);
   let dropHooksProvided = useRef(isListDroppable);
   useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
     if (dragHooksProvided.current !== isListDraggable) {
       console.warn('Drag hooks were provided during one render, but not another. This should be avoided as it may produce unexpected behavior.');
     }
@@ -373,7 +376,7 @@ export const ListBoxItem = /*#__PURE__*/ createLeafComponent('item', function Li
   });
 
   useEffect(() => {
-    if (!item.textValue) {
+    if (!item.textValue && process.env.NODE_ENV !== 'production') {
       console.warn('A `textValue` prop is required for <ListBoxItem> elements with non-plain text children in order to support accessibility features such as type to select.');
     }
   }, [item.textValue]);

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -389,6 +389,9 @@ function TableInner({props, forwardedRef: ref, selectionState, collection}: Tabl
   let dragHooksProvided = useRef(hasDragHooks);
   let dropHooksProvided = useRef(hasDropHooks);
   useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
     if (dragHooksProvided.current !== hasDragHooks) {
       console.warn('Drag hooks were provided during one render, but not another. This should be avoided as it may produce unexpected behavior.');
     }
@@ -701,7 +704,7 @@ export const Column = /*#__PURE__*/ createLeafComponent('column', (props: Column
   let isResizing = false;
   if (layoutState) {
     isResizing = layoutState.resizingColumn === column.key;
-  } else {
+  } else if (process.env.NODE_ENV !== 'production') {
     for (let prop in ['width', 'defaultWidth', 'minWidth', 'maxWidth']) {
       if (prop in column.props) {
         console.warn(`The ${prop} prop on a <Column> only applies when a <Table> is wrapped in a <ResizableTableContainer>. If you aren't using column resizing, you can set the width of a column with CSS.`);
@@ -1067,7 +1070,7 @@ export const Row = /*#__PURE__*/ createBranchComponent(
 
     let dragButtonRef = useRef<HTMLButtonElement>(null);
     useEffect(() => {
-      if (dragState && !dragButtonRef.current) {
+      if (dragState && !dragButtonRef.current && process.env.NODE_ENV !== 'production') {
         console.warn('Draggable items in a Table must contain a <Button slot="drag"> element so that keyboard and screen reader users can drag them.');
       }
     // eslint-disable-next-line

--- a/packages/react-aria-components/src/TagGroup.tsx
+++ b/packages/react-aria-components/src/TagGroup.tsx
@@ -227,7 +227,7 @@ export const Tag = /*#__PURE__*/ createLeafComponent('item', (props: TagProps, f
   });
 
   useEffect(() => {
-    if (!item.textValue) {
+    if (!item.textValue && process.env.NODE_ENV !== 'production') {
       console.warn('A `textValue` prop is required for <Tag> elements with non-plain text children for accessibility.');
     }
   }, [item.textValue]);

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -384,14 +384,14 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent('item', <T extends o
   });
 
   useEffect(() => {
-    if (!item.textValue) {
+    if (!item.textValue && process.env.NODE_ENV !== 'production') {
       console.warn('A `textValue` prop is required for <TreeItem> elements in order to support accessibility features such as type to select.');
     }
   }, [item.textValue]);
 
   let expandButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
-    if (hasChildItems && !expandButtonRef.current) {
+    if (hasChildItems && !expandButtonRef.current && process.env.NODE_ENV !== 'production') {
       console.warn('Expandable tree items must contain a expand button so screen reader users can expand/collapse the item.');
     }
   // eslint-disable-next-line


### PR DESCRIPTION
This reduces production bundle sizes for our libraries by making some parts of the code gated behind `process.env.NODE_ENV` checks. This is now possible as of Parcel v2.14.0: https://github.com/parcel-bundler/parcel/pull/10102 In particular, console warnings and errors now only appear in development, and will be compiled away in production apps to avoid including those strings.

Also, some fallback code in usePress, useHover, useMove, etc. for environments that don't support pointer events is now only included when `NODE_ENV === 'test'`. These branches are not used in any real browser because all browsers have supported pointer events for a while now, but JSDOM still does not support them, so we need to keep this code to avoid breaking everyone's tests. However, omitting them in browser builds should be safe and cuts the bundle size of these hooks in half.