### PR TITLE
fix: Relax Parcel version range in public plugins

### DIFF
--- a/packages/dev/parcel-resolver-optimize-locales/package.json
+++ b/packages/dev/parcel-resolver-optimize-locales/package.json
@@ -3,10 +3,10 @@
   "version": "1.2.0",
   "main": "LocalesResolver.js",
   "engines": {
-    "parcel": "^2.12.0"
+    "parcel": "^2.0.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.14.0"
+    "@parcel/plugin": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dev/parcel-transformer-s2-icon/package.json
+++ b/packages/dev/parcel-transformer-s2-icon/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@adobe/spectrum-tokens": "^13.0.0-beta.56",
-    "@parcel/plugin": "^2.14.0",
+    "@parcel/plugin": "^2.0.0",
     "@svgr/core": "^8.1.0",
     "@svgr/plugin-jsx": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4735,7 +4735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/plugin@npm:2.14.0, @parcel/plugin@npm:^2.10.2, @parcel/plugin@npm:^2.14.0":
+"@parcel/plugin@npm:2.14.0, @parcel/plugin@npm:^2.0.0, @parcel/plugin@npm:^2.10.2, @parcel/plugin@npm:^2.14.0":
   version: 2.14.0
   resolution: "@parcel/plugin@npm:2.14.0"
   dependencies:
@@ -6460,7 +6460,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-aria/parcel-resolver-optimize-locales@workspace:packages/dev/parcel-resolver-optimize-locales"
   dependencies:
-    "@parcel/plugin": "npm:^2.14.0"
+    "@parcel/plugin": "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7817,7 +7817,7 @@ __metadata:
   resolution: "@react-spectrum/parcel-transformer-s2-icon@workspace:packages/dev/parcel-transformer-s2-icon"
   dependencies:
     "@adobe/spectrum-tokens": "npm:^13.0.0-beta.56"
-    "@parcel/plugin": "npm:^2.14.0"
+    "@parcel/plugin": "npm:^2.0.0"
     "@svgr/core": "npm:^8.1.0"
     "@svgr/plugin-jsx": "npm:^8.1.0"
     "@svgr/plugin-svgo": "npm:^8.1.0"


### PR DESCRIPTION
From audit. Public Parcel plugins should not force people to upgrade to the latest version.