### PR TITLE
feat(image): Pass crossOrigin prop in to Image

### DIFF
--- a/packages/@react-spectrum/image/src/Image.tsx
+++ b/packages/@react-spectrum/image/src/Image.tsx
@@ -61,7 +61,8 @@ function Image(props: SpectrumImageProps, ref: DOMRef<HTMLDivElement>) {
         style={{objectFit}}
         className={classNames(styles, 'spectrum-Image-img')} 
         onError={props?.onError}
-        onLoad={props?.onLoad} />
+        onLoad={props?.onLoad} 
+        crossOrigin={props?.crossOrigin} />
     </div>
   );
 });

--- a/packages/@react-spectrum/image/test/Image.test.js
+++ b/packages/@react-spectrum/image/test/Image.test.js
@@ -37,4 +37,41 @@ describe('Image', () => {
 
     expect(mockOnErrorCallback).toBeCalled();
   });
+
+  describe('crossorigin attribute', () => {
+    test('anonymous', () => {
+      const {container} = render(
+        <Image
+          src="https://i.imgur.com/Z7AzH2c.png"
+          alt="Sky and roof"
+          crossOrigin="anonymous" />
+      );
+
+      const img = container.querySelector('img');
+      expect(img).toHaveAttribute('crossorigin', 'anonymous');
+    });
+
+    test('use-credentials', () => {
+      const {container} = render(
+        <Image
+          src="https://i.imgur.com/Z7AzH2c.png"
+          alt="Sky and roof"
+          crossOrigin="use-credentials" />
+      );
+
+      const img = container.querySelector('img');
+      expect(img).toHaveAttribute('crossorigin', 'use-credentials');
+    });
+    
+    test('unset', () => {
+      const {container} = render(
+        <Image
+          src="https://i.imgur.com/Z7AzH2c.png"
+          alt="Sky and roof" />
+      );
+
+      const img = container.querySelector('img');
+      expect(img).not.toHaveAttribute('crossorigin');
+    });
+  });
 });

--- a/packages/@react-types/image/src/index.d.ts
+++ b/packages/@react-types/image/src/index.d.ts
@@ -33,7 +33,12 @@ export interface ImageProps {
   /**
    * Called when the image has successfully loaded, see [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).
    */
-  onLoad?: ReactEventHandler<HTMLImageElement>
+  onLoad?: ReactEventHandler<HTMLImageElement>,
+  /**
+   * Indicates if the fetching of the image must be done using a CORS request.
+   * [See MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin).
+   */
+  crossOrigin?: 'anonymous' | 'use-credentials'
 }
 
 export interface SpectrumImageProps extends ImageProps, DOMProps, StyleProps {


### PR DESCRIPTION
- Allow setting the crossOrigin prop on the Image component
- Added unit tests
- Updated doc strings for the prop (matching the s2 Image component)
- Fixes #8531

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:
- Check the Image component in Storybook, ensure it's still loading
- Ensure the unit tests pass

## 🧢 Your Project:
Deephaven