### PR TITLE
feat: Add `CollectionNode` to collection renderer

### DIFF
--- a/packages/@react-spectrum/s2/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/s2/src/Breadcrumbs.tsx
@@ -29,7 +29,7 @@ import {baseColor, focusRing, size, style} from '../style' with { type: 'macro' 
 import ChevronIcon from '../ui-icons/Chevron';
 import {Collection, DOMRef, DOMRefValue, LinkDOMProps, Node} from '@react-types/shared';
 import {controlFont, controlSize, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
-import {createContext, forwardRef, Fragment, ReactNode, RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import {createContext, forwardRef, ReactNode, RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import FolderIcon from '../s2wf-icons/S2_Icon_FolderBreadcrumb_20_N.svg';
 import {forwardRefType} from './types';
 import {inertValue, useLayoutEffect} from '@react-aria/utils';
@@ -380,6 +380,7 @@ let CollapsingCollectionRenderer: CollectionRenderer = {
 };
 
 let useCollectionRender = (collection: Collection<Node<unknown>>) => {
+  let {CollectionNode = DefaultCollectionRenderer.CollectionNode} = useContext(CollectionRendererContext);
   let {containerRef, onAction} = useContext(CollapseContext) ?? {};
   let [visibleItems, setVisibleItems] = useState(collection.size);
   let {size = 'M'} = useContext(InternalBreadcrumbsContext);
@@ -468,13 +469,13 @@ let useCollectionRender = (collection: Collection<Node<unknown>>) => {
       <HiddenBreadcrumbs items={children} size={size} listRef={listRef} />
       {visibleItems < collection.size && collection.size > 2 ? (
         <>
-          {children[0].render?.(children[0])}
+          <CollectionNode node={children[0]} parent={null} collection={collection} />
           <BreadcrumbMenu items={children.slice(1, sliceIndex)} onAction={onAction} />
-          {children.slice(sliceIndex).map(node => <Fragment key={node.key}>{node.render?.(node)}</Fragment >)}
+          {children.slice(sliceIndex).map(node => <CollectionNode node={node} parent={null} collection={collection} key={node.key} />)}
         </>
       ) : (
         <>
-          {children.map(node => <Fragment key={node.key}>{node.render?.(node)}</Fragment>)}
+          {children.map(node => <CollectionNode node={node} parent={null} collection={collection} key={node.key} />)}
         </>
       )}
     </>

--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -108,7 +108,20 @@ export const Section = /*#__PURE__*/ createBranchComponent('section', <T extends
   return render(props, ref, section, 'react-aria-Section');
 });
 
-export interface CollectionBranchProps {
+export interface CollectionNodeProps<T = Node<unknown>> extends HTMLAttributes<HTMLElement> {
+  /** The collection of items to render. */
+  collection: ICollection<Node<unknown>>,
+  /** The node of the item to render. */
+  node: T,
+  /** The parent node of the item to render. */
+  parent: T | null,
+  /** The content that should be rendered before the item. */
+  before?: ReactNode,
+  /** The content that should be rendered after the item. */
+  after?: ReactNode
+}
+
+export interface CollectionBranchProps extends HTMLAttributes<HTMLElement> {
   /** The collection of items to render. */
   collection: ICollection<Node<unknown>>,
   /** The parent node of the items to render. */
@@ -128,7 +141,7 @@ export interface CollectionRootProps extends HTMLAttributes<HTMLElement> {
   renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode
 }
 
-export interface CollectionRenderer {
+export interface CollectionRenderer<T = Node<unknown>> {
   /** Whether this is a virtualized collection. */
   isVirtualized?: boolean,
   /** A delegate object that provides layout information for items in the collection. */
@@ -138,15 +151,25 @@ export interface CollectionRenderer {
   /** A component that renders the root collection items. */
   CollectionRoot: React.ComponentType<CollectionRootProps>,
    /** A component that renders the child collection items. */
-  CollectionBranch: React.ComponentType<CollectionBranchProps>
+  CollectionBranch: React.ComponentType<CollectionBranchProps>,
+  /** A component that renders the collection item. */
+  CollectionNode?: React.ComponentType<CollectionNodeProps<T>>
 }
 
-export const DefaultCollectionRenderer: CollectionRenderer = {
+interface DefaultRenderer extends CollectionRenderer<Node<unknown>> {
+  /** A component that renders the collection item. */
+  CollectionNode: React.ComponentType<CollectionNodeProps<Node<unknown>>>
+}
+
+export const DefaultCollectionRenderer: DefaultRenderer = {
   CollectionRoot({collection, renderDropIndicator}) {
     return useCollectionRender(collection, null, renderDropIndicator);
   },
   CollectionBranch({collection, parent, renderDropIndicator}) {
     return useCollectionRender(collection, parent, renderDropIndicator);
+  },
+  CollectionNode({node, before, after}) {
+    return <>{before}{node.render?.(node)}{after}</>;
   }
 };
 
@@ -155,22 +178,22 @@ function useCollectionRender(
   parent: Node<unknown> | null,
   renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode
 ) {
+  let {CollectionNode = DefaultCollectionRenderer.CollectionNode} = useContext(CollectionRendererContext);
+
   return useCachedChildren({
     items: parent ? collection.getChildren!(parent.key) : collection,
-    dependencies: [renderDropIndicator],
+    dependencies: [CollectionNode, renderDropIndicator],
     children(node) {
-      let rendered = node.render!(node);
-      if (!renderDropIndicator || node.type !== 'item') {
-        return rendered;
+      let pseudoProps = {};
+
+      if (renderDropIndicator && node.type !== 'item') {
+        pseudoProps = {
+          before: renderDropIndicator({type: 'item', key: node.key, dropPosition: 'before'}),
+          after: renderAfterDropIndicators(collection, node, renderDropIndicator)
+        };
       }
 
-      return (
-        <>
-          {renderDropIndicator({type: 'item', key: node.key, dropPosition: 'before'})}
-          {rendered}
-          {renderAfterDropIndicators(collection, node, renderDropIndicator)}
-        </>
-      );
+      return <CollectionNode {...pseudoProps} node={node} parent={parent} collection={collection} key={node.key} />;
     }
   });
 }
@@ -211,7 +234,7 @@ export function renderAfterDropIndicators(collection: ICollection<Node<unknown>>
   return afterIndicators;
 }
 
-export const CollectionRendererContext = createContext<CollectionRenderer>(DefaultCollectionRenderer);
+export const CollectionRendererContext = createContext<CollectionRenderer<any>>(DefaultCollectionRenderer);
 
 type PersistedKeysReturnValue = Set<Key> | null;
 export function usePersistedKeys(focusedKey: Key | null): PersistedKeysReturnValue {


### PR DESCRIPTION
This adds an optional `CollectionNode` component to the collection renderer interface, which enables customization of a nodes render output without having to re-implement the entire renderer. This can be useful to build wrapper components which modify a nodes pseudo content without breaking an existing custom renderer, e.g. `<Virtualizer />`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
