### PR TITLE
feat: allow dom props on alert dialog. add test ids to alert dialog buttons

### DIFF
--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -13,13 +13,13 @@
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import {Button} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
-import {chain} from '@react-aria/utils';
+import {chain, filterDOMProps} from '@react-aria/utils';
 import {classNames, useStyleProps} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {Dialog} from './Dialog';
 import {DialogContext, DialogContextValue} from './context';
 import {Divider} from '@react-spectrum/divider';
-import {DOMRef} from '@react-types/shared';
+import {DOMProps, DOMRef} from '@react-types/shared';
 import {Heading} from '@react-spectrum/text';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -50,6 +50,9 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
     onCancel = () => {},
     onPrimaryAction = () => {},
     onSecondaryAction = () => {},
+    cancelProps = {} as DOMProps,
+    primaryProps = {} as DOMProps,
+    secondaryProps = {} as DOMProps,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
@@ -71,7 +74,8 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
       isHidden={styleProps.hidden}
       size="M"
       role="alertdialog"
-      ref={ref}>
+      ref={ref}
+      {...filterDOMProps(props)}>
       <Heading>{title}</Heading>
       {(variant === 'error' || variant === 'warning') &&
         <AlertMedium
@@ -85,7 +89,8 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
           <Button
             variant="secondary"
             onPress={() => chain(onClose(), onCancel())}
-            autoFocus={autoFocusButton === 'cancel'}>
+            autoFocus={autoFocusButton === 'cancel'}
+            {...filterDOMProps(cancelProps)}>
             {cancelLabel}
           </Button>
         }
@@ -94,7 +99,8 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
             variant="secondary"
             onPress={() => chain(onClose(), onSecondaryAction())}
             isDisabled={isSecondaryActionDisabled}
-            autoFocus={autoFocusButton === 'secondary'}>
+            autoFocus={autoFocusButton === 'secondary'}
+            {...filterDOMProps(secondaryProps)}>
             {secondaryActionLabel}
           </Button>
         }
@@ -102,7 +108,8 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
           variant={confirmVariant}
           onPress={() => chain(onClose(), onPrimaryAction())}
           isDisabled={isPrimaryActionDisabled}
-          autoFocus={autoFocusButton === 'primary'}>
+          autoFocus={autoFocusButton === 'primary'}
+          {...filterDOMProps(primaryProps)}>
           {primaryActionLabel}
         </Button>
       </ButtonGroup>

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -19,7 +19,7 @@ import {Content} from '@react-spectrum/view';
 import {Dialog} from './Dialog';
 import {DialogContext, DialogContextValue} from './context';
 import {Divider} from '@react-spectrum/divider';
-import {DOMProps, DOMRef} from '@react-types/shared';
+import {DOMRef} from '@react-types/shared';
 import {Heading} from '@react-spectrum/text';
 // @ts-ignore
 import intlMessages from '../intl/*.json';

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -50,9 +50,6 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
     onCancel = () => {},
     onPrimaryAction = () => {},
     onSecondaryAction = () => {},
-    cancelDOMProps = {} as DOMProps,
-    primaryDOMProps = {} as DOMProps,
-    secondaryDOMProps = {} as DOMProps,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
@@ -90,7 +87,7 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
             variant="secondary"
             onPress={() => chain(onClose(), onCancel())}
             autoFocus={autoFocusButton === 'cancel'}
-            {...filterDOMProps(cancelProps)}>
+            data-testid="rsp-alertDialog-cancelButton">
             {cancelLabel}
           </Button>
         }
@@ -100,7 +97,7 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
             onPress={() => chain(onClose(), onSecondaryAction())}
             isDisabled={isSecondaryActionDisabled}
             autoFocus={autoFocusButton === 'secondary'}
-            {...filterDOMProps(secondaryProps)}>
+            data-testid="rsp-alertDialog-secondaryButton">
             {secondaryActionLabel}
           </Button>
         }
