### PR TITLE
Ability to reset the timezone

### DIFF
--- a/packages/@internationalized/date/src/index.ts
+++ b/packages/@internationalized/date/src/index.ts
@@ -63,6 +63,8 @@ export {
   today,
   getHoursInDay,
   getLocalTimeZone,
+  setLocalTimeZone,
+  resetLocalTimeZone,
   startOfMonth,
   startOfWeek,
   startOfYear,

--- a/packages/@internationalized/date/src/queries.ts
+++ b/packages/@internationalized/date/src/queries.ts
@@ -133,12 +133,21 @@ let localTimeZone: string | null = null;
 
 /** Returns the time zone identifier for the current user. */
 export function getLocalTimeZone(): string {
-  // TODO: invalidate this somehow?
   if (localTimeZone == null) {
     localTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
 
   return localTimeZone!;
+}
+
+/** Sets the time zone identifier for the current user. */
+export function setLocalTimeZone(timeZone: string): void {
+  localTimeZone = timeZone;
+}
+
+/** Resets the time zone identifier for the current user. */
+export function resetLocalTimeZone(): void {
+  localTimeZone = null;
 }
 
 /** Returns the first date of the month for the given date. */

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -349,11 +349,12 @@ describe('queries', function () {
 
   describe('getLocalTimeZone', function () {
     it('gets local time zone', function () {
-      expect(getLocalTimeZone()).toBe('America/New_York');
+      const systemTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+      expect(getLocalTimeZone()).toBe(systemTimeZone);
       setLocalTimeZone('America/Denver');
       expect(getLocalTimeZone()).toBe('America/Denver');
       resetLocalTimeZone();
-      expect(getLocalTimeZone()).toBe('America/New_York');
+      expect(getLocalTimeZone()).toBe(systemTimeZone);
     });
   });
 });

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -17,6 +17,7 @@ import {
   endOfYear,
   EthiopicCalendar,
   getDayOfWeek,
+  getLocalTimeZone,
   getMinimumDayInMonth,
   getMinimumMonthInYear,
   getWeeksInMonth,
@@ -31,6 +32,8 @@ import {
   maxDate,
   minDate,
   PersianCalendar,
+  resetLocalTimeZone,
+  setLocalTimeZone,
   startOfMonth,
   startOfWeek,
   startOfYear,
@@ -341,6 +344,16 @@ describe('queries', function () {
       let b = new CalendarDate('AD', 1, 1, 1);
       expect(a.compare(b)).toBeLessThan(0);
       expect(b.compare(a)).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getLocalTimeZone', function () {
+    it('gets local time zone', function () {
+      expect(getLocalTimeZone()).toBe('America/New_York');
+      setLocalTimeZone('America/Denver');
+      expect(getLocalTimeZone()).toBe('America/Denver');
+      resetLocalTimeZone();
+      expect(getLocalTimeZone()).toBe('America/New_York');
     });
   });
 });


### PR DESCRIPTION
Currently, `getLocalTimeZone()` caches the timezone. There's a todo to have a way to invalidate it, this PR resolves that.

I was writing timezone dependent tests in our own project and needed a way to fake the user's timezone. Due to the cache this wasn't possible.

This adds:
- A `setLocalTimeZone` method that allows you to specify a timezone explicitly.
- A `resetLocalTimeZone` to clear the cache which will naturally resolve itself next time `getLocalTimeZone` is used.

References discussion https://github.com/adobe/react-spectrum/discussions/7195

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

This PR only exposes two new methods which aren't used in any components. To test this pull request, just run the tests.