### PR TITLE
feat: Add support for automatic reset after React 19 form actions

### DIFF
--- a/packages/@react-aria/button/src/useToggleButtonGroup.ts
+++ b/packages/@react-aria/button/src/useToggleButtonGroup.ts
@@ -68,6 +68,7 @@ export function useToggleButtonGroupItem(props: AriaToggleButtonGroupItemOptions
 export function useToggleButtonGroupItem(props: AriaToggleButtonGroupItemOptions<ElementType>, state: ToggleGroupState, ref: RefObject<any>): ToggleButtonAria<HTMLAttributes<any>> {
   let toggleState: ToggleState = {
     isSelected: state.selectedKeys.has(props.id),
+    defaultSelected: false,
     setSelected(isSelected) {
       state.setSelected(props.id, isSelected);
     },

--- a/packages/@react-aria/checkbox/src/useCheckboxGroupItem.ts
+++ b/packages/@react-aria/checkbox/src/useCheckboxGroupItem.ts
@@ -30,6 +30,7 @@ export function useCheckboxGroupItem(props: AriaCheckboxGroupItemProps, state: C
   const toggleState = useToggleState({
     isReadOnly: props.isReadOnly || state.isReadOnly,
     isSelected: state.isSelected(props.value),
+    defaultSelected: state.defaultValue.includes(props.value),
     onChange(isSelected) {
       if (isSelected) {
         state.addValue(props.value);

--- a/packages/@react-aria/color/src/useColorArea.ts
+++ b/packages/@react-aria/color/src/useColorArea.ts
@@ -69,12 +69,7 @@ export function useColorArea(props: AriaColorAreaOptions, state: ColorAreaState)
     }
   }, [inputXRef]);
 
-  useFormReset(inputXRef, [state.xValue, state.yValue], ([x, y]) => {
-    let newColor = state.value
-      .withChannelValue(state.channels.xChannel, x)
-      .withChannelValue(state.channels.yChannel, y);
-    state.setValue(newColor);
-  });
+  useFormReset(inputXRef, state.defaultValue, state.setValue);
 
   let [valueChangedViaKeyboard, setValueChangedViaKeyboard] = useState(false);
   let [valueChangedViaInputChangeEvent, setValueChangedViaInputChangeEvent] = useState(false);

--- a/packages/@react-aria/color/src/useColorField.ts
+++ b/packages/@react-aria/color/src/useColorField.ts
@@ -20,7 +20,7 @@ import {
   useCallback,
   useState
 } from 'react';
-import {mergeProps, useId} from '@react-aria/utils';
+import {mergeProps, useFormReset, useId} from '@react-aria/utils';
 import {privateValidationStateProp} from '@react-stately/form';
 import {useFocusWithin, useScrollWheel} from '@react-aria/interactions';
 import {useFormattedTextField} from '@react-aria/textfield';
@@ -108,13 +108,17 @@ export function useColorField(
     ...props,
     id: inputId,
     value: inputValue,
-    defaultValue: undefined,
+    // Intentionally invalid value that will be ignored by onChange during form reset
+    // This is handled separately below.
+    defaultValue: '!',
     validate: undefined,
     [privateValidationStateProp]: state,
     type: 'text',
     autoComplete: 'off',
     onChange
   }, state, ref);
+
+  useFormReset(ref, state.defaultColorValue, state.setColorValue);
 
   inputProps = mergeProps(inputProps, spinButtonProps, focusWithinProps, {
     role: 'textbox',

--- a/packages/@react-aria/color/src/useColorWheel.ts
+++ b/packages/@react-aria/color/src/useColorWheel.ts
@@ -58,7 +58,7 @@ export function useColorWheel(props: AriaColorWheelOptions, state: ColorWheelSta
     }
   }, [inputRef]);
 
-  useFormReset(inputRef, state.hue, state.setHue);
+  useFormReset(inputRef, state.defaultValue, state.setValue);
 
   let currentPosition = useRef<{x: number, y: number} | null>(null);
 

--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -210,6 +210,7 @@ export function useComboBox<T>(props: AriaComboBoxOptions<T>, state: ComboBoxSta
     onKeyDown: !isReadOnly ? chain(state.isOpen && collectionProps.onKeyDown, onKeyDown, props.onKeyDown) : props.onKeyDown,
     onBlur,
     value: state.inputValue,
+    defaultValue: state.defaultInputValue,
     onFocus,
     autoComplete: 'off',
     validate: undefined,

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -138,7 +138,7 @@ export function useDateField<T extends DateValue>(props: AriaDateFieldOptions<T>
     autoFocusRef.current = false;
   }, [focusManager]);
 
-  useFormReset(props.inputRef, state.value, state.setValue);
+  useFormReset(props.inputRef, state.defaultValue, state.setValue);
   useFormValidation({
     ...props,
     focus() {

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -136,6 +136,7 @@ export function useDatePicker<T extends DateValue>(props: AriaDatePickerProps<T>
       [roleSymbol]: 'presentation',
       'aria-describedby': ariaDescribedBy,
       value: state.value,
+      defaultValue: state.defaultValue,
       onChange: state.setValue,
       placeholderValue: props.placeholderValue,
       hideTimeZone: props.hideTimeZone,

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -183,6 +183,7 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
       ...startFieldProps,
       ...commonFieldProps,
       value: state.value?.start ?? null,
+      defaultValue: state.defaultValue?.start,
       onChange: start => state.setDateTime('start', start),
       autoFocus: props.autoFocus,
       name: props.startName,
@@ -201,6 +202,7 @@ export function useDateRangePicker<T extends DateValue>(props: AriaDateRangePick
       ...endFieldProps,
       ...commonFieldProps,
       value: state.value?.end ?? null,
+      defaultValue: state.defaultValue?.end,
       onChange: end => state.setDateTime('end', end),
       name: props.endName,
       [privateValidationStateProp]: {

--- a/packages/@react-aria/numberfield/src/useNumberField.ts
+++ b/packages/@react-aria/numberfield/src/useNumberField.ts
@@ -208,7 +208,7 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
     validate: undefined,
     [privateValidationStateProp]: state,
     value: inputValue,
-    defaultValue: undefined, // defaultValue already used to populate state.inputValue, unneeded here
+    defaultValue: '!', // an invalid value so that form reset is ignored in onChange above
     autoComplete: 'off',
     'aria-label': props['aria-label'] || undefined,
     'aria-labelledby': props['aria-labelledby'] || undefined,
@@ -225,7 +225,7 @@ export function useNumberField(props: AriaNumberFieldProps, state: NumberFieldSt
     errorMessage
   }, state, inputRef);
 
-  useFormReset(inputRef, state.numberValue, state.setNumberValue);
+  useFormReset(inputRef, state.defaultNumberValue, state.setNumberValue);
 
   let inputProps: InputHTMLAttributes<HTMLInputElement> = mergeProps(
     spinButtonProps,

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -94,7 +94,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
   }
 
   let {name, descriptionId, errorMessageId, validationBehavior} = radioGroupData.get(state)!;
-  useFormReset(ref, state.selectedValue, state.setSelectedValue);
+  useFormReset(ref, state.defaultSelectedValue, state.setSelectedValue);
   useFormValidation({validationBehavior}, state, ref);
 
   return {

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -69,7 +69,7 @@ export function useHiddenSelect<T>(props: AriaHiddenSelectOptions, state: Select
   let {validationBehavior, isRequired} = data;
   let {visuallyHiddenProps} = useVisuallyHidden();
 
-  useFormReset(props.selectRef, state.selectedKey, state.setSelectedKey);
+  useFormReset(props.selectRef, state.defaultSelectedKey, state.setSelectedKey);
   useFormValidation({
     validationBehavior,
     focus: () => triggerRef.current?.focus()

--- a/packages/@react-aria/slider/src/useSliderThumb.ts
+++ b/packages/@react-aria/slider/src/useSliderThumb.ts
@@ -227,7 +227,7 @@ export function useSliderThumb(
     }
   ) : {};
 
-  useFormReset(inputRef, value, (v) => {
+  useFormReset(inputRef, state.defaultValues[index], (v) => {
     state.setThumbValue(index, v);
   });
 

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -19,7 +19,8 @@ import React, {
   type JSX,
   LabelHTMLAttributes,
   RefObject,
-  useEffect
+  useEffect,
+  useState
 } from 'react';
 import {useControlledState} from '@react-stately/utils';
 import {useField} from '@react-aria/label';
@@ -142,7 +143,8 @@ export function useTextField<T extends TextFieldIntrinsicElements = DefaultEleme
     pattern: props.pattern
   };
 
-  useFormReset(ref, value, setValue);
+  let [initialValue] = useState(value);
+  useFormReset(ref, props.defaultValue ?? initialValue, setValue);
   useFormValidation(props, validationState, ref);
 
   useEffect(() => {

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -81,7 +81,7 @@ export function useToggle(props: AriaToggleProps, state: ToggleState, ref: RefOb
   let interactions = mergeProps(pressProps, focusableProps);
   let domProps = filterDOMProps(props, {labelable: true});
 
-  useFormReset(ref, state.isSelected, state.setSelected);
+  useFormReset(ref, state.defaultSelected, state.setSelected);
 
   return {
     labelProps: mergeProps(labelProps, {onClick: e => e.preventDefault()}),

--- a/packages/@react-aria/utils/src/useEffectEvent.ts
+++ b/packages/@react-aria/utils/src/useEffectEvent.ts
@@ -10,12 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import {useCallback, useRef} from 'react';
+import React, {useCallback, useRef} from 'react';
 import {useLayoutEffect} from './useLayoutEffect';
+
+// Use the earliest effect type possible. useInsertionEffect runs during the mutation phase,
+// before all layout effects, but is available only in React 18 and later.
+const useEarlyEffect = React['useInsertionEffect'] ?? useLayoutEffect;
 
 export function useEffectEvent<T extends Function>(fn?: T): T {
   const ref = useRef<T | null | undefined>(null);
-  useLayoutEffect(() => {
+  useEarlyEffect(() => {
     ref.current = fn;
   }, [fn]);
   // @ts-ignore

--- a/packages/@react-aria/utils/src/useFormReset.ts
+++ b/packages/@react-aria/utils/src/useFormReset.ts
@@ -11,7 +11,7 @@
  */
 
 import {RefObject} from '@react-types/shared';
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 import {useEffectEvent} from './useEffectEvent';
 
 export function useFormReset<T>(
@@ -19,15 +19,15 @@ export function useFormReset<T>(
   initialValue: T,
   onReset: (value: T) => void
 ): void {
-  let resetValue = useRef(initialValue);
   let handleReset = useEffectEvent(() => {
     if (onReset) {
-      onReset(resetValue.current);
+      onReset(initialValue);
     }
   });
 
   useEffect(() => {
     let form = ref?.current?.form;
+
     form?.addEventListener('reset', handleReset);
     return () => {
       form?.removeEventListener('reset', handleReset);

--- a/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
+++ b/packages/@react-spectrum/autocomplete/src/MobileSearchAutocomplete.tsx
@@ -126,7 +126,7 @@ function ForwardMobileSearchAutocomplete<T extends object>(props: SpectrumSearch
     inputProps.onChange = () => {};
   }
 
-  useFormReset(inputRef, state.inputValue, state.setInputValue);
+  useFormReset(inputRef, state.defaultInputValue, state.setInputValue);
 
   return (
     <>

--- a/packages/@react-spectrum/autocomplete/test/SearchAutocomplete.test.js
+++ b/packages/@react-spectrum/autocomplete/test/SearchAutocomplete.test.js
@@ -2459,6 +2459,31 @@ describe('SearchAutocomplete', function () {
         expect(combobox).toHaveValue('');
       });
 
+      if (parseInt(React.version, 10) >= 19) {
+        it('resets to defaultInputValue when submitting form action', async () => {
+          function Test() {        
+            const [value, formAction] = React.useActionState(() => 'hi', 'test');
+            
+            return (
+              <Provider theme={theme}>
+                <form action={formAction}>
+                  <ExampleSearchAutocomplete defaultInputValue={value} />
+                  <input type="submit" data-testid="submit" />
+                </form>
+              </Provider>
+            );
+          }
+    
+          let {getByTestId, getByRole} = render(<Test />);
+          let input = getByRole('combobox');
+          expect(input).toHaveValue('test');
+    
+          let button = getByTestId('submit');
+          await act(async () => await user.click(button));
+          expect(input).toHaveValue('hi');
+        });
+      }
+
       describe('validation', () => {
         describe('validationBehavior=native', () => {
           it('supports isRequired', async () => {
@@ -2748,6 +2773,31 @@ describe('SearchAutocomplete', function () {
         await user.click(reset);
         expect(input).toHaveValue('');
       });
+
+      if (parseInt(React.version, 10) >= 19) {
+        it('resets to defaultInputValue when submitting form action', async () => {
+          function Test() {
+            const [value, formAction] = React.useActionState(() => 'hi', 'test');
+            
+            return (
+              <Provider theme={theme}>
+                <form action={formAction}>
+                  <ExampleSearchAutocomplete name="combobox" defaultInputValue={value} />
+                  <input type="submit" data-testid="submit" />
+                </form>
+              </Provider>
+            );
+          }
+    
+          let {getByTestId} = render(<Test />);
+          let input = document.querySelector('input[name=combobox]');
+          expect(input).toHaveValue('test');
+    
+          let button = getByTestId('submit');
+          await act(async () => await user.click(button));
+          expect(input).toHaveValue('hi');
+        });
+      }
 
       describe('validation', () => {
         describe('validationBehavior=native', () => {

--- a/packages/@react-spectrum/checkbox/test/Checkbox.test.js
+++ b/packages/@react-spectrum/checkbox/test/Checkbox.test.js
@@ -292,6 +292,29 @@ describe('Checkbox', function () {
     expect(input).not.toBeChecked();
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultSelected when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => true, false);
+        
+        return (
+          <form action={formAction}>
+            <Checkbox defaultSelected={value}>Test</Checkbox>
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('checkbox');
+      expect(input).not.toBeChecked();
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toBeChecked();
+    });
+  }
+
   describe('validation', () => {
     describe('validationBehavior=native', () => {
       it('supports isRequired', async () => {

--- a/packages/@react-spectrum/checkbox/test/CheckboxGroup.test.js
+++ b/packages/@react-spectrum/checkbox/test/CheckboxGroup.test.js
@@ -415,6 +415,39 @@ describe('CheckboxGroup', () => {
     expect(checkboxes[2]).not.toBeChecked();
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => ['dogs', 'cats'], []);
+        
+        return (
+          <Provider theme={theme}>
+            <form action={formAction}>
+              <CheckboxGroup name="pets" label="Pets" defaultValue={value}>
+                <Checkbox value="dogs">Dogs</Checkbox>
+                <Checkbox value="cats">Cats</Checkbox>
+                <Checkbox value="dragons">Dragons</Checkbox>
+              </CheckboxGroup>
+              <input type="submit" data-testid="submit" />
+            </form>
+          </Provider>
+        );
+      }
+
+      let {getByTestId, getAllByRole} = render(<Test />);
+      let checkboxes = getAllByRole('checkbox');
+      for (let checkbox of checkboxes) {
+        expect(checkbox).not.toBeChecked();
+      }
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).toBeChecked();
+      expect(checkboxes[2]).not.toBeChecked();
+    });
+  }
+
   describe('validation', () => {
     describe('validationBehavior=native', () => {
       it('supports group level isRequired', async () => {

--- a/packages/@react-spectrum/color/test/ColorArea.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorArea.test.tsx
@@ -675,5 +675,31 @@ describe('ColorArea', () => {
       expect(inputs[0]).toHaveValue('100');
       expect(inputs[1]).toHaveValue('200');
     });
+
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultValue when submitting form action', async () => {
+        function Test() {        
+          const [value, formAction] = React.useActionState(() => '#f00', '#000');
+          
+          return (
+            <form action={formAction}>
+              <ColorArea defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          );
+        }
+
+        let {getByTestId, getAllByRole} = render(<Test />);
+        let inputs = getAllByRole('slider', {hidden: true});
+
+        expect(inputs[0]).toHaveValue('0');
+        expect(inputs[1]).toHaveValue('0');
+
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(inputs[0]).toHaveValue('255');
+        expect(inputs[1]).toHaveValue('0');
+      });
+    }
   });
 });

--- a/packages/@react-spectrum/color/test/ColorField.test.js
+++ b/packages/@react-spectrum/color/test/ColorField.test.js
@@ -374,6 +374,54 @@ describe('ColorField', function () {
     expect(onChangeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('supports form reset', async () => {
+    function Test() {
+      let [value, setValue] = React.useState(parseColor('#7f0000'));
+      return (
+        <form>
+          <ColorField value={value} onChange={setValue} />
+          <input type="reset" data-testid="reset" />
+        </form>
+      );
+    }
+
+    let {getByTestId, getByRole} = render(<Test />);
+    let input = getByRole('textbox');
+
+    expect(input).toHaveValue('#7F0000');
+    await user.tab();
+    await user.keyboard('#000');
+    await user.tab();
+    expect(input).toHaveValue('#000000');
+
+    let button = getByTestId('reset');
+    await user.click(button);
+    expect(input).toHaveValue('#7F0000');
+  });
+
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => '#f00', '#000');
+        
+        return (
+          <form action={formAction}>
+            <ColorField defaultValue={value} />
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('textbox');
+      expect(input).toHaveValue('#000000');
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toHaveValue('#FF0000');
+    });
+  }
+
   describe('channel', function () {
     it('should support the channel prop', async function () {
       let onChange = jest.fn();
@@ -413,6 +461,54 @@ describe('ColorField', function () {
       expect(colorField).toHaveValue('');
       expect(onChange).toHaveBeenCalledWith(null);
     });
+
+    it('supports form reset', async () => {
+      function Test() {
+        let [value, setValue] = React.useState(parseColor('#ff0'));
+        return (
+          <form>
+            <ColorField channel="red" value={value} onChange={setValue} />
+            <input type="reset" data-testid="reset" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('textbox');
+
+      expect(input).toHaveValue('255');
+      await user.tab();
+      await user.keyboard('0');
+      await user.tab();
+      expect(input).toHaveValue('0');
+
+      let button = getByTestId('reset');
+      await user.click(button);
+      expect(input).toHaveValue('255');
+    });
+
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultValue when submitting form action', async () => {
+        function Test() {        
+          const [value, formAction] = React.useActionState(() => '#f00', '#000');
+          
+          return (
+            <form action={formAction}>
+              <ColorField channel="red" defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          );
+        }
+
+        let {getByTestId, getByRole} = render(<Test />);
+        let input = getByRole('textbox');
+        expect(input).toHaveValue('0');
+
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(input).toHaveValue('255');
+      });
+    }
   });
 
   describe('validation', () => {

--- a/packages/@react-spectrum/color/test/ColorSlider.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorSlider.test.tsx
@@ -291,6 +291,29 @@ describe('ColorSlider', () => {
     expect(input).toHaveValue('127');
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => '#f00', '#000');
+        
+        return (
+          <form action={formAction}>
+            <ColorSlider channel="red" defaultValue={value} />
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('slider');
+      expect(input).toHaveValue('0');
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toHaveValue('255');
+    });
+  }
+
   describe('keyboard events', () => {
     it('works', async () => {
       let defaultColor = parseColor('#000000');

--- a/packages/@react-spectrum/color/test/ColorWheel.test.tsx
+++ b/packages/@react-spectrum/color/test/ColorWheel.test.tsx
@@ -126,6 +126,29 @@ describe('ColorWheel', () => {
     expect(input).toHaveValue('15');
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => 'hsl(15, 100%, 50%)', 'hsl(0, 0%, 0%)');
+        
+        return (
+          <form action={formAction}>
+            <ColorWheel defaultValue={value} />
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('slider');
+      expect(input).toHaveValue('0');
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toHaveValue('15');
+    });
+  }
+
   describe('labelling', () => {
     it('should support a custom aria-label', () => {
       let {getByRole} = render(<ColorWheel aria-label="Color hue" />);

--- a/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
+++ b/packages/@react-spectrum/combobox/src/MobileComboBox.tsx
@@ -117,7 +117,11 @@ export const MobileComboBox = React.forwardRef(function MobileComboBox(props: Sp
     inputProps.onChange = () => {};
   }
 
-  useFormReset(inputRef, String(inputProps.value ?? ''), formValue === 'text' ? state.setInputValue : state.setSelectedKey);
+  useFormReset<any>(
+    inputRef,
+    formValue === 'text' ? state.defaultInputValue : state.defaultSelectedKey,
+    formValue === 'text' ? state.setInputValue : state.setSelectedKey
+  );
 
   return (
     <>

--- a/packages/@react-spectrum/combobox/test/ComboBox.test.js
+++ b/packages/@react-spectrum/combobox/test/ComboBox.test.js
@@ -5266,6 +5266,31 @@ describe('ComboBox', function () {
         expect(combobox).toHaveValue('');
       });
 
+      if (parseInt(React.version, 10) >= 19) {
+        it('resets to defaultSelectedKey when submitting form action', async () => {
+          function Test() {        
+            const [value, formAction] = React.useActionState(() => '2', '1');
+            
+            return (
+              <Provider theme={theme}>
+                <form action={formAction}>
+                  <ExampleComboBox defaultSelectedKey={value} />
+                  <input type="submit" data-testid="submit" />
+                </form>
+              </Provider>
+            );
+          }
+    
+          let {getByTestId, getByRole} = render(<Test />);
+          let input = getByRole('combobox');
+          expect(input).toHaveValue('One');
+    
+          let button = getByTestId('submit');
+          await act(async () => await user.click(button));
+          expect(input).toHaveValue('Two');
+        });
+      }
+
       it('should support formValue', () => {
         let {getByRole, rerender} = render(<ExampleComboBox name="test" selectedKey="2" />);
         let input = getByRole('combobox');
@@ -5569,6 +5594,31 @@ describe('ComboBox', function () {
         await user.click(reset);
         expect(input).toHaveValue('');
       });
+
+      if (parseInt(React.version, 10) >= 19) {
+        it('resets to defaultSelectedKey when submitting form action', async () => {
+          function Test() {
+            const [value, formAction] = React.useActionState(() => '2', '1');
+            
+            return (
+              <Provider theme={theme}>
+                <form action={formAction}>
+                  <ExampleComboBox name="combobox" defaultSelectedKey={value} />
+                  <input type="submit" data-testid="submit" />
+                </form>
+              </Provider>
+            );
+          }
+    
+          let {getByTestId} = render(<Test />);
+          let input = document.querySelector('input[name=combobox]');
+          expect(input).toHaveValue('One');
+    
+          let button = getByTestId('submit');
+          await act(async () => await user.click(button));
+          expect(input).toHaveValue('Two');
+        });
+      }
 
       it('should support formValue', () => {
         let {rerender} = render(<ExampleComboBox name="test" selectedKey="2" />);

--- a/packages/@react-spectrum/datepicker/test/DateField.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateField.test.js
@@ -378,6 +378,29 @@ describe('DateField', function () {
       expect(input).toHaveValue('2020-02-03');
     });
 
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultValue when submitting form action', async () => {
+        function Test() {
+          const [value, formAction] = React.useActionState(() => new CalendarDate(2025, 2, 3), new CalendarDate(2020, 2, 3));
+          
+          return (
+            <form action={formAction}>
+              <DateField label="Value" name="date" defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          );
+        }
+  
+        let {getByTestId} = render(<Test />);
+        let input = document.querySelector('input[name=date]');
+        expect(input).toHaveValue('2020-02-03');
+  
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(input).toHaveValue('2025-02-03');
+      });
+    }
+
     describe('validation', () => {
       describe('validationBehavior=native', () => {
         it('supports isRequired', async () => {

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -2042,6 +2042,29 @@ describe('DatePicker', function () {
       expect(input).toHaveValue('2020-02-03');
     });
 
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultValue when submitting form action', async () => {
+        function Test() {
+          const [value, formAction] = React.useActionState(() => new CalendarDate(2025, 2, 3), new CalendarDate(2020, 2, 3));
+          
+          return (
+            <form action={formAction}>
+              <DatePicker label="Value" name="date" defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          );
+        }
+  
+        let {getByTestId} = render(<Test />);
+        let input = document.querySelector('input[name=date]');
+        expect(input).toHaveValue('2020-02-03');
+  
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(input).toHaveValue('2025-02-03');
+      });
+    }
+
     describe('validation', () => {
       describe('validationBehavior=native', () => {
         it('supports isRequired', async () => {

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -1524,6 +1524,32 @@ describe('DateRangePicker', function () {
       expect(end).toHaveValue('2022-04-08');
     });
 
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultValue when submitting form action', async () => {
+        function Test() {
+          const [value, formAction] = React.useActionState(() => ({start: new CalendarDate(2025, 2, 3), end: new CalendarDate(2025, 4, 8)}), {start: new CalendarDate(2020, 2, 3), end: new CalendarDate(2022, 4, 8)});
+          
+          return (
+            <form action={formAction}>
+              <DateRangePicker startName="start" endName="end" label="Value" defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          );
+        }
+  
+        let {getByTestId} = render(<Test />);
+        let start = document.querySelector('input[name=start]');
+        let end = document.querySelector('input[name=end]');
+        expect(start).toHaveValue('2020-02-03');
+        expect(end).toHaveValue('2022-04-08');
+  
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(start).toHaveValue('2025-02-03');
+        expect(end).toHaveValue('2025-04-08');
+      });
+    }
+
     describe('validation', () => {
       describe('validationBehavior=native', () => {
         it('supports isRequired', async () => {

--- a/packages/@react-spectrum/datepicker/test/TimeField.test.js
+++ b/packages/@react-spectrum/datepicker/test/TimeField.test.js
@@ -296,6 +296,29 @@ describe('TimeField', function () {
       expect(input).toHaveValue('08:30:00');
     });
 
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultValue when submitting form action', async () => {
+        function Test() {
+          const [value, formAction] = React.useActionState(() => new Time(10, 30), new Time(8, 30));
+          
+          return (
+            <form action={formAction}>
+              <TimeField label="Value" name="time" defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          );
+        }
+  
+        let {getByTestId} = render(<Test />);
+        let input = document.querySelector('input[name=time]');
+        expect(input).toHaveValue('08:30:00');
+  
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(input).toHaveValue('10:30:00');
+      });
+    }
+
     describe('validation', () => {
       describe('validationBehavior=native', () => {
         it('supports isRequired', async () => {

--- a/packages/@react-spectrum/form/stories/Form.stories.tsx
+++ b/packages/@react-spectrum/form/stories/Form.stories.tsx
@@ -13,7 +13,7 @@
 import {action} from '@storybook/addon-actions';
 import {Button} from '@react-spectrum/button';
 import {ButtonGroup} from '@react-spectrum/buttongroup';
-import {CalendarDate} from '@internationalized/date';
+import {CalendarDate, parseDate, parseDateTime, parseTime} from '@internationalized/date';
 import {chain} from '@react-aria/utils';
 import {Checkbox, CheckboxGroup} from '@react-spectrum/checkbox';
 import {ColorField} from '@react-spectrum/color';
@@ -439,33 +439,34 @@ export const WithTranslations: FormStory = {
 };
 
 function Render(props: any = {}) {
+  let formData = props.formData || new FormData();
   return (
     <Form {...props}>
-      <CheckboxGroup label="Pets" name="pets" validate={v => v.includes('dogs') ? 'No dogs' : null}>
+      <CheckboxGroup label="Pets" name="pets" validate={v => v.includes('dogs') ? 'No dogs' : null} defaultValue={formData.getAll('pets')}>
         <Checkbox value="dogs">Dogs</Checkbox>
         <Checkbox value="cats">Cats</Checkbox>
         <Checkbox value="dragons">Dragons</Checkbox>
       </CheckboxGroup>
-      <ComboBox label="More Animals" name="combobox">
+      <ComboBox label="More Animals" name="combobox" defaultInputValue={formData.get('combobox')}>
         <Item key="red panda">Red Panda</Item>
         <Item key="aardvark">Aardvark</Item>
         <Item key="kangaroo">Kangaroo</Item>
         <Item key="snake">Snake</Item>
       </ComboBox>
-      <SearchAutocomplete label="Search Animals" name="searchAutocomplete">
+      <SearchAutocomplete label="Search Animals" name="searchAutocomplete" defaultInputValue={formData.get('searchAutocomplete')}>
         <Item key="red panda">Red Panda</Item>
         <Item key="aardvark">Aardvark</Item>
         <Item key="kangaroo">Kangaroo</Item>
         <Item key="snake">Snake</Item>
       </SearchAutocomplete>
-      <NumberField label="Years lived there" name="years" />
-      <Picker label="State" items={states} name="state">
+      <NumberField label="Years lived there" name="years" defaultValue={formData.get('years') ? Number(formData.get('years')) : undefined} />
+      <Picker label="State" items={states} name="state" defaultSelectedKey={formData.get('state')}>
         {item => <Item key={item.abbr}>{item.name}</Item>}
       </Picker>
-      <Picker label="Country" items={countries} name="country">
+      <Picker label="Country" items={countries} name="country" defaultSelectedKey={formData.get('country')}>
         {item => <Item key={item.name}>{item.name}</Item>}
       </Picker>
-      <Picker label="Favorite color" name="color" description="Select any color you like." errorMessage="Please select a nicer color.">
+      <Picker label="Favorite color" name="color" description="Select any color you like." errorMessage="Please select a nicer color." defaultSelectedKey={formData.get('color')}>
         <Item>Red</Item>
         <Item>Orange</Item>
         <Item>Yellow</Item>
@@ -473,24 +474,25 @@ function Render(props: any = {}) {
         <Item>Blue</Item>
         <Item>Purple</Item>
       </Picker>
-      <RadioGroup label="Favorite pet" name="favorite-pet-group">
+      <RadioGroup label="Favorite pet" name="favorite-pet-group" defaultValue={formData.get('favorite-pet-group')}>
         <Radio value="dogs">Dogs</Radio>
         <Radio value="cats">Cats</Radio>
         <Radio value="dragons">Dragons</Radio>
       </RadioGroup>
-      <SearchField label="Search" name="search" />
-      <Switch name="switch">Low power mode</Switch>
-      <TextArea name="comments" label="Comments" description="Express yourself!" errorMessage="No wrong answers, except for this one." />
+      <SearchField label="Search" name="search" defaultValue={formData.get('search')} />
+      <Switch name="switch" defaultSelected={formData.get('switch') === 'on'}>Low power mode</Switch>
+      <TextArea name="comments" label="Comments" description="Express yourself!" errorMessage="No wrong answers, except for this one." defaultValue={formData.get('comments')} />
       <TextField
         label="City"
         name="city"
+        defaultValue={formData.get('city')}
         contextualHelp={(
           <ContextualHelp>
             <Heading>What is a segment?</Heading>
             <Content>Segments identify who your visitors are, what devices and services they use, where they navigated from, and much more.</Content>
           </ContextualHelp>
         )} />
-      <TextField label="Zip code" description="Please enter a five-digit zip code." pattern="[0-9]{5}" name="zip" />
+      <TextField label="Zip code" description="Please enter a five-digit zip code." pattern="[0-9]{5}" name="zip" defaultValue={formData.get('zip')} />
       <TagGroup label="Favorite tags" description="Select your favorite tags." errorMessage="Incorrect combination of tags.">
         <Item key="1">Cool Tag 1</Item>
         <Item key="2">Cool Tag 2</Item>
@@ -499,12 +501,12 @@ function Render(props: any = {}) {
         <Item key="5">Cool Tag 5</Item>
         <Item key="6">Cool Tag 6</Item>
       </TagGroup>
-      <ColorField label="Color" name="color" />
-      <DateField label="Date" granularity="minute" name="date" />
-      <TimeField label="Time" name="time" />
-      <DatePicker label="Date picker" name="datePicker" />
-      <DateRangePicker label="Date range" startName="startDate" endName="endDate" />
-      <TextField type="email" label="Email" name="email" />
+      <ColorField label="Color" name="color" defaultValue={formData.get('color')} />
+      <DateField label="Date" granularity="minute" name="date" defaultValue={formData.get('date') ? parseDateTime(formData.get('date')) : null} />
+      <TimeField label="Time" name="time" defaultValue={formData.get('time') ? parseTime(formData.get('time')) : null} />
+      <DatePicker label="Date picker" name="datePicker" defaultValue={formData.get('datePicker') ? parseDate(formData.get('datePicker')) : null} />
+      <DateRangePicker label="Date range" startName="startDate" endName="endDate" defaultValue={formData.get('startDate') && formData.get('endDate') ? {start: parseDate(formData.get('startDate')), end: parseDate(formData.get('endDate'))} : null} />
+      <TextField type="email" label="Email" name="email" defaultValue={formData.get('email')} />
       {props.showSubmit && (
         <ButtonGroup>
           <Button variant="primary" type="submit">Submit</Button>
@@ -800,4 +802,39 @@ export const NumberFieldFormSubmit: FormStory = {
     );
   },
   parameters: {description: {data: 'Try using "Enter" to submit the form from the NumberField. It should call an action in the actions panel.'}}
+};
+
+interface State {
+  formData: FormData,
+  errors: Record<string, string>
+}
+
+function FormActionExample() {
+  const action = (previousState: State, formData: FormData): State => {
+    let errors = {};
+    for (let key of formData.keys()) {
+      errors[key] = 'Some error for ' + key;
+    }
+    return {
+      formData,
+      errors
+    };
+  };
+
+  const [{errors, formData}, formAction] = React.useActionState(action, {
+    errors: {},
+    formData: new FormData()
+  });
+  
+  return (
+    <Render
+      action={formAction}
+      validationErrors={errors}
+      showSubmit
+      formData={formData} />
+  );
+}
+
+export const FormAction: FormStory = {
+  render: () => <FormActionExample />
 };

--- a/packages/@react-spectrum/numberfield/test/NumberField.test.js
+++ b/packages/@react-spectrum/numberfield/test/NumberField.test.js
@@ -2309,6 +2309,31 @@ describe('NumberField', function () {
     expect(input).toHaveValue('10');
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {
+        const [value, formAction] = React.useActionState(() => 33, 22);
+        
+        return (
+          <Provider theme={theme}>
+            <form action={formAction}>
+              <NumberField label="Value" defaultValue={value} />
+              <input type="submit" data-testid="submit" />
+            </form>
+          </Provider>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('textbox');
+      expect(input).toHaveValue('22');
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toHaveValue('33');
+    });
+  }
+
   describe('validation', () => {
     describe('validationBehavior=native', () => {
       it('supports isRequired', async () => {

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -2109,6 +2109,38 @@ describe('Picker', function () {
       expect(input).toHaveValue('one');
     });
 
+    if (parseInt(React.version, 10) >= 19) {
+      it('resets to defaultSelectedKey when submitting form action', async () => {
+        function Test() {        
+          const [value, formAction] = React.useActionState(() => 'two', 'one');
+          
+          return (
+            <Provider theme={theme}>
+              <form action={formAction}>
+                <Picker data-testid="picker" name="picker" label="Test" defaultSelectedKey={value}>
+                  <Item key="one">One</Item>
+                  <Item key="two">Two</Item>
+                  <Item key="three">Three</Item>
+                </Picker>
+                <input type="submit" data-testid="submit" />
+              </form>
+            </Provider>
+          );
+        }
+  
+        let {getByTestId} = render(<Test />);
+        let picker = getByTestId('picker');
+        let input = document.querySelector('[name=picker]');
+        expect(picker).toHaveTextContent('One');
+        expect(input).toHaveValue('one');
+  
+        let button = getByTestId('submit');
+        await user.click(button);
+        expect(picker).toHaveTextContent('Two');
+        expect(input).toHaveValue('two');
+      });
+    }
+
     describe('validation', () => {
       describe('validationBehavior=native', () => {
         it('supports isRequired', async () => {

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -460,6 +460,40 @@ describe('Radios', function () {
     expect(radios[2]).not.toBeChecked();
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => 'cats', 'dogs');
+        
+        return (
+          <Provider theme={theme}>
+            <form action={formAction}>
+              <RadioGroup name="pet" label="Favorite Pet" defaultValue={value}>
+                <Radio value="dogs">Dogs</Radio>
+                <Radio value="cats">Cats</Radio>
+                <Radio value="dragons">Dragons</Radio>
+              </RadioGroup>
+              <input type="submit" data-testid="submit" />
+            </form>
+          </Provider>
+        );
+      }
+
+      let {getByTestId, getAllByRole} = render(<Test />);
+      let radios = getAllByRole('radio');
+
+      expect(radios[0]).toBeChecked();
+      expect(radios[1]).not.toBeChecked();
+      expect(radios[2]).not.toBeChecked();
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(radios[0]).not.toBeChecked();
+      expect(radios[1]).toBeChecked();
+      expect(radios[2]).not.toBeChecked();
+    });
+  }
+
   describe('Radio group supports roving tabIndex ', function () {
     afterEach(() => {
       radioBehavior.reset();

--- a/packages/@react-spectrum/s2/src/RangeSlider.tsx
+++ b/packages/@react-spectrum/s2/src/RangeSlider.tsx
@@ -58,12 +58,19 @@ export const RangeSlider = /*#__PURE__*/ forwardRef(function RangeSlider(props: 
 
   let {direction} = useLocale();
   let cssDirection = direction === 'rtl' ? 'right' : 'left';
+  let defaultThumbValues: number[] | undefined = undefined;
+  if (props.defaultValue != null) {
+    defaultThumbValues = [props.defaultValue.start, props.defaultValue.end];
+  } else if (props.value == null) {
+    // make sure that useSliderState knows we have two handles
+    defaultThumbValues = [props.minValue ?? 0, props.maxValue ?? 100];
+  }
 
   return (
     <SliderBase
       {...props}
       value={props.value ? [props.value.start, props.value.end] : undefined}
-      defaultValue={props.defaultValue ? [props.defaultValue.start, props.defaultValue.end] : [props.minValue ?? 0, props.maxValue ?? 100]}
+      defaultValue={defaultThumbValues}
       onChange={v => props.onChange?.({start: v[0], end: v[1]})}
       onChangeEnd={v => props.onChangeEnd?.({start: v[0], end: v[1]})}
       sliderRef={domRef}>

--- a/packages/@react-spectrum/slider/src/RangeSlider.tsx
+++ b/packages/@react-spectrum/slider/src/RangeSlider.tsx
@@ -26,14 +26,18 @@ import {useLocale, useLocalizedStringFormatter} from '@react-aria/i18n';
  */
 export const RangeSlider = React.forwardRef(function RangeSlider(props: SpectrumRangeSliderProps, ref: FocusableRef<HTMLDivElement>) {
   let {onChange, onChangeEnd, value, defaultValue, getValueLabel, ...otherProps} = props;
+  let defaultThumbValues: number[] | undefined = undefined;
+  if (defaultValue != null) {
+    defaultThumbValues = [defaultValue.start, defaultValue.end];
+  } else if (value == null) {
+    // make sure that useSliderState knows we have two handles
+    defaultThumbValues = [props.minValue ?? 0, props.maxValue ?? 100];
+  }
 
   let baseProps: Omit<SliderBaseProps<number[]>, 'children'> = {
     ...otherProps,
     value: value != null ? [value.start, value.end] : undefined,
-    defaultValue: defaultValue != null
-      ? [defaultValue.start, defaultValue.end]
-      // make sure that useSliderState knows we have two handles
-      : [props.minValue ?? 0, props.maxValue ?? 100],
+    defaultValue: defaultThumbValues,
     onChange(v) {
       onChange?.({start: v[0], end: v[1]});
     },

--- a/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
+++ b/packages/@react-spectrum/slider/test/RangeSlider.test.tsx
@@ -226,6 +226,31 @@ describe('RangeSlider', function () {
     expect(inputs[1]).toHaveValue('40');
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => ({start: 0, end: 100}), {start: 10, end: 40});
+        
+        return (
+          <form action={formAction}>
+            <RangeSlider label="Value" defaultValue={value} />
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getAllByRole} = render(<Test />);
+      let inputs = getAllByRole('slider');
+      expect(inputs[0]).toHaveValue('10');
+      expect(inputs[1]).toHaveValue('40');
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(inputs[0]).toHaveValue('0');
+      expect(inputs[1]).toHaveValue('100');
+    });
+  }
+
   describe('formatOptions', () => {
     it('prefixes the value with a plus sign if needed', function () {
       let {getAllByRole, getByRole} = render(

--- a/packages/@react-spectrum/slider/test/Slider.test.tsx
+++ b/packages/@react-spectrum/slider/test/Slider.test.tsx
@@ -224,6 +224,29 @@ describe('Slider', function () {
     expect(input).toHaveValue('10');
   });
 
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultValue when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => 50, 10);
+        
+        return (
+          <form action={formAction}>
+            <Slider label="Value" defaultValue={value} />
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('slider');
+      expect(input).toHaveValue('10');
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toHaveValue('50');
+    });
+  }
+
   describe('formatOptions', () => {
     it('prefixes the value with a plus sign if needed', function () {
       let {getByRole} = render(

--- a/packages/@react-spectrum/switch/test/Switch.test.js
+++ b/packages/@react-spectrum/switch/test/Switch.test.js
@@ -207,4 +207,27 @@ describe('Switch', function () {
     await user.click(button);
     expect(input).not.toBeChecked();
   });
+
+  if (parseInt(React.version, 10) >= 19) {
+    it('resets to defaultSelected when submitting form action', async () => {
+      function Test() {        
+        const [value, formAction] = React.useActionState(() => true, false);
+        
+        return (
+          <form action={formAction}>
+            <Switch defaultSelected={value}>Test</Switch>
+            <input type="submit" data-testid="submit" />
+          </form>
+        );
+      }
+
+      let {getByTestId, getByRole} = render(<Test />);
+      let input = getByRole('switch');
+      expect(input).not.toBeChecked();
+
+      let button = getByTestId('submit');
+      await user.click(button);
+      expect(input).toBeChecked();
+    });
+  }
 });

--- a/packages/@react-stately/checkbox/src/useCheckboxGroupState.ts
+++ b/packages/@react-stately/checkbox/src/useCheckboxGroupState.ts
@@ -13,12 +13,14 @@
 import {CheckboxGroupProps} from '@react-types/checkbox';
 import {FormValidationState, mergeValidation, useFormValidationState} from '@react-stately/form';
 import {useControlledState} from '@react-stately/utils';
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import {ValidationResult, ValidationState} from '@react-types/shared';
 
 export interface CheckboxGroupState extends FormValidationState {
   /** Current selected values. */
   readonly value: readonly string[],
+  /** Default selected values. */
+  readonly defaultValue: readonly string[],
 
   /** Whether the checkbox group is disabled. */
   readonly isDisabled: boolean,
@@ -66,6 +68,7 @@ export interface CheckboxGroupState extends FormValidationState {
  */
 export function useCheckboxGroupState(props: CheckboxGroupProps = {}): CheckboxGroupState {
   let [selectedValues, setValue] = useControlledState(props.value, props.defaultValue || [], props.onChange);
+  let [initialValues] = useState(selectedValues);
   let isRequired = !!props.isRequired && selectedValues.length === 0;
 
   let invalidValues = useRef(new Map<string, ValidationResult>());
@@ -78,6 +81,7 @@ export function useCheckboxGroupState(props: CheckboxGroupProps = {}): CheckboxG
   const state: CheckboxGroupState = {
     ...validation,
     value: selectedValues,
+    defaultValue: props.defaultValue ?? initialValues,
     setValue(value) {
       if (props.isReadOnly || props.isDisabled) {
         return;
@@ -95,7 +99,8 @@ export function useCheckboxGroupState(props: CheckboxGroupProps = {}): CheckboxG
         return;
       }
       if (!selectedValues.includes(value)) {
-        setValue(selectedValues.concat(value));
+        selectedValues = selectedValues.concat(value);
+        setValue(selectedValues);
       }
     },
     removeValue(value) {

--- a/packages/@react-stately/color/src/useColorAreaState.ts
+++ b/packages/@react-stately/color/src/useColorAreaState.ts
@@ -18,6 +18,8 @@ import {useMemo, useRef, useState} from 'react';
 export interface ColorAreaState {
   /** The current color value displayed by the color area. */
   readonly value: Color,
+  /** The default value of the color area. */
+  readonly defaultValue: Color,
   /** Sets the current color value. If a string is passed, it will be parsed to a Color. */
   setValue(value: string | Color): void,
 
@@ -94,6 +96,7 @@ export function useColorAreaState(props: ColorAreaProps): ColorAreaState {
 
   // safe to cast value and defaultValue to Color, one of them will always be defined because if neither are, we assign a default
   let [colorValue, setColorState] = useControlledState<Color>(value as Color, defaultValue as Color, onChange);
+  let [initialValue] = useState(colorValue);
   let color = useMemo(() => colorSpace && colorValue ? colorValue.toFormat(colorSpace) : colorValue, [colorValue, colorSpace]);
   let valueRef = useRef(color);
   let setColor = (color: Color) => {
@@ -138,6 +141,7 @@ export function useColorAreaState(props: ColorAreaProps): ColorAreaState {
     xChannelPageStep: pageSizeX,
     yChannelPageStep: pageSizeY,
     value: color,
+    defaultValue: value !== undefined ? initialValue : defaultValue as Color,
     setValue(value) {
       setColor(normalizeColor(value));
     },

--- a/packages/@react-stately/color/src/useColorFieldState.ts
+++ b/packages/@react-stately/color/src/useColorFieldState.ts
@@ -28,6 +28,10 @@ export interface ColorFieldState extends FormValidationState {
    * Updated based on the `inputValue` as the user types.
    */
   readonly colorValue: Color | null,
+  /** The default value of the color field. */
+  readonly defaultColorValue: Color | null,
+  /** Sets the color value of the field. */
+  setColorValue(value: Color | null): void,
   /** Sets the current text value of the input. */
   setInputValue(value: string): void,
   /**
@@ -70,9 +74,9 @@ export function useColorFieldState(
   } = props;
   let {step} = MIN_COLOR.getChannelRange('red');
 
-  let initialValue = useColor(value);
   let initialDefaultValue = useColor(defaultValue);
-  let [colorValue, setColorValue] = useControlledState<Color | null>(initialValue!, initialDefaultValue!, onChange);
+  let [colorValue, setColorValue] = useControlledState<Color | null>(useColor(value), initialDefaultValue!, onChange);
+  let [initialValue] = useState(colorValue);
   let [inputValue, setInputValue] = useState(() => (value || defaultValue) && colorValue ? colorValue.toString('hex') : '');
 
   let validation = useFormValidationState({
@@ -167,6 +171,8 @@ export function useColorFieldState(
     ...validation,
     validate,
     colorValue,
+    defaultColorValue: initialDefaultValue ?? initialValue,
+    setColorValue,
     inputValue,
     setInputValue,
     commit,

--- a/packages/@react-stately/color/src/useColorSliderState.ts
+++ b/packages/@react-stately/color/src/useColorSliderState.ts
@@ -14,7 +14,7 @@ import {Color, ColorSliderProps} from '@react-types/color';
 import {normalizeColor, parseColor} from './Color';
 import {SliderState, useSliderState} from '@react-stately/slider';
 import {useControlledState} from '@react-stately/utils';
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 
 export interface ColorSliderState extends SliderState {
   /** The current color value represented by the color slider. */
@@ -52,6 +52,9 @@ export function useColorSliderState(props: ColorSliderStateOptions): ColorSlider
   // safe to cast value and defaultValue to Color, one of them will always be defined because if neither are, we throw an error
   let [colorValue, setColor] = useControlledState<Color>(value as Color, defaultValue as Color, onChange);
   let color = useMemo(() => colorSpace && colorValue ? colorValue.toFormat(colorSpace) : colorValue, [colorValue, colorSpace]);
+  let [initialValue] = useState(colorValue);
+  let defaultColorValue = (defaultValue as Color) ?? initialValue;
+  let defaultColor = useMemo(() => colorSpace && defaultColorValue ? defaultColorValue.toFormat(colorSpace) : defaultColorValue, [defaultColorValue, colorSpace]);
   let sliderState = useSliderState({
     ...color.getChannelRange(channel),
     ...otherProps,
@@ -59,6 +62,7 @@ export function useColorSliderState(props: ColorSliderStateOptions): ColorSlider
     // @ts-ignore
     numberFormatter: null,
     value: color.getChannelValue(channel),
+    defaultValue: defaultColor.getChannelValue(channel),
     onChange(v) {
       setColor(color.withChannelValue(channel, v));
     },

--- a/packages/@react-stately/color/src/useColorWheelState.ts
+++ b/packages/@react-stately/color/src/useColorWheelState.ts
@@ -18,6 +18,8 @@ import {useMemo, useRef, useState} from 'react';
 export interface ColorWheelState {
   /** The current color value represented by the color wheel. */
   readonly value: Color,
+  /** The default color value. */
+  readonly defaultValue: Color,
   /** Sets the color value represented by the color wheel, and triggers `onChange`. */
   setValue(value: string | Color): void,
 
@@ -110,6 +112,7 @@ export function useColorWheelState(props: ColorWheelProps): ColorWheelState {
 
   // safe to cast value and defaultValue to Color, one of them will always be defined because if neither are, we assign a default
   let [stateValue, setValueState] = useControlledState<Color>(propsValue as Color, defaultValue as Color, onChange);
+  let [initialValue] = useState(stateValue);
   let value = useMemo(() => {
     let colorSpace = stateValue.getColorSpace();
     return colorSpace === 'hsl' || colorSpace === 'hsb' ? stateValue : stateValue.toFormat('hsl');
@@ -140,6 +143,7 @@ export function useColorWheelState(props: ColorWheelProps): ColorWheelState {
 
   return {
     value,
+    defaultValue: propsValue !== undefined ? initialValue : defaultValue as Color,
     step,
     pageStep,
     setValue(v) {

--- a/packages/@react-stately/datepicker/src/useDateFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useDateFieldState.ts
@@ -42,6 +42,8 @@ export interface DateSegment {
 export interface DateFieldState extends FormValidationState {
   /** The current field value. */
   value: DateValue | null,
+  /** The default field value. */
+  defaultValue: DateValue | null,
   /** The current value, converted to a native JavaScript `Date` object.  */
   dateValue: Date,
   /** The calendar system currently in use. */
@@ -180,6 +182,7 @@ export function useDateFieldState<T extends DateValue = DateValue>(props: DateFi
     props.onChange
   );
 
+  let [initialValue] = useState(value);
   let calendarValue = useMemo(() => convertValue(value, calendar) ?? null, [value, calendar]);
 
   // We keep track of the placeholder date separately in state so that onChange is not called
@@ -338,6 +341,7 @@ export function useDateFieldState<T extends DateValue = DateValue>(props: DateFi
   return {
     ...validation,
     value: calendarValue,
+    defaultValue: props.defaultValue ?? initialValue,
     dateValue,
     calendar,
     setValue,

--- a/packages/@react-stately/datepicker/src/useDatePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDatePickerState.ts
@@ -30,6 +30,8 @@ export interface DatePickerStateOptions<T extends DateValue> extends DatePickerP
 export interface DatePickerState extends OverlayTriggerState, FormValidationState {
   /** The currently selected date. */
   value: DateValue | null,
+  /** The default date. */
+  defaultValue: DateValue | null,
   /** Sets the selected date. */
   setValue(value: DateValue | null): void,
   /**
@@ -74,6 +76,7 @@ export interface DatePickerState extends OverlayTriggerState, FormValidationStat
 export function useDatePickerState<T extends DateValue = DateValue>(props: DatePickerStateOptions<T>): DatePickerState {
   let overlayState = useOverlayTriggerState(props);
   let [value, setValue] = useControlledState<DateValue | null, MappedDateValue<T> | null>(props.value, props.defaultValue || null, props.onChange);
+  let [initialValue] = useState(value);
 
   let v = (value || props.placeholderValue || null);
   let [granularity, defaultTimeZone] = useDefaultProps(v, props.granularity);
@@ -161,6 +164,7 @@ export function useDatePickerState<T extends DateValue = DateValue>(props: DateP
   return {
     ...validation,
     value,
+    defaultValue: props.defaultValue ?? initialValue,
     setValue,
     dateValue: selectedDate,
     timeValue: selectedTime,

--- a/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
+++ b/packages/@react-stately/datepicker/src/useDateRangePickerState.ts
@@ -32,6 +32,8 @@ type TimeRange = RangeValue<TimeValue>;
 export interface DateRangePickerState extends OverlayTriggerState, FormValidationState {
   /** The currently selected date range. */
   value: RangeValue<DateValue | null>,
+  /** The default selected date range. */
+  defaultValue: DateRange | null,
   /** Sets the selected date range. */
   setValue(value: DateRange | null): void,
   /**
@@ -83,6 +85,7 @@ export interface DateRangePickerState extends OverlayTriggerState, FormValidatio
 export function useDateRangePickerState<T extends DateValue = DateValue>(props: DateRangePickerStateOptions<T>): DateRangePickerState {
   let overlayState = useOverlayTriggerState(props);
   let [controlledValue, setControlledValue] = useControlledState<DateRange | null, RangeValue<MappedDateValue<T>> | null>(props.value, props.defaultValue || null, props.onChange);
+  let [initialValue] = useState(controlledValue);
   let [placeholderValue, setPlaceholderValue] = useState<RangeValue<DateValue | null>>(() => controlledValue || {start: null, end: null});
 
   // Reset the placeholder if the value prop is set to null.
@@ -93,8 +96,9 @@ export function useDateRangePickerState<T extends DateValue = DateValue>(props: 
 
   let value = controlledValue || placeholderValue;
 
-  let setValue = (value: RangeValue<DateValue | null> | null) => {
-    setPlaceholderValue(value || {start: null, end: null});
+  let setValue = (newValue: RangeValue<DateValue | null> | null) => {
+    value = newValue || {start: null, end: null};
+    setPlaceholderValue(value);
     if (isCompleteRange(value)) {
       setControlledValue(value);
     } else {
@@ -192,6 +196,7 @@ export function useDateRangePickerState<T extends DateValue = DateValue>(props: 
   return {
     ...validation,
     value,
+    defaultValue: props.defaultValue ?? initialValue,
     setValue,
     dateRange,
     timeRange,

--- a/packages/@react-stately/datepicker/src/useTimeFieldState.ts
+++ b/packages/@react-stately/datepicker/src/useTimeFieldState.ts
@@ -36,19 +36,20 @@ export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFi
     placeholderValue = new Time(),
     minValue,
     maxValue,
+    defaultValue,
     granularity,
     validate
   } = props;
 
   let [value, setValue] = useControlledState<TimeValue | null, MappedTimeValue<T> | null>(
     props.value,
-    props.defaultValue ?? null,
+    defaultValue ?? null,
     props.onChange
   );
 
   let v = value || placeholderValue;
   let day = v && 'day' in v ? v : undefined;
-  let defaultValueTimeZone = props.defaultValue && 'timeZone' in props.defaultValue ? props.defaultValue.timeZone : undefined;
+  let defaultValueTimeZone = defaultValue && 'timeZone' in defaultValue ? defaultValue.timeZone : undefined;
   let placeholderDate = useMemo(() => {
     let valueTimeZone = v && 'timeZone' in v ? v.timeZone : undefined;
 
@@ -59,6 +60,7 @@ export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFi
 
   let timeValue = useMemo(() => value && 'day' in value ? toTime(value) : value as Time, [value]);
   let dateTime = useMemo(() => value == null ? null : convertValue(value), [value]);
+  let defaultDateTime = useMemo(() => defaultValue == null ? null : convertValue(defaultValue), [defaultValue]);
   let onChange = newValue => {
     setValue(day || defaultValueTimeZone ? newValue : newValue && toTime(newValue));
   };
@@ -66,7 +68,7 @@ export function useTimeFieldState<T extends TimeValue = TimeValue>(props: TimeFi
   let state = useDateFieldState({
     ...props,
     value: dateTime,
-    defaultValue: undefined,
+    defaultValue: defaultDateTime,
     minValue: minDate,
     maxValue: maxDate,
     onChange,

--- a/packages/@react-stately/numberfield/src/useNumberFieldState.ts
+++ b/packages/@react-stately/numberfield/src/useNumberFieldState.ts
@@ -27,6 +27,8 @@ export interface NumberFieldState extends FormValidationState {
    * Updated based on the `inputValue` as the user types.
    */
   numberValue: number,
+  /** The default value of the input. */
+  defaultNumberValue: number,
   /** The minimum value of the number field. */
   minValue?: number,
   /** The maximum value of the number field. */
@@ -111,6 +113,7 @@ export function useNumberFieldState(
   }
 
   let [numberValue, setNumberValue] = useControlledState<number>(value, isNaN(defaultValue) ? NaN : defaultValue, onChange);
+  let [initialValue] = useState(numberValue);
   let [inputValue, setInputValue] = useState(() => isNaN(numberValue) ? '' : new NumberFormatter(locale, formatOptions).format(numberValue));
 
   let numberParser = useMemo(() => new NumberParser(locale, formatOptions), [locale, formatOptions]);
@@ -273,6 +276,7 @@ export function useNumberFieldState(
     minValue,
     maxValue,
     numberValue: parsedValue,
+    defaultNumberValue: isNaN(defaultValue) ? initialValue : defaultValue,
     setNumberValue,
     setInputValue,
     inputValue,

--- a/packages/@react-stately/radio/src/useRadioGroupState.ts
+++ b/packages/@react-stately/radio/src/useRadioGroupState.ts
@@ -45,6 +45,9 @@ export interface RadioGroupState extends FormValidationState {
   /** The currently selected value. */
   readonly selectedValue: string | null,
 
+  /** The default selected value. */
+  readonly defaultSelectedValue: string | null,
+
   /** Sets the selected value. */
   setSelectedValue(value: string | null): void,
 
@@ -66,6 +69,7 @@ export function useRadioGroupState(props: RadioGroupProps): RadioGroupState  {
   // Preserved here for backward compatibility. React Aria now generates the name instead of stately.
   let name = useMemo(() => props.name || `radio-group-${instance}-${++i}`, [props.name]);
   let [selectedValue, setSelected] = useControlledState(props.value, props.defaultValue ?? null, props.onChange);
+  let [initialValue] = useState(selectedValue);
   let [lastFocusedValue, setLastFocusedValue] = useState<string | null>(null);
 
   let validation = useFormValidationState({
@@ -86,6 +90,7 @@ export function useRadioGroupState(props: RadioGroupProps): RadioGroupState  {
     ...validation,
     name,
     selectedValue: selectedValue,
+    defaultSelectedValue: props.value !== undefined ? initialValue : props.defaultValue ?? null,
     setSelectedValue,
     lastFocusedValue,
     setLastFocusedValue,

--- a/packages/@react-stately/select/src/useSelectState.ts
+++ b/packages/@react-stately/select/src/useSelectState.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionStateBase, FocusStrategy} from '@react-types/shared';
+import {CollectionStateBase, FocusStrategy, Key} from '@react-types/shared';
 import {FormValidationState, useFormValidationState} from '@react-stately/form';
 import {OverlayTriggerState, useOverlayTriggerState} from '@react-stately/overlays';
 import {SelectProps} from '@react-types/select';
@@ -20,6 +20,9 @@ import {useMemo, useState} from 'react';
 export interface SelectStateOptions<T> extends Omit<SelectProps<T>, 'children'>, CollectionStateBase<T> {}
 
 export interface SelectState<T> extends SingleSelectListState<T>, OverlayTriggerState, FormValidationState {
+  /** The default selected key. */
+  readonly defaultSelectedKey: Key | null,
+
   /** Whether the select is currently focused. */
   readonly isFocused: boolean,
 
@@ -63,11 +66,13 @@ export function useSelectState<T extends object>(props: SelectStateOptions<T>): 
 
   let [isFocused, setFocused] = useState(false);
   let isEmpty = useMemo(() => listState.collection.size === 0 || (listState.collection.size === 1 && listState.collection.getItem(listState.collection.getFirstKey()!)?.type === 'loader'), [listState.collection]);
+  let [initialSelectedKey] = useState(listState.selectedKey);
 
   return {
     ...validationState,
     ...listState,
     ...triggerState,
+    defaultSelectedKey: props.defaultSelectedKey ?? initialSelectedKey,
     focusStrategy,
     open(focusStrategy: FocusStrategy | null = null) {
       // Don't open if the collection is empty.

--- a/packages/@react-stately/slider/src/useSliderState.ts
+++ b/packages/@react-stately/slider/src/useSliderState.ts
@@ -21,6 +21,10 @@ export interface SliderState {
    */
   readonly values: number[],
   /**
+   * The default values for each thumb.
+   */
+  readonly defaultValues: number[],
+  /**
    * Get the value for the specified thumb.
    * @param index
    */
@@ -182,8 +186,8 @@ export function useSliderState<T extends number | number[]>(props: SliderStateOp
     return snapValueToStep(val, min, max, step);
   }), [minValue, maxValue, step]);
 
-  let value = useMemo(() => restrictValues(convertValue(props.value)), [props.value]);
-  let defaultValue = useMemo(() => restrictValues(convertValue(props.defaultValue) ?? [minValue])!, [props.defaultValue, minValue]);
+  let value = useMemo(() => restrictValues(convertValue(props.value)), [props.value, restrictValues]);
+  let defaultValue = useMemo(() => restrictValues(convertValue(props.defaultValue) ?? [minValue])!, [props.defaultValue, minValue, restrictValues]);
   let onChange = createOnChange(props.value, props.defaultValue, props.onChange);
   let onChangeEnd = createOnChange(props.value, props.defaultValue, props.onChangeEnd);
 
@@ -192,6 +196,7 @@ export function useSliderState<T extends number | number[]>(props: SliderStateOp
     defaultValue,
     onChange
   );
+  let [initialValues] = useState(values);
   const [isDraggings, setDraggingsState] = useState<boolean[]>(new Array(values.length).fill(false));
   const isEditablesRef = useRef<boolean[]>(new Array(values.length).fill(true));
   const [focusedIndex, setFocusedIndex] = useState<number | undefined>(undefined);
@@ -288,6 +293,7 @@ export function useSliderState<T extends number | number[]>(props: SliderStateOp
 
   return {
     values: values,
+    defaultValues: props.defaultValue !== undefined ? defaultValue : initialValues,
     getThumbValue: (index: number) => values[index],
     setThumbValue: updateValue,
     setThumbPercent,

--- a/packages/@react-stately/toggle/src/useToggleState.ts
+++ b/packages/@react-stately/toggle/src/useToggleState.ts
@@ -12,12 +12,16 @@
 
 import {ToggleStateOptions} from '@react-types/checkbox';
 import {useControlledState} from '@react-stately/utils';
+import {useState} from 'react';
 
 export type {ToggleStateOptions};
 
 export interface ToggleState {
   /** Whether the toggle is selected. */
   readonly isSelected: boolean,
+
+  /** Whether the toggle is selected by default. */
+  readonly defaultSelected: boolean,
 
   /** Updates selection state. */
   setSelected(isSelected: boolean): void,
@@ -35,6 +39,7 @@ export function useToggleState(props: ToggleStateOptions = {}): ToggleState {
   // have to provide an empty function so useControlledState doesn't throw a fit
   // can't use useControlledState's prop calling because we need the event object from the change
   let [isSelected, setSelected] = useControlledState(props.isSelected, props.defaultSelected || false, props.onChange);
+  let [initialValue] = useState(isSelected);
 
   function updateSelected(value) {
     if (!isReadOnly) {
@@ -50,6 +55,7 @@ export function useToggleState(props: ToggleStateOptions = {}): ToggleState {
 
   return {
     isSelected,
+    defaultSelected: props.defaultSelected ?? initialValue,
     setSelected: updateSelected,
     toggle: toggleState
   };


### PR DESCRIPTION
Fixes #6830

In React 19, when a `<form>` has an `action` prop that is a function, React will automatically reset the form after the action completes. This occurs after the commit phase of the render following the action so that the `defaultValue` can be updated based on the data returned by the server (but before layout effects run).

Unlike the builtin `<input>` element, most of our components use controlled state internally, even when they appear uncontrolled to the user. Changing the `defaultValue` prop normally does nothing, but with native inputs resetting the form does use the current `defaultValue` not the original value when the input first mounted. This PR updates all of our components to follow that behavior as well, by updating the internal state to match the current `defaultValue` when the form is reset.

This also fixes the validation errors being reset after an action, which occurred because the reset event would fire immediately after the validation errors returned by the server were set. Unfortunately react does not give us a way to detect this case, so this implements a best effort: if `form.reset()` is called programmatically outside a user event, we ignore it and do not clear the validation errors.