### PR TITLE
Fix: circular dependency in @internationalized/date

### DIFF
--- a/packages/@internationalized/date/src/utils.ts
+++ b/packages/@internationalized/date/src/utils.ts
@@ -10,28 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import {CalendarDate, CalendarDateTime} from './CalendarDate';
-
 export type Mutable<T> = {
   -readonly[P in keyof T]: T[P]
 };
 
 export function mod(amount: number, numerator: number): number {
   return amount - numerator * Math.floor(amount / numerator);
-}
-
-export function copy(date: CalendarDate): Mutable<CalendarDate> {
-  if (date.era) {
-    return new CalendarDate(date.calendar, date.era, date.year, date.month, date.day);
-  } else {
-    return new CalendarDate(date.calendar, date.year, date.month, date.day);
-  }
-}
-
-export function copyDateTime(date: CalendarDateTime): Mutable<CalendarDateTime> {
-  if (date.era) {
-    return new CalendarDateTime(date.calendar, date.era, date.year, date.month, date.day, date.hour, date.minute, date.second, date.millisecond);
-  } else {
-    return new CalendarDateTime(date.calendar, date.year, date.month, date.day, date.hour, date.minute, date.second);
-  }
 }


### PR DESCRIPTION
Closes [a relevant issue](https://github.com/adobe/react-spectrum/issues/6394)

The `copy` and `copyDateTime` seem to be unused and not exported outside of the package.
They also break Vercel deployments of the projects that use `@internationalized/date` for some reason (probably connected with the [heroui issue](https://github.com/heroui-inc/heroui/issues/3560)), that's why I made the fix.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

All existing tests should pass.

