### PR TITLE
Feat: Add lifecycle callback to `useId`

### DIFF
--- a/packages/@react-aria/utils/src/useId.ts
+++ b/packages/@react-aria/utils/src/useId.ts
@@ -37,6 +37,7 @@ if (typeof FinalizationRegistry !== 'undefined') {
 /**
  * If a default is not provided, generate an id.
  * @param defaultId - Default component id.
+ * @param cleanupCallback - A callback for when the id is no longer in use. Useful because id's don't always go out of use due to unmounting as it may have originated from a parent component.
  */
 export function useId(defaultId?: string, cleanupCallback?: (id: string) => void): string {
   let [value, setValue] = useState(defaultId);


### PR DESCRIPTION
This PR adds support for lifecycle hooks to a `useId`. This can be useful to build global state with unique ids as the key, in scenarios where a common state object isn't accessible.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
