### PR TITLE
fix: missing page.css.map

### DIFF
--- a/packages/@react-spectrum/s2/package.json
+++ b/packages/@react-spectrum/s2/package.json
@@ -129,6 +129,7 @@
     "dist",
     "style",
     "page.css",
+    "page.css.map",
     "icons",
     "illustrations",
     "src"


### PR DESCRIPTION
Closes [Missing page.css.map in @react-spectrum/s2 Package](https://github.com/adobe/react-spectrum/issues/8355#top)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
