### PR TITLE
fix: Use scrollbar-gutter: stable instead of padding in usePreventScroll

### DIFF
--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -71,7 +71,10 @@ export function usePreventScroll(options: PreventScrollOptions = {}): void {
 // add some padding to prevent the page from shifting when the scrollbar is hidden.
 function preventScrollStandard() {
   return chain(
-    setStyle(document.documentElement, 'paddingRight', `${window.innerWidth - document.documentElement.clientWidth}px`),
+    // Use scrollbar-gutter when supported because it also works for fixed positioned elements.
+    'scrollbarGutter' in document.documentElement.style
+      ? setStyle(document.documentElement, 'scrollbarGutter', 'stable')
+      : setStyle(document.documentElement, 'paddingRight', `${window.innerWidth - document.documentElement.clientWidth}px`),
     setStyle(document.documentElement, 'overflow', 'hidden')
   );
 }


### PR DESCRIPTION
Fixes #1216, fixes #5470, fixes  #4782

Uses the new [scrollbar-gutter](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) CSS property instead of padding to offset the scrollbar width when available. This prevents fixed position elements from shifting as well. For example, try opening a popover/modal in our docs with scrollbars turned on. On this branch the right sidenav no longer moves.

The Chrome bug blocking this before was fixed in Chrome 136 https://issues.chromium.org/issues/40792788