### PR TITLE
fix: prevent `useTooltipTrigger` from setting `tabIndex`

### DIFF
--- a/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
+++ b/packages/@react-aria/tooltip/src/useTooltipTrigger.ts
@@ -139,9 +139,9 @@ export function useTooltipTrigger(props: TooltipTriggerProps, state: TooltipTrig
       'aria-describedby': state.isOpen ? tooltipId : undefined,
       ...mergeProps(focusableProps, hoverProps, {
         onPointerDown: onPressStart,
-        onKeyDown: onPressStart,
-        tabIndex: undefined
-      })
+        onKeyDown: onPressStart
+      }),
+      tabIndex: undefined
     },
     tooltipProps: {
       id: tooltipId


### PR DESCRIPTION
Closes #8556

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
