### PR TITLE
feat: add maxSpace option to @react-stately/layout GridLayout

### DIFF
--- a/packages/@react-stately/layout/src/GridLayout.ts
+++ b/packages/@react-stately/layout/src/GridLayout.ts
@@ -40,7 +40,7 @@ export interface GridLayoutOptions {
    * The maximum allowed horizontal space between items.
    * @default Infinity
    */
-  maxSpace?: number,
+  maxHorizontalSpace?: number,
   /**
    * The maximum number of columns.
    * @default Infinity
@@ -84,7 +84,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
       || (!(newOptions.minItemSize || DEFAULT_OPTIONS.minItemSize).equals(oldOptions.minItemSize || DEFAULT_OPTIONS.minItemSize))
       || (!(newOptions.maxItemSize || DEFAULT_OPTIONS.maxItemSize).equals(oldOptions.maxItemSize || DEFAULT_OPTIONS.maxItemSize))
       || (!(newOptions.minSpace || DEFAULT_OPTIONS.minSpace).equals(oldOptions.minSpace || DEFAULT_OPTIONS.minSpace))
-      || newOptions.maxSpace !== oldOptions.maxSpace;
+      || newOptions.maxHorizontalSpace !== oldOptions.maxHorizontalSpace;
   }
 
   update(invalidationContext: InvalidationContext<O>): void {
@@ -93,7 +93,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
       maxItemSize = DEFAULT_OPTIONS.maxItemSize,
       preserveAspectRatio = DEFAULT_OPTIONS.preserveAspectRatio,
       minSpace = DEFAULT_OPTIONS.minSpace,
-      maxSpace = DEFAULT_OPTIONS.maxSpace,
+      maxHorizontalSpace = DEFAULT_OPTIONS.maxSpace,
       maxColumns = DEFAULT_OPTIONS.maxColumns,
       dropIndicatorThickness = DEFAULT_OPTIONS.dropIndicatorThickness
     } = invalidationContext.layoutOptions || {};
@@ -126,7 +126,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
     itemHeight = Math.max(minItemSize.height, Math.min(maxItemHeight, itemHeight));
 
     // Compute the horizontal spacing, content height and horizontal margin
-    let horizontalSpacing = Math.min(maxSpace, Math.floor((visibleWidth - numColumns * itemWidth) / (numColumns + 1)));
+    let horizontalSpacing = Math.min(maxHorizontalSpace, Math.floor((visibleWidth - numColumns * itemWidth) / (numColumns + 1)));
     this.gap = new Size(horizontalSpacing, minSpace.height);
     this.margin = Math.floor((visibleWidth - numColumns * itemWidth - horizontalSpacing * (numColumns + 1)) / 2);
 

--- a/packages/@react-stately/layout/src/GridLayout.ts
+++ b/packages/@react-stately/layout/src/GridLayout.ts
@@ -37,6 +37,11 @@ export interface GridLayoutOptions {
    */
   minSpace?: Size,
   /**
+   * The maximum allowed horizontal space between items.
+   * @default Infinity
+   */
+  maxSpace?: number,
+  /**
    * The maximum number of columns.
    * @default Infinity
    */
@@ -53,6 +58,7 @@ const DEFAULT_OPTIONS = {
   maxItemSize: new Size(Infinity, Infinity),
   preserveAspectRatio: false,
   minSpace: new Size(18, 18),
+  maxSpace: Infinity,
   maxColumns: Infinity,
   dropIndicatorThickness: 2
 };
@@ -76,7 +82,8 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
       || newOptions.preserveAspectRatio !== oldOptions.preserveAspectRatio
       || (!(newOptions.minItemSize || DEFAULT_OPTIONS.minItemSize).equals(oldOptions.minItemSize || DEFAULT_OPTIONS.minItemSize))
       || (!(newOptions.maxItemSize || DEFAULT_OPTIONS.maxItemSize).equals(oldOptions.maxItemSize || DEFAULT_OPTIONS.maxItemSize))
-      || (!(newOptions.minSpace || DEFAULT_OPTIONS.minSpace).equals(oldOptions.minSpace || DEFAULT_OPTIONS.minSpace));
+      || (!(newOptions.minSpace || DEFAULT_OPTIONS.minSpace).equals(oldOptions.minSpace || DEFAULT_OPTIONS.minSpace))
+      || newOptions.maxSpace !== oldOptions.maxSpace;
   }
 
   update(invalidationContext: InvalidationContext<O>): void {
@@ -85,6 +92,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
       maxItemSize = DEFAULT_OPTIONS.maxItemSize,
       preserveAspectRatio = DEFAULT_OPTIONS.preserveAspectRatio,
       minSpace = DEFAULT_OPTIONS.minSpace,
+      maxSpace = DEFAULT_OPTIONS.maxSpace,
       maxColumns = DEFAULT_OPTIONS.maxColumns,
       dropIndicatorThickness = DEFAULT_OPTIONS.dropIndicatorThickness
     } = invalidationContext.layoutOptions || {};

