### PR TITLE
fix: React 19 strict mode drag and drop bug

### DIFF
--- a/packages/@react-aria/dnd/src/useDrag.ts
+++ b/packages/@react-aria/dnd/src/useDrag.ts
@@ -12,13 +12,13 @@
 
 import {AriaButtonProps} from '@react-types/button';
 import {DragEndEvent, DragItem, DragMoveEvent, DragPreviewRenderer, DragStartEvent, DropOperation, PressEvent, RefObject} from '@react-types/shared';
-import {DragEvent, HTMLAttributes, useRef, useState} from 'react';
+import {DragEvent, HTMLAttributes, useEffect, useRef, useState} from 'react';
 import * as DragManager from './DragManager';
 import {DROP_EFFECT_TO_DROP_OPERATION, DROP_OPERATION, EFFECT_ALLOWED} from './constants';
 import {globalDropEffect, setGlobalAllowedDropOperations, setGlobalDropEffect, useDragModality, writeToDataTransfer} from './utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {isVirtualClick, isVirtualPointerEvent, useDescription, useGlobalListeners, useLayoutEffect} from '@react-aria/utils';
+import {isVirtualClick, isVirtualPointerEvent, useDescription, useGlobalListeners} from '@react-aria/utils';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 
 export interface DragOptions {
@@ -82,11 +82,11 @@ export function useDrag(options: DragOptions): DragResult {
     y: 0
   }).current;
   state.options = options;
-  let isDraggingRef = useRef(false);
+  let isDraggingRef = useRef<Element | null>(null);
   let [isDragging, setDraggingState] = useState(false);
-  let setDragging = (isDragging) => {
-    isDraggingRef.current = isDragging;
-    setDraggingState(isDragging);
+  let setDragging = (element: Element | null) => {
+    isDraggingRef.current = element;
+    setDraggingState(!!element);
   };
   let {addGlobalListener, removeAllGlobalListeners} = useGlobalListeners();
   let modalityOnPointerDown = useRef<string>(null);
@@ -186,8 +186,9 @@ export function useDrag(options: DragOptions): DragResult {
 
     // Wait a frame before we set dragging to true so that the browser has time to
     // render the preview image before we update the element that has been dragged.
+    let target = e.target;
     requestAnimationFrame(() => {
-      setDragging(true);
+      setDragging(target as Element);
     });
   };
 
@@ -231,7 +232,7 @@ export function useDrag(options: DragOptions): DragResult {
       options.onDragEnd(event);
     }
 
-    setDragging(false);
+    setDragging(null);
     removeAllGlobalListeners();
     setGlobalAllowedDropOperations(DROP_OPERATION.none);
     setGlobalDropEffect(undefined);
@@ -240,9 +241,11 @@ export function useDrag(options: DragOptions): DragResult {
   // If the dragged element is removed from the DOM via onDrop, onDragEnd won't fire: https://bugzilla.mozilla.org/show_bug.cgi?id=460801
   // In this case, we need to manually call onDragEnd on cleanup
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     return () => {
-      if (isDraggingRef.current) {
+      // Check that the dragged element has actually unmounted from the DOM and not a React Strict Mode false positive.
+      // https://github.com/facebook/react/issues/29585
+      if (isDraggingRef.current && !isDraggingRef.current.isConnected) {
         if (typeof state.options.onDragEnd === 'function') {
           let event: DragEndEvent = {
             type: 'dragend',
@@ -253,7 +256,7 @@ export function useDrag(options: DragOptions): DragResult {
           state.options.onDragEnd(event);
         }
 
-        setDragging(false);
+        setDragging(null);
         setGlobalAllowedDropOperations(DROP_OPERATION.none);
         setGlobalDropEffect(undefined);
       }
@@ -285,14 +288,14 @@ export function useDrag(options: DragOptions): DragResult {
         ? state.options.getAllowedDropOperations()
         : ['move', 'copy', 'link'],
       onDragEnd(e) {
-        setDragging(false);
+        setDragging(null);
         if (typeof state.options.onDragEnd === 'function') {
           state.options.onDragEnd(e);
         }
       }
     }, stringFormatter);
 
-    setDragging(true);
+    setDragging(target);
   };
 
   let modality = useDragModality();

--- a/packages/@react-spectrum/list/test/ListViewDnd.test.js
+++ b/packages/@react-spectrum/list/test/ListViewDnd.test.js
@@ -434,12 +434,7 @@ describe('ListView', function () {
         expect(onDrop).toHaveBeenCalledTimes(1);
 
         fireEvent(cell, new DragEvent('dragend', {dataTransfer, clientX: 1, clientY: 110}));
-        // TODO: fix in strict mode, due to https://github.com/facebook/react/issues/29585
-        if (isReact19) {
-          expect(onDragEnd).toHaveBeenCalledTimes(2);
-        } else {
-          expect(onDragEnd).toHaveBeenCalledTimes(1);
-        }
+        expect(onDragEnd).toHaveBeenCalledTimes(1);
 
         act(() => jest.runAllTimers());
 
@@ -482,18 +477,10 @@ describe('ListView', function () {
         fireEvent(grid, new DragEvent('drop', {dataTransfer, clientX: 1, clientY: 150}));
         act(() => jest.runAllTimers());
         await act(async () => Promise.resolve());
-        if (isReact19) {
-          expect(onDrop).toHaveBeenCalledTimes(1);
-        } else {
-          expect(onDrop).toHaveBeenCalledTimes(1);
-        }
+        expect(onDrop).toHaveBeenCalledTimes(1);
 
         fireEvent(cell, new DragEvent('dragend', {dataTransfer, clientX: 1, clientY: 150}));
-        if (isReact19) {
-          expect(onDragEnd).toHaveBeenCalledTimes(2);
-        } else {
-          expect(onDragEnd).toHaveBeenCalledTimes(1);
-        }
+        expect(onDrop).toHaveBeenCalledTimes(1);
 
         act(() => jest.runAllTimers());
 


### PR DESCRIPTION
Closes #8548

Due to https://github.com/facebook/react/issues/29585, React sometimes triggers extra effect cleanups when elements are reordered. This can occur during virtualized scrolling. When keyboard dragging and scrolling the dragged element out of view, the drop target would unexpectedly shift to another target. The layout effect caused the drag to be aborted and the global state to reset, resulting in our `isInternal` checks failing.

This stores the actual dragged element in a ref instead of just a boolean. Then in the effect cleanup we check if the element has actually unmounted from the DOM. This will ignore false positives caused by strict mode where React calls the cleanup function even when not actually unmounting.