### PR TITLE
fix: Tree Dnd updates

### DIFF
--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -16,7 +16,7 @@ import {DragEndEvent, DragItem, DropActivateEvent, DropEnterEvent, DropEvent, Dr
 import {getDragModality, getTypes} from './utils';
 import {isVirtualClick, isVirtualPointerEvent} from '@react-aria/utils';
 import type {LocalizedStringFormatter} from '@internationalized/string';
-import {useEffect, useState} from 'react';
+import {RefObject, useEffect, useState} from 'react';
 
 let dropTargets = new Map<Element, DropTarget>();
 let dropItems = new Map<Element, DroppableItem>();
@@ -32,7 +32,8 @@ interface DropTarget {
   onDropTargetEnter?: (target: DroppableCollectionTarget | null) => void,
   onDropActivate?: (e: DropActivateEvent, target: DroppableCollectionTarget | null) => void,
   onDrop?: (e: DropEvent, target: DroppableCollectionTarget | null) => void,
-  onKeyDown?: (e: KeyboardEvent, dragTarget: DragTarget) => void
+  onKeyDown?: (e: KeyboardEvent, dragTarget: DragTarget) => void,
+  activateButtonRef?: RefObject<FocusableElement | null>
 }
 
 export function registerDropTarget(target: DropTarget) {
@@ -47,7 +48,8 @@ export function registerDropTarget(target: DropTarget) {
 interface DroppableItem {
   element: FocusableElement,
   target: DroppableCollectionTarget,
-  getDropOperation?: (types: Set<string>, allowedOperations: DropOperation[]) => DropOperation
+  getDropOperation?: (types: Set<string>, allowedOperations: DropOperation[]) => DropOperation,
+  activateButtonRef?: RefObject<FocusableElement | null>
 }
 
 export function registerDropItem(item: DroppableItem) {
@@ -241,7 +243,7 @@ class DragSession {
     this.cancelEvent(e);
 
     if (e.key === 'Enter') {
-      if (e.altKey) {
+      if (e.altKey || e.target === this.getCurrentActivateButton()) {
         this.activate();
       } else {
         this.drop();
@@ -249,7 +251,18 @@ class DragSession {
     }
   }
 
+  getCurrentActivateButton(): FocusableElement | null {
+    return this.currentDropItem?.activateButtonRef?.current ?? this.currentDropTarget?.activateButtonRef?.current ?? null;
+  }
+
   onFocus(e: FocusEvent) {
+    let activateButton = this.getCurrentActivateButton();
+    if (e.target === activateButton) {
+      // TODO: canceling this breaks the focus ring. Revisit when we support tabbing.
+      this.cancelEvent(e);
+      return;
+    }
+
     // Prevent focus events, except to the original drag target.
     if (e.target !== this.dragTarget.element) {
       this.cancelEvent(e);
@@ -265,6 +278,9 @@ class DragSession {
       this.validDropTargets.find(target => target.element.contains(e.target as HTMLElement));
 
     if (!dropTarget) {
+      // if (e.target === activateButton) {
+      //   activateButton.focus();
+      // }
       if (this.currentDropTarget) {
         this.currentDropTarget.element.focus();
       } else {
@@ -274,10 +290,18 @@ class DragSession {
     }
 
     let item = dropItems.get(e.target as HTMLElement);
-    this.setCurrentDropTarget(dropTarget, item);
+    if (dropTarget) {
+      this.setCurrentDropTarget(dropTarget, item);
+    }
   }
 
   onBlur(e: FocusEvent) {
+    let activateButton = this.getCurrentActivateButton();
+    if (e.relatedTarget === activateButton) {
+      this.cancelEvent(e);
+      return;
+    }
+
     if (e.target !== this.dragTarget.element) {
       this.cancelEvent(e);
     }
@@ -296,6 +320,11 @@ class DragSession {
   onClick(e: MouseEvent) {
     this.cancelEvent(e);
     if (isVirtualClick(e) || this.isVirtualClick) {
+      if (e.target === this.getCurrentActivateButton()) {
+        this.activate();
+        return;
+      }
+
       if (e.target === this.dragTarget.element) {
         this.cancel();
         return;
@@ -319,7 +348,7 @@ class DragSession {
 
   cancelEvent(e: Event) {
     // Allow focusin and focusout on the drag target so focus ring works properly.
-    if ((e.type === 'focusin' || e.type === 'focusout') && e.target === this.dragTarget?.element) {
+    if ((e.type === 'focusin' || e.type === 'focusout') && (e.target === this.dragTarget?.element || e.target === this.getCurrentActivateButton())) {
       return;
     }
 
@@ -375,14 +404,23 @@ class DragSession {
 
     this.restoreAriaHidden = ariaHideOutside([
       this.dragTarget.element,
-      ...validDropItems.map(item => item.element),
-      ...visibleDropTargets.map(target => target.element)
+      ...validDropItems.flatMap(item => item.activateButtonRef?.current ? [item.element, item.activateButtonRef?.current] : [item.element]),
+      ...visibleDropTargets.flatMap(target => target.activateButtonRef?.current ? [target.element, target.activateButtonRef?.current] : [target.element]),
     ]);
 
     this.mutationObserver.observe(document.body, {subtree: true, attributes: true, attributeFilter: ['aria-hidden']});
   }
 
   next() {
+    // TODO: Allow tabbing to the activate button. Revisit once we fix the focus ring.
+    // For now, the activate button is reachable by screen readers and ArrowLeft/ArrowRight
+    // is usable specifically by Tree. Will need tabbing for other components.
+    // let activateButton = this.getCurrentActivateButton();
+    // if (activateButton && document.activeElement !== activateButton) {
+    //   activateButton.focus();
+    //   return;
+    // }
+
     if (!this.currentDropTarget) {
       this.setCurrentDropTarget(this.validDropTargets[0]);
       return;
@@ -409,6 +447,15 @@ class DragSession {
   }
 
   previous() {
+    // let activateButton = this.getCurrentActivateButton();
+    // if (activateButton && document.activeElement === activateButton) {
+    //   let target = this.currentDropItem ?? this.currentDropTarget;
+    //   if (target) {
+    //     target.element.focus();
+    //     return;
+    //   }
+    // }
+
     if (!this.currentDropTarget) {
       this.setCurrentDropTarget(this.validDropTargets[this.validDropTargets.length - 1]);
       return;
@@ -487,7 +534,6 @@ class DragSession {
       if (this.currentDropTarget && typeof this.currentDropTarget.onDropTargetEnter === 'function') {
         this.currentDropTarget.onDropTargetEnter(item.target);
       }
-
       item.element.focus();
       this.currentDropItem = item;
 
@@ -578,12 +624,13 @@ class DragSession {
 
   activate() {
     if (this.currentDropTarget && typeof this.currentDropTarget.onDropActivate === 'function') {
+      let target = this.currentDropItem?.target ?? null;
       let rect = this.currentDropTarget.element.getBoundingClientRect();
       this.currentDropTarget.onDropActivate({
         type: 'dropactivate',
         x: rect.left + (rect.width / 2),
         y: rect.top + (rect.height / 2)
-      }, null);
+      }, target);
     }
   }
 }

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -320,7 +320,7 @@ class DragSession {
   onClick(e: MouseEvent) {
     this.cancelEvent(e);
     if (isVirtualClick(e) || this.isVirtualClick) {
-      if (e.target === this.getCurrentActivateButton()) {
+      if (this.getCurrentActivateButton()?.contains(e.target as Node)) {
         this.activate();
         return;
       }

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -624,7 +624,7 @@ class DragSession {
     announce(this.stringFormatter.format('dropComplete'));
   }
 
-  activate(dropTarget: DropTarget | null, dropItem: DroppableItem | null) {
+  activate(dropTarget: DropTarget | null, dropItem: DroppableItem | null | undefined) {
     if (dropTarget && typeof dropTarget.onDropActivate === 'function') {
       let target = dropItem?.target ?? null;
       let rect = dropTarget.element.getBoundingClientRect();

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -321,7 +321,7 @@ class DragSession {
     this.cancelEvent(e);
     if (isVirtualClick(e) || this.isVirtualClick) {
       let dropElements = dropItems.values();
-      let item = [...dropElements].find(item => item.element === e.target as HTMLElement || item.activateButtonRef?.current === e.target as HTMLElement);
+      let item = [...dropElements].find(item =>  item.activateButtonRef?.current?.contains(e.target as HTMLElement));
       let dropTarget = this.validDropTargets.find(target => target.element.contains(e.target as HTMLElement));
       let activateButton = item?.activateButtonRef?.current ?? dropTarget?.activateButtonRef?.current;
       if (activateButton?.contains(e.target as HTMLElement) && dropTarget) {

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -243,7 +243,7 @@ class DragSession {
     this.cancelEvent(e);
 
     if (e.key === 'Enter') {
-      if (e.altKey || e.target === this.getCurrentActivateButton()) {
+      if (e.altKey || this.getCurrentActivateButton()?.contains(e.target as Node)) {
         this.activate();
       } else {
         this.drop();

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -321,7 +321,7 @@ class DragSession {
     this.cancelEvent(e);
     if (isVirtualClick(e) || this.isVirtualClick) {
       let dropElements = dropItems.values();
-      let item = [...dropElements].find(item =>  item.activateButtonRef?.current?.contains(e.target as HTMLElement));
+      let item = [...dropElements].find(item => item.element === e.target as HTMLElement || item.activateButtonRef?.current?.contains(e.target as HTMLElement));
       let dropTarget = this.validDropTargets.find(target => target.element.contains(e.target as HTMLElement));
       let activateButton = item?.activateButtonRef?.current ?? dropTarget?.activateButtonRef?.current;
       if (activateButton?.contains(e.target as HTMLElement) && dropTarget) {

--- a/packages/@react-aria/dnd/src/DragManager.ts
+++ b/packages/@react-aria/dnd/src/DragManager.ts
@@ -405,7 +405,7 @@ class DragSession {
     this.restoreAriaHidden = ariaHideOutside([
       this.dragTarget.element,
       ...validDropItems.flatMap(item => item.activateButtonRef?.current ? [item.element, item.activateButtonRef?.current] : [item.element]),
-      ...visibleDropTargets.flatMap(target => target.activateButtonRef?.current ? [target.element, target.activateButtonRef?.current] : [target.element]),
+      ...visibleDropTargets.flatMap(target => target.activateButtonRef?.current ? [target.element, target.activateButtonRef?.current] : [target.element])
     ]);
 
     this.mutationObserver.observe(document.body, {subtree: true, attributes: true, attributeFilter: ['aria-hidden']});

--- a/packages/@react-aria/dnd/src/useDropIndicator.ts
+++ b/packages/@react-aria/dnd/src/useDropIndicator.ts
@@ -12,7 +12,7 @@
 
 import * as DragManager from './DragManager';
 import {DroppableCollectionState} from '@react-stately/dnd';
-import {DropTarget, Key, RefObject} from '@react-types/shared';
+import {DropTarget, FocusableElement, Key, RefObject} from '@react-types/shared';
 import {getDroppableCollectionId} from './utils';
 import {HTMLAttributes} from 'react';
 // @ts-ignore
@@ -23,7 +23,9 @@ import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 export interface DropIndicatorProps {
   /** The drop target that the drop indicator represents. */
-  target: DropTarget
+  target: DropTarget,
+  /** The ref to the activate button. */
+  activateButtonRef?: RefObject<FocusableElement | null>
 }
 
 export interface DropIndicatorAria {

--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -30,7 +30,6 @@ import {
   DropTargetDelegate,
   Key,
   KeyboardDelegate,
-  KeyboardEvents,
   Node,
   RefObject
 } from '@react-types/shared';
@@ -48,7 +47,8 @@ export interface DroppableCollectionOptions extends DroppableCollectionProps {
   keyboardDelegate: KeyboardDelegate,
   /** A delegate object that provides drop targets for pointer coordinates within the collection. */
   dropTargetDelegate: DropTargetDelegate,
-  onKeyDown?: KeyboardEvents['onKeyDown']
+  /** A custom keyboard event handler for drop targets. */
+  onKeyDown?: (e: KeyboardEvent) => void
 }
 
 export interface DroppableCollectionResult {
@@ -94,6 +94,7 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
       onRootDrop,
       onItemDrop,
       onReorder,
+      onMove,
       acceptedDragTypes = 'all',
       shouldAcceptItemDrop
     } = localState.props;
@@ -134,9 +135,13 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
         await onRootDrop({items: filteredItems, dropOperation});
       }
 
-      if (target.type === 'item') {
+      if (target.type === 'item') {        
         if (target.dropPosition === 'on' && onItemDrop) {
           await onItemDrop({items: filteredItems, dropOperation, isInternal, target});
+        }
+
+        if (onMove && isInternal) {
+          await onMove({keys: draggingKeys, dropOperation, target});
         }
 
         if (target.dropPosition !== 'on') {
@@ -750,7 +755,7 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
             break;
           }
         }
-        localState.props.onKeyDown?.(e as any);
+        localState.props.onKeyDown?.(e);
       }
     });
   }, [localState, ref, onDrop, direction]);

--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -135,7 +135,7 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
         await onRootDrop({items: filteredItems, dropOperation});
       }
 
-      if (target.type === 'item') {        
+      if (target.type === 'item') {
         if (target.dropPosition === 'on' && onItemDrop) {
           await onItemDrop({items: filteredItems, dropOperation, isInternal, target});
         }
@@ -595,17 +595,17 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
       onDropTargetEnter(target) {
         localState.state.setTarget(target);
       },
-      onDropActivate(e) {
+      onDropActivate(e, target) {
         if (
-          localState.state.target?.type === 'item' &&
-          localState.state.target?.dropPosition === 'on' &&
+          target?.type === 'item' &&
+          target?.dropPosition === 'on' &&
           typeof localState.props.onDropActivate === 'function'
         ) {
           localState.props.onDropActivate({
             type: 'dropactivate',
             x: e.x, // todo
             y: e.y,
-            target: localState.state.target
+            target
           });
         }
       },

--- a/packages/@react-aria/dnd/src/useDroppableItem.ts
+++ b/packages/@react-aria/dnd/src/useDroppableItem.ts
@@ -12,14 +12,16 @@
 
 import * as DragManager from './DragManager';
 import {DroppableCollectionState} from '@react-stately/dnd';
-import {DropTarget, RefObject} from '@react-types/shared';
+import {DropTarget, FocusableElement, RefObject} from '@react-types/shared';
 import {getDroppableCollectionRef, getTypes, globalDndState, isInternalDropOperation} from './utils';
 import {HTMLAttributes, useEffect} from 'react';
 import {useVirtualDrop} from './useVirtualDrop';
 
 export interface DroppableItemOptions {
   /** The drop target represented by the item. */
-  target: DropTarget
+  target: DropTarget,
+  /** The ref to the activate button. */
+  activateButtonRef?: RefObject<FocusableElement | null>
 }
 
 export interface DroppableItemResult {
@@ -50,10 +52,11 @@ export function useDroppableItem(options: DroppableItemOptions, state: Droppable
             isInternal,
             draggingKeys
           });
-        }
+        },
+        activateButtonRef: options.activateButtonRef
       });
     }
-  }, [ref, options.target, state, droppableCollectionRef]);
+  }, [ref, options.target, state, droppableCollectionRef, options.activateButtonRef]);
 
   let dragSession = DragManager.useDragSession();
   let {draggingKeys} = globalDndState;

--- a/packages/@react-stately/dnd/src/useDroppableCollectionState.ts
+++ b/packages/@react-stately/dnd/src/useDroppableCollectionState.ts
@@ -59,6 +59,7 @@ export function useDroppableCollectionState(props: DroppableCollectionStateOptio
     onRootDrop,
     onItemDrop,
     onReorder,
+    onMove,
     shouldAcceptItemDrop,
     collection,
     selectionManager,
@@ -95,13 +96,32 @@ export function useDroppableCollectionState(props: DroppableCollectionStateOptio
 
     if (acceptedDragTypes === 'all' || acceptedDragTypes.some(type => types.has(type))) {
       let isValidInsert = onInsert && target.type === 'item' && !isInternal && (target.dropPosition === 'before' || target.dropPosition === 'after');
-      let isValidReorder = onReorder && target.type === 'item' && isInternal && (target.dropPosition === 'before' || target.dropPosition === 'after');
+      let isValidReorder = onReorder
+        && target.type === 'item'
+        && isInternal
+        && (target.dropPosition === 'before' || target.dropPosition === 'after')
+        && isDraggingWithinParent(collection, target, draggingKeys);
+
+      let isItemDropAllowed = target.type !== 'item'
+        || target.dropPosition !== 'on'
+        || (!shouldAcceptItemDrop || shouldAcceptItemDrop(target, types));
+
+      let isValidMove = onMove
+        && target.type === 'item'
+        && isInternal
+        && isItemDropAllowed;
+
       // Feedback was that internal root drop was weird so preventing that from happening
       let isValidRootDrop = onRootDrop && target.type === 'root' && !isInternal;
+      
       // Automatically prevent items (i.e. folders) from being dropped on themselves.
-      let isValidOnItemDrop = onItemDrop && target.type === 'item' && target.dropPosition === 'on' && !(isInternal && target.key != null && draggingKeys.has(target.key)) && (!shouldAcceptItemDrop || shouldAcceptItemDrop(target, types));
+      let isValidOnItemDrop = onItemDrop 
+        && target.type === 'item' 
+        && target.dropPosition === 'on' 
+        && !(isInternal && target.key != null && draggingKeys.has(target.key)) 
+        && isItemDropAllowed;
 
-      if (onDrop || isValidInsert || isValidReorder || isValidRootDrop || isValidOnItemDrop) {
+      if (onDrop || isValidInsert || isValidReorder || isValidMove || isValidRootDrop || isValidOnItemDrop) {
         if (getDropOperation) {
           return getDropOperation(target, types, allowedOperations);
         } else {
@@ -111,7 +131,7 @@ export function useDroppableCollectionState(props: DroppableCollectionStateOptio
     }
 
     return 'cancel';
-  }, [isDisabled, acceptedDragTypes, getDropOperation, onInsert, onRootDrop, onItemDrop, shouldAcceptItemDrop, onReorder, onDrop]);
+  }, [isDisabled, collection, acceptedDragTypes, getDropOperation, onInsert, onRootDrop, onItemDrop, shouldAcceptItemDrop, onReorder, onMove, onDrop]);
 
   return {
     collection,
@@ -186,4 +206,17 @@ function isEqualDropTarget(a?: DropTarget | null, b?: DropTarget | null) {
     case 'item':
       return b?.type === 'item' && b?.key === a.key && b?.dropPosition === a.dropPosition;
   }
+}
+
+function isDraggingWithinParent(collection: Collection<Node<unknown>>, target: ItemDropTarget, draggingKeys: Set<Key>) {
+  let targetNode = collection.getItem(target.key);
+
+  for (let key of draggingKeys) {
+    let node = collection.getItem(key);
+    if (node?.parentKey !== targetNode?.parentKey) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/packages/@react-types/shared/src/dnd.d.ts
+++ b/packages/@react-types/shared/src/dnd.d.ts
@@ -218,9 +218,17 @@ export interface DroppableCollectionUtilityOptions {
    */
   onItemDrop?: (e: DroppableCollectionOnItemDropEvent) => void,
   /**
-   * Handler that is called when items are reordered via drag in the source collection.
+   * Handler that is called when items are reordered within the collection.
+   * This handler only allows dropping between items, not on items.
+   * It does not allow moving items to a different parent item within a tree.
    */
   onReorder?: (e: DroppableCollectionReorderEvent) => void,
+  /**
+   * Handler that is called when items are moved within the source collection.
+   * This handler allows dropping both on or between items, and items may be
+   * moved to a different parent item within a tree.
+   */
+  onMove?: (e: DroppableCollectionReorderEvent) => void,
   /**
    * A function returning whether a given target in the droppable collection is a valid "on" drop target for the current drag types.
    */

--- a/packages/@react-types/shared/src/dnd.d.ts
+++ b/packages/@react-types/shared/src/dnd.d.ts
@@ -240,7 +240,6 @@ export interface DroppableCollectionBaseProps {
   onDropEnter?: (e: DroppableCollectionEnterEvent) => void,
   /**
    * Handler that is called after a valid drag is held over a drop target for a period of time.
-   * @private
    */
   onDropActivate?: (e: DroppableCollectionActivateEvent) => void,
   /** Handler that is called when a valid drag exits a drop target. */

--- a/packages/react-aria-components/example/index.css
+++ b/packages/react-aria-components/example/index.css
@@ -11,6 +11,16 @@ html {
   width: 300px;
   height: 300px;
   overflow: auto;
+
+  :global(.react-aria-DropIndicator) {
+    margin-left: calc(var(--tree-item-level) * 15px);
+  }
+
+  &[data-drop-target] {
+    outline: 2px solid purple;
+    outline-offset: -2px;
+    background: rgb(from purple r g b / 20%);
+  }
 }
 
 .tree-item {
@@ -51,6 +61,12 @@ html {
   &.selected {
     background: lightseagreen;
     color: white;
+  }
+
+  &.drop-target {
+    outline: 2px solid purple;
+    outline-offset: -2px;
+    background: rgb(from purple r g b / 20%);
   }
 }
 

--- a/packages/react-aria-components/example/index.css
+++ b/packages/react-aria-components/example/index.css
@@ -46,6 +46,11 @@ html {
   [slot=chevron] {
     width: 20px;
     height: 20px;
+    outline: none;
+
+    &[data-focus-visible] {
+      outline: 2px solid purple;
+    }
   }
 
   &.focus-visible {

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -288,11 +288,12 @@ function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInne
           }
         },
         onDropActivate: (e) => {
-          // Expand collapsed item when dragging over
+          // Expand collapsed item when dragging over. For keyboard, allow collapsing.
           if (e.target.type === 'item') {
             let key = e.target.key;
             let item = state.collection.getItem(key);
-            if (item && item.hasChildNodes && expandedKeys !== 'all' && !expandedKeys.has(key)) {
+            let isExpanded = expandedKeys !== 'all' && expandedKeys.has(key);
+            if (item && item.hasChildNodes && (!isExpanded || dragAndDropHooks?.isVirtualDragging?.())) {
               state.toggleKey(key);
             }
           }
@@ -522,11 +523,13 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent('item', <T extends o
   }
 
   let dropIndicator: DropIndicatorAria | null = null;
+  let expandButtonRef = useRef<HTMLButtonElement>(null);
   let dropIndicatorRef = useRef<HTMLDivElement>(null);
   let {visuallyHiddenProps} = useVisuallyHidden();
   if (dropState && dragAndDropHooks) {
     dropIndicator = dragAndDropHooks.useDropIndicator!({
-      target: {type: 'item', key: item.key, dropPosition: 'on'}
+      target: {type: 'item', key: item.key, dropPosition: 'on'},
+      activateButtonRef: expandButtonRef
     }, dropState, dropIndicatorRef);
   }
 
@@ -570,7 +573,6 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent('item', <T extends o
     }
   }, [item.textValue]);
 
-  let expandButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     if (hasChildItems && !expandButtonRef.current && process.env.NODE_ENV !== 'production') {
       console.warn('Expandable tree items must contain a expand button so screen reader users can expand/collapse the item.');

--- a/packages/react-aria-components/src/useDragAndDrop.tsx
+++ b/packages/react-aria-components/src/useDragAndDrop.tsx
@@ -104,6 +104,7 @@ export function useDragAndDrop(options: DragAndDropOptions): DragAndDrop {
       onInsert,
       onItemDrop,
       onReorder,
+      onMove,
       onRootDrop,
       getItems,
       renderDragPreview,
@@ -112,7 +113,7 @@ export function useDragAndDrop(options: DragAndDropOptions): DragAndDrop {
     } = options;
 
     let isDraggable = !!getItems;
-    let isDroppable = !!(onDrop || onInsert || onItemDrop || onReorder || onRootDrop);
+    let isDroppable = !!(onDrop || onInsert || onItemDrop || onReorder || onMove || onRootDrop);
 
     let hooks = {} as DragAndDropHooks;
     if (isDraggable) {

--- a/packages/react-aria-components/stories/Tree.stories.tsx
+++ b/packages/react-aria-components/stories/Tree.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {Button, Checkbox, CheckboxProps, Collection, Key, ListLayout, Menu, MenuTrigger, Popover, Text, Tree, TreeItem, TreeItemContent, TreeItemProps, TreeProps, useDragAndDrop, Virtualizer} from 'react-aria-components';
+import {Button, Checkbox, CheckboxProps, Collection, DroppableCollectionReorderEvent, isTextDropItem, Key, ListLayout, Menu, MenuTrigger, Popover, Text, Tree, TreeItem, TreeItemContent, TreeItemProps, TreeProps, useDragAndDrop, Virtualizer} from 'react-aria-components';
 import {classNames} from '@react-spectrum/utils';
 import {MyMenuItem} from './utils';
 import React, {ReactNode} from 'react';
@@ -238,11 +238,12 @@ const DynamicTreeItem = (props: DynamicTreeItemProps) => {
     <>
       <TreeItem
         {...props}
-        className={({isFocused, isSelected, isHovered, isFocusVisible}) => classNames(styles, 'tree-item', {
+        className={({isFocused, isSelected, isHovered, isFocusVisible, isDropTarget}) => classNames(styles, 'tree-item', {
           focused: isFocused,
           'focus-visible': isFocusVisible,
           selected: isSelected,
-          hovered: isHovered
+          hovered: isHovered,
+          'drop-target': isDropTarget
         })}>
         <TreeItemContent>
           {({isExpanded, hasChildItems, level, selectionBehavior, selectionMode}) => (
@@ -565,16 +566,24 @@ function TreeDragAndDropExample(args) {
   });
 
   let getItems = (keys) => [...keys].map(key => {
-    let item = treeData.getItem(key);
+    let item = treeData.getItem(key)!;
     return {
-      'text/plain': item?.value.name
+      'text/plain': item.value.name,
+      'tree-item': JSON.stringify(item.value)
     };
   });
 
   let {dragAndDropHooks} = useDragAndDrop({
     getItems,
     getAllowedDropOperations: () => ['move'],
-    onReorder(e) {
+    shouldAcceptItemDrop: (target) => {
+      if (args.shouldAcceptItemDrop === 'folders') {
+        let item = treeData.getItem(target.key);
+        return item?.value?.childItems?.length > 0;
+      }
+      return true;
+    },
+    [args.dropFunction]: (e: DroppableCollectionReorderEvent) => {
       console.log(`moving [${[...e.keys].join(',')}] ${e.target.dropPosition} ${e.target.key}`);
       try {
         if (e.target.dropPosition === 'before') {
@@ -610,7 +619,86 @@ function TreeDragAndDropExample(args) {
   );
 }
 
+function SecondTree(args) {
+  let treeData = useTreeData<any>({
+    initialItems: [],
+    getKey: item => item.id,
+    getChildren: item => item.childItems
+  });
+
+  let getItems = async (e) => {
+    return await Promise.all(e.items.filter(isTextDropItem).map(async item => {
+      let parsed = JSON.parse(await item.getText('tree-item'));
+      let convertItem = item => ({
+        ...item,
+        id: Math.random().toString(36),
+        childItems: item.childItems?.map(convertItem)
+      });
+      return convertItem(parsed);
+    }));
+  };
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    acceptedDragTypes: ['tree-item'],
+    async onInsert(e) {
+      let items = await getItems(e);
+      if (e.target.dropPosition === 'before') {
+        treeData.insertBefore(e.target.key, ...items);
+      } else if (e.target.dropPosition === 'after') {
+        treeData.insertAfter(e.target.key, ...items);
+      }
+    },
+    async onItemDrop(e) {
+      let items = await getItems(e);
+      treeData.insert(e.target.key, 0, ...items);
+    },
+    async onRootDrop(e) {
+      let items = await getItems(e);
+      treeData.insert(null, 0, ...items);
+    }
+  });
+
+  return (
+    <Tree 
+      dragAndDropHooks={dragAndDropHooks} 
+      {...args} 
+      className={styles.tree} 
+      aria-label="Tree with drag and drop" 
+      items={treeData.items}
+      renderEmptyState={() => 'Drop items here'}>
+      {(item: any) => (
+        <DynamicTreeItem id={item.key} childItems={item.children ?? []} textValue={item.value.name} supportsDragging>
+          {item.value.name}
+        </DynamicTreeItem>
+      )}
+    </Tree>
+  );
+}
+
 export const TreeWithDragAndDrop = {
   ...TreeExampleDynamic,
-  render: TreeDragAndDropExample
+  render: function TreeDndExample(args) {
+    return (
+      <div style={{display: 'flex', gap: 12}}>
+        <TreeDragAndDropExample {...args} />
+        <SecondTree {...args} />
+      </div>
+    );
+  },
+  args: {
+    dropFunction: 'onMove',
+    shouldAcceptItemDrop: 'all',
+    ...TreeExampleDynamic.args
+  },
+  argTypes: {
+    dropFunction: {
+      control: 'radio',
+      options: ['onMove', 'onReorder']
+    },
+    shouldAcceptItemDrop: {
+      control: 'radio',
+      options: ['all', 'folders']
+    },
+    ...TreeExampleDynamic.argTypes
+  }
 };


### PR DESCRIPTION
* Support onMove event, which allows moving between parents. onReorder now only allows reordering within the same parent.
* Fix accessibility of drop indicators (they should have role=row/gridcell instead of role=option)
* Fix dropping between the parent item and its first child
* Made ArrowLeft/ArrowRight to expand while dragging work while focused on the item rather than the drop indicator after it. Also fixed RTL
* Made the chevron visible to screen readers so mobile users can expand/collapse an item while dragging. For now, this is not tabbable (since keyboard users can use arrow keys to expand/collapse). This will be needed for other components, but needs further work on propagating the focus event so the focus ring becomes visible.