### PR TITLE
docs: Update TanStack Router guide

### DIFF
--- a/packages/dev/docs/pages/react-aria/routing.mdx
+++ b/packages/dev/docs/pages/react-aria/routing.mdx
@@ -268,29 +268,17 @@ export default function App() {
 }
 ```
 
-### TanStack Router
+## TanStack Router
 
-To use [TanStack Router](https://tanstack.com/router) with React Aria, render React Aria's `RouterProvider` inside your root route. Use `router.navigate` in the `navigate` prop, and `router.buildLocation` in the `useHref` prop. You can also configure TypeScript to get autocomplete for the `href` prop by declaring the `RouterConfig` type using the types provided by TanStack Router.
+To use [TanStack Router](https://tanstack.com/router) with React Aria, use the [createLink](https://tanstack.com/router/latest/docs/framework/react/guide/custom-link) function to wrap each React Aria component as a link. `RouterProvider` is not needed.
 
 ```tsx
-import {useRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
-import {RouterProvider} from 'react-aria-components';
+// src/Link.tsx
+import {createLink} from '@tanstack/react-router';
+import {Link as ReactAriaLink, MenuItem} from 'react-aria-components';
 
-declare module 'react-aria-components' {
-  interface RouterConfig {
-    href: ToOptions;
-    routerOptions: Omit<NavigateOptions, keyof ToOptions>;
-  }
-}
-
-function RootRoute() {
-  let router = useRouter();
-  return (
-    <RouterProvider 
-      navigate={(href, opts) => router.navigate({...href, ...opts})}
-      useHref={href => router.buildLocation(href).href}>
-      {/* ...*/}
-    </RouterProvider>
-  );
-}
+export const Link = createLink(ReactAriaLink);
+export const MenuItemLink = createLink(MenuItem);
 ```
+
+In you app, use these components instead of importing directly from `react-aria-components`.

--- a/packages/dev/docs/pages/react-aria/routing.mdx
+++ b/packages/dev/docs/pages/react-aria/routing.mdx
@@ -270,7 +270,7 @@ export default function App() {
 
 ## TanStack Router
 
-To use [TanStack Router](https://tanstack.com/router) with React Aria, use the [createLink](https://tanstack.com/router/latest/docs/framework/react/guide/custom-link) function to wrap each React Aria component as a link. `RouterProvider` is not needed.
+To use [TanStack Router](https://tanstack.com/router) with React Aria Components v1.11.0 or later, use the [createLink](https://tanstack.com/router/latest/docs/framework/react/guide/custom-link) function to wrap each React Aria component as a link. `RouterProvider` is not needed.
 
 ```tsx
 // src/Link.tsx
@@ -281,4 +281,4 @@ export const Link = createLink(ReactAriaLink);
 export const MenuItemLink = createLink(MenuItem);
 ```
 
-In you app, use these components instead of importing directly from `react-aria-components`.
+In your app, use these components instead of importing directly from `react-aria-components`.

--- a/packages/dev/docs/pages/react-spectrum/routing.mdx
+++ b/packages/dev/docs/pages/react-spectrum/routing.mdx
@@ -272,7 +272,7 @@ export default function App() {
 
 ## TanStack Router
 
-To use [TanStack Router](https://tanstack.com/router) with React Spectrum, use the [createLink](https://tanstack.com/router/latest/docs/framework/react/guide/custom-link) function to wrap each React Spectrum component as a link. `RouterProvider` is not needed.
+To use [TanStack Router](https://tanstack.com/router) with React Spectrum v3.43.0 or later, use the [createLink](https://tanstack.com/router/latest/docs/framework/react/guide/custom-link) function to wrap each React Spectrum component as a link. `RouterProvider` is not needed.
 
 ```tsx
 // src/Link.tsx
@@ -283,4 +283,4 @@ export const Link = createLink(SpectrumLink);
 export const ItemLink = createLink(Item);
 ```
 
-In you app, use these components instead of importing directly from `@adobe/react-spectrum`.
+In your app, use these components instead of importing directly from `@adobe/react-spectrum`.

--- a/packages/dev/docs/pages/react-spectrum/routing.mdx
+++ b/packages/dev/docs/pages/react-spectrum/routing.mdx
@@ -270,32 +270,17 @@ export default function App() {
 }
 ```
 
-### TanStack Router
+## TanStack Router
 
-To use [TanStack Router](https://tanstack.com/router) with React Spectrum, render React Spectrum's `Provider` inside your root route. Use `router.navigate` in the `navigate` prop, and `router.buildLocation` in the `useHref` prop. You can also configure TypeScript to get autocomplete for the `href` prop by declaring the `RouterConfig` type using the types provided by TanStack Router.
+To use [TanStack Router](https://tanstack.com/router) with React Spectrum, use the [createLink](https://tanstack.com/router/latest/docs/framework/react/guide/custom-link) function to wrap each React Spectrum component as a link. `RouterProvider` is not needed.
 
 ```tsx
-import {useRouter, type NavigateOptions, type ToOptions} from '@tanstack/react-router';
-import {Provider, defaultTheme} from '@adobe/react-spectrum';
+// src/Link.tsx
+import {createLink} from '@tanstack/react-router';
+import {Link as SpectrumLink, Item} from '@adobe/react-spectrum';
 
-declare module '@adobe/react-spectrum' {
-  interface RouterConfig {
-    href: ToOptions['to'];
-    routerOptions: Omit<NavigateOptions, keyof ToOptions>;
-  }
-}
-
-function RootRoute() {
-  let router = useRouter();
-  return (
-    <Provider
-      theme={defaultTheme}
-      router={{
-        navigate: (to, options) => router.navigate({to, ...options}),
-        useHref: to => router.buildLocation({to}).href
-      }}>
-      {/* ...*/}
-    </Provider>
-  );
-}
+export const Link = createLink(SpectrumLink);
+export const ItemLink = createLink(Item);
 ```
+
+In you app, use these components instead of importing directly from `@adobe/react-spectrum`.


### PR DESCRIPTION
Since we pass through DOM events now, it's possible to use TanStack Router's `createLink` function directly instead of using RouterProvider. This has the benefit that it automatically supports the TypeScript features of TanStack, and also works with their pre-fetching. Updating the docs accordingly. Also sent a PR to update the docs on the TanStack site: https://github.com/TanStack/router/pull/4757