### PR TITLE
fix(TreeDropTargetDelegate): only normalize to 'after' target if valid

### DIFF
--- a/packages/react-aria-components/src/TreeDropTargetDelegate.ts
+++ b/packages/react-aria-components/src/TreeDropTargetDelegate.ts
@@ -84,11 +84,15 @@ export class TreeDropTargetDelegate<T> {
     if (target.dropPosition === 'before') {
       let keyBefore = this.state!.collection.getKeyBefore(target.key);
       if (keyBefore != null) {
-        target = {
+        let convertedTarget = {
           type: 'item',
           key: keyBefore,
           dropPosition: 'after'
         } as const;
+
+        if (isValidDropTarget(convertedTarget)) {
+          target = convertedTarget;
+        }
       }
     }
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8561

We normalize to the 'after' drop target, but previously this could have been one of the dragged items (not a valid drop target). Now, we make sure the normalized target is a valid drop target before using it.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Try steps from  https://github.com/adobe/react-spectrum/issues/8561

## 🧢 Your Project:

<!--- Company/project for pull request -->
