### PR TITLE
Improve ListBox perf caused by excessive re-rendering

### DIFF
--- a/packages/@react-stately/list/src/useListState.ts
+++ b/packages/@react-stately/list/src/useListState.ts
@@ -63,11 +63,11 @@ export function useListState<T extends object>(props: ListProps<T>): ListState<T
 
   useFocusedKeyReset(collection, selectionManager);
 
-  return {
+  return useMemo(() => ({
     collection,
     disabledKeys,
     selectionManager
-  };
+  }), [collection, disabledKeys, selectionManager]);
 }
 
 /**
@@ -75,13 +75,13 @@ export function useListState<T extends object>(props: ListProps<T>): ListState<T
  */
 export function UNSTABLE_useFilteredListState<T extends object>(state: ListState<T>, filter: ((nodeValue: string) => boolean) | null | undefined): ListState<T> {
   let collection = useMemo(() => filter ? state.collection.UNSTABLE_filter!(filter) : state.collection, [state.collection, filter]);
-  let selectionManager = state.selectionManager.withCollection(collection);
+  let selectionManager = useMemo(() => state.selectionManager.withCollection(collection), [collection]);
   useFocusedKeyReset(collection, selectionManager);
-  return {
+  return useMemo(() => ({
     collection,
     selectionManager,
     disabledKeys: state.disabledKeys
-  };
+  }), [collection, selectionManager, state.disabledKeys]);
 }
 
 function useFocusedKeyReset<T>(collection: Collection<Node<T>>, selectionManager: SelectionManager) {

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -249,7 +249,7 @@ function ListBoxInner<T extends object>({state: inputState, props, listBoxRef}: 
           values={[
             [ListBoxContext, props],
             [ListStateContext, state],
-            [DragAndDropContext, {dragAndDropHooks, dragState, dropState}],
+            [DragAndDropContext, useMemo(() => ({dragAndDropHooks, dragState, dropState}), [dragAndDropHooks, dragState, dropState])],
             [SeparatorContext, {elementType: 'div'}],
             [DropIndicatorContext, {render: ListBoxDropIndicatorWrapper}],
             [SectionContext, {name: 'ListBoxSection', render: ListBoxSectionInner}]


### PR DESCRIPTION
I use a `Select` (`ListBox`) to display a list of countries in an address component for my project. There are about ~200 countries, few enough that virtualization isn't necessary. However, there is a notice delay when hovering the mouse over countries, or changing the selected country using the keyboard.

This delay stems from the `ListBox` re-rendering _every_ `ListBoxItem` whenever the hovered item changes:

https://github.com/user-attachments/assets/2c771cfe-53b1-46eb-8dc6-39158e1b9113

In the lower right corner, you can see the FPS drop sharply.

I tracked down the source to several un-memoized objects that get re-created every render. As React diffs props by reference, this causes a full render on _all_ `ListBoxItem`s. I added `useMemo(..)`s were appropriate, and now the performance is much smoother - only two re-renders occur (the newly and previously hovered items):

https://github.com/user-attachments/assets/73cf53de-b5fd-42a2-8a04-48751a4bd767

## ✅ Pull Request Checklist:

- [] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
  - I did not create an issue for this PR, but I can if you'd like.
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

I used the `React Aria Components > Select Many` story without any modifications to demonstrate the issue/fix:

![image](https://github.com/user-attachments/assets/d33a9313-2fd1-4f4e-b2c3-3e8116921363)

I used the [React Scan](https://react-scan.com/) extension to identify the un-memoized objects - I had to force the `Popover` within the Select Many example open with `isOpen={true}` so I could select it with React Scan.

## 🧢 Your Project:

RSP
