### PR TITLE
chore: Improve S2 story argTypes

### DIFF
--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -19,7 +19,6 @@ import {
   ButtonRenderProps,
   ContextValue,
   InputContext,
-  Text,
   useContextProps
 } from 'react-aria-components';
 import {baseColor, space, style} from '../style' with {type: 'macro'};
@@ -245,7 +244,6 @@ export const NumberField = forwardRef(function NumberField(props: NumberFieldPro
                     </StepButton>
                   </div>}
                 </FieldGroup>
-                {descriptionMessage && <Text slot="description">{descriptionMessage}</Text>}
                 <HelpText
                   size={size}
                   isDisabled={isDisabled}

--- a/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
@@ -23,6 +23,9 @@ const meta: Meta<typeof Accordion> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'Accordion'
 };

--- a/packages/@react-spectrum/s2/stories/ActionBar.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionBar.stories.tsx
@@ -23,6 +23,9 @@ const meta: Meta<typeof ActionBar> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'ActionBar'
 };

--- a/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionButton.stories.tsx
@@ -28,7 +28,8 @@ const meta: Meta<typeof ActionButton> = {
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp'])
+    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp']),
+    children: {table: {disable: true}}
   },
   title: 'ActionButton'
 };

--- a/packages/@react-spectrum/s2/stories/ActionButtonGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionButtonGroup.stories.tsx
@@ -23,6 +23,9 @@ const meta: Meta<typeof ActionButtonGroup> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   title: 'ActionButtonGroup'

--- a/packages/@react-spectrum/s2/stories/ActionMenu.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ActionMenu.stories.tsx
@@ -22,7 +22,8 @@ const meta: Meta<typeof ActionMenu<any>> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onAction', 'onOpenChange'])
+    ...categorizeArgTypes('Events', ['onAction', 'onOpenChange']),
+    children: {table: {disable: true}}
   },
   title: 'ActionMenu'
 };

--- a/packages/@react-spectrum/s2/stories/Avatar.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Avatar.stories.tsx
@@ -16,7 +16,11 @@ import {style} from '../style' with { type: 'macro' };
 
 const meta: Meta<typeof Avatar> = {
   component: Avatar,
-  argTypes: {},
+  argTypes: {
+    size: {
+      control: 'number'
+    }
+  },
   parameters: {
     layout: 'centered'
   },

--- a/packages/@react-spectrum/s2/stories/AvatarGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/AvatarGroup.stories.tsx
@@ -16,9 +16,11 @@ import {style} from '../style' with {type: 'macro'};
 
 const meta: Meta<typeof AvatarGroup> = {
   component: AvatarGroup,
-  argTypes: {},
   parameters: {
     layout: 'centered'
+  },
+  argTypes: {
+    children: {table: {disable: true}}
   },
   tags: ['autodocs'],
   title: 'AvatarGroup'

--- a/packages/@react-spectrum/s2/stories/Badge.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Badge.stories.tsx
@@ -20,6 +20,9 @@ const meta: Meta<typeof Badge> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'Badge'
 };

--- a/packages/@react-spectrum/s2/stories/Breadcrumbs.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Breadcrumbs.stories.tsx
@@ -31,7 +31,8 @@ const meta: Meta<typeof Breadcrumbs> = {
     },
     onAction: {
       table: {category: 'Events'}
-    }
+    },
+    children: {table: {disable: true}}
   },
   tags: ['autodocs'],
   title: 'Breadcrumbs'

--- a/packages/@react-spectrum/s2/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Button.stories.tsx
@@ -26,7 +26,8 @@ const meta: Meta<typeof Button> = {
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp'])
+    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp']),
+    children: {table: {disable: true}}
   },
   title: 'Button'
 };

--- a/packages/@react-spectrum/s2/stories/ButtonGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ButtonGroup.stories.tsx
@@ -20,6 +20,9 @@ const meta: Meta<typeof ButtonGroup> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'ButtonGroup'
 };

