### PR TITLE
feat: Provide GroupContext in TextField

### DIFF
--- a/packages/@react-spectrum/s2/src/ColorField.tsx
+++ b/packages/@react-spectrum/s2/src/ColorField.tsx
@@ -92,7 +92,7 @@ export const ColorField = forwardRef(function ColorField(props: ColorFieldProps,
           contextualHelp={props.contextualHelp}>
           {label}
         </FieldLabel>
-        <FieldGroup role="presentation" isDisabled={isDisabled} isInvalid={isInvalid} size={props.size}>
+        <FieldGroup size={props.size}>
           <Input ref={inputRef} />
           {isInvalid && <FieldErrorIcon isDisabled={isDisabled} />}
         </FieldGroup>

--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -199,9 +199,6 @@ export const NumberField = forwardRef(function NumberField(props: NumberFieldPro
                   {label}
                 </FieldLabel>
                 <FieldGroup
-                  role="presentation"
-                  isDisabled={isDisabled}
-                  isInvalid={isInvalid}
                   size={size}
                   styles={style({
                     ...fieldInput(),

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -135,8 +135,7 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldP
           contextualHelp={props.contextualHelp}>
           {label}
         </FieldLabel>
-        {/* TODO: set GroupContext in RAC TextField */}
-        <FieldGroup role="presentation" isDisabled={isDisabled} isInvalid={isInvalid} size={props.size} styles={fieldGroupCss}>
+        <FieldGroup size={props.size} styles={fieldGroupCss}>
           <InputContext.Consumer>
             {ctx => (
               <InputContext.Provider value={{...ctx, ref: mergeRefs((ctx as any)?.ref, inputRef)}}>

--- a/packages/react-aria-components/src/ColorField.tsx
+++ b/packages/react-aria-components/src/ColorField.tsx
@@ -15,6 +15,7 @@ import {ColorChannel, ColorFieldState, ColorSpace, useColorChannelFieldState, us
 import {ColorFieldContext} from './RSPContexts';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps} from '@react-aria/utils';
+import {GroupContext} from './Group';
 import {InputContext} from './Input';
 import {InputDOMProps, ValidationResult} from '@react-types/shared';
 import {LabelContext} from './Label';
@@ -190,6 +191,7 @@ function useChildren(
         [ColorFieldStateContext, state],
         [InputContext, {...inputProps, ref: inputRef}],
         [LabelContext, {...labelProps, ref: labelRef}],
+        [GroupContext, {role: 'presentation', isInvalid: validation.isInvalid, isDisabled: props.isDisabled || false}],
         [TextContext, {
           slots: {
             description: descriptionProps,

--- a/packages/react-aria-components/src/TextField.tsx
+++ b/packages/react-aria-components/src/TextField.tsx
@@ -16,6 +16,7 @@ import {createHideableComponent} from '@react-aria/collections';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {FormContext} from './Form';
+import {GroupContext} from './Group';
 import {InputContext} from './Input';
 import {LabelContext} from './Label';
 import React, {createContext, ForwardedRef, useCallback, useRef, useState} from 'react';
@@ -110,6 +111,7 @@ export const TextField = /*#__PURE__*/ createHideableComponent(function TextFiel
           [LabelContext, {...labelProps, ref: labelRef}],
           [InputContext, {...mergeProps(inputProps, inputContextProps), ref: inputOrTextAreaRef}],
           [TextAreaContext, {...inputProps, ref: inputOrTextAreaRef}],
+          [GroupContext, {role: 'presentation', isInvalid: validation.isInvalid, isDisabled: props.isDisabled || false}],
           [TextContext, {
             slots: {
               description: descriptionProps,


### PR DESCRIPTION
Closes #7451

We set `GroupContext` in all of our other field components (e.g. NumberField, SearchField, etc.). For convenience of styling, set it in TextField and ColorField too. These have `role="presentation"` but the data attributes for disabled / invalid can still be useful. We had a todo in S2 for this as well.