### PR TITLE
fix(useTreeData): stale duplicate items when moving to root

### DIFF
--- a/packages/@react-stately/data/test/useTreeData.test.js
+++ b/packages/@react-stately/data/test/useTreeData.test.js
@@ -610,6 +610,43 @@ describe('useTreeData', function () {
     expect(result.current.items[1].children[2]).toBe(
       initialResult.items[0].children[2]
     );
+
+    /*
+      Expected tree structure after moving 'Stacy' to root:
+      - Stacy
+      - David
+        |-- John
+        |   -- Suzie
+        |-- Sam
+        |   -- Brad
+        |-- Jane
+    */
+    let stacyNode = result.current.getItem('Stacy');
+    expect(stacyNode.parentKey).toBeNull();
+    expect(stacyNode.children).toHaveLength(0);
+    expect(stacyNode).toBe(result.current.items[0]);
+
+    let davidNode = result.current.getItem('David');
+    expect(davidNode.parentKey).toBeNull();
+    expect(davidNode.children.map(c => c.key)).toEqual(['John', 'Sam', 'Jane']);
+    expect(davidNode).toBe(result.current.items[1]);
+
+    let samNode = result.current.getItem('Sam');
+    expect(samNode.parentKey).toBe('David');
+    expect(samNode.children.map(c => c.key)).toEqual(['Brad']);
+    expect(samNode).toBe(result.current.items[1].children[1]);
+
+    let bradNode = result.current.getItem('Brad');
+    expect(bradNode.parentKey).toBe('Sam');
+    expect(bradNode).toBe(result.current.items[1].children[1].children[0]);
+
+    let johnNode = result.current.getItem('John');
+    expect(johnNode.parentKey).toBe('David');
+    expect(johnNode).toBe(result.current.items[1].children[0]);
+
+    let janeNode = result.current.getItem('Jane');
+    expect(janeNode.parentKey).toBe('David');
+    expect(janeNode).toBe(result.current.items[1].children[2]);
   });
 
   it('should move an item to a new index within its current parent', function () {
@@ -876,6 +913,7 @@ describe('useTreeData', function () {
       result.current.move('Eli', 'David', 1);
     });
     expect(result.current.items[0].key).toEqual('David');
+
     expect(result.current.items[0].children[0].key).toEqual('John');
     expect(result.current.items[0].children[1].key).toEqual('Eli');
     expect(result.current.items[1].key).toEqual('Emily');


### PR DESCRIPTION
Fixes a `RangeError: Maximum call stack size exceeded` error that could be reproduced by doing the following operations in the RAC Tree DnD stories:

1. Drag “Reports 1” to top of tree (above the first item)
2. Drag “Reports” to top of tree (above the first item)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
