### PR TITLE
Revert "fix: ignore typing leading zeros in DateField segments (#8447)"

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -256,8 +256,7 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
           if (shouldSetValue) {
             focusManager.focusNext();
           }
-        } else if (shouldSetValue) {
-          // Don't accept leading zeros except for fields that accept 0 as a entire value (aka 00 for minutes/seconds/etc)
+        } else {
           enteredKeys.current = newValue;
         }
         break;
@@ -326,6 +325,7 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
         if (ref.current) {
           ref.current.textContent = compositionRef.current;
         }
+
         // Android sometimes fires key presses of letters as composition events. Need to handle am/pm keys here too.
         // Can also happen e.g. with Pinyin keyboard on iOS.
         if (data != null && (startsWith(am, data) || startsWith(pm, data))) {
@@ -387,9 +387,9 @@ export function useDateSegment(segment: DateSegment, state: DateFieldState, ref:
 
   let segmentStyle: CSSProperties = {caretColor: 'transparent'};
   if (direction === 'rtl') {
-    // While the bidirectional algorithm seems to work properly on inline elements with actual values, it returns different results for placeholder strings.
+    // While the bidirectional algorithm seems to work properly on inline elements with actual values, it returns different results for placeholder strings. 
     // To ensure placeholder render in correct format, we apply the CSS equivalent of LRE (left-to-right embedding). See https://www.unicode.org/reports/tr9/#Explicit_Directional_Embeddings.
-    // However, we apply this to both placeholders and date segments with an actual value because the date segments will shift around when deleting otherwise.
+    // However, we apply this to both placeholders and date segments with an actual value because the date segments will shift around when deleting otherwise. 
     segmentStyle.unicodeBidi = 'embed';
     let format = options[segment.type];
     if (format === 'numeric' || format === '2-digit') {

--- a/packages/@react-spectrum/datepicker/test/DateField.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateField.test.js
@@ -235,11 +235,7 @@ describe('DateField', function () {
           errorMessage="Date unavailable." />
       );
       await user.tab();
-      await user.keyboard('1');
-      await user.keyboard('[ArrowRight]');
-      await user.keyboard('1');
-      await user.keyboard('[ArrowRight]');
-      await user.keyboard('1980');
+      await user.keyboard('01011980');
       expect(tree.getByText('Date unavailable.')).toBeInTheDocument();
     });
 
@@ -249,7 +245,7 @@ describe('DateField', function () {
           <DateField label="Date" showFormatHelpText />
         </Provider>
       );
-
+  
       let segments = Array.from(getByRole('group').querySelectorAll('[data-testid]'));
       let segmentTypes = segments.map(s => s.getAttribute('data-testid'));
       expect(segmentTypes).toEqual(['year', 'month', 'day']);

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -1426,8 +1426,7 @@ describe('DatePicker', function () {
 
       it('should support typing into the month segment', function () {
         testInput('month,', new CalendarDate(2019, 2, 3), '1', new CalendarDate(2019, 1, 3), false);
-        testInput('month,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 1, 3), false);
-        testInput('month,', new CalendarDate(2019, 2, 3), '012', new CalendarDate(2019, 12, 3), true);
+        testInput('month,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 1, 3), true);
         testInput('month,', new CalendarDate(2019, 2, 3), '12', new CalendarDate(2019, 12, 3), true);
         testInput('month,', new CalendarDate(2019, 2, 3), '4', new CalendarDate(2019, 4, 3), true);
         testIgnored('month,', new CalendarDate(2019, 2, 3), '0');
@@ -1436,8 +1435,7 @@ describe('DatePicker', function () {
 
       it('should support typing into the day segment', function () {
         testInput('day,', new CalendarDate(2019, 2, 3), '1', new CalendarDate(2019, 2, 1), false);
-        testInput('day,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 2, 1), false);
-        testInput('day,', new CalendarDate(2019, 2, 3), '012', new CalendarDate(2019, 2, 12), true);
+        testInput('day,', new CalendarDate(2019, 2, 3), '01', new CalendarDate(2019, 2, 1), true);
         testInput('day,', new CalendarDate(2019, 2, 3), '12', new CalendarDate(2019, 2, 12), true);
         testInput('day,', new CalendarDate(2019, 2, 3), '4', new CalendarDate(2019, 2, 4), true);
         testIgnored('day,', new CalendarDate(2019, 2, 3), '0');
@@ -1446,19 +1444,14 @@ describe('DatePicker', function () {
 
       it('should support typing into the year segment', function () {
         testInput('year,', new CalendarDate(2019, 2, 3), '1993', new CalendarDate(1993, 2, 3), false);
-        testInput('year,', new CalendarDate(2019, 2, 3), '0199', new CalendarDate(199, 2, 3), false);
-        testInput('year,', new CalendarDate(2019, 2, 3), '01993', new CalendarDate(1993, 2, 3), false);
-        testInput('year,', new CalendarDateTime(2019, 2, 3, 8), '0199', new CalendarDateTime(199, 2, 3, 8), false);
         testInput('year,', new CalendarDateTime(2019, 2, 3, 8), '1993', new CalendarDateTime(1993, 2, 3, 8), true);
-        testInput('year,', new CalendarDateTime(2019, 2, 3, 8), '01993', new CalendarDateTime(1993, 2, 3, 8), true);
         testIgnored('year,', new CalendarDate(2019, 2, 3), '0');
       });
 
       it('should support typing into the hour segment in 12 hour time', function () {
         // AM
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '1', new CalendarDateTime(2019, 2, 3, 1), false);
-        testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '01', new CalendarDateTime(2019, 2, 3, 1), false);
-        testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '011', new CalendarDateTime(2019, 2, 3, 11), true);
+        testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '01', new CalendarDateTime(2019, 2, 3, 1), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '11', new CalendarDateTime(2019, 2, 3, 11), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '12', new CalendarDateTime(2019, 2, 3, 0), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 8), '4', new CalendarDateTime(2019, 2, 3, 4), true);
@@ -1466,8 +1459,7 @@ describe('DatePicker', function () {
 
         // PM
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '1', new CalendarDateTime(2019, 2, 3, 13), false);
-        testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '01', new CalendarDateTime(2019, 2, 3, 13), false);
-        testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '011', new CalendarDateTime(2019, 2, 3, 23), true);
+        testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '01', new CalendarDateTime(2019, 2, 3, 13), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '11', new CalendarDateTime(2019, 2, 3, 23), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '12', new CalendarDateTime(2019, 2, 3, 12), true);
         testInput('hour,', new CalendarDateTime(2019, 2, 3, 20), '4', new CalendarDateTime(2019, 2, 3, 16), true);

--- a/packages/react-aria-components/test/DateField.test.js
+++ b/packages/react-aria-components/test/DateField.test.js
@@ -374,44 +374,6 @@ describe('DateField', () => {
     expect(segmentTypes).toEqual(['year', 'literal', 'month', 'day']);
   });
 
-  it('should not store leading zeros when typing into the segments', async () => {
-    let {getAllByRole} = render(
-      <DateField>
-        <Label>Date</Label>
-        <DateInput>
-          {segment => <DateSegment segment={segment} />}
-        </DateInput>
-      </DateField>
-    );
-
-    let segements = getAllByRole('spinbutton');
-    let monthSegment = segements[0];
-    await user.click(monthSegment);
-    expect(monthSegment).toHaveFocus();
-    await user.keyboard('11');
-    expect(monthSegment).toHaveTextContent('11');
-    await user.click(monthSegment);
-    await user.keyboard('012');
-    expect(monthSegment).toHaveTextContent('12');
-
-    let daysSegment = segements[1];
-    await user.click(daysSegment);
-    expect(daysSegment).toHaveFocus();
-    await user.keyboard('11');
-    expect(daysSegment).toHaveTextContent('11');
-    await user.click(daysSegment);
-    await user.keyboard('012');
-    expect(daysSegment).toHaveTextContent('12');
-
-    let yearsSegment = segements[2];
-    await user.click(yearsSegment);
-    expect(yearsSegment).toHaveFocus();
-    await user.keyboard('1111');
-    expect(yearsSegment).toHaveTextContent('1111');
-    await user.keyboard('002222');
-    expect(yearsSegment).toHaveTextContent('2222');
-  });
-
   it('should support autofill', async() => {
     let {getByRole} = render(
       <DateField>


### PR DESCRIPTION
This reverts commit 7e14ffa419f59827dffb4f3ef142726e1686c36d.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
