### PR TITLE
Feat: Add support for multiple adjacent collections

### DIFF
--- a/packages/@react-aria/collections/src/CollectionBuilder.tsx
+++ b/packages/@react-aria/collections/src/CollectionBuilder.tsx
@@ -37,6 +37,7 @@ export interface CollectionRenderProps<C extends BaseCollection<object>> {
   /** A hook that will be called by the collection builder to render the children. */
   useCollectionChildren?: (children: CollectionChildren<C>) => CollectionChildren<C>
   // TODO: Do we also want useCollection() to wrap createCollection()?
+  // TODO: Do we also want useCollectionDocument() to wrap doc retrieval?
 }
 
 interface CollectionRef<C extends BaseCollection<object>, E extends Element> extends RefObject<E | null>, CollectionRenderProps<C> {}

--- a/packages/@react-aria/collections/src/index.ts
+++ b/packages/@react-aria/collections/src/index.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-export {CollectionBuilder, Collection, createLeafComponent, createBranchComponent, useCollectionRef} from './CollectionBuilder';
-export {createHideableComponent, useIsHidden} from './Hidden';
+export {CollectionBuilder, Collection, createLeafComponent, createBranchComponent, useCollectionRef, useCollectionDocument} from './CollectionBuilder';
+export {createHideableComponent, useIsHidden, Hidden} from './Hidden';
 export {useCachedChildren} from './useCachedChildren';
 export {BaseCollection, CollectionNode} from './BaseCollection';
 

--- a/packages/@react-aria/collections/src/index.ts
+++ b/packages/@react-aria/collections/src/index.ts
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-export {CollectionBuilder, Collection, createLeafComponent, createBranchComponent} from './CollectionBuilder';
+export {CollectionBuilder, Collection, createLeafComponent, createBranchComponent, useCollectionRef} from './CollectionBuilder';
 export {createHideableComponent, useIsHidden} from './Hidden';
 export {useCachedChildren} from './useCachedChildren';
 export {BaseCollection, CollectionNode} from './BaseCollection';
 
-export type {CollectionBuilderProps, CollectionProps} from './CollectionBuilder';
+export type {CollectionBuilderProps, CollectionProps, CollectionRenderProps} from './CollectionBuilder';
 export type {CachedChildrenOptions} from './useCachedChildren';

