### PR TITLE
fix: UNSAFE_className story

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
         "packages/@react-spectrum/tree/**",
         "packages/@react-spectrum/color/src/*.tsx",
         "packages/@react-spectrum/s2/**/*.{js,ts,tsx}",
+        "packages/@react-spectrum/s2/stories/**",
         ".storybook-s2/**"
       ]
     },


### PR DESCRIPTION
Was broken by toast change to css modules exclusions. Adding back stories here.