### PR TITLE
feat: Support placeholders in S2 components

### DIFF
--- a/.storybook-s2/docs/Migrating.jsx
+++ b/.storybook-s2/docs/Migrating.jsx
@@ -133,7 +133,6 @@ export function Migrating() {
         <H3>ColorField</H3>
         <ul className="sb-unstyled">
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>Remove <Code>placeholder</Code> (it has been removed due to accessibility issues)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
         </ul>
@@ -155,7 +154,6 @@ export function Migrating() {
         <ul className="sb-unstyled">
           <li className={style({font: 'body', marginY: 8})}>Change <Code>menuWidth</Code> value from a <Code>DimensionValue</Code> to a pixel value</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>Remove <Code>placeholder</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({font: 'body', marginY: 8})}>Update <Code>Item</Code> to be a <Code>ComboBoxItem</Code></li>
@@ -338,7 +336,6 @@ export function Migrating() {
 
         <H3>SearchField</H3>
         <ul className="sb-unstyled">
-          <li className={style({font: 'body', marginY: 8})}>Remove <Code>placeholder</Code> (it has been removed due to accessibility issues)</li>
           <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out icon (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
@@ -405,7 +402,6 @@ export function Migrating() {
         <ul className="sb-unstyled">
           <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>icon</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>Remove <Code>placeholder</Code>  (it has been removed due to accessibility issues)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
         </ul>
@@ -414,7 +410,6 @@ export function Migrating() {
         <ul className="sb-unstyled">
           <li className={style({font: 'body', marginY: 8})}>[PENDING] Comment out <Code>icon</Code> (it has not been implemented yet)</li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>isQuiet</Code> (it is no longer supported in Spectrum 2)</li>
-          <li className={style({font: 'body', marginY: 8})}>Remove <Code>placeholder</Code>  (it has been removed due to accessibility issues)</li>
           <li className={style({font: 'body', marginY: 8})}>Change <Code>validationState="invalid"</Code> to <Code>isInvalid</Code></li>
           <li className={style({font: 'body', marginY: 8})}>Remove <Code>validationState="valid"</Code> (it is no longer supported in Spectrum 2)</li>
         </ul>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -447,29 +447,6 @@ export default [{
     },
 }, {
     files: [
-        "packages/**/*.ts",
-        "packages/**/*.tsx"
-    ],
-
-    rules: {
-        "@typescript-eslint/explicit-module-boundary-types": ERROR,
-    },
-}, {
-    files: [
-        "**/dev/**",
-        "**/test/**",
-        "**/stories/**",
-        "**/docs/**",
-        "**/chromatic/**",
-        "**/chromatic-fc/**",
-        "**/__tests__/**"
-    ],
-
-    rules: {
-        "@typescript-eslint/explicit-module-boundary-types": OFF,
-    },
-}, {
-    files: [
         "packages/@react-aria/focus/src/**/*.ts",
         "packages/@react-aria/focus/src/**/*.tsx",
     ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -447,6 +447,29 @@ export default [{
     },
 }, {
     files: [
+        "packages/**/*.ts",
+        "packages/**/*.tsx"
+    ],
+
+    rules: {
+        "@typescript-eslint/explicit-module-boundary-types": ERROR,
+    },
+}, {
+    files: [
+        "**/dev/**",
+        "**/test/**",
+        "**/stories/**",
+        "**/docs/**",
+        "**/chromatic/**",
+        "**/chromatic-fc/**",
+        "**/__tests__/**"
+    ],
+
+    rules: {
+        "@typescript-eslint/explicit-module-boundary-types": OFF,
+    },
+}, {
+    files: [
         "packages/@react-aria/focus/src/**/*.ts",
         "packages/@react-aria/focus/src/**/*.tsx",
     ],

--- a/packages/@react-spectrum/s2/chromatic/Accordion.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/Accordion.stories.tsx
@@ -45,7 +45,7 @@ export const Example: Story = {
               People
             </DisclosureTitle>
             <DisclosurePanel>
-              <TextField label="Name" styles={style({maxWidth: 176})} />
+              <TextField label="Name" styles={style({maxWidth: 176})} placeholder="Enter your name" />
             </DisclosurePanel>
           </Disclosure>
         </Accordion>
@@ -107,7 +107,7 @@ export const WithDisabledDisclosure: Story = {
               People
             </DisclosureTitle>
             <DisclosurePanel>
-              <TextField label="Name" />
+              <TextField label="Name" placeholder="Enter your name" />
             </DisclosurePanel>
           </Disclosure>
         </Accordion>
@@ -152,7 +152,7 @@ export const WithActionButton: Story = {
               <ActionButton><NewIcon aria-label="new icon" /></ActionButton>
             </DisclosureHeader>
             <DisclosurePanel>
-              <TextField label="Name" styles={style({maxWidth: 176})} />
+              <TextField label="Name" styles={style({maxWidth: 176})} placeholder="Enter your name" />
             </DisclosurePanel>
           </Disclosure>
         </Accordion>

--- a/packages/@react-spectrum/s2/chromatic/ColorField.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/ColorField.stories.tsx
@@ -45,7 +45,7 @@ const Template = ({combos, ...args}: ColorFieldProps & {combos: any[]}): ReactEl
           key = 'default';
         }
         return (
-          <ColorField data-testid={fullComboName} defaultValue="#e21" label={key} description="test description" errorMessage="test error" {...c} {...args}  />
+          <ColorField data-testid={fullComboName} defaultValue="#e21" label={key} description="test description" errorMessage="test error" placeholder="######" {...c} {...args}  />
         );
       })}
     </div>

--- a/packages/@react-spectrum/s2/chromatic/Forms.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/Forms.stories.tsx
@@ -62,9 +62,9 @@ type Story = StoryObj<typeof Form>;
 export const Example: Story = {
   render: (args) => (
     <Form {...args}>
-      <TextField label="First Name" name="firstName" />
-      <TextField label="Last Name" name="firstName" />
-      <TextField label="Email" name="email" type="email" description="Enter an email" />
+      <TextField label="First Name" name="firstName" placeholder="John" />
+      <TextField label="Last Name" name="lastName" placeholder="Doe" />
+      <TextField label="Email" name="email" type="email" description="Enter an email" placeholder="abc@123.com" />
       <CheckboxGroup label="Favorite sports">
         <Checkbox value="soccer">Soccer</Checkbox>
         <Checkbox value="baseball">Baseball</Checkbox>
@@ -75,10 +75,10 @@ export const Example: Story = {
         <Radio value="dog">Dog</Radio>
         <Radio value="plant" isDisabled>Plant</Radio>
       </RadioGroup>
-      <TextField label="City" name="city" description="A long description to test help text wrapping." />
-      <TextField label="A long label to test wrapping behavior" name="long" />
+      <TextField label="City" name="city" description="A long description to test help text wrapping." placeholder="Some city" />
+      <TextField label="A long label to test wrapping behavior" name="long" placeholder="looooooooooong" />
       <SearchField label="Search" name="search" />
-      <TextArea label="Comment" name="comment" />
+      <TextArea label="Comment" name="comment" placeholder="Enter your comment here" />
       <Switch>Wi-Fi</Switch>
       <Checkbox>I agree to the terms</Checkbox>
       <Slider label="Cookies"  defaultValue={30} />
@@ -91,9 +91,9 @@ export const Example: Story = {
 export const MixedForm: Story = {
   render: (args) => (
     <Form {...args}>
-      <TextField label="First Name" name="firstName" />
-      <TextField label="Last Name" name="firstName" />
-      <TextField label="Email" name="email" type="email" description="Enter an email" />
+      <TextField label="First Name" name="firstName" placeholder="John" />
+      <TextField label="Last Name" name="lastName" placeholder="Doe" />
+      <TextField label="Email" name="email" type="email" description="Enter an email" placeholder="abc@123.com" />
       <CheckboxGroup aria-label="Favorite sports">
         <Checkbox value="soccer">Soccer</Checkbox>
         <Checkbox value="baseball">Baseball</Checkbox>
@@ -143,7 +143,7 @@ const CustomLabelsExampleRender = (args: FormProps): ReactElement => {
         <ToggleButton>
           Enable color
         </ToggleButton>
-        <ColorField aria-label="Fill color" styles={style({width: 144})} />
+        <ColorField aria-label="Fill color" styles={style({width: 144})} placeholder="######" />
         <ColorSlider channel="alpha" defaultValue="#000" />
       </div>
       <Divider size="S" />
@@ -152,7 +152,7 @@ const CustomLabelsExampleRender = (args: FormProps): ReactElement => {
         <ToggleButton>
           Enable search
         </ToggleButton>
-        <TextField aria-label="Query" styles={style({width: 144})} />
+        <TextField aria-label="Query" styles={style({width: 144})} placeholder="Search here" />
         <ComboBox aria-label="Search terms" styles={style({width: 144})}>
           <ComboBoxItem>search term 1</ComboBoxItem>
           <ComboBoxItem>search term 2</ComboBoxItem>

--- a/packages/@react-spectrum/s2/chromatic/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/TextField.stories.tsx
@@ -34,7 +34,8 @@ type Story = StoryObj<typeof TextField>;
 export const Example: Story = {
   render: (args) => <TextField {...args} />,
   args: {
-    label: 'Name'
+    label: 'Name',
+    placeholder: 'Enter your name'
   }
 };
 
@@ -57,6 +58,7 @@ export const ContextualHelpExample: Story = {
   ),
   args: {
     label: 'Segment',
+    placeholder: 'Enter your name',
     contextualHelp: (
       <ContextualHelp>
         <Heading>What is a segment?</Heading>
@@ -80,14 +82,16 @@ export const ContextualHelpExample: Story = {
 export const TextAreaExample: StoryObj<typeof TextArea> = {
   render: (args) => <TextArea {...args} />,
   args: {
-    label: 'Comment'
+    label: 'Comment',
+    placeholder: 'Enter your name'
   }
 };
 
 export const CustomWidth: Story = {
   render: (args) => <TextField {...args} styles={style({width: 384})} />,
   args: {
-    label: 'Name'
+    label: 'Name',
+    placeholder: 'Enter your name'
   },
   parameters: {
     docs: {
@@ -99,7 +103,8 @@ export const CustomWidth: Story = {
 export const SmallWidth: Story = {
   render: (args) => <TextField {...args} styles={style({width: 48})} />,
   args: {
-    label: 'Name'
+    label: 'Name',
+    placeholder: 'Enter your name'
   },
   parameters: {
     docs: {
@@ -111,7 +116,8 @@ export const SmallWidth: Story = {
 export const UNSAFEWidth: Story = {
   render: (args) => <TextField {...args} UNSAFE_style={{width: 384}} />,
   args: {
-    label: 'Name'
+    label: 'Name',
+    placeholder: 'Enter your name'
   },
   parameters: {
     docs: {

--- a/packages/@react-spectrum/s2/src/ColorField.tsx
+++ b/packages/@react-spectrum/s2/src/ColorField.tsx
@@ -23,6 +23,7 @@ import {FormContext, useFormProps} from './Form';
 import {GlobalDOMAttributes, HelpTextProps, SpectrumLabelableProps} from '@react-types/shared';
 import {style} from '../style' with {type: 'macro'};
 import {TextFieldRef} from '@react-types/textfield';
+import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 export interface ColorFieldProps extends Omit<AriaColorFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
@@ -74,6 +75,8 @@ export const ColorField = forwardRef(function ColorField(props: ColorFieldProps,
       return inputRef.current;
     }
   }));
+
+  usePlaceholderWarning(props.placeholder, 'ColorField', inputRef);
 
   return (
     <AriaColorField

--- a/packages/@react-spectrum/s2/src/ColorField.tsx
+++ b/packages/@react-spectrum/s2/src/ColorField.tsx
@@ -13,7 +13,8 @@
 import {
   ColorField as AriaColorField,
   ColorFieldProps as AriaColorFieldProps,
-  ContextValue
+  ContextValue,
+  InputProps
 } from 'react-aria-components';
 import {createContext, forwardRef, Ref, useContext, useImperativeHandle, useRef} from 'react';
 import {createFocusableRef} from '@react-spectrum/utils';
@@ -26,17 +27,13 @@ import {TextFieldRef} from '@react-types/textfield';
 import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface ColorFieldProps extends Omit<AriaColorFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
+export interface ColorFieldProps extends Omit<AriaColorFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps, Pick<InputProps, 'placeholder'> {
   /**
    * The size of the color field.
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL',
-  /**
-   * Temporary text that occupies the text input when it is empty.
-   */
-  placeholder?: string
+  size?: 'S' | 'M' | 'L' | 'XL'
 }
 
 export const ColorFieldContext = createContext<ContextValue<Partial<ColorFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/ColorField.tsx
+++ b/packages/@react-spectrum/s2/src/ColorField.tsx
@@ -31,7 +31,11 @@ export interface ColorFieldProps extends Omit<AriaColorFieldProps, 'children' | 
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL'
+  size?: 'S' | 'M' | 'L' | 'XL',
+  /**
+   * Temporary text that occupies the text input when it is empty.
+   */
+  placeholder?: string
 }
 
 export const ColorFieldContext = createContext<ContextValue<Partial<ColorFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -21,6 +21,7 @@ import {
   ComboBoxStateContext,
   ContextValue,
   InputContext,
+  InputProps,
   ListBox,
   ListBoxItem,
   ListBoxItemProps,
@@ -83,7 +84,8 @@ export interface ComboBoxProps<T extends object> extends
   HelpTextProps,
   Pick<ListBoxProps<T>, 'items' | 'dependencies'>,
   Pick<AriaPopoverProps, 'shouldFlip'>,
-  Pick<AsyncLoadable, 'onLoadMore'>  {
+  Pick<AsyncLoadable, 'onLoadMore'>,
+  Pick<InputProps, 'placeholder'>  {
     /** The contents of the collection. */
     children: ReactNode | ((item: T) => ReactNode),
     /**
@@ -101,11 +103,7 @@ export interface ComboBoxProps<T extends object> extends
     /** Width of the menu. By default, matches width of the trigger. Note that the minimum width of the dropdown is always equal to the trigger's width. */
     menuWidth?: number,
     /** The current loading state of the ComboBox. Determines whether or not the progress circle should be shown. */
-    loadingState?: LoadingState,
-    /**
-     * Temporary text that occupies the text input when it is empty.
-     */
-    placeholder?: string
+    loadingState?: LoadingState
 }
 
 export const ComboBoxContext = createContext<ContextValue<Partial<ComboBoxProps<any>>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -64,7 +64,6 @@ import {pressScale} from './pressScale';
 import {ProgressCircle} from './ProgressCircle';
 import {TextFieldRef} from '@react-types/textfield';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
-import {usePlaceholderWarning} from './placeholder-utils';
 import {useScale} from './utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
@@ -581,7 +580,6 @@ const ComboboxInner = forwardRef(function ComboboxInner(props: ComboBoxProps<any
     );
   }
   let scale = useScale();
-  usePlaceholderWarning(props.placeholder, 'ComboBox', inputRef);
 
   return (
     <>

--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -101,7 +101,11 @@ export interface ComboBoxProps<T extends object> extends
     /** Width of the menu. By default, matches width of the trigger. Note that the minimum width of the dropdown is always equal to the trigger's width. */
     menuWidth?: number,
     /** The current loading state of the ComboBox. Determines whether or not the progress circle should be shown. */
-    loadingState?: LoadingState
+    loadingState?: LoadingState,
+    /**
+     * Temporary text that occupies the text input when it is empty.
+     */
+    placeholder?: string
 }
 
 export const ComboBoxContext = createContext<ContextValue<Partial<ComboBoxProps<any>>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -64,6 +64,7 @@ import {pressScale} from './pressScale';
 import {ProgressCircle} from './ProgressCircle';
 import {TextFieldRef} from '@react-types/textfield';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
+import {usePlaceholderWarning} from './placeholder-utils';
 import {useScale} from './utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
@@ -580,6 +581,7 @@ const ComboboxInner = forwardRef(function ComboboxInner(props: ComboBoxProps<any
     );
   }
   let scale = useScale();
+  usePlaceholderWarning(props.placeholder, 'ComboBox', inputRef);
 
   return (
     <>

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -231,7 +231,10 @@ export const Input = forwardRef(function Input(props: InputProps, ref: Forwarded
       className={UNSAFE_className + mergeStyles(style({
         padding: 0,
         backgroundColor: 'transparent',
-        color: 'inherit',
+        color: {
+          default: 'inherit',
+          '::placeholder': 'gray-600'
+        },
         fontFamily: 'inherit',
         fontSize: 'inherit',
         fontWeight: 'inherit',

--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -33,7 +33,6 @@ import {GlobalDOMAttributes, HelpTextProps, SpectrumLabelableProps} from '@react
 import {pressScale} from './pressScale';
 import {TextFieldRef} from '@react-types/textfield';
 import {useButton, useFocusRing, useHover} from 'react-aria';
-import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 
@@ -177,8 +176,6 @@ export const NumberField = forwardRef(function NumberField(props: NumberFieldPro
       return inputRef.current;
     }
   }));
-
-  usePlaceholderWarning(props.placeholder, 'NumberField', inputRef);
 
   return (
     <AriaNumberField

--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -19,6 +19,7 @@ import {
   ButtonRenderProps,
   ContextValue,
   InputContext,
+  InputProps,
   useContextProps
 } from 'react-aria-components';
 import {baseColor, space, style} from '../style' with {type: 'macro'};
@@ -40,7 +41,8 @@ export interface NumberFieldProps extends
   Omit<AriaNumberFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>,
   StyleProps,
   SpectrumLabelableProps,
-  HelpTextProps {
+  HelpTextProps,
+  Pick<InputProps, 'placeholder'> {
   /**
    * Whether to hide the increment and decrement buttons.
    * @default false
@@ -51,11 +53,7 @@ export interface NumberFieldProps extends
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL',
-  /**
-   * Temporary text that occupies the text input when it is empty.
-   */
-  placeholder?: string
+  size?: 'S' | 'M' | 'L' | 'XL'
 }
 
 export const NumberFieldContext = createContext<ContextValue<Partial<NumberFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -33,6 +33,7 @@ import {GlobalDOMAttributes, HelpTextProps, SpectrumLabelableProps} from '@react
 import {pressScale} from './pressScale';
 import {TextFieldRef} from '@react-types/textfield';
 import {useButton, useFocusRing, useHover} from 'react-aria';
+import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 
@@ -177,6 +178,7 @@ export const NumberField = forwardRef(function NumberField(props: NumberFieldPro
     }
   }));
 
+  usePlaceholderWarning(props.placeholder, 'NumberField', inputRef);
 
   return (
     <AriaNumberField

--- a/packages/@react-spectrum/s2/src/NumberField.tsx
+++ b/packages/@react-spectrum/s2/src/NumberField.tsx
@@ -51,7 +51,11 @@ export interface NumberFieldProps extends
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL'
+  size?: 'S' | 'M' | 'L' | 'XL',
+  /**
+   * Temporary text that occupies the text input when it is empty.
+   */
+  placeholder?: string
 }
 
 export const NumberFieldContext = createContext<ContextValue<Partial<NumberFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/SearchField.tsx
+++ b/packages/@react-spectrum/s2/src/SearchField.tsx
@@ -29,6 +29,7 @@ import {IconContext} from './Icon';
 import {raw} from '../style/style-macro' with {type: 'macro'};
 import SearchIcon from '../s2wf-icons/S2_Icon_Search_20_N.svg';
 import {TextFieldRef} from '@react-types/textfield';
+import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'className' | 'style' | 'children' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
@@ -80,6 +81,8 @@ export const SearchField = /*#__PURE__*/ forwardRef(function SearchField(props: 
       return inputRef.current;
     }
   }));
+
+  usePlaceholderWarning(props.placeholder, 'SearchField', inputRef);
 
   return (
     <AriaSearchField

--- a/packages/@react-spectrum/s2/src/SearchField.tsx
+++ b/packages/@react-spectrum/s2/src/SearchField.tsx
@@ -37,7 +37,11 @@ export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'className'
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL'
+  size?: 'S' | 'M' | 'L' | 'XL',
+  /**
+   * Temporary text that occupies the text input when it is empty.
+   */
+  placeholder?: string
 }
 
 export const SearchFieldContext = createContext<ContextValue<Partial<SearchFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/SearchField.tsx
+++ b/packages/@react-spectrum/s2/src/SearchField.tsx
@@ -29,7 +29,6 @@ import {IconContext} from './Icon';
 import {raw} from '../style/style-macro' with {type: 'macro'};
 import SearchIcon from '../s2wf-icons/S2_Icon_Search_20_N.svg';
 import {TextFieldRef} from '@react-types/textfield';
-import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'className' | 'style' | 'children' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
@@ -81,8 +80,6 @@ export const SearchField = /*#__PURE__*/ forwardRef(function SearchField(props: 
       return inputRef.current;
     }
   }));
-
-  usePlaceholderWarning(props.placeholder, 'SearchField', inputRef);
 
   return (
     <AriaSearchField

--- a/packages/@react-spectrum/s2/src/SearchField.tsx
+++ b/packages/@react-spectrum/s2/src/SearchField.tsx
@@ -14,6 +14,7 @@ import {
   SearchField as AriaSearchField,
   SearchFieldProps as AriaSearchFieldProps,
   ContextValue,
+  InputProps,
   Provider
 } from 'react-aria-components';
 import {baseColor, fontRelative, style} from '../style' with {type: 'macro'};
@@ -31,17 +32,13 @@ import SearchIcon from '../s2wf-icons/S2_Icon_Search_20_N.svg';
 import {TextFieldRef} from '@react-types/textfield';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'className' | 'style' | 'children' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
+export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'className' | 'style' | 'children' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps, Pick<InputProps, 'placeholder'> {
   /**
    * The size of the SearchField.
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL',
-  /**
-   * Temporary text that occupies the text input when it is empty.
-   */
-  placeholder?: string
+  size?: 'S' | 'M' | 'L' | 'XL'
 }
 
 export const SearchFieldContext = createContext<ContextValue<Partial<SearchFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -18,6 +18,7 @@ import {
   composeRenderProps,
   ContextValue,
   InputContext,
+  InputProps,
   useSlottedContext
 } from 'react-aria-components';
 import {centerPadding, controlSize, field, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
@@ -33,17 +34,13 @@ import {TextFieldRef} from '@react-types/textfield';
 import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
+export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps, Pick<InputProps, 'placeholder'> {
   /**
    * The size of the text field.
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL',
-  /**
-   * Temporary text that occupies the text input when it is empty.
-   */
-  placeholder?: string
+  size?: 'S' | 'M' | 'L' | 'XL'
 }
 
 export const TextFieldContext = createContext<ContextValue<Partial<TextFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -25,11 +25,12 @@ import {createContext, forwardRef, ReactNode, Ref, useContext, useImperativeHand
 import {createFocusableRef} from '@react-spectrum/utils';
 import {FieldErrorIcon, FieldGroup, FieldLabel, HelpText, Input} from './Field';
 import {FormContext, useFormProps} from './Form';
-import {GlobalDOMAttributes, HelpTextProps, SpectrumLabelableProps} from '@react-types/shared';
+import {GlobalDOMAttributes, HelpTextProps, RefObject, SpectrumLabelableProps} from '@react-types/shared';
 import {mergeRefs} from '@react-aria/utils';
 import {style} from '../style' with {type: 'macro'};
 import {StyleString} from '../style/types';
 import {TextFieldRef} from '@react-types/textfield';
+import {usePlaceholderWarning} from './placeholder-utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'className' | 'style' | keyof GlobalDOMAttributes>, StyleProps, SpectrumLabelableProps, HelpTextProps {
@@ -39,7 +40,6 @@ export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'c
    * @default 'M'
    */
   size?: 'S' | 'M' | 'L' | 'XL',
-  // TODO: put warning about needing to provide this for cases where the text field is not focused and doesn't have text
   /**
    * Temporary text that occupies the text input when it is empty.
    */
@@ -105,6 +105,8 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldP
     UNSAFE_className = '',
     ...textFieldProps
   } = props;
+
+  usePlaceholderWarning(props.placeholder, 'TextField/Area', inputRef);
 
   // Expose imperative interface for ref
   useImperativeHandle(ref, () => ({
@@ -185,10 +187,11 @@ function TextAreaInput() {
       input.style.alignSelf = prevAlignment;
     }
   };
+  let {ref} = useSlottedContext(InputContext) ?? {};
 
   return (
     <AriaTextArea
-      ref={onHeightChange}
+      ref={mergeRefs(onHeightChange, ref as RefObject<HTMLTextAreaElement | null>)}
       // Workaround for baseline alignment bug in Safari.
       // https://bugs.webkit.org/show_bug.cgi?id=142968
       placeholder={placeholder ?? ' '}

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -38,7 +38,12 @@ export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'c
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL'
+  size?: 'S' | 'M' | 'L' | 'XL',
+  // TODO: put warning about needing to provide this for cases where the text field is not focused and doesn't have text
+  /**
+   * Temporary text that occupies the text input when it is empty.
+   */
+  placeholder?: string
 }
 
 export const TextFieldContext = createContext<ContextValue<Partial<TextFieldProps>, TextFieldRef>>(null);
@@ -159,7 +164,7 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldP
 
 function TextAreaInput() {
   // Force re-render when value changes so we update the height.
-  useSlottedContext(AriaTextAreaContext) ?? {};
+  let {placeholder} = useSlottedContext(AriaTextAreaContext) ?? {};
   let onHeightChange = (input: HTMLTextAreaElement) => {
     // TODO: only do this if an explicit height is not given?
     if (input) {
@@ -186,7 +191,7 @@ function TextAreaInput() {
       ref={onHeightChange}
       // Workaround for baseline alignment bug in Safari.
       // https://bugs.webkit.org/show_bug.cgi?id=142968
-      placeholder=" "
+      placeholder={placeholder ?? ' '}
       className={style({
         paddingX: 0,
         paddingY: centerPadding(),

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -201,7 +201,10 @@ function TextAreaInput() {
         minHeight: controlSize(),
         boxSizing: 'border-box',
         backgroundColor: 'transparent',
-        color: 'inherit',
+        color: {
+          default: 'inherit',
+          '::placeholder': 'gray-600'
+        },
         fontFamily: 'inherit',
         fontSize: 'inherit',
         fontWeight: 'inherit',

--- a/packages/@react-spectrum/s2/src/placeholder-utils.tsx
+++ b/packages/@react-spectrum/s2/src/placeholder-utils.tsx
@@ -17,7 +17,7 @@ export function usePlaceholderWarning(placeholder: string | undefined, component
   let checkPlaceholder = useEffectEvent((input: HTMLInputElement | null) => {
     if (!placeholder && input) {
       if (getActiveElement(getOwnerDocument(input)) !== input && (!input.value || input.value === '')) {
-        console.warn(`Your ${componentType} is empty and not focused but doesn't have a placeholder. Please add one.`);
+        console.warn(`Your ${componentType} is empty and not focused but doesn't have a placeholder. Please add one to the element with the following id: ${input.id}.`);
       }
     }
   });

--- a/packages/@react-spectrum/s2/src/placeholder-utils.tsx
+++ b/packages/@react-spectrum/s2/src/placeholder-utils.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {RefObject, useEffect} from 'react';
+import {useEffectEvent, useEvent} from '@react-aria/utils';
+
+export function usePlaceholderWarning(placeholder: string | undefined, componentType: string, inputRef: RefObject<HTMLInputElement | null>): void {
+  let checkPlaceholder = useEffectEvent((input: HTMLInputElement | null) => {
+    if (!placeholder && input) {
+      if (document.activeElement !== input && (!input.value || input.value === '') && process.env.NODE_ENV !== 'production') {
+        console.warn(`Your ${componentType} is empty and not focused but doesn't have a placeholder. Please add one.`);
+      }
+    }
+  });
+
+  useEffect(() => {
+    checkPlaceholder(inputRef.current);
+  }, [checkPlaceholder, inputRef]);
+
+  useEvent(inputRef, 'blur', (e) => checkPlaceholder(e.target as HTMLInputElement));
+}

--- a/packages/@react-spectrum/s2/src/placeholder-utils.tsx
+++ b/packages/@react-spectrum/s2/src/placeholder-utils.tsx
@@ -23,8 +23,17 @@ export function usePlaceholderWarning(placeholder: string | undefined, component
   });
 
   useEffect(() => {
-    checkPlaceholder(inputRef.current);
-  }, [checkPlaceholder, inputRef]);
+    let timer;
+    if (componentType === 'ComboBox') {
+      timer = setTimeout(() => {
+        checkPlaceholder(inputRef.current);
+      }, 50);
+    } else {
+      checkPlaceholder(inputRef.current);
+    }
+
+    return () => clearTimeout(timer);
+  }, [checkPlaceholder, inputRef, componentType]);
 
   useEvent(inputRef, 'blur', (e) => checkPlaceholder(e.target as HTMLInputElement));
 }

--- a/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Accordion.stories.tsx
@@ -51,7 +51,7 @@ export const Example: Story = {
               People
             </DisclosureTitle>
             <DisclosurePanel>
-              <TextField label="Name" styles={style({maxWidth: 176})} />
+              <TextField label="Name" styles={style({maxWidth: 176})} placeholder="Enter your name" />
             </DisclosurePanel>
           </Disclosure>
         </Accordion>
@@ -113,7 +113,7 @@ export const WithDisabledDisclosure: Story = {
               People
             </DisclosureTitle>
             <DisclosurePanel>
-              <TextField label="Name" />
+              <TextField label="Name" placeholder="Enter your name" />
             </DisclosurePanel>
           </Disclosure>
         </Accordion>
@@ -155,7 +155,7 @@ function ControlledAccordion(props) {
             People
           </DisclosureTitle>
           <DisclosurePanel>
-            <TextField label="Name" />
+            <TextField label="Name" placeholder="Enter your name" />
           </DisclosurePanel>
         </Disclosure>
       </Accordion>
@@ -193,7 +193,7 @@ export const ControlledOpen: Story = {
             People
           </DisclosureTitle>
           <DisclosurePanel>
-            <TextField label="Name" />
+            <TextField label="Name" placeholder="Enter your name" />
           </DisclosurePanel>
         </Disclosure>
       </Accordion>
@@ -231,7 +231,7 @@ export const WithActionButton: Story = {
               <ActionButton><NewIcon aria-label="new icon" /></ActionButton>
             </DisclosureHeader>
             <DisclosurePanel>
-              <TextField label="Name" styles={style({maxWidth: 176})} />
+              <TextField label="Name" styles={style({maxWidth: 176})} placeholder="Enter your name" />
             </DisclosurePanel>
           </Disclosure>
         </Accordion>
@@ -239,4 +239,3 @@ export const WithActionButton: Story = {
     );
   }
 };
-

--- a/packages/@react-spectrum/s2/stories/ColorField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ColorField.stories.tsx
@@ -32,7 +32,11 @@ const meta: Meta<typeof ColorField> = {
     label: {control: {type: 'text'}},
     description: {control: {type: 'text'}},
     errorMessage: {control: {type: 'text'}},
-    contextualHelp: {table: {disable: true}}
+    contextualHelp: {table: {disable: true}},
+    placeholder: {control: {type: 'text'}}
+  },
+  args: {
+    placeholder: '######'
   },
   title: 'ColorField'
 };
@@ -43,8 +47,7 @@ type Story = StoryObj<typeof ColorField>;
 export const Example: Story = {
   render: (args) => <ColorField {...args} />,
   args: {
-    label: 'Color',
-    placeholder: '######'
+    label: 'Color'
   }
 };
 

--- a/packages/@react-spectrum/s2/stories/ColorField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ColorField.stories.tsx
@@ -43,7 +43,8 @@ type Story = StoryObj<typeof ColorField>;
 export const Example: Story = {
   render: (args) => <ColorField {...args} />,
   args: {
-    label: 'Color'
+    label: 'Color',
+    placeholder: '######'
   }
 };
 

--- a/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
@@ -32,7 +32,11 @@ const meta: Meta<typeof ComboBox<any>> = {
     description: {control: {type: 'text'}},
     errorMessage: {control: {type: 'text'}},
     children: {table: {disable: true}},
-    contextualHelp: {table: {disable: true}}
+    contextualHelp: {table: {disable: true}},
+    placeholder: {control: {type: 'text'}}
+  },
+  args: {
+    // placeholder: 'Select a value'
   },
   title: 'ComboBox'
 };
@@ -42,8 +46,8 @@ type Story = StoryObj<typeof ComboBox<any>>;
 
 export const Example: Story = {
   render: (args: ComboBoxProps<any>) => (
-    <ComboBox {...args}>
-      <ComboBoxItem>Chocolate</ComboBoxItem>
+    <ComboBox selectedKey="1">
+      <ComboBoxItem id="1">Chocolate</ComboBoxItem>
       <ComboBoxItem>Mint</ComboBoxItem>
       <ComboBoxItem>Strawberry</ComboBoxItem>
       <ComboBoxItem>Vanilla</ComboBoxItem>

--- a/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ComboBox.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta<typeof ComboBox<any>> = {
     placeholder: {control: {type: 'text'}}
   },
   args: {
-    // placeholder: 'Select a value'
+    placeholder: 'Select a value'
   },
   title: 'ComboBox'
 };
@@ -46,7 +46,7 @@ type Story = StoryObj<typeof ComboBox<any>>;
 
 export const Example: Story = {
   render: (args: ComboBoxProps<any>) => (
-    <ComboBox selectedKey="1">
+    <ComboBox {...args}>
       <ComboBoxItem id="1">Chocolate</ComboBoxItem>
       <ComboBoxItem>Mint</ComboBoxItem>
       <ComboBoxItem>Strawberry</ComboBoxItem>

--- a/packages/@react-spectrum/s2/stories/CustomDialog.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CustomDialog.stories.tsx
@@ -101,7 +101,7 @@ export const SideImage: Story = {
           <div className={style({padding: {default: 24, sm: 32}, flexGrow: 1, display: 'flex', flexDirection: 'column', rowGap: 32})}>
             <div className={style({display: 'flex', flexDirection: 'column', rowGap: 32, flexGrow: 1})}>
               <Heading slot="title" styles={style({font: 'heading', marginY: 0})}>Add new</Heading>
-              <TextField label="Name" isRequired />
+              <TextField label="Name" isRequired placeholder="Enter your name" />
               <DropZone>
                 <IllustratedMessage orientation="horizontal" size="S">
                   <DropToUpload />

--- a/packages/@react-spectrum/s2/stories/Form.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Form.stories.tsx
@@ -67,9 +67,9 @@ type Story = StoryObj<typeof Form>;
 export const Example: Story = {
   render: (args) => (
     <Form {...args}>
-      <TextField label="First Name" name="firstName" />
-      <TextField label="Last Name" name="firstName" />
-      <TextField label="Email" name="email" type="email" description="Enter an email" />
+      <TextField label="First Name" name="firstName" placeholder="John" />
+      <TextField label="Last Name" name="lastName" placeholder="Doe" />
+      <TextField label="Email" name="email" type="email" description="Enter an email" placeholder="123@abc.com" />
       <Picker label="Country" name="country">
         <PickerItem id="canada">Canada</PickerItem>
         <PickerItem id="united-states">United States</PickerItem>
@@ -86,10 +86,10 @@ export const Example: Story = {
         <Radio value="dog">Dog</Radio>
         <Radio value="plant" isDisabled>Plant</Radio>
       </RadioGroup>
-      <TextField label="City" name="city" description="A long description to test help text wrapping." />
-      <TextField label="A long label to test wrapping behavior" name="long" />
+      <TextField label="City" name="city" description="A long description to test help text wrapping." placeholder="Some city" />
+      <TextField label="A long label to test wrapping behavior" name="long" placeholder="loooooooooooooooooooooog" />
       <SearchField label="Search" name="search" />
-      <TextArea label="Comment" name="comment" />
+      <TextArea label="Comment" name="comment" placeholder="Enter your comment here" />
       <Switch>Wi-Fi</Switch>
       <Checkbox>I agree to the terms</Checkbox>
       <Slider label="Cookies"  defaultValue={30} />
@@ -102,9 +102,9 @@ export const Example: Story = {
 export const MixedForm: Story = {
   render: (args) => (
     <Form {...args}>
-      <TextField label="First Name" name="firstName" />
-      <TextField label="Last Name" name="firstName" />
-      <TextField label="Email" name="email" type="email" description="Enter an email" />
+      <TextField label="First Name" name="firstName" placeholder="John" />
+      <TextField label="Last Name" name="lastName" placeholder="Doe" />
+      <TextField label="Email" name="email" type="email" description="Enter an email" placeholder="123@abc.com" />
       <CheckboxGroup aria-label="Favorite sports">
         <Checkbox value="soccer">Soccer</Checkbox>
         <Checkbox value="baseball">Baseball</Checkbox>
@@ -155,7 +155,7 @@ const CustomLabelsExampleRender = (args: FormProps): ReactElement => {
         <ToggleButton>
           Enable color
         </ToggleButton>
-        <ColorField aria-label="Fill color" styles={style({width: 144})} />
+        <ColorField aria-label="Fill color" styles={style({width: 144})} placeholder="######" />
         <ColorSlider channel="alpha" defaultValue="#000" />
       </div>
       <Divider size="S" />
@@ -164,7 +164,7 @@ const CustomLabelsExampleRender = (args: FormProps): ReactElement => {
         <ToggleButton>
           Enable search
         </ToggleButton>
-        <TextField aria-label="Query" styles={style({width: 144})} />
+        <TextField aria-label="Query" styles={style({width: 144})} placeholder="Enter your name" />
         <ComboBox aria-label="Search terms" styles={style({width: 144})}>
           <ComboBoxItem>search term 1</ComboBoxItem>
           <ComboBoxItem>search term 2</ComboBoxItem>

--- a/packages/@react-spectrum/s2/stories/NumberField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/NumberField.stories.tsx
@@ -33,7 +33,11 @@ const meta: Meta<typeof NumberField> = {
     label: {control: {type: 'text'}},
     description: {control: {type: 'text'}},
     errorMessage: {control: {type: 'text'}},
-    contextualHelp: {table: {disable: true}}
+    contextualHelp: {table: {disable: true}},
+    placeholder: {control: {type: 'text'}}
+  },
+  args: {
+    placeholder: 'How many items?'
   },
   tags: ['autodocs'],
   title: 'NumberField'
@@ -102,4 +106,3 @@ export const ContextualHelpExample: Story = {
     label: 'Quantity'
   }
 };
-

--- a/packages/@react-spectrum/s2/stories/Popover.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Popover.stories.tsx
@@ -104,8 +104,8 @@ export const HelpCenter: Story = {
           <TabPanel id="feedback" styles={style({margin: 12})}>
             <p className={style({font: 'body', marginTop: 0})}>How are we doing? Share your feedback here.</p>
             <Form>
-              <TextField label="Subject" />
-              <TextField label="Description" isRequired />
+              <TextField label="Subject" placeholder="Subject" />
+              <TextField label="Description" isRequired placeholder="Enter your description here" />
               <Switch>Adobe can contact me for further questions concerning this feedback</Switch>
               <Button styles={style({marginStart: 'auto'})}>Submit</Button>
             </Form>

--- a/packages/@react-spectrum/s2/stories/SearchField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/SearchField.stories.tsx
@@ -34,7 +34,11 @@ const meta: Meta<typeof SearchField> = {
     label: {control: {type: 'text'}},
     description: {control: {type: 'text'}},
     errorMessage: {control: {type: 'text'}},
-    contextualHelp: {table: {disable: true}}
+    contextualHelp: {table: {disable: true}},
+    placeholder: {control: {type: 'text'}}
+  },
+  args: {
+    placeholder: 'Enter your search here'
   },
   title: 'SearchField'
 };

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -28,7 +28,8 @@ const meta: Meta<typeof TextField> = {
     label: {control: {type: 'text'}},
     description: {control: {type: 'text'}},
     errorMessage: {control: {type: 'text'}},
-    contextualHelp: {table: {disable: true}}
+    contextualHelp: {table: {disable: true}},
+    placeholder: {control: {type: 'text', defaultValue: 'Enter a name'}}
   },
   title: 'TextField'
 };

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -29,7 +29,10 @@ const meta: Meta<typeof TextField> = {
     description: {control: {type: 'text'}},
     errorMessage: {control: {type: 'text'}},
     contextualHelp: {table: {disable: true}},
-    placeholder: {control: {type: 'text', defaultValue: 'Enter a name'}}
+    placeholder: {control: {type: 'text'}}
+  },
+  args: {
+    placeholder: 'Enter your name'
   },
   title: 'TextField'
 };

--- a/packages/@react-spectrum/s2/test/ColorField.test.tsx
+++ b/packages/@react-spectrum/s2/test/ColorField.test.tsx
@@ -27,12 +27,12 @@ describe('ColorField', () => {
       <ColorField label="Color" />
     );
 
-    expect(spy).toHaveBeenCalledWith('Your ColorField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Your ColorField is empty and not focused but doesn\'t have a placeholder. Please add one to the element with the following id: '));
     spy.mockClear();
 
     await user.tab();
     await user.tab();
-    expect(spy).toHaveBeenCalledWith('Your ColorField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Your ColorField is empty and not focused but doesn\'t have a placeholder. Please add one to the element with the following id: '));
     spy.mockClear();
 
     let input = getByRole('textbox');

--- a/packages/@react-spectrum/s2/test/ColorField.test.tsx
+++ b/packages/@react-spectrum/s2/test/ColorField.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {ColorField} from '../src';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+describe('ColorField', () => {
+  let user;
+  beforeAll(() => {
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+
+  it('should warn if the ColorField renders/blurs without a placeholder', async () => {
+    let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    let {getByRole, rerender} = render(
+      <ColorField label="Color" />
+    );
+
+    expect(spy).toHaveBeenCalledWith('Your ColorField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    await user.tab();
+    await user.tab();
+    expect(spy).toHaveBeenCalledWith('Your ColorField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    let input = getByRole('textbox');
+    await user.click(input);
+    await user.keyboard('AAAAAA');
+    await user.tab();
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<ColorField label="Color" placeholder="test" />);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<ColorField label="Color" autoFocus />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@react-spectrum/s2/test/Combobox.test.tsx
+++ b/packages/@react-spectrum/s2/test/Combobox.test.tsx
@@ -212,23 +212,18 @@ describe('Combobox', () => {
     warn.mockRestore();
   });
 
-  it('should warn if the Combobox renders/blurs without a placeholder', async () => {
+  it('should not warn if the Combobox renders/blurs without a placeholder', async () => {
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let items = [{name: 'Chocolate'}, {name: 'Mint'}, {name: 'Chocolate Chip'}];
     let {rerender} = render(
       <DynamicCombobox items={items} />
     );
-    // Since Combobox takes multiple renders to populate its input value if a selected key is provided
-    // we have a delay for the placeholder warning
-    act(() => {jest.runAllTimers();});
 
-    expect(warnSpy).toHaveBeenCalledWith('Your ComboBox is empty and not focused but doesn\'t have a placeholder. Please add one.');
-    warnSpy.mockClear();
+    expect(warnSpy).not.toBeCalled();
 
     await user.tab();
     await user.tab();
-    expect(warnSpy).toHaveBeenCalledWith('Your ComboBox is empty and not focused but doesn\'t have a placeholder. Please add one.');
-    warnSpy.mockClear();
+    expect(warnSpy).not.toBeCalled();
 
     rerender(<DynamicCombobox items={items} placeholder="test" />);
     expect(warnSpy).not.toHaveBeenCalled();

--- a/packages/@react-spectrum/s2/test/Combobox.test.tsx
+++ b/packages/@react-spectrum/s2/test/Combobox.test.tsx
@@ -218,6 +218,9 @@ describe('Combobox', () => {
     let {rerender} = render(
       <DynamicCombobox items={items} />
     );
+    // Since Combobox takes multiple renders to populate its input value if a selected key is provided
+    // we have a delay for the placeholder warning
+    act(() => {jest.runAllTimers();});
 
     expect(warnSpy).toHaveBeenCalledWith('Your ComboBox is empty and not focused but doesn\'t have a placeholder. Please add one.');
     warnSpy.mockClear();

--- a/packages/@react-spectrum/s2/test/NumberField.test.tsx
+++ b/packages/@react-spectrum/s2/test/NumberField.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {NumberField} from '../src';
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+describe('NumberField', () => {
+  let user;
+  beforeAll(() => {
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+
+  it('should warn if the NumberField renders/blurs without a placeholder', async () => {
+    let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    let {getByRole, rerender} = render(
+      <NumberField label="Quantity" />
+    );
+
+    expect(spy).toHaveBeenCalledWith('Your NumberField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    await user.tab();
+    await user.tab();
+    expect(spy).toHaveBeenCalledWith('Your NumberField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    let input = getByRole('textbox');
+    await user.click(input);
+    await user.keyboard('1');
+    await user.tab();
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<NumberField label="Quantity" placeholder="test" />);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<NumberField label="Quantity" autoFocus />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@react-spectrum/s2/test/NumberField.test.tsx
+++ b/packages/@react-spectrum/s2/test/NumberField.test.tsx
@@ -21,19 +21,17 @@ describe('NumberField', () => {
     user = userEvent.setup({delay: null, pointerMap});
   });
 
-  it('should warn if the NumberField renders/blurs without a placeholder', async () => {
+  it('should not warn if the NumberField renders/blurs without a placeholder', async () => {
     let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let {getByRole, rerender} = render(
       <NumberField label="Quantity" />
     );
 
-    expect(spy).toHaveBeenCalledWith('Your NumberField is empty and not focused but doesn\'t have a placeholder. Please add one.');
-    spy.mockClear();
+    expect(spy).not.toBeCalled();
 
     await user.tab();
     await user.tab();
-    expect(spy).toHaveBeenCalledWith('Your NumberField is empty and not focused but doesn\'t have a placeholder. Please add one.');
-    spy.mockClear();
+    expect(spy).not.toBeCalled();
 
     let input = getByRole('textbox');
     await user.click(input);

--- a/packages/@react-spectrum/s2/test/SearchField.test.tsx
+++ b/packages/@react-spectrum/s2/test/SearchField.test.tsx
@@ -41,4 +41,31 @@ describe('SearchField', () => {
     await user.keyboard('Foo');
     expect(group).not.toHaveAttribute('data-focus-visible');
   });
+
+  it('should warn if the SearchField renders/blurs without a placeholder', async () => {
+    let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    let {getByRole, rerender} = render(
+      <SearchField label="Search" />
+    );
+
+    expect(spy).toHaveBeenCalledWith('Your SearchField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    await user.tab();
+    await user.tab();
+    expect(spy).toHaveBeenCalledWith('Your SearchField is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    let input = getByRole('searchbox');
+    await user.click(input);
+    await user.keyboard('Foo');
+    await user.tab();
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<SearchField label="Search" placeholder="test" />);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<SearchField label="Search" autoFocus />);
+    expect(spy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/@react-spectrum/s2/test/SearchField.test.tsx
+++ b/packages/@react-spectrum/s2/test/SearchField.test.tsx
@@ -42,19 +42,16 @@ describe('SearchField', () => {
     expect(group).not.toHaveAttribute('data-focus-visible');
   });
 
-  it('should warn if the SearchField renders/blurs without a placeholder', async () => {
+  it('should not warn if the SearchField renders/blurs without a placeholder', async () => {
     let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let {getByRole, rerender} = render(
       <SearchField label="Search" />
     );
 
-    expect(spy).toHaveBeenCalledWith('Your SearchField is empty and not focused but doesn\'t have a placeholder. Please add one.');
-    spy.mockClear();
-
+    expect(spy).not.toBeCalled();
     await user.tab();
     await user.tab();
-    expect(spy).toHaveBeenCalledWith('Your SearchField is empty and not focused but doesn\'t have a placeholder. Please add one.');
-    spy.mockClear();
+    expect(spy).not.toBeCalled();
 
     let input = getByRole('searchbox');
     await user.click(input);

--- a/packages/@react-spectrum/s2/test/TextField.test.tsx
+++ b/packages/@react-spectrum/s2/test/TextField.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {pointerMap, render} from '@react-spectrum/test-utils-internal';
+import React from 'react';
+import {TextArea, TextField} from '../src';
+import userEvent from '@testing-library/user-event';
+
+describe('TextField', () => {
+  let user;
+  beforeAll(() => {
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+
+  it('should warn if the TextField renders/blurs without a placeholder', async () => {
+    let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    let {getByRole, rerender} = render(
+      <TextField label="Name" />
+    );
+
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    await user.tab();
+    await user.tab();
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    let input = getByRole('textbox');
+    await user.click(input);
+    await user.keyboard('Foo');
+    await user.tab();
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<TextField label="Name" placeholder="test" />);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<TextField label="Name" autoFocus />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should warn if the TextArea renders/blurs without a placeholder', async () => {
+    let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    let {getByRole, rerender} = render(
+      <TextArea label="Name" />
+    );
+
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    await user.tab();
+    await user.tab();
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    spy.mockClear();
+
+    let input = getByRole('textbox');
+    await user.click(input);
+    await user.keyboard('Foo');
+    await user.tab();
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<TextArea label="Name" placeholder="test" />);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender(<TextArea label="Name" autoFocus />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@react-spectrum/s2/test/TextField.test.tsx
+++ b/packages/@react-spectrum/s2/test/TextField.test.tsx
@@ -24,15 +24,15 @@ describe('TextField', () => {
   it('should warn if the TextField renders/blurs without a placeholder', async () => {
     let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let {getByRole, rerender} = render(
-      <TextField label="Name" />
+      <TextField id="1" label="Name" />
     );
 
-    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one to the element with the following id: 1.');
     spy.mockClear();
 
     await user.tab();
     await user.tab();
-    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one to the element with the following id: 1.');
     spy.mockClear();
 
     let input = getByRole('textbox');
@@ -51,15 +51,15 @@ describe('TextField', () => {
   it('should warn if the TextArea renders/blurs without a placeholder', async () => {
     let spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let {getByRole, rerender} = render(
-      <TextArea label="Name" />
+      <TextArea id="1" label="Name" />
     );
 
-    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one to the element with the following id: 1.');
     spy.mockClear();
 
     await user.tab();
     await user.tab();
-    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one.');
+    expect(spy).toHaveBeenCalledWith('Your TextField/Area is empty and not focused but doesn\'t have a placeholder. Please add one to the element with the following id: 1.');
     spy.mockClear();
 
     let input = getByRole('textbox');

--- a/packages/dev/codemods/src/s1-to-s2/UPGRADE.md
+++ b/packages/dev/codemods/src/s1-to-s2/UPGRADE.md
@@ -49,7 +49,6 @@ Note that `[PENDING]` indicates that future changes will occur before the final 
 
 ## ColorField
 - Remove `isQuiet` (it is no longer supported)
-- Remove `placeholder` (it has been removed for accessibility reasons)
 - Change `validationState=“invalid”` to `isInvalid`
 - Remove `validationState=“valid”` (it is no longer supported)
 
@@ -59,7 +58,6 @@ Note that `[PENDING]` indicates that future changes will occur before the final 
 - Change `menuWidth` value from a `DimensionValue` to a pixel value
 - Remove `isQuiet` (it is no longer supported)
 - [PENDING] Comment out `loadingState` (it has not been implemented yet)
-- Remove `placeholder` (it is no longer supported)
 - Change `validationState=“invalid”` to `isInvalid`
 - Remove `validationState=“valid”` (it is no longer supported)
 - [PENDING] Comment out `onLoadMore` (it has not been implemented yet)
@@ -134,7 +132,6 @@ Note that `[PENDING]` indicates that future changes will occur before the final 
 - Remove `showErrorIcon` (it has been removed for accessibility reasons)
 
 ## SearchField
-- Remove `placeholder` (it has been removed for accessibility reasons)
 - [PENDING] Comment out icon (it has not been implemented yet)
 - Remove `isQuiet` (it is no longer supported)
 - Change `validationState=“invalid”` to `isInvalid`
@@ -169,14 +166,12 @@ Note that `[PENDING]` indicates that future changes will occur before the final 
 ## TextArea
 - [PENDING] Comment out `icon` (it has not been implemented yet)
 - Remove `isQuiet` (it is no longer supported)
-- Remove `placeholder`  (it has been removed for accessibility reasons)
 - Change `validationState=“invalid”` to `isInvalid`
 - Remove `validationState=“valid”` (it is no longer supported)
 
 ## TextField
 - [PENDING] Comment out `icon` (it has not been implemented yet)
 - Remove `isQuiet` (it is no longer supported)
-- Remove `placeholder`  (it has been removed for accessibility reasons)
 - Change `validationState=“invalid”` to `isInvalid`
 - Remove `validationState=“valid”` (it is no longer supported)
 

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/colorfield.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/colorfield.test.ts.snap
@@ -6,12 +6,6 @@ exports[`Removes isQuiet 1`] = `
 <ColorField label="Primary Color" />"
 `;
 
-exports[`Removes placeholder 1`] = `
-"import { ColorField } from "@react-spectrum/s2";
-
-<ColorField label="Primary Color" />"
-`;
-
 exports[`changes validationState to isInvalid or nothing 1`] = `
 "import { ColorField } from "@react-spectrum/s2";
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/combobox.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/combobox.test.ts.snap
@@ -89,31 +89,6 @@ let props = {isQuiet: true};
 </div>"
 `;
 
-exports[`Removes placeholder 1`] = `
-"import { ComboBoxItem, ComboBox } from "@react-spectrum/s2";
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <ComboBox>
-    <ComboBoxItem>Red Panda</ComboBoxItem>
-    <ComboBoxItem>Cat</ComboBoxItem>
-  </ComboBox>
-  <ComboBox>
-    <ComboBoxItem>Red Panda</ComboBoxItem>
-    <ComboBoxItem>Cat</ComboBoxItem>
-  </ComboBox>
-  <ComboBox>
-    <ComboBoxItem>Red Panda</ComboBoxItem>
-    <ComboBoxItem>Cat</ComboBoxItem>
-  </ComboBox>
-  <ComboBox // TODO(S2-upgrade): check this spread for style props
-  {...props}>
-    <ComboBoxItem>Red Panda</ComboBoxItem>
-    <ComboBoxItem>Cat</ComboBoxItem>
-  </ComboBox>
-</div>"
-`;
-
 exports[`Static - Converts menuWidth to px value 1`] = `
 "import { ComboBoxItem, ComboBox } from "@react-spectrum/s2";
 let menuWidth = 'size-10';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/searchfield.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/searchfield.test.ts.snap
@@ -15,19 +15,6 @@ let props = {isQuiet: true};
 </div>"
 `;
 
-exports[`Removes placeholder 1`] = `
-"import { SearchField } from "@react-spectrum/s2";
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <SearchField />
-  <SearchField />
-  <SearchField />
-  <SearchField // TODO(S2-upgrade): check this spread for style props
-  {...props} />
-</div>"
-`;
-
 exports[`changes validationState to isInvalid or nothing 1`] = `
 "import { SearchField } from "@react-spectrum/s2";
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/textarea.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/textarea.test.ts.snap
@@ -15,19 +15,6 @@ let props = {isQuiet: true};
 </div>"
 `;
 
-exports[`Removes placeholder 1`] = `
-"import { TextArea } from "@react-spectrum/s2";
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <TextArea />
-  <TextArea />
-  <TextArea />
-  <TextArea // TODO(S2-upgrade): check this spread for style props
-  {...props} />
-</div>"
-`;
-
 exports[`changes validationState to isInvalid or nothing 1`] = `
 "import { TextArea } from "@react-spectrum/s2";
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/textfield.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/textfield.test.ts.snap
@@ -15,19 +15,6 @@ let props = {isQuiet: true};
 </div>"
 `;
 
-exports[`Removes placeholder 1`] = `
-"import { TextField } from "@react-spectrum/s2";
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <TextField />
-  <TextField />
-  <TextField />
-  <TextField // TODO(S2-upgrade): check this spread for style props
-  {...props} />
-</div>"
-`;
-
 exports[`changes validationState to isInvalid or nothing 1`] = `
 "import { TextField } from "@react-spectrum/s2";
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/colorfield.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/colorfield.test.ts
@@ -12,12 +12,6 @@ import {ColorField} from '@adobe/react-spectrum';
 <ColorField label="Primary Color" isQuiet />
 `);
 
-test('Removes placeholder', `
-import {ColorField} from '@adobe/react-spectrum';
-
-<ColorField label="Primary Color" placeholder="Color" />
-`);
-
 test('changes validationState to isInvalid or nothing', `
 import {ColorField} from '@adobe/react-spectrum';
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/combobox.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/combobox.test.ts
@@ -166,30 +166,6 @@ let props = {isQuiet: true};
 </div>
 `);
 
-test('Removes placeholder', `
-import {ComboBox, Item} from '@adobe/react-spectrum';
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <ComboBox placeholder="is this actually removed?">
-    <Item>Red Panda</Item>
-    <Item>Cat</Item>
-  </ComboBox>
-  <ComboBox placeholder={"is this actually removed?"}>
-    <Item>Red Panda</Item>
-    <Item>Cat</Item>
-  </ComboBox>
-  <ComboBox placeholder={placeholder}>
-    <Item>Red Panda</Item>
-    <Item>Cat</Item>
-  </ComboBox>
-  <ComboBox {...props}>
-    <Item>Red Panda</Item>
-    <Item>Cat</Item>
-  </ComboBox>
-</div>
-`);
-
 test('changes validationState to isInvalid or nothing', `
 import {ComboBox, Item} from '@adobe/react-spectrum';
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/searchfield.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/searchfield.test.ts
@@ -6,18 +6,6 @@ const test = (name: string, input: string) => {
   defineSnapshotTest(transform, {}, input, name);
 };
 
-test('Removes placeholder', `
-import {SearchField} from '@adobe/react-spectrum';
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <SearchField placeholder="is this actually removed?" />
-  <SearchField placeholder={"is this actually removed?"} />
-  <SearchField placeholder={placeholder} />
-  <SearchField {...props} />
-</div>
-`);
-
 test('Removes isQuiet', `
 import {SearchField} from '@adobe/react-spectrum';
 let isQuiet = true;

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/textarea.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/textarea.test.ts
@@ -20,18 +20,6 @@ let props = {isQuiet: true};
 </div>
 `);
 
-test('Removes placeholder', `
-import {TextArea} from '@adobe/react-spectrum';
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <TextArea placeholder="is this actually removed?" />
-  <TextArea placeholder={"is this actually removed?"} />
-  <TextArea placeholder={placeholder} />
-  <TextArea {...props} />
-</div>
-`);
-
 test('changes validationState to isInvalid or nothing', `
 import {TextArea} from '@adobe/react-spectrum';
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/textfield.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/textfield.test.ts
@@ -20,18 +20,6 @@ let props = {isQuiet: true};
 </div>
 `);
 
-test('Removes placeholder', `
-import {TextField} from '@adobe/react-spectrum';
-let placeholder = 'is this actually removed?';
-let props = {placeholder: 'is this actually removed?'};
-<div>
-  <TextField placeholder="is this actually removed?" />
-  <TextField placeholder={"is this actually removed?"} />
-  <TextField placeholder={placeholder} />
-  <TextField {...props} />
-</div>
-`);
-
 test('changes validationState to isInvalid or nothing', `
 import {TextField} from '@adobe/react-spectrum';
 let validationState = 'invalid';

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ColorField/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ColorField/transform.ts
@@ -5,16 +5,12 @@ import * as t from '@babel/types';
 /**
  * Transforms ColorField:
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
- * - Remove placeholder (it has been removed due to accessibility issues).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
  */
 export default function transformColorField(path: NodePath<t.JSXElement>): void {
   // Remove isQuiet
   removeProp(path, {propName: 'isQuiet'});
-
-  // Remove placeholder
-  removeProp(path, {propName: 'placeholder'});
 
   // Change validationState="invalid" to isInvalid
   updatePropNameAndValue(path, {

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/ComboBox/transform.ts
@@ -10,7 +10,6 @@ import * as t from '@babel/types';
  * Transforms ComboBox:
  * - Change menuWidth value from a DimensionValue to a pixel value.
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
- * - Remove placeholder (it is no longer supported in Spectrum 2).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
  */
@@ -20,9 +19,6 @@ export default function transformComboBox(path: NodePath<t.JSXElement>): void {
 
   // Remove isQuiet
   removeProp(path, {propName: 'isQuiet'});
-
-  // Remove placeholder
-  removeProp(path, {propName: 'placeholder'});
 
   // Change validationState="invalid" to isInvalid
   updatePropNameAndValue(path, {

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/SearchField/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/SearchField/transform.ts
@@ -4,16 +4,12 @@ import * as t from '@babel/types';
 
 /**
  * Transforms SearchField:
- * - Remove placeholder (it has been removed due to accessibility issues).
  * - Comment out icon (it has not been implemented yet).
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
  */
 export default function transformSearchField(path: NodePath<t.JSXElement>): void {
-  // Remove placeholder
-  removeProp(path, {propName: 'placeholder'});
-
   // Comment out icon
   commentOutProp(path, {propName: 'icon'});
 

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/TextArea/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/TextArea/transform.ts
@@ -6,7 +6,6 @@ import * as t from '@babel/types';
  * Transforms TextArea:
  * - Comment out icon (it has not been implemented yet).
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
- * - Remove placeholder (it has been removed due to accessibility issues).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
  */
@@ -16,9 +15,6 @@ export default function transformTextArea(path: NodePath<t.JSXElement>): void {
 
   // Remove isQuiet
   removeProp(path, {propName: 'isQuiet'});
-
-  // Remove placeholder
-  removeProp(path, {propName: 'placeholder'});
 
   // Change validationState="invalid" to isInvalid
   updatePropNameAndValue(path, {

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/TextField/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/TextField/transform.ts
@@ -6,7 +6,6 @@ import * as t from '@babel/types';
  * Transforms TextField:
  * - Comment out icon (it has not been implemented yet).
  * - Remove isQuiet (it is no longer supported in Spectrum 2).
- * - Remove placeholder (it has been removed due to accessibility issues).
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
  */
@@ -16,9 +15,6 @@ export default function transformTextField(path: NodePath<t.JSXElement>): void {
 
   // Remove isQuiet
   removeProp(path, {propName: 'isQuiet'});
-
-  // Remove placeholder
-  removeProp(path, {propName: 'placeholder'});
 
   // Change validationState="invalid" to isInvalid
   updatePropNameAndValue(path, {

--- a/packages/react-aria-components/src/Input.tsx
+++ b/packages/react-aria-components/src/Input.tsx
@@ -43,7 +43,13 @@ export interface InputRenderProps {
   isInvalid: boolean
 }
 
-export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className' | 'style'>, HoverEvents, StyleRenderProps<InputRenderProps> {}
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className' | 'style'>, HoverEvents, StyleRenderProps<InputRenderProps> {
+  /**
+   * Temporary text that occupies the text input when it is empty.
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/placeholder).
+   */
+  placeholder?: string | undefined
+}
 
 export const InputContext = createContext<ContextValue<InputProps, HTMLInputElement>>({});
 


### PR DESCRIPTION
Closes https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=122037979

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test placeholders for TextField/Area, Combobox, Picker, ColorArea, NumberField, SearchField. Note that there should be a warning that fires if a placeholder/value isn't present and the input isn't focused 

## 🧢 Your Project:

RSP
