### PR TITLE
fix: Delay onPressUp to native onClick event

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -385,7 +385,9 @@ export function usePress(props: PressHookProps): PressResult {
             shouldStopPropagation = stopPressStart && stopPressUp && stopPressEnd;
           } else if (state.isPressed && state.pointerType !== 'keyboard') {
             let pointerType = state.pointerType || (e.nativeEvent as PointerEvent).pointerType as PointerType || 'virtual';
-            shouldStopPropagation = triggerPressEnd(createEvent(e.currentTarget, e), pointerType, true);
+            let stopPressUp = triggerPressUp(createEvent(e.currentTarget, e), pointerType);
+            let stopPressEnd =  triggerPressEnd(createEvent(e.currentTarget, e), pointerType, true);
+            shouldStopPropagation = stopPressUp && stopPressEnd;
             state.isOverTarget = false;
             triggerClick(e);
             cancel(e);
@@ -507,8 +509,8 @@ export function usePress(props: PressHookProps): PressResult {
           return;
         }
 
-        // Only handle left clicks
-        if (e.button === 0) {
+        // Only handle left clicks. If isPressed is true, delay until onClick.
+        if (e.button === 0 && !state.isPressed) {
           triggerPressUp(e, state.pointerType || e.pointerType);
         }
       };
@@ -651,7 +653,7 @@ export function usePress(props: PressHookProps): PressResult {
           return;
         }
 
-        if (!state.ignoreEmulatedMouseEvents && e.button === 0) {
+        if (!state.ignoreEmulatedMouseEvents && e.button === 0 && !state.isPressed) {
           triggerPressUp(e, state.pointerType || 'mouse');
         }
       };

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -388,17 +388,6 @@ describe('usePress', function () {
           pressed: true
         },
         {
-          type: 'pressup',
-          target: el.parentElement,
-          pointerType: 'mouse',
-          ctrlKey: false,
-          metaKey: false,
-          shiftKey: false,
-          altKey: false,
-          x: 0,
-          y: 0
-        },
-        {
           type: 'pressend',
           target: el.parentElement,
           pointerType: 'mouse',

--- a/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
+++ b/packages/@react-spectrum/calendar/test/RangeCalendar.test.js
@@ -923,6 +923,7 @@ describe('RangeCalendar', () => {
 
       // mouse up should
       fireEvent.mouseUp(getByText('10'), {detail: 1});
+      fireEvent.click(getByText('10'), {detail: 1});
       selectedDates = getAllByLabelText('selected', {exact: false});
       expect(selectedDates[0].textContent).toBe('10');
       expect(selectedDates[selectedDates.length - 1].textContent).toBe('10');
@@ -967,6 +968,7 @@ describe('RangeCalendar', () => {
 
       // mouse up should
       fireEvent.mouseUp(getByText('20'), {detail: 1});
+      fireEvent.click(getByText('20'), {detail: 1});
       selectedDates = getAllByLabelText('selected', {exact: false});
       expect(selectedDates[0].textContent).toBe('20');
       expect(selectedDates[selectedDates.length - 1].textContent).toBe('20');


### PR DESCRIPTION
Fixes #8363

Regression introduced in #8275. Select triggers onSelectionChange during onPressUp rather than onPress. This occurs during the onPointerUp event rather than onClick. When this happens, the popover's `isOpen` state changes to false, which removes the underlay and disables useInteractOutside. Due to the exit animation, the popover is not immediately removed from the DOM, so the onClick event is still fired on the menu item. However since useInteractOutside is already disabled, this results in the parent overlay (which is now the "top-most") closing as well.

We can fix this by delaying onPressUp until onClick as well. When starting from a different origin (e.g. dragging and releasing over an item), we'll still trigger onPressUp during onPointerUp since an onClick will not be fired in this case.