### PR TITLE
feat: add select only option to listbox toggle mode

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -150,10 +150,16 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
         }
       } else if (e && e.shiftKey) {
         manager.extendSelection(key);
-      } else if (manager.selectionBehavior === 'toggle' && (e.pointerType === 'touch' || e.pointerType === 'virtual' || !isCtrlKeyPressed(e))) {
+      } else if (e && (e.pointerType === 'touch' || e.pointerType === 'virtual')) {
         // if touch or virtual (VO) then we just want to toggle, otherwise it's impossible to multi select because they don't have modifier keys
-        // if ctrl is pressed in toggle mode, we want to replace selection
         manager.toggleSelection(key);
+      } else if (manager.selectionBehavior === 'toggle' ) {
+        // if ctrl is pressed in toggle mode, we want to replace selection
+        if (isCtrlKeyPressed(e)) {
+          manager.replaceSelection(key);
+        } else {
+          manager.toggleSelection(key);
+        }
       } else {
         manager.replaceSelection(key);
       }

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -150,8 +150,9 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
         }
       } else if (e && e.shiftKey) {
         manager.extendSelection(key);
-      } else if (manager.selectionBehavior === 'toggle' || (e && (isCtrlKeyPressed(e) || e.pointerType === 'touch' || e.pointerType === 'virtual'))) {
+      } else if (manager.selectionBehavior === 'toggle' && (e.pointerType === 'touch' || e.pointerType === 'virtual' || !isCtrlKeyPressed(e))) {
         // if touch or virtual (VO) then we just want to toggle, otherwise it's impossible to multi select because they don't have modifier keys
+        // if ctrl is pressed in toggle mode, we want to replace selection
         manager.toggleSelection(key);
       } else {
         manager.replaceSelection(key);

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -153,7 +153,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
       } else if (e && (e.pointerType === 'touch' || e.pointerType === 'virtual')) {
         // if touch or virtual (VO) then we just want to toggle, otherwise it's impossible to multi select because they don't have modifier keys
         manager.toggleSelection(key);
-      } else if (manager.selectionBehavior === 'toggle' ) {
+      } else if (manager.selectionBehavior === 'toggle') {
         // if ctrl is pressed in toggle mode, we want to replace selection
         if (isCtrlKeyPressed(e)) {
           manager.replaceSelection(key);

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -161,7 +161,12 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
           manager.toggleSelection(key);
         }
       } else {
-        manager.replaceSelection(key);
+        // if ctrl is pressed in replace mode, we want to toggle selection
+        if (isCtrlKeyPressed(e)) {
+          manager.toggleSelection(key);
+        } else {
+          manager.replaceSelection(key);
+        }
       }
     }
   };


### PR DESCRIPTION
In some cases when using the default selection behavior for the ListBox which is toggle in multi selection mode, you want the ability to clear out all existing selections and only "focus" on one option. 

As I see it, this is complimentary to the existing feature where it is possible to switch to "toggle" mode when holding ctrl/cmd in selection behavior replace. This is essentially the inverse of that behavior.
