### PR TITLE
feat: expose `closeOnSelect` prop in S2 MenuItem

### DIFF
--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -157,6 +157,7 @@ export let menuitem = style({
   },
   paddingBottom: '--labelPadding',
   backgroundColor: { // TODO: revisit color when I have access to dev mode again
+    // @ts-expect-error Expression produces a union type that is too complex to represent
     default: {
       default: 'transparent',
       isFocused: baseColor('gray-100').isFocusVisible
@@ -301,6 +302,7 @@ let keyboard = style({
   color: {
     default: 'gray-600',
     isDisabled: 'disabled',
+    // @ts-expect-error Expression produces a union type that is too complex to represent
     forcedColors: {
       isDisabled: 'GrayText'
     }

--- a/packages/@react-spectrum/s2/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Menu.stories.tsx
@@ -242,6 +242,27 @@ export const DynamicExample: Story = {
   }
 };
 
+export const PreventDefaultClosingBehavior: Story = {
+  render: (args) => {
+    return (
+      <MenuTrigger {...args}>
+        <Button aria-label="Closing behavior"><More /></Button>
+        <Menu {...args}>
+          <MenuItem>I will close the menu by default</MenuItem>
+          <MenuItem closeOnSelect={false}>I will not close the menu</MenuItem>
+          <SubmenuTrigger>
+            <MenuItem>Submenu</MenuItem>
+            <Menu>
+              <MenuItem closeOnSelect>I will close the menu</MenuItem>
+              <MenuItem closeOnSelect={false}>I will not close the menu</MenuItem>
+            </Menu>
+          </SubmenuTrigger>
+        </Menu>
+      </MenuTrigger>
+    );
+  }
+};
+
 export const SelectionGroups = (args) => {
   let [group1, setGroup1] = useState<Selection>(new Set([1]));
   let [group2, setGroup2] = useState<Selection>(new Set());

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -349,7 +349,12 @@ export interface MenuItemProps<T = object> extends RenderProps<MenuItemRenderPro
   /** Whether the item is disabled. */
   isDisabled?: boolean,
   /** Handler that is called when the item is selected. */
-  onAction?: () => void
+  onAction?: () => void,
+  /**
+   * Whether the menu should close when the menu item is selected.
+   * @default true
+   */
+  closeOnSelect?: boolean
 }
 
 const MenuItemContext = createContext<ContextValue<MenuItemProps, HTMLDivElement>>(null);


### PR DESCRIPTION
I also added 2 `// @ts-expect-error` comments in `Menu.tsx` to silence a linting error my IDE was giving me with the style macros. If these should be removed that's fine with me!