### PR TITLE
fix: minor typo in CalendarDate docs

### DIFF
--- a/packages/@internationalized/date/docs/CalendarDate.mdx
+++ b/packages/@internationalized/date/docs/CalendarDate.mdx
@@ -86,7 +86,7 @@ See the [Calendar](Calendar.html#implementations) docs for details about the sup
 
 Many calendar systems have only one era, or a modern era and a pre-modern era (e.g. AD and BC in the Gregorian calendar). However, other calendar systems may have many eras. For example, the Japanese calendar has eras for the reign of each Emperor. `CalendarDate` represents eras using string identifiers, which can be passed as an additional parameter to the constructor before the year. When eras are present, years are numbered starting from 1 within the era.
 
-This example creates a date in the Japanese calendar system, which is equivalent to April 4th, 2020 in the Gregorian calendar.
+This example creates a date in the Japanese calendar system, which is equivalent to April 30th, 2019 in the Gregorian calendar.
 
 ```tsx
 import {JapaneseCalendar} from '@internationalized/date';

--- a/packages/@internationalized/date/docs/CalendarDate.mdx
+++ b/packages/@internationalized/date/docs/CalendarDate.mdx
@@ -72,7 +72,7 @@ date.toString(); // '2022-02-03'
 
 By default, `CalendarDate` uses the Gregorian calendar system, but many other calendar systems that are used around the world are supported, such as Hebrew, Indian, Islamic, Buddhist, Ethiopic, and more. A <TypeLink links={docs.links} type={docs.exports.Calendar} /> instance can be passed to the `CalendarDate` constructor to represent dates in that calendar system.
 
-This example creates a date in the Buddhist calendar system, which is equivalent to April 4th, 2020 in the Gregorian calendar.
+This example creates a date in the Buddhist calendar system, which is equivalent to April 30th, 2020 in the Gregorian calendar.
 
 ```tsx
 import {BuddhistCalendar} from '@internationalized/date';


### PR DESCRIPTION
```
let date = new CalendarDate(new BuddhistCalendar(), 2563, 4, 30);
```

The Gregorian calendar equivalent of the mentioned Buddhist calendar date should be April 30th. Currently it says April 4th in the docs.
