### PR TITLE
fix: do not dispatch loadMore if hook is still in loading state

### DIFF
--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -13,7 +13,6 @@
 import {action} from '@storybook/addon-actions';
 import {
   ActionButton,
-  ActionButtonGroup,
   Cell,
   Column,
   Content,
@@ -33,7 +32,7 @@ import {categorizeArgTypes} from './utils';
 import Filter from '../s2wf-icons/S2_Icon_Filter_20_N.svg';
 import FolderOpen from '../spectrum-illustrations/linear/FolderOpen';
 import type {Meta, StoryObj} from '@storybook/react';
-import {ReactElement, useEffect, useState} from 'react';
+import {ReactElement, useState} from 'react';
 import {SortDescriptor} from 'react-aria-components';
 import {style} from '../style/spectrum-theme' with {type: 'macro'};
 import {useAsyncList} from '@react-stately/data';
@@ -1389,62 +1388,3 @@ const ResizableTable = () => {
     }
   }
 };
-
-
-export const Test = {
-  render: () => {
-    return <SWTable />;
-  }
-};
-
-function SWTable() {
-  const [film, setFilm] = useState(undefined);
-
-  interface Item {
-    id: string,
-    title: string
-  }
-
-  let list = useAsyncList<Item>({
-    async load({signal, cursor}) {
-      if (cursor) {
-        cursor = cursor.replace(/^http:\/\//i, 'https://');
-      }
-      let items = [];
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search&film=${film}`, {signal});
-      let json = await res.json();
-      items = json.results.map((element) => ({title: element.name}));
-
-      return {
-        items: items,
-        cursor: json.next
-      };
-    }
-  });
-
-  useEffect(() => {
-    list.reload();
-  }, [film]);
-
-  return (
-    <div>
-      <ActionButtonGroup aria-label="group">
-        <ActionButton onPress={() => setFilm(undefined)}>All</ActionButton>
-        <ActionButton onPress={() => setFilm('https://swapi.py4e.com/api/films/1/')}>A New Hope</ActionButton>
-      </ActionButtonGroup>
-      <TableView aria-label="Characters" loadingState={list.loadingState} onLoadMore={list.loadMore} styles={style({height: 200, width: 400})}>
-        <TableHeader>
-          <Column isRowHeader>Name</Column>
-        </TableHeader>
-        <TableBody items={list.items}>
-          {
-            item => (<Row id={item.title}>
-              <Cell>{item.title}</Cell>
-            </Row>)
-          }
-        </TableBody>
-      </TableView>
-    </div>
-  );
-}

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -1400,10 +1400,13 @@ export const Test = {
 function SWTable() {
   const [film, setFilm] = useState(undefined);
 
+  interface Item {
+    id: string,
+    title: string
+  }
 
-  let list = useAsyncList({
+  let list = useAsyncList<Item>({
     async load({signal, cursor}) {
-      console.log('load', cursor, film);
       if (cursor) {
         cursor = cursor.replace(/^http:\/\//i, 'https://');
       }
@@ -1411,7 +1414,7 @@ function SWTable() {
       await new Promise(resolve => setTimeout(resolve, 1500));
       let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search&film=${film}`, {signal});
       let json = await res.json();
-      items = json.results.map((element, index) => ({title: element.name}));
+      items = json.results.map((element) => ({title: element.name}));
 
       return {
         items: items,

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -11,12 +11,29 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionButton, Cell, Column, Content, Heading, IllustratedMessage, Link, MenuItem, MenuSection, Row, TableBody, TableHeader, TableView, TableViewProps, Text} from '../src';
+import {
+  ActionButton,
+  ActionButtonGroup,
+  Cell,
+  Column,
+  Content,
+  Heading,
+  IllustratedMessage,
+  Link,
+  MenuItem,
+  MenuSection,
+  Row,
+  TableBody,
+  TableHeader,
+  TableView,
+  TableViewProps,
+  Text
+} from '../src';
 import {categorizeArgTypes} from './utils';
 import Filter from '../s2wf-icons/S2_Icon_Filter_20_N.svg';
 import FolderOpen from '../spectrum-illustrations/linear/FolderOpen';
 import type {Meta, StoryObj} from '@storybook/react';
-import {ReactElement, useState} from 'react';
+import {ReactElement, useEffect, useState} from 'react';
 import {SortDescriptor} from 'react-aria-components';
 import {style} from '../style/spectrum-theme' with {type: 'macro'};
 import {useAsyncList} from '@react-stately/data';
@@ -1372,3 +1389,59 @@ const ResizableTable = () => {
     }
   }
 };
+
+
+export const Test = {
+  render: () => {
+    return <SWTable />;
+  }
+};
+
+function SWTable() {
+  const [film, setFilm] = useState(undefined);
+
+
+  let list = useAsyncList({
+    async load({signal, cursor}) {
+      console.log('load', cursor, film);
+      if (cursor) {
+        cursor = cursor.replace(/^http:\/\//i, 'https://');
+      }
+      let items = [];
+      await new Promise(resolve => setTimeout(resolve, 1500));
+      let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search&film=${film}`, {signal});
+      let json = await res.json();
+      items = json.results.map((element, index) => ({title: element.name}));
+
+      return {
+        items: items,
+        cursor: json.next
+      };
+    }
+  });
+
+  useEffect(() => {
+    list.reload();
+  }, [film]);
+
+  return (
+    <div>
+      <ActionButtonGroup aria-label="group">
+        <ActionButton onPress={() => setFilm(undefined)}>All</ActionButton>
+        <ActionButton onPress={() => setFilm('https://swapi.py4e.com/api/films/1/')}>A New Hope</ActionButton>
+      </ActionButtonGroup>
+      <TableView aria-label="Characters" loadingState={list.loadingState} onLoadMore={list.loadMore} styles={style({height: 200, width: 400})}>
+        <TableHeader>
+          <Column isRowHeader>Name</Column>
+        </TableHeader>
+        <TableBody items={list.items}>
+          {
+            item => (<Row id={item.title}>
+              <Cell>{item.title}</Cell>
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    </div>
+  );
+}

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -33,7 +33,7 @@ import {Meta, StoryFn, StoryObj} from '@storybook/react';
 import NoSearchResults from '@spectrum-icons/illustrations/NoSearchResults';
 import {Picker} from '@react-spectrum/picker';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
-import React, {JSX, useCallback, useEffect, useState} from 'react';
+import React, {JSX, useCallback, useState} from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
 import {Switch} from '@react-spectrum/switch';
 import {TextField} from '@react-spectrum/textfield';
@@ -2262,61 +2262,3 @@ export const AsyncLoadOverflowWrapReproStory: TableStory = {
 };
 
 export {Performance} from './Performance';
-
-
-export const Test = {
-  render: () => {
-    return <SWTable />;
-  }
-};
-
-function SWTable() {
-  const [film, setFilm] = useState(undefined);
-
-  interface Item {
-    id: string,
-    title: string
-  }
-
-  let list = useAsyncList<Item>({
-    async load({signal, cursor}) {
-      console.log('load', cursor, film);
-      if (cursor) {
-        cursor = cursor.replace(/^http:\/\//i, 'https://');
-      }
-      let items = [];
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search&film=${film}`, {signal});
-      let json = await res.json();
-      items = json.results.map((element) => ({title: element.name}));
-
-      return {
-        items: items,
-        cursor: json.next
-      };
-    }
-  });
-
-  useEffect(() => {
-    list.reload();
-  }, [film]);
-
-  return (
-    <div>
-      <ActionButton onPress={() => setFilm(undefined)}>All</ActionButton>
-      <ActionButton onPress={() => setFilm('https://swapi.py4e.com/api/films/1/')}>A New Hope</ActionButton>
-      <TableView aria-label="Characters"  height={200} width={400}>
-        <TableHeader>
-          <Column isRowHeader>Name</Column>
-        </TableHeader>
-        <TableBody items={list.items} loadingState={list.loadingState} onLoadMore={list.loadMore}>
-          {
-            item => (<Row key={item.title}>
-              <Cell>{item.title}</Cell>
-            </Row>)
-          }
-        </TableBody>
-      </TableView>
-    </div>
-  );
-}

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -33,7 +33,7 @@ import {Meta, StoryFn, StoryObj} from '@storybook/react';
 import NoSearchResults from '@spectrum-icons/illustrations/NoSearchResults';
 import {Picker} from '@react-spectrum/picker';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
-import React, {JSX, useCallback, useState} from 'react';
+import React, {JSX, useCallback, useEffect, useState} from 'react';
 import {SearchField} from '@react-spectrum/searchfield';
 import {Switch} from '@react-spectrum/switch';
 import {TextField} from '@react-spectrum/textfield';
@@ -2262,3 +2262,57 @@ export const AsyncLoadOverflowWrapReproStory: TableStory = {
 };
 
 export {Performance} from './Performance';
+
+
+export const Test = {
+  render: () => {
+    return <SWTable />;
+  }
+};
+
+function SWTable() {
+  const [film, setFilm] = useState(undefined);
+
+
+  let list = useAsyncList({
+    async load({signal, cursor}) {
+      console.log('load', cursor, film);
+      if (cursor) {
+        cursor = cursor.replace(/^http:\/\//i, 'https://');
+      }
+      let items = [];
+      await new Promise(resolve => setTimeout(resolve, 1500));
+      let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search&film=${film}`, {signal});
+      let json = await res.json();
+      items = json.results.map((element, index) => ({title: element.name}));
+
+      return {
+        items: items,
+        cursor: json.next
+      };
+    }
+  });
+
+  useEffect(() => {
+    list.reload();
+  }, [film]);
+
+  return (
+    <div>
+      <ActionButton onPress={() => setFilm(undefined)}>All</ActionButton>
+      <ActionButton onPress={() => setFilm('https://swapi.py4e.com/api/films/1/')}>A New Hope</ActionButton>
+      <TableView aria-label="Characters"  height={200} width={400}>
+        <TableHeader>
+          <Column isRowHeader>Name</Column>
+        </TableHeader>
+        <TableBody items={list.items} loadingState={list.loadingState} onLoadMore={list.loadMore}>
+          {
+            item => (<Row key={item.title}>
+              <Cell>{item.title}</Cell>
+            </Row>)
+          }
+        </TableBody>
+      </TableView>
+    </div>
+  );
+}

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -2273,8 +2273,12 @@ export const Test = {
 function SWTable() {
   const [film, setFilm] = useState(undefined);
 
+  interface Item {
+    id: string,
+    title: string
+  }
 
-  let list = useAsyncList({
+  let list = useAsyncList<Item>({
     async load({signal, cursor}) {
       console.log('load', cursor, film);
       if (cursor) {
@@ -2284,7 +2288,7 @@ function SWTable() {
       await new Promise(resolve => setTimeout(resolve, 1500));
       let res = await fetch(cursor || `https://swapi.py4e.com/api/people/?search&film=${film}`, {signal});
       let json = await res.json();
-      items = json.results.map((element, index) => ({title: element.name}));
+      items = json.results.map((element) => ({title: element.name}));
 
       return {
         items: items,

--- a/packages/@react-stately/data/src/useAsyncList.ts
+++ b/packages/@react-stately/data/src/useAsyncList.ts
@@ -339,7 +339,7 @@ export function useAsyncList<T, C = string>(options: AsyncListOptions<T, C>): As
     },
     loadMore() {
       // Ignore if already loading more or if performing server side filtering.
-      if (data.state === 'loadingMore' || data.state === 'filtering' || data.cursor == null) {
+      if (data.state === 'loading' || data.state === 'loadingMore' || data.state === 'filtering' || data.cursor == null) {
         return;
       }
 

--- a/packages/@react-stately/data/test/useAsyncList.test.js
+++ b/packages/@react-stately/data/test/useAsyncList.test.js
@@ -334,6 +334,56 @@ describe('useAsyncList', () => {
     expect(result.current.items).toEqual(ITEMS);
   });
 
+  it('should prevent loadMore from firing if in the middle of a load', async () => {
+    let load = jest.fn().mockImplementation(getItems);
+    let {result} = renderHook(
+      () => useAsyncList({load})
+    );
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.items).toEqual([]);
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.items).toEqual([]);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.items).toEqual(ITEMS);
+
+    await act(async () => {
+      result.current.reload();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.items).toEqual([]);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.items).toEqual([]);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.items).toEqual(ITEMS);
+  });
+
+
   it('should ignore duplicate loads where first resolves first', async () => {
     let load = jest.fn().mockImplementation(getItems2);
     let sort = jest.fn().mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({items: ITEMS2}), 100)));


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
- in the S2 storybook, load the TableView > Test story
- note when switching between the `All` and `A New Hope` film filters, there's only one load call (logged in console as well)
- also note that when switching from `All` -> `A New Hope`, there's only 1 load called initially, and the second page call isnt made until scrolling down more (previous to this fix, the call would be made immediately)

## 🧢 Your Project:

<!--- Company/project for pull request -->