--- a/packages/@react-aria/collections/test/CollectionBuilder.test.js
+++ b/packages/@react-aria/collections/test/CollectionBuilder.test.js
@@ -107,8 +107,8 @@ describe('CollectionBuilder', () => {
     };
 
     let Synchronizer = ({spy: Spy, children}) => {
-      let useCollectionContent = React.useCallback(() => false, []);
-      let useCollectionChildren = React.useCallback(() => () => false, []);
+      let useCollectionContent = React.useCallback(() => null, []);
+      let useCollectionChildren = React.useCallback(() => () => null, []);
         
       let refA = useCollectionRef({useCollectionContent, useCollectionChildren}, React.useRef(null));
       let refB = useCollectionRef({useCollectionContent, useCollectionChildren}, React.useRef(null));
@@ -135,8 +135,8 @@ describe('CollectionBuilder', () => {
     };
   
     let TwoWaySynchronizer = ({spy: Spy, children}) => {
-      let useCollectionContent = React.useCallback(() => false, []);
-      let useCollectionChildren = React.useCallback(() => () => false, []);
+      let useCollectionContent = React.useCallback(() => null, []);
+      let useCollectionChildren = React.useCallback(() => () => null, []);
   
       let stateA = useCollectionDocument();
       let stateB = useCollectionDocument();

--- a/packages/@react-aria/collections/test/CollectionBuilder.test.js
+++ b/packages/@react-aria/collections/test/CollectionBuilder.test.js
@@ -1,4 +1,4 @@
-import {Collection, CollectionBuilder, createLeafComponent} from '../src';
+import {Collection, CollectionBuilder, createLeafComponent, useCollectionRef} from '../src';
 import React from 'react';
 import {render} from '@testing-library/react';
 
@@ -6,8 +6,8 @@ const Item = createLeafComponent('item', () => {
   return <div />;
 });
 
-const renderItems = (items, spyCollection) => (
-  <CollectionBuilder content={<Collection>{items.map((item) => <Item key={item} />)}</Collection>}>
+const renderItems = (items, spyCollection, collectionRef) => (
+  <CollectionBuilder content={<Collection>{items.map((item) => <Item key={item} />)}</Collection>} collectionRef={collectionRef}>
     {collection => {
       spyCollection.current = collection;
       return null;
@@ -29,5 +29,30 @@ describe('CollectionBuilder', () => {
     expect(spyCollection.current.frozen).toBe(true);
     expect(spyCollection.current.firstKey).toBe(null);
     expect(spyCollection.current.lastKey).toBe(null);
+  });
+
+  it('should support modifying the content via useCollectionChildren', () => {
+    let spyCollection = {};
+    let ref = {current: null};
+    let TestBench = () => {
+      let collectionRef = useCollectionRef({useCollectionContent: () => false}, ref);
+      return renderItems(['a'], spyCollection, collectionRef);
+    };
+    render(<TestBench />);
+    expect(spyCollection.current.frozen).toBe(true);
+    expect(spyCollection.current.firstKey).toBe(null);
+    expect(spyCollection.current.lastKey).toBe(null);
+  });
+
+  it('should support modifying the rendered children via useCollectionChildren', () => {
+    let spyCollection = {};
+    let ref = {current: null};
+    let TestBench = () => {
+      let collectionRef = useCollectionRef({useCollectionChildren: (children) => (c) => <div ref={ref} children={children(c)} />}, ref);
+      return renderItems([], spyCollection, collectionRef);
+    };
+    render(<TestBench />);
+    expect(spyCollection.current.frozen).toBe(true);
+    expect(ref.current).not.toBe(null);
   });
 });

--- a/packages/@react-aria/collections/test/CollectionBuilder.test.js
+++ b/packages/@react-aria/collections/test/CollectionBuilder.test.js
@@ -1,4 +1,5 @@
-import {Collection, CollectionBuilder, createLeafComponent, useCollectionRef} from '../src';
+import {Collection, CollectionBuilder, createLeafComponent, useCollectionDocument, useCollectionRef} from '../src';
+import {mergeRefs, useObjectRef} from '@react-aria/utils';
 import React from 'react';
 import {render} from '@testing-library/react';
 
@@ -7,7 +8,7 @@ const Item = createLeafComponent('item', () => {
 });
 
 const renderItems = (items, spyCollection, collectionRef) => (
-  <CollectionBuilder content={<Collection>{items.map((item) => <Item key={item} />)}</Collection>} collectionRef={collectionRef}>
+  <CollectionBuilder content={<Collection>{items.map((item) => <Item id={item} key={item} textValue={item} />)}</Collection>} collectionRef={collectionRef}>
     {collection => {
       spyCollection.current = collection;
       return null;
@@ -31,7 +32,7 @@ describe('CollectionBuilder', () => {
     expect(spyCollection.current.lastKey).toBe(null);
   });
 
-  it('should support modifying the content via useCollectionChildren', () => {
+  it('should support modifying the content via useCollectionContent', () => {
     let spyCollection = {};
     let ref = {current: null};
     let TestBench = () => {
@@ -54,5 +55,163 @@ describe('CollectionBuilder', () => {
     render(<TestBench />);
     expect(spyCollection.current.frozen).toBe(true);
     expect(ref.current).not.toBe(null);
+  });
+
+  describe('synchronization', () => {
+    let CollectionAContext = React.createContext(null);
+    let CollectionAStateContext = React.createContext(null);
+    let CollectionBContext = React.createContext(null);
+    let CollectionBStateContext = React.createContext(null);
+  
+    let CollectionA = React.forwardRef(({items}, ref) => {
+      let ctx = React.useContext(CollectionAContext);
+      let state = React.useContext(CollectionAStateContext);
+      let mergedRef = useObjectRef(React.useMemo(() => mergeRefs(ref, ctx), [ref, ctx]));
+  
+      if (state) {
+        return (
+          <div data-testid="collection-a">
+            {Array.from(state).map(item => <div data-testid={item.key} key={item.key} />)}
+          </div>
+        );
+      }
+  
+      return renderItems(items, {}, mergedRef);
+    });
+  
+    let CollectionB = React.forwardRef(({items}, ref) => {
+      let ctx = React.useContext(CollectionBContext);
+      let state = React.useContext(CollectionBStateContext);
+      let mergedRef = useObjectRef(React.useMemo(() => mergeRefs(ref, ctx), [ref, ctx]));
+  
+      if (state) {
+        return (
+          <div data-testid="collection-b">
+            {Array.from(state).map(item => <div data-testid={item.key} key={item.key} />)}
+          </div>
+        );
+      }
+  
+      return renderItems(items, {}, mergedRef);
+    });
+  
+    let Synchronized = ({collectionA, collectionB, children, filterFn}) => {
+      let synchronized = React.useMemo(() => filterFn(collectionA, collectionB), [filterFn, collectionA, collectionB]);
+      return (
+        <CollectionAStateContext.Provider value={synchronized.collectionA}>
+          <CollectionBStateContext.Provider value={synchronized.collectionB}>
+            {children}
+          </CollectionBStateContext.Provider>
+        </CollectionAStateContext.Provider>
+      );
+    };
+
+    let Synchronizer = ({spy: Spy, children}) => {
+      let useCollectionContent = React.useCallback(() => false, []);
+      let useCollectionChildren = React.useCallback(() => () => false, []);
+        
+      let refA = useCollectionRef({useCollectionContent, useCollectionChildren}, React.useRef(null));
+      let refB = useCollectionRef({useCollectionContent, useCollectionChildren}, React.useRef(null));
+  
+      let contentA = <CollectionBContext.Provider value={refB}>{children}</CollectionBContext.Provider>;
+      let contentB = <CollectionAContext.Provider value={refA}>{children}</CollectionAContext.Provider>;
+
+      // One way because changes in the DocumentB will not trigger a rerender of DocumentA
+      let filterFn = React.useCallback((cA, cB) => {
+        let keysA = new Set(cA.getKeys());
+        return {collectionA: cA, collectionB: cB.UNSTABLE_filter(item => keysA.has(item))};
+      }, []);
+  
+      return (
+        <CollectionBuilder content={contentA}>
+          {(c1) => (<CollectionBuilder content={contentB}>
+            {(c2) => (<>
+              <Synchronized collectionA={c1} collectionB={c2} children={children} filterFn={filterFn} />
+              <Spy collectionA={c1} collectionB={c2} />
+            </>)}
+          </CollectionBuilder>)}
+        </CollectionBuilder>
+      );
+    };
+  
+    let TwoWaySynchronizer = ({spy: Spy, children}) => {
+      let useCollectionContent = React.useCallback(() => false, []);
+      let useCollectionChildren = React.useCallback(() => () => false, []);
+  
+      let stateA = useCollectionDocument();
+      let stateB = useCollectionDocument();
+  
+      let useCollectionDocumentA = React.useCallback(() => stateA, [stateA]);
+      let useCollectionDocumentB = React.useCallback(() => stateB, [stateB]);
+  
+      let refA = useCollectionRef({useCollectionContent, useCollectionChildren}, React.useRef(null));
+      let contentA = <CollectionBContext.Provider value={refA}>{children}</CollectionBContext.Provider>;
+  
+      let refB = useCollectionRef({useCollectionContent, useCollectionChildren}, React.useRef(null));
+      let contentB = <CollectionAContext.Provider value={refB}>{children}</CollectionAContext.Provider>;
+  
+      let refA2 = useCollectionRef({useCollectionDocument: useCollectionDocumentA}, React.useRef(null));
+      let refB2 = useCollectionRef({useCollectionDocument: useCollectionDocumentB}, React.useRef(null));
+
+      let filterFn = React.useCallback((cA, cB) => {
+        let keysA = new Set(cA.getKeys()), keysB = new Set(cB.getKeys());
+        let collectionA = cA.UNSTABLE_filter(item => keysB.has(item));
+        let collectionB = cB.UNSTABLE_filter(item => keysA.has(item));
+        return {collectionA, collectionB};
+      }, []);
+  
+      return (
+        <>
+          <CollectionBuilder content={contentA} collectionRef={refA2} children={useCollectionChildren()} />
+          <CollectionBuilder content={contentB} collectionRef={refB2} children={useCollectionChildren()} />
+          <Synchronized collectionA={stateA.collection} collectionB={stateB.collection} children={children} filterFn={filterFn} />
+          <Spy collectionA={stateA.collection} collectionB={stateB.collection} />
+        </>
+      );
+    };
+
+    it('should support one-way synchronization of multiple collections', () => {
+      let Spy = jest.fn();
+      
+      // Synchronizer will force CollectionB to only be rendered with keys of CollectionA
+      let {queryAllByTestId} = render(
+        <Synchronizer spy={Spy}>
+          <CollectionA items={['a', 'b']} />
+          <CollectionB items={['a', 'c']} />
+        </Synchronizer>
+      );
+  
+      expect(Spy).toHaveBeenCalledTimes(2);
+      expect(Spy.mock.calls[1][0].collectionA.getFirstKey()).toBe('a');
+      expect(Spy.mock.calls[1][0].collectionA.getLastKey()).toBe('b');
+      expect(Spy.mock.calls[1][0].collectionB.getFirstKey()).toBe('a');
+      expect(Spy.mock.calls[1][0].collectionB.getLastKey()).toBe('c');
+  
+      expect(queryAllByTestId('a')).toHaveLength(2);
+      expect(queryAllByTestId('b')).toHaveLength(1);
+      expect(queryAllByTestId('c')).toHaveLength(0);
+    });
+      
+    it('should support two-way synchronization of multiple collections', () => {
+      let Spy = jest.fn();
+      
+      // TwoWaySynchronizer will force both collections to only be rendered with mutually shared keys
+      let {queryAllByTestId} = render(
+        <TwoWaySynchronizer spy={Spy}>
+          <CollectionA items={['a', 'b']} />
+          <CollectionB items={['a', 'c']} />
+        </TwoWaySynchronizer>
+      );
+  
+      expect(Spy).toHaveBeenCalledTimes(2);
+      expect(Spy.mock.calls[1][0].collectionA.getFirstKey()).toBe('a');
+      expect(Spy.mock.calls[1][0].collectionA.getLastKey()).toBe('b');
+      expect(Spy.mock.calls[1][0].collectionB.getFirstKey()).toBe('a');
+      expect(Spy.mock.calls[1][0].collectionB.getLastKey()).toBe('c');
+  
+      expect(queryAllByTestId('a')).toHaveLength(2);
+      expect(queryAllByTestId('b')).toHaveLength(0);
+      expect(queryAllByTestId('c')).toHaveLength(0);
+    });
   });
 });

--- a/packages/@react-aria/collections/test/CollectionBuilder.test.js
+++ b/packages/@react-aria/collections/test/CollectionBuilder.test.js
@@ -171,7 +171,7 @@ describe('CollectionBuilder', () => {
     };
 
     it('should support one-way synchronization of multiple collections', () => {
-      let Spy = jest.fn();
+      let Spy = jest.fn(() => null);
       
       // Synchronizer will force CollectionB to only be rendered with keys of CollectionA
       let {queryAllByTestId} = render(
@@ -193,7 +193,7 @@ describe('CollectionBuilder', () => {
     });
       
     it('should support two-way synchronization of multiple collections', () => {
-      let Spy = jest.fn();
+      let Spy = jest.fn(() => null);
       
       // TwoWaySynchronizer will force both collections to only be rendered with mutually shared keys
       let {queryAllByTestId} = render(

--- a/packages/@react-aria/utils/src/mergeRefs.ts
+++ b/packages/@react-aria/utils/src/mergeRefs.ts
@@ -20,7 +20,7 @@ export function mergeRefs<T>(...refs: Array<Ref<T> | MutableRefObject<T> | null 
     return refs[0];
   }
 
-  return (value: T | null) => {
+  let callbackRef = (value: T | null) => {
     let hasCleanup = false;
 
     const cleanups = refs.map(ref => {
@@ -41,6 +41,8 @@ export function mergeRefs<T>(...refs: Array<Ref<T> | MutableRefObject<T> | null 
       };
     }
   };
+
+  return Object.assign(callbackRef, ...refs.filter(Boolean));
 }
 
 function setRef<T>(ref: Ref<T> | MutableRefObject<T> | null | undefined, value: T) {

--- a/packages/@react-aria/utils/src/useObjectRef.ts
+++ b/packages/@react-aria/utils/src/useObjectRef.ts
@@ -49,6 +49,7 @@ export function useObjectRef<T>(ref?: ((instance: T | null) => (() => void) | vo
 
   return useMemo(
     () => ({
+      ...ref,
       get current() {
         return objRef.current;
       },
@@ -64,6 +65,6 @@ export function useObjectRef<T>(ref?: ((instance: T | null) => (() => void) | vo
         }
       }
     }),
-    [refEffect]
+    [ref, refEffect]
   );
 }

--- a/packages/@react-aria/utils/test/mergeRefs.test.tsx
+++ b/packages/@react-aria/utils/test/mergeRefs.test.tsx
@@ -33,18 +33,15 @@ describe('mergeRefs', () => {
   });
 
   it('should support additional properties on the refs', () => {
-    let ref1;
-    let ref2;
-
-    const TextField = (props) => {
-      ref1 = useRef(null);
-      ref1.foo = 'bar';
-
-      ref2 = mergeRefs(ref1, ref2);
-      return <input {...props} ref={ref2} />;
-    };
-    render(<TextField />);
-    expect(ref2.foo).toBe('bar');
+    // We mock refs here because they are only mutable in React18+
+    let ref1 = {current: null};
+    let ref2 = {current: null, foo: 'bar'};
+    let ref3 = (() => {}) as any;
+    ref3.baz = 'foo';
+    
+    let ref = mergeRefs(ref1, ref2, ref3) as any;
+    expect(ref.foo).toBe('bar');
+    expect(ref.baz).toBe('foo');
   });
 
   if (parseInt(React.version.split('.')[0], 10) >= 19) {

--- a/packages/@react-aria/utils/test/mergeRefs.test.tsx
+++ b/packages/@react-aria/utils/test/mergeRefs.test.tsx
@@ -32,6 +32,21 @@ describe('mergeRefs', () => {
     expect(ref1.current).toBe(ref2.current);
   });
 
+  it('should support additional properties on the refs', () => {
+    let ref1;
+    let ref2;
+
+    const TextField = (props) => {
+      ref1 = useRef(null);
+      ref1.foo = 'bar';
+
+      ref2 = mergeRefs(ref1, ref2);
+      return <input {...props} ref={ref2} />;
+    };
+    render(<TextField />);
+    expect(ref2.foo).toBe('bar');
+  });
+
   if (parseInt(React.version.split('.')[0], 10) >= 19) {
     it('merge Ref Cleanup', () => {
       const cleanUp = jest.fn();

--- a/packages/@react-aria/utils/test/useObjectRef.test.js
+++ b/packages/@react-aria/utils/test/useObjectRef.test.js
@@ -63,6 +63,17 @@ describe('useObjectRef', () => {
     expect(ref).toHaveBeenCalledTimes(1);
   });
 
+  it('should support additional properties on the ref', () => {
+    const TextField = React.forwardRef((props, forwardedRef) => {
+      const ref = useObjectRef(forwardedRef);
+      return <input {...props} ref={ref} />;
+    });
+
+    let ref = {current: null, foo: 'bar'};
+    render(<TextField ref={ref} />);
+    expect(ref.foo).toBe('bar');
+  });
+
   /**
    * This describe would completely fail if `useObjectRef` did not account
    * for order of execution and rendering, especially when other components

--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -146,7 +146,8 @@ export const Tabs = forwardRef(function Tabs(props: TabsProps, ref: DOMRef<HTMLD
           'aria-labelledby': props['aria-labelledby']
         }]
       ]}>
-      <CollectionBuilder content={props.children}>
+      {/* @ts-expect-error */}
+      <CollectionBuilder content={props.children} collectionRef={ref}>
         {collection => (
           <CollapsingTabs
             {...props}

--- a/packages/@react-spectrum/s2/src/TagGroup.tsx
+++ b/packages/@react-spectrum/s2/src/TagGroup.tsx
@@ -92,7 +92,8 @@ export const TagGroup = /*#__PURE__*/ (forwardRef as forwardRefType)(function Ta
   let {onRemove} = props;
   return (
     <InternalTagGroupContext.Provider value={{onRemove}}>
-      <CollectionBuilder content={<Collection {...props} />}>
+      {/* @ts-expect-error */}
+      <CollectionBuilder content={<Collection {...props} />} collectionRef={ref}>
         {collection => <TagGroupInner props={props} forwardedRef={ref} collection={collection} />}
       </CollectionBuilder>
     </InternalTagGroupContext.Provider>

--- a/packages/react-aria-components/src/Breadcrumbs.tsx
+++ b/packages/react-aria-components/src/Breadcrumbs.tsx
@@ -38,7 +38,7 @@ export const Breadcrumbs = /*#__PURE__*/ (forwardRef as forwardRefType)(function
   let DOMProps = filterDOMProps(props, {global: true});
 
   return (
-    <CollectionBuilder content={<Collection {...props} />}>
+    <CollectionBuilder content={<Collection {...props} />} collectionRef={ref}>
       {collection => (
         <ol
           ref={ref}

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -87,7 +87,7 @@ export const ComboBox = /*#__PURE__*/ (forwardRef as forwardRefType)(function Co
   ), [children, isDisabled, isInvalid, isRequired, props.items, props.defaultItems]);
 
   return (
-    <CollectionBuilder content={content}>
+    <CollectionBuilder content={content} collectionRef={ref}>
       {collection => <ComboBoxInner props={props} collection={collection} comboBoxRef={ref} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -90,7 +90,7 @@ export const GridList = /*#__PURE__*/ (forwardRef as forwardRefType)(function Gr
   [props, ref] = useContextProps(props, ref, GridListContext);
 
   return (
-    <CollectionBuilder content={<Collection {...props} />}>
+    <CollectionBuilder content={<Collection {...props} />} collectionRef={ref}>
       {collection => <GridListInner props={props} collection={collection} gridListRef={ref} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -100,7 +100,7 @@ export const ListBox = /*#__PURE__*/ (forwardRef as forwardRefType)(function Lis
   }
 
   return (
-    <CollectionBuilder content={<Collection {...props} />}>
+    <CollectionBuilder content={<Collection {...props} />} collectionRef={ref}>
       {collection => <StandaloneListBox props={props} listBoxRef={ref} collection={collection} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -169,7 +169,7 @@ export const Menu = /*#__PURE__*/ (forwardRef as forwardRefType)(function Menu<T
 
   // Delay rendering the actual menu until we have the collection so that auto focus works properly.
   return (
-    <CollectionBuilder content={<Collection {...props} />}>
+    <CollectionBuilder content={<Collection {...props} />} collectionRef={ref}>
       {collection => <MenuInner props={props} collection={collection} menuRef={ref} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -94,7 +94,7 @@ export const Select = /*#__PURE__*/ (forwardRef as forwardRefType)(function Sele
   ), [children, isDisabled, isInvalid, isRequired]);
 
   return (
-    <CollectionBuilder content={content}>
+    <CollectionBuilder content={content} collectionRef={ref}>
       {collection => <SelectInner props={props} collection={collection} selectRef={ref} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -348,7 +348,7 @@ export const Table = forwardRef(function Table(props: TableProps, ref: Forwarded
   );
 
   return (
-    <CollectionBuilder content={content} createCollection={() => new TableCollection<any>()}>
+    <CollectionBuilder content={content} createCollection={() => new TableCollection<any>()} collectionRef={ref}>
       {collection => <TableInner props={props} forwardedRef={ref as any} selectionState={selectionState} collection={collection} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -131,7 +131,7 @@ export const Tabs = /*#__PURE__*/ (forwardRef as forwardRefType)(function Tabs(p
   ), [children, orientation]);
 
   return (
-    <CollectionBuilder content={children}>
+    <CollectionBuilder content={children} collectionRef={ref}>
       {collection => <TabsInner props={props} collection={collection} tabsRef={ref} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/TagGroup.tsx
+++ b/packages/react-aria-components/src/TagGroup.tsx
@@ -61,7 +61,7 @@ export const TagListContext = createContext<ContextValue<TagListProps<any>, HTML
 export const TagGroup = /*#__PURE__*/ (forwardRef as forwardRefType)(function TagGroup(props: TagGroupProps, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, TagGroupContext);
   return (
-    <CollectionBuilder content={props.children}>
+    <CollectionBuilder content={props.children} collectionRef={ref}>
       {collection => <TagGroupInner props={props} forwardedRef={ref} collection={collection} />}
     </CollectionBuilder>
   );

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -164,7 +164,7 @@ export const Tree = /*#__PURE__*/ (forwardRef as forwardRefType)(function Tree<T
   [props, ref] = useContextProps(props, ref, TreeContext);
 
   return (
-    <CollectionBuilder content={<Collection {...props} />}>
+    <CollectionBuilder content={<Collection {...props} />} collectionRef={ref}>
       {collection => <TreeInner props={props} collection={collection} treeRef={ref} />}
     </CollectionBuilder>
   );


### PR DESCRIPTION
This PR adds support for hooking into the `CollectionBuilder` of child collections via a new `useCollectionRef` hook. This hook supports the attachment of wrapper hooks to the ref of the collection element, which enables advanced controlled use cases, such as a hoisting multiple collections to a parent component.

Background: We make use of this in our `Carousel`, which provides a custom collection renderer to implement its scroll controls and infinite loops. `Carousel` supports an adjacent collection next to a `GridList` or `ListBox` for the tabbed carousel pattern, so we require a way to target the renderer & builder of specific slots 👍 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
