### PR TITLE
chore: Enable package.json exports support

### DIFF
--- a/.circleci/comment.js
+++ b/.circleci/comment.js
@@ -11,7 +11,7 @@ async function run() {
   let pr;
   // If we aren't running on a PR commit, double check if this is a branch created for a fork. If so, we'll need to
   // comment the build link on the fork.
-  if (!process.env.CIRCLE_PULL_REQUEST) {
+  if (true) {
     try {
       const commit = await octokit.git.getCommit({
         owner: 'adobe',
@@ -41,7 +41,7 @@ async function run() {
             break;
           }
         }
-      } else if (process.env.CIRCLE_BRANCH === 'main') {
+      } else if (true) {
         //If it isn't a PR commit, then we are on main. Create a comment for the test app and docs build
         await octokit.repos.createCommitComment({
           owner: 'adobe',

--- a/.circleci/comment.js
+++ b/.circleci/comment.js
@@ -11,7 +11,7 @@ async function run() {
   let pr;
   // If we aren't running on a PR commit, double check if this is a branch created for a fork. If so, we'll need to
   // comment the build link on the fork.
-  if (true) {
+  if (!process.env.CIRCLE_PULL_REQUEST) {
     try {
       const commit = await octokit.git.getCommit({
         owner: 'adobe',
@@ -41,7 +41,7 @@ async function run() {
             break;
           }
         }
-      } else if (true) {
+      } else if (process.env.CIRCLE_BRANCH === 'main') {
         //If it isn't a PR commit, then we are on main. Create a comment for the test app and docs build
         await octokit.repos.createCommitComment({
           owner: 'adobe',

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -860,9 +860,9 @@ workflows:
           requires:
             - install
       - verdaccio:
-          filters:
-            branches:
-              only: main
+          # filters:
+            # branches:
+            #   only: main
           requires:
             - install
       - v-docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -860,9 +860,9 @@ workflows:
           requires:
             - install
       - verdaccio:
-          # filters:
-            # branches:
-            #   only: main
+          filters:
+            branches:
+              only: main
           requires:
             - install
       - v-docs:

--- a/.storybook-s2/custom-addons/provider/index.js
+++ b/.storybook-s2/custom-addons/provider/index.js
@@ -5,7 +5,7 @@ import {getQueryParams} from '@storybook/preview-api';
 // Importing from src so that HMR works.
 // Without this, all HMR updates will bubble through the index.ts and up 
 // to the root instead of stopping at the story files.
-import {Provider} from '@react-spectrum/s2/src/Provider';
+import {Provider} from '../../../packages/@react-spectrum/s2/src/Provider';
 
 document.body.style.margin = '0';
 

--- a/.storybook-s2/docs/Icons.jsx
+++ b/.storybook-s2/docs/Icons.jsx
@@ -4,7 +4,7 @@ import {ActionButton, Text} from '@react-spectrum/s2';
 import {H2, H3, P, Code, Pre, Link} from './typography';
 import {highlight} from './highlight' with {type: 'macro'};
 import {IconColors} from './Colors';
-import CheckmarkCircle from '../../packages/@react-spectrum/s2/s2wf-icons/S2_Icon_CheckmarkCircle_20_N.svg';
+import CheckmarkCircle from '@react-spectrum/s2/icons/CheckmarkCircle';
 import {iconStyle} from '../../packages/@react-spectrum/s2/style' with {type: 'macro'};
 
 export function Icons() {

--- a/.storybook-s2/docs/Illustrations.jsx
+++ b/.storybook-s2/docs/Illustrations.jsx
@@ -1,11 +1,10 @@
 import linearIllustrations from '@react-spectrum/s2/spectrum-illustrations/linear/*.tsx';
 import gradientIllustrations from '@react-spectrum/s2/spectrum-illustrations/gradient/*/*.tsx';
-import Paste from '@react-spectrum/s2/s2wf-icons/S2_Icon_Paste_20_N.svg';
+import Paste from '@react-spectrum/s2/icons/Paste';
 import { style } from '../../packages/@react-spectrum/s2/style/spectrum-theme' with {type: 'macro'};
-import {ActionButton, Text} from '@react-spectrum/s2';
+import {ActionButton, Radio, RadioGroup} from '@react-spectrum/s2';
 import {H2, H3, P, Code, Pre, Link} from './typography';
 import {highlight} from './highlight' with {type: 'macro'};
-import { Radio, RadioGroup } from '../../packages/@react-spectrum/s2/src';
 import { useState } from 'react';
 
 export function Illustrations() {

--- a/.storybook-s2/docs/Intro.jsx
+++ b/.storybook-s2/docs/Intro.jsx
@@ -1,13 +1,13 @@
 import { style } from '../../packages/@react-spectrum/s2/style/spectrum-theme' with {type: 'macro'};
-import {Button, LinkButton, ButtonGroup, Checkbox, Content, Dialog, DialogTrigger, Footer, Header, Heading, Image, InlineAlert, Menu, MenuItem, MenuSection, MenuTrigger, SubmenuTrigger, Switch, Text} from '@react-spectrum/s2';
-import NewIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_New_20_N.svg';
-import ImgIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_Image_20_N.svg';
-import CopyIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_Copy_20_N.svg';
-import CommentTextIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_CommentText_20_N.svg';
-import ClockPendingIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_ClockPending_20_N.svg';
-import CommunityIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_Community_20_N.svg';
-import DeviceTabletIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_DeviceTablet_20_N.svg';
-import DeviceDesktopIcon from '@react-spectrum/s2/s2wf-icons/S2_Icon_DeviceDesktop_20_N.svg';
+import {Button, ButtonGroup, Checkbox, Content, Dialog, DialogTrigger, Footer, Header, Heading, Image, InlineAlert, Menu, MenuItem, MenuSection, MenuTrigger, SubmenuTrigger, Switch, Text} from '@react-spectrum/s2';
+import NewIcon from '@react-spectrum/s2/icons/New';
+import ImgIcon from '@react-spectrum/s2/icons/Image';
+import CopyIcon from '@react-spectrum/s2/icons/Copy';
+import CommentTextIcon from '@react-spectrum/s2/icons/CommentText';
+import ClockPendingIcon from '@react-spectrum/s2/icons/ClockPending';
+import CommunityIcon from '@react-spectrum/s2/icons/Community';
+import DeviceTabletIcon from '@react-spectrum/s2/icons/DeviceTablet';
+import DeviceDesktopIcon from '@react-spectrum/s2/icons/DeviceDesktop';
 import {highlight} from './highlight' with {type: 'macro'};
 import {H2, H3, H4, P, Pre, Code, Strong, Link} from './typography';
 

--- a/.storybook-s2/preview.tsx
+++ b/.storybook-s2/preview.tsx
@@ -1,4 +1,4 @@
-import '@react-spectrum/s2/src/page';
+import '@react-spectrum/s2/page';
 import { themes } from '@storybook/theming';
 import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
 import { store } from 'storybook-dark-mode/dist/esm/Tool';

--- a/.storybook-s2/preview.tsx
+++ b/.storybook-s2/preview.tsx
@@ -1,4 +1,4 @@
-import '@react-spectrum/s2/page';
+import '@react-spectrum/s2/page.css';
 import { themes } from '@storybook/theming';
 import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
 import { store } from 'storybook-dark-mode/dist/esm/Tool';

--- a/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch
+++ b/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch
@@ -1,0 +1,13 @@
+diff --git a/index.d.ts b/index.d.ts
+index ba9855b0a36d5fbd70f92da611f3e1e96f203ee3..167de6defae46d391a45cc63dd11403722fb1619 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -4,7 +4,7 @@
+  */
+ export function mdxjs(
+   options?:
+-    | import('micromark-extension-mdx-expression/dev/lib/syntax').Options
++    | Options
+     | undefined
+ ): Extension
+ export type Extension = import('micromark-util-types').Extension

--- a/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch
+++ b/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch
@@ -1,0 +1,13 @@
+diff --git a/index.d.ts b/index.d.ts
+index c5da87629f94c457947bc712439c94b028cd5d81..3bec2ed83b30a40f84f51665eebf7a67d1a628c1 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -4,7 +4,7 @@
+  *
+  * @type {import('unified').Plugin<[Options?]|Array<void>, Root>}
+  */
+-export default function remarkMdx(options?: void | import("micromark-extension-mdx-expression/dev/lib/syntax").Options | undefined): void | import("unified").Transformer<import("mdast").Root, import("mdast").Root>;
++export default function remarkMdx(options?: void | import("micromark-extension-mdx-expression").Options | undefined): void | import("unified").Transformer<import("mdast").Root, import("mdast").Root>;
+ export type Root = import('mdast').Root;
+ export type Options = import('micromark-extension-mdxjs').Options;
+ export type DoNotTouchAsThisImportItIncludesMdxInTree = typeof import("mdast-util-mdx");

--- a/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch
+++ b/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/index.d.ts b/lib/index.d.ts
+index 0e8563eb2fe2aad42400d3aad666f36df0dbc16a..d20f18817ab64c586de59eb411fd739ece028a95 100644
+--- a/lib/index.d.ts
++++ b/lib/index.d.ts
+@@ -1,6 +1,6 @@
+ /** @type {import('unified').Plugin<[Options?] | void[], string, Root>} */
+ export default function remarkParse(
+-  options: void | import('mdast-util-from-markdown/lib').Options | undefined
++  options: void | import('mdast-util-from-markdown').Options | undefined
+ ): void
+ export type Root = import('mdast').Root
+ export type Options = import('mdast-util-from-markdown').Options

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -312,6 +312,7 @@ export default [{
                 "@spectrum-icons/ui",
                 "@spectrum-icons/workflow",
                 "@spectrum-icons/illustrations",
+                "@react-spectrum/s2/icons"
             ],
         }],
 

--- a/package.json
+++ b/package.json
@@ -227,7 +227,6 @@
     "postcss-custom-properties": "13.2.0",
     "postcss-import": "15.1.0",
     "react-refresh": "0.9.0",
-    "remark-parse": "10.0.1",
     "browserslist": "4.24.0",
     "caniuse-lite": "1.0.30001563",
     "@types/react": "npm:types-react@19.0.0-rc.0",
@@ -239,9 +238,9 @@
     "@types/node@npm:*": "^22",
     "@types/node@npm:^18.0.0": "^22",
     "@types/node@npm:>= 8": "^22",
-    "micromark-extension-mdxjs@npm:^1.0.0": "patch:micromark-extension-mdxjs@npm%3A1.0.0#~/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch",
-    "remark-mdx@npm:^2.0.0-rc.2": "patch:remark-mdx@npm%3A2.0.0-rc.2#~/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch",
-    "remark-parse@npm:^10.0.0": "patch:remark-parse@npm%3A10.0.1#~/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch"
+    "micromark-extension-mdxjs": "patch:micromark-extension-mdxjs@npm%3A1.0.0#~/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch",
+    "remark-mdx": "patch:remark-mdx@npm%3A2.0.0-rc.2#~/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch",
+    "remark-parse": "patch:remark-parse@npm%3A10.0.1#~/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch"
   },
   "@parcel/transformer-css": {
     "cssModules": {

--- a/package.json
+++ b/package.json
@@ -266,6 +266,9 @@
   "alias": {
     "@storybook/react-dom-shim": "@storybook/react-dom-shim/dist/react-18"
   },
+  "@parcel/resolver-default": {
+    "packageExports": true
+  },
   "@parcel/bundler-default": {
     "manualSharedBundles": [
       {

--- a/package.json
+++ b/package.json
@@ -238,7 +238,10 @@
     "@testing-library/user-event": "patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch",
     "@types/node@npm:*": "^22",
     "@types/node@npm:^18.0.0": "^22",
-    "@types/node@npm:>= 8": "^22"
+    "@types/node@npm:>= 8": "^22",
+    "micromark-extension-mdxjs@npm:^1.0.0": "patch:micromark-extension-mdxjs@npm%3A1.0.0#~/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch",
+    "remark-mdx@npm:^2.0.0-rc.2": "patch:remark-mdx@npm%3A2.0.0-rc.2#~/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch",
+    "remark-parse@npm:^10.0.0": "patch:remark-parse@npm%3A10.0.1#~/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch"
   },
   "@parcel/transformer-css": {
     "cssModules": {
@@ -264,7 +267,9 @@
     }
   },
   "alias": {
-    "@storybook/react-dom-shim": "@storybook/react-dom-shim/dist/react-18"
+    "@storybook/react-dom-shim": "@storybook/react-dom-shim/dist/react-18",
+    "react-dom/client.js": "react-dom/client",
+    "react-dom/index.js": "react-dom"
   },
   "@parcel/resolver-default": {
     "packageExports": true

--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     ".": {
-      "types": ["./dist/types.d.ts", "./src/index.ts"],
+      "types": [
+        "./dist/types.d.ts",
+        "./src/index.ts"
+      ],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -7,7 +7,7 @@
   "module": "dist/module.js",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "types": ["./dist/types.d.ts", "./src/index.ts"],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/@internationalized/date/package.json
+++ b/packages/@internationalized/date/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/date/package.json
+++ b/packages/@internationalized/date/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/message/package.json
+++ b/packages/@internationalized/message/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/message/package.json
+++ b/packages/@internationalized/message/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/number/package.json
+++ b/packages/@internationalized/number/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/number/package.json
+++ b/packages/@internationalized/number/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/string/package.json
+++ b/packages/@internationalized/string/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@internationalized/string/package.json
+++ b/packages/@internationalized/string/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/actiongroup/package.json
+++ b/packages/@react-aria/actiongroup/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/actiongroup/package.json
+++ b/packages/@react-aria/actiongroup/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/aria-modal-polyfill/package.json
+++ b/packages/@react-aria/aria-modal-polyfill/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/aria-modal-polyfill/package.json
+++ b/packages/@react-aria/aria-modal-polyfill/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/autocomplete/package.json
+++ b/packages/@react-aria/autocomplete/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/autocomplete/package.json
+++ b/packages/@react-aria/autocomplete/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/breadcrumbs/package.json
+++ b/packages/@react-aria/breadcrumbs/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/breadcrumbs/package.json
+++ b/packages/@react-aria/breadcrumbs/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/button/package.json
+++ b/packages/@react-aria/button/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/button/package.json
+++ b/packages/@react-aria/button/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/calendar/package.json
+++ b/packages/@react-aria/calendar/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/calendar/package.json
+++ b/packages/@react-aria/calendar/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/checkbox/package.json
+++ b/packages/@react-aria/checkbox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/checkbox/package.json
+++ b/packages/@react-aria/checkbox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/collections/package.json
+++ b/packages/@react-aria/collections/package.json
@@ -8,7 +8,10 @@
   "types": "dist/types.d.ts",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/collections/package.json
+++ b/packages/@react-aria/collections/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/color/package.json
+++ b/packages/@react-aria/color/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/color/package.json
+++ b/packages/@react-aria/color/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/combobox/package.json
+++ b/packages/@react-aria/combobox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/combobox/package.json
+++ b/packages/@react-aria/combobox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/datepicker/package.json
+++ b/packages/@react-aria/datepicker/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/datepicker/package.json
+++ b/packages/@react-aria/datepicker/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/dialog/package.json
+++ b/packages/@react-aria/dialog/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/dialog/package.json
+++ b/packages/@react-aria/dialog/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/disclosure/package.json
+++ b/packages/@react-aria/disclosure/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/disclosure/package.json
+++ b/packages/@react-aria/disclosure/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/dnd/package.json
+++ b/packages/@react-aria/dnd/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/dnd/package.json
+++ b/packages/@react-aria/dnd/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/focus/package.json
+++ b/packages/@react-aria/focus/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/focus/package.json
+++ b/packages/@react-aria/focus/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/form/package.json
+++ b/packages/@react-aria/form/package.json
@@ -8,7 +8,10 @@
   "types": "dist/types.d.ts",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/form/package.json
+++ b/packages/@react-aria/form/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/grid/package.json
+++ b/packages/@react-aria/grid/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/grid/package.json
+++ b/packages/@react-aria/grid/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/gridlist/package.json
+++ b/packages/@react-aria/gridlist/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/gridlist/package.json
+++ b/packages/@react-aria/gridlist/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/i18n/package.json
+++ b/packages/@react-aria/i18n/package.json
@@ -8,7 +8,10 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "types": ["./dist/types.d.ts", "./src/index.ts"],
+      "types": [
+        "./dist/types.d.ts",
+        "./src/index.ts"
+      ],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/@react-aria/i18n/package.json
+++ b/packages/@react-aria/i18n/package.json
@@ -7,11 +7,13 @@
   "module": "dist/module.js",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "source": "./src/index.ts",
+      "types": ["./dist/types.d.ts", "./src/index.ts"],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },
     "./server": {
+      "source": "./src/server.tsx",
       "import": "./server/index.mjs",
       "require": "./server/index.js"
     }

--- a/packages/@react-aria/interactions/package.json
+++ b/packages/@react-aria/interactions/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/interactions/package.json
+++ b/packages/@react-aria/interactions/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/label/package.json
+++ b/packages/@react-aria/label/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/label/package.json
+++ b/packages/@react-aria/label/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/landmark/package.json
+++ b/packages/@react-aria/landmark/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/landmark/package.json
+++ b/packages/@react-aria/landmark/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/link/package.json
+++ b/packages/@react-aria/link/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/link/package.json
+++ b/packages/@react-aria/link/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/listbox/package.json
+++ b/packages/@react-aria/listbox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/listbox/package.json
+++ b/packages/@react-aria/listbox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/live-announcer/package.json
+++ b/packages/@react-aria/live-announcer/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/live-announcer/package.json
+++ b/packages/@react-aria/live-announcer/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/menu/package.json
+++ b/packages/@react-aria/menu/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/menu/package.json
+++ b/packages/@react-aria/menu/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/meter/package.json
+++ b/packages/@react-aria/meter/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/meter/package.json
+++ b/packages/@react-aria/meter/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/numberfield/package.json
+++ b/packages/@react-aria/numberfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/numberfield/package.json
+++ b/packages/@react-aria/numberfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/overlays/package.json
+++ b/packages/@react-aria/overlays/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/overlays/package.json
+++ b/packages/@react-aria/overlays/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/progress/package.json
+++ b/packages/@react-aria/progress/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/index.js"
   },

--- a/packages/@react-aria/progress/package.json
+++ b/packages/@react-aria/progress/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/index.js"
   },

--- a/packages/@react-aria/radio/package.json
+++ b/packages/@react-aria/radio/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/radio/package.json
+++ b/packages/@react-aria/radio/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/searchfield/package.json
+++ b/packages/@react-aria/searchfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/searchfield/package.json
+++ b/packages/@react-aria/searchfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/selection/package.json
+++ b/packages/@react-aria/selection/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/selection/package.json
+++ b/packages/@react-aria/selection/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/separator/package.json
+++ b/packages/@react-aria/separator/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/separator/package.json
+++ b/packages/@react-aria/separator/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/slider/package.json
+++ b/packages/@react-aria/slider/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/slider/package.json
+++ b/packages/@react-aria/slider/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/spinbutton/package.json
+++ b/packages/@react-aria/spinbutton/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/spinbutton/package.json
+++ b/packages/@react-aria/spinbutton/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/ssr/package.json
+++ b/packages/@react-aria/ssr/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/ssr/package.json
+++ b/packages/@react-aria/ssr/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/steplist/package.json
+++ b/packages/@react-aria/steplist/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/steplist/package.json
+++ b/packages/@react-aria/steplist/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/switch/package.json
+++ b/packages/@react-aria/switch/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/switch/package.json
+++ b/packages/@react-aria/switch/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tabs/package.json
+++ b/packages/@react-aria/tabs/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tabs/package.json
+++ b/packages/@react-aria/tabs/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tag/package.json
+++ b/packages/@react-aria/tag/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tag/package.json
+++ b/packages/@react-aria/tag/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/test-utils/package.json
+++ b/packages/@react-aria/test-utils/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/test-utils/package.json
+++ b/packages/@react-aria/test-utils/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/test-utils/src/userEventMaps.ts
+++ b/packages/@react-aria/test-utils/src/userEventMaps.ts
@@ -1,4 +1,4 @@
-import {pointerKey} from '@testing-library/user-event/system/pointer/shared';
+import {pointerKey} from '@testing-library/user-event';
 
 export let pointerMap: pointerKey[] = [
   {name: 'MouseLeft', pointerType: 'mouse', button: 'primary', height: 1, width: 1, pressure: 0.5},

--- a/packages/@react-aria/textfield/package.json
+++ b/packages/@react-aria/textfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/textfield/package.json
+++ b/packages/@react-aria/textfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/toast/package.json
+++ b/packages/@react-aria/toast/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/toast/package.json
+++ b/packages/@react-aria/toast/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/toggle/package.json
+++ b/packages/@react-aria/toggle/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/toggle/package.json
+++ b/packages/@react-aria/toggle/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/toolbar/package.json
+++ b/packages/@react-aria/toolbar/package.json
@@ -8,7 +8,10 @@
   "types": "dist/types.d.ts",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/toolbar/package.json
+++ b/packages/@react-aria/toolbar/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tooltip/package.json
+++ b/packages/@react-aria/tooltip/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tooltip/package.json
+++ b/packages/@react-aria/tooltip/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tree/package.json
+++ b/packages/@react-aria/tree/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/tree/package.json
+++ b/packages/@react-aria/tree/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/utils/package.json
+++ b/packages/@react-aria/utils/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/utils/package.json
+++ b/packages/@react-aria/utils/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/virtualizer/package.json
+++ b/packages/@react-aria/virtualizer/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/virtualizer/package.json
+++ b/packages/@react-aria/virtualizer/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/visually-hidden/package.json
+++ b/packages/@react-aria/visually-hidden/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-aria/visually-hidden/package.json
+++ b/packages/@react-aria/visually-hidden/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/accordion/package.json
+++ b/packages/@react-spectrum/accordion/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/accordion/package.json
+++ b/packages/@react-spectrum/accordion/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/actionbar/package.json
+++ b/packages/@react-spectrum/actionbar/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/actionbar/package.json
+++ b/packages/@react-spectrum/actionbar/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/actiongroup/package.json
+++ b/packages/@react-spectrum/actiongroup/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/actiongroup/package.json
+++ b/packages/@react-spectrum/actiongroup/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/autocomplete/package.json
+++ b/packages/@react-spectrum/autocomplete/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/autocomplete/package.json
+++ b/packages/@react-spectrum/autocomplete/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/avatar/package.json
+++ b/packages/@react-spectrum/avatar/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/avatar/package.json
+++ b/packages/@react-spectrum/avatar/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/badge/chromatic-fc/Badge.stories.tsx
+++ b/packages/@react-spectrum/badge/chromatic-fc/Badge.stories.tsx
@@ -12,7 +12,7 @@
 
 import {Badge} from '..';
 import {BadgeStory, renderVariants} from '../chromatic/Badge.stories';
-import CheckmarkCircle from '@spectrum-icons/workflow/src/CheckmarkCircle';
+import CheckmarkCircle from '@spectrum-icons/workflow/CheckmarkCircle';
 import {ComponentMeta} from '@storybook/react';
 import React from 'react';
 import {Text} from '@react-spectrum/text';

--- a/packages/@react-spectrum/badge/chromatic/Badge.stories.tsx
+++ b/packages/@react-spectrum/badge/chromatic/Badge.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {Badge} from '../';
-import CheckmarkCircle from '@spectrum-icons/workflow/src/CheckmarkCircle';
+import CheckmarkCircle from '@spectrum-icons/workflow/CheckmarkCircle';
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
 import {Flex} from '@react-spectrum/layout';
 import React from 'react';

--- a/packages/@react-spectrum/badge/package.json
+++ b/packages/@react-spectrum/badge/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/badge/package.json
+++ b/packages/@react-spectrum/badge/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/breadcrumbs/package.json
+++ b/packages/@react-spectrum/breadcrumbs/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/breadcrumbs/package.json
+++ b/packages/@react-spectrum/breadcrumbs/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/buttongroup/package.json
+++ b/packages/@react-spectrum/buttongroup/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/buttongroup/package.json
+++ b/packages/@react-spectrum/buttongroup/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
+++ b/packages/@react-spectrum/calendar/stories/Calendar.stories.tsx
@@ -14,7 +14,7 @@ import {ActionButton} from '@react-spectrum/button';
 import {Calendar} from '../';
 import {CalendarDate, CalendarDateTime, getLocalTimeZone, parseZonedDateTime, today, ZonedDateTime} from '@internationalized/date';
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
-import {Custom454Calendar} from '@internationalized/date/tests/customCalendarImpl';
+import {Custom454Calendar} from '../../../@internationalized/date/tests/customCalendarImpl';
 import {DateValue} from '@react-types/calendar';
 import {Flex} from '@react-spectrum/layout';
 import {Item, Picker, Section} from '@react-spectrum/picker';
@@ -289,7 +289,7 @@ function ControlledFocus(props) {
   );
 }
 
-function CustomCalendar(props) { 
+function CustomCalendar(props) {
   return (
     <ControlledFocus {...props} createCalendar={() => new Custom454Calendar()} focusedValue={new CalendarDate(2023, 2, 5)} />
   );

--- a/packages/@react-spectrum/calendar/stories/RangeCalendar.stories.tsx
+++ b/packages/@react-spectrum/calendar/stories/RangeCalendar.stories.tsx
@@ -13,7 +13,7 @@
 import {action} from '@storybook/addon-actions';
 import {CalendarDate, CalendarDateTime, getLocalTimeZone, isWeekend, parseZonedDateTime, today} from '@internationalized/date';
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
-import {Custom454Calendar} from '@internationalized/date/tests/customCalendarImpl';
+import {Custom454Calendar} from '../../../@internationalized/date/tests/customCalendarImpl';
 import {DateValue} from '@react-types/calendar';
 import {Flex} from '@react-spectrum/layout';
 import {RangeCalendar} from '../';

--- a/packages/@react-spectrum/card/package.json
+++ b/packages/@react-spectrum/card/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/card/package.json
+++ b/packages/@react-spectrum/card/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/checkbox/package.json
+++ b/packages/@react-spectrum/checkbox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/checkbox/package.json
+++ b/packages/@react-spectrum/checkbox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/color/package.json
+++ b/packages/@react-spectrum/color/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/color/package.json
+++ b/packages/@react-spectrum/color/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/combobox/package.json
+++ b/packages/@react-spectrum/combobox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/combobox/package.json
+++ b/packages/@react-spectrum/combobox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/contextualhelp/package.json
+++ b/packages/@react-spectrum/contextualhelp/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/contextualhelp/package.json
+++ b/packages/@react-spectrum/contextualhelp/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/datepicker/stories/DatePicker.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DatePicker.stories.tsx
@@ -17,7 +17,7 @@ import {chain} from '@react-aria/utils';
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
 import {Content} from '@react-spectrum/view';
 import {ContextualHelp} from '@react-spectrum/contextualhelp';
-import {Custom454Calendar} from '@internationalized/date/tests/customCalendarImpl';
+import {Custom454Calendar} from '../../../@internationalized/date/tests/customCalendarImpl';
 import {DatePicker} from '../';
 import {DateValue} from '@react-types/calendar';
 import {Flex} from '@react-spectrum/layout';

--- a/packages/@react-spectrum/datepicker/stories/DateRangePicker.stories.tsx
+++ b/packages/@react-spectrum/datepicker/stories/DateRangePicker.stories.tsx
@@ -14,7 +14,7 @@ import {action} from '@storybook/addon-actions';
 import {ActionButton} from '@react-spectrum/button';
 import {CalendarDate, getLocalTimeZone, isWeekend, parseDate, today, toZoned} from '@internationalized/date';
 import {chain} from '@react-aria/utils';
-import {Custom454Calendar} from '@internationalized/date/tests/customCalendarImpl';
+import {Custom454Calendar} from '../../../@internationalized/date/tests/customCalendarImpl';
 import {DateRange} from '@react-types/datepicker';
 import {DateRangePicker} from '../';
 import {DateValue} from '@react-types/calendar';

--- a/packages/@react-spectrum/dialog/package.json
+++ b/packages/@react-spectrum/dialog/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/dialog/package.json
+++ b/packages/@react-spectrum/dialog/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/divider/package.json
+++ b/packages/@react-spectrum/divider/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/divider/package.json
+++ b/packages/@react-spectrum/divider/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/dnd/package.json
+++ b/packages/@react-spectrum/dnd/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/dnd/package.json
+++ b/packages/@react-spectrum/dnd/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/dropzone/package.json
+++ b/packages/@react-spectrum/dropzone/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/dropzone/package.json
+++ b/packages/@react-spectrum/dropzone/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/dropzone/stories/DropZone.stories.tsx
+++ b/packages/@react-spectrum/dropzone/stories/DropZone.stories.tsx
@@ -15,7 +15,7 @@ import {Button} from '@react-spectrum/button';
 import {Cell, Column, Row, TableBody, TableHeader, TableView} from '@react-spectrum/table';
 import {classNames} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
-import {Draggable} from '@react-aria/dnd/stories/dnd.stories';
+import {Draggable} from '../../../@react-aria/dnd/stories/dnd.stories';
 import {DropEvent, FileDropItem, TextDropItem, useDrag} from 'react-aria';
 import {DropZone} from '../';
 import File from '@spectrum-icons/illustrations/File';

--- a/packages/@react-spectrum/filetrigger/package.json
+++ b/packages/@react-spectrum/filetrigger/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/filetrigger/package.json
+++ b/packages/@react-spectrum/filetrigger/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/form/package.json
+++ b/packages/@react-spectrum/form/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/form/package.json
+++ b/packages/@react-spectrum/form/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/icon/package.json
+++ b/packages/@react-spectrum/icon/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/icon/package.json
+++ b/packages/@react-spectrum/icon/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/illustratedmessage/chromatic/IllustratedMessage.Languages.stories.tsx
+++ b/packages/@react-spectrum/illustratedmessage/chromatic/IllustratedMessage.Languages.stories.tsx
@@ -14,7 +14,7 @@ import {Content} from '@react-spectrum/view';
 import {Flex} from '@react-spectrum/layout';
 import {Heading} from '@react-spectrum/text';
 import {IllustratedMessage} from '..';
-import NotFound from '@spectrum-icons/illustrations/src/NotFound';
+import NotFound from '@spectrum-icons/illustrations/NotFound';
 import React from 'react';
 
 type IllustratedMessageStory = ComponentStoryObj<typeof IllustratedMessage>;

--- a/packages/@react-spectrum/illustratedmessage/chromatic/IllustratedMessage.stories.tsx
+++ b/packages/@react-spectrum/illustratedmessage/chromatic/IllustratedMessage.stories.tsx
@@ -11,12 +11,12 @@
  */
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
 import {Content} from '@react-spectrum/view';
-import Error from '@spectrum-icons/illustrations/src/Error';
+import Error from '@spectrum-icons/illustrations/Error';
 import {Heading} from '@react-spectrum/text';
 import {IllustratedMessage} from '../';
 import {Link} from '@react-spectrum/link';
-import NoSearchResults from '@spectrum-icons/illustrations/src/NoSearchResults';
-import NotFound from '@spectrum-icons/illustrations/src/NotFound';
+import NoSearchResults from '@spectrum-icons/illustrations/NoSearchResults';
+import NotFound from '@spectrum-icons/illustrations/NotFound';
 import React from 'react';
 import Timeout from '@spectrum-icons/illustrations/Timeout';
 import Unauthorized from '@spectrum-icons/illustrations/Unauthorized';

--- a/packages/@react-spectrum/illustratedmessage/package.json
+++ b/packages/@react-spectrum/illustratedmessage/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/illustratedmessage/package.json
+++ b/packages/@react-spectrum/illustratedmessage/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/image/package.json
+++ b/packages/@react-spectrum/image/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/image/package.json
+++ b/packages/@react-spectrum/image/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/inlinealert/package.json
+++ b/packages/@react-spectrum/inlinealert/package.json
@@ -8,7 +8,10 @@
   "types": "dist/types.d.ts",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/inlinealert/package.json
+++ b/packages/@react-spectrum/inlinealert/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/label/package.json
+++ b/packages/@react-spectrum/label/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/label/package.json
+++ b/packages/@react-spectrum/label/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/labeledvalue/docs/types.ts
+++ b/packages/@react-spectrum/labeledvalue/docs/types.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import {DateTime, LabeledValueBaseProps} from '@react-spectrum/labeledvalue/src/LabeledValue';
 import {RangeValue} from '@react-types/shared';
 import {ReactElement} from 'react';

--- a/packages/@react-spectrum/labeledvalue/package.json
+++ b/packages/@react-spectrum/labeledvalue/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/labeledvalue/package.json
+++ b/packages/@react-spectrum/labeledvalue/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/layout/package.json
+++ b/packages/@react-spectrum/layout/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/layout/package.json
+++ b/packages/@react-spectrum/layout/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/link/package.json
+++ b/packages/@react-spectrum/link/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/link/package.json
+++ b/packages/@react-spectrum/link/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/list/package.json
+++ b/packages/@react-spectrum/list/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/list/package.json
+++ b/packages/@react-spectrum/list/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/list/stories/ListViewDnD.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListViewDnD.stories.tsx
@@ -1,7 +1,7 @@
 import {action} from '@storybook/addon-actions';
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
 import {DragBetweenListsExample, DragBetweenListsRootOnlyExample, DragExample, DragIntoItemExample, ReorderExample} from './ListViewDnDExamples';
-import {Droppable} from '@react-aria/dnd/stories/dnd.stories';
+import {Droppable} from '../../../@react-aria/dnd/stories/dnd.stories';
 import {Flex} from '@react-spectrum/layout';
 import {ListView} from '../';
 import React from 'react';

--- a/packages/@react-spectrum/list/stories/ListViewDnDUtil.stories.tsx
+++ b/packages/@react-spectrum/list/stories/ListViewDnDUtil.stories.tsx
@@ -1,7 +1,7 @@
 import {action} from '@storybook/addon-actions';
 import {ComponentMeta, ComponentStoryObj} from '@storybook/react';
 import {DragBetweenListsComplex, DragBetweenListsOverride, DragExampleUtilHandlers, FinderDropUtilHandlers, InsertExampleUtilHandlers, ItemDropExampleUtilHandlers, ReorderExampleUtilHandlers, RootDropExampleUtilHandlers} from './ListViewDnDUtilExamples';
-import {Droppable} from '@react-aria/dnd/stories/dnd.stories';
+import {Droppable} from '../../../@react-aria/dnd/stories/dnd.stories';
 import {Flex} from '@react-spectrum/layout';
 import {ListView} from '../';
 import React from 'react';

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/menu/package.json
+++ b/packages/@react-spectrum/menu/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/menu/package.json
+++ b/packages/@react-spectrum/menu/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/meter/package.json
+++ b/packages/@react-spectrum/meter/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/meter/package.json
+++ b/packages/@react-spectrum/meter/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/numberfield/package.json
+++ b/packages/@react-spectrum/numberfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/numberfield/package.json
+++ b/packages/@react-spectrum/numberfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/overlays/package.json
+++ b/packages/@react-spectrum/overlays/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/overlays/package.json
+++ b/packages/@react-spectrum/overlays/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/progress/package.json
+++ b/packages/@react-spectrum/progress/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/progress/package.json
+++ b/packages/@react-spectrum/progress/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/provider/package.json
+++ b/packages/@react-spectrum/provider/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/provider/package.json
+++ b/packages/@react-spectrum/provider/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/radio/package.json
+++ b/packages/@react-spectrum/radio/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/radio/package.json
+++ b/packages/@react-spectrum/radio/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/s2/icon.d.ts
+++ b/packages/@react-spectrum/s2/icon.d.ts
@@ -1,0 +1,5 @@
+import type {ReactNode} from 'react';
+import type {IconProps} from './src/Icon';
+
+declare function Icon(props: IconProps): ReactNode;
+export default Icon;

--- a/packages/@react-spectrum/s2/package.json
+++ b/packages/@react-spectrum/s2/package.json
@@ -18,7 +18,10 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "types": ["./dist/types.d.ts", "./src/index.ts"],
+      "types": [
+        "./dist/types.d.ts",
+        "./src/index.ts"
+      ],
       "module": "./dist/module.mjs",
       "import": "./dist/module.mjs",
       "require": "./dist/main.cjs"
@@ -29,21 +32,30 @@
     },
     "./style": {
       "source": "./style/index.ts",
-      "types": ["./style/dist/types.d.ts", "./style/index.ts"],
+      "types": [
+        "./style/dist/types.d.ts",
+        "./style/index.ts"
+      ],
       "module": "./style/dist/module.mjs",
       "import": "./style/dist/module.mjs",
       "require": "./style/dist/main.cjs"
     },
     "./icons/*": {
       "source": "./s2wf-icons/S2_Icon_*_20_N.svg",
-      "types": ["./icons/*.d.ts", "./icon.d.ts"],
+      "types": [
+        "./icons/*.d.ts",
+        "./icon.d.ts"
+      ],
       "module": "./icons/*.mjs",
       "import": "./icons/*.mjs",
       "require": "./icons/*.cjs"
     },
     "./illustrations/*": {
       "source": "./spectrum-illustrations/*.tsx",
-      "types": ["./illustrations/*.d.ts", "./icon.d.ts"],
+      "types": [
+        "./illustrations/*.d.ts",
+        "./icon.d.ts"
+      ],
       "module": "./illustrations/*.mjs",
       "import": "./illustrations/*.mjs",
       "require": "./illustrations/*.cjs"

--- a/packages/@react-spectrum/s2/package.json
+++ b/packages/@react-spectrum/s2/package.json
@@ -17,26 +17,33 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "source": "./src/index.ts",
+      "types": ["./dist/types.d.ts", "./src/index.ts"],
       "module": "./dist/module.mjs",
       "import": "./dist/module.mjs",
       "require": "./dist/main.cjs"
     },
-    "./page.css": "./page.css",
+    "./page.css": {
+      "source": "./src/page.ts",
+      "default": "./page.css"
+    },
     "./style": {
-      "types": "./style/dist/types.d.ts",
+      "source": "./style/index.ts",
+      "types": ["./style/dist/types.d.ts", "./style/index.ts"],
       "module": "./style/dist/module.mjs",
       "import": "./style/dist/module.mjs",
       "require": "./style/dist/main.cjs"
     },
     "./icons/*": {
-      "types": "./icons/*.d.ts",
+      "source": "./s2wf-icons/S2_Icon_*_20_N.svg",
+      "types": ["./icons/*.d.ts", "./icon.d.ts"],
       "module": "./icons/*.mjs",
       "import": "./icons/*.mjs",
       "require": "./icons/*.cjs"
     },
     "./illustrations/*": {
-      "types": "./illustrations/*.d.ts",
+      "source": "./spectrum-illustrations/*.tsx",
+      "types": ["./illustrations/*.d.ts", "./icon.d.ts"],
       "module": "./illustrations/*.mjs",
       "import": "./illustrations/*.mjs",
       "require": "./illustrations/*.cjs"

--- a/packages/@react-spectrum/searchfield/package.json
+++ b/packages/@react-spectrum/searchfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/searchfield/package.json
+++ b/packages/@react-spectrum/searchfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/searchwithin/package.json
+++ b/packages/@react-spectrum/searchwithin/package.json
@@ -8,7 +8,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/searchwithin/package.json
+++ b/packages/@react-spectrum/searchwithin/package.json
@@ -7,7 +7,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/slider/package.json
+++ b/packages/@react-spectrum/slider/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/slider/package.json
+++ b/packages/@react-spectrum/slider/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/statuslight/package.json
+++ b/packages/@react-spectrum/statuslight/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/statuslight/package.json
+++ b/packages/@react-spectrum/statuslight/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/steplist/package.json
+++ b/packages/@react-spectrum/steplist/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/steplist/package.json
+++ b/packages/@react-spectrum/steplist/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/story-utils/package.json
+++ b/packages/@react-spectrum/story-utils/package.json
@@ -8,7 +8,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/story-utils/package.json
+++ b/packages/@react-spectrum/story-utils/package.json
@@ -7,7 +7,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/switch/package.json
+++ b/packages/@react-spectrum/switch/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/switch/package.json
+++ b/packages/@react-spectrum/switch/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/table/test/TableSizing.test.tsx
+++ b/packages/@react-spectrum/table/test/TableSizing.test.tsx
@@ -22,7 +22,7 @@ import {HidingColumns} from '../stories/HidingColumns';
 import {Key} from '@react-types/shared';
 import {Provider} from '@react-spectrum/provider';
 import React, {useRef} from 'react';
-import {resizingTests} from '@react-aria/table/test/tableResizingTests';
+import {resizingTests} from '../../../@react-aria/table/test/tableResizingTests';
 import {Scale} from '@react-types/provider';
 import {setInteractionModality} from '@react-aria/interactions';
 import {theme} from '@react-spectrum/theme-default';

--- a/packages/@react-spectrum/tabs/package.json
+++ b/packages/@react-spectrum/tabs/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tabs/package.json
+++ b/packages/@react-spectrum/tabs/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tag/package.json
+++ b/packages/@react-spectrum/tag/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tag/package.json
+++ b/packages/@react-spectrum/tag/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/test-utils/package.json
+++ b/packages/@react-spectrum/test-utils/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/test-utils/package.json
+++ b/packages/@react-spectrum/test-utils/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/text/package.json
+++ b/packages/@react-spectrum/text/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/text/package.json
+++ b/packages/@react-spectrum/text/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/textfield/package.json
+++ b/packages/@react-spectrum/textfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/textfield/package.json
+++ b/packages/@react-spectrum/textfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-dark/package.json
+++ b/packages/@react-spectrum/theme-dark/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-dark/package.json
+++ b/packages/@react-spectrum/theme-dark/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-default/package.json
+++ b/packages/@react-spectrum/theme-default/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-default/package.json
+++ b/packages/@react-spectrum/theme-default/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-express/package.json
+++ b/packages/@react-spectrum/theme-express/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-express/package.json
+++ b/packages/@react-spectrum/theme-express/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-light/package.json
+++ b/packages/@react-spectrum/theme-light/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/theme-light/package.json
+++ b/packages/@react-spectrum/theme-light/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/toast/package.json
+++ b/packages/@react-spectrum/toast/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/toast/package.json
+++ b/packages/@react-spectrum/toast/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tooltip/package.json
+++ b/packages/@react-spectrum/tooltip/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tooltip/package.json
+++ b/packages/@react-spectrum/tooltip/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tree/package.json
+++ b/packages/@react-spectrum/tree/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/tree/package.json
+++ b/packages/@react-spectrum/tree/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/utils/package.json
+++ b/packages/@react-spectrum/utils/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/utils/package.json
+++ b/packages/@react-spectrum/utils/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/view/package.json
+++ b/packages/@react-spectrum/view/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/view/package.json
+++ b/packages/@react-spectrum/view/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/well/package.json
+++ b/packages/@react-spectrum/well/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-spectrum/well/package.json
+++ b/packages/@react-spectrum/well/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/autocomplete/package.json
+++ b/packages/@react-stately/autocomplete/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/autocomplete/package.json
+++ b/packages/@react-stately/autocomplete/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/calendar/package.json
+++ b/packages/@react-stately/calendar/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/calendar/package.json
+++ b/packages/@react-stately/calendar/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/checkbox/package.json
+++ b/packages/@react-stately/checkbox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/checkbox/package.json
+++ b/packages/@react-stately/checkbox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/collections/package.json
+++ b/packages/@react-stately/collections/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/collections/package.json
+++ b/packages/@react-stately/collections/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/color/package.json
+++ b/packages/@react-stately/color/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/color/package.json
+++ b/packages/@react-stately/color/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/combobox/package.json
+++ b/packages/@react-stately/combobox/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/combobox/package.json
+++ b/packages/@react-stately/combobox/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/data/package.json
+++ b/packages/@react-stately/data/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/data/package.json
+++ b/packages/@react-stately/data/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/datepicker/package.json
+++ b/packages/@react-stately/datepicker/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/datepicker/package.json
+++ b/packages/@react-stately/datepicker/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/disclosure/package.json
+++ b/packages/@react-stately/disclosure/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/disclosure/package.json
+++ b/packages/@react-stately/disclosure/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/dnd/package.json
+++ b/packages/@react-stately/dnd/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/dnd/package.json
+++ b/packages/@react-stately/dnd/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/flags/package.json
+++ b/packages/@react-stately/flags/package.json
@@ -8,7 +8,10 @@
   "types": "dist/types.d.ts",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/flags/package.json
+++ b/packages/@react-stately/flags/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/form/package.json
+++ b/packages/@react-stately/form/package.json
@@ -8,7 +8,10 @@
   "types": "dist/types.d.ts",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/form/package.json
+++ b/packages/@react-stately/form/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/grid/package.json
+++ b/packages/@react-stately/grid/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/grid/package.json
+++ b/packages/@react-stately/grid/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/layout/package.json
+++ b/packages/@react-stately/layout/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/layout/package.json
+++ b/packages/@react-stately/layout/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/list/package.json
+++ b/packages/@react-stately/list/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/list/package.json
+++ b/packages/@react-stately/list/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/menu/package.json
+++ b/packages/@react-stately/menu/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/menu/package.json
+++ b/packages/@react-stately/menu/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/numberfield/package.json
+++ b/packages/@react-stately/numberfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/numberfield/package.json
+++ b/packages/@react-stately/numberfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/overlays/package.json
+++ b/packages/@react-stately/overlays/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/overlays/package.json
+++ b/packages/@react-stately/overlays/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/radio/package.json
+++ b/packages/@react-stately/radio/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/radio/package.json
+++ b/packages/@react-stately/radio/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/searchfield/package.json
+++ b/packages/@react-stately/searchfield/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/searchfield/package.json
+++ b/packages/@react-stately/searchfield/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/select/package.json
+++ b/packages/@react-stately/select/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/select/package.json
+++ b/packages/@react-stately/select/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/selection/package.json
+++ b/packages/@react-stately/selection/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/selection/package.json
+++ b/packages/@react-stately/selection/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/slider/package.json
+++ b/packages/@react-stately/slider/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/slider/package.json
+++ b/packages/@react-stately/slider/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/steplist/package.json
+++ b/packages/@react-stately/steplist/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/steplist/package.json
+++ b/packages/@react-stately/steplist/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/table/package.json
+++ b/packages/@react-stately/table/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/table/package.json
+++ b/packages/@react-stately/table/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/tabs/package.json
+++ b/packages/@react-stately/tabs/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/tabs/package.json
+++ b/packages/@react-stately/tabs/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/toast/package.json
+++ b/packages/@react-stately/toast/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/toast/package.json
+++ b/packages/@react-stately/toast/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/toggle/package.json
+++ b/packages/@react-stately/toggle/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/toggle/package.json
+++ b/packages/@react-stately/toggle/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/tooltip/package.json
+++ b/packages/@react-stately/tooltip/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/tooltip/package.json
+++ b/packages/@react-stately/tooltip/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/tree/package.json
+++ b/packages/@react-stately/tree/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/tree/package.json
+++ b/packages/@react-stately/tree/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/utils/package.json
+++ b/packages/@react-stately/utils/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/utils/package.json
+++ b/packages/@react-stately/utils/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/virtualizer/package.json
+++ b/packages/@react-stately/virtualizer/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/@react-stately/virtualizer/package.json
+++ b/packages/@react-stately/virtualizer/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -10,7 +10,10 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "types": ["./dist/types.d.ts", "./src/index.ts"],
+      "types": [
+        "./dist/types.d.ts",
+        "./src/index.ts"
+      ],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -9,7 +9,8 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "source": "./src/index.ts",
+      "types": ["./dist/types.d.ts", "./src/index.ts"],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -8,7 +8,10 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "types": ["./dist/types.d.ts", "./src/index.ts"],
+      "types": [
+        "./dist/types.d.ts",
+        "./src/index.ts"
+      ],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -7,7 +7,8 @@
   "module": "dist/module.js",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "source": "./src/index.ts",
+      "types": ["./dist/types.d.ts", "./src/index.ts"],
       "import": "./dist/import.mjs",
       "require": "./dist/main.js"
     },

--- a/packages/react-stately/package.json
+++ b/packages/react-stately/package.json
@@ -6,7 +6,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/packages/react-stately/package.json
+++ b/packages/react-stately/package.json
@@ -7,7 +7,10 @@
   "module": "dist/module.js",
   "exports": {
     "source": "./src/index.ts",
-    "types": ["./dist/types.d.ts", "./src/index.ts"],
+    "types": [
+      "./dist/types.d.ts",
+      "./src/index.ts"
+    ],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/plop-templates/@react-aria/package.json.hbs
+++ b/plop-templates/@react-aria/package.json.hbs
@@ -8,7 +8,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/plop-templates/@react-spectrum/package.json.hbs
+++ b/plop-templates/@react-spectrum/package.json.hbs
@@ -8,7 +8,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/plop-templates/@react-stately/package.json.hbs
+++ b/plop-templates/@react-stately/package.json.hbs
@@ -8,7 +8,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/plop-templates/@scope/package.json.hbs
+++ b/plop-templates/@scope/package.json.hbs
@@ -8,7 +8,8 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "exports": {
-    "types": "./dist/types.d.ts",
+    "source": "./src/index.ts",
+    "types": ["./dist/types.d.ts", "./src/index.ts"],
     "import": "./dist/import.mjs",
     "require": "./dist/main.js"
   },

--- a/scripts/buildBranchAPI.js
+++ b/scripts/buildBranchAPI.js
@@ -86,6 +86,9 @@ async function build() {
     scripts: {
       build: 'yarn parcel build packages/@react-spectrum/actiongroup',
       postinstall: 'patch-package'
+    },
+    '@parcel/resolver-default': {
+      packageExports: true
     }
   };
 

--- a/scripts/buildPublishedAPI.js
+++ b/scripts/buildPublishedAPI.js
@@ -72,6 +72,9 @@ async function build() {
     scripts: {
       build: 'yarn parcel build packages/@react-spectrum/actiongroup',
       postinstall: 'patch-package'
+    },
+    '@parcel/resolver-default': {
+      packageExports: true
     }
   };
 
@@ -105,6 +108,9 @@ async function build() {
     scripts: {
       build: 'yarn parcel build packages/@react-spectrum/actiongroup',
       postinstall: 'patch-package'
+    },
+    '@parcel/resolver-default': {
+      packageExports: true
     }
   };
 

--- a/scripts/buildWebsite.js
+++ b/scripts/buildWebsite.js
@@ -84,7 +84,10 @@ async function build() {
       postinstall: 'patch-package',
       createRssFeed: "node scripts/createFeed.mjs"
     },
-    '@parcel/transformer-css': packageJSON['@parcel/transformer-css']
+    '@parcel/transformer-css': packageJSON['@parcel/transformer-css'],
+    '@parcel/resolver-default': {
+      packageExports: true
+    }
   };
 
 
@@ -161,19 +164,6 @@ async function build() {
 
   // Install dependencies from npm
   await run('yarn', ['--no-immutable'], {cwd: dir, stdio: 'inherit'});
-
-  // Copy package.json for each package into docs dir so we can find the correct version numbers
-  for (let p of packages) {
-    if (fs.existsSync(path.join(dir, 'node_modules', p))) {
-      fs.copySync(path.join(dir, 'node_modules', p), path.join(dir, 'docs', p));
-    }
-  }
-
-  // Patch react-aria-components package.json for example CSS.
-  let p = path.join(dir, 'docs', 'react-aria-components', 'package.json');
-  let json = JSON.parse(fs.readFileSync(p));
-  json.sideEffects = ['*.css'];
-  fs.writeFileSync(p, JSON.stringify(json, false, 2));
 
   // Build the website
   await run('yarn', ['build'], {cwd: dir, stdio: 'inherit'});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     // allows importing of json files, needed for locales as of right now
     "resolveJsonModule": true,
     // Search under node_modules for non-relative imports.
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "module": "esnext",
     // Process & infer types from .js files.
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -28448,6 +28448,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-parse@patch:remark-parse@npm%3A10.0.1#~/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch":
+  version: 10.0.1
+  resolution: "remark-parse@patch:remark-parse@npm%3A10.0.1#~/.yarn/patches/remark-parse-npm-10.0.1-e654d7df78.patch::version=10.0.1&hash=53e21c"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^1.0.0"
+    unified: "npm:^10.0.0"
+  checksum: 10c0/a35712b4edc27af4b81b5697c3c259e3e45743dc9a41bbf53b5960eefebe0c8199bc21639dd0acaeec2c040d7dab8b66f35ef93ff6cf84168143eeefc76be910
+  languageName: node
+  linkType: hard
+
 "remark-rehype@npm:^10.0.0":
   version: 10.1.0
   resolution: "remark-rehype@npm:10.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24017,7 +24017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromark-extension-mdxjs@npm:^1.0.0":
+"micromark-extension-mdxjs@npm:1.0.0":
   version: 1.0.0
   resolution: "micromark-extension-mdxjs@npm:1.0.0"
   dependencies:
@@ -24030,6 +24030,22 @@ __metadata:
     micromark-util-combine-extensions: "npm:^1.0.0"
     micromark-util-types: "npm:^1.0.0"
   checksum: 10c0/51de1f7e8cadfe601ae4180d7a2402de40a02fec04d5f4deaa65061dbf39d81e3e56f0fcd55a43343c24593e371945a73a0a47fe723d02d99168b08c8945697d
+  languageName: node
+  linkType: hard
+
+"micromark-extension-mdxjs@patch:micromark-extension-mdxjs@npm%3A1.0.0#~/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch":
+  version: 1.0.0
+  resolution: "micromark-extension-mdxjs@patch:micromark-extension-mdxjs@npm%3A1.0.0#~/.yarn/patches/micromark-extension-mdxjs-npm-1.0.0-d2b6b69e4a.patch::version=1.0.0&hash=5369db"
+  dependencies:
+    acorn: "npm:^8.0.0"
+    acorn-jsx: "npm:^5.0.0"
+    micromark-extension-mdx-expression: "npm:^1.0.0"
+    micromark-extension-mdx-jsx: "npm:^1.0.0"
+    micromark-extension-mdx-md: "npm:^1.0.0"
+    micromark-extension-mdxjs-esm: "npm:^1.0.0"
+    micromark-util-combine-extensions: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+  checksum: 10c0/642b86dffa985c1ed3f128b45b8837f1b068fa9382cee827ca2c892b4fa368aab38ebae605490a584092fbfeaaddb8e4c09c2c5cf7371cc0221c75ed00f27134
   languageName: node
   linkType: hard
 
@@ -28401,13 +28417,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-mdx@npm:^2.0.0-rc.2":
+"remark-mdx@npm:2.0.0-rc.2":
   version: 2.0.0-rc.2
   resolution: "remark-mdx@npm:2.0.0-rc.2"
   dependencies:
     mdast-util-mdx: "npm:^1.0.0"
     micromark-extension-mdxjs: "npm:^1.0.0"
   checksum: 10c0/7f8f9e858ae3bfbe1143c2d71ce85f67aaf18206f4be24e5e3988e884a2202cd0c7ae1621a3054af86e3c1346f219a5126029f44b59b05702f1f2e406660c6e4
+  languageName: node
+  linkType: hard
+
+"remark-mdx@patch:remark-mdx@npm%3A2.0.0-rc.2#~/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch":
+  version: 2.0.0-rc.2
+  resolution: "remark-mdx@patch:remark-mdx@npm%3A2.0.0-rc.2#~/.yarn/patches/remark-mdx-npm-2.0.0-rc.2-7a71234e1f.patch::version=2.0.0-rc.2&hash=c7e3eb"
+  dependencies:
+    mdast-util-mdx: "npm:^1.0.0"
+    micromark-extension-mdxjs: "npm:^1.0.0"
+  checksum: 10c0/a4ec91b738d0609c88b6d565474770f268e461d5b0a27f258640f3d74273c715386a43d052313a58f6624b8349bd054ef9a3a4b957afbcafd5bd710714daaeb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In collaboration with @snowystinger. Prerequisite for Storybook 8 and RSC support for new website.

This enables [package.json exports](https://nodejs.org/api/packages.html#package-entry-points) support in Parcel, and TypeScript's `"moduleResolution": "bundler"` mode. This makes our packages behave more like they do outside our repo. I added `"source"` fields to each export so that we can resolve without building the dist folders. And fallback `"types"` fields for source as well.

This means we can no longer access sub-paths from packages that are not exported. To do that, you can use relative paths (but be careful to only do that in tests/stories/docs, and not in published code).