### PR TITLE
fix: Divider S2 better flex behaviour

### DIFF
--- a/packages/@react-spectrum/s2/src/Divider.tsx
+++ b/packages/@react-spectrum/s2/src/Divider.tsx
@@ -61,6 +61,8 @@ export const divider = style<DividerSpectrumProps & {isStaticColor: boolean}>({
   borderStyle: 'none',
   borderRadius: 'full',
   margin: 0,
+  flexGrow: 0,
+  flexShrink: 0,
   height: {
     orientation: {
       horizontal: {


### PR DESCRIPTION
Closes <!-- Github issue # here -->
This prevents the Divider from growing or shrinking in a flex container by default. It's come up internally a few times.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
