### PR TITLE
fix: preventing Talkback erroneously focusing valid icon and adding similar support for MobileCombobox 

### DIFF
--- a/packages/@react-spectrum/combobox/intl/en-US.json
+++ b/packages/@react-spectrum/combobox/intl/en-US.json
@@ -3,6 +3,6 @@
   "noResults": "No results",
   "clear": "Clear",
   "invalid": "(invalid)",
-  "valid": "valid"
+  "valid": "(valid)"
 
 }

--- a/packages/@react-spectrum/combobox/intl/en-US.json
+++ b/packages/@react-spectrum/combobox/intl/en-US.json
@@ -2,5 +2,7 @@
   "loading": "Loading...",
   "noResults": "No results",
   "clear": "Clear",
-  "invalid": "(invalid)"
+  "invalid": "(invalid)",
+  "valid": "valid"
+
 }

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -182,7 +182,7 @@ export const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: Co
   let validId = useId();
   let validationIcon = validationState === 'invalid'
     ? <AlertMedium id={invalidId} aria-label={stringFormatter.format('invalid')} />
-    : <CheckmarkMedium id={validId} aria-hidden aria-label={stringFormatter.format('valid')} />;
+    : <CheckmarkMedium id={validId} aria-label={stringFormatter.format('valid')} />;
 
   let validation = React.cloneElement(validationIcon, {
     UNSAFE_className: classNames(
@@ -203,7 +203,8 @@ export const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: Co
       props['aria-labelledby'],
       props['aria-label'] && !props['aria-labelledby'] ? props.id : null,
       valueId,
-      validationState === 'invalid' ? invalidId : null
+      validationState === 'invalid' ? invalidId : null,
+      validationState === 'valid' ? validId : null
     ].filter(Boolean).join(' '),
     elementType: 'div'
   }, objRef);
@@ -213,17 +214,7 @@ export const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: Co
       focusClass={classNames(styles, 'is-focused')}
       focusRingClass={classNames(styles, 'focus-ring')}>
       <div
-        {...mergeProps(
-          hoverProps,
-          buttonProps,
-          validationState === 'valid' && !isDisabled
-            ? {
-              'aria-describedby': buttonProps['aria-describedby']
-                  ? `${buttonProps['aria-describedby']} ${validId}`
-                  : validId
-            }
-            : undefined
-        )}
+        {...mergeProps(hoverProps, buttonProps)}
         aria-haspopup="dialog"
         ref={objRef}
         style={{...style, outline: 'none'}}

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -179,9 +179,10 @@ export const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: Co
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/combobox');
   let valueId = useId();
   let invalidId = useId();
+  let validId = useId();
   let validationIcon = validationState === 'invalid'
     ? <AlertMedium id={invalidId} aria-label={stringFormatter.format('invalid')} />
-    : <CheckmarkMedium />;
+    : <CheckmarkMedium id={validId} aria-hidden aria-label={stringFormatter.format('valid')} />;
 
   let validation = React.cloneElement(validationIcon, {
     UNSAFE_className: classNames(
@@ -212,7 +213,17 @@ export const ComboBoxButton = React.forwardRef(function ComboBoxButton(props: Co
       focusClass={classNames(styles, 'is-focused')}
       focusRingClass={classNames(styles, 'focus-ring')}>
       <div
-        {...mergeProps(hoverProps, buttonProps)}
+        {...mergeProps(
+          hoverProps,
+          buttonProps,
+          validationState === 'valid' && !isDisabled
+            ? {
+              'aria-describedby': buttonProps['aria-describedby']
+                  ? `${buttonProps['aria-describedby']} ${validId}`
+                  : validId
+            }
+            : undefined
+        )}
         aria-haspopup="dialog"
         ref={objRef}
         style={{...style, outline: 'none'}}

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -98,7 +98,7 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldB
   let validId = useId();
   let validationIcon = isInvalid
     ? <AlertMedium />
-    : <CheckmarkMedium id={validId} aria-label={stringFormatter.format('valid')} />;
+    : <CheckmarkMedium id={validId} aria-hidden aria-label={stringFormatter.format('valid')} />;
   let validation = cloneElement(validationIcon, {
     UNSAFE_className: classNames(
       styles,

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -107,6 +107,15 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldB
     )
   });
 
+  // Add validation icon IDREF to aria-describedby when validationState is valid
+  let inputPropsAriaDescribedBy = inputProps['aria-describedby'];
+  if (
+    !isInvalid && validationState === 'valid' && !isLoading && !isDisabled &&
+    (!inputPropsAriaDescribedBy || !inputPropsAriaDescribedBy.includes(validId))
+  ) {
+    inputProps['aria-describedby'] = [inputPropsAriaDescribedBy, validId].join(' ').trim();
+  }
+
   let {focusProps, isFocusVisible} = useFocusRing({
     isTextInput: true,
     autoFocus
@@ -129,18 +138,7 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldB
         )
       }>
       <ElementType
-        {...mergeProps(
-            inputProps,
-            hoverProps,
-            focusProps,
-            validationState === 'valid' && !isLoading && !isDisabled
-              ? {
-                'aria-describedby': inputProps['aria-describedby']
-                    ? `${inputProps['aria-describedby']} ${validId}`
-                    : validId
-              }
-              : undefined
-          )}
+        {...mergeProps(inputProps, hoverProps, focusProps)}
         ref={inputRef as any}
         rows={multiLine ? 1 : undefined}
         className={


### PR DESCRIPTION
From testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test Combobox on mobile and make sure it is announced as "valid" when focused and `validationState="valid"`. Also test that TextField still announces "valid" when focused and is in the valid state

## 🧢 Your Project:

RSP
