### PR TITLE
fix: Do not move backward through DateField segments when pressing Enter

### DIFF
--- a/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
+++ b/packages/@react-aria/datepicker/src/useDatePickerGroup.ts
@@ -110,7 +110,7 @@ export function useDatePickerGroup(state: DatePickerState | DateRangePickerState
       }
     },
     onPress(e) {
-      if (e.pointerType !== 'mouse') {
+      if (e.pointerType === 'touch' || e.pointerType === 'pen') {
         focusLast();
       }
     }

--- a/packages/react-aria-components/test/DateField.test.js
+++ b/packages/react-aria-components/test/DateField.test.js
@@ -338,4 +338,21 @@ describe('DateField', () => {
     await user.keyboard('{backspace}');
     expect(document.activeElement).toBe(segments[0]);
   });
+
+  it('should do nothing when pressing enter', async () => {
+    let {getAllByRole} = render(
+      <DateField defaultValue={new CalendarDate(2024, 12, 31)}>
+        <Label>Birth date</Label>
+        <DateInput>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </DateField>
+    );
+  
+    let segments = getAllByRole('spinbutton');
+    await user.click(segments[2]);
+    expect(segments[2]).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(segments[2]).toHaveFocus();
+  });
 });


### PR DESCRIPTION
Fixes #5102

This usePress is intended to handle clicking/tapping outside the segments in the field's whitespace. That should focus the last segment. It should do nothing when pointerType is keyboard.