### PR TITLE
docs: fix tanstack router full ToOptions

### DIFF
--- a/packages/dev/docs/pages/react-aria/routing.mdx
+++ b/packages/dev/docs/pages/react-aria/routing.mdx
@@ -278,7 +278,7 @@ import {RouterProvider} from 'react-aria-components';
 
 declare module 'react-aria-components' {
   interface RouterConfig {
-    href: ToOptions['to'];
+    href: ToOptions;
     routerOptions: Omit<NavigateOptions, keyof ToOptions>;
   }
 }
@@ -287,8 +287,8 @@ function RootRoute() {
   let router = useRouter();
   return (
     <RouterProvider 
-      navigate={(to, options) => router.navigate({to, ...options})}
-      useHref={to => router.buildLocation({to}).href}>
+      navigate={(href, opts) => router.navigate({...href, ...options})}
+      useHref={href => router.buildLocation(href).href}>
       {/* ...*/}
     </RouterProvider>
   );


### PR DESCRIPTION
* Change href to use full tanstack router `ToOptions`
* Rename `to` param to `href` since it contains full ToOptions

The previous declarations using `to` doesn't allow for passing in `params`.