### PR TITLE
chore: export `useControlledState` from `react-stately` and `react-aria-components`

### DIFF
--- a/packages/@react-stately/utils/src/useControlledState.ts
+++ b/packages/@react-stately/utils/src/useControlledState.ts
@@ -15,9 +15,9 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 /**
  * Provides state management for controlled and uncontrolled values.
  *
- * @param value The controlled value. Pass `undefined` to make the component uncontrolled.
- * @param defaultValue The initial value when uncontrolled.
- * @param onChange Callback fired whenever the value changes.
+ * @param value - The controlled value. Pass `undefined` to make the component uncontrolled.
+ * @param defaultValue - The initial value when uncontrolled.
+ * @param onChange - Callback fired whenever the value changes.
  */
 export function useControlledState<T, C = T>(value: Exclude<T, undefined>, defaultValue: Exclude<T, undefined> | undefined, onChange?: (v: C, ...args: any[]) => void): [T, (value: T, ...args: any[]) => void];
 export function useControlledState<T, C = T>(value: Exclude<T, undefined> | undefined, defaultValue: Exclude<T, undefined>, onChange?: (v: C, ...args: any[]) => void): [T, (value: T, ...args: any[]) => void];

--- a/packages/@react-stately/utils/src/useControlledState.ts
+++ b/packages/@react-stately/utils/src/useControlledState.ts
@@ -12,6 +12,13 @@
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 
+/**
+ * Provides state management for controlled and uncontrolled values.
+ *
+ * @param value The controlled value. Pass `undefined` to make the component uncontrolled.
+ * @param defaultValue The initial value when uncontrolled.
+ * @param onChange Callback fired whenever the value changes.
+ */
 export function useControlledState<T, C = T>(value: Exclude<T, undefined>, defaultValue: Exclude<T, undefined> | undefined, onChange?: (v: C, ...args: any[]) => void): [T, (value: T, ...args: any[]) => void];
 export function useControlledState<T, C = T>(value: Exclude<T, undefined> | undefined, defaultValue: Exclude<T, undefined>, onChange?: (v: C, ...args: any[]) => void): [T, (value: T, ...args: any[]) => void];
 export function useControlledState<T, C = T>(value: T, defaultValue: T, onChange?: (v: C, ...args: any[]) => void): [T, (value: T, ...args: any[]) => void] {

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -83,6 +83,7 @@ export {DIRECTORY_DRAG_TYPE, isDirectoryDropItem, isFileDropItem, isTextDropItem
 export {FormValidationContext, parseColor, getColorChannels, ToastQueue as UNSTABLE_ToastQueue} from 'react-stately';
 export {ListLayout, GridLayout, WaterfallLayout} from '@react-stately/layout';
 export {Layout, LayoutInfo, Size, Rect, Point} from '@react-stately/virtualizer';
+export {useControlledState} from '@react-stately/utils';
 
 export type {AutocompleteProps} from './Autocomplete';
 export type {BreadcrumbsProps, BreadcrumbProps, BreadcrumbRenderProps} from './Breadcrumbs';

--- a/packages/react-stately/package.json
+++ b/packages/react-stately/package.json
@@ -53,6 +53,7 @@
     "@react-stately/toggle": "^3.9.0",
     "@react-stately/tooltip": "^3.5.6",
     "@react-stately/tree": "^3.9.1",
+    "@react-stately/utils": "^3.10.8",
     "@react-types/shared": "^3.31.0"
   },
   "peerDependencies": {

--- a/packages/react-stately/src/index.ts
+++ b/packages/react-stately/src/index.ts
@@ -60,3 +60,4 @@ export {useToggleState, useToggleGroupState} from '@react-stately/toggle';
 export {useTooltipTriggerState} from '@react-stately/tooltip';
 export {useTreeState} from '@react-stately/tree';
 export {FormValidationContext} from '@react-stately/form';
+export {useControlledState} from '@react-stately/utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -26299,6 +26299,7 @@ __metadata:
     "@react-stately/toggle": "npm:^3.9.0"
     "@react-stately/tooltip": "npm:^3.5.6"
     "@react-stately/tree": "npm:^3.9.1"
+    "@react-stately/utils": "npm:^3.10.8"
     "@react-types/shared": "npm:^3.31.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1


### PR DESCRIPTION
Closes #6222

Seems fine to export since we use this in React Spectrum v3/S2 people might want to similarly use it without needing to install the individual package. If we have other concerns, I can close this and close the original issue.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
