### PR TITLE
fix: ensure that only the dragged items content is added to e.dataTransfer

### DIFF
--- a/packages/@react-aria/dnd/src/useDrag.ts
+++ b/packages/@react-aria/dnd/src/useDrag.ts
@@ -115,6 +115,9 @@ export function useDrag(options: DragOptions): DragResult {
       });
     }
 
+    // Clear any data that may already be in the drag event (e.g. if the user has text of the page highlighted)
+    e.dataTransfer.clearData?.();
+
     let items = options.getItems();
     writeToDataTransfer(e.dataTransfer, items);
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8672

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the useDrag docs, highlight the page content, then perform the drag operation in the example. There shouldn't be a error in the console. Sanity test other DnD flows

## 🧢 Your Project:

RSP
