### PR TITLE
fix: empty option in HiddenSelect

### DIFF
--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -136,7 +136,7 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>): JSX.Element | null
         <label>
           {label}
           <select {...selectProps} ref={selectRef}>
-            <option />
+            <option label=" " />
             {[...state.collection.getKeys()].map(key => {
               let item = state.collection.getItem(key);
               if (item && item.type === 'item') {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/4084

As noted [here](https://github.com/adobe/react-spectrum/issues/4084#issuecomment-1442527365), this fixes an HTML validation issue, not a WCAG issue.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
