### PR TITLE
fix(dnd): Virtualized Tree DnD fixes 2

### DIFF
--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -85,7 +85,14 @@ export function useDndPersistedKeys(selectionManager: MultipleSelectionManager, 
           if (!node) {
             break;
           }
-          // Stop once we find a node at the same level or higher
+          // Skip over non-item nodes (e.g., loaders) since they can't be drop targets.
+          // eslint-disable-next-line max-depth
+          if (node.type !== 'item') {
+            nextKey = dropState.collection.getKeyAfter(nextKey);
+            continue;
+          }
+
+          // Stop once we find an item at the same level or higher
           // eslint-disable-next-line max-depth
           if ((node.level ?? 0) <= targetLevel) {
             break;

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -76,6 +76,7 @@ export function useDndPersistedKeys(selectionManager: MultipleSelectionManager, 
     if (dropState.target.dropPosition === 'after') {
       // Normalize to the "before" drop position since we only render those to the DOM.
       let nextKey = dropState.collection.getKeyAfter(dropTargetKey);
+      let lastDescendantKey: Key | null = null;
       if (nextKey != null) {
         let targetLevel = dropState.collection.getItem(dropTargetKey)?.level ?? 0;
         // Skip over any rows that are descendants of the target ("after" position should be after all children)
@@ -97,11 +98,14 @@ export function useDndPersistedKeys(selectionManager: MultipleSelectionManager, 
           if ((node.level ?? 0) <= targetLevel) {
             break;
           }
+          
+          lastDescendantKey = nextKey;
           nextKey = dropState.collection.getKeyAfter(nextKey);
         }
       }
 
-      dropTargetKey = nextKey ?? dropTargetKey;
+      // If nextKey is null (end of collection), use the last descendant
+      dropTargetKey = nextKey ?? lastDescendantKey ?? dropTargetKey;
     }
   }
 


### PR DESCRIPTION
Fixes to useDndPersistedKeys:
- For the last item in a collection, persist the last descendent of that item so we have the correct 'after' drop target.
- Skip non-item nodes since they can't be drop targets.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

In the `Tree with drag and drop (virtualized)` story, keyboard navigate down to "Reports". Start a keyboard drag of "Reports" . The correct drop target ('after' Reports) should be scrolled to and visible.

## 🧢 Your Project:

<!--- Company/project for pull request -->