--- a/packages/@react-stately/layout/src/GridLayout.ts
+++ b/packages/@react-stately/layout/src/GridLayout.ts
@@ -125,9 +125,10 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
     let itemHeight = minItemSize.height + Math.floor((maxItemHeight - minItemSize.height) * t);
     itemHeight = Math.max(minItemSize.height, Math.min(maxItemHeight, itemHeight));
 
-    // Compute the horizontal spacing and content height
-    let horizontalSpacing = Math.floor((visibleWidth - numColumns * itemWidth) / (numColumns + 1));
+    // Compute the horizontal spacing, content height and horizontal margin
+    let horizontalSpacing = Math.min(maxSpace, Math.floor((visibleWidth - numColumns * itemWidth) / (numColumns + 1)));
     this.gap = new Size(horizontalSpacing, minSpace.height);
+    this.margin = Math.floor((visibleWidth - numColumns * itemWidth - horizontalSpacing * (numColumns + 1)) / 2);
 
     // If there is a skeleton loader within the last 2 items in the collection, increment the collection size
     // so that an additional row is added for the skeletons.
@@ -142,7 +143,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
       }
       lastKey = collection.getKeyBefore(lastKey);
     }
-    
+
     let rows = Math.ceil(collectionSize / numColumns);
     let iterator = collection[Symbol.iterator]();
     let y = rows > 0 ? minSpace.height : 0;

--- a/packages/@react-stately/layout/src/GridLayout.ts
+++ b/packages/@react-stately/layout/src/GridLayout.ts
@@ -75,6 +75,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
   protected numColumns: number = 0;
   private contentSize: Size = new Size();
   private layoutInfos: Map<Key, LayoutInfo> = new Map();