@@ -109,7 +106,7 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
           onPress={() => chain(onClose(), onPrimaryAction())}
           isDisabled={isPrimaryActionDisabled}
           autoFocus={autoFocusButton === 'primary'}
-          {...filterDOMProps(primaryProps)}>
+          data-testid="rsp-alertDialog-confirmButton">
           {primaryActionLabel}
         </Button>
       </ButtonGroup>

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -50,9 +50,9 @@ export const AlertDialog = forwardRef(function AlertDialog(props: SpectrumAlertD
     onCancel = () => {},
     onPrimaryAction = () => {},
     onSecondaryAction = () => {},
-    cancelProps = {} as DOMProps,
-    primaryProps = {} as DOMProps,
-    secondaryProps = {} as DOMProps,
+    cancelDOMProps = {} as DOMProps,
+    primaryDOMProps = {} as DOMProps,
+    secondaryDOMProps = {} as DOMProps,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -175,14 +175,14 @@ export const AutoFocusCancel = () => renderAlert({
   autoFocusButton: 'cancel',
   'data-testid': 'alert-dialog',
   cancelProps: {
-    'data-testid': 'alert-dialog-cancel-btn',
+    'data-testid': 'alert-dialog-cancel-btn'
   },
   secondaryProps: {
-    'data-testid': 'alert-dialog-secondary-btn',
+    'data-testid': 'alert-dialog-secondary-btn'
   },
   primaryProps: {
-    'data-testid': 'alert-dialog-primary-btn',
-  },
+    'data-testid': 'alert-dialog-primary-btn'
+  }
 } as SpectrumAlertDialogProps);
 
 AutoFocusCancel.story = {

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -174,15 +174,6 @@ export const AutoFocusCancel = () => renderAlert({
   onCancel: action('cancel'),
   autoFocusButton: 'cancel',
   'data-testid': 'alert-dialog',
-  cancelDOMProps: {
-    'data-testid': 'alert-dialog-cancel-btn'
-  },
-  secondaryDOMProps: {
-    'data-testid': 'alert-dialog-secondary-btn'
-  },
-  primaryDOMProps: {
-    'data-testid': 'alert-dialog-primary-btn'
-  }
 } as SpectrumAlertDialogProps);
 
 AutoFocusCancel.story = {

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -172,8 +172,18 @@ export const AutoFocusCancel = () => renderAlert({
   onPrimaryAction: action('primary'),
   onSecondaryAction: action('secondary'),
   onCancel: action('cancel'),
-  autoFocusButton: 'cancel'
-});
+  autoFocusButton: 'cancel',
+  'data-testid': 'alert-dialog',
+  cancelProps: {
+    'data-testid': 'alert-dialog-cancel-btn',
+  },
+  secondaryProps: {
+    'data-testid': 'alert-dialog-secondary-btn',
+  },
+  primaryProps: {
+    'data-testid': 'alert-dialog-primary-btn',
+  },
+} as SpectrumAlertDialogProps);
 
 AutoFocusCancel.story = {
   name: 'autoFocus cancel'

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -174,13 +174,13 @@ export const AutoFocusCancel = () => renderAlert({
   onCancel: action('cancel'),
   autoFocusButton: 'cancel',
   'data-testid': 'alert-dialog',
-  cancelProps: {
+  cancelDOMProps: {
     'data-testid': 'alert-dialog-cancel-btn'
   },
-  secondaryProps: {
+  secondaryDOMProps: {
     'data-testid': 'alert-dialog-secondary-btn'
   },
-  primaryProps: {
+  primaryDOMProps: {
     'data-testid': 'alert-dialog-primary-btn'
   }
 } as SpectrumAlertDialogProps);

--- a/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/AlertDialog.stories.tsx
@@ -173,7 +173,7 @@ export const AutoFocusCancel = () => renderAlert({
   onSecondaryAction: action('secondary'),
   onCancel: action('cancel'),
   autoFocusButton: 'cancel',
-  'data-testid': 'alert-dialog',
+  'data-testid': 'alert-dialog'
 } as SpectrumAlertDialogProps);
 
 AutoFocusCancel.story = {

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -188,10 +188,7 @@ describe('AlertDialog', function () {
           primaryActionLabel="confirm"
           secondaryActionLabel="secondary"
           autoFocusButton="secondary"
-          data-testid="alert-dialog"
-          cancelDOMProps={{'data-testid': 'alert-dialog-cancel-btn'}}
-          secondaryDOMProps={{'data-testid': 'alert-dialog-secondary-btn'}}
-          primaryDOMProps={{'data-testid': 'alert-dialog-primary-btn'}}>
+          data-testid="alert-dialog">
           Content body
         </AlertDialog>
       </Provider>

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -177,4 +177,34 @@ describe('AlertDialog', function () {
     let button = getByText('secondary').closest('button');
     expect(document.activeElement).toBe(button);
   });
+
+  it('can add test ids', function () {
+    let {getByTestId} = render(
+      <Provider theme={theme}>
+        <AlertDialog
+          variant="confirmation"
+          title="the title"
+          cancelLabel="cancel"
+          primaryActionLabel="confirm"
+          secondaryActionLabel="secondary"
+          autoFocusButton="secondary"
+          data-testid="alert-dialog"
+          cancelProps={{ 'data-testid': 'alert-dialog-cancel-btn' }}
+          secondaryProps={{ 'data-testid': 'alert-dialog-secondary-btn' }}
+          primaryProps={{ 'data-testid': 'alert-dialog-primary-btn' }}
+        >
+          Content body
+        </AlertDialog>
+      </Provider>
+    );
+
+    let dialog = getByTestId('alert-dialog');
+    expect(dialog).toBeDefined();
+    let cancelBtn = getByTestId('alert-dialog-cancel-btn');
+    expect(cancelBtn).toBeDefined();
+    let secondaryBtn = getByTestId('alert-dialog-secondary-btn');
+    expect(secondaryBtn).toBeDefined();
+    let primaryBtn = getByTestId('alert-dialog-primary-btn');
+    expect(primaryBtn).toBeDefined();
+  });
 });

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -189,9 +189,9 @@ describe('AlertDialog', function () {
           secondaryActionLabel="secondary"
           autoFocusButton="secondary"
           data-testid="alert-dialog"
-          cancelProps={{'data-testid': 'alert-dialog-cancel-btn'}}
-          secondaryProps={{'data-testid': 'alert-dialog-secondary-btn'}}
-          primaryProps={{'data-testid': 'alert-dialog-primary-btn'}}>
+          cancelDOMProps={{'data-testid': 'alert-dialog-cancel-btn'}}
+          secondaryDOMProps={{'data-testid': 'alert-dialog-secondary-btn'}}
+          primaryDOMProps={{'data-testid': 'alert-dialog-primary-btn'}}>
           Content body
         </AlertDialog>
       </Provider>

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -196,11 +196,11 @@ describe('AlertDialog', function () {
 
     let dialog = getByTestId('alert-dialog');
     expect(dialog).toBeDefined();
-    let cancelBtn = getByTestId('alert-dialog-cancel-btn');
+    let cancelBtn = getByTestId('rsp-alertDialog-cancelButton');
     expect(cancelBtn).toBeDefined();
-    let secondaryBtn = getByTestId('alert-dialog-secondary-btn');
+    let secondaryBtn = getByTestId('rsp-alertDialog-secondaryButton');
     expect(secondaryBtn).toBeDefined();
-    let primaryBtn = getByTestId('alert-dialog-primary-btn');
+    let primaryBtn = getByTestId('rsp-alertDialog-confirmButton');
     expect(primaryBtn).toBeDefined();
   });
 });

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -189,10 +189,9 @@ describe('AlertDialog', function () {
           secondaryActionLabel="secondary"
           autoFocusButton="secondary"
           data-testid="alert-dialog"
-          cancelProps={{ 'data-testid': 'alert-dialog-cancel-btn' }}
-          secondaryProps={{ 'data-testid': 'alert-dialog-secondary-btn' }}
-          primaryProps={{ 'data-testid': 'alert-dialog-primary-btn' }}
-        >
+          cancelProps={{'data-testid': 'alert-dialog-cancel-btn'}}
+          secondaryProps={{'data-testid': 'alert-dialog-secondary-btn'}}
+          primaryProps={{'data-testid': 'alert-dialog-primary-btn'}}>
           Content body
         </AlertDialog>
       </Provider>

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -97,6 +97,6 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   /** Handler that is called when the secondary button is pressed. */
   onSecondaryAction?: () => void,
   /** Button to focus by default when the dialog opens. */
-  autoFocusButton?: 'cancel' | 'primary' | 'secondary',
+  autoFocusButton?: 'cancel' | 'primary' | 'secondary'
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -99,10 +99,10 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   /** Button to focus by default when the dialog opens. */
   autoFocusButton?: 'cancel' | 'primary' | 'secondary',
   /** DOM props to add to cancel button */
-  cancelProps?: DOMProps,
+  cancelProps?: DOMProps & AriaLabelingProps,
   /** DOM props to add to primary button */
-  primaryProps?: DOMProps,
+  primaryProps?: DOMProps & AriaLabelingProps,
   /** DOM props to add to secondary button */
-  secondaryProps?: DOMProps,
+  secondaryProps?: DOMProps & AriaLabelingProps,
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -97,6 +97,12 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   /** Handler that is called when the secondary button is pressed. */
   onSecondaryAction?: () => void,
   /** Button to focus by default when the dialog opens. */
-  autoFocusButton?: 'cancel' | 'primary' | 'secondary'
+  autoFocusButton?: 'cancel' | 'primary' | 'secondary',
+  /** DOM props to add to cancel button */
+  cancelProps?: DOMProps,
+  /** DOM props to add to primary button */
+  primaryProps?: DOMProps,
+  /** DOM props to add to secondary button */
+  secondaryProps?: DOMProps,
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -98,11 +98,5 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   onSecondaryAction?: () => void,
   /** Button to focus by default when the dialog opens. */
   autoFocusButton?: 'cancel' | 'primary' | 'secondary',
-  /** DOM props to add to cancel button. */
-  cancelDOMProps?: DOMProps & AriaLabelingProps,
-  /** DOM props to add to primary button. */
-  primaryDOMProps?: DOMProps & AriaLabelingProps,
-  /** DOM props to add to secondary button. */
-  secondaryDOMProps?: DOMProps & AriaLabelingProps
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -99,10 +99,10 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   /** Button to focus by default when the dialog opens. */
   autoFocusButton?: 'cancel' | 'primary' | 'secondary',
   /** DOM props to add to cancel button. */
-  cancelProps?: DOMProps & AriaLabelingProps,
+  cancelDOMProps?: DOMProps & AriaLabelingProps,
   /** DOM props to add to primary button. */
-  primaryProps?: DOMProps & AriaLabelingProps,
+  primaryDOMProps?: DOMProps & AriaLabelingProps,
   /** DOM props to add to secondary button. */
-  secondaryProps?: DOMProps & AriaLabelingProps
+  secondaryDOMProps?: DOMProps & AriaLabelingProps
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -98,11 +98,11 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   onSecondaryAction?: () => void,
   /** Button to focus by default when the dialog opens. */
   autoFocusButton?: 'cancel' | 'primary' | 'secondary',
-  /** DOM props to add to cancel button */
+  /** DOM props to add to cancel button. */
   cancelProps?: DOMProps & AriaLabelingProps,
-  /** DOM props to add to primary button */
+  /** DOM props to add to primary button. */
   primaryProps?: DOMProps & AriaLabelingProps,
-  /** DOM props to add to secondary button */
-  secondaryProps?: DOMProps & AriaLabelingProps,
+  /** DOM props to add to secondary button. */
+  secondaryProps?: DOMProps & AriaLabelingProps
   // allowsKeyboardConfirmation?: boolean, // triggers primary action
 }


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8369

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check storybook entry

## 🧢 Your Project:

<!--- Company/project for pull request -->
