### PR TITLE
useDrag: clearData is onDragStart before writeToDataTransfer

### DIFF
--- a/packages/@react-aria/dnd/src/useDrag.ts
+++ b/packages/@react-aria/dnd/src/useDrag.ts
@@ -116,6 +116,8 @@ export function useDrag(options: DragOptions): DragResult {
     }
 
     let items = options.getItems();
+    // Clear existing data (e.g. selected text on the page would be included in some browsers)
+    e.dataTransfer.clearData();
     writeToDataTransfer(e.dataTransfer, items);
 
     let allowed = DROP_OPERATION.all;

--- a/packages/@react-aria/dnd/test/mocks.js
+++ b/packages/@react-aria/dnd/test/mocks.js
@@ -125,6 +125,14 @@ export class DataTransfer {
   getData(type) {
     return this.items._items.find(item => item.kind === 'string' && item.type === type)?._data;
   }
+
+  clearData(type) {
+    if (type) {
+      this.items._items = this.items._items.filter(item => item.type !== type);
+    } else {
+      this.items._items = [];
+    }
+  }
 }
 
 export class DragEvent extends MouseEvent {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8672

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the useDrag docs and select some text on the page, then try dragging and dropping the "Drag me" element into the drop area. The drop area should just show "hello world" and not include any text that was selected.

## 🧢 Your Project:

<!--- Company/project for pull request -->
