### PR TITLE
fix: S2 notification badge follow-ups

### DIFF
--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -313,6 +313,7 @@ export const ActionButton = forwardRef(function ActionButton(props: ActionButton
           }],
           [NotificationBadgeContext, {
             size: props.size === 'XS' ? undefined : props.size,
+            isDisabled: props.isDisabled,
             styles: style({position: 'absolute', top: '--badgeTop', insetStart: '[var(--badgePosition)]', marginTop: '[calc((self(height) * -1)/2)]', marginStart: '[calc((self(height) * -1)/2)]'})
           }]
         ]}>

--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -223,14 +223,13 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
     type: 'top',
     value: {
       default: '[calc(self(height)/2 - var(--iconWidth)/2)]',
-      [iconOnly]: '[calc(self(height)/2 - var(--iconWidth)/2)]',
       [textOnly]: 0
     }
   },
   '--buttonPaddingX': {
     type: 'paddingStart',
     value: {
-      default: '[calc(self(height, self(minHeight)) * 3 / 8)]',
+      default: 'edge-to-text',
       [iconOnly]: 0
     }
   },

--- a/packages/@react-spectrum/s2/src/NotificationBadge.tsx
+++ b/packages/@react-spectrum/s2/src/NotificationBadge.tsx
@@ -39,10 +39,17 @@ export interface NotificationBadgeProps extends DOMProps, AriaLabelingProps, Sty
   value?: number | null
 }
 
