### PR TITLE
docs: fix wrong links/typos

### DIFF
--- a/packages/@react-aria/menu/docs/useMenu.mdx
+++ b/packages/@react-aria/menu/docs/useMenu.mdx
@@ -27,7 +27,7 @@ import tailwindPreview from 'url:./tailwind.png';
 
 ---
 category: Collections
-keywords: [menu trigger, mutli-select menu, aria]
+keywords: [menu trigger, multi-select menu, aria]
 ---
 
 # useMenu

--- a/packages/@react-spectrum/picker/docs/Picker.mdx
+++ b/packages/@react-spectrum/picker/docs/Picker.mdx
@@ -52,7 +52,7 @@ keywords: [select, collections, dropdown]
 ```
 
 ## Content
-Picker follows the [Collection Components](../react-stately/collections.html) API, accepting both static and dynamic collections. Similar to [Menu](MenuTrigger.html), Picker accepts `<Item>` elements as children, each with a `key` prop. Basic usage of Picker, seen in the example above, shows multiple options populated with a string. Static collections, as in this example, can be used when the full list of options is known ahead of time.
+Picker follows the [Collection Components](../react-stately/collections.html) API, accepting both static and dynamic collections. Similar to [Menu](Menu.html), Picker accepts `<Item>` elements as children, each with a `key` prop. Basic usage of Picker, seen in the example above, shows multiple options populated with a string. Static collections, as in this example, can be used when the full list of options is known ahead of time.
 
 Dynamic collections, as shown below, can be used when the options come from an external data source such as an API call, or update over time. Providing the data in this way allows Picker to automatically cache the rendering of each item, which dramatically improves performance.
 

--- a/packages/@react-spectrum/text/docs/Keyboard.mdx
+++ b/packages/@react-spectrum/text/docs/Keyboard.mdx
@@ -45,7 +45,7 @@ which can be used within a Spectrum container such as a [Menu](Menu.html).
 from the parent container. In addition, `Keyboard` will be automatically
 placed within the container's layout according to Spectrum guidelines.
 
-See [Menu](MenuTrigger.html#complex-menu-items) for examples of how to use the
+See [Menu](Menu.html#complex-menu-items) for examples of how to use the
 `Keyboard` component in the context of a Spectrum container.
 See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd) for more
 information about the semantics of the `kbd` element.

--- a/packages/dev/docs/pages/react-spectrum/layout.mdx
+++ b/packages/dev/docs/pages/react-spectrum/layout.mdx
@@ -248,7 +248,7 @@ and `Dialog` takes care of positioning and styling them properly for the dialog 
 these items can change depending on the screen size. For example, the buttons in full screen dialogs move from the
 top to the bottom on mobile.
 
-Another example of this is the complex items supported by [Picker](Picker.html) and [Menu](MenuTrigger.html). These components allow
+Another example of this is the complex items supported by [Picker](Picker.html) and [Menu](Menu.html). These components allow
 icons, text, and descriptions to be added as children of items, and the layout and styling is handled automatically.
 The icon and main text element of an item are placed in slots automatically, and the description text element is
 placed using the `slot` prop to specify a named area.

--- a/packages/react-aria-components/docs/ColorSlider.mdx
+++ b/packages/react-aria-components/docs/ColorSlider.mdx
@@ -457,7 +457,7 @@ A `<SliderOutput>` renders the current value of the color slider as text.
 
 ### SliderTrack
 
-The `<SliderTrack>` component renders a gradient repreresenting the colors that can be selected for the color channel, and contains a `<ColorThumb>` element.
+The `<SliderTrack>` component renders a gradient representing the colors that can be selected for the color channel, and contains a `<ColorThumb>` element.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>

--- a/packages/react-aria-components/docs/ColorWheel.mdx
+++ b/packages/react-aria-components/docs/ColorWheel.mdx
@@ -272,7 +272,7 @@ The `aria-valuetext` of the `<input>` element is formatted according to the user
 
 ### ColorWheelTrack
 
-The `<ColorWheelTrack>` component renders a circular gradient repreresenting the colors that can be selected for the color channel.
+The `<ColorWheelTrack>` component renders a circular gradient representing the colors that can be selected for the color channel.
 
 <details>
   <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show props</summary>

--- a/packages/react-aria-components/docs/FileTrigger.mdx
+++ b/packages/react-aria-components/docs/FileTrigger.mdx
@@ -68,7 +68,7 @@ function Example(){
 
 ## Features
 
-A file input can be created with an `<input type=“file”>` element, but this supports limited styling options and may not integrate well with the overall design of a website or application. To overcome this, `FileTrigger` extends the functionality of the standard file input element by working with a pressable child such as a `Button` to create accessible file inputs that can be style as needed.
+A file input can be created with an `<input type=“file”>` element, but this supports limited styling options and may not integrate well with the overall design of a website or application. To overcome this, `FileTrigger` extends the functionality of the standard file input element by working with a pressable child such as a `Button` to create accessible file inputs that can be styled as needed.
 
 * **Customizable** – Works with any pressable React Aria or React Spectrum component, and custom components built with [usePress](usePress.html).
 

--- a/packages/react-aria-components/docs/Menu.mdx
+++ b/packages/react-aria-components/docs/Menu.mdx
@@ -29,7 +29,7 @@ import {StarterKits} from '@react-spectrum/docs/src/StarterKits';
 
 ---
 category: Collections
-keywords: [menu trigger, mutli-select menu, aria]
+keywords: [menu trigger, multi-select menu, aria]
 type: component
 ---
 

--- a/packages/react-aria-components/docs/Tree.mdx
+++ b/packages/react-aria-components/docs/Tree.mdx
@@ -252,7 +252,7 @@ import {
 
 A tree can be built using the [&lt;ul&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul), [&lt;li&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li),
  and [&lt;ol&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol), but is very limited in functionality especially when it comes to user interactions.
-HTML lists are meant for static content, rather than heirarchies with rich interactions like focusable elements within cells, keyboard navigation, item selection, sorting, etc.
+HTML lists are meant for static content, rather than hierarchies with rich interactions like focusable elements within cells, keyboard navigation, item selection, sorting, etc.
 `Tree` helps achieve accessible and interactive tree components that can be styled as needed.
 
 * **Item selection** – Single or multiple selection, with optional checkboxes, disabled items, and both `toggle` and `replace` selection behaviors.
@@ -632,9 +632,9 @@ Items may also have an action specified by directly applying `onAction` on the `
       id="ivysaur"
       title="Ivysaur">
       <MyTreeItem
