### PR TITLE
fix(S2): inert value and img empty src string in React 19

### DIFF
--- a/packages/@react-spectrum/s2/chromatic/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/CardView.stories.tsx
@@ -27,26 +27,17 @@ const meta: Meta<typeof CardView> = {
 export default meta;
 
 const cardViewStyles = style({
-  width: {
-    default: 'screen',
-    viewMode: {
-      docs: 'full'
-    }
-  },
-  height: {
-    default: 'screen',
-    viewMode: {
-      docs: 600
-    }
-  }
+  width: 'screen',
+  maxWidth: 'full',
+  height: 600
 });
 
-export const Empty = (args: CardViewProps<any>, {viewMode}) => {
+export const Empty = (args: CardViewProps<any>) => {
   return (
     <CardView
       aria-label="Assets"
       {...args}
-      styles={cardViewStyles({viewMode})}
+      styles={cardViewStyles}
       renderEmptyState={() => (
         <IllustratedMessage size="L">
           <EmptyIcon />

--- a/packages/@react-spectrum/s2/src/Image.tsx
+++ b/packages/@react-spectrum/s2/src/Image.tsx
@@ -228,7 +228,7 @@ export const Image = forwardRef(function Image(props: ImageProps, domRef: Forwar
       {!errorState && (
         <img
           {...getFetchPriorityProp(fetchPriority)}
-          src={src}
+          src={src || undefined}
           alt={alt}
           crossOrigin={crossOrigin}
           decoding={decoding}

--- a/packages/@react-spectrum/s2/src/Skeleton.tsx
+++ b/packages/@react-spectrum/s2/src/Skeleton.tsx
@@ -126,7 +126,8 @@ export function SkeletonWrapper({children}: {children: SkeletonElement}): ReactN
       {isLoading ? cloneElement(children, {
         ref: mergeRefs(childRef, animation),
         className: (children.props.className || '') + ' ' + loadingStyle,
-        inert: 'true'
+        // @ts-ignore - compatibility with React < 19
+        inert: inertValue(true)
       }) : children}
     </SkeletonContext.Provider>
   );

--- a/packages/@react-spectrum/s2/stories/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CardView.stories.tsx
@@ -101,7 +101,8 @@ function PhotoCard({item, layout}: {item: Item, layout: string}) {
   );
 }
 
-export const Example = (args: CardViewProps<any>, {viewMode}) => {
+export const Example = (args: CardViewProps<any> & {viewMode: string}) => {
+  let {viewMode} = args;
   let list = useAsyncList<Item, number | null>({
     async load({signal, cursor, items}) {
       let page = cursor || 1;
@@ -154,10 +155,14 @@ export const Example = (args: CardViewProps<any>, {viewMode}) => {
 Example.args = {
   loadingState: 'idle',
   onAction: null,
-  selectionMode: 'multiple'
+  selectionMode: 'multiple',
+  decorators: [
+    (Story, {viewMode}) => <Story viewMode={viewMode} />
+  ]
 };
 
-export const Empty = (args: CardViewProps<any>, {viewMode}) => {
+export const Empty = (args: CardViewProps<any> & {viewMode: string}) => {
+  let {viewMode} = args;
   return (
     <CardView
       aria-label="Assets"
@@ -173,6 +178,12 @@ export const Empty = (args: CardViewProps<any>, {viewMode}) => {
       {[]}
     </CardView>
   );
+};
+
+Empty.args = {
+  decorators: [
+    (Story, {viewMode}) => <Story viewMode={viewMode} />
+  ]
 };
 
 interface Topic {
@@ -202,7 +213,8 @@ function TopicCard({topic}: {topic: Topic}) {
   );
 }
 
-export const CollectionCards = (args: CardViewProps<any>, {viewMode}) => {
+export const CollectionCards = (args: CardViewProps<any> & {viewMode: string}) => {
+  let {viewMode} = args;
   let list = useAsyncList<Topic, number | null>({
     async load({signal, cursor}) {
       let page = cursor || 1;
@@ -253,5 +265,8 @@ export const CollectionCards = (args: CardViewProps<any>, {viewMode}) => {
 
 CollectionCards.args = {
   loadingState: 'idle',
-  onAction: null
+  onAction: null,
+  decorators: [
+    (Story, {viewMode}) => <Story viewMode={viewMode} />
+  ]
 };

--- a/packages/@react-spectrum/s2/stories/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CardView.stories.tsx
@@ -29,18 +29,9 @@ const meta: Meta<typeof CardView> = {
 export default meta;
 
 const cardViewStyles = style({
-  width: {
-    default: 'screen',
-    viewMode: {
-      docs: 'full'
-    }
-  },
-  height: {
-    default: 'screen',
-    viewMode: {
-      docs: 600
-    }
-  }
+  width: 'screen',
+  maxWidth: 'full',
+  height: 600
 });
 
 type Item = {
@@ -101,7 +92,7 @@ function PhotoCard({item, layout}: {item: Item, layout: string}) {
   );
 }
 
-export const Example = (args: CardViewProps<any>, {viewMode}) => {
+export const Example = (args: CardViewProps<any>) => {
   let list = useAsyncList<Item, number | null>({
     async load({signal, cursor, items}) {
       let page = cursor || 1;
@@ -126,7 +117,7 @@ export const Example = (args: CardViewProps<any>, {viewMode}) => {
       {...args}
       loadingState={loadingState}
       onLoadMore={args.loadingState === 'idle' ? list.loadMore : undefined}
-      styles={cardViewStyles({viewMode})}>
+      styles={cardViewStyles}>
       <Collection items={items} dependencies={[args.layout]}>
         {item => <PhotoCard item={item} layout={args.layout || 'grid'} />}
       </Collection>
@@ -157,12 +148,12 @@ Example.args = {
   selectionMode: 'multiple'
 };
 
-export const Empty = (args: CardViewProps<any>, {viewMode}) => {
+export const Empty = (args: CardViewProps<any>) => {
   return (
     <CardView
       aria-label="Assets"
       {...args}
-      styles={cardViewStyles({viewMode})}
+      styles={cardViewStyles}
       renderEmptyState={() => (
         <IllustratedMessage size="L">
           <EmptyIcon />
@@ -202,7 +193,7 @@ function TopicCard({topic}: {topic: Topic}) {
   );
 }
 
-export const CollectionCards = (args: CardViewProps<any>, {viewMode}) => {
+export const CollectionCards = (args: CardViewProps<any>) => {
   let list = useAsyncList<Topic, number | null>({
     async load({signal, cursor}) {
       let page = cursor || 1;
@@ -224,7 +215,7 @@ export const CollectionCards = (args: CardViewProps<any>, {viewMode}) => {
       {...args}
       loadingState={loadingState}
       onLoadMore={args.loadingState === 'idle' ? list.loadMore : undefined}
-      styles={cardViewStyles({viewMode})}>
+      styles={cardViewStyles}>
       <Collection items={items}>
         {topic => <TopicCard topic={topic} />}
       </Collection>

--- a/packages/@react-spectrum/s2/stories/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CardView.stories.tsx
@@ -101,8 +101,7 @@ function PhotoCard({item, layout}: {item: Item, layout: string}) {
   );
 }
 
-export const Example = (args: CardViewProps<any> & {viewMode: string}) => {
-  let {viewMode} = args;
+export const Example = (args: CardViewProps<any>, {viewMode}) => {
   let list = useAsyncList<Item, number | null>({
     async load({signal, cursor, items}) {
       let page = cursor || 1;
@@ -155,14 +154,10 @@ export const Example = (args: CardViewProps<any> & {viewMode: string}) => {
 Example.args = {
   loadingState: 'idle',
   onAction: null,
-  selectionMode: 'multiple',
-  decorators: [
-    (Story, {viewMode}) => <Story viewMode={viewMode} />
-  ]
+  selectionMode: 'multiple'
 };
 
-export const Empty = (args: CardViewProps<any> & {viewMode: string}) => {
-  let {viewMode} = args;
+export const Empty = (args: CardViewProps<any>, {viewMode}) => {
   return (
     <CardView
       aria-label="Assets"
@@ -178,12 +173,6 @@ export const Empty = (args: CardViewProps<any> & {viewMode: string}) => {
       {[]}
     </CardView>
   );
-};
-
-Empty.args = {
-  decorators: [
-    (Story, {viewMode}) => <Story viewMode={viewMode} />
-  ]
 };
 
 interface Topic {
@@ -213,8 +202,7 @@ function TopicCard({topic}: {topic: Topic}) {
   );
 }
 
-export const CollectionCards = (args: CardViewProps<any> & {viewMode: string}) => {
-  let {viewMode} = args;
+export const CollectionCards = (args: CardViewProps<any>, {viewMode}) => {
   let list = useAsyncList<Topic, number | null>({
     async load({signal, cursor}) {
       let page = cursor || 1;
@@ -265,8 +253,5 @@ export const CollectionCards = (args: CardViewProps<any> & {viewMode: string}) =
 
 CollectionCards.args = {
   loadingState: 'idle',
-  onAction: null,
-  decorators: [
-    (Story, {viewMode}) => <Story viewMode={viewMode} />
-  ]
+  onAction: null
 };

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -300,7 +300,8 @@ export const TabPanel = /*#__PURE__*/ createHideableComponent(function TabPanel(
     values: {
       isFocused,
       isFocusVisible,
-      isInert: !isSelected,
+      // @ts-ignore - compatibility with React < 19
+      isInert: inertValue(!isSelected),
       state
     }
   });


### PR DESCRIPTION
- Fixes CardView story formats 
- Fixes `inert` value error (for React 19) in Skeleton and RAC Tabs
- Fixes empty `src` string error in Image

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check S2 CardView and ActionBar stories and verify they render without issues.

## 🧢 Your Project:

<!--- Company/project for pull request -->
