### PR TITLE
fix: Style macro class name conflict

### DIFF
--- a/packages/@react-spectrum/s2/style/properties.json
+++ b/packages/@react-spectrum/s2/style/properties.json
@@ -166,7 +166,7 @@
     "touchAction": "__X",
     "translate": "__Y",
     "wordBreak": "__Z",
-    "--fs": "__Q"
+    "--fs": "__0"
   },
   "values": {
     "--iconPrimary": {


### PR DESCRIPTION
Fixes https://github.com/adobe/react-spectrum/commit/864cbff7a3ff69908c5dc01080f976aca75fa9ec#r162472024

The script that generated this (which is not yet committed because it is horrible) had a bug that generated a class name conflict with `--fs` and `scrollSnapStop` (both `__Q`).