### PR TITLE
chore(s2): update migration guide and codemods for release

### DIFF
--- a/.storybook-s2/docs/Migrating.jsx
+++ b/.storybook-s2/docs/Migrating.jsx
@@ -349,6 +349,7 @@ export function Migrating() {
           <li className={style({font: 'body', marginY: 8})}>For <Code>Column</Code> and <Code>Row</Code>: Update <Code>key</Code> to be <Code>id</Code> (and keep <Code>key</Code> if rendered inside <Code>array.map</Code>)</li>
           <li className={style({font: 'body', marginY: 8})}>For dynamic tables, pass a <Code>columns</Code> prop into <Code>Row</Code></li>
           <li className={style({font: 'body', marginY: 8})}>For <Code>Row</Code>: Update dynamic render function to pass in <Code>column</Code> instead of <Code>columnKey</Code></li>
+          <li className={style({font: 'body', marginY: 8})}>Move <Code>loadingState</Code> and <Code>onLoadMore</Code> from <Code>TableBody</Code> to <Code>TableView</Code></li>
           <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>UNSTABLE_allowsExpandableRows</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>UNSTABLE_onExpandedChange</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>UNSTABLE_expandedKeys</Code> (it has not been implemented yet)</li>

--- a/.storybook-s2/docs/Migrating.jsx
+++ b/.storybook-s2/docs/Migrating.jsx
@@ -106,7 +106,6 @@ export function Migrating() {
           <li className={style({font: 'body', marginY: 8})}>Change <Code>variant="cta"</Code> to <Code>variant="accent"</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>variant="overBackground"</Code> to <Code>variant="primary" staticColor="white"</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>style</Code> to <Code>fillStyle</Code></li>
-          <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>isPending</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({font: 'body', marginY: 8})}>If <Code>href</Code> is present, the <Code>Button</Code> should be converted to a <Code>LinkButton</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>elementType</Code> (it is no longer supported in Spectrum 2)</li>

--- a/.storybook-s2/docs/Migrating.jsx
+++ b/.storybook-s2/docs/Migrating.jsx
@@ -276,8 +276,6 @@ export function Migrating() {
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>isLoading</Code> (it has not been implemented yet)</li>
-          <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>onLoadMore</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Update <Code>Item</Code> to be a <Code>PickerItem</Code></li>
         </ul>
 

--- a/.storybook-s2/docs/Migrating.jsx
+++ b/.storybook-s2/docs/Migrating.jsx
@@ -152,11 +152,9 @@ export function Migrating() {
         <ul className="sb-unstyled">
           <li className={style({font: 'body', marginY: 8})}>Change <Code>menuWidth</Code> value from a <Code>DimensionValue</Code> to a pixel value</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>loadingState</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>placeholder</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>onLoadMore</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Update <Code>Item</Code> to be a <Code>ComboBoxItem</Code></li>
         </ul>
 

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/button.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/button.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Comments out isPending 1`] = `
-"import { Button } from "@react-spectrum/s2";
-
-<div>
-  // TODO(S2-upgrade): isPending has not been implemented yet.
-  <Button>Test</Button>
-  // TODO(S2-upgrade): isPending has not been implemented yet.
-  <Button>Test</Button>
-</div>"
-`;
-
 exports[`Converts Button to LinkButton if it has href prop 1`] = `
 "import { LinkButton, Button } from "@react-spectrum/s2";
 
@@ -33,6 +22,15 @@ import {FakeComponent} from 'fake-package';
     Test
     <FakeComponent variant="overBackground">Test</FakeComponent>
   </Button>
+</div>"
+`;
+
+exports[`Keeps isPending 1`] = `
+"import { Button } from "@react-spectrum/s2";
+
+<div>
+  <Button isPending>Test</Button>
+  <Button isPending={true}>Test</Button>
 </div>"
 `;
 

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/combobox.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/combobox.test.ts.snap
@@ -42,6 +42,20 @@ const items = [
 </div>"
 `;
 
+exports[`Keeps loadingState and onLoadMore 1`] = `
+"import { ComboBoxItem, ComboBox } from "@react-spectrum/s2";
+  <>
+    <ComboBox loadingState="loading" onLoadMore={() => {}}>
+      <ComboBoxItem>Red Panda</ComboBoxItem>
+      <ComboBoxItem>Cat</ComboBoxItem>
+    </ComboBox>
+    <ComboBox loadingState={true ? 'loading' : 'idle'} onLoadMore={() => {}}>
+      <ComboBoxItem>Red Panda</ComboBoxItem>
+      <ComboBoxItem>Cat</ComboBoxItem>
+    </ComboBox>
+  </>"
+`;
+
 exports[`Removes isQuiet 1`] = `
 "import { ComboBoxItem, ComboBox } from "@react-spectrum/s2";
 let isQuiet = true;

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
@@ -25,6 +25,20 @@ let options = [
 </div>"
 `;
 
+exports[`Keeps isLoading and onLoadMore 1`] = `
+"import { PickerItem, Picker } from "@react-spectrum/s2";
+    <>
+      <Picker label="Ice Cream" isLoading onLoadMore={() => {}}>
+        <PickerItem>Red Panda</PickerItem>
+        <PickerItem>Cat</PickerItem>
+      </Picker>
+      <Picker label="Ice Cream" isLoading={false} onLoadMore={() => {}}>
+        <PickerItem>Red Panda</PickerItem>
+        <PickerItem>Cat</PickerItem>
+      </Picker>
+    </>"
+`;
+
 exports[`Static - Converts menuWidth to px value 1`] = `
 "import { PickerItem, Picker } from "@react-spectrum/s2";
 let menuWidth = 'size-10';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/table.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/table.test.ts.snap
@@ -249,6 +249,27 @@ let items = [
 </TableView>"
 `;
 
+exports[`Move loadingState and onLoadMore from TableBody to TableView 1`] = `
+"import { Cell, Column, Row, TableBody, TableHeader, TableView } from "@react-spectrum/s2";
+
+<TableView loadingState="loading" onLoadMore={() => {}}>
+  <TableHeader>
+    <Column id="test" isRowHeader={true}>Test</Column>
+    <Column id="blah">Blah</Column>
+  </TableHeader>
+  <TableBody>
+    <Row>
+      <Cell>Test1</Cell>
+      <Cell>One</Cell>
+    </Row>
+    <Row>
+      <Cell>Test2</Cell>
+      <Cell>One</Cell>
+    </Row>
+  </TableBody>
+</TableView>"
+`;
+
 exports[`Static TableView 1`] = `
 "import { Cell, Column, Row, TableBody, TableHeader, TableView } from "@react-spectrum/s2";
 

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/button.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/button.test.ts
@@ -24,7 +24,7 @@ import {Button as RSPButton} from '@adobe/react-spectrum';
 </div>
 `);
 
-test('Comments out isPending', `
+test('Keeps isPending', `
 import {Button} from '@adobe/react-spectrum';
 
 <div>

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/combobox.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/combobox.test.ts
@@ -223,3 +223,17 @@ import {ComboBox, Section, Item} from '@adobe/react-spectrum';
   </Section>
 </ComboBox>
 `);
+
+test('Keeps loadingState and onLoadMore', `
+  import {ComboBox, Section, Item} from '@adobe/react-spectrum';
+  <>
+    <ComboBox loadingState="loading" onLoadMore={() => {}}>
+      <Item>Red Panda</Item>
+      <Item>Cat</Item>
+    </ComboBox>
+    <ComboBox loadingState={true ? 'loading' : 'idle'} onLoadMore={() => {}}>
+      <Item>Red Panda</Item>
+      <Item>Cat</Item>
+    </ComboBox>
+  </>
+  `);

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
@@ -148,3 +148,17 @@ import {Picker, Section, Item} from '@adobe/react-spectrum';
   </Section>
 </Picker>
 `);
+
+test('Keeps isLoading and onLoadMore', `
+  import {Picker, Section, Item} from '@adobe/react-spectrum';
+    <>
+      <Picker label="Ice Cream" isLoading onLoadMore={() => {}}>
+        <Item>Red Panda</Item>
+        <Item>Cat</Item>
+      </Picker>
+      <Picker label="Ice Cream" isLoading={false} onLoadMore={() => {}}>
+        <Item>Red Panda</Item>
+        <Item>Cat</Item>
+      </Picker>
+    </>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/table.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/table.test.ts
@@ -265,3 +265,24 @@ let items = [
   </TableBody>
 </TableView>
 `);
+
+test('Move loadingState and onLoadMore from TableBody to TableView', `
+import {Cell, Column, Row, TableBody, TableHeader, TableView}  from '@adobe/react-spectrum';
+
+<TableView>
+  <TableHeader>
+    <Column key="test">Test</Column>
+    <Column key="blah">Blah</Column>
+  </TableHeader>
+  <TableBody loadingState="loading" onLoadMore={() => {}}>
+    <Row>
+      <Cell>Test1</Cell>
+      <Cell>One</Cell>
+    </Row>
+    <Row>
+      <Cell>Test2</Cell>
+      <Cell>One</Cell>
+    </Row>
+  </TableBody>
+</TableView>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Button/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Button/transform.ts
@@ -1,12 +1,11 @@
+import {NodePath} from '@babel/traverse';
 import {
-  commentOutProp,
   removeProp,
   updateComponentIfPropPresent,
   updatePropName,
   updatePropNameAndValue,
   updatePropValueAndAddNewPropName
 } from '../../shared/transforms';
-import {NodePath} from '@babel/traverse';
 import * as t from '@babel/types';
 
 /**
@@ -14,7 +13,6 @@ import * as t from '@babel/types';
  * - Change variant="cta" to variant="accent"
  * - Change variant="overBackground" to variant="primary" staticColor="white"
  * - Change style to fillStyle
- * - Comment out isPending (it has not been implemented yet)
  * - Remove isQuiet (it is no longer supported in Spectrum 2)
  * - If href is present, the Button should be converted to a LinkButton
  * - Remove elementType (it is no longer supported in Spectrum 2).
@@ -43,9 +41,6 @@ export default function transformButton(path: NodePath<t.JSXElement>) {
     oldPropName: 'style',
     newPropName: 'fillStyle'
   });
-
-  // Comment out isPending
-  commentOutProp(path, {propName: 'isPending'});
 
   // Remove isQuiet
   removeProp(path, {propName: 'isQuiet'});

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
@@ -1,5 +1,4 @@
 import {
-  commentOutProp,
   convertDimensionValueToPx,
   removeProp,
   updatePropNameAndValue

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
@@ -11,11 +11,9 @@ import * as t from '@babel/types';
  * Transforms ComboBox:
  * - Change menuWidth value from a DimensionValue to a pixel value.
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
- * - Comment out loadingState (it has not been implemented yet).
  * - Remove placeholder (it is no longer supported in Spectrum 2).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
- * - Comment out onLoadMore (it has not been implemented yet).
  */
 export default function transformComboBox(path: NodePath<t.JSXElement>) {
   // Change menuWidth value from a DimensionValue to a pixel value

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
@@ -24,9 +24,6 @@ export default function transformComboBox(path: NodePath<t.JSXElement>) {
   // Remove isQuiet
   removeProp(path, {propName: 'isQuiet'});
 
-  // Comment out loadingState
-  commentOutProp(path, {propName: 'loadingState'});
-
   // Remove placeholder
   removeProp(path, {propName: 'placeholder'});
 
@@ -40,7 +37,4 @@ export default function transformComboBox(path: NodePath<t.JSXElement>) {
 
   // Remove validationState="valid"
   removeProp(path, {propName: 'validationState', propValue: 'valid'});
-
-  // Comment out onLoadMore
-  commentOutProp(path, {propName: 'onLoadMore'});
 } 

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Picker/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Picker/transform.ts
@@ -1,5 +1,4 @@
 import {
-  commentOutProp,
   convertDimensionValueToPx,
   removeProp,
   updatePropNameAndValue
@@ -13,8 +12,6 @@ import * as t from '@babel/types';
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
- * - Comment out isLoading (it has not been implemented yet).
- * - Comment out onLoadMore (it has not been implemented yet).
  */
 export default function transformPicker(path: NodePath<t.JSXElement>) {
   // Change menuWidth value from a DimensionValue to a pixel value
@@ -33,10 +30,4 @@ export default function transformPicker(path: NodePath<t.JSXElement>) {
 
   // Remove validationState="valid"
   removeProp(path, {propName: 'validationState', propValue: 'valid'});
-
-  // Comment out isLoading
-  commentOutProp(path, {propName: 'isLoading'});
-
-  // Comment out onLoadMore
-  commentOutProp(path, {propName: 'onLoadMore'});
 } 


### PR DESCRIPTION
Updates the S2 migration guide and codemods to be up to date for the upcoming release including:
- ComboBox: `onLoadmore` and `loadingState` are no longer commented out
- Picker: `onLoadmore` and `isLoading` are no longer commented out
- Button: `isPending` is no longer commented out
- TableView: `onLoadmore` and `loadingState` move from TableBody to TableView

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
