### PR TITLE
Revert "feat(dnd): pass keys and draggedKey as arguments to renderDropIndicator (#8459)"

### DIFF
--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -114,7 +114,7 @@ export interface CollectionBranchProps {
   /** The parent node of the items to render. */
   parent: Node<unknown>,
   /** A function that renders a drop indicator between items. */
-  renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode
+  renderDropIndicator?: (target: ItemDropTarget) => ReactNode
 }
 
 export interface CollectionRootProps extends HTMLAttributes<HTMLElement> {
@@ -125,7 +125,7 @@ export interface CollectionRootProps extends HTMLAttributes<HTMLElement> {
   /** A ref to the scroll container for the collection. */
   scrollRef?: RefObject<HTMLElement | null>,
   /** A function that renders a drop indicator between items. */
-  renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode
+  renderDropIndicator?: (target: ItemDropTarget) => ReactNode
 }
 
 export interface CollectionRenderer {
@@ -153,7 +153,7 @@ export const DefaultCollectionRenderer: CollectionRenderer = {
 function useCollectionRender(
   collection: ICollection<Node<unknown>>,
   parent: Node<unknown> | null,
-  renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode
+  renderDropIndicator?: (target: ItemDropTarget) => ReactNode
 ) {
   return useCachedChildren({
     items: parent ? collection.getChildren!(parent.key) : collection,
@@ -175,7 +175,7 @@ function useCollectionRender(
   });
 }
 
-export function renderAfterDropIndicators(collection: ICollection<Node<unknown>>, node: Node<unknown>, renderDropIndicator: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode): ReactNode {
+export function renderAfterDropIndicators(collection: ICollection<Node<unknown>>, node: Node<unknown>, renderDropIndicator: (target: ItemDropTarget) => ReactNode): ReactNode {
   let key = node.key;
   let keyAfter = collection.getKeyAfter(key);
   let nextItemInFlattenedCollection = keyAfter != null ? collection.getItem(keyAfter) : null;

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -47,23 +47,17 @@ export const DropIndicator = forwardRef(function DropIndicator(props: DropIndica
 
 type RenderDropIndicatorRetValue = ((target: ItemDropTarget) => ReactNode | undefined) | undefined
 
-export function useRenderDropIndicator(dragAndDropHooks?: DragAndDropHooks, dropState?: DroppableCollectionState, dragState?: DraggableCollectionState): RenderDropIndicatorRetValue {
+export function useRenderDropIndicator(dragAndDropHooks?: DragAndDropHooks, dropState?: DroppableCollectionState): RenderDropIndicatorRetValue {
   let renderDropIndicator = dragAndDropHooks?.renderDropIndicator;
   let isVirtualDragging = dragAndDropHooks?.isVirtualDragging?.();
   let fn = useCallback((target: ItemDropTarget) => {
     // Only show drop indicators when virtual dragging or this is the current drop target.
     if (isVirtualDragging || dropState?.isDropTarget(target)) {
-      if (renderDropIndicator) {
-        let keys = dragState?.draggingKeys ?? undefined;
-        let draggedKey = dragState?.draggedKey ?? undefined;
-        return renderDropIndicator(target, keys, draggedKey);
-      } else {
-        return <DropIndicator target={target} />;
-      }
+      return renderDropIndicator ? renderDropIndicator(target) : <DropIndicator target={target} />;
     }
     // We invalidate whenever the target changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dropState?.target, isVirtualDragging, renderDropIndicator, dragState?.draggingKeys, dragState?.draggedKey]);
+  }, [dropState?.target, isVirtualDragging, renderDropIndicator]);
   return dragAndDropHooks?.useDropIndicator ? fn : undefined;
 }
 

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -252,7 +252,7 @@ function GridListInner<T extends object>({props, collection, gridListRef: ref}: 
             collection={collection}
             scrollRef={ref}
             persistedKeys={useDndPersistedKeys(selectionManager, dragAndDropHooks, dropState)}
-            renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState, dragState)} />
+            renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState)} />
         </Provider>
         {emptyState}
         {dragPreview}

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -261,7 +261,7 @@ function ListBoxInner<T extends object>({state: inputState, props, listBoxRef}: 
             collection={collection}
             scrollRef={listBoxRef}
             persistedKeys={useDndPersistedKeys(selectionManager, dragAndDropHooks, dropState)}
-            renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState, dragState)} />
+            renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState)} />
         </Provider>
         {emptyState}
         {dragPreview}
@@ -274,7 +274,7 @@ export interface ListBoxSectionProps<T> extends SectionProps<T> {}
 
 function ListBoxSectionInner<T extends object>(props: ListBoxSectionProps<T>, ref: ForwardedRef<HTMLElement>, section: Node<T>, className = 'react-aria-ListBoxSection') {
   let state = useContext(ListStateContext)!;
-  let {dragAndDropHooks, dragState, dropState} = useContext(DragAndDropContext)!;
+  let {dragAndDropHooks, dropState} = useContext(DragAndDropContext)!;
   let {CollectionBranch} = useContext(CollectionRendererContext);
   let [headingRef, heading] = useSlot();
   let {headingProps, groupProps} = useListBoxSection({
@@ -299,7 +299,7 @@ function ListBoxSectionInner<T extends object>(props: ListBoxSectionProps<T>, re
         <CollectionBranch
           collection={state.collection}
           parent={section}
-          renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState, dragState)} />
+          renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState)} />
       </HeaderContext.Provider>
     </section>
   );

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -924,7 +924,7 @@ export const TableBody = /*#__PURE__*/ createBranchComponent('tablebody', <T ext
   let {isVirtualized} = useContext(CollectionRendererContext);
   let collection = state.collection;
   let {CollectionBranch} = useContext(CollectionRendererContext);
-  let {dragAndDropHooks, dragState, dropState} = useContext(DragAndDropContext);
+  let {dragAndDropHooks, dropState} = useContext(DragAndDropContext);
   let isDroppable = !!dragAndDropHooks?.useDroppableCollectionState && !dropState?.isDisabled;
   let isRootDropTarget = isDroppable && !!dropState && (dropState.isDropTarget({type: 'root'}) ?? false);
 
@@ -982,7 +982,7 @@ export const TableBody = /*#__PURE__*/ createBranchComponent('tablebody', <T ext
       <CollectionBranch
         collection={collection}
         parent={collection.body}
-        renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState, dragState)} />
+        renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState)} />
       {emptyState}
     </TBody>
   );

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -404,7 +404,7 @@ function TreeInner<T extends object>({props, collection, treeRef: ref}: TreeInne
               collection={state.collection}
               persistedKeys={useDndPersistedKeys(state.selectionManager, dragAndDropHooks, dropState)}
               scrollRef={ref}
-              renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState, dragState)} />
+              renderDropIndicator={useRenderDropIndicator(dragAndDropHooks, dropState)} />
           </Provider>
           {emptyState}
         </div>

