### PR TITLE
fix: useMove broken by NODE_ENV check

### DIFF
--- a/packages/@react-aria/interactions/src/useMove.ts
+++ b/packages/@react-aria/interactions/src/useMove.ts
@@ -93,7 +93,7 @@ export function useMove(props: MoveEvents): MoveResult {
       state.current.didMove = false;
     };
 
-    if (typeof PointerEvent === 'undefined') {
+    if (typeof PointerEvent === 'undefined' && process.env.NODE_ENV === 'test') {
       let onMouseMove = (e: MouseEvent) => {
         if (e.button === 0) {
           move(e, 'mouse', e.pageX - (state.current.lastPosition?.pageX ?? 0), e.pageY - (state.current.lastPosition?.pageY ?? 0));
@@ -151,7 +151,7 @@ export function useMove(props: MoveEvents): MoveResult {
         addGlobalListener(window, 'touchend', onTouchEnd, false);
         addGlobalListener(window, 'touchcancel', onTouchEnd, false);
       };
-    } else if (process.env.NODE_ENV === 'test') {
+    } else {
       let onPointerMove = (e: PointerEvent) => {
         if (e.pointerId === state.current.id) {
           let pointerType = (e.pointerType || 'mouse') as PointerType;


### PR DESCRIPTION
useMove was broken by #7977. The `NODE_ENV` check was on the wrong branch, resulting in sliders no longer moving when dragged.