### PR TITLE
fix: remove duplicate "color" in ColorWheelRenderProps comment

### DIFF
--- a/packages/react-aria-components/src/ColorWheel.tsx
+++ b/packages/react-aria-components/src/ColorWheel.tsx
@@ -13,7 +13,7 @@ export interface ColorWheelRenderProps {
    */
   isDisabled: boolean,
   /**
-   * State of the color color wheel.
+   * State of the color wheel.
    */
   state: ColorWheelState
 }


### PR DESCRIPTION
Minor documentation fix - corrects duplicate "color" word in ColorWheelRenderProps interface comment

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

No testing required: this PR only fixes a typo in a code comment

## 🧢 Your Project:

<!--- Company/project for pull request -->
