### PR TITLE
fix(s2): Add role=presentation to ListBox section headings

### DIFF
--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -304,7 +304,11 @@ export const ComboBox = /*#__PURE__*/ (forwardRef as forwardRefType)(function Co
               <Provider
                 values={[
                   [HeaderContext, {styles: sectionHeader({size})}],
-                  [HeadingContext, {styles: sectionHeading}],
+                  [HeadingContext, {
+                    // @ts-ignore
+                    role: 'presentation',
+                    styles: sectionHeading
+                  }],
                   [TextContext, {
                     slots: {
                       'description': {styles: description({size})}

--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -361,7 +361,11 @@ export const Menu = /*#__PURE__*/ (forwardRef as forwardRefType)(function Menu<T
       <Provider
         values={[
           [HeaderContext, {styles: sectionHeader({size})}],
-          [HeadingContext, {styles: sectionHeading}],
+          [HeadingContext, {
+            // @ts-ignore
+            role: 'presentation',
+            styles: sectionHeading
+          }],
           [TextContext, {
             slots: {
               'description': {styles: description({size})}

--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -395,7 +395,11 @@ export const Picker = /*#__PURE__*/ (forwardRef as forwardRefType)(function Pick
               <Provider
                 values={[
                   [HeaderContext, {styles: sectionHeader({size})}],
-                  [HeadingContext, {styles: sectionHeading}],
+                  [HeadingContext, {
+                    // @ts-ignore
+                    role: 'presentation',
+                    styles: sectionHeading
+                  }],
                   [TextContext, {
                     slots: {
                       description: {styles: description({size})}

--- a/packages/@react-spectrum/s2/src/TabsPicker.tsx
+++ b/packages/@react-spectrum/s2/src/TabsPicker.tsx
@@ -253,7 +253,11 @@ function Picker<T extends object>(props: PickerProps<T>, ref: FocusableRef<HTMLB
               <Provider
                 values={[
                   [HeaderContext, {styles: sectionHeader({size})}],
-                  [HeadingContext, {styles: sectionHeading}],
+                  [HeadingContext, {
+                    // @ts-ignore
+                    role: 'presentation',
+                    styles: sectionHeading
+                  }],
                   [TextContext, {
                     slots: {
                       description: {styles: description({size})}


### PR DESCRIPTION
The listbox aria pattern does not allow headings. For now apply `role="presentation"` like we did in v3 using ts-ignore. Further API discussions to be had in the future.