### PR TITLE
fix: user agent brands check

### DIFF
--- a/packages/@react-aria/utils/src/platform.ts
+++ b/packages/@react-aria/utils/src/platform.ts
@@ -14,10 +14,9 @@ function testUserAgent(re: RegExp) {
   if (typeof window === 'undefined' || window.navigator == null) {
     return false;
   }
-  return (
-    window.navigator['userAgentData']?.brands.some((brand: {brand: string, version: string}) => re.test(brand.brand))
-  ) ||
-  re.test(window.navigator.userAgent);
+  let brands = window.navigator['userAgentData']?.brands;
+  return Array.isArray(brands) && brands.some((brand: {brand: string, version: string}) => re.test(brand.brand)) ||
+    re.test(window.navigator.userAgent);
 }
 
 function testPlatform(re: RegExp) {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8457

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check that platforms are still correct: https://reactspectrum.blob.core.windows.net/reactspectrum/6093f6b85878c9cc3e04eb17d59ac98f5b8ef509/storybook/index.html?path=/story/platform--default&providerSwitcher-express=false

Not sure I have access to any of the browsers that can reproduce the original issue, but if someone does, feel free to verify the fix.

## 🧢 Your Project:

<!--- Company/project for pull request -->
