### PR TITLE
docs(RAC): FileType docs TypeScript fix

### DIFF
--- a/packages/react-aria-components/docs/FileTrigger.mdx
+++ b/packages/react-aria-components/docs/FileTrigger.mdx
@@ -49,7 +49,7 @@ function Example(){
     <>
       <FileTrigger
         onSelect={(e) => {
-          let files = Array.from(e);
+          let files = e ? Array.from(e) : [];
           let filenames = files.map((file) => file.name);
           setFile(filenames);
         }}>


### PR DESCRIPTION
Fixing a Typescript error in the FileType example, https://react-spectrum.adobe.com/react-aria/FileTrigger.html#example.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Copy the FileType "Example" into an IDE and confirm there are no TypeScript errors.