### PR TITLE
updates command palette example to fix SSR

### DIFF
--- a/packages/react-aria-components/docs/examples/command-palette.mdx
+++ b/packages/react-aria-components/docs/examples/command-palette.mdx
@@ -66,7 +66,13 @@ function CommandPaletteExample() {
 
   let [isOpen, setOpen] = useState(false);
   let {contains} = useFilter({sensitivity: 'base'});
-  let isMac = useMemo(() => /Mac/.test(navigator.platform), []);
+  let isMac = useMemo(
+    () =>
+      typeof navigator === 'undefined'
+        ? false
+        : /mac(os|intosh)/i.test(navigator.userAgent),
+    []
+  )
 
   useEffect(() => {
     const handleKeyDown = (e) => {


### PR DESCRIPTION
The command palette example currently errors during the SSR pass since `useMemo` runs during SSR and `window.navigator` for the `isMac` flag will not be defined causing an error. This also updates from the deprecated `navigator.platform` to `navigator.userAgent`.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Example works the same as before.

## 🧢 Your Project:

<!--- Company/project for pull request -->
