### PR TITLE
fix: prevent disabled item from receiving focus when clicked

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -382,7 +382,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
   return {
     itemProps: mergeProps(
       itemProps,
-      allowsSelection || hasPrimaryAction || shouldUseVirtualFocus ? pressProps : {},
+      allowsSelection || hasPrimaryAction || (shouldUseVirtualFocus && !isDisabled) ? pressProps : {},
       longPressEnabled ? longPressProps : {},
       {onDoubleClick, onDragStartCapture, onClick, id},
       // Prevent DOM focus from moving on mouse down when using virtual focus


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8116

Pretty sure it broke in this commit? https://github.com/adobe/react-spectrum/pull/7561/commits/7fd803a4a85e03d605aa798b2ad1cbdb1cd5bcc6

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test RAC Combobox disabled options in the docs. You should not be able to select a disabled item. Would be good to check other collection components that contain selectable items that can be disabled

## 🧢 Your Project:

<!--- Company/project for pull request -->
