### PR TITLE
chore: Update font and line heights to latest design

### DIFF
--- a/.storybook-s2/preview-head.html
+++ b/.storybook-s2/preview-head.html
@@ -1,24 +1,118 @@
-<!--
-  This web project loads adobe clean, adobe clean serif, myriad-arabic, myriad-hebrew, adobe-clean-han-japanese,
-  adobe-clean-han-korean, adobe-clean-han-simplified-c, and adobe-clean-han-traditional.
-  These fonts and this web project are managed by a team account.
--->
-<script>
-(function(d) {
-  var config = {
-    kitId: 'fqj0dxc',
-    scriptTimeout: 3000,
-    async: true
-  },
-  h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
-})(document);
-</script>
 <style>
-@font-face {
-    font-family: "Source Code Pro";
-    src: url("https://use.typekit.net/af/398a64/00000000000000007735dc06/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/398a64/00000000000000007735dc06/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/398a64/00000000000000007735dc06/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-    font-display: swap;
+  @font-face {
+    font-family: "source-code-pro";
+    src: url("https://use.typekit.net/af/88da4d/00000000000000007758ce1a/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("woff2"), url("https://use.typekit.net/af/88da4d/00000000000000007758ce1a/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("woff"), url("https://use.typekit.net/af/88da4d/00000000000000007758ce1a/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 700;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "source-code-pro";
+    src: url("https://use.typekit.net/af/80f457/00000000000000007758ce1d/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/80f457/00000000000000007758ce1d/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/80f457/00000000000000007758ce1d/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("opentype");
+    font-display: auto;
     font-style: normal;
     font-weight: 400;
-}
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-arabic";
+    src: url("https://use.typekit.net/af/dfb464/00000000000000007735a2f9/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("woff2"), url("https://use.typekit.net/af/dfb464/00000000000000007735a2f9/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("woff"), url("https://use.typekit.net/af/dfb464/00000000000000007735a2f9/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 700;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-arabic";
+    src: url("https://use.typekit.net/af/560a53/00000000000000007735a300/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/560a53/00000000000000007735a300/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/560a53/00000000000000007735a300/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 400;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-arabic";
+    src: url("https://use.typekit.net/af/0f9162/00000000000000007735a307/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n6&v=3") format("woff2"), url("https://use.typekit.net/af/0f9162/00000000000000007735a307/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n6&v=3") format("woff"), url("https://use.typekit.net/af/0f9162/00000000000000007735a307/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n6&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 600;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-arabic";
+    src: url("https://use.typekit.net/af/ab2792/00000000000000007735a309/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n9&v=3") format("woff2"), url("https://use.typekit.net/af/ab2792/00000000000000007735a309/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n9&v=3") format("woff"), url("https://use.typekit.net/af/ab2792/00000000000000007735a309/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n9&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 900;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-hebrew";
+    src: url("https://use.typekit.net/af/ffca46/00000000000000007735a30a/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("woff2"), url("https://use.typekit.net/af/ffca46/00000000000000007735a30a/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("woff"), url("https://use.typekit.net/af/ffca46/00000000000000007735a30a/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n7&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 700;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-hebrew";
+    src: url("https://use.typekit.net/af/e90860/00000000000000007735a313/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/e90860/00000000000000007735a313/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/e90860/00000000000000007735a313/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n4&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 400;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "myriad-hebrew";
+    src: url("https://use.typekit.net/af/619974/00000000000000007735a31f/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n6&v=3") format("woff2"), url("https://use.typekit.net/af/619974/00000000000000007735a31f/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n6&v=3") format("woff"), url("https://use.typekit.net/af/619974/00000000000000007735a31f/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n6&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 600;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "adobe-clean-spectrum-srf-vf";
+    src: url("https://use.typekit.net/af/245fcd/0000000000000000775c046c/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n1&v=3") format("woff2"), url("https://use.typekit.net/af/245fcd/0000000000000000775c046c/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n1&v=3") format("woff"), url("https://use.typekit.net/af/245fcd/0000000000000000775c046c/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n1&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 100 1000;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "adobe-clean-spectrum-srf-vf";
+    src: url("https://use.typekit.net/af/87953f/0000000000000000775c046d/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=i1&v=3") format("woff2"), url("https://use.typekit.net/af/87953f/0000000000000000775c046d/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=i1&v=3") format("woff"), url("https://use.typekit.net/af/87953f/0000000000000000775c046d/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=i1&v=3") format("opentype");
+    font-display: auto;
+    font-style: italic;
+    font-weight: 100 1000;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "adobe-clean-spectrum-vf";
+    src: url("https://use.typekit.net/af/56e7ef/0000000000000000775c0484/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=i1&v=3") format("woff2"), url("https://use.typekit.net/af/56e7ef/0000000000000000775c0484/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=i1&v=3") format("woff"), url("https://use.typekit.net/af/56e7ef/0000000000000000775c0484/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=i1&v=3") format("opentype");
+    font-display: auto;
+    font-style: italic;
+    font-weight: 100 900;
+    font-stretch: normal;
+  }
+
+  @font-face {
+    font-family: "adobe-clean-spectrum-vf";
+    src: url("https://use.typekit.net/af/b1226a/0000000000000000775c0485/31/l?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n1&v=3") format("woff2"), url("https://use.typekit.net/af/b1226a/0000000000000000775c0485/31/d?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n1&v=3") format("woff"), url("https://use.typekit.net/af/b1226a/0000000000000000775c0485/31/a?primer=f592e0a4b9356877842506ce344308576437e4f677d7c9b78ca2162e6cad991a&fvd=n1&v=3") format("opentype");
+    font-display: auto;
+    font-style: normal;
+    font-weight: 100 900;
+    font-stretch: normal;
+  }
 </style>

--- a/packages/@react-spectrum/s2/src/page.macro.ts
+++ b/packages/@react-spectrum/s2/src/page.macro.ts
@@ -30,9 +30,11 @@ export function generatePageStyles(this: MacroContext | void): void {
         --s2-container-bg: ${colorToken(tokens['background-base-color'])};
         background: var(--s2-container-bg);
         --s2-scale: 1;
+        --s2-font-size-base: 14;
 
         @media not ((hover: hover) and (pointer: fine)) {
           --s2-scale: 1.25;
+          --s2-font-size-base: 17;
         }
 
         &[data-color-scheme=light] {
@@ -70,6 +72,7 @@ export function generateDefaultColorSchemeStyles(this: MacroContext | void): voi
           --lightningcss-light: initial;
           --lightningcss-dark: ;
           --s2-scale: 1;
+          --s2-font-size-base: 14;
 
           @media (prefers-color-scheme: dark) {
             --lightningcss-light: ;
@@ -78,6 +81,7 @@ export function generateDefaultColorSchemeStyles(this: MacroContext | void): voi
 
           @media not ((hover: hover) and (pointer: fine)) {
             --s2-scale: 1.25;
+            --s2-font-size-base: 17;
           }
         }
       }`

--- a/packages/@react-spectrum/s2/style/tokens.ts
+++ b/packages/@react-spectrum/s2/style/tokens.ts
@@ -133,17 +133,38 @@ export function generateOverlayColorScale(bg = 'var(--s2-container-bg)'): ColorS
   };
 }
 
-function pxToRem(px: string | number) {
-  if (typeof px === 'string') {
-    px = parseFloat(px);
-  }
-  return px / 16 + 'rem';
-}
+const indexes = {
+  'font-size-25': -3,
+  'font-size-50': -2,
+  'font-size-75': -1,
+  'font-size-100': 0,
+  'font-size-200': 1,
+  'font-size-300': 2,
+  'font-size-400': 3,
+  'font-size-500': 4,
+  'font-size-600': 5,
+  'font-size-700': 6,
+  'font-size-800': 7,
+  'font-size-900': 8,
+  'font-size-1000': 9,
+  'font-size-1100': 10,
+  'font-size-1200': 11,
+  'font-size-1300': 12,
+  'font-size-1400': 13,
+  'font-size-1500': 14
+};
 
-export function fontSizeToken(name: keyof typeof tokens): {default: string, touch: string} {
-  let token = tokens[name] as typeof tokens['font-size-100'];
-  return {
-    default: pxToRem(token.sets.desktop.value),
-    touch: pxToRem(token.sets.mobile.value)
-  };
+/** Returns the index of a font token relative to font-size-100 (which is index 0). */
+export function fontSizeToken(name: keyof typeof tokens): number {
+  let token = tokens[name] as typeof tokens['font-size-100'] | typeof tokens['heading-size-m'];
+  if ('ref' in token) {
+    name = token.ref.slice(1, -1) as keyof typeof tokens;
+  }
+
+  let index = indexes[name];
+  if (index == null) {
+    throw new Error('Unknown font size ' + name);
+  }
+
+  return index;
 }

--- a/packages/@react-spectrum/s2/style/types.ts
+++ b/packages/@react-spectrum/s2/style/types.ts
@@ -17,7 +17,7 @@ export type CustomValue = string | number | boolean;
 export type Value = CustomValue | readonly any[];
 export type PropertyValueDefinition<T> = T | {[condition: string]: PropertyValueDefinition<T>};
 export type PropertyValueMap<T extends CSSValue = CSSValue> = {
-  [name in T]: PropertyValueDefinition<string>
+  [name in T]: PropertyValueDefinition<CSSValue>
 };
 
 export type CustomProperty = `--${string}`;


### PR DESCRIPTION
Setup for new adobe-clean-spectrum-vf font. Line heights are now calculated based on the font size, linearly interpolating between 1.3 and 1.15 as the font size grows. I did this with a calc rather than hard coding each line height for each font size and desktop/mobile scale. Font sizes are also now calculated based on the logarithmic scale, with an `--s2-font-size-base` variable controlling the base font size (14 on desktop, 17 on mobile).