### PR TITLE
update optimize-locales plugin type

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.d.ts
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.d.ts
@@ -4,5 +4,5 @@ type Options = {
   locales: readonly string[]
 };
 
-declare const plugin: UnpluginInstance<Options, boolean>;
+declare const plugin: UnpluginInstance<Options, false>;
 export = plugin;


### PR DESCRIPTION
this updates the optimize-locales plugin type:

the second generic in `UnpluginInstance` is for nested plugins, see https://github.com/unjs/unplugin/blob/466f4d5be7ba048d81613d853c34d7eea2518507/src/types.ts#L162

setting to `false` instead of `boolean` means that the optimize-locales plugin will be typed as just `Plugin` instead of `Array<Plugin> | Plugin>`.