-        onAction={() => alert(`Opening Venisaur...`)}
-        id="venisaur"
-        title="Venisaur" />
+        onAction={() => alert(`Opening Venusaur...`)}
+        id="venusaur"
+        title="Venusaur" />
     </MyTreeItem>
   </MyTreeItem>
 </Tree>
@@ -660,8 +660,8 @@ Tree items may also be links to another page or website. This can be achieved by
       href="https://pokemondb.net/pokedex/ivysaur"
       target="_blank">
       <MyTreeItem
-        id="venisaur"
-        title="Venisaur"
+        id="venusaur"
+        title="Venusaur"
         href="https://pokemondb.net/pokedex/venusaur"
         target="_blank" />
     </MyTreeItem>
@@ -691,7 +691,7 @@ Note that you are responsible for the styling of disabled items, however, the se
     {/*- begin highlight -*/}
     <MyTreeItem id="ivysaur" title="Ivysaur" isDisabled>
     {/*- end highlight -*/}
-      <MyTreeItem id="venisaur" title="Venisaur" />
+      <MyTreeItem id="venusaur" title="Venusaur" />
     </MyTreeItem>
   </MyTreeItem>
 </Tree>
@@ -713,7 +713,7 @@ When `disabledBehavior` is set to `selection`, interactions such as focus, dragg
     {/*- begin highlight -*/}
     <MyTreeItem id="ivysaur" title="Ivysaur" isDisabled>
     {/*- end highlight -*/}
-      <MyTreeItem id="venisaur" title="Venisaur" />
+      <MyTreeItem id="venusaur" title="Venusaur" />
     </MyTreeItem>
   </MyTreeItem>
 </Tree>


### PR DESCRIPTION
Updating outdated menu links, along with some typos while we're at it

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
