### PR TITLE
fix: make it so vertical tabs don't immediately wrap unless minWidth is applied

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tabs/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tabs/index.css
@@ -290,6 +290,7 @@ governing permissions and limitations under the License.
 
   &.spectrum-Tabs--vertical {
     flex-grow: 0;
+    min-width: fit-content;
   }
 }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
