### PR TITLE
fix: selected item scrolls into view in rac select story

### DIFF
--- a/packages/react-aria-components/stories/Select.stories.tsx
+++ b/packages/react-aria-components/stories/Select.stories.tsx
@@ -146,23 +146,23 @@ export const AsyncVirtualizedCollectionRenderSelect = (args) => {
         <span aria-hidden="true" style={{paddingLeft: 25}}>▼</span>
       </Button>
       <Virtualizer
-          layout={ListLayout}
-          layoutOptions={{
-            rowHeight: 25,
-            loaderHeight: 30
-          }}>
+        layout={ListLayout}
+        layoutOptions={{
+          rowHeight: 25,
+          loaderHeight: 30
+        }}>
         <Popover>
           <OverlayArrow>
             <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>
           </OverlayArrow>
-            <ListBox className={styles.menu}>
-              <Collection items={list.items}>
-                {item => (
-                  <MyListBoxItem id={item.name}>{item.name}</MyListBoxItem>
-                )}
-              </Collection>
-              <MyListBoxLoaderIndicator isLoading={list.loadingState === 'loadingMore'} onLoadMore={list.loadMore} />
-            </ListBox>
+          <ListBox className={styles.menu}>
+            <Collection items={list.items}>
+              {item => (
+                <MyListBoxItem id={item.name}>{item.name}</MyListBoxItem>
+              )}
+            </Collection>
+            <MyListBoxLoaderIndicator isLoading={list.loadingState === 'loadingMore'} onLoadMore={list.loadMore} />
+          </ListBox>
         </Popover>
       </Virtualizer>
     </Select>

--- a/packages/react-aria-components/stories/Select.stories.tsx
+++ b/packages/react-aria-components/stories/Select.stories.tsx
@@ -145,26 +145,26 @@ export const AsyncVirtualizedCollectionRenderSelect = (args) => {
         {list.isLoading && <LoadingSpinner style={{right: '20px', left: 'unset', top: '0px', height: '100%', width: 20}} />}
         <span aria-hidden="true" style={{paddingLeft: 25}}>▼</span>
       </Button>
-      <Popover>
-        <OverlayArrow>
-          <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>
-        </OverlayArrow>
-        <Virtualizer
+      <Virtualizer
           layout={ListLayout}
           layoutOptions={{
             rowHeight: 25,
             loaderHeight: 30
           }}>
-          <ListBox className={styles.menu}>
-            <Collection items={list.items}>
-              {item => (
-                <MyListBoxItem id={item.name}>{item.name}</MyListBoxItem>
-              )}
-            </Collection>
-            <MyListBoxLoaderIndicator isLoading={list.loadingState === 'loadingMore'} onLoadMore={list.loadMore} />
-          </ListBox>
-        </Virtualizer>
-      </Popover>
+        <Popover>
+          <OverlayArrow>
+            <svg width={12} height={12}><path d="M0 0,L6 6,L12 0" /></svg>
+          </OverlayArrow>
+            <ListBox className={styles.menu}>
+              <Collection items={list.items}>
+                {item => (
+                  <MyListBoxItem id={item.name}>{item.name}</MyListBoxItem>
+                )}
+              </Collection>
+              <MyListBoxLoaderIndicator isLoading={list.loadingState === 'loadingMore'} onLoadMore={list.loadMore} />
+            </ListBox>
+        </Popover>
+      </Virtualizer>
     </Select>
   );
 };


### PR DESCRIPTION
Pretty sure this is the same issue I encountered with S2 Picker where we fixed the Virtualized RAC Select but S2 Picker still wasn't scrolling into view. 

For details about this issue, see [comment](https://github.com/adobe/react-spectrum/pull/8110#discussion_r2076319076)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test Async Virtualized Collection Rendered Select story and make sure the selected item scrolls into view

## 🧢 Your Project:

<!--- Company/project for pull request -->
