### PR TITLE
ignore typing leading zeros in all datefield segements

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -256,7 +256,8 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
           if (shouldSetValue) {
             focusManager.focusNext();
           }
-        } else {
+        } else if (shouldSetValue) {
+          // Don't accept leading zeros except for fields that accept 0 as a value (aka minutes/seconds/etc)
           enteredKeys.current = newValue;
         }
         break;
@@ -325,7 +326,6 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
         if (ref.current) {
           ref.current.textContent = compositionRef.current;
         }
-
         // Android sometimes fires key presses of letters as composition events. Need to handle am/pm keys here too.
         // Can also happen e.g. with Pinyin keyboard on iOS.
         if (data != null && (startsWith(am, data) || startsWith(pm, data))) {
@@ -387,9 +387,9 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
 
   let segmentStyle: CSSProperties = {caretColor: 'transparent'};
   if (direction === 'rtl') {
-    // While the bidirectional algorithm seems to work properly on inline elements with actual values, it returns different results for placeholder strings. 
+    // While the bidirectional algorithm seems to work properly on inline elements with actual values, it returns different results for placeholder strings.
     // To ensure placeholder render in correct format, we apply the CSS equivalent of LRE (left-to-right embedding). See https://www.unicode.org/reports/tr9/#Explicit_Directional_Embeddings.
-    // However, we apply this to both placeholders and date segments with an actual value because the date segments will shift around when deleting otherwise. 
+    // However, we apply this to both placeholders and date segments with an actual value because the date segments will shift around when deleting otherwise.
     segmentStyle.unicodeBidi = 'embed';
     let format = options[segment.type];
     if (format === 'numeric' || format === '2-digit') {

--- a/packages/@react-spectrum/datepicker/test/DateField.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateField.test.js
@@ -235,7 +235,11 @@ describe('DateField', function () {
           errorMessage="Date unavailable." />
       );
       await user.tab();
-      await user.keyboard('01011980');
+      await user.keyboard('1');
+      await user.keyboard('[ArrowRight]');
+      await user.keyboard('1');
+      await user.keyboard('[ArrowRight]');
+      await user.keyboard('1980');
       expect(tree.getByText('Date unavailable.')).toBeInTheDocument();
     });
 
@@ -245,7 +249,7 @@ describe('DateField', function () {
           <DateField label="Date" showFormatHelpText />
         </Provider>
       );
-  
+
       let segments = Array.from(getByRole('group').querySelectorAll('[data-testid]'));
       let segmentTypes = segments.map(s => s.getAttribute('data-testid'));
       expect(segmentTypes).toEqual(['year', 'month', 'day']);

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -1426,7 +1426,8 @@ describe('DatePicker', function () {
 
       it('should support typing into the month segment', function () {
         testInput('month,', new CalendarDate(2019, 2, 3), '1', new CalendarDate(2019, 1, 3), false);
-        testInput('month,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 1, 3), true);
+        testInput('month,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 1, 3), false);
+        testInput('month,', new CalendarDate(2019, 2, 3), '012', new CalendarDate(2019, 12, 3), true);
         testInput('month,', new CalendarDate(2019, 2, 3), '12', new CalendarDate(2019, 12, 3), true);
         testInput('month,', new CalendarDate(2019, 2, 3), '4', new CalendarDate(2019, 4, 3), true);
         testIgnored('month,', new CalendarDate(2019, 2, 3), '0');
@@ -1435,7 +1436,8 @@ describe('DatePicker', function () {
 
       it('should support typing into the day segment', function () {
         testInput('day,', new CalendarDate(2019, 2, 3), '1', new CalendarDate(2019, 2, 1), false);
-        testInput('day,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 2, 1), true);
+        testInput('day,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 2, 1), false);
+        testInput('day,', new CalendarDate(2019, 2, 3), '012', new CalendarDate(2019, 2, 12), true);
         testInput('day,', new CalendarDate(2019, 2, 3), '12', new CalendarDate(2019, 2, 12), true);
         testInput('day,', new CalendarDate(2019, 2, 3), '4', new CalendarDate(2019, 2, 4), true);
         testIgnored('day,', new CalendarDate(2019, 2, 3), '0');
@@ -1444,14 +1446,19 @@ describe('DatePicker', function () {
 
       it('should support typing into the year segment', function () {
         testInput('year,', new CalendarDate(2019, 2, 3), '1993', new CalendarDate(1993, 2, 3), false);
+        testInput('year,', new CalendarDate(2019, 2, 3), '0199', new CalendarDate(199, 2, 3), false);
+        testInput('year,', new CalendarDate(2019, 2, 3), '01993', new CalendarDate(1993, 2, 3), false);
+        testInput('year,', new CalendarDateTime(2019, 2, 3, 8), '0199', new CalendarDateTime(199, 2, 3, 8), false);
         testInput('year,', new CalendarDateTime(2019, 2, 3, 8), '1993', new CalendarDateTime(1993, 2, 3, 8), true);
+        testInput('year,', new CalendarDateTime(2019, 2, 3, 8), '01993', new CalendarDateTime(1993, 2, 3, 8), true);
         testIgnored('year,', new CalendarDate(2019, 2, 3), '0');
       });
 
       it('should support typing into the hour segment in 12 hour time', function () {
         // AM
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '1', new CalendarDateTime(2019, 2, 3, 1), false);
-        testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '01', new CalendarDateTime(2019, 2, 3, 1), true);
+        testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '01', new CalendarDateTime(2019, 2, 3, 1), false);
+        testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '011', new CalendarDateTime(2019, 2, 3, 11), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '11', new CalendarDateTime(2019, 2, 3, 11), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '12', new CalendarDateTime(2019, 2, 3, 0), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '4', new CalendarDateTime(2019, 2, 3, 4), true);
@@ -1459,7 +1466,8 @@ describe('DatePicker', function () {
 
         // PM
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '1', new CalendarDateTime(2019, 2, 3, 13), false);
-        testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '01', new CalendarDateTime(2019, 2, 3, 13), true);
+        testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '01', new CalendarDateTime(2019, 2, 3, 13), false);
+        testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '011', new CalendarDateTime(2019, 2, 3, 23), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '11', new CalendarDateTime(2019, 2, 3, 23), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '12', new CalendarDateTime(2019, 2, 3, 12), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '4', new CalendarDateTime(2019, 2, 3, 16), true);

--- a/packages/react-aria-components/test/DateField.test.js
+++ b/packages/react-aria-components/test/DateField.test.js
@@ -204,12 +204,12 @@ describe('DateField', () => {
         {({isDisabled}) => (
           <>
             <Label>Birth date</Label>
-            <DateInput 
+            <DateInput
               data-disabled-state={isDisabled ? 'disabled' : null}>
               {segment => <DateSegment segment={segment} />}
             </DateInput>
           </>
-        )} 
+        )}
       </DateField>
     );
     let group = getByRole('group');
@@ -317,7 +317,7 @@ describe('DateField', () => {
         </DateInput>
       </DateField>
     );
-  
+
     let segments = getAllByRole('spinbutton');
     await user.click(segments[2]);
     expect(document.activeElement).toBe(segments[2]);
@@ -348,7 +348,7 @@ describe('DateField', () => {
         </DateInput>
       </DateField>
     );
-  
+
     let segments = getAllByRole('spinbutton');
     await user.click(segments[2]);
     expect(segments[2]).toHaveFocus();
@@ -371,5 +371,43 @@ describe('DateField', () => {
     let segments = Array.from(getByRole('group').querySelectorAll('.react-aria-DateSegment'));
     let segmentTypes = segments.map(s => s.getAttribute('data-type'));
     expect(segmentTypes).toEqual(['year', 'literal', 'month', 'day']);
+  });
+
+  it('should not store leading zeros when typing into the segments', async () => {
+    let {getAllByRole} = render(
+      <DateField>
+        <Label>Date</Label>
+        <DateInput>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </DateField>
+    );
+
+    let segements = getAllByRole('spinbutton');
+    let monthSegment = segements[0];
+    await user.click(monthSegment);
+    expect(monthSegment).toHaveFocus();
+    await user.keyboard('11');
+    expect(monthSegment).toHaveTextContent('11');
+    await user.click(monthSegment);
+    await user.keyboard('012');
+    expect(monthSegment).toHaveTextContent('12');
+
+    let daysSegment = segements[1];
+    await user.click(daysSegment);
+    expect(daysSegment).toHaveFocus();
+    await user.keyboard('11');
+    expect(daysSegment).toHaveTextContent('11');
+    await user.click(daysSegment);
+    await user.keyboard('012');
+    expect(daysSegment).toHaveTextContent('12');
+
+    let yearsSegment = segements[2];
+    await user.click(yearsSegment);
+    expect(yearsSegment).toHaveFocus();
+    await user.keyboard('1111');
+    expect(yearsSegment).toHaveTextContent('1111');
+    await user.keyboard('002222');
+    expect(yearsSegment).toHaveTextContent('2222');
   });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8366

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the DateField/DatePicker stories and verify that typing `0` in any of the fields is ignored (except for minutes/etc fields that accept `00`). An example would be that typing `012` in the day field should yield `12` and not `01`. Note that mobile/keyboard users will now need to manually move focus to the next field when entering a value whose length is smaller than the max width of a field's  (e.g. like `1` in the day field)

Test that the original bug doesn't reproduce:
1. Go to any DateField and type in a valid year (e.g. `2000`)
2. Type `002025`. You should get `2025` now

## 🧢 Your Project:

RSP