-export const NotificationBadgeContext = createContext<ContextValue<Partial<NotificationBadgeProps>, DOMRefValue<HTMLDivElement>>>(null);
+interface NotificationBadgeContextProps extends Partial<NotificationBadgeProps> {
+  isDisabled?: boolean
+}
+
+export const NotificationBadgeContext = createContext<ContextValue<Partial<NotificationBadgeContextProps>, DOMRefValue<HTMLDivElement>>>(null);
 
 const badge = style({
-  display: 'flex',
+  display: {
+    default: 'flex',
+    isDisabled: 'none'
+  },
   font: 'control',
   color: {
     default: 'white',
@@ -111,8 +118,9 @@ export const NotificationBadge = forwardRef(function Badge(props: NotificationBa
   let {
     size = 'S',
     value,
+    isDisabled = false,
     ...otherProps
-  } = props;
+  } = props as NotificationBadgeContextProps;
   let domRef = useDOMRef(ref);
   let {locale} = useLocale();
   let formattedValue = '';
@@ -151,7 +159,7 @@ export const NotificationBadge = forwardRef(function Badge(props: NotificationBa
       {...filterDOMProps(otherProps, {labelable: true})}
       role={ariaLabel && 'img'}
       aria-label={ariaLabel}
-      className={(props.UNSAFE_className || '') + badge({size, isIndicatorOnly, isSingleDigit, isDoubleDigit}, props.styles)}
+      className={(props.UNSAFE_className || '') + badge({size, isIndicatorOnly, isSingleDigit, isDoubleDigit, isDisabled}, props.styles)}
       style={props.UNSAFE_style}
       ref={domRef}>
       {formattedValue}

--- a/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
@@ -208,7 +208,7 @@ const NotificationBadgesExample = (args) => {
 
   return (
     <div style={{display: 'flex', gap: 8, padding: 8, justifyContent: 'center'}}>
-      <ActionButton aria-label="Messages has new activity" {...args}><CommentIcon /><NotificationBadge value={105} /></ActionButton>
+      <ActionButton aria-label="Messages has new activity" {...args}><CommentIcon /><NotificationBadge /></ActionButton>
       <ActionButton aria-label={`${formattedValue} notifications`} {...args}><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
       <ActionButton {...args}><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
       <ActionButton {...args}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
@@ -230,10 +230,11 @@ let formattedValue = useNumberFormatter().format(badgeValue);
 
 return (
   <div style={{display: 'flex', gap: 8, padding: 8, justifyContent: 'center'}}>
-    <ActionButton aria-label="Messages has new activity" {...props}><CommentIcon /><NotificationBadge /></ActionButton>
-    <ActionButton aria-label={\`\${formattedValue} notifications\`}  {...props}><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
-    <ActionButton {...props}><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
-    <ActionButton {...props}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
+    <ActionButton aria-label="Messages has new activity"><CommentIcon /><NotificationBadge /></ActionButton>
+    <ActionButton aria-label={\`\${formattedValue} notifications\`} ><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
+    <ActionButton><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
+    {/* cannot have an isQuiet label-only Action Button with a Notification Badge */}
+    <ActionButton><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
   </div>
         )`;
       }

--- a/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
@@ -208,7 +208,7 @@ const NotificationBadgesExample = (args) => {
 
   return (
     <div style={{display: 'flex', gap: 8, padding: 8, justifyContent: 'center'}}>
-      <ActionButton aria-label="Messages has new activity" {...args}><CommentIcon /><NotificationBadge /></ActionButton>
+      <ActionButton aria-label="Messages has new activity" {...args}><CommentIcon /><NotificationBadge value={105} /></ActionButton>
       <ActionButton aria-label={`${formattedValue} notifications`} {...args}><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
       <ActionButton {...args}><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
       <ActionButton {...args}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
@@ -224,16 +224,17 @@ NotificationBadges.parameters = {
   docs: {
     source: {
       transform: () => {
-        return `let badgeValue = 10;
-        let formattedValue = useNumberFormatter().format(badgeValue);
-      
-        return (
-          <div style={{display: 'flex', gap: 8, padding: 8, justifyContent: 'center'}}>
-            <ActionButton aria-label="Messages has new activity" {...props}><CommentIcon /><NotificationBadge /></ActionButton>
-            <ActionButton aria-label={\`\${formattedValue} notifications\`}  {...props}><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
-            <ActionButton {...props}><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
-            <ActionButton {...props}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
-          </div>
+        return `
+let badgeValue = 10;
+let formattedValue = useNumberFormatter().format(badgeValue);
+
+return (
+  <div style={{display: 'flex', gap: 8, padding: 8, justifyContent: 'center'}}>
+    <ActionButton aria-label="Messages has new activity" {...props}><CommentIcon /><NotificationBadge /></ActionButton>
+    <ActionButton aria-label={\`\${formattedValue} notifications\`}  {...props}><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
+    <ActionButton {...props}><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
+    <ActionButton {...props}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
+  </div>
         )`;
       }
     }

--- a/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
@@ -205,13 +205,12 @@ export const Avatars: Story = {
 const NotificationBadgesExample = (args) => {
   let badgeValue = 10;
   let formattedValue = useNumberFormatter().format(badgeValue);
-
   return (
     <div style={{display: 'flex', gap: 8, padding: 8, justifyContent: 'center'}}>
       <ActionButton aria-label="Messages has new activity" {...args}><CommentIcon /><NotificationBadge /></ActionButton>
       <ActionButton aria-label={`${formattedValue} notifications`} {...args}><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
       <ActionButton {...args}><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
-      <ActionButton {...args}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
+      {!args.isQuiet && <ActionButton {...args}><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>}
     </div>
   );
 };
@@ -233,8 +232,8 @@ return (
     <ActionButton aria-label="Messages has new activity"><CommentIcon /><NotificationBadge /></ActionButton>
     <ActionButton aria-label={\`\${formattedValue} notifications\`} ><BellIcon /><NotificationBadge value={badgeValue} /></ActionButton>
     <ActionButton><CommentIcon /><Text>Messages</Text><NotificationBadge value={5} /></ActionButton>
-    {/* cannot have an isQuiet label-only Action Button with a Notification Badge */}
-    <ActionButton><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>
+    {/* Cannot have an label-only quiet Action Button with a Notification Badge */}
+    {!isQuiet && <ActionButton><Text>Notifications</Text><NotificationBadge value={105} /></ActionButton>}
   </div>
         )`;
       }


### PR DESCRIPTION
notes from design:

1. Notification badge cannot be used on a label-only quiet button. they are updating their guidelines to include this information
2. Remove the badge when an action button is disabled
3. No answers for static colors, they will workshop
4. Badges should be swapped with an indicator to avoid visual collision but they are exploring other options (probably something the app needs to do)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