--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -11,7 +11,7 @@
  */
 
 import {CollectionBranchProps, CollectionRenderer, CollectionRendererContext, CollectionRootProps, renderAfterDropIndicators} from './Collection';
-import {DropTargetDelegate, ItemDropTarget, Key, Node} from '@react-types/shared';
+import {DropTargetDelegate, ItemDropTarget, Node} from '@react-types/shared';
 import {Layout, ReusableView, useVirtualizerState, VirtualizerState} from '@react-stately/virtualizer';
 import React, {createContext, JSX, ReactNode, useContext, useMemo} from 'react';
 import {useScrollView, VirtualizerItem} from '@react-aria/virtualizer';
@@ -117,14 +117,14 @@ function CollectionBranch({parent, renderDropIndicator}: CollectionBranchProps) 
   return renderChildren(parentView, Array.from(parentView.children), renderDropIndicator);
 }
 
-function renderChildren(parent: View | null, children: View[], renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode) {
+function renderChildren(parent: View | null, children: View[], renderDropIndicator?: (target: ItemDropTarget) => ReactNode) {
   return children.map(view => renderWrapper(parent, view, renderDropIndicator));
 }
 
 function renderWrapper(
   parent: View | null,
   reusableView: View,
-  renderDropIndicator?: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode
+  renderDropIndicator?: (target: ItemDropTarget) => ReactNode
 ): ReactNode {
   let rendered = (
     <VirtualizerItem
@@ -141,9 +141,9 @@ function renderWrapper(
   if (node?.type === 'item' && renderDropIndicator && layout.getDropTargetLayoutInfo) {
     rendered = (
       <React.Fragment key={reusableView.key}>
-        {renderDropIndicatorWrapper(parent, reusableView, {type: 'item', key: reusableView.content!.key, dropPosition: 'before'}, (target, keys, draggedKey) => renderDropIndicator(target, keys, draggedKey))}
+        {renderDropIndicatorWrapper(parent, reusableView, {type: 'item', key: reusableView.content!.key, dropPosition: 'before'}, renderDropIndicator)}
         {rendered}
-        {renderAfterDropIndicators(collection, node, (target, keys, draggedKey) => renderDropIndicatorWrapper(parent, reusableView, target, (innerTarget, innerKeys, innerDraggedKey) => renderDropIndicator(innerTarget, innerKeys, innerDraggedKey), keys, draggedKey))}
+        {renderAfterDropIndicators(collection, node, target => renderDropIndicatorWrapper(parent, reusableView, target, renderDropIndicator))}
       </React.Fragment>
     );
   }
@@ -155,11 +155,9 @@ function renderDropIndicatorWrapper(
   parent: View | null,
   reusableView: View,
   target: ItemDropTarget,
-  renderDropIndicator: (target: ItemDropTarget, keys?: Set<Key>, draggedKey?: Key) => ReactNode,
-  keys: Set<Key> = new Set(),
-  draggedKey?: Key
+  renderDropIndicator: (target: ItemDropTarget) => ReactNode
 ) {
-  let indicator = renderDropIndicator(target, keys, draggedKey);
+  let indicator = renderDropIndicator(target);
   if (indicator) {
     let layoutInfo = reusableView.virtualizer.layout.getDropTargetLayoutInfo!(target);
     indicator = (

--- a/packages/react-aria-components/src/useDragAndDrop.tsx
+++ b/packages/react-aria-components/src/useDragAndDrop.tsx
@@ -59,7 +59,7 @@ interface DropHooks {
   useDroppableCollection?: (props: DroppableCollectionOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DroppableCollectionResult,
   useDroppableItem?: (options: DroppableItemOptions, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DroppableItemResult,
   useDropIndicator?: (props: AriaDropIndicatorProps, state: DroppableCollectionState, ref: RefObject<HTMLElement | null>) => DropIndicatorAria,
-  renderDropIndicator?: (target: DropTarget, keys?: Set<Key>, draggedKey?: Key) => JSX.Element,
+  renderDropIndicator?: (target: DropTarget) => JSX.Element,
   dropTargetDelegate?: DropTargetDelegate,
   ListDropTargetDelegate: typeof ListDropTargetDelegate
 }
@@ -87,7 +87,7 @@ export interface DragAndDropOptions extends Omit<DraggableCollectionProps, 'prev
    * This should render a `<DropIndicator>` element. If this function is not provided, a
    * default DropIndicator is provided.
    */
-  renderDropIndicator?: (target: DropTarget, keys?: Set<Key>, draggedKey?: Key) => JSX.Element,
+  renderDropIndicator?: (target: DropTarget) => JSX.Element,
   /** A custom delegate object that provides drop targets for pointer coordinates within the collection. */
   dropTargetDelegate?: DropTargetDelegate,
   /** Whether the drag and drop events should be disabled. */

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -194,69 +194,6 @@ ListBoxDnd.story = {
   }
 };
 
-export const ListBoxDndCustomDropIndicator: StoryFn<ListBoxProps<typeof albums[0]>> = (props) => {
-  let list = useListData({
-    initialItems: albums
-  });
-
-  let {dragAndDropHooks} = useDragAndDrop({
-    getItems: (keys) => [...keys].map(key => ({'text/plain': list.getItem(key)?.title ?? ''})),
-    onReorder(e) {
-      if (e.target.dropPosition === 'before') {
-        list.moveBefore(e.target.key, e.keys);
-      } else if (e.target.dropPosition === 'after') {
-        list.moveAfter(e.target.key, e.keys);
-      }
-    },
-    renderDropIndicator(target, keys, draggedKey) {
-      return (
-        <DropIndicator target={target} style={({isDropTarget}) => ({width: '150px', height: '150px', background: isDropTarget ? 'blue' : 'transparent', color: 'white', display: isDropTarget ? 'flex' : 'none', alignItems: 'center', justifyContent: 'center', flexDirection: 'column'})}>
-          <div>
-            keys: {keys ? Array.from(keys).join(', ') : 'undefined'}
-          </div>
-          <div>
-            draggedKey: {draggedKey}
-          </div>
-        </DropIndicator>
-      );
-    }
-  });
-
-  return (
-    <ListBox
-      {...props}
-      aria-label="Albums"
-      items={list.items}
-      selectionMode="multiple"
-      dragAndDropHooks={dragAndDropHooks}>
-      {item => (
-        <ListBoxItem>
-          <img src={item.image} alt="" />
-          <Text slot="label">{item.title}</Text>
-          <Text slot="description">{item.artist}</Text>
-        </ListBoxItem>
-      )}
-    </ListBox>
-  );
-};
-
-ListBoxDndCustomDropIndicator.story = {
-  args: {
-    layout: 'stack',
-    orientation: 'horizontal'
-  },
-  argTypes: {
-    layout: {
-      control: 'radio',
-      options: ['stack', 'grid']
-    },
-    orientation: {
-      control: 'radio',
-      options: ['horizontal', 'vertical']
-    }
-  }
-};
-
 interface PreviewOffsetArgs {
   /** Strategy for positioning the preview. */
   mode: 'default' | 'custom',

--- a/packages/react-aria-components/test/GridList.test.js
+++ b/packages/react-aria-components/test/GridList.test.js
@@ -851,42 +851,6 @@ describe('GridList', () => {
       expect(onReorder).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass keys and draggedKey to renderDropIndicator', async () => {
-      let onReorder = jest.fn();
-      let renderDropIndicatorCalls = [];
-      let mockRenderDropIndicator = jest.fn((target, keys, draggedKey) => {
-        renderDropIndicatorCalls.push({target, keys, draggedKey});
-        return <DropIndicator target={target}>Keys: {keys ? keys.size : 0} DraggedKey: {draggedKey || 'none'}</DropIndicator>;
-      });
-
-      let {getAllByRole} = render(
-        <DraggableGridList 
-          onReorder={onReorder} 
-          renderDropIndicator={mockRenderDropIndicator} />
-      );
-      
-      await user.tab();
-      await user.keyboard('{ArrowRight}');
-      await user.keyboard('{Enter}');
-      act(() => jest.runAllTimers());
-
-      expect(mockRenderDropIndicator).toHaveBeenCalled();
-      
-      renderDropIndicatorCalls.forEach(call => {
-        expect(call.target).toBeDefined();
-        expect(call.keys).toBeInstanceOf(Set);
-        expect(call.keys.size).toBe(1);
-        expect(call.keys.has('cat')).toBe(true);
-        expect(call.draggedKey).toBe('cat');
-      });
-
-      let rows = getAllByRole('row');
-      expect(rows[0]).toHaveTextContent('Keys: 1 DraggedKey: cat');
-
-      fireEvent.keyDown(document.activeElement, {key: 'Enter'});
-      fireEvent.keyUp(document.activeElement, {key: 'Enter'});
-    });
-
     it('should support dropping on rows', async () => {
       let onItemDrop = jest.fn();
       let {getAllByRole} = render(<>

--- a/packages/react-aria-components/test/ListBox.test.js
+++ b/packages/react-aria-components/test/ListBox.test.js
@@ -1114,42 +1114,6 @@ describe('ListBox', () => {
       expect(onReorder).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass keys and draggedKey to renderDropIndicator', () => {
-      let onReorder = jest.fn();
-      let renderDropIndicatorCalls = [];
-      let mockRenderDropIndicator = jest.fn((target, keys, draggedKey) => {
-        renderDropIndicatorCalls.push({target, keys, draggedKey});
-        return <DropIndicator target={target}>Test Keys: {keys ? keys.size : 0} DraggedKey: {draggedKey || 'none'}</DropIndicator>;
-      });
-
-      let {getAllByRole} = render(
-        <DraggableListBox 
-          onReorder={onReorder} 
-          renderDropIndicator={mockRenderDropIndicator} />
-      );
-      
-      let option = getAllByRole('option')[0];
-      fireEvent.keyDown(option, {key: 'Enter'});
-      fireEvent.keyUp(option, {key: 'Enter'});
-      act(() => jest.runAllTimers());
-
-      expect(mockRenderDropIndicator).toHaveBeenCalled();
-      
-      renderDropIndicatorCalls.forEach(call => {
-        expect(call.target).toBeDefined();
-        expect(call.keys).toBeInstanceOf(Set);
-        expect(call.keys.size).toBe(1);
-        expect(call.keys.has('cat')).toBe(true);
-        expect(call.draggedKey).toBe('cat');
-      });
-
-      let options = getAllByRole('option');
-      expect(options[0]).toHaveTextContent('Test Keys: 1 DraggedKey: cat');
-      
-      fireEvent.keyDown(document.activeElement, {key: 'Enter'});
-      fireEvent.keyUp(document.activeElement, {key: 'Enter'});
-    });
-
     it('should support dropping on options', () => {
       let onItemDrop = jest.fn();
       let {getAllByRole} = render(<>

--- a/packages/react-aria-components/test/Tree.test.tsx
+++ b/packages/react-aria-components/test/Tree.test.tsx
@@ -1744,36 +1744,6 @@ describe('Tree', () => {
       expect(onReorder).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass keys and draggedKey to renderDropIndicator', async () => {
-      let onReorder = jest.fn();
-      let renderDropIndicatorCalls: {target: HTMLElement, keys: Set<string>, draggedKey: string}[] = [];
-      let mockRenderDropIndicator = jest.fn((target, keys, draggedKey) => {
-        renderDropIndicatorCalls.push({target, keys, draggedKey});
-        return <DropIndicator target={target}>Test {keys.size} keys {draggedKey ? 'dragging ' + draggedKey : 'no drag'}</DropIndicator>;
-      });
-
-      let {getAllByRole} = render(<DraggableTree onReorder={onReorder} renderDropIndicator={mockRenderDropIndicator} />);
-      await user.tab();
-      await user.keyboard('{ArrowRight}');
-      await user.keyboard('{Enter}');
-      act(() => jest.runAllTimers());
-
-      expect(mockRenderDropIndicator).toHaveBeenCalled();
-      
-      renderDropIndicatorCalls.forEach(call => {
-        expect(call.target).toBeDefined();
-        expect(call.keys).toBeInstanceOf(Set);
-        expect(call.keys.size).toBe(1);
-        expect(call.keys.has('projects')).toBe(true);
-        expect(call.draggedKey).toBe('projects');
-      });
-
-      let rows = getAllByRole('row');
-      expect(rows[0]).toHaveTextContent('Test 1 keys dragging projects');
-
-      await user.keyboard('{Enter}');
-    });
-
     it('should support dropping on items', async () => {
       let onItemDrop = jest.fn();
       let {getAllByRole} = render(<>


### PR DESCRIPTION
This reverts commit 66d65a9c21e92278d8c7f3c95c1e506e2160734e.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