--- a/packages/@react-spectrum/s2/stories/Card.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Card.stories.tsx
@@ -39,7 +39,8 @@ const meta: Meta<CardProps & {isLoading?: boolean}> = {
     value: {table: {disable: true}},
     textValue: {table: {disable: true}},
     onAction: {table: {disable: true}},
-    isDisabled: {table: {disable: true}}
+    isDisabled: {table: {disable: true}},
+    children: {table: {disable: true}}
   },
   decorators: (children, {args}) => (
     <Skeleton isLoading={args.isLoading || false}>

--- a/packages/@react-spectrum/s2/stories/Checkbox.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Checkbox.stories.tsx
@@ -22,7 +22,8 @@ const meta: Meta<typeof Checkbox> = {
   tags: ['autodocs'],
   argTypes: {
     inputRef: {control: {disable: true}},
-    onChange: {table: {category: 'Events'}}
+    onChange: {table: {category: 'Events'}},
+    children: {table: {disable: true}}
   },
   title: 'Checkbox'
 };

--- a/packages/@react-spectrum/s2/stories/CheckboxGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CheckboxGroup.stories.tsx
@@ -29,7 +29,12 @@ const meta: Meta<typeof CheckboxGroup> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onChange: {table: {category: 'Events'}}
+    onChange: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    children: {table: {disable: true}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'CheckboxGroup'
 };

--- a/packages/@react-spectrum/s2/stories/ColorArea.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ColorArea.stories.tsx
@@ -21,7 +21,8 @@ const meta: Meta<typeof ColorArea> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onChange', 'onChangeEnd'])
+    ...categorizeArgTypes('Events', ['onChange', 'onChangeEnd']),
+    value: {control: {type: 'text'}}
   },
   title: 'ColorArea'
 };

--- a/packages/@react-spectrum/s2/stories/ColorField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ColorField.stories.tsx
@@ -28,7 +28,11 @@ const meta: Meta<typeof ColorField> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onChange: {table: {category: 'Events'}}
+    onChange: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'ColorField'
 };

--- a/packages/@react-spectrum/s2/stories/ColorSlider.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ColorSlider.stories.tsx
@@ -22,7 +22,8 @@ const meta: Meta<typeof ColorSlider> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onChange', 'onChangeEnd'])
+    ...categorizeArgTypes('Events', ['onChange', 'onChangeEnd']),
+    contextualHelp: {table: {disable: true}}
   },
   title: 'ColorSlider'
 };

--- a/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
@@ -26,7 +26,12 @@ const meta: Meta<typeof ComboBox<any>> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onInputChange', 'onOpenChange', 'onSelectionChange'])
+    ...categorizeArgTypes('Events', ['onInputChange', 'onOpenChange', 'onSelectionChange']),
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    children: {table: {disable: true}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'ComboBox'
 };

--- a/packages/@react-spectrum/s2/stories/ContextualHelp.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ContextualHelp.stories.tsx
@@ -9,7 +9,8 @@ const meta: Meta<typeof ContextualHelp> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onOpenChange: {table: {category: 'Events'}}
+    onOpenChange: {table: {category: 'Events'}},
+    children: {table: {disable: true}}
   },
   title: 'ContextualHelp'
 };

--- a/packages/@react-spectrum/s2/stories/CustomDialog.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CustomDialog.stories.tsx
@@ -21,6 +21,9 @@ const meta: Meta<typeof CustomDialog> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'CustomDialog'
 };

--- a/packages/@react-spectrum/s2/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Dialog.stories.tsx
@@ -23,6 +23,9 @@ const meta: Meta<typeof Dialog> = {
       controls: {exclude: ['showHero', 'showHeading', 'showHeader', 'showFooter', 'showButtons', 'paragraphs', 'title']}
     }
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'Dialog'
 };

--- a/packages/@react-spectrum/s2/stories/Disclosure.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Disclosure.stories.tsx
@@ -37,7 +37,8 @@ const meta: Meta<typeof Disclosure> = {
     },
     isDisabled: {
       control: {type: 'boolean'}
-    }
+    },
+    children: {table: {disable: true}}
   },
   title: 'Disclosure'
 };

--- a/packages/@react-spectrum/s2/stories/DropZone.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/DropZone.stories.tsx
@@ -27,7 +27,8 @@ const meta: Meta<typeof DropZone> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onDrop', 'onDropActivate', 'onDropEnter', 'onDropExit', 'onDropMove'])
+    ...categorizeArgTypes('Events', ['onDrop', 'onDropActivate', 'onDropEnter', 'onDropExit', 'onDropMove']),
+    children: {table: {disable: true}}
   },
   title: 'DropZone'
 };

