### PR TITLE
fix: react types backwards compat for Tabs

### DIFF
--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -261,7 +261,7 @@ function TabLine(props: TabLineProps) {
  * A TabList is used within Tabs to group tabs that a user can switch between.
  * The keys of the items within the <TabList> must match up with a corresponding item inside the <TabPanels>.
  */
-export function TabList<T>(props: SpectrumTabListProps<T>): ReactNode {
+export function TabList<T>(props: SpectrumTabListProps<T>): ReactElement {
   const tabContext = useContext(TabContext)!;
   const {refs, tabState, tabProps, tabPanelProps} = tabContext;
   const {isQuiet, density, isEmphasized, orientation} = tabProps;
@@ -337,7 +337,7 @@ export function TabList<T>(props: SpectrumTabListProps<T>): ReactNode {
  * TabPanels is used within Tabs as a container for the content of each tab.
  * The keys of the items within the <TabPanels> must match up with a corresponding item inside the <TabList>.
  */
-export function TabPanels<T extends object>(props: SpectrumTabPanelsProps<T>): ReactNode {
+export function TabPanels<T extends object>(props: SpectrumTabPanelsProps<T>): ReactElement {
   const {tabState, tabProps} = useContext(TabContext)!;
   const {tabListState} = tabState;
 


### PR DESCRIPTION
Closes  https://github.com/adobe/react-spectrum/issues/8650

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
