### PR TITLE
fix: pass dom props to button group

### DIFF
--- a/packages/@react-spectrum/s2/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/s2/src/ButtonGroup.tsx
@@ -14,13 +14,13 @@ import {ButtonContext, LinkButtonContext} from './Button';
 import {ContextValue, Provider, SlotProps} from 'react-aria-components';
 import {createContext, forwardRef, ReactNode, useCallback, useRef} from 'react';
 import {DOMProps, DOMRef, DOMRefValue} from '@react-types/shared';
+import {filterDOMProps, useLayoutEffect, useValueEffect} from '@react-aria/utils';
 import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {style} from '../style' with {type: 'macro'};
 import {
   useDOMRef,
   useResizeObserver
 } from '@react-spectrum/utils';
-import {useLayoutEffect, useValueEffect} from '@react-aria/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 interface ButtonGroupStyleProps {
@@ -112,7 +112,8 @@ export const ButtonGroup = forwardRef(function ButtonGroup(props: ButtonGroupPro
     orientation = 'horizontal',
     align = 'start',
     children,
-    isDisabled
+    isDisabled,
+    ...otherProps
   } = props;
 
   let [hasOverflow, setHasOverflow] = useValueEffect(false);
@@ -165,6 +166,7 @@ export const ButtonGroup = forwardRef(function ButtonGroup(props: ButtonGroupPro
   let context = {styles: style({flexShrink: 0}), size, isDisabled};
   return (
     <div
+      {...filterDOMProps(otherProps)}
       ref={domRef}
       style={props.UNSAFE_style}
       className={(props.UNSAFE_className || '') + buttongroup({


### PR DESCRIPTION
seems like we missed passing down props to button group in S2

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
