### PR TITLE
fix: ensuring IME composition works with controlled input fields

### DIFF
--- a/packages/@react-aria/numberfield/test/useNumberField.test.ts
+++ b/packages/@react-aria/numberfield/test/useNumberField.test.ts
@@ -1,6 +1,6 @@
 import {AriaNumberFieldProps} from '@react-types/numberfield';
 import React from 'react';
-import {renderHook} from '@react-spectrum/test-utils-internal';
+import {act, renderHook} from '@react-spectrum/test-utils-internal';
 import {useLocale} from '@react-aria/i18n';
 import {useNumberField} from '../';
 import {useNumberFieldState} from '@react-stately/numberfield';
@@ -70,9 +70,13 @@ describe('useNumberField hook', () => {
       expect(onCut).toHaveBeenCalled();
       inputProps.onPaste?.({} as any);
       expect(onPaste).toHaveBeenCalled();
-      inputProps.onCompositionStart?.({} as any);
+      act(() => {
+        inputProps.onCompositionStart?.({} as any);
+      });
       expect(onCompositionStart).toHaveBeenCalled();
-      inputProps.onCompositionEnd?.({} as any);
+      act(() => {
+        inputProps.onCompositionEnd?.({} as any);
+      });
       expect(onCompositionEnd).toHaveBeenCalled();
       inputProps.onCompositionUpdate?.({} as any);
       expect(onCompositionUpdate).toHaveBeenCalled();

--- a/packages/@react-aria/numberfield/test/useNumberField.test.ts
+++ b/packages/@react-aria/numberfield/test/useNumberField.test.ts
@@ -1,6 +1,6 @@
+import {actHook as act, renderHook} from '@react-spectrum/test-utils-internal';
 import {AriaNumberFieldProps} from '@react-types/numberfield';
 import React from 'react';
-import {act, renderHook} from '@react-spectrum/test-utils-internal';
 import {useLocale} from '@react-aria/i18n';
 import {useNumberField} from '../';
 import {useNumberFieldState} from '@react-stately/numberfield';


### PR DESCRIPTION
from testing 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Make sure you can type in combobox and autocomplete with Android (and maybe iPhone? depends if typing in iPhone is also by default a compositional event). Also make sure that typing with an IME works on desktop still. onChange in a textfield should still only fire when you end your IME composition.

## 🧢 Your Project:

RSP
