### PR TITLE
chore: TS explicit module boundary starters

### DIFF
--- a/starters/tailwind/src/AlertDialog.tsx
+++ b/starters/tailwind/src/AlertDialog.tsx
@@ -22,7 +22,7 @@ export function AlertDialog({
   onAction,
   children,
   ...props
-}: AlertDialogProps) {
+}: AlertDialogProps): ReactNode {
   return (
     <Dialog role="alertdialog" {...props}>
       {({ close }) => (

--- a/starters/tailwind/src/Autocomplete.tsx
+++ b/starters/tailwind/src/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import {
   Autocomplete as AriaAutocomplete,
   AutocompleteProps as AriaAutocompleteProps,
@@ -24,7 +24,7 @@ export function Autocomplete<T extends object>({
   children,
   label,
   ...props
-}: AutocompleteProps<T>) {
+}: AutocompleteProps<T>): ReactNode {
   let { contains } = useFilter({ sensitivity: "base" });
   return (
     <div className="p-3 border-2 border-gray-200 rounded-xl dark:border-zinc-700">

--- a/starters/tailwind/src/Breadcrumbs.tsx
+++ b/starters/tailwind/src/Breadcrumbs.tsx
@@ -1,15 +1,15 @@
 import { ChevronRight } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Breadcrumb as AriaBreadcrumb, Breadcrumbs as AriaBreadcrumbs, BreadcrumbProps, BreadcrumbsProps, LinkProps } from 'react-aria-components';
 import { twMerge } from 'tailwind-merge';
 import { Link } from './Link';
 import { composeTailwindRenderProps } from './utils';
 
-export function Breadcrumbs<T extends object>(props: BreadcrumbsProps<T>) {
+export function Breadcrumbs<T extends object>(props: BreadcrumbsProps<T>): ReactNode {
   return <AriaBreadcrumbs {...props} className={twMerge('flex gap-1', props.className)} />;
 }
 
-export function Breadcrumb(props: BreadcrumbProps & Omit<LinkProps, 'className'>) {
+export function Breadcrumb(props: BreadcrumbProps & Omit<LinkProps, 'className'>): ReactNode {
   return (
     <AriaBreadcrumb {...props} className={composeTailwindRenderProps(props.className, 'flex items-center gap-1')}>
       <Link variant="secondary" {...props} />

--- a/starters/tailwind/src/Button.tsx
+++ b/starters/tailwind/src/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { composeRenderProps, Button as RACButton, ButtonProps as RACButtonProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 import { focusRing } from './utils';
@@ -26,7 +26,7 @@ let button = tv({
   }
 });
 
-export function Button(props: ButtonProps) {
+export function Button(props: ButtonProps): ReactNode {
   return (
     <RACButton
       {...props}

--- a/starters/tailwind/src/Calendar.tsx
+++ b/starters/tailwind/src/Calendar.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Calendar as AriaCalendar,
   CalendarGridHeader as AriaCalendarGridHeader,
@@ -37,7 +37,7 @@ export interface CalendarProps<T extends DateValue> extends Omit<AriaCalendarPro
 
 export function Calendar<T extends DateValue>(
   { errorMessage, ...props }: CalendarProps<T>
-) {
+): ReactNode {
   return (
     <AriaCalendar {...props}>
       <CalendarHeader />
@@ -52,7 +52,7 @@ export function Calendar<T extends DateValue>(
   );
 }
 
-export function CalendarHeader() {
+export function CalendarHeader(): ReactNode {
   let {direction} = useLocale();
 
   return (
@@ -68,7 +68,7 @@ export function CalendarHeader() {
   );
 }
 
-export function CalendarGridHeader() {
+export function CalendarGridHeader(): ReactNode {
   return (
     <AriaCalendarGridHeader>
       {(day) => (

--- a/starters/tailwind/src/Checkbox.tsx
+++ b/starters/tailwind/src/Checkbox.tsx
@@ -12,7 +12,7 @@ export interface CheckboxGroupProps extends Omit<AriaCheckboxGroupProps, 'childr
   errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
-export function CheckboxGroup(props: CheckboxGroupProps) {
+export function CheckboxGroup(props: CheckboxGroupProps): ReactNode {
   return (
     <AriaCheckboxGroup {...props} className={composeTailwindRenderProps(props.className, 'flex flex-col gap-2')}>
       <Label>{props.label}</Label>
@@ -52,7 +52,7 @@ const boxStyles = tv({
 
 const iconStyles = 'w-4 h-4 text-white group-disabled:text-gray-400 dark:text-slate-900 dark:group-disabled:text-slate-600 forced-colors:text-[HighlightText]';
 
-export function Checkbox(props: CheckboxProps) {
+export function Checkbox(props: CheckboxProps): ReactNode {
   return (
     <AriaCheckbox {...props} className={composeRenderProps(props.className, (className, renderProps) => checkboxStyles({...renderProps, className}))}>
       {({isSelected, isIndeterminate, ...renderProps}) => (

--- a/starters/tailwind/src/ColorArea.tsx
+++ b/starters/tailwind/src/ColorArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ColorArea as AriaColorArea,
   ColorAreaProps as AriaColorAreaProps
@@ -8,7 +8,7 @@ import { ColorThumb } from './ColorThumb';
 
 export interface ColorAreaProps extends AriaColorAreaProps {}
 
-export function ColorArea(props: ColorAreaProps) {
+export function ColorArea(props: ColorAreaProps): ReactNode {
   return (
     <AriaColorArea
       {...props}

--- a/starters/tailwind/src/ColorField.tsx
+++ b/starters/tailwind/src/ColorField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ColorField as AriaColorField,
   ColorFieldProps as AriaColorFieldProps,
@@ -25,7 +25,7 @@ export interface ColorFieldProps extends AriaColorFieldProps {
 
 export function ColorField(
   { label, description, errorMessage, ...props }: ColorFieldProps
-) {
+): ReactNode {
   return (
     <AriaColorField {...props} className={composeTailwindRenderProps(props.className, 'flex flex-col gap-1')}>
       {label && <Label>{label}</Label>}

--- a/starters/tailwind/src/ColorPicker.tsx
+++ b/starters/tailwind/src/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {Button, ColorPicker as AriaColorPicker, ColorPickerProps as AriaColorPickerProps, DialogTrigger} from 'react-aria-components';
 import {ColorSwatch} from './ColorSwatch';
 import {ColorArea} from './ColorArea';
@@ -19,7 +19,7 @@ export interface ColorPickerProps extends AriaColorPickerProps {
   children?: React.ReactNode;
 }
 
-export function ColorPicker({ label, children, ...props }: ColorPickerProps) {
+export function ColorPicker({ label, children, ...props }: ColorPickerProps): ReactNode {
   return (
     <AriaColorPicker {...props}>
       <DialogTrigger>

--- a/starters/tailwind/src/ColorSlider.tsx
+++ b/starters/tailwind/src/ColorSlider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ColorSlider as AriaColorSlider,
   ColorSliderProps as AriaColorSliderProps,
@@ -27,7 +27,7 @@ interface ColorSliderProps extends AriaColorSliderProps {
   label?: string;
 }
 
-export function ColorSlider({ label, ...props }: ColorSliderProps) {
+export function ColorSlider({ label, ...props }: ColorSliderProps): ReactNode {
   return (
     <AriaColorSlider {...props} className={composeTailwindRenderProps(props.className, 'orientation-horizontal:grid orientation-vertical:flex grid-cols-[1fr_auto] flex-col items-center gap-2 orientation-horizontal:w-56')}>
       <Label>{label}</Label>

--- a/starters/tailwind/src/ColorSwatch.tsx
+++ b/starters/tailwind/src/ColorSwatch.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {ColorSwatch as AriaColorSwatch, ColorSwatchProps} from 'react-aria-components';
 import { composeTailwindRenderProps } from './utils';
 
-export function ColorSwatch(props: ColorSwatchProps) {
+export function ColorSwatch(props: ColorSwatchProps): ReactNode {
   return (
-    <AriaColorSwatch 
+    <AriaColorSwatch
       {...props}
       className={composeTailwindRenderProps(props.className, 'w-8 h-8 rounded-xs border border-black/10')}
       style={({color}) => ({

--- a/starters/tailwind/src/ColorSwatchPicker.tsx
+++ b/starters/tailwind/src/ColorSwatchPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ColorSwatchPicker as AriaColorSwatchPicker,
   ColorSwatchPickerItem as AriaColorSwatchPickerItem,
@@ -11,7 +11,7 @@ import {tv} from 'tailwind-variants';
 
 export function ColorSwatchPicker(
   { children, ...props }: Omit<ColorSwatchPickerProps, 'layout'>
-) {
+): ReactNode {
   return (
     <AriaColorSwatchPicker {...props} className={composeTailwindRenderProps(props.className, 'flex gap-1')}>
       {children}

--- a/starters/tailwind/src/ColorThumb.tsx
+++ b/starters/tailwind/src/ColorThumb.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {ColorThumb as AriaColorThumb, ColorThumbProps} from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
@@ -17,7 +17,7 @@ const thumbStyles = tv({
   }
 });
 
-export function ColorThumb(props: ColorThumbProps) {
+export function ColorThumb(props: ColorThumbProps): ReactNode {
   return (
     <AriaColorThumb
       {...props}

--- a/starters/tailwind/src/ColorWheel.tsx
+++ b/starters/tailwind/src/ColorWheel.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {ColorWheel as AriaColorWheel, ColorWheelProps as AriaColorWheelProps, ColorWheelTrack} from 'react-aria-components';
 import { ColorThumb } from './ColorThumb';
 
 export interface ColorWheelProps extends Omit<AriaColorWheelProps, 'outerRadius' | 'innerRadius'> {}
 
-export function ColorWheel(props: ColorWheelProps) {
+export function ColorWheel(props: ColorWheelProps): ReactNode {
   return (
     <AriaColorWheel {...props} outerRadius={100} innerRadius={74}>
       <ColorWheelTrack

--- a/starters/tailwind/src/ComboBox.tsx
+++ b/starters/tailwind/src/ComboBox.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ComboBox as AriaComboBox,
   ComboBoxProps as AriaComboBoxProps,
@@ -22,7 +22,7 @@ export interface ComboBoxProps<T extends object> extends Omit<AriaComboBoxProps<
 
 export function ComboBox<T extends object>(
   { label, description, errorMessage, children, items, ...props }: ComboBoxProps<T>
-) {
+): ReactNode {
   return (
     <AriaComboBox {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-1')}>
       <Label>{label}</Label>
@@ -43,10 +43,10 @@ export function ComboBox<T extends object>(
   );
 }
 
-export function ComboBoxItem(props: ListBoxItemProps) {
+export function ComboBoxItem(props: ListBoxItemProps): ReactNode {
   return <DropdownItem {...props} />;
 }
 
-export function ComboBoxSection<T extends object>(props: DropdownSectionProps<T>) {
+export function ComboBoxSection<T extends object>(props: DropdownSectionProps<T>): ReactNode {
   return <DropdownSection {...props} />;
 }

--- a/starters/tailwind/src/DateField.tsx
+++ b/starters/tailwind/src/DateField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   DateField as AriaDateField,
   DateFieldProps as AriaDateFieldProps,
@@ -20,7 +20,7 @@ export interface DateFieldProps<T extends DateValue> extends AriaDateFieldProps<
 
 export function DateField<T extends DateValue>(
   { label, description, errorMessage, ...props }: DateFieldProps<T>
-) {
+): ReactNode {
   return (
     <AriaDateField {...props} className={composeTailwindRenderProps(props.className, 'flex flex-col gap-1')}>
       {label && <Label>{label}</Label>}
@@ -46,7 +46,7 @@ const segmentStyles = tv({
   }
 });
 
-export function DateInput(props: Omit<DateInputProps, 'children'>) {
+export function DateInput(props: Omit<DateInputProps, 'children'>): ReactNode {
   return (
     <AriaDateInput className={renderProps => fieldGroupStyles({...renderProps, class: 'block min-w-[150px] px-2 py-1.5 text-sm'})} {...props}>
       {(segment) => <DateSegment segment={segment} className={segmentStyles} />}

--- a/starters/tailwind/src/DatePicker.tsx
+++ b/starters/tailwind/src/DatePicker.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   DatePicker as AriaDatePicker,
   DatePickerProps as AriaDatePickerProps,
@@ -23,7 +23,7 @@ export interface DatePickerProps<T extends DateValue>
 
 export function DatePicker<T extends DateValue>(
   { label, description, errorMessage, ...props }: DatePickerProps<T>
-) {
+): ReactNode {
   return (
     <AriaDatePicker {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-1')}>
       {label && <Label>{label}</Label>}

--- a/starters/tailwind/src/DateRangePicker.tsx
+++ b/starters/tailwind/src/DateRangePicker.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   DateRangePicker as AriaDateRangePicker,
   DateRangePickerProps as AriaDateRangePickerProps,
@@ -23,7 +23,7 @@ export interface DateRangePickerProps<T extends DateValue>
 
 export function DateRangePicker<T extends DateValue>(
   { label, description, errorMessage, ...props }: DateRangePickerProps<T>
-) {
+): ReactNode {
   return (
     <AriaDateRangePicker {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-1')}>
       {label && <Label>{label}</Label>}

--- a/starters/tailwind/src/Dialog.tsx
+++ b/starters/tailwind/src/Dialog.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { DialogProps, Dialog as RACDialog } from 'react-aria-components';
 import { twMerge } from 'tailwind-merge';
 
-export function Dialog(props: DialogProps) {
+export function Dialog(props: DialogProps): ReactNode {
   return <RACDialog {...props} className={twMerge('outline outline-0 p-6 [[data-placement]>&]:p-4 max-h-[inherit] overflow-auto relative', props.className)} />;
 }

--- a/starters/tailwind/src/Disclosure.tsx
+++ b/starters/tailwind/src/Disclosure.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { ReactNode, useContext } from "react";
 import {
   Disclosure as AriaDisclosure,
   DisclosureGroup as AriaDisclosureGroup,
@@ -54,7 +54,7 @@ export interface DisclosureProps extends AriaDisclosureProps {
   children: React.ReactNode;
 }
 
-export function Disclosure({ children, ...props }: DisclosureProps) {
+export function Disclosure({ children, ...props }: DisclosureProps): ReactNode {
   let isInGroup = useContext(DisclosureGroupStateContext) !== null;
   return (
     <AriaDisclosure
@@ -70,7 +70,7 @@ export interface DisclosureHeaderProps {
   children: React.ReactNode;
 }
 
-export function DisclosureHeader({ children }: DisclosureHeaderProps) {
+export function DisclosureHeader({ children }: DisclosureHeaderProps): ReactNode {
   let { isExpanded } = useContext(DisclosureStateContext)!;
   let isInGroup = useContext(DisclosureGroupStateContext) !== null;
   return (
@@ -94,7 +94,7 @@ export interface DisclosurePanelProps extends AriaDisclosurePanelProps {
   children: React.ReactNode;
 }
 
-export function DisclosurePanel({ children, ...props }: DisclosurePanelProps) {
+export function DisclosurePanel({ children, ...props }: DisclosurePanelProps): ReactNode {
   return (
     <AriaDisclosurePanel {...props} className={composeTailwindRenderProps(props.className, 'group-data-[expanded]:px-4 group-data-[expanded]:py-2')}>
       {children}
@@ -106,7 +106,7 @@ export interface DisclosureGroupProps extends AriaDisclosureGroupProps {
   children: React.ReactNode;
 }
 
-export function DisclosureGroup({ children, ...props }: DisclosureGroupProps) {
+export function DisclosureGroup({ children, ...props }: DisclosureGroupProps): ReactNode   {
   return (
     <AriaDisclosureGroup {...props} className={composeTailwindRenderProps(props.className, 'border border-gray-200 dark:border-zinc-600 rounded-lg')}>
       {children}

--- a/starters/tailwind/src/Field.tsx
+++ b/starters/tailwind/src/Field.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { FieldErrorProps, Group, GroupProps, InputProps, LabelProps, FieldError as RACFieldError, Input as RACInput, Label as RACLabel, Text, TextProps, composeRenderProps } from "react-aria-components";
 import { twMerge } from 'tailwind-merge';
 import { tv } from 'tailwind-variants';
 import { composeTailwindRenderProps, focusRing } from "./utils";
 
-export function Label(props: LabelProps) {
+export function Label(props: LabelProps): ReactNode {
   return <RACLabel {...props} className={twMerge('text-sm text-gray-500 dark:text-zinc-400 font-medium cursor-default w-fit', props.className)} />;
 }
 
-export function Description(props: TextProps) {
+export function Description(props: TextProps): ReactNode {
   return <Text {...props} slot="description" className={twMerge('text-sm text-gray-600', props.className)} />;
 }
 
-export function FieldError(props: FieldErrorProps) {
+export function FieldError(props: FieldErrorProps): ReactNode {
   return <RACFieldError {...props} className={composeTailwindRenderProps(props.className, 'text-sm text-red-600 forced-colors:text-[Mark]')} />
 }
 
@@ -29,18 +29,18 @@ export const fieldBorderStyles = tv({
       true: 'border-gray-200 dark:border-zinc-700 forced-colors:border-[GrayText]'
     }
   }
-});
+}) as any;
 
 export const fieldGroupStyles = tv({
   extend: focusRing,
   base: 'group flex items-center h-9 bg-white dark:bg-zinc-900 forced-colors:bg-[Field] border-2 rounded-lg overflow-hidden',
   variants: fieldBorderStyles.variants
-});
+}) as any;
 
-export function FieldGroup(props: GroupProps) {
+export function FieldGroup(props: GroupProps): ReactNode {
   return <Group {...props} className={composeRenderProps(props.className, (className, renderProps) => fieldGroupStyles({...renderProps, className}))} />;
 }
 
-export function Input(props: InputProps) {
+export function Input(props: InputProps): ReactNode {
   return <RACInput {...props} className={composeTailwindRenderProps(props.className, 'px-2 py-1.5 flex-1 min-w-0 outline outline-0 bg-white dark:bg-zinc-900 text-sm text-gray-800 dark:text-zinc-200 disabled:text-gray-200 dark:disabled:text-zinc-600')} />
 }

--- a/starters/tailwind/src/Form.tsx
+++ b/starters/tailwind/src/Form.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { FormProps, Form as RACForm } from 'react-aria-components';
 import { twMerge } from 'tailwind-merge';
 
-export function Form(props: FormProps) {
+export function Form(props: FormProps): ReactNode {
   return <RACForm {...props} className={twMerge('flex flex-col gap-4', props.className)} />;
 }

--- a/starters/tailwind/src/GridList.tsx
+++ b/starters/tailwind/src/GridList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   GridList as AriaGridList,
   GridListItem as AriaGridListItem,
@@ -12,7 +12,7 @@ import { composeTailwindRenderProps, focusRing } from './utils';
 
 export function GridList<T extends object>(
   { children, ...props }: GridListProps<T>
-) {
+): ReactNode {
   return (
     <AriaGridList {...props} className={composeTailwindRenderProps(props.className, 'overflow-auto relative border border-gray-200 dark:border-zinc-600 rounded-lg')}>
       {children}
@@ -34,7 +34,7 @@ const itemStyles = tv({
   }
 });
 
-export function GridListItem({ children, ...props }: GridListItemProps) {
+export function GridListItem({ children, ...props }: GridListItemProps): ReactNode {
   let textValue = typeof children === 'string' ? children : undefined;
   return (
     <AriaGridListItem textValue={textValue} {...props} className={itemStyles}>

--- a/starters/tailwind/src/Link.tsx
+++ b/starters/tailwind/src/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Link as AriaLink, LinkProps as AriaLinkProps, composeRenderProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 import { focusRing } from './utils';
@@ -21,6 +21,6 @@ const styles = tv({
   }
 });
 
-export function Link(props: LinkProps) {
+export function Link(props: LinkProps): ReactNode {
   return <AriaLink {...props} className={composeRenderProps(props.className, (className, renderProps) =>  styles({...renderProps, className, variant: props.variant}))} />;
 }

--- a/starters/tailwind/src/ListBox.tsx
+++ b/starters/tailwind/src/ListBox.tsx
@@ -1,5 +1,5 @@
 import { Check } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ListBox as AriaListBox,
   ListBoxItem as AriaListBoxItem,
@@ -18,7 +18,7 @@ interface ListBoxProps<T> extends Omit<AriaListBoxProps<T>, 'layout' | 'orientat
 
 export function ListBox<T extends object>(
   { children, ...props }: ListBoxProps<T>
-) {
+): ReactNode {
   return (
     <AriaListBox {...props} className={composeTailwindRenderProps(props.className, 'outline-0 p-1 border border-gray-300 dark:border-zinc-600 rounded-lg')}>
       {children}
@@ -38,9 +38,9 @@ export const itemStyles = tv({
       true: 'text-slate-300 dark:text-zinc-600 forced-colors:text-[GrayText]'
     }
   }
-});
+}) as any;
 
-export function ListBoxItem(props: ListBoxItemProps) {
+export function ListBoxItem(props: ListBoxItemProps): ReactNode {
   let textValue = props.textValue || (typeof props.children === 'string' ? props.children : undefined);
   return (
     <AriaListBoxItem {...props} textValue={textValue} className={itemStyles}>
@@ -70,9 +70,9 @@ export const dropdownItemStyles = tv({
       className: 'bg-gray-100 dark:bg-zinc-700/60'
     }
   ]
-});
+}) as any;
 
-export function DropdownItem(props: ListBoxItemProps) {
+export function DropdownItem(props: ListBoxItemProps): ReactNode {
   let textValue = props.textValue || (typeof props.children === 'string' ? props.children : undefined);
   return (
     <AriaListBoxItem {...props} textValue={textValue} className={dropdownItemStyles}>
@@ -93,7 +93,7 @@ export interface DropdownSectionProps<T> extends SectionProps<T> {
   items?: any
 }
 
-export function DropdownSection<T extends object>(props: DropdownSectionProps<T>) {
+export function DropdownSection<T extends object>(props: DropdownSectionProps<T>): ReactNode {
   return (
     <ListBoxSection className="first:-mt-[5px] after:content-[''] after:block after:h-[5px]">
       <Header className="text-sm font-semibold text-gray-500 dark:text-zinc-300 px-4 py-1 truncate sticky -top-[5px] -mt-px -mx-1 z-10 bg-gray-100/60 dark:bg-zinc-700/60 backdrop-blur-md supports-[-moz-appearance:none]:bg-gray-100 border-y border-y-gray-200 dark:border-y-zinc-700 [&+*]:mt-1">{props.title}</Header>

--- a/starters/tailwind/src/Menu.tsx
+++ b/starters/tailwind/src/Menu.tsx
@@ -1,5 +1,5 @@
 import { Check, ChevronRight } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Menu as AriaMenu,
   MenuItem as AriaMenuItem,
@@ -20,7 +20,7 @@ interface MenuProps<T> extends AriaMenuProps<T> {
   placement?: PopoverProps['placement']
 }
 
-export function Menu<T extends object>(props: MenuProps<T>) {
+export function Menu<T extends object>(props: MenuProps<T>): ReactNode {
   return (
     <Popover placement={props.placement} className="min-w-[150px]">
       <AriaMenu {...props} className="p-1 outline outline-0 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]" />
@@ -28,7 +28,7 @@ export function Menu<T extends object>(props: MenuProps<T>) {
   );
 }
 
-export function MenuItem(props: MenuItemProps) {
+export function MenuItem(props: MenuItemProps): ReactNode {
   let textValue = props.textValue || (typeof props.children === 'string' ? props.children : undefined);
   return (
     <AriaMenuItem textValue={textValue} {...props} className={dropdownItemStyles}>
@@ -49,7 +49,7 @@ export function MenuItem(props: MenuItemProps) {
   );
 }
 
-export function MenuSeparator(props: SeparatorProps) {
+export function MenuSeparator(props: SeparatorProps): ReactNode {
   return <Separator {...props} className="mx-3 my-1 border-b border-gray-300 dark:border-zinc-700" />
 }
 
@@ -58,7 +58,7 @@ export interface MenuSectionProps<T> extends AriaMenuSectionProps<T> {
   items?: any
 }
 
-export function MenuSection<T extends object>(props: MenuSectionProps<T>) {
+export function MenuSection<T extends object>(props: MenuSectionProps<T>): ReactNode {
   return (
     <AriaMenuSection {...props} className="first:-mt-[5px] after:content-[''] after:block after:h-[5px]">
       <Header className="text-sm font-semibold text-gray-500 dark:text-zinc-300 px-4 py-1 truncate sticky -top-[5px] -mt-px -mx-1 z-10 bg-gray-100/60 dark:bg-zinc-700/60 backdrop-blur-md supports-[-moz-appearance:none]:bg-gray-100 border-y border-y-gray-200 dark:border-y-zinc-700 [&+*]:mt-1">{props.title}</Header>

--- a/starters/tailwind/src/Meter.tsx
+++ b/starters/tailwind/src/Meter.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Meter as AriaMeter,
   MeterProps as AriaMeterProps
@@ -11,7 +11,7 @@ export interface MeterProps extends AriaMeterProps {
   label?: string;
 }
 
-export function Meter({ label, ...props }: MeterProps) {
+export function Meter({ label, ...props }: MeterProps): ReactNode {
   return (
     <AriaMeter {...props} className={composeTailwindRenderProps(props.className, 'flex flex-col gap-1')}>
       {({ percentage, valueText }) => (
@@ -32,7 +32,7 @@ export function Meter({ label, ...props }: MeterProps) {
   );
 }
 
-function getColor(percentage: number) {
+function getColor(percentage: number): string {
   if (percentage < 70) {
     return 'bg-green-600';
   }

--- a/starters/tailwind/src/Modal.tsx
+++ b/starters/tailwind/src/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ModalOverlay, ModalOverlayProps, Modal as RACModal } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
@@ -26,7 +26,7 @@ const modalStyles = tv({
   }
 });
 
-export function Modal(props: ModalOverlayProps) {
+export function Modal(props: ModalOverlayProps): ReactNode {
   return (
     <ModalOverlay {...props} className={overlayStyles}>
       <RACModal {...props} className={modalStyles} />

--- a/starters/tailwind/src/NumberField.tsx
+++ b/starters/tailwind/src/NumberField.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   NumberField as AriaNumberField,
   NumberFieldProps as AriaNumberFieldProps,
@@ -18,7 +18,7 @@ export interface NumberFieldProps extends AriaNumberFieldProps {
 
 export function NumberField(
   { label, description, errorMessage, ...props }: NumberFieldProps
-) {
+): ReactNode {
   return (
     <AriaNumberField {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-1')}>
       <Label>{label}</Label>
@@ -42,6 +42,6 @@ export function NumberField(
   );
 }
 
-function StepperButton(props: ButtonProps) {
+function StepperButton(props: ButtonProps): ReactNode {
   return <Button {...props} className="px-0.5 cursor-default text-gray-500 pressed:bg-gray-100 group-disabled:text-gray-200 dark:text-zinc-400 dark:pressed:bg-zinc-800 dark:group-disabled:text-zinc-600 forced-colors:group-disabled:text-[GrayText]" />
 }

--- a/starters/tailwind/src/Popover.tsx
+++ b/starters/tailwind/src/Popover.tsx
@@ -6,7 +6,7 @@ import {
   PopoverContext,
   useSlottedContext
 } from 'react-aria-components';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {tv} from 'tailwind-variants';
 
 export interface PopoverProps extends Omit<AriaPopoverProps, 'children'> {
@@ -26,7 +26,7 @@ const styles = tv({
   }
 });
 
-export function Popover({ children, showArrow, className, ...props }: PopoverProps) {
+export function Popover({ children, showArrow, className, ...props }: PopoverProps): ReactNode {
   let popoverContext = useSlottedContext(PopoverContext)!;
   let isSubmenu = popoverContext?.trigger === 'SubmenuTrigger';
   let offset = showArrow ? 12 : 8;

--- a/starters/tailwind/src/ProgressBar.tsx
+++ b/starters/tailwind/src/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   ProgressBar as AriaProgressBar,
   ProgressBarProps as AriaProgressBarProps
@@ -10,7 +10,7 @@ export interface ProgressBarProps extends AriaProgressBarProps {
   label?: string;
 }
 
-export function ProgressBar({ label, ...props }: ProgressBarProps) {
+export function ProgressBar({ label, ...props }: ProgressBarProps): ReactNode {
   return (
     <AriaProgressBar {...props} className={composeTailwindRenderProps(props.className, 'flex flex-col gap-1')}>
       {({ percentage, valueText, isIndeterminate }) => (

--- a/starters/tailwind/src/RadioGroup.tsx
+++ b/starters/tailwind/src/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Radio as RACRadio, RadioGroup as RACRadioGroup, RadioGroupProps as RACRadioGroupProps, RadioProps, ValidationResult } from 'react-aria-components';
+import { Radio as RACRadio, RadioGroup as RACRadioGroup, RadioGroupProps as RACRadioGroupProps, RadioProps as RACRadioProps, ValidationResult } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 import { Description, FieldError, Label } from './Field';
 import { composeTailwindRenderProps, focusRing } from './utils';
@@ -11,7 +11,11 @@ export interface RadioGroupProps extends Omit<RACRadioGroupProps, 'children'> {
   errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
-export function RadioGroup(props: RadioGroupProps) {
+export interface RadioProps extends Omit<RACRadioProps, 'children'> {
+  children?: ReactNode,
+}
+
+export function RadioGroup(props: RadioGroupProps): ReactNode {
   return (
     <RACRadioGroup {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-2')}>
       <Label>{props.label}</Label>
@@ -41,13 +45,15 @@ const styles = tv({
   }
 });
 
-export function Radio(props: RadioProps) {
+export function Radio(props: RadioProps): ReactNode {
   return (
     <RACRadio {...props} className={composeTailwindRenderProps(props.className, 'flex relative gap-2 items-center group text-gray-800 disabled:text-gray-300 dark:text-zinc-200 dark:disabled:text-zinc-600 forced-colors:disabled:text-[GrayText] text-sm transition')}>
-      {renderProps => <>
-        <div className={styles(renderProps)} />
-        {props.children}
-      </>}
+      {renderProps => (
+        <>
+          <div className={styles(renderProps)} />
+          {props.children}
+        </>
+      )}
     </RACRadio>
   );
 }

--- a/starters/tailwind/src/RangeCalendar.tsx
+++ b/starters/tailwind/src/RangeCalendar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   RangeCalendar as AriaRangeCalendar,
   RangeCalendarProps as AriaRangeCalendarProps,
@@ -38,7 +38,7 @@ const cell = tv({
 
 export function RangeCalendar<T extends DateValue>(
   { errorMessage, ...props }: RangeCalendarProps<T>
-) {
+): ReactNode {
   return (
     <AriaRangeCalendar {...props}>
       <CalendarHeader />

--- a/starters/tailwind/src/SearchField.tsx
+++ b/starters/tailwind/src/SearchField.tsx
@@ -1,5 +1,5 @@
 import { SearchIcon, XIcon } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   SearchField as AriaSearchField,
   SearchFieldProps as AriaSearchFieldProps,
@@ -17,7 +17,7 @@ export interface SearchFieldProps extends AriaSearchFieldProps {
 
 export function SearchField(
   { label, description, errorMessage, ...props }: SearchFieldProps
-) {
+): ReactNode {
   return (
     <AriaSearchField {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-1 min-w-[40px]')}>
       {label && <Label>{label}</Label>}

--- a/starters/tailwind/src/Select.tsx
+++ b/starters/tailwind/src/Select.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Select as AriaSelect,
   SelectProps as AriaSelectProps,
@@ -36,7 +36,7 @@ export interface SelectProps<T extends object> extends Omit<AriaSelectProps<T>, 
 
 export function Select<T extends object>(
   { label, description, errorMessage, children, items, ...props }: SelectProps<T>
-) {
+): ReactNode {
   return (
     <AriaSelect {...props} className={composeTailwindRenderProps(props.className, 'group flex flex-col gap-1')}>
       {label && <Label>{label}</Label>}
@@ -55,10 +55,10 @@ export function Select<T extends object>(
   );
 }
 
-export function SelectItem(props: ListBoxItemProps) {
+export function SelectItem(props: ListBoxItemProps): ReactNode {
   return <DropdownItem {...props} />;
 }
 
-export function SelectSection<T extends object>(props: DropdownSectionProps<T>) {
+export function SelectSection<T extends object>(props: DropdownSectionProps<T>): ReactNode {
   return <DropdownSection {...props} />;
 }

--- a/starters/tailwind/src/Separator.tsx
+++ b/starters/tailwind/src/Separator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Separator as RACSeparator, SeparatorProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
@@ -15,7 +15,7 @@ const styles = tv({
   }
 });
 
-export function Separator(props: SeparatorProps) {
+export function Separator(props: SeparatorProps): ReactNode {
   return (
     <RACSeparator
       {...props}

--- a/starters/tailwind/src/Slider.tsx
+++ b/starters/tailwind/src/Slider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Slider as AriaSlider,
   SliderProps as AriaSliderProps,
@@ -44,7 +44,7 @@ export interface SliderProps<T> extends AriaSliderProps<T> {
 
 export function Slider<T extends number | number[]>(
   { label, thumbLabels, ...props }: SliderProps<T>
-) {
+): ReactNode {
   return (
     <AriaSlider {...props} className={composeTailwindRenderProps(props.className, 'orientation-horizontal:grid orientation-vertical:flex grid-cols-[1fr_auto] flex-col items-center gap-2 orientation-horizontal:w-64')}>
       <Label>{label}</Label>

--- a/starters/tailwind/src/Switch.tsx
+++ b/starters/tailwind/src/Switch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Switch as AriaSwitch,
   SwitchProps as AriaSwitchProps
@@ -37,7 +37,7 @@ const handle = tv({
   }
 });
 
-export function Switch({ children, ...props }: SwitchProps) {
+export function Switch({ children, ...props }: SwitchProps): ReactNode {
   return (
     <AriaSwitch {...props} className={composeTailwindRenderProps(props.className, 'group relative flex gap-2 items-center text-gray-800 disabled:text-gray-300 dark:text-zinc-200 dark:disabled:text-zinc-600 forced-colors:disabled:text-[GrayText] text-sm transition')}>
       {(renderProps) => (

--- a/starters/tailwind/src/Table.tsx
+++ b/starters/tailwind/src/Table.tsx
@@ -1,5 +1,5 @@
 import { ArrowUp } from 'lucide-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Cell as AriaCell,
   Column as AriaColumn,
@@ -19,12 +19,11 @@ import {
   composeRenderProps,
   useTableOptions
 } from 'react-aria-components';
-import { twMerge } from 'tailwind-merge';
 import { tv } from 'tailwind-variants';
 import { Checkbox } from './Checkbox';
 import { composeTailwindRenderProps, focusRing } from './utils';
 
-export function Table(props: TableProps) {
+export function Table(props: TableProps): ReactNode {
   return (
     <ResizableTableContainer className="max-h-[280px] w-[550px] overflow-auto scroll-pt-[2.281rem] relative border border-gray-200 dark:border-zinc-600 rounded-lg">
       <AriaTable {...props} className="border-separate border-spacing-0" />
@@ -42,7 +41,7 @@ const resizerStyles = tv({
   base: 'w-px px-[8px] translate-x-[8px] box-content py-1 h-5 bg-clip-content bg-gray-400 dark:bg-zinc-500 forced-colors:bg-[ButtonBorder] cursor-col-resize rounded-xs resizing:bg-blue-600 forced-colors:resizing:bg-[Highlight] resizing:w-[2px] resizing:pl-[7px] -outline-offset-2'
 });
 
-export function Column(props: ColumnProps) {
+export function Column(props: ColumnProps): ReactNode {
   return (
     <AriaColumn {...props} className={composeTailwindRenderProps(props.className, '[&:hover]:z-20 focus-within:z-20 text-start text-sm font-semibold text-gray-700 dark:text-zinc-300 cursor-default')}>
       {composeRenderProps(props.children, (children, { allowsSorting, sortDirection }) => (
@@ -70,7 +69,7 @@ export function Column(props: ColumnProps) {
   );
 }
 
-export function TableHeader<T extends object>(props: TableHeaderProps<T>) {
+export function TableHeader<T extends object>(props: TableHeaderProps<T>): ReactNode {
   let { selectionBehavior, selectionMode, allowsDragging } = useTableOptions();
 
   return (
@@ -96,7 +95,7 @@ const rowStyles = tv({
 
 export function Row<T extends object>(
   { id, columns, children, ...otherProps }: RowProps<T>
-) {
+): ReactNode {
   let { selectionBehavior, allowsDragging } = useTableOptions();
 
   return (
@@ -123,7 +122,7 @@ const cellStyles = tv({
   base: 'border-b border-b-gray-200 dark:border-b-zinc-700 group-last/row:border-b-0 [--selected-border:var(--color-blue-200)] dark:[--selected-border:var(--color-blue-900)] group-selected/row:border-(--selected-border) in-[:has(+[data-selected])]:border-(--selected-border) p-2 truncate -outline-offset-2'
 });
 
-export function Cell(props: CellProps) {
+export function Cell(props: CellProps): ReactNode {
   return (
     <AriaCell {...props} className={cellStyles} />
   );

--- a/starters/tailwind/src/Tabs.tsx
+++ b/starters/tailwind/src/Tabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Tab as RACTab,
   TabList as RACTabList,
@@ -23,7 +23,7 @@ const tabsStyles = tv({
   }
 });
 
-export function Tabs(props: TabsProps) {
+export function Tabs(props: TabsProps): ReactNode {
   return (
     <RACTabs
       {...props}
@@ -44,7 +44,7 @@ const tabListStyles = tv({
   }
 });
 
-export function TabList<T extends object>(props: TabListProps<T>) {
+export function TabList<T extends object>(props: TabListProps<T>): ReactNode {
   return (
     <RACTabList
       {...props}
@@ -69,7 +69,7 @@ const tabProps = tv({
   }
 });
 
-export function Tab(props: TabProps) {
+export function Tab(props: TabProps): ReactNode {
   return (
     <RACTab
       {...props}
@@ -85,7 +85,7 @@ const tabPanelStyles = tv({
   base: 'flex-1 p-4 text-sm text-gray-900 dark:text-zinc-100'
 });
 
-export function TabPanel(props: TabPanelProps) {
+export function TabPanel(props: TabPanelProps): ReactNode {
   return (
     <RACTabPanel
       {...props}

--- a/starters/tailwind/src/TagGroup.tsx
+++ b/starters/tailwind/src/TagGroup.tsx
@@ -1,5 +1,5 @@
 import { XIcon } from 'lucide-react';
-import React, { createContext, useContext } from 'react';
+import React, { createContext, ReactNode, useContext } from 'react';
 import {
   Tag as AriaTag,
   TagGroup as AriaTagGroup,
@@ -47,12 +47,12 @@ const tagStyles = tv({
     }
   },
   compoundVariants: (Object.keys(colors) as Color[]).map((color) => ({
-    isSelected: false,
-    isDisabled: false,
+    isSelected: undefined,
+    isDisabled: undefined,
     color,
     class: colors[color]
   }))
-});
+}) as any;
 
 export interface TagGroupProps<T> extends Omit<AriaTagGroupProps, 'children'>, Pick<TagListProps<T>, 'items' | 'children' | 'renderEmptyState'> {
   color?: Color;
@@ -61,7 +61,8 @@ export interface TagGroupProps<T> extends Omit<AriaTagGroupProps, 'children'>, P
   errorMessage?: string;
 }
 
-export interface TagProps extends AriaTagProps {
+export interface TagProps extends Omit<AriaTagProps, 'children'> {
+  children?: ReactNode;
   color?: Color
 }
 
@@ -75,7 +76,7 @@ export function TagGroup<T extends object>(
     renderEmptyState,
     ...props
   }: TagGroupProps<T>
-) {
+): ReactNode {
   return (
     <AriaTagGroup {...props} className={twMerge('flex flex-col gap-1', props.className)}>
       <Label>{label}</Label>
@@ -95,7 +96,7 @@ const removeButtonStyles = tv({
   base: 'cursor-default rounded-full transition-[background-color] p-0.5 flex items-center justify-center hover:bg-black/10 dark:hover:bg-white/10 pressed:bg-black/20 dark:pressed:bg-white/20'
 });
 
-export function Tag({ children, color, ...props }: TagProps) {
+export function Tag({ children, color, ...props }: TagProps): ReactNode {
   let textValue = typeof children === 'string' ? children : undefined;
   let groupColor = useContext(ColorContext);
   return (

--- a/starters/tailwind/src/TextField.tsx
+++ b/starters/tailwind/src/TextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   TextField as AriaTextField,
   TextFieldProps as AriaTextFieldProps,
@@ -26,11 +26,11 @@ export interface TextFieldProps extends AriaTextFieldProps {
 
 export function TextField(
   { label, description, errorMessage, ...props }: TextFieldProps
-) {
+): ReactNode {
   return (
     <AriaTextField {...props} className={composeTailwindRenderProps(props.className, 'flex flex-col gap-1')}>
       {label && <Label>{label}</Label>}
-      <Input className={inputStyles} />
+      <Input className={(renderProps) => inputStyles(renderProps as any)} />
       {description && <Description>{description}</Description>}
       <FieldError>{errorMessage}</FieldError>
     </AriaTextField>

--- a/starters/tailwind/src/TimeField.tsx
+++ b/starters/tailwind/src/TimeField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   TimeField as AriaTimeField,
   TimeFieldProps as AriaTimeFieldProps,
@@ -17,7 +17,7 @@ export interface TimeFieldProps<T extends TimeValue>
 
 export function TimeField<T extends TimeValue>(
   { label, description, errorMessage, ...props }: TimeFieldProps<T>
-) {
+): ReactNode {
   return (
     <AriaTimeField {...props}>
       <Label>{label}</Label>

--- a/starters/tailwind/src/ToggleButton.tsx
+++ b/starters/tailwind/src/ToggleButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ToggleButton as RACToggleButton, ToggleButtonProps, composeRenderProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 import { focusRing } from './utils';
@@ -17,7 +17,7 @@ let styles = tv({
   }
 });
 
-export function ToggleButton(props: ToggleButtonProps) {
+export function ToggleButton(props: ToggleButtonProps): ReactNode {
   return (
     <RACToggleButton
       {...props}

--- a/starters/tailwind/src/ToggleButtonGroup.tsx
+++ b/starters/tailwind/src/ToggleButtonGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { composeRenderProps, ToggleButtonGroup as RACToggleButtonGroup, ToggleButtonGroupProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
@@ -12,7 +12,7 @@ const styles = tv({
   }
 });
 
-export function ToggleButtonGroup(props: ToggleButtonGroupProps) {
+export function ToggleButtonGroup(props: ToggleButtonGroupProps): ReactNode {
   return (
     <RACToggleButtonGroup
       {...props}

--- a/starters/tailwind/src/Toolbar.tsx
+++ b/starters/tailwind/src/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Toolbar as RACToolbar, ToolbarProps, composeRenderProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
@@ -12,7 +12,7 @@ const styles = tv({
   }
 })
 
-export function Toolbar(props: ToolbarProps) {
+export function Toolbar(props: ToolbarProps): ReactNode {
   return (
     <RACToolbar
       {...props}

--- a/starters/tailwind/src/Tooltip.tsx
+++ b/starters/tailwind/src/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Tooltip as AriaTooltip,
   TooltipProps as AriaTooltipProps,
@@ -23,7 +23,7 @@ const styles = tv({
   }
 });
 
-export function Tooltip({ children, ...props }: TooltipProps) {
+export function Tooltip({ children, ...props }: TooltipProps): ReactNode {
   return (
     <AriaTooltip {...props} offset={10} className={composeRenderProps(props.className, (className, renderProps) => styles({...renderProps, className}))}>
       <OverlayArrow>

--- a/starters/tailwind/src/Tree.tsx
+++ b/starters/tailwind/src/Tree.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Tree as AriaTree,
   TreeItem as AriaTreeItem,
@@ -29,7 +29,7 @@ const itemStyles = tv({
 
 export function Tree<T extends object>(
   { children, ...props }: TreeProps<T>
-) {
+): ReactNode {
   return (
     <AriaTree {...props} className={composeTailwindRenderProps(props.className, 'overflow-auto relative border border-gray-200 dark:border-zinc-600 rounded-lg')}>
       {children}
@@ -37,7 +37,7 @@ export function Tree<T extends object>(
   );
 }
 
-export function TreeItem(props: TreeItemProps) {
+export function TreeItem(props: TreeItemProps): ReactNode {
   return (
     <AriaTreeItem className={itemStyles} {...props} />
   )
@@ -68,7 +68,7 @@ const chevron = tv({
   }
 });
 
-export function TreeItemContent({ children, ...props }: TreeItemContentProps) {
+export function TreeItemContent({ children, ...props }: TreeItemContentProps): ReactNode {
   return (
     <AriaTreeItemContent {...props}>
       {({ selectionMode, selectionBehavior, hasChildItems, isExpanded, isDisabled }) => (

--- a/starters/tailwind/src/utils.ts
+++ b/starters/tailwind/src/utils.ts
@@ -10,7 +10,7 @@ export const focusRing = tv({
       true: 'outline-2'
     }
   }
-});
+}) as any;
 
 export function composeTailwindRenderProps<T>(className: string | ((v: T) => string) | undefined, tw: string): string | ((v: T) => string) {
   return composeRenderProps(className, (className) => twMerge(tw, className));


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Same test instructions as https://github.com/adobe/react-spectrum/pull/8375

Require some opinions here, should the starters adhere to this? For some reason they *are* checked during `tsc`. 
If they should, then do we want ReactNode? or JSX.Element?

I think it should be ReactNode because newer versions of React appear to prefer that.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
