### PR TITLE
fix: Correct the PortalProvider's getContainer typings

### DIFF
--- a/packages/@react-aria/overlays/src/PortalProvider.tsx
+++ b/packages/@react-aria/overlays/src/PortalProvider.tsx
@@ -14,7 +14,7 @@ import React, {createContext, ReactNode, useContext} from 'react';
 
 export interface PortalProviderProps {
   /** Should return the element where we should portal to. Can clear the context by passing null. */
-  getContainer?: (() => HTMLElement) | null,
+  getContainer?: (() => HTMLElement | null) | null,
   /** The content of the PortalProvider. Should contain all children that want to portal their overlays to the element returned by the provided `getContainer()`. */
   children: ReactNode
 }

--- a/packages/@react-aria/overlays/src/PortalProvider.tsx
+++ b/packages/@react-aria/overlays/src/PortalProvider.tsx
@@ -14,7 +14,7 @@ import React, {createContext, ReactNode, useContext} from 'react';
 
 export interface PortalProviderProps {
   /** Should return the element where we should portal to. Can clear the context by passing null. */
-  getContainer?: () => HTMLElement | null,
+  getContainer?: (() => HTMLElement) | null,
   /** The content of the PortalProvider. Should contain all children that want to portal their overlays to the element returned by the provided `getContainer()`. */
   children: ReactNode
 }


### PR DESCRIPTION
Closes 

There was a small issue in the `getContainer`'s typings. 

There is the following code
```
    <PortalContext.Provider value={{getContainer: getContainer === null ? undefined : getContainer ?? ctxGetContainer}}>
```

Which means `getContainer` is intented to be null sometimes. There is a comment that also imply this: 
```
Can clear the context by passing null.
```

But at the moment, `getContainer` does not accept the null value.

before: 
```
(() => HTMLElement | null) | undefined
```
now: 
```
(() => HTMLElement | null) | null | undefined
```

