### PR TITLE
fix: Mark copies of Parcel storybook packages as private

### DIFF
--- a/packages/dev/parcel-config-storybook/package.json
+++ b/packages/dev/parcel-config-storybook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@parcel/config-storybook",
   "version": "0.0.2",
+  "private": true,
   "main": "storybook-config.json",
   "engines": {
     "parcel": "^2.8.0"

--- a/packages/dev/parcel-resolver-storybook/package.json
+++ b/packages/dev/parcel-resolver-storybook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@parcel/resolver-storybook",
   "version": "0.0.0",
+  "private": true,
   "main": "dist/StorybookResolver.js",
   "source": "StorybookResolver.ts",
   "publishConfig": {

--- a/packages/dev/parcel-transformer-storybook/package.json
+++ b/packages/dev/parcel-transformer-storybook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@parcel/transformer-storybook",
   "version": "0.0.2",
+  "private": true,
   "main": "dist/StoryTransformer.js",
   "source": "StoryTransformer.ts",
   "engines": {

--- a/packages/dev/storybook-builder-parcel/package.json
+++ b/packages/dev/storybook-builder-parcel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "storybook-builder-parcel",
   "version": "0.0.1",
+  "private": true,
   "main": "preset.js",
   "dependencies": {
     "@parcel/core": "^2.13.1",

--- a/packages/dev/storybook-react-parcel/package.json
+++ b/packages/dev/storybook-react-parcel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "storybook-react-parcel",
   "version": "0.0.1",
+  "private": true,
   "main": "preset.js",
   "dependencies": {
     "@storybook/react": "^8.6.14",


### PR DESCRIPTION
Fixes verdaccio build.

Parcel packages for Storybook were copied into our repo for SB 8 work, but we forgot to mark them as private. Looks like we've been publishing nightly versions of them from our repo instead of the real one for a while 😬.

Additionally, they don't get version bumped by the verdaccio script, so when it goes to publish it conflicts with the existing version on npm and errors. Unfortunately this does not seem to fail the Circle CI build, which then moves on to the v-docs step. That proceeds to install the latest version from npm rather than the actual verdaccio build (which was never published). And now this fails during the build because we depend on new exports that aren't there in the current npm release.