### PR TITLE
perf(useHover): minimize unnecessary global events

### DIFF
--- a/packages/@react-aria/interactions/src/useHover.ts
+++ b/packages/@react-aria/interactions/src/useHover.ts
@@ -48,7 +48,7 @@ function setGlobalIgnoreEmulatedMouseEvents() {
   }, 50);
 }
 
-function handleGlobalPointerEvent(e) {
+function handleGlobalPointerEvent(e: PointerEvent) {
   if (e.pointerType === 'touch') {
     setGlobalIgnoreEmulatedMouseEvents();
   }
@@ -59,10 +59,12 @@ function setupGlobalTouchEvents() {
     return;
   }
 
-  if (typeof PointerEvent !== 'undefined') {
-    document.addEventListener('pointerup', handleGlobalPointerEvent);
-  } else if (process.env.NODE_ENV === 'test') {
-    document.addEventListener('touchend', setGlobalIgnoreEmulatedMouseEvents);
+  if (hoverCount === 0) {
+    if (typeof PointerEvent !== 'undefined') {
+      document.addEventListener('pointerup', handleGlobalPointerEvent);
+    } else if (process.env.NODE_ENV === 'test') {
+      document.addEventListener('touchend', setGlobalIgnoreEmulatedMouseEvents);
+    }
   }
 
   hoverCount++;


### PR DESCRIPTION
No issue link.

`useEffect(setupGlobalTouchEvents, [])` keeps adding the `handleGlobalPointerEvent` listener to document every time it runs. Although adding the same function means the event handler will only execute once, this unnecessary addition could still be avoided.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Local tests passed.

## 🧢 Your Project:

Private.
