### PR TITLE
docs: remove BoxAlignmentStyleProps unset "@default" from types

### DIFF
--- a/packages/@react-types/shared/src/style.d.ts
+++ b/packages/@react-types/shared/src/style.d.ts
@@ -209,20 +209,11 @@ export interface ViewStyleProps<C extends ColorVersion> extends StyleProps {
 }
 
 export interface BoxAlignmentStyleProps {
-  /**
-   * The distribution of space around items along the main axis. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
-   * @default 'stretch'
-   */
+  /** The distribution of space around items along the main axis. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content). */
   justifyContent?: Responsive<'start' | 'end' | 'center' | 'left' | 'right' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | 'baseline' | 'first baseline' | 'last baseline' | 'safe center' | 'unsafe center'>,
-  /**
-   * The distribution of space around child items along the cross axis. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
-   * @default 'start'
-   */
+  /** The distribution of space around child items along the cross axis. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).*/
   alignContent?: Responsive<'start' | 'end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | 'baseline' | 'first baseline' | 'last baseline' | 'safe center' | 'unsafe center'>,
-  /**
-   * The alignment of children within their container. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
-   * @default 'stretch'
-   */
+  /** The alignment of children within their container. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items). */
   alignItems?: Responsive<'start' | 'end' | 'center' | 'stretch' | 'self-start' | 'self-end' | 'baseline' | 'first baseline' | 'last baseline' | 'safe center' | 'unsafe center'>,
   /** The space to display between both rows and columns. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/gap). */
   gap?: Responsive<DimensionValue>,


### PR DESCRIPTION
`Grid` and `Flex` share the defaults doc strings set for `justifyContent`, `alignContent` and `alignItems`, from `BoxAlignmentStyleProps`. However, no such defaults are actually set by the components, they are just passthroughStyle props for grid and normalize flex-start/start flex-end/end for flex, but neither explicitly set the stated defaults. They resolve in as just `normal` computed styles by the browser.

The doc string is misleading, and should be removed. My guess was the defaults were written as such to reference the fast that a browsers "normal" setting behaves similar to the defaults mentioned, so maybe that's why they were added? Or maybe at one point those were the defaults? However, claiming to set a default in the doc string, when it is not in the component is confusing.

Doc strings shown as default: 
![image](https://github.com/user-attachments/assets/1bf6f35d-994d-4b21-b407-02fdcd44dada)

Defaults not actually set:
![image](https://github.com/user-attachments/assets/45e51dab-b8ff-4f92-8c77-a1dc5a6a1905)

PR removes the docstring only, component behaviour is as current (no default).