--- a/packages/@react-spectrum/s2/stories/FullscreenDialog.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/FullscreenDialog.stories.tsx
@@ -18,6 +18,9 @@ const meta: Meta<typeof FullscreenDialog> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'FullscreenDialog'
 };

--- a/packages/@react-spectrum/s2/stories/IllustratedMessage.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/IllustratedMessage.stories.tsx
@@ -20,6 +20,9 @@ const meta: Meta<typeof IllustratedMessage> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'IllustratedMessage'
 };

--- a/packages/@react-spectrum/s2/stories/InlineAlert.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/InlineAlert.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof InlineAlert> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'InlineAlert'
 };

--- a/packages/@react-spectrum/s2/stories/LinkButton.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/LinkButton.stories.tsx
@@ -24,7 +24,8 @@ const meta: Meta<typeof LinkButton> = {
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp'])
+    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp']),
+    children: {table: {disable: true}}
   },
   title: 'LinkButton'
 };

--- a/packages/@react-spectrum/s2/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Menu.stories.tsx
@@ -42,7 +42,8 @@ const meta: Meta<typeof CombinedMenu> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onAction', 'onClose', 'onOpenChange', 'onScroll', 'onSelectionChange'])
+    ...categorizeArgTypes('Events', ['onAction', 'onClose', 'onOpenChange', 'onScroll', 'onSelectionChange']),
+    children: {table: {disable: true}}
   },
   title: 'Menu'
 };

--- a/packages/@react-spectrum/s2/stories/Meter.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Meter.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof Meter> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    label: {control: {type: 'text'}}
+  },
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   title: 'Meter'

--- a/packages/@react-spectrum/s2/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/NumberField.stories.tsx
@@ -29,6 +29,12 @@ const meta: Meta<typeof NumberField> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    contextualHelp: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'NumberField'
 };

--- a/packages/@react-spectrum/s2/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Picker.stories.tsx
@@ -39,7 +39,12 @@ const meta: Meta<typeof Picker<any>> = {
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onOpenChange', 'onSelectionChange'])
+    ...categorizeArgTypes('Events', ['onOpenChange', 'onSelectionChange']),
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    children: {table: {disable: true}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'Picker'
 };

--- a/packages/@react-spectrum/s2/stories/Popover.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Popover.stories.tsx
@@ -30,6 +30,9 @@ const meta: Meta<typeof Popover> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'Popover'
 };

--- a/packages/@react-spectrum/s2/stories/ProgressBar.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ProgressBar.stories.tsx
@@ -20,6 +20,9 @@ const meta: Meta<typeof ProgressBar> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    label: {control: {type: 'text'}}
+  },
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   title: 'ProgressBar'

--- a/packages/@react-spectrum/s2/stories/RadioGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/RadioGroup.stories.tsx
@@ -30,7 +30,12 @@ const meta: Meta<typeof RadioGroup> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onChange: {table: {category: 'Events'}}
+    onChange: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    children: {table: {disable: true}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'RadioGroup'
 };

--- a/packages/@react-spectrum/s2/stories/RangeSlider.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/RangeSlider.stories.tsx
@@ -24,7 +24,9 @@ const meta: Meta<typeof RangeSlider> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onChangeEnd: {table: {category: 'Events'}}
+    onChangeEnd: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'RangeSlider'
 };

--- a/packages/@react-spectrum/s2/stories/SearchField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/SearchField.stories.tsx
@@ -30,7 +30,11 @@ const meta: Meta<typeof SearchField> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onChange', 'onClear', 'onSubmit'])
+    ...categorizeArgTypes('Events', ['onChange', 'onClear', 'onSubmit']),
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'SearchField'
 };

--- a/packages/@react-spectrum/s2/stories/SegmentedControl.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/SegmentedControl.stories.tsx
@@ -26,6 +26,9 @@ const meta: Meta<typeof SegmentedControl> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'SegmentedControl'
 };

--- a/packages/@react-spectrum/s2/stories/Slider.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Slider.stories.tsx
@@ -25,7 +25,9 @@ const meta: Meta<typeof Slider> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onChangeEnd: {table: {category: 'Events'}}
+    onChangeEnd: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'Slider'
 };

