### PR TITLE
fix(ScrollView): don't report empty visible rect when the content suspends

### DIFF
--- a/packages/@react-aria/virtualizer/src/ScrollView.tsx
+++ b/packages/@react-aria/virtualizer/src/ScrollView.tsx
@@ -184,7 +184,7 @@ export function useScrollView(props: ScrollViewProps, ref: RefObject<HTMLElement
       // adjusted space. In very specific cases this might result in the scrollbars disappearing
       // again, resulting in extra padding. We stop after a maximum of two layout passes to avoid
       // an infinite loop. This matches how browsers behavior with native CSS grid layout.
-      if (!isTestEnv && clientWidth !== dom.clientWidth || clientHeight !== dom.clientHeight) {
+      if (!isTestEnv && (dom.checkVisibility?.() ?? true) && (clientWidth !== dom.clientWidth || clientHeight !== dom.clientHeight)) {
         state.width = dom.clientWidth;
         state.height = dom.clientHeight;
         flush(() => {


### PR DESCRIPTION
Closes #8214

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] ~~Added/updated unit tests and storybook for this change (for new code or code which already has tests).~~
   It requires in-browser testing environment. Let me know if you do have test setup with Cypress, Playwright or other such tools.
- [x] Filled out test instructions.
- [ ] ~~Updated documentation (if it already exists for this component).~~
   N/A
- [ ] ~~Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)~~
   N/A

## 📝 Test Instructions:

The reproduction codesandbox link provided in the issue can be used to test the fix..

## 🧢 Your Project:

https://github.com/alirezamirian/jui
