### PR TITLE
fix popover rendering issues on legacy Android WebView

### DIFF
--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -515,7 +515,9 @@ export function calculatePosition(opts: PositionOpts): PositionResult {
 
 function getOffset(node: Element): Offset {
   let {top, left, width, height} = node.getBoundingClientRect();
-  let {scrollTop, scrollLeft, clientTop, clientLeft} = document.documentElement;
+  let { scrollTop: elementScrollTop, scrollLeft: scrollLeft, clientTop: clientTop, clientLeft: clientLeft } = document.documentElement;
+  // This is a workaround to ensure we get the correct scrollTop value.
+  let scrollTop = elementScrollTop || document.body.scrollTop || 0;
   return {
     top: top + scrollTop - clientTop,
     left: left + scrollLeft - clientLeft,


### PR DESCRIPTION
This update ensures proper positioning of all components that rely on the `calculatePosition` method in older browsers. Since document.documentElement.scrollTop always returns 0, even when the page is scrolled down, the solution introduces a fallback to document.body.scrollTop to accurately determine the scroll position.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

- Use an affected version of Android WebView (tested on version 85).
- Scroll down the page to create a noticeable scroll offset.
- Open the popover component.
- Observe the positioning of the popover—it should appear significantly lower than the expected position.
