### PR TITLE
fix: Virtualized Tree DnD drop indicator

### DIFF
--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -587,6 +587,22 @@ export class ListLayout<T, O extends ListLayoutOptions = ListLayoutOptions> exte
     if (target.dropPosition === 'before') {
       rect = new Rect(layoutInfo.rect.x, layoutInfo.rect.y - this.dropIndicatorThickness / 2, layoutInfo.rect.width, this.dropIndicatorThickness);
     } else if (target.dropPosition === 'after') {
+      // Render after last visible descendant of the drop target.
+      let targetNode = this.collection.getItem(target.key);
+      if (targetNode) {
+        let targetLevel = targetNode.level ?? 0;
+        let currentKey = this.collection.getKeyAfter(target.key);
+
+        while (currentKey != null) {
+          let node = this.collection.getItem(currentKey);
+          if (!node || node.level <= targetLevel) {
+            break;
+          }
+
+          layoutInfo = this.getLayoutInfo(currentKey) || layoutInfo;
+          currentKey = this.collection.getKeyAfter(currentKey);
+        }
+      }
       rect = new Rect(layoutInfo.rect.x, layoutInfo.rect.maxY - this.dropIndicatorThickness / 2, layoutInfo.rect.width, this.dropIndicatorThickness);
     } else {
       rect = layoutInfo.rect;

--- a/packages/react-aria-components/stories/Tree.stories.tsx
+++ b/packages/react-aria-components/stories/Tree.stories.tsx
@@ -876,3 +876,22 @@ export const TreeWithDragAndDrop = {
     ...TreeExampleDynamic.argTypes
   }
 };
+
+function TreeDragAndDropVirtualizedRender(args) {
+  return (
+    <div style={{display: 'flex', gap: 12, flexWrap: 'wrap'}}>
+      <Virtualizer layout={ListLayout} layoutOptions={{rowHeight: 30}}>
+        <TreeDragAndDropExample defaultExpandedKeys={['projects', 'reports', 'project-2', 'project-5', 'report-1', 'reports-1', 'reports-1A', 'reports-1AB']} {...args} />
+      </Virtualizer>
+      <Virtualizer layout={ListLayout} layoutOptions={{rowHeight: 30}}>
+        <SecondTree {...args} />
+      </Virtualizer>
+    </div>
+  );
+}
+
+export const TreeWithDragAndDropVirtualized = {
+  ...TreeWithDragAndDrop,
+  render: TreeDragAndDropVirtualizedRender,
+  name: 'Tree with drag and drop (virtualized)'
+};


### PR DESCRIPTION
Fixes drop indicators for "after" an expanded item to be after the last child (was rendering before the first child).

Previously, you would get behavior like this:

https://github.com/user-attachments/assets/fe47b4ed-0547-4485-9bcb-e66982a7d583


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test new story: https://reactspectrum.blob.core.windows.net/reactspectrum/952182bc2a0e9c8a1373918d32c48bb803c7dc8f/storybook/index.html?path=/story/react-aria-components--tree-with-drag-and-drop-virtualized&providerSwitcher-express=false

## 🧢 Your Project:

<!--- Company/project for pull request -->
