### PR TITLE
fix: Improve tree dnd keyboard navigation

### DIFF
--- a/packages/@react-aria/dnd/package.json
+++ b/packages/@react-aria/dnd/package.json
@@ -28,6 +28,7 @@
     "@react-aria/live-announcer": "^3.4.2",
     "@react-aria/overlays": "^3.27.1",
     "@react-aria/utils": "^3.29.0",
+    "@react-stately/collections": "^3.12.4",
     "@react-stately/dnd": "^3.5.4",
     "@react-types/button": "^3.12.1",
     "@react-types/shared": "^3.29.1",

--- a/packages/@react-aria/dnd/src/DropTargetKeyboardNavigation.ts
+++ b/packages/@react-aria/dnd/src/DropTargetKeyboardNavigation.ts
@@ -1,0 +1,273 @@
+import {Collection, DropTarget, Key, KeyboardDelegate, Node} from '@react-types/shared';
+import {getChildNodes} from '@react-stately/collections';
+
+export function navigate(
+  keyboardDelegate: KeyboardDelegate,
+  collection: Collection<Node<unknown>>,
+  target: DropTarget | null | undefined,
+  direction: 'left' | 'right' | 'up' | 'down',
+  rtl = false,
+  wrap = false
+): DropTarget | null {
+  switch (direction) {
+    case 'left':
+      return rtl 
+        ? nextDropTarget(keyboardDelegate, collection, target, wrap, 'left')
+        : previousDropTarget(keyboardDelegate, collection, target, wrap, 'left');
+    case 'right':
+      return rtl 
+        ? previousDropTarget(keyboardDelegate, collection, target, wrap, 'right')
+        : nextDropTarget(keyboardDelegate, collection, target, wrap, 'right');
+    case 'up':
+      return previousDropTarget(keyboardDelegate, collection, target, wrap);
+    case 'down':
+      return nextDropTarget(keyboardDelegate, collection, target, wrap);
+  }
+}
+
+function nextDropTarget(
+  keyboardDelegate: KeyboardDelegate,
+  collection: Collection<Node<unknown>>,
+  target: DropTarget | null | undefined,
+  wrap = false,
+  horizontal: 'left' | 'right' | null = null
+): DropTarget | null {
+  if (!target) {
+    return {
+      type: 'root'
+    };
+  }
+
+  if (target.type === 'root') {
+    let nextKey = keyboardDelegate.getFirstKey?.() ?? null;
+    if (nextKey != null) {
+      return {
+        type: 'item',
+        key: nextKey,
+        dropPosition: 'before'
+      };
+    }
+
+    return null;
+  }
+
+  if (target.type === 'item') {
+    let nextKey: Key | null | undefined = null;
+    if (horizontal) {
+      nextKey = horizontal === 'right' ? keyboardDelegate.getKeyRightOf?.(target.key) : keyboardDelegate.getKeyLeftOf?.(target.key);
+    } else {
+      nextKey = keyboardDelegate.getKeyBelow?.(target.key);
+    }
+    let nextCollectionKey = collection.getKeyAfter(target.key);
+
+    // If the keyboard delegate did not move to the next key in the collection,
+    // jump to that key with the same drop position. Otherwise, try the other
+    // drop positions on the current key first.
+    if (nextKey != null && nextKey !== nextCollectionKey) {
+      return {
+        type: 'item',
+        key: nextKey,
+        dropPosition: target.dropPosition
+      };
+    }
+    
+    switch (target.dropPosition) {
+      case 'before': {
+        return {
+          type: 'item',
+          key: target.key,
+          dropPosition: 'on'
+        };
+      }
+      case 'on': {
+        // If there are nested items, traverse to them prior to the "after" position of this target.
+        // If the next key is on the same level, then its "before" position is equivalent to this item's "after" position.
+        let targetNode = collection.getItem(target.key);
+        let nextNode = nextKey != null ? collection.getItem(nextKey) : null;
+        if (targetNode && nextNode && nextNode.level >= targetNode.level) {
+          return {
+            type: 'item',
+            key: nextNode.key,
+            dropPosition: 'before'
+          };
+        }
+
+        return {
+          type: 'item',
+          key: target.key,
+          dropPosition: 'after'
+        };
+      }
+      case 'after': {
+        // If this is the last sibling in a level, traverse to the parent.
+        let targetNode = collection.getItem(target.key);        
+        if (targetNode && targetNode.nextKey == null && targetNode.parentKey != null) {
+          // If the parent item has an item after it, use the "before" position.
+          let parentNode = collection.getItem(targetNode.parentKey);
+          if (parentNode?.nextKey != null) {
+            return {
+              type: 'item',
+              key: parentNode.nextKey,
+              dropPosition: 'before'
+            };
+          }
+
+          if (parentNode) {
+            return {
+              type: 'item',
+              key: parentNode.key,
+              dropPosition: 'after'
+            };
+          }
+        }
+
+        if (targetNode?.nextKey != null) {
+          return {
+            type: 'item',
+            key: targetNode.nextKey,
+            dropPosition: 'on'
+          };
+        }
+      }
+    }
+  }
+
+  if (wrap) {
+    return {
+      type: 'root'
+    };
+  }
+
+  return null;
+}
+
+function previousDropTarget(
+  keyboardDelegate: KeyboardDelegate,
+  collection: Collection<Node<unknown>>,
+  target: DropTarget | null | undefined,
+  wrap = false,
+  horizontal: 'left' | 'right' | null = null
+): DropTarget | null {
+  // Start after the last root-level item.
+  if (!target || (wrap && target.type === 'root')) {
+    // Keyboard delegate gets the deepest item but we want the shallowest.
+    let prevKey: Key | null = null;
+    let lastKey = keyboardDelegate.getLastKey?.();
+    while (lastKey != null) {
+      prevKey = lastKey;
+      let node = collection.getItem(lastKey);
+      lastKey = node?.parentKey;
+    }
+
+    if (prevKey != null) {
+      return {
+        type: 'item',
+        key: prevKey,
+        dropPosition: 'after'
+      };
+    }
+
+    return null;
+  }
+
+  if (target.type === 'item') {
+    let prevKey: Key | null | undefined = null;
+    if (horizontal) {
+      prevKey = horizontal === 'left' ? keyboardDelegate.getKeyLeftOf?.(target.key) : keyboardDelegate.getKeyRightOf?.(target.key);
+    } else {
+      prevKey = keyboardDelegate.getKeyAbove?.(target.key);
+    }
+    let prevCollectionKey = collection.getKeyBefore(target.key);
+
+    // If the keyboard delegate did not move to the next key in the collection,
+    // jump to that key with the same drop position. Otherwise, try the other
+    // drop positions on the current key first.
+    if (prevKey != null && prevKey !== prevCollectionKey) {
+      return {
+        type: 'item',
+        key: prevKey,
+        dropPosition: target.dropPosition
+      };
+    }
+
+    switch (target.dropPosition) {
+      case 'before': {
+        // Move after the last child of the previous item.
+        let targetNode = collection.getItem(target.key);
+        if (targetNode && targetNode.prevKey != null) {
+          let lastChild = getLastChild(collection, targetNode.prevKey);
+          if (lastChild) {
+            return lastChild;
+          }
+        }
+
+        if (prevKey != null) {
+          return {
+            type: 'item',
+            key: prevKey,
+            dropPosition: 'on'
+          };
+        }
+
+        return {
+          type: 'root'
+        };
+      }
+      case 'on': {
+        return {
+          type: 'item',
+          key: target.key,
+          dropPosition: 'before'
+        };
+      }
+      case 'after': {
+        // Move after the last child of this item.
+        let lastChild = getLastChild(collection, target.key);
+        if (lastChild) {
+          return lastChild;
+        }
+
+        return {
+          type: 'item',
+          key: target.key,
+          dropPosition: 'on'
+        };
+      }
+    }
+  }
+
+  if (target.type !== 'root') {
+    return {
+      type: 'root'
+    };
+  }
+
+  return null;
+}
+
+function getLastChild(collection: Collection<Node<unknown>>, key: Key): DropTarget | null {
+  // getChildNodes still returns child tree items even when the item is collapsed.
+  // Checking if the next item has a greater level is a silly way to determine if the item is expanded.
+  let targetNode = collection.getItem(key);
+  let nextKey = collection.getKeyAfter(key);
+  let nextNode = nextKey != null ? collection.getItem(nextKey) : null;
+  if (targetNode && nextNode && nextNode.level > targetNode.level) {
+    let children = getChildNodes(targetNode, collection);
+    let lastChild: Node<unknown> | null = null;
+    for (let child of children) {
+      if (child.type === 'item') {
+        lastChild = child;
+      }
+    }
+
+    if (lastChild) {
+      return {
+        type: 'item',
+        key: lastChild.key,
+        dropPosition: 'after'
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/@react-aria/dnd/src/useDropIndicator.ts
+++ b/packages/@react-aria/dnd/src/useDropIndicator.ts
@@ -71,28 +71,32 @@ export function useDropIndicator(props: DropIndicatorProps, state: DroppableColl
   } else {
     let before: Key | null | undefined;
     let after: Key | null | undefined;
-    if (collection.getFirstKey() === target.key && target.dropPosition === 'before') {
-      before = null;
+    if (target.dropPosition === 'before') {
+      let prevKey = collection.getItem(target.key)?.prevKey;
+      let prevNode = prevKey != null ? collection.getItem(prevKey) : null;
+      before = prevNode?.type === 'item' ? prevNode.key : null;
     } else {
-      before = target.dropPosition === 'before' ? collection.getKeyBefore(target.key) : target.key;
+      before = target.key;
     }
 
-    if (collection.getLastKey() === target.key && target.dropPosition === 'after') {
-      after = null;
+    if (target.dropPosition === 'after') {
+      let nextKey = collection.getItem(target.key)?.nextKey;
+      let nextNode = nextKey != null ? collection.getItem(nextKey) : null;
+      after = nextNode?.type === 'item' ? nextNode.key : null;
     } else {
-      after = target.dropPosition === 'after' ? collection.getKeyAfter(target.key) : target.key;
+      after = target.key;
     }
 
-    if (before && after) {
+    if (before != null && after != null) {
       label = stringFormatter.format('insertBetween', {
         beforeItemText: getText(before),
         afterItemText: getText(after)
       });
-    } else if (before) {
+    } else if (before != null) {
       label = stringFormatter.format('insertAfter', {
         itemText: getText(before)
       });
-    } else if (after) {
+    } else if (after != null) {
       label = stringFormatter.format('insertBefore', {
         itemText: getText(after)
       });

--- a/packages/@react-aria/dnd/src/useDroppableCollection.ts
+++ b/packages/@react-aria/dnd/src/useDroppableCollection.ts
@@ -37,6 +37,7 @@ import * as DragManager from './DragManager';
 import {DroppableCollectionState} from '@react-stately/dnd';
 import {HTMLAttributes, useCallback, useEffect, useRef} from 'react';
 import {mergeProps, useId, useLayoutEffect} from '@react-aria/utils';
+import {navigate} from './DropTargetKeyboardNavigation';
 import {setInteractionModality} from '@react-aria/interactions';
 import {useAutoScroll} from './useAutoScroll';
 import {useDrop} from './useDrop';
@@ -65,9 +66,6 @@ interface DroppingState {
   isInternal: boolean,
   timeout: ReturnType<typeof setTimeout> | undefined
 }
-
-const DROP_POSITIONS: DropPosition[] = ['before', 'on', 'after'];
-const DROP_POSITIONS_RTL: DropPosition[] = ['after', 'on', 'before'];
 
 /**
  * Handles drop interactions for a collection component, with support for traditional mouse and touch
@@ -371,118 +369,12 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
       return;
     }
 
-    let getNextTarget = (target: DropTarget | null | undefined, wrap = true, horizontal = false): DropTarget | null => {
-      if (!target) {
-        return {
-          type: 'root'
-        };
-      }
-
-      let {keyboardDelegate} = localState.props;
-      let nextKey: Key | null | undefined;
-      if (target?.type === 'item') {
-        nextKey = horizontal ? keyboardDelegate.getKeyRightOf?.(target.key) : keyboardDelegate.getKeyBelow?.(target.key);
-      } else {
-        nextKey = horizontal && direction === 'rtl' ? keyboardDelegate.getLastKey?.() : keyboardDelegate.getFirstKey?.();
-      }
-      let dropPositions = horizontal && direction === 'rtl' ? DROP_POSITIONS_RTL : DROP_POSITIONS;
-      let dropPosition: DropPosition = dropPositions[0];
-
-      if (target.type === 'item') {
-        // If the the keyboard delegate returned the next key in the collection,
-        // first try the other positions in the current key. Otherwise (e.g. in a grid layout),
-        // jump to the same drop position in the new key.
-        let nextCollectionKey = horizontal && direction === 'rtl' ? localState.state.collection.getKeyBefore(target.key) : localState.state.collection.getKeyAfter(target.key);
-        if (nextKey == null || nextKey === nextCollectionKey) {
-          let positionIndex = dropPositions.indexOf(target.dropPosition);
-          let nextDropPosition = dropPositions[positionIndex + 1];
-          if (positionIndex < dropPositions.length - 1 && !(nextDropPosition === dropPositions[2] && nextKey != null)) {
-            return {
-              type: 'item',
-              key: target.key,
-              dropPosition: nextDropPosition
-            };
-          }
-
-          // If the last drop position was 'after', then 'before' on the next key is equivalent.
-          // Switch to 'on' instead.
-          if (target.dropPosition === dropPositions[2]) {
-            dropPosition = 'on';
-          }
-        } else {
-          dropPosition = target.dropPosition;
-        }
-      }
-
-      if (nextKey == null) {
-        if (wrap) {
-          return {
-            type: 'root'
-          };
-        }
-
-        return null;
-      }
-
-      return {
-        type: 'item',
-        key: nextKey,
-        dropPosition
-      };
+    let getNextTarget = (target: DropTarget | null | undefined, wrap = true, key: 'left' | 'right' | 'up' | 'down' = 'down') => {
+      return navigate(localState.props.keyboardDelegate, localState.state.collection, target, key, direction === 'rtl', wrap);
     };
 
-    let getPreviousTarget = (target: DropTarget | null | undefined, wrap = true, horizontal = false): DropTarget | null => {
-      let {keyboardDelegate} = localState.props;
-      let nextKey: Key | null | undefined;
-      if (target?.type === 'item') {
-        nextKey = horizontal ? keyboardDelegate.getKeyLeftOf?.(target.key) : keyboardDelegate.getKeyAbove?.(target.key);
-      } else {
-        nextKey = horizontal && direction === 'rtl' ? keyboardDelegate.getFirstKey?.() : keyboardDelegate.getLastKey?.();
-      }
-      let dropPositions = horizontal && direction === 'rtl' ? DROP_POSITIONS_RTL : DROP_POSITIONS;
-      let dropPosition: DropPosition = !target || target.type === 'root' ? dropPositions[2] : 'on';
-
-      if (target?.type === 'item') {
-        // If the the keyboard delegate returned the previous key in the collection,
-        // first try the other positions in the current key. Otherwise (e.g. in a grid layout),
-        // jump to the same drop position in the new key.
-        let prevCollectionKey = horizontal && direction === 'rtl' ? localState.state.collection.getKeyAfter(target.key) : localState.state.collection.getKeyBefore(target.key);
-        if (nextKey == null || nextKey === prevCollectionKey) {
-          let positionIndex = dropPositions.indexOf(target.dropPosition);
-          let nextDropPosition = dropPositions[positionIndex - 1];
-          if (positionIndex > 0 && nextDropPosition !== dropPositions[2]) {
-            return {
-              type: 'item',
-              key: target.key,
-              dropPosition: nextDropPosition
-            };
-          }
-
-          // If the last drop position was 'before', then 'after' on the previous key is equivalent.
-          // Switch to 'on' instead.
-          if (target.dropPosition === dropPositions[0]) {
-            dropPosition = 'on';
-          }
-        } else {
-          dropPosition = target.dropPosition;
-        }
-      }
-
-      if (nextKey == null) {
-        if (wrap) {
-          return {
-            type: 'root'
-          };
-        }
-
-        return null;
-      }
-
-      return {
-        type: 'item',
-        key: nextKey,
-        dropPosition
-      };
+    let getPreviousTarget = (target: DropTarget | null | undefined, wrap = true) => {
+      return getNextTarget(target, wrap, 'up');
     };
 
     let nextValidTarget = (
@@ -621,28 +513,28 @@ export function useDroppableCollection(props: DroppableCollectionOptions, state:
         switch (e.key) {
           case 'ArrowDown': {
             if (keyboardDelegate.getKeyBelow) {
-              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, getNextTarget);
+              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, (target, wrap) => getNextTarget(target, wrap, 'down'));
               localState.state.setTarget(target);
             }
             break;
           }
           case 'ArrowUp': {
             if (keyboardDelegate.getKeyAbove) {
-              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, getPreviousTarget);
+              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, (target, wrap) => getNextTarget(target, wrap, 'up'));
               localState.state.setTarget(target);
             }
             break;
           }
           case 'ArrowLeft': {
             if (keyboardDelegate.getKeyLeftOf) {
-              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, (target, wrap) => getPreviousTarget(target, wrap, true));
+              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, (target, wrap) => getNextTarget(target, wrap, 'left'));
               localState.state.setTarget(target);
             }
             break;
           }
           case 'ArrowRight': {
             if (keyboardDelegate.getKeyRightOf) {
-              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, (target, wrap) => getNextTarget(target, wrap, true));
+              let target = nextValidTarget(localState.state.target, types, drag.allowedDropOperations, (target, wrap) => getNextTarget(target, wrap, 'right'));
               localState.state.setTarget(target);
             }
             break;

--- a/packages/@react-aria/dnd/test/DropTargetKeyboardNavigation.test.tsx
+++ b/packages/@react-aria/dnd/test/DropTargetKeyboardNavigation.test.tsx
@@ -1,0 +1,343 @@
+import {Collection, DropTarget, Key, KeyboardDelegate, Node} from '@react-types/shared';
+import {createRef} from 'react';
+import {ListKeyboardDelegate} from 'react-aria';
+import {navigate} from '../src/DropTargetKeyboardNavigation';
+
+interface Item {
+  id: string,
+  name: string,
+  childItems?: Item[]
+}
+
+let rows: Item[] = [
+  {id: 'projects', name: 'Projects', childItems: [
+    {id: 'project-1', name: 'Project 1'},
+    {id: 'project-2', name: 'Project 2', childItems: [
+      {id: 'project-2A', name: 'Project 2A'},
+      {id: 'project-2B', name: 'Project 2B'},
+      {id: 'project-2C', name: 'Project 2C'}
+    ]},
+    {id: 'project-3', name: 'Project 3'},
+    {id: 'project-4', name: 'Project 4'},
+    {id: 'project-5', name: 'Project 5', childItems: [
+      {id: 'project-5A', name: 'Project 5A'},
+      {id: 'project-5B', name: 'Project 5B'},
+      {id: 'project-5C', name: 'Project 5C'}
+    ]}
+  ]},
+  {id: 'reports', name: 'Reports', childItems: [
+    {id: 'reports-1', name: 'Reports 1', childItems: [
+      {id: 'reports-1A', name: 'Reports 1A', childItems: [
+        {id: 'reports-1AB', name: 'Reports 1AB', childItems: [
+          {id: 'reports-1ABC', name: 'Reports 1ABC'}
+        ]}
+      ]},
+      {id: 'reports-1B', name: 'Reports 1B'},
+      {id: 'reports-1C', name: 'Reports 1C'}
+    ]},
+    {id: 'reports-2', name: 'Reports 2'}
+  ]}
+];
+
+// Collection implementation backed by item objects above.
+// This way we don't need to render React components to test.
+class TestCollection implements Collection<Node<Item>> {
+  map: Map<Key, Node<Item>>;
+  rootNodes: Node<Item>[];
+
+  constructor(items: Item[]) {
+    this.map = new Map<Key, Node<Item>>();
+    let visitItem = (item: Item, index: number, level = 0, parentKey: string | null = null): Node<Item> => {
+      let childNodes = item.childItems ? visitItems(item.childItems, level + 1, item.id) : [];
+      return {
+        type: 'item',
+        key: item.id,
+        value: item,
+        level: level,
+        hasChildNodes: childNodes.length > 0,
+        childNodes,
+        rendered: null,
+        textValue: '',
+        index,
+        parentKey
+      };
+    };
+
+    let visitItems = (items: Item[], level: number, parentKey: string | null): Node<Item>[] => {
+      let last: Node<Item> | null = null;
+      let index = 0;
+      let nodes: Node<Item>[] = [];
+      for (let item of items) {
+        let node = visitItem(item, index, level, parentKey);
+        this.map.set(item.id, node);
+        nodes.push(node);
+        node.prevKey = last?.key;
+        if (last) {
+          last.nextKey = node.key;
+        }
+        last = node;
+        index++;
+      }
+
+      return nodes;
+    };
+
+    this.rootNodes = visitItems(items, 0, null);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  getKeys(): Iterable<Key> {
+    return this.map.keys();
+  }
+
+  [Symbol.iterator]() {
+    return this.rootNodes.values();
+  }
+
+  at(): Node<Item> | null {
+    throw new Error();
+  }
+
+  getItem(key: Key): Node<Item> | null {
+    return this.map.get(key) ?? null;
+  }
+
+  getFirstKey(): Key | null {
+    return this.rootNodes[0]?.key ?? null;
+  }
+
+  getLastKey(): Key | null {
+    let lastNode = this.rootNodes.at(-1);
+    let lastKey = lastNode?.prevKey;
+    while (lastNode?.hasChildNodes) {
+      lastNode = Array.from(lastNode.childNodes).at(-1);
+      lastKey = lastNode!.key;
+    }
+
+    return lastKey ?? null;
+  }
+
+  getKeyBefore(key: Key): Key | null {
+    let item = this.map.get(key);
+    if (!item) {
+      return null;
+    }
+
+    if (item.prevKey == null) {
+      return item.parentKey ?? null;
+    }
+
+    let prevKey = item.prevKey;
+    let prevNode = this.map.get(prevKey);
+    while (prevNode?.hasChildNodes) {
+      prevNode = Array.from(prevNode.childNodes).at(-1);
+      prevKey = prevNode!.key;
+    }
+
+    return prevKey;
+  }
+
+  getKeyAfter(key: Key): Key | null {
+    let item = this.map.get(key);
+    if (!item) {
+      return null;
+    }
+
+    if (item.hasChildNodes) {
+      return item.childNodes[0].key;
+    }
+
+    if (item.nextKey != null) {
+      return item.nextKey;
+    }
+
+    let parentKey = item.parentKey;
+    while (parentKey != null) {
+      let parentNode = this.map.get(parentKey)!;
+      if (parentNode.nextKey != null) {
+        return parentNode.nextKey;
+      }
+      parentKey = parentNode.parentKey;
+    }
+
+    return null;
+  }
+
+  getChildren(key: Key): Iterable<Node<Item>> {
+    let item = this.map.get(key);
+    return item?.childNodes ?? [];
+  }
+}
+
+let collection = new TestCollection(rows);
+let expectedTargets = [
+  {type: 'root'},
+  {type: 'item', key: 'projects', dropPosition: 'before'},
+  {type: 'item', key: 'projects', dropPosition: 'on'},
+  {type: 'item', key: 'project-1', dropPosition: 'before'},
+  {type: 'item', key: 'project-1', dropPosition: 'on'},
+  {type: 'item', key: 'project-2', dropPosition: 'before'},
+  {type: 'item', key: 'project-2', dropPosition: 'on'},
+  {type: 'item', key: 'project-2A', dropPosition: 'before'},
+  {type: 'item', key: 'project-2A', dropPosition: 'on'},
+  {type: 'item', key: 'project-2B', dropPosition: 'before'},
+  {type: 'item', key: 'project-2B', dropPosition: 'on'},
+  {type: 'item', key: 'project-2C', dropPosition: 'before'},
+  {type: 'item', key: 'project-2C', dropPosition: 'on'},
+  {type: 'item', key: 'project-2C', dropPosition: 'after'},
+  {type: 'item', key: 'project-3', dropPosition: 'before'},
+  {type: 'item', key: 'project-3', dropPosition: 'on'},
+  {type: 'item', key: 'project-4', dropPosition: 'before'},
+  {type: 'item', key: 'project-4', dropPosition: 'on'},
+  {type: 'item', key: 'project-5', dropPosition: 'before'},
+  {type: 'item', key: 'project-5', dropPosition: 'on'},
+  {type: 'item', key: 'project-5A', dropPosition: 'before'},
+  {type: 'item', key: 'project-5A', dropPosition: 'on'},
+  {type: 'item', key: 'project-5B', dropPosition: 'before'},
+  {type: 'item', key: 'project-5B', dropPosition: 'on'},
+  {type: 'item', key: 'project-5C', dropPosition: 'before'},
+  {type: 'item', key: 'project-5C', dropPosition: 'on'},
+  {type: 'item', key: 'project-5C', dropPosition: 'after'},
+  {type: 'item', key: 'project-5', dropPosition: 'after'},
+  {type: 'item', key: 'reports', dropPosition: 'before'},
+  {type: 'item', key: 'reports', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1', dropPosition: 'before'},
+  {type: 'item', key: 'reports-1', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1A', dropPosition: 'before'},
+  {type: 'item', key: 'reports-1A', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1AB', dropPosition: 'before'},
+  {type: 'item', key: 'reports-1AB', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1ABC', dropPosition: 'before'},
+  {type: 'item', key: 'reports-1ABC', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1ABC', dropPosition: 'after'},
+  {type: 'item', key: 'reports-1AB', dropPosition: 'after'},
+  {type: 'item', key: 'reports-1B', dropPosition: 'before'},
+  {type: 'item', key: 'reports-1B', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1C', dropPosition: 'before'},
+  {type: 'item', key: 'reports-1C', dropPosition: 'on'},
+  {type: 'item', key: 'reports-1C', dropPosition: 'after'},
+  {type: 'item', key: 'reports-2', dropPosition: 'before'},
+  {type: 'item', key: 'reports-2', dropPosition: 'on'},
+  {type: 'item', key: 'reports-2', dropPosition: 'after'},
+  {type: 'item', key: 'reports', dropPosition: 'after'}
+];
+
+describe('drop target keyboard navigation', () => {
+  it('sanity test collection', () => {
+    let nextKeys: Key[] = [];
+    let key = collection.getFirstKey();
+    while (key != null) {
+      nextKeys.push(key);
+      key = collection.getKeyAfter(key);
+    }
+
+    let expectedKeys = [
+      'projects',
+      'project-1',
+      'project-2',
+      'project-2A',
+      'project-2B',
+      'project-2C',
+      'project-3',
+      'project-4',
+      'project-5',
+      'project-5A',
+      'project-5B',
+      'project-5C',
+      'reports',
+      'reports-1',
+      'reports-1A',
+      'reports-1AB',
+      'reports-1ABC',
+      'reports-1B',
+      'reports-1C',
+      'reports-2'
+    ];
+    
+    expect(nextKeys).toEqual(expectedKeys);
+
+    let prevKeys: Key[] = [];
+    key = collection.getLastKey();
+    while (key != null) {
+      prevKeys.push(key);
+      key = collection.getKeyBefore(key);
+    }
+
+    expect(prevKeys).toEqual(expectedKeys.toReversed());
+  });
+
+  function collect(keyboardDelegate: KeyboardDelegate, direction: 'up' | 'down' | 'left' | 'right', rtl = false) {
+    let results: DropTarget[] = [];
+    let target: DropTarget | null = null;
+    do {
+      target = navigate(keyboardDelegate, collection, target, direction, rtl);
+      if (target != null) {
+        results.push(target);
+      }
+    } while (target != null);
+    return results;
+  }
+
+  it('should navigate forward vertically', () => {
+    let keyboardDelegate = new ListKeyboardDelegate(collection, new Set(), createRef());
+    let results = collect(keyboardDelegate, 'down');
+    expect(results).toEqual(expectedTargets);
+  });
+
+  it('should navigate backward vertically', () => {
+    let keyboardDelegate = new ListKeyboardDelegate(collection, new Set(), createRef());
+    let results = collect(keyboardDelegate, 'up');
+    expect(results.toReversed()).toEqual(expectedTargets);
+  });
+
+  it('should navigate forward horizontally (ltr)', () => {
+    let keyboardDelegate = new ListKeyboardDelegate({
+      collection,
+      ref: createRef(),
+      orientation: 'horizontal',
+      direction: 'ltr'
+    });
+
+    let results = collect(keyboardDelegate, 'right');
+    expect(results).toEqual(expectedTargets);
+  });
+
+  it('should navigate forward horizontally (rtl)', () => {
+    let keyboardDelegate = new ListKeyboardDelegate({
+      collection,
+      ref: createRef(),
+      orientation: 'horizontal',
+      direction: 'rtl'
+    });
+
+    let results = collect(keyboardDelegate, 'left', true);
+    expect(results).toEqual(expectedTargets);
+  });
+
+  it('should navigate backward horizontally (ltr)', () => {
+    let keyboardDelegate = new ListKeyboardDelegate({
+      collection,
+      ref: createRef(),
+      orientation: 'horizontal',
+      direction: 'ltr'
+    });
+
+    let results = collect(keyboardDelegate, 'left');
+    expect(results.toReversed()).toEqual(expectedTargets);
+  });
+
+  it('should navigate backward horizontally (rtl)', () => {
+    let keyboardDelegate = new ListKeyboardDelegate({
+      collection,
+      ref: createRef(),
+      orientation: 'horizontal',
+      direction: 'rtl'
+    });
+
+    let results = collect(keyboardDelegate, 'right', true);
+    expect(results.toReversed()).toEqual(expectedTargets);
+  });
+});

--- a/packages/@react-stately/dnd/src/useDroppableCollectionState.ts
+++ b/packages/@react-stately/dnd/src/useDroppableCollectionState.ts
@@ -73,10 +73,14 @@ export function useDroppableCollectionState(props: DroppableCollectionStateOptio
   let getOppositeTarget = (target: ItemDropTarget): ItemDropTarget | null => {
     if (target.dropPosition === 'before') {
       let key = collection.getKeyBefore(target.key);
-      return key != null ? {type: 'item', key, dropPosition: 'after'} : null;
+      return key != null && collection.getItem(key)?.level === collection.getItem(target.key)?.level 
+        ? {type: 'item', key, dropPosition: 'after'} 
+        : null;
     } else if (target.dropPosition === 'after') {
       let key = collection.getKeyAfter(target.key);
-      return key != null ? {type: 'item', key, dropPosition: 'before'} : null;
+      return key != null && collection.getItem(key)?.level === collection.getItem(target.key)?.level
+        ? {type: 'item', key, dropPosition: 'before'} 
+        : null;
     }
     return null;
   };

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -12,7 +12,7 @@
 import {CollectionBase, DropTargetDelegate, ItemDropTarget, Key, LayoutDelegate, RefObject} from '@react-types/shared';
 import {createBranchComponent, useCachedChildren} from '@react-aria/collections';
 import {Collection as ICollection, Node, SelectionBehavior, SelectionMode, SectionProps as SharedSectionProps} from 'react-stately';
-import React, {createContext, ForwardedRef, HTMLAttributes, JSX, ReactElement, ReactNode, useContext, useMemo} from 'react';
+import React, {cloneElement, createContext, ForwardedRef, HTMLAttributes, isValidElement, JSX, ReactElement, ReactNode, useContext, useMemo} from 'react';
 import {StyleProps} from './utils';
 
 export interface CollectionProps<T> extends Omit<CollectionBase<T>, 'children'> {
@@ -164,17 +164,51 @@ function useCollectionRender(
         return rendered;
       }
 
-      let key = node.key;
-      let keyAfter = collection.getKeyAfter(key);
       return (
         <>
-          {renderDropIndicator({type: 'item', key, dropPosition: 'before'})}
+          {renderDropIndicator({type: 'item', key: node.key, dropPosition: 'before'})}
           {rendered}
-          {((keyAfter == null || collection.getItem(keyAfter)?.type !== 'item')) && renderDropIndicator({type: 'item', key, dropPosition: 'after'})}
+          {renderAfterDropIndicators(collection, node, renderDropIndicator)}
         </>
       );
     }
   });
+}
+
+export function renderAfterDropIndicators(collection: ICollection<Node<unknown>>, node: Node<unknown>, renderDropIndicator: (target: ItemDropTarget) => ReactNode): ReactNode {
+  let key = node.key;
+  let keyAfter = collection.getKeyAfter(key);
+  let nextItemInFlattenedCollection = keyAfter != null ? collection.getItem(keyAfter) : null;
+  while (nextItemInFlattenedCollection != null && nextItemInFlattenedCollection.type !== 'item') {
+    keyAfter = collection.getKeyAfter(nextItemInFlattenedCollection.key);
+    nextItemInFlattenedCollection = keyAfter != null ? collection.getItem(keyAfter) : null;
+  }
+
+  let nextItemInSameLevel = node.nextKey != null ? collection.getItem(node.nextKey) : null;
+  while (nextItemInSameLevel != null && nextItemInSameLevel.type !== 'item') {
+    nextItemInSameLevel = nextItemInSameLevel.nextKey != null ? collection.getItem(nextItemInSameLevel.nextKey) : null;
+  }
+
+  // Render one or more "after" drop indicators when the next item in the flattened collection
+  // has a smaller level, is not an item, or there are no more items in the collection.
+  // Otherwise, the "after" position is equivalent to the next item's "before" position.
+  let afterIndicators: ReactNode[] = [];
+  if (nextItemInSameLevel == null) {
+    let current: Node<unknown> | null = node;
+    while (current && (!nextItemInFlattenedCollection || (current.parentKey !== nextItemInFlattenedCollection.parentKey && nextItemInFlattenedCollection.level < current.level))) {
+      let indicator = renderDropIndicator({
+        type: 'item',
+        key: current.key,
+        dropPosition: 'after'
+      });
+      if (isValidElement(indicator)) {
+        afterIndicators.push(cloneElement(indicator, {key: `${current.key}-after`}));
+      }
+      current = current.parentKey != null ? collection.getItem(current.parentKey) : null;
+    }
+  }
+
+  return afterIndicators;
 }
 
 export const CollectionRendererContext = createContext<CollectionRenderer>(DefaultCollectionRenderer);

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AriaTreeItemOptions, AriaTreeProps, DraggableItemResult, DropIndicatorAria, DropIndicatorProps, DroppableCollectionResult, FocusScope, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing,  useGridListSelectionCheckbox, useHover, useLocale, useTree, useTreeItem, useVisuallyHidden} from 'react-aria';
+import {AriaTreeItemOptions, AriaTreeProps, DraggableItemResult, DropIndicatorAria, DropIndicatorProps, DroppableCollectionResult, FocusScope, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing,  useGridListSelectionCheckbox, useHover, useId, useLocale, useTree, useTreeItem, useVisuallyHidden} from 'react-aria';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './RSPContexts';
 import {Collection, CollectionBuilder, CollectionNode, createBranchComponent, createLeafComponent, useCachedChildren} from '@react-aria/collections';
@@ -528,11 +528,12 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent('item', <T extends o
   let dropIndicator: DropIndicatorAria | null = null;
   let expandButtonRef = useRef<HTMLButtonElement>(null);
   let dropIndicatorRef = useRef<HTMLDivElement>(null);
+  let activateButtonRef = useRef<HTMLDivElement>(null);
   let {visuallyHiddenProps} = useVisuallyHidden();
   if (dropState && dragAndDropHooks) {
     dropIndicator = dragAndDropHooks.useDropIndicator!({
       target: {type: 'item', key: item.key, dropPosition: 'on'},
-      activateButtonRef: expandButtonRef
+      activateButtonRef
     }, dropState, dropIndicatorRef);
   }
 
@@ -609,12 +610,29 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent('item', <T extends o
     }
   });
 
+  let activateButtonId = useId();
+
   return (
     <>
       {dropIndicator && !dropIndicator.isHidden && (
-        <div role="row" style={{height: 0}}>
-          <div role="gridcell" style={{padding: 0}}>
+        <div
+          role="row"
+          aria-level={rowProps['aria-level']}
+          aria-expanded={rowProps['aria-expanded']}
+          aria-label={dropIndicator.dropIndicatorProps['aria-label']}>
+          <div role="gridcell" aria-colindex={1} style={{display: 'contents'}}>
             <div role="button" {...visuallyHiddenProps} {...dropIndicator.dropIndicatorProps} ref={dropIndicatorRef} />
+            {rowProps['aria-expanded'] != null ? (
+              // Button to allow touch screen reader users to expand the item while dragging.
+              <div
+                role="button"
+                {...visuallyHiddenProps}
+                id={activateButtonId}
+                aria-label={expandButtonProps['aria-label']}
+                aria-labelledby={`${activateButtonId} ${rowProps.id}`}
+                tabIndex={-1}
+                ref={activateButtonRef} />
+            ) : null}
           </div>
         </div>
       )}
@@ -805,7 +823,6 @@ function TreeDropIndicatorWrapper(props: DropIndicatorProps, ref: ForwardedRef<H
   ref = useObjectRef(ref);
   let {dragAndDropHooks, dropState} = useContext(DragAndDropContext)!;
   let buttonRef = useRef<HTMLDivElement>(null);
-  let level = dropState && props.target.type === 'item' ? (dropState.collection.getItem(props.target.key)?.level || 0) + 1 : 1;
   let {dropIndicatorProps, isHidden, isDropTarget} = dragAndDropHooks!.useDropIndicator!(
     props,
     dropState!,
@@ -815,8 +832,17 @@ function TreeDropIndicatorWrapper(props: DropIndicatorProps, ref: ForwardedRef<H
   if (isHidden) {
     return null;
   }
+
+  let level = dropState && props.target.type === 'item' ? (dropState.collection.getItem(props.target.key)?.level || 0) + 1 : 1;
+
   return (
-    <TreeDropIndicatorForwardRef {...props} dropIndicatorProps={dropIndicatorProps} isDropTarget={isDropTarget} ref={ref} buttonRef={buttonRef} level={level} />
+    <TreeDropIndicatorForwardRef 
+      {...props}
+      dropIndicatorProps={dropIndicatorProps}
+      isDropTarget={isDropTarget}
+      ref={ref}
+      buttonRef={buttonRef}
+      level={level} />
   );
 }
 
@@ -852,6 +878,7 @@ function TreeDropIndicator(props: TreeDropIndicatorProps, ref: ForwardedRef<HTML
     <div
       {...renderProps}
       role="row"
+      aria-level={level}
       ref={ref as RefObject<HTMLDivElement | null>}
       data-drop-target={isDropTarget || undefined}>
       <div role="gridcell">

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -276,11 +276,14 @@ function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInne
             if (target?.type === 'item' && target.dropPosition === 'after') {
               let nextKey = state.collection.getKeyAfter(target.key);
               if (nextKey != null) {
-                target = {
+                let beforeTarget = {
                   type: 'item',
                   key: nextKey,
                   dropPosition: 'before'
-                };
+                } as const;
+                if (isValidDropTarget(beforeTarget)) {
+                  return beforeTarget;
+                }
               }
             }
 

--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionBranchProps, CollectionRenderer, CollectionRendererContext, CollectionRootProps} from './Collection';
-import {DropPosition, DropTarget, DropTargetDelegate, ItemDropTarget, Node} from '@react-types/shared';
+import {CollectionBranchProps, CollectionRenderer, CollectionRendererContext, CollectionRootProps, renderAfterDropIndicators} from './Collection';
+import {DropTargetDelegate, ItemDropTarget, Node} from '@react-types/shared';
 import {Layout, ReusableView, useVirtualizerState, VirtualizerState} from '@react-stately/virtualizer';
 import React, {createContext, JSX, ReactNode, useContext, useMemo} from 'react';
 import {useScrollView, VirtualizerItem} from '@react-aria/virtualizer';
@@ -137,13 +137,13 @@ function renderWrapper(
   );
 
   let {collection, layout} = reusableView.virtualizer;
-  let {key, type} = reusableView.content!;
-  if (type === 'item' && renderDropIndicator && layout.getDropTargetLayoutInfo) {
+  let node = reusableView.content!;
+  if (node.type === 'item' && renderDropIndicator && layout.getDropTargetLayoutInfo) {
     rendered = (
       <React.Fragment key={reusableView.key}>
-        {renderDropIndicatorWrapper(parent, reusableView, 'before', renderDropIndicator)}
+        {renderDropIndicatorWrapper(parent, reusableView, {type: 'item', key: reusableView.content!.key, dropPosition: 'before'}, renderDropIndicator)}
         {rendered}
-        {collection.getKeyAfter(key) == null && renderDropIndicatorWrapper(parent, reusableView, 'after', renderDropIndicator)}
+        {renderAfterDropIndicators(collection, node, target => renderDropIndicatorWrapper(parent, reusableView, target, renderDropIndicator))}
       </React.Fragment>
     );
   }
@@ -154,10 +154,9 @@ function renderWrapper(
 function renderDropIndicatorWrapper(
   parent: View | null,
   reusableView: View,
-  dropPosition: DropPosition,
+  target: ItemDropTarget,
   renderDropIndicator: (target: ItemDropTarget) => ReactNode
 ) {
-  let target: DropTarget = {type: 'item', key: reusableView.content!.key, dropPosition};
   let indicator = renderDropIndicator(target);
   if (indicator) {
     let layoutInfo = reusableView.virtualizer.layout.getDropTargetLayoutInfo!(target);

--- a/packages/react-aria-components/stories/Tree.stories.tsx
+++ b/packages/react-aria-components/stories/Tree.stories.tsx
@@ -679,7 +679,7 @@ export const TreeWithDragAndDrop = {
   ...TreeExampleDynamic,
   render: function TreeDndExample(args) {
     return (
-      <div style={{display: 'flex', gap: 12}}>
+      <div style={{display: 'flex', gap: 12, flexWrap: 'wrap'}}>
         <TreeDragAndDropExample {...args} />
         <SecondTree {...args} />
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6208,6 +6208,7 @@ __metadata:
     "@react-aria/live-announcer": "npm:^3.4.2"
     "@react-aria/overlays": "npm:^3.27.1"
     "@react-aria/utils": "npm:^3.29.0"
+    "@react-stately/collections": "npm:^3.12.4"
     "@react-stately/dnd": "npm:^3.5.4"
     "@react-types/button": "npm:^3.12.1"
     "@react-types/shared": "npm:^3.29.1"


### PR DESCRIPTION
Improves keyboard navigation in tree drag and drop so that it traverses through the before/after drop positions of each level of the tree in a predictable order. An item may now have more than one "after" drop indicator, one for each level of the tree up to the level of the next item. The code to implement this was somewhat complicated so I pulled it out into its own file that could be unit tested independently.

This also changes the drop indicators to have better labels. Instead of "Insert between X and Y" when those items are in different levels, it now will read "Insert before X" or Insert after Y" when it is the first or last item of a level.

Also realized that making the chevron of the original item the activate button broke the a11y tree, because then there are two visible rows for each item: one for the drop indicator, and another for the button. This creates a visually hidden activate button inside the drop indicator row to avoid this. This is only used by touch screen reader users. Keyboard users can press the left and right arrow keys to expand and collapse a row.

Added some additional aria attributes to the drop indicator rows as well, e.g. `aria-level` and `aria-expanded`. The expand/collapse state does seem to be announced by both VO and NVDA (but only when it changes, not when initially focusing the item), but I couldn't get the level to announce. Probably because the row is not actually focused, the button inside is. If this is important we may need custom announcements.

Remaining work is to allow selecting a level using a mouse, probably based on the X position.