### PR TITLE
fix: apply aria-details on the calendar

### DIFF
--- a/packages/@react-aria/calendar/src/useCalendarBase.ts
+++ b/packages/@react-aria/calendar/src/useCalendarBase.ts
@@ -93,6 +93,7 @@ export function useCalendarBase(props: CalendarPropsBase & DOMProps & AriaLabeli
   return {
     calendarProps: mergeProps(domProps, labelProps, {
       role: 'application',
+      'aria-details': props['aria-details'] || undefined,
       'aria-describedby': props['aria-describedby'] || undefined
     }),
     nextButtonProps: {

--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -83,6 +83,21 @@ describe('Calendar', () => {
     }
   });
 
+  it('should support aria props on the Calendar', () => {
+    let {getByRole} = renderCalendar({      
+      'aria-label': 'label',
+      'aria-labelledby': 'labelledby',
+      'aria-describedby': 'describedby',
+      'aria-details': 'details'
+    });
+
+    let group = getByRole('application');
+    expect(group).toHaveAttribute('aria-label', expect.stringContaining('label'));
+    expect(group).toHaveAttribute('aria-labelledby', expect.stringContaining('labelledby'));
+    expect(group).toHaveAttribute('aria-describedby', 'describedby');
+    expect(group).toHaveAttribute('aria-details', 'details');    
+  });
+
   it('should support custom CalendarGridHeader', () => {
     let {getByRole} = render(
       <Calendar aria-label="Appointment date">


### PR DESCRIPTION
## Found During Testing

Applying the aria-details prop, which was not passed to the final `calendarProps`.

This PR fixes an issue where the aria-details was set in the RAC `Calendar` | `RangeCalendar`, but was not being applied to the rendered component.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
