### PR TITLE
fix: updating visibleDuration now updates the output of useCalendarState

### DIFF
--- a/packages/@react-stately/calendar/src/utils.ts
+++ b/packages/@react-stately/calendar/src/utils.ts
@@ -70,6 +70,36 @@ export function alignEnd(date: CalendarDate, duration: DateDuration, locale: str
   return constrainStart(date, aligned, duration, locale, minValue, maxValue);
 }
 
+export function calculateStartDate(selectionAlignment: 'start' | 'end' | 'center' | undefined, focusedDate: CalendarDate, visibleDuration: DateDuration, locale: string, minValue: DateValue | null |undefined, maxValue: DateValue | null | undefined) : CalendarDate {
+  switch (selectionAlignment) {
+    case 'start':
+      return alignStart(
+        focusedDate,
+        visibleDuration,
+        locale,
+        minValue,
+        maxValue
+      );
+    case 'end':
+      return alignEnd(
+        focusedDate,
+        visibleDuration,
+        locale,
+        minValue,
+        maxValue
+      );
+    case 'center':
+    default:
+      return alignCenter(
+        focusedDate,
+        visibleDuration,
+        locale,
+        minValue,
+        maxValue
+      );
+  }
+}
+
 export function constrainStart(
   date: CalendarDate,
   aligned: CalendarDate,


### PR DESCRIPTION
Closes [7809](https://github.com/adobe/react-spectrum/issues/7809)

## ✅ Pull Request Checklist:

- [ ✅  ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
