### PR TITLE
fix(LabeledValue): gracefully handle null/undefined value

### DIFF
--- a/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
+++ b/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
@@ -114,7 +114,7 @@ export const LabeledValue = React.forwardRef(function LabeledValue<T extends Spe
     children = <FormattedNumber value={value} formatOptions={formatOptions as Intl.NumberFormatOptions} />;
   }
 
-  if (typeof value === 'object' && ('calendar' in value || 'hour' in value) || (value instanceof Date)) {
+  if ((value instanceof Date) || (value != null && typeof value === 'object' && ('calendar' in value || 'hour' in value))) {
     children = <FormattedDate value={value} formatOptions={formatOptions as Intl.DateTimeFormatOptions} />;
   }
 

--- a/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
+++ b/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
@@ -102,11 +102,11 @@ export const LabeledValue = React.forwardRef(function LabeledValue<T extends Spe
     children = <FormattedStringList value={value} formatOptions={formatOptions as Intl.ListFormatOptions} />;
   }
 
-  if (value != null && typeof value === 'object' && 'start' in value && typeof (value as any).start === 'number' && typeof (value as any).end === 'number') {
+  if (value != null && typeof value === 'object' && 'start' in value && typeof value.start === 'number' && typeof value.end === 'number') {
     children = <FormattedNumber value={value as NumberValue} formatOptions={formatOptions as Intl.NumberFormatOptions}  />;
   }
 
-  if (value != null && typeof value === 'object' && 'start' in value && typeof (value as any).start !== 'number' && typeof (value as any).end !== 'number') {
+  if (value != null && typeof value === 'object' && 'start' in value && typeof value.start !== 'number' && typeof value.end !== 'number') {
     children = <FormattedDate value={value as DateTimeValue} formatOptions={formatOptions as Intl.DateTimeFormatOptions} />;
   }
 
@@ -114,7 +114,7 @@ export const LabeledValue = React.forwardRef(function LabeledValue<T extends Spe
     children = <FormattedNumber value={value} formatOptions={formatOptions as Intl.NumberFormatOptions} />;
   }
 
-  if ((value instanceof Date) || (value != null && typeof value === 'object' && ('calendar' in value || 'hour' in value))) {
+  if (typeof value === 'object' && ('calendar' in value || 'hour' in value) || (value instanceof Date)) {
     children = <FormattedDate value={value} formatOptions={formatOptions as Intl.DateTimeFormatOptions} />;
   }
 

--- a/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
+++ b/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
@@ -125,6 +125,9 @@ export const LabeledValue = React.forwardRef(function LabeledValue<T extends Spe
   if (React.isValidElement(value)) {
     children = value;
   }
+  if (value === null || value === undefined && process.env.NODE_ENV !== 'production') {
+    console.warn('LabeledValue cannot display null or undefined values.');
+  }
 
   return (
     <Field {...props as any} wrapperProps={filterDOMProps(props as any)} ref={domRef} elementType="span" wrapperClassName={classNames(labelStyles, 'spectrum-LabeledValue')}>

--- a/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
+++ b/packages/@react-spectrum/labeledvalue/src/LabeledValue.tsx
@@ -102,11 +102,11 @@ export const LabeledValue = React.forwardRef(function LabeledValue<T extends Spe
     children = <FormattedStringList value={value} formatOptions={formatOptions as Intl.ListFormatOptions} />;
   }
 
-  if (typeof value === 'object' && 'start' in value && typeof value.start === 'number' && typeof value.end === 'number') {
+  if (value != null && typeof value === 'object' && 'start' in value && typeof (value as any).start === 'number' && typeof (value as any).end === 'number') {
     children = <FormattedNumber value={value as NumberValue} formatOptions={formatOptions as Intl.NumberFormatOptions}  />;
   }
 
-  if (typeof value === 'object' && 'start' in value && typeof value.start !== 'number' && typeof value.end !== 'number') {
+  if (value != null && typeof value === 'object' && 'start' in value && typeof (value as any).start !== 'number' && typeof (value as any).end !== 'number') {
     children = <FormattedDate value={value as DateTimeValue} formatOptions={formatOptions as Intl.DateTimeFormatOptions} />;
   }
 
@@ -114,7 +114,7 @@ export const LabeledValue = React.forwardRef(function LabeledValue<T extends Spe
     children = <FormattedNumber value={value} formatOptions={formatOptions as Intl.NumberFormatOptions} />;
   }
 
-  if (typeof value === 'object' && ('calendar' in value || 'hour' in value) || (value instanceof Date)) {
+  if ((value instanceof Date) || (value != null && typeof value === 'object' && ('calendar' in value || 'hour' in value))) {
     children = <FormattedDate value={value} formatOptions={formatOptions as Intl.DateTimeFormatOptions} />;
   }
 

--- a/packages/@react-spectrum/labeledvalue/stories/LabeledValue.stories.tsx
+++ b/packages/@react-spectrum/labeledvalue/stories/LabeledValue.stories.tsx
@@ -149,7 +149,7 @@ export const WithContextualHelp: LabeledValueStory = {
 export const NullValue: LabeledValueStory = {
   args: {
     label: 'Test',
-    value: null
+    value: null as any
   },
   name: 'null value'
 };

--- a/packages/@react-spectrum/labeledvalue/stories/LabeledValue.stories.tsx
+++ b/packages/@react-spectrum/labeledvalue/stories/LabeledValue.stories.tsx
@@ -145,3 +145,20 @@ export const WithContextualHelp: LabeledValueStory = {
   },
   name: 'contextual help'
 };
+
+export const NullValue: LabeledValueStory = {
+  args: {
+    label: 'Test',
+    value: null
+  },
+  name: 'null value'
+};
+
+
+export const UndefinedValue: LabeledValueStory = {
+  args: {
+    label: 'Test',
+    value: undefined
+  },
+  name: 'undefined value'
+};


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5001

Ideally, users won't end up in this state (due to Typescript), but we want to avoid crashing the page if they do pass in undefined/null for some reason (e.g. loading values from type-unsafe API). This avoids runtime errors like:

```
TypeError: Cannot use 'in' operator to search for 'start' in null
```

It will now just render an empty string, and show a console warning in development. The warning should be enough to allow developers to add an relevant fallback.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
