### PR TITLE
fix: prevent combobox from closing when navigating through items with keyboard

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -505,7 +505,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
 
   // Scroll the focused element into view when the focusedKey changes.
   let lastFocusedKey = useRef(manager.focusedKey);
-  let raf = useRef<number | null>(null);
+  let raf = useRef<ReturnType<typeof requestAnimationFrame>>(undefined);
   useEffect(() => {
     if (manager.isFocused && manager.focusedKey != null && (manager.focusedKey !== lastFocusedKey.current || didAutoFocusRef.current) && scrollRef.current && ref.current) {
       let modality = getInteractionModality();
@@ -525,12 +525,12 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
         raf.current = requestAnimationFrame(() => {
           if (scrollRef.current) {
             scrollIntoView(scrollRef.current, element);
+            // Avoid scroll in iOS VO, since it may cause overlay to close (i.e. RAC submenu)
+            if (modality !== 'virtual') {
+              scrollIntoViewport(element, {containingElement: ref.current});
+            }
           }
         });
-        // Avoid scroll in iOS VO, since it may cause overlay to close (i.e. RAC submenu)
-        if (modality !== 'virtual') {
-          scrollIntoViewport(element, {containingElement: ref.current});
-        }
       }
     }
 
@@ -541,7 +541,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
 
     lastFocusedKey.current = manager.focusedKey;
     didAutoFocusRef.current = false;
-  });
+  }, [manager.focusedKey, manager.isFocused, ref, scrollRef]);
 
   useEffect(() => {
     return () => {

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -541,7 +541,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
 
     lastFocusedKey.current = manager.focusedKey;
     didAutoFocusRef.current = false;
-  }, [manager.focusedKey, manager.isFocused, ref, scrollRef]);
+  });
 
   useEffect(() => {
     return () => {

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -505,7 +505,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
 
   // Scroll the focused element into view when the focusedKey changes.
   let lastFocusedKey = useRef(manager.focusedKey);
-  let raf = useRef<ReturnType<typeof requestAnimationFrame>>(undefined);
+  let raf = useRef<number | null>(null);
   useEffect(() => {
     if (manager.isFocused && manager.focusedKey != null && (manager.focusedKey !== lastFocusedKey.current || didAutoFocusRef.current) && scrollRef.current && ref.current) {
       let modality = getInteractionModality();

--- a/packages/@react-spectrum/tag/test/TagGroup.test.js
+++ b/packages/@react-spectrum/tag/test/TagGroup.test.js
@@ -608,7 +608,7 @@ describe('TagGroup', function () {
       .mockImplementationOnce(() => ({x: 200, y: 400, width: 95, height: 32, top: 400, right: 290, bottom: 435, left: 200}))
       .mockImplementationOnce(() => ({x: 200, y: 300, width: 200, height: 128, top: 300, right: 400, bottom: 435, left: 200}))
       .mockImplementationOnce(() => ({x: 265, y: 335, width: 75, height: 32, top: 335, right: 345, bottom: 370, left: 265}))
-      .mockImplementationOnce(() => ({x: 200, y: 300, width: 75, height: 32, top: 300, right: 275, bottom: 335, left: 200}));
+      .mockImplementationOnce(() => ({x: 200, y: 300, width: 75, height: 32, top: 300, right: 275, bottom: 335, left: 200}))
     let {getAllByRole} = render(
       <Provider theme={theme}>
         <TagGroup
@@ -635,6 +635,7 @@ describe('TagGroup', function () {
     expect(buttons[1]).toHaveTextContent('Clear');
 
     await user.tab();
+    act(() => jest.runAllTimers());
     expect(document.activeElement).toBe(tags[0]);
 
     await user.tab();

--- a/packages/@react-spectrum/tag/test/TagGroup.test.js
+++ b/packages/@react-spectrum/tag/test/TagGroup.test.js
@@ -608,7 +608,7 @@ describe('TagGroup', function () {
       .mockImplementationOnce(() => ({x: 200, y: 400, width: 95, height: 32, top: 400, right: 290, bottom: 435, left: 200}))
       .mockImplementationOnce(() => ({x: 200, y: 300, width: 200, height: 128, top: 300, right: 400, bottom: 435, left: 200}))
       .mockImplementationOnce(() => ({x: 265, y: 335, width: 75, height: 32, top: 335, right: 345, bottom: 370, left: 265}))
-      .mockImplementationOnce(() => ({x: 200, y: 300, width: 75, height: 32, top: 300, right: 275, bottom: 335, left: 200}))
+      .mockImplementationOnce(() => ({x: 200, y: 300, width: 75, height: 32, top: 300, right: 275, bottom: 335, left: 200}));
     let {getAllByRole} = render(
       <Provider theme={theme}>
         <TagGroup


### PR DESCRIPTION
Closes #8298 

Seems like the order that `scrollIntoView` and `scrolIntoViewport` matters so wrap it all in a raf

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

I can't seem to actually reproduce in our storybook but I can within our docs.

1. Go to V3 Combobox docs
2. Using the first example, resize the screen so that the popover is scrollable. Ensure that there is enough space below so that the popover will open on the bottom and not the top
3. Open the popover using the keyboard, and navigate throw the items using the down arrow
4. The popover should not close when you move past the last visible item

Would be good to test to make sure that V3 Picker still scroll into view with this change. You can test with the "long item text" story


## 🧢 Your Project:

<!--- Company/project for pull request -->
