### PR TITLE
fix: remove github label when translation no longer needed

### DIFF
--- a/packages/@react-spectrum/accordion/src/Accordion.tsx
+++ b/packages/@react-spectrum/accordion/src/Accordion.tsx
@@ -47,9 +47,7 @@ export const Accordion = /*#__PURE__*/(forwardRef as forwardRefType)(function Ac
   );
 });
 
-export interface SpectrumDisclosureProps extends Omit<DisclosureProps, 'className' | 'style' | 'children'>,
-  AriaLabelingProps,
-  StyleProps {
+export interface SpectrumDisclosureProps extends Omit<DisclosureProps, 'className' | 'style' | 'children'>, AriaLabelingProps, StyleProps {
   /** Whether the Disclosure should be displayed with a quiet style. */
   isQuiet?: boolean,
   /** The contents of the disclosure. The first child should be the header, and the second child should be the panel. */
@@ -91,7 +89,7 @@ export const DisclosurePanel = /*#__PURE__*/(forwardRef as forwardRefType)(funct
     <RACDisclosurePanel
       ref={domRef}
       {...styleProps as Omit<React.HTMLAttributes<HTMLElement>, 'role'>}
-      className={classNames(styles, 'spectrum-Accordion-itemContent', styleProps.className)}
+      className={classNames(styles, 'spectrum-Accordion-itemContent', styleProps.className)} 
       {...props}>
       {props.children}
     </RACDisclosurePanel>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

testing labeler action

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
