### PR TITLE
fix: Allow user to set `containerPadding` in React Aria Tooltip

### DIFF
--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -142,6 +142,7 @@ function TooltipInner(props: TooltipProps & {isExiting: boolean, tooltipRef: Ref
     arrowSize: arrowWidth,
     arrowBoundaryOffset: props.arrowBoundaryOffset,
     shouldFlip: props.shouldFlip,
+    containerPadding: props.containerPadding,
     onClose: () => state.close(true)
   });
 

--- a/packages/react-aria-components/stories/Tooltip.stories.tsx
+++ b/packages/react-aria-components/stories/Tooltip.stories.tsx
@@ -333,3 +333,17 @@ export const TooltipArrowBoundaryOffsetExample: StoryObj<typeof TooltipArrowBoun
   },
   render: (args) => <TooltipArrowBoundaryOffsetExampleRender {...args} />
 };
+
+export const TooltipContainerPaddingExample: StoryObj<typeof Tooltip> = {
+  render: (args) => (
+    <TooltipTrigger>
+      <Button style={{position: 'absolute', top: 0, left: 0}}>Tooltip trigger</Button>
+      <Tooltip {...args}>
+        I am a tooltip
+      </Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    containerPadding: 10
+  }
+};


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8624
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
