### PR TITLE
fix: check for element visibility should take react aria attribute into consideration

### DIFF
--- a/packages/@react-aria/utils/src/isElementVisible.ts
+++ b/packages/@react-aria/utils/src/isElementVisible.ts
@@ -63,8 +63,7 @@ function isAttributeVisible(element: Element, childElement?: Element) {
  */
 export function isElementVisible(element: Element, childElement?: Element): boolean {
   if (supportsCheckVisibility) {
-    console.log('checkVisibility', element);
-    return element.checkVisibility() && !element.closest('[data-react-aria-prevent-focus]');
+    return element.checkVisibility();
   }
 
   return (

--- a/packages/@react-aria/utils/src/isElementVisible.ts
+++ b/packages/@react-aria/utils/src/isElementVisible.ts
@@ -63,9 +63,10 @@ function isAttributeVisible(element: Element, childElement?: Element) {
  */
 export function isElementVisible(element: Element, childElement?: Element): boolean {
   if (supportsCheckVisibility) {
-    return element.checkVisibility();
+    console.log('checkVisibility', element);
+    return element.checkVisibility() && !element.closest('[data-react-aria-prevent-focus]');
   }
-  
+
   return (
     element.nodeName !== '#comment' &&
     isStyleVisible(element) &&

--- a/packages/@react-aria/utils/src/isElementVisible.ts
+++ b/packages/@react-aria/utils/src/isElementVisible.ts
@@ -63,7 +63,7 @@ function isAttributeVisible(element: Element, childElement?: Element) {
  */
 export function isElementVisible(element: Element, childElement?: Element): boolean {
   if (supportsCheckVisibility) {
-    return element.checkVisibility();
+    return element.checkVisibility() && !element.closest('[data-react-aria-prevent-focus]');
   }
 
   return (

--- a/packages/react-aria-components/stories/Toolbar.stories.tsx
+++ b/packages/react-aria-components/stories/Toolbar.stories.tsx
@@ -10,9 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import {Checkbox, Link, ToggleButton, Toolbar, ToolbarProps} from 'react-aria-components';
+import {Button, Checkbox, Group, Label, Link, ListBox, Popover, Select, SelectValue, Separator, ToggleButton, Toolbar, ToolbarProps} from 'react-aria-components';
 import {classNames} from '@react-spectrum/utils';
 import {Meta, StoryObj} from '@storybook/react';
+import {MyListBoxItem} from './utils';
 import {Orientation} from 'react-stately';
 import React from 'react';
 import styles from '../example/index.css';
@@ -53,6 +54,54 @@ export const ToolbarExample: ToolbarStory = {
         <label htmlFor="after">Input After Toolbar</label>
         <input id="after" type="text" />
       </div>
+    );
+  }
+};
+
+export const SelectSupport: ToolbarStory = {
+  args: {
+    orientation: 'horizontal' as Orientation
+  },
+  render: (props: ToolbarProps) => {
+    return (
+      <Toolbar {...props} aria-label="Text formatting">
+        <Group aria-label="Style">
+          <ToggleButton aria-label="Bold">
+            <b>B</b>
+          </ToggleButton>
+          <ToggleButton aria-label="Italic">
+            <i>I</i>
+          </ToggleButton>
+          <ToggleButton aria-label="Underline">
+            <u>U</u>
+          </ToggleButton>
+        </Group>
+        <Separator orientation="vertical" />
+        <Select>
+          <Label>Favorite Animal</Label>
+          <Button>
+            <SelectValue />
+            <span aria-hidden="true">▼</span>
+          </Button>
+          <Popover>
+            <ListBox>
+              <MyListBoxItem>Aardvark</MyListBoxItem>
+              <MyListBoxItem>Cat</MyListBoxItem>
+              <MyListBoxItem>Dog</MyListBoxItem>
+              <MyListBoxItem>Kangaroo</MyListBoxItem>
+              <MyListBoxItem>Panda</MyListBoxItem>
+              <MyListBoxItem>Snake</MyListBoxItem>
+            </ListBox>
+          </Popover>
+        </Select>
+        <Separator orientation="vertical" />
+
+        <Group aria-label="Clipboard">
+          <Button>Copy</Button>
+          <Button>Paste</Button>
+          <Button>Cut</Button>
+        </Group>
+      </Toolbar>
     );
   }
 };


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8636

Can't test in jsdom because it behaved correctly both ways, it seems to be wrong about element visibility compared to browsers.

Test in the story.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
