### PR TITLE
fix: Fix crash on defaultItems in S2 Combobox

### DIFF
--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -433,6 +433,7 @@ const ComboboxInner = forwardRef(function ComboboxInner(props: ComboBoxProps<any
     description: descriptionMessage,
     errorMessage,
     children,
+    defaultItems,
     items,
     size = 'M',
     labelPosition = 'top',
@@ -555,10 +556,10 @@ const ComboboxInner = forwardRef(function ComboboxInner(props: ComboBoxProps<any
     </UNSTABLE_ListBoxLoadingSentinel>
   );
 
-  if (typeof children === 'function' && items) {
+  if (typeof children === 'function') {
     renderer = (
       <>
-        <Collection items={items}>
+        <Collection items={items ?? defaultItems}>
           {children}
         </Collection>
         {listBoxLoadingCircle}

--- a/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
@@ -95,7 +95,7 @@ export const Dynamic: Story = {
   ),
   args: {
     label: 'Favorite ice cream flavor',
-    items
+    defaultItems: items
   }
 };
 
@@ -106,7 +106,7 @@ function VirtualizedCombobox(props) {
   }
 
   return (
-    <ComboBox {...props} items={items}>
+    <ComboBox {...props} defaultItems={items}>
       {(item) => <ComboBoxItem id={(item as IExampleItem).id} textValue={(item as IExampleItem).label}>{(item as IExampleItem).label}</ComboBoxItem>}
     </ComboBox>
   );


### PR DESCRIPTION
Noticed in my local test app that the `defaultItems` prop stopped working in S2 ComboBox. It caused a React crash on "Functions are not valid as a react child", due to the if statement only checking for items and not defaultItems. Apparently we had no stories for this case, so I modified a couple.