### PR TITLE
fix: Fix S2 button/taggroup coloring so they apply on keyboard focus only

### DIFF
--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -95,7 +95,7 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
         default: lightDark('accent-900', 'accent-700'),
         isHovered: lightDark('accent-1000', 'accent-600'),
         isPressed: lightDark('accent-1000', 'accent-600'),
-        isFocused: lightDark('accent-1000', 'accent-600')
+        isFocusVisible: lightDark('accent-1000', 'accent-600')
       },
       isDisabled: {
         default: 'gray-100',

--- a/packages/@react-spectrum/s2/src/Button.tsx
+++ b/packages/@react-spectrum/s2/src/Button.tsx
@@ -116,13 +116,13 @@ const button = style<ButtonRenderProps & ButtonStyleProps & {isStaticColor: bool
             default: lightDark('accent-900', 'accent-700'),
             isHovered: lightDark('accent-1000', 'accent-600'),
             isPressed: lightDark('accent-1000', 'accent-600'),
-            isFocused: lightDark('accent-1000', 'accent-600')
+            isFocusVisible: lightDark('accent-1000', 'accent-600')
           },
           negative: {
             default: lightDark('negative-900', 'negative-700'),
             isHovered: lightDark('negative-1000', 'negative-600'),
             isPressed: lightDark('negative-1000', 'negative-600'),
-            isFocused: lightDark('negative-1000', 'negative-600')
+            isFocusVisible: lightDark('negative-1000', 'negative-600')
           },
           premium: 'gray-100',
           genai: 'gray-100'
@@ -347,7 +347,7 @@ export const Button = forwardRef(function Button(props: ButtonProps, ref: Focusa
         isStaticColor: !!staticColor
       }, props.styles)}>
       {(renderProps) => (<>
-        {variant === 'genai' || variant === 'premium' 
+        {variant === 'genai' || variant === 'premium'
           ? (
             <span
               className={gradient({

--- a/packages/@react-spectrum/s2/src/TagGroup.tsx
+++ b/packages/@react-spectrum/s2/src/TagGroup.tsx
@@ -442,7 +442,7 @@ const tagStyles = style<TagRenderProps & {size?: 'S' | 'M' | 'L', isEmphasized?:
         default: lightDark('accent-900', 'accent-700'),
         isHovered: lightDark('accent-1000', 'accent-600'),
         isPressed: lightDark('accent-1000', 'accent-600'),
-        isFocused: lightDark('accent-1000', 'accent-600')
+        isFocusVisible: lightDark('accent-1000', 'accent-600')
       }
     },
     isDisabled: 'disabled',


### PR DESCRIPTION
Focus visible styles were being applied on standard focus

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
