### PR TITLE
fix: Disclosure chevron appearance when title wraps

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/accordion/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/accordion/index.css
@@ -33,6 +33,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Accordion-itemIndicator {
   display: block;
+  flex-shrink: 0;
 
   padding-inline-start: var(--spectrum-accordion-icon-gap);
   padding-inline-end: var(--spectrum-accordion-icon-gap);

--- a/packages/@react-spectrum/accordion/chromatic/Accordion.stories.tsx
+++ b/packages/@react-spectrum/accordion/chromatic/Accordion.stories.tsx
@@ -99,3 +99,26 @@ export const Quiet = {
   render: Template,
   args: {isQuiet: true}
 };
+
+export const WithWrappingTitle = {
+  render: (args) => (
+    <Accordion maxWidth="size-3000" {...args}>
+      <Disclosure id="files">
+        <DisclosureTitle>
+          Long long long long long long long long long long long long long  long long long wrapping title 
+        </DisclosureTitle>
+        <DisclosurePanel>
+          Files content
+        </DisclosurePanel>
+      </Disclosure>
+      <Disclosure id="people">
+        <DisclosureTitle>
+          People
+        </DisclosureTitle>
+        <DisclosurePanel>
+          People content
+        </DisclosurePanel>
+      </Disclosure>
+    </Accordion>
+  )
+};

--- a/packages/@react-spectrum/accordion/chromatic/Disclosure.stories.tsx
+++ b/packages/@react-spectrum/accordion/chromatic/Disclosure.stories.tsx
@@ -46,3 +46,14 @@ export const Quiet = {
   render: Template,
   args: {isQuiet: true}
 };
+
+export const WrappingTitle = (args) => (
+  <Disclosure maxWidth="size-3000" {...args}>
+    <DisclosureTitle>
+      Long long long long long long long long long long long long long  long long long wrapping title 
+    </DisclosureTitle>
+    <DisclosurePanel>
+      Files content
+    </DisclosurePanel>
+  </Disclosure>
+);

--- a/packages/@react-spectrum/accordion/stories/Accordion.stories.tsx
+++ b/packages/@react-spectrum/accordion/stories/Accordion.stories.tsx
@@ -88,3 +88,26 @@ export const WithDisabledDisclosure: AccordionStory = {
     </Accordion>
   )
 };
+
+export const WithWrappingTitle: AccordionStory = {
+  render: (args) => (
+    <Accordion maxWidth="size-3000" {...args}>
+      <Disclosure id="files">
+        <DisclosureTitle>
+          Long long long long long long long long long long long long long  long long long wrapping title 
+        </DisclosureTitle>
+        <DisclosurePanel>
+          Files content
+        </DisclosurePanel>
+      </Disclosure>
+      <Disclosure id="people">
+        <DisclosureTitle>
+          People
+        </DisclosureTitle>
+        <DisclosurePanel>
+          People content
+        </DisclosurePanel>
+      </Disclosure>
+    </Accordion>
+  )
+};

--- a/packages/@react-spectrum/accordion/stories/Disclosure.stories.tsx
+++ b/packages/@react-spectrum/accordion/stories/Disclosure.stories.tsx
@@ -42,3 +42,16 @@ export const Default: DisclosureStory = {
     </Disclosure>
   )
 };
+
+export const WrappingTitle: DisclosureStory = {
+  render: (args) => (
+    <Disclosure maxWidth="size-3000" {...args}>
+      <DisclosureTitle>
+        Long long long long long long long long long long long long long  long long long wrapping title 
+      </DisclosureTitle>
+      <DisclosurePanel>
+        Files content
+      </DisclosurePanel>
+    </Disclosure>
+  )
+};


### PR DESCRIPTION
Before:
<img width="264" alt="Screenshot 2025-05-12 at 9 50 10 AM" src="https://github.com/user-attachments/assets/88ab264e-9703-4f2b-a8b3-6c70d51d51a9" />

After:
<img width="264" alt="Screenshot 2025-05-12 at 9 49 54 AM" src="https://github.com/user-attachments/assets/e843544e-acd5-4b00-9677-1e093d2da8cd" />



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check new stories:
- https://reactspectrum.blob.core.windows.net/reactspectrum/bc4a31946387368b9857890a509bed07a4d24cc1/storybook/index.html?path=/story/disclosure--wrapping-title&providerSwitcher-express=false
- https://reactspectrum.blob.core.windows.net/reactspectrum/bc4a31946387368b9857890a509bed07a4d24cc1/storybook/index.html?path=/story/accordion--with-wrapping-title&providerSwitcher-express=false

## 🧢 Your Project:

<!--- Company/project for pull request -->
