### PR TITLE
fix: Virtualizer with useIsSSR

### DIFF
--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -137,8 +137,8 @@ function renderWrapper(
   );
 
   let {collection, layout} = reusableView.virtualizer;
-  let node = reusableView.content!;
-  if (node.type === 'item' && renderDropIndicator && layout.getDropTargetLayoutInfo) {
+  let node = reusableView.content;
+  if (node?.type === 'item' && renderDropIndicator && layout.getDropTargetLayoutInfo) {
     rendered = (
       <React.Fragment key={reusableView.key}>
         {renderDropIndicatorWrapper(parent, reusableView, {type: 'item', key: reusableView.content!.key, dropPosition: 'before'}, renderDropIndicator)}


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8293

In collaboration with @LFDanLu , we tried to write a test that mimicked what Next was doing in our SSR tests, but we couldn't get it to reproduce there. The flow diverges pretty quickly, in the test we immediately have a full collection, but in Next, there's a period of time where it's not been processed yet.
I'm assuming there is something happening with concurrency, but that's just a hunch. Open to suggestions on a test for this.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