+  private margin: number = 0;
 
   shouldInvalidateLayoutOptions(newOptions: O, oldOptions: O): boolean {
     return newOptions.maxColumns !== oldOptions.maxColumns
@@ -173,7 +174,7 @@ export class GridLayout<T, O extends GridLayoutOptions = GridLayoutOptions> exte
         if (skeleton) {
           content = oldLayoutInfo && oldLayoutInfo.content.key === key ? oldLayoutInfo.content : {...skeleton, key};
         }
-        let x = horizontalSpacing + col * (itemWidth + horizontalSpacing);
+        let x = horizontalSpacing + col * (itemWidth + horizontalSpacing) + this.margin;
         let height = itemHeight;
         let estimatedSize = !preserveAspectRatio;
         if (oldLayoutInfo && estimatedSize) {

--- a/packages/react-aria-components/stories/GridList.stories.tsx
+++ b/packages/react-aria-components/stories/GridList.stories.tsx
@@ -200,7 +200,20 @@ export const VirtualizedGridList: StoryObj<typeof VirtualizedGridListRender> = {
   }
 };
 
-export let VirtualizedGridListGrid: GridListStory = () => {
+interface VirtualizedGridListGridProps {
+  maxItemSizeWidth?: number,
+  maxColumns?: number,
+  minHorizontalSpace?: number,
+  maxHorizontalSpace?: number
+}
+
+export let VirtualizedGridListGrid: StoryFn<VirtualizedGridListGridProps> = (args) => {
+  const {
+    maxItemSizeWidth = 65,
+    maxColumns = Infinity,
+    minHorizontalSpace = 0,
+    maxHorizontalSpace = Infinity
+  } = args;
   let items: {id: number, name: string}[] = [];
   for (let i = 0; i < 10000; i++) {
     items.push({id: i, name: `Item ${i}`});
@@ -211,13 +224,47 @@ export let VirtualizedGridListGrid: GridListStory = () => {
       layout={GridLayout}
       layoutOptions={{
         minItemSize: new Size(40, 40),
-        maxSpace: 5
+        maxItemSize: new Size(maxItemSizeWidth, 40),
+        minSpace: new Size(minHorizontalSpace, 18),
+        maxColumns,
+        maxHorizontalSpace
       }}>
       <GridList className={styles.menu} layout="grid" style={{height: 400, width: 400}} aria-label="virtualized listbox" items={items}>
         {item => <MyGridListItem>{item.name}</MyGridListItem>}
       </GridList>
     </Virtualizer>
   );
+};
+
+VirtualizedGridListGrid.story = {
+  args: {
+    maxItemSizeWidth: 65,
+    maxColumns: undefined,
+    minHorizontalSpace: 0,
+    maxHorizontalSpace: undefined
+  },
+  argTypes: {
+    maxItemSizeWidth: {
+      control: 'number',
+      description: 'Maximum width of each item in the grid list.',
+      defaultValue: 65
+    },
+    maxColumns: {
+      control: 'number',
+      description: 'Maximum number of columns in the grid list.',
+      defaultValue: undefined
+    },
+    minHorizontalSpace: {
+      control: 'number',
+      description: 'Minimum horizontal space between grid items.',
+      defaultValue: 0
+    },
+    maxHorizontalSpace: {
+      control: 'number',
+      description: 'Maximum horizontal space between grid items.',
+      defaultValue: undefined
+    }
+  }
 };
 
 let renderEmptyState = ({isLoading}) => {

--- a/packages/react-aria-components/stories/GridList.stories.tsx
+++ b/packages/react-aria-components/stories/GridList.stories.tsx
@@ -210,7 +210,8 @@ export let VirtualizedGridListGrid: GridListStory = () => {
     <Virtualizer
       layout={GridLayout}
       layoutOptions={{
-        minItemSize: new Size(40, 40)
+        minItemSize: new Size(40, 40),
+        maxSpace: 5
       }}>
       <GridList className={styles.menu} layout="grid" style={{height: 400, width: 400}} aria-label="virtualized listbox" items={items}>
         {item => <MyGridListItem>{item.name}</MyGridListItem>}


### PR DESCRIPTION
Closes #8655 

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
  - [x] I added updated an existing storybook with using that option
  - I didn't find existing test for this file
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
  - from what I can see, running docs locally automatically updated them, so I guess nothing more is necessary?
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
  - not applicable here?

## 📝 Test Instructions:

Run the storybook (locally)
Under "React Aria Components > GridList > Virtualized Grid List Grid"
| before (without `maxSpace`) | after (with `maxSpace: 5`) |
|-|-|
| <img width="419" height="422" alt="image" src="https://github.com/user-attachments/assets/37c55aa5-2445-4003-9b3a-b31439d6a3c7" /> | <img width="421" height="423" alt="image" src="https://github.com/user-attachments/assets/f4cc969f-70d5-4479-9a73-42331eab49d7" /> |

you can also test for more complex combination by modifying the `layoutOptions`.
For example with `layoutOptions`:
```js
{
  minItemSize: new Size(40, 40),
  maxItemSize: new Size(65, 40),
  maxColumns: 3
}
```
| before (without `maxSpace`) | after (with `maxSpace: 5`) |
|-|-|
| <img width="427" height="423" alt="image" src="https://github.com/user-attachments/assets/7742f7db-45a5-4133-aaa0-888cb117b80c" /> | <img width="425" height="422" alt="image" src="https://github.com/user-attachments/assets/3b07644a-a6ad-4e42-ab5a-896fdb04d3ae" /> |


## 🧢 Your Project:

Algolia Visual Editor is available in the Algolia Dashboard & allows to create Rules to curate results for specific queries.
It makes use of Drag & Drop capabilities to allow to "pin" records to specific position (see example around 1min20s [in this video](https://youtu.be/CSOofqlnO-4?si=XLlmohpKAL1KQKfX&t=77))
we're currently in the process of migrating our existing drag & drop library (and virtualizer) to use `react-aria-components`.
In order to be able to consistently render grids of records across many pages in the Algolia Dashboard, we need to have a fixed gap between grid items. `maxSpace` will unlock this possibility without having to resort to artificially reduce the Virtualizer width with additional pre-computations