### PR TITLE
fix: make sure tap highlight doesn't appear in S2 Calendar on iOS

### DIFF
--- a/packages/@react-spectrum/s2/src/Calendar.tsx
+++ b/packages/@react-spectrum/s2/src/Calendar.tsx
@@ -174,6 +174,7 @@ const cellInnerStyles = style<CalendarCellRenderProps & {selectionMode: 'single'
   backgroundColor: {
     default: 'transparent',
     isHovered: 'gray-100',
+    isPressed: 'gray-100',
     isDisabled: 'transparent',
     isToday: {
       default: baseColor('gray-300'),

--- a/packages/@react-spectrum/s2/src/Calendar.tsx
+++ b/packages/@react-spectrum/s2/src/Calendar.tsx
@@ -70,7 +70,8 @@ const calendarStyles = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 24,
-  width: 'fit'
+  width: 'fit',
+  disableTapHighlight: true
 }, getAllowedOverrides());
 
 const headerStyles = style({


### PR DESCRIPTION
from testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
