### PR TITLE
chore: Temporarily add version postfix to style macro class names

### DIFF
--- a/packages/@react-spectrum/s2/style/__tests__/style-macro.test.js
+++ b/packages/@react-spectrum/s2/style/__tests__/style-macro.test.js
@@ -40,14 +40,14 @@ describe('style-macro', () => {
       "@layer _.a, _.b, _.c;
 
       @layer _.b {
-        .Jbs:first-child {
+        .Jbs8:first-child {
           margin-top: 0.25rem;
         }
       }
 
       @layer _.c.p {
         @media (min-width: 64rem) {
-          .Jbpv:first-child {
+          .Jbpv8:first-child {
             margin-top: 0.5rem;
           }
         }
@@ -55,7 +55,7 @@ describe('style-macro', () => {
 
       "
     `);
-    expect(js).toMatchInlineSnapshot('" Jbs Jbpv"');
+    expect(js).toMatchInlineSnapshot('" Jbs8 Jbpv8"');
   });
 
   it('should support self references', () => {
@@ -69,47 +69,47 @@ describe('style-macro', () => {
       "@layer _.a;
 
       @layer _.a {
-        ._kc {
+        ._kc8 {
           border-top-width: 2px;
         }
 
 
-        .hc {
+        .hc8 {
           border-bottom-width: 2px;
         }
 
 
-        .mCPFGYc {
+        .mCPFGYc8 {
           border-inline-start-width: var(--m);
         }
 
 
-        .lc {
+        .lc8 {
           border-inline-end-width: 2px;
         }
 
 
-        .SMBFGYc {
+        .SMBFGYc8 {
           padding-inline-start: var(--S);
         }
 
 
-        .Rv {
+        .Rv8 {
           padding-inline-end: calc(var(--F, var(--M)) * 3 / 8);
         }
 
 
-        .ZjUQgKd {
+        .ZjUQgKd8 {
           width: calc(200px - var(--m) - var(--S));
         }
 
 
-        .-m_-mc {
+        .-m_-mc8 {
           --m: 2px;
         }
 
 
-        .-S_-Sv {
+        .-S_-Sv8 {
           --S: calc(var(--F, var(--M)) * 3 / 8);
         }
       }
@@ -118,7 +118,7 @@ describe('style-macro', () => {
     `);
 
     expect(js).toMatchInlineSnapshot(
-      '" _kc hc mCPFGYc lc SMBFGYc Rv ZjUQgKd -m_-mc -S_-Sv"'
+      '" _kc8 hc8 mCPFGYc8 lc8 SMBFGYc8 Rv8 ZjUQgKd8 -m_-mc8 -S_-Sv8"'
     );
   });
 
@@ -136,9 +136,9 @@ describe('style-macro', () => {
       color: 'green-400'
     });
 
-    expect(js()).toMatchInlineSnapshot('"  gw pg"');
-    expect(overrides).toMatchInlineSnapshot('" g8tmWqb pHJ3AUd"');
-    expect(js({}, overrides)).toMatchInlineSnapshot('"  g8tmWqb pg"');
+    expect(js()).toMatchInlineSnapshot('"  gw8 pg8"');
+    expect(overrides).toMatchInlineSnapshot('" g8tmWqb8 pHJ3AUd8"');
+    expect(js({}, overrides)).toMatchInlineSnapshot('"  g8tmWqb8 pg8"');
   });
 
   it('should support allowed overrides for properties that expand into multiple', () => {
@@ -153,9 +153,9 @@ describe('style-macro', () => {
       translateX: 40
     });
 
-    expect(js()).toMatchInlineSnapshot('"  -_7PloMd-B __Ya"');
-    expect(overrides).toMatchInlineSnapshot('" -_7PloMd-D __Ya"');
-    expect(js({}, overrides)).toMatchInlineSnapshot('"  -_7PloMd-D __Ya"');
+    expect(js()).toMatchInlineSnapshot('"  -_7PloMd-B8 __Ya8"');
+    expect(overrides).toMatchInlineSnapshot('" -_7PloMd-D8 __Ya8"');
+    expect(js({}, overrides)).toMatchInlineSnapshot('"  -_7PloMd-D8 __Ya8"');
   });
 
   it('should support allowed overrides for shorthands', () => {
@@ -170,9 +170,9 @@ describe('style-macro', () => {
       padding: 40
     });
 
-    expect(js()).toMatchInlineSnapshot('"  Tk Qk Sk Rk"');
-    expect(overrides).toMatchInlineSnapshot('" Tm Qm Sm Rm"');
-    expect(js({}, overrides)).toMatchInlineSnapshot('"  Tm Qm Sm Rm"');
+    expect(js()).toMatchInlineSnapshot('"  Tk8 Qk8 Sk8 Rk8"');
+    expect(overrides).toMatchInlineSnapshot('" Tm8 Qm8 Sm8 Rm8"');
+    expect(js({}, overrides)).toMatchInlineSnapshot('"  Tm8 Qm8 Sm8 Rm8"');
   });
 
   it("should support allowed overrides for values that aren't defined", () => {
@@ -187,9 +187,9 @@ describe('style-macro', () => {
       minWidth: 32
     });
 
-    expect(js()).toMatchInlineSnapshot('"  gE"');
-    expect(overrides).toMatchInlineSnapshot('" Nk"');
-    expect(js({}, overrides)).toMatchInlineSnapshot('"  Nk gE"');
+    expect(js()).toMatchInlineSnapshot('"  gE8"');
+    expect(overrides).toMatchInlineSnapshot('" Nk8"');
+    expect(js({}, overrides)).toMatchInlineSnapshot('"  Nk8 gE8"');
   });
 
   it('should support runtime conditions', () => {
@@ -210,32 +210,32 @@ describe('style-macro', () => {
       "@layer _.a;
 
       @layer _.a {
-        .gH {
+        .gH8 {
           background-color: light-dark(rgb(233, 233, 233), rgb(44, 44, 44));
         }
 
 
-        .gF {
+        .gF8 {
           background-color: light-dark(rgb(225, 225, 225), rgb(50, 50, 50));
         }
 
 
-        .gE {
+        .gE8 {
           background-color: light-dark(rgb(218, 218, 218), rgb(57, 57, 57));
         }
 
 
-        .pt {
+        .pt8 {
           color: light-dark(rgb(41, 41, 41), rgb(219, 219, 219));
         }
 
 
-        .po {
+        .po8 {
           color: light-dark(rgb(19, 19, 19), rgb(242, 242, 242));
         }
 
 
-        .pm {
+        .pm8 {
           color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));
         }
       }
@@ -243,9 +243,9 @@ describe('style-macro', () => {
       "
     `);
 
-    expect(js({})).toMatchInlineSnapshot('"  gH pt"');
-    expect(js({isHovered: true})).toMatchInlineSnapshot('"  gF po"');
-    expect(js({isPressed: true})).toMatchInlineSnapshot('"  gE pm"');
+    expect(js({})).toMatchInlineSnapshot('"  gH8 pt8"');
+    expect(js({isHovered: true})).toMatchInlineSnapshot('"  gF8 po8"');
+    expect(js({isPressed: true})).toMatchInlineSnapshot('"  gE8 pm8"');
   });
 
   it('should support nested runtime conditions', () => {
@@ -264,33 +264,33 @@ describe('style-macro', () => {
       "@layer _.a;
 
       @layer _.a {
-        .gH {
+        .gH8 {
           background-color: light-dark(rgb(233, 233, 233), rgb(44, 44, 44));
         }
 
 
-        .gF {
+        .gF8 {
           background-color: light-dark(rgb(225, 225, 225), rgb(50, 50, 50));
         }
 
 
-        .g_h {
+        .g_h8 {
           background-color: light-dark(rgb(75, 117, 255), rgb(64, 105, 253));
         }
 
 
-        .g3 {
+        .g38 {
           background-color: light-dark(rgb(59, 99, 251), rgb(86, 129, 255));
         }
       }
 
       "
     `);
-    expect(js({})).toMatchInlineSnapshot('"  gH"');
-    expect(js({isHovered: true})).toMatchInlineSnapshot('"  gF"');
-    expect(js({isSelected: true})).toMatchInlineSnapshot('"  g_h"');
+    expect(js({})).toMatchInlineSnapshot('"  gH8"');
+    expect(js({isHovered: true})).toMatchInlineSnapshot('"  gF8"');
+    expect(js({isSelected: true})).toMatchInlineSnapshot('"  g_h8"');
     expect(js({isSelected: true, isHovered: true})).toMatchInlineSnapshot(
-      '"  g3"'
+      '"  g38"'
     );
   });
 
@@ -305,9 +305,9 @@ describe('style-macro', () => {
       }
     });
 
-    expect(js({variant: 'accent'})).toMatchInlineSnapshot('"  gY"');
-    expect(js({variant: 'primary'})).toMatchInlineSnapshot('"  gjQquMe"');
-    expect(js({variant: 'secondary'})).toMatchInlineSnapshot('"  gw"');
+    expect(js({variant: 'accent'})).toMatchInlineSnapshot('"  gY8"');
+    expect(js({variant: 'primary'})).toMatchInlineSnapshot('"  gjQquMe8"');
+    expect(js({variant: 'secondary'})).toMatchInlineSnapshot('"  gw8"');
   });
 
   it('supports runtime conditions nested inside css conditions', () => {
@@ -325,14 +325,14 @@ describe('style-macro', () => {
 
       @layer _.b.l {
         @media (forced-colors: active) {
-          .plb {
+          .plb8 {
             color: ButtonText;
           }
         }
 
 
         @media (forced-colors: active) {
-          .ple {
+          .ple8 {
             color: HighlightText;
           }
         }
@@ -341,8 +341,8 @@ describe('style-macro', () => {
       "
     `);
 
-    expect(js({})).toMatchInlineSnapshot('"  plb"');
-    expect(js({isSelected: true})).toMatchInlineSnapshot('"  ple"');
+    expect(js({})).toMatchInlineSnapshot('"  plb8"');
+    expect(js({isSelected: true})).toMatchInlineSnapshot('"  ple8"');
   });
 
   it('should expand shorthand properties to longhands', () => {
@@ -350,27 +350,27 @@ describe('style-macro', () => {
       padding: 24
     });
 
-    expect(js).toMatchInlineSnapshot('" Th Qh Sh Rh"');
+    expect(js).toMatchInlineSnapshot('" Th8 Qh8 Sh8 Rh8"');
     expect(css).toMatchInlineSnapshot(`
       "@layer _.a;
 
       @layer _.a {
-        .Th {
+        .Th8 {
           padding-top: 24px;
         }
 
 
-        .Qh {
+        .Qh8 {
           padding-bottom: 24px;
         }
 
 
-        .Sh {
+        .Sh8 {
           padding-inline-start: 24px;
         }
 
 
-        .Rh {
+        .Rh8 {
           padding-inline-end: 24px;
         }
       }
@@ -388,7 +388,7 @@ describe('style-macro', () => {
       "@layer _.a;
 
       @layer _.a {
-        .gpQzfVb {
+        .gpQzfVb8 {
           background-color: rgb(from light-dark(rgb(39, 77, 234), rgb(105, 149, 254)) r g b / 50%);
         }
       }
@@ -409,7 +409,7 @@ describe('style-macro', () => {
       "@layer _.a;
 
       @layer _.a {
-        .-FUeYm-gE {
+        .-FUeYm-gE8 {
           --foo: light-dark(rgb(218, 218, 218), rgb(57, 57, 57));
         }
       }

--- a/packages/@react-spectrum/s2/style/style-macro.ts
+++ b/packages/@react-spectrum/s2/style/style-macro.ts
@@ -11,7 +11,12 @@
  */
 
 import type {Condition, CSSProperties, CSSValue, CustomValue, Property, PropertyValueDefinition, PropertyValueMap, RenderProps, ShorthandProperty, StyleFunction, StyleValue, Theme, ThemeProperties, Value} from './types';
+import fs from 'fs';
 import * as propertyInfo from './properties.json';
+
+// Postfix all class names with version for now.
+const json = JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8'));
+const POSTFIX = json.version.replace(/[0.]/g, '');
 
 export class ArbitraryProperty<T extends Value> implements Property<T> {
   property: string;
@@ -541,6 +546,7 @@ export function createTheme<T extends Theme>(theme: T): StyleFunction<ThemePrope
           }
 
           className += propertyInfo.values[cssProperty]?.[String(value)] ?? generateArbitraryValueSelector(String(value));
+          className += POSTFIX;
           rules.push(new StyleRule(className, key, String(value)));
         }
 

--- a/packages/@react-spectrum/s2/style/style-macro.ts
+++ b/packages/@react-spectrum/s2/style/style-macro.ts
@@ -16,7 +16,7 @@ import * as propertyInfo from './properties.json';
 
 // Postfix all class names with version for now.
 const json = JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8'));
-const POSTFIX = json.version.replace(/[0.]/g, '');
+const POSTFIX = json.version.includes('nightly') ? json.version.match(/-nightly-(.*)/)[1] : json.version.replace(/[0.]/g, '');
 
 export class ArbitraryProperty<T extends Value> implements Property<T> {
   property: string;


### PR DESCRIPTION
We're not quite ready to stabilize the style macro class names in this release since we are still playing with how the CSS is generated. For now, add a postfix based on the version number so that the class names don't conflict with any prior or future versions.

This is not optimal long term since it forces browser cache invalidation on every upgrade even if the css did not change. We will aim to remove this before S2 reaches 1.0.