--- a/packages/@react-spectrum/s2/stories/StatusLight.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/StatusLight.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof StatusLight> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'StatusLight'
 };

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -42,6 +42,7 @@ const meta: Meta<typeof TableView> = {
   },
   argTypes: {
     ...categorizeArgTypes('Events', ['onAction', 'onLoadMore', 'onResizeStart', 'onResize', 'onResizeEnd', 'onSelectionChange', 'onSortChange']),
+    children: {table: {disable: true}},
     onAction: {
       options: Object.keys(onActionOptions), // An array of serializable values
       mapping: onActionOptions, // Maps serializable option values to complex arg values

--- a/packages/@react-spectrum/s2/stories/Tabs.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Tabs.stories.tsx
@@ -23,6 +23,9 @@ const meta: Meta<typeof Tabs> = {
   parameters: {
     layout: 'centered'
   },
+  argTypes: {
+    children: {table: {disable: true}}
+  },
   tags: ['autodocs'],
   title: 'Tabs'
 };

--- a/packages/@react-spectrum/s2/stories/TagGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TagGroup.stories.tsx
@@ -40,7 +40,11 @@ const meta: Meta<typeof TagGroup<any>> = {
     onRemove: {
       control: {type: 'boolean'}
     },
-    onSelectionChange: {table: {category: 'Events'}}
+    onSelectionChange: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    children: {table: {disable: true}}
   },
   tags: ['autodocs'],
   title: 'TagGroup'

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -24,7 +24,11 @@ const meta: Meta<typeof TextField> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onChange: {table: {category: 'Events'}}
+    onChange: {table: {category: 'Events'}},
+    label: {control: {type: 'text'}},
+    description: {control: {type: 'text'}},
+    errorMessage: {control: {type: 'text'}},
+    contextualHelp: {table: {disable: true}}
   },
   title: 'TextField'
 };

--- a/packages/@react-spectrum/s2/stories/ToggleButton.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ToggleButton.stories.tsx
@@ -23,7 +23,8 @@ const meta: Meta<typeof ToggleButton> = {
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp', 'onChange'])
+    ...categorizeArgTypes('Events', ['onPress', 'onPressChange', 'onPressEnd', 'onPressStart', 'onPressUp', 'onChange']),
+    children: {table: {disable: true}}
   },
   title: 'ToggleButton'
 };

--- a/packages/@react-spectrum/s2/stories/ToggleButtonGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ToggleButtonGroup.stories.tsx
@@ -26,7 +26,8 @@ const meta: Meta<typeof ToggleButtonGroup> = {
   decorators: [StaticColorDecorator],
   tags: ['autodocs'],
   argTypes: {
-    ...categorizeArgTypes('Events', ['onSelectionChange'])
+    ...categorizeArgTypes('Events', ['onSelectionChange']),
+    children: {table: {disable: true}}
   },
   title: 'ToggleButtonGroup'
 };

--- a/packages/@react-spectrum/s2/stories/Tooltip.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Tooltip.stories.tsx
@@ -24,7 +24,8 @@ const meta: Meta<typeof CombinedTooltip> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    onOpenChange: {table: {category: 'Events'}}
+    onOpenChange: {table: {category: 'Events'}},
+    children: {table: {disable: true}}
   },
   decorators: [(Story) => <div style={{height: '100px', width: '200px', display: 'flex', alignItems: 'end', justifyContent: 'center', paddingBottom: 10}}><Story /></div>],
   title: 'Tooltip'

--- a/packages/@react-spectrum/s2/stories/TreeView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TreeView.stories.tsx
@@ -51,6 +51,7 @@ const meta: Meta<typeof TreeView> = {
   },
   argTypes: {
     ...categorizeArgTypes('Events', ['onAction', 'onSelectionChange']),
+    children: {table: {disable: true}},
     onAction: {
       options: Object.keys(onActionOptions), // An array of serializable values
       mapping: onActionOptions, // Maps serializable option values to complex arg values


### PR DESCRIPTION
Attempting to set certain args in S2 stories would cause storybook to crash. In particular anything that has a `ReactNode` type creates an object control instead of string. That defaults to `{}`, which causes the story to crash (objects are not valid react elements). This overrides these argTypes to use a string control instead. Also omitted children in most cases since they are hard coded in the story and setting them would do nothing.