### PR TITLE
fix: preserve aria labels for cell and column of table

### DIFF
--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -746,7 +746,7 @@ export const Column = /*#__PURE__*/ createLeafComponent('column', (props: Column
   }
 
   let TH = useElementType('th');
-  let DOMProps = filterDOMProps(props as any, {global: true});
+  let DOMProps = filterDOMProps(props as any, {global: true, labelable: true});
   delete DOMProps.id;
 
   return (
@@ -1239,7 +1239,7 @@ export const Cell = /*#__PURE__*/ createLeafComponent('cell', (props: CellProps,
   });
 
   let TD = useElementType('td');
-  let DOMProps = filterDOMProps(props as any, {global: true});
+  let DOMProps = filterDOMProps(props as any, {global: true, labelable: true});
   delete DOMProps.id;
 
   return (

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -334,6 +334,21 @@ describe('Table', () => {
     }
   });
 
+  it('should support aria-label props on column and cells', () => {
+    let {getAllByRole} = renderTable({
+      columnProps: {'aria-label': 'aria column label'},
+      cellProps: {'aria-label': 'aria cell label'}
+    });
+
+    for (let cell of getAllByRole('columnheader')) {
+      expect(cell).toHaveAttribute('aria-label', 'aria column label');
+    }
+
+    for (let cell of getAllByRole('gridcell')) {
+      expect(cell).toHaveAttribute('aria-label', 'aria cell label');
+    }
+  });
+
   it('should render checkboxes for selection', async () => {
     let {getAllByRole} = renderTable({
       tableProps: {selectionMode: 'multiple'}
@@ -2649,7 +2664,7 @@ describe('Table', () => {
       let {getByRole} = renderTable({rowProps: {onAction, onPressStart, onPressEnd, onPress, onClick}});
       let tableTester = testUtilUser.createTester('Table', {root: getByRole('grid')});
       await tableTester.triggerRowAction({row: 1, interactionType});
-  
+
       expect(onAction).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Preserve aria label prop passed into Cell and Column 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Cell and Column components of Table should apply aria label attributes in the DOM.

<img width="1449" alt="image" src="https://github.com/user-attachments/assets/387ef95f-eb60-44e8-94c8-884ea8623df6" />



