### PR TITLE
chore: Replace deprecated mozInputSource check for virtual click detection

### DIFF
--- a/packages/@react-aria/utils/src/isVirtualEvent.ts
+++ b/packages/@react-aria/utils/src/isVirtualEvent.ts
@@ -25,7 +25,7 @@ import {isAndroid} from './platform';
 
 export function isVirtualClick(event: MouseEvent | PointerEvent): boolean {
   // JAWS/NVDA with Firefox.
-  if ((event as any).mozInputSource === 0 && event.isTrusted) {
+  if ((event as PointerEvent).pointerType === '' && event.isTrusted) {
     return true;
   }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test that virtual clicks are still properly detected for JAWS/NVDA, sanity check other screenreader/browser combinations.
To test, can try the drag and drop stories and attempt keyboard drag and drop 

A sample flow can be found via https://github.com/adobe/react-spectrum/pull/3221, copied below. Some of the drag messages may not be exactly as below but the overall flow should be the same

1. Using Windows with either JAWS or NVDA screen reader, open https://reactspectrum.blob.core.windows.net/reactspectrum/1331d8e41e11a79c5d05e9086e4c5f8781d566b4/storybook/index.html?path=/story/drag-and-drop--default&id=drag-and-drop--default&providerSwitcher-toastPosition=bottom&viewMode=story
2. In browse mode/virtual cursor mode, navigate to the button labelled "Drag me."
3. The dragDescriptionVirtual message, "Click to start dragging." does not get announced.
4. Press Space or Enter key to activate the "Drag me" button and start dragging.
5. NVDA or JAWS should shift into forms mode.
6. The live announcer will announce the, dragStartedVirtual message, "Started dragging. Navigate to a drop target, then click or press Enter to drop," followed by the endDragVirtual message, "Dragging. Click to cancel drag."
7. Use down arrow to move the virtual cursor to the first available drop target, a button labelled, "Drop here."
8. The screen reader should to announce the dropDescriptionVirtual, "Click to drop."
9. Press Enter key to complete drop action.
10. The live announcer will announce the dropComplete message, "Drop complete."

## 🧢 Your Project:

RSP
