### PR TITLE
fix: Virtualized Tree DnD fixes

### DIFF
--- a/packages/@react-stately/layout/src/ListLayout.ts
+++ b/packages/@react-stately/layout/src/ListLayout.ts
@@ -585,7 +585,7 @@ export class ListLayout<T, O extends ListLayoutOptions = ListLayoutOptions> exte
     let layoutInfo = this.getLayoutInfo(target.key)!;
     let rect: Rect;
     if (target.dropPosition === 'before') {
-      rect = new Rect(layoutInfo.rect.x, layoutInfo.rect.y - this.dropIndicatorThickness / 2, layoutInfo.rect.width, this.dropIndicatorThickness);
+      rect = new Rect(layoutInfo.rect.x, Math.max(0, layoutInfo.rect.y - this.dropIndicatorThickness / 2), layoutInfo.rect.width, this.dropIndicatorThickness);
     } else if (target.dropPosition === 'after') {
       // Render after last visible descendant of the drop target.
       let targetNode = this.collection.getItem(target.key);

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -75,7 +75,26 @@ export function useDndPersistedKeys(selectionManager: MultipleSelectionManager, 
     dropTargetKey = dropState.target.key;
     if (dropState.target.dropPosition === 'after') {
       // Normalize to the "before" drop position since we only render those to the DOM.
-      dropTargetKey = dropState.collection.getKeyAfter(dropTargetKey) ?? dropTargetKey;
+      let nextKey = dropState.collection.getKeyAfter(dropTargetKey);
+      if (nextKey != null) {
+        let targetLevel = dropState.collection.getItem(dropTargetKey)?.level ?? 0;
+        // Skip over any rows that are descendants of the target (can't drop an item into itself)
+        while (nextKey) {
+          let node = dropState.collection.getItem(nextKey);
+          // eslint-disable-next-line max-depth
+          if (!node) {
+            break;
+          }
+          // Stop once we find a node at the same level or higher
+          // eslint-disable-next-line max-depth
+          if ((node.level ?? 0) <= targetLevel) {
+            break;
+          }
+          nextKey = dropState.collection.getKeyAfter(nextKey);
+        }
+      }
+
+      dropTargetKey = nextKey ?? dropTargetKey;
     }
   }
 

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -78,7 +78,7 @@ export function useDndPersistedKeys(selectionManager: MultipleSelectionManager, 
       let nextKey = dropState.collection.getKeyAfter(dropTargetKey);
       if (nextKey != null) {
         let targetLevel = dropState.collection.getItem(dropTargetKey)?.level ?? 0;
-        // Skip over any rows that are descendants of the target (can't drop an item into itself)
+        // Skip over any rows that are descendants of the target ("after" position should be after all children)
         while (nextKey) {
           let node = dropState.collection.getItem(nextKey);
           // eslint-disable-next-line max-depth


### PR DESCRIPTION
Fixes:
- Before-first-item drop indicator had -1px top positioning, making it hidden. Now we clamp to 0.
- Incorrect 'before' nextKey was being persisted for dnd. We now persist the 'before' the next key that isn't inside the target item. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

In [Tree with drag and drop (virtualized)](https://reactspectrum.blob.core.windows.net/reactspectrum/77d10acd3a3260b8d90e08cad399fcbed849639f/storybook/index.html?path=/story/react-aria-components-tree--tree-with-drag-and-drop-virtualized&providerSwitcher-express=false) story, scroll the tree all the way down, then back up. Tab to the first item's drag button and press 'Enter'. The correct drop target should be visible and scrolled to. Previously the collection itself would be showed as focused, and the drop target wouldn't show until manually scrolled into view.

## 🧢 Your Project:

<!--- Company/project for pull request -->
