### PR TITLE
Fix: DOMLayoutDelegate miscalculates item & visible rects

### DIFF
--- a/packages/@react-aria/dnd/test/useDroppableCollection.test.js
+++ b/packages/@react-aria/dnd/test/useDroppableCollection.test.js
@@ -56,7 +56,7 @@ describe('useDroppableCollection', () => {
       return this.getBoundingClientRect().top;
     });
 
-    jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function () {
+    jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(function () {
       return this.getBoundingClientRect().height;
     });
 

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -33,8 +33,8 @@ export class DOMLayoutDelegate implements LayoutDelegate {
     let rect = item.getBoundingClientRect();
 
     return {
-      x: rect.left - container.offsetLeft - container.clientLeft,
-      y: rect.top - container.offsetTop - container.clientTop,
+      x: rect.left - container.offsetLeft - container.clientLeft + container.scrollLeft,
+      y: rect.top - container.offsetTop - container.clientTop + container.scrollTop,
       width: rect.width,
       height: rect.height
     };

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -33,7 +33,7 @@ export class DOMLayoutDelegate implements LayoutDelegate {
     let rect = item.getBoundingClientRect();
 
     return {
-      x: rect.left - container.offsetLeft - container.clientLeft
+      x: rect.left - container.offsetLeft - container.clientLeft,
       y: rect.top - container.offsetTop - container.clientTop,
       width: rect.width,
       height: rect.height

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -31,10 +31,11 @@ export class DOMLayoutDelegate implements LayoutDelegate {
     }
 
     let rect = item.getBoundingClientRect();
+    let containerRect = container.getBoundingClientRect();
 
     return {
-      x: rect.left - container.offsetLeft - container.clientLeft + container.scrollLeft,
-      y: rect.top - container.offsetTop - container.clientTop + container.scrollTop,
+      x: rect.left - containerRect.left - container.clientLeft + container.scrollLeft,
+      y: rect.top - containerRect.top - container.clientTop + container.scrollTop,
       width: rect.width,
       height: rect.height
     };

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -30,17 +30,16 @@ export class DOMLayoutDelegate implements LayoutDelegate {
       return null;
     }
 
-    let containerRect = container.getBoundingClientRect();
-    let itemRect = item.getBoundingClientRect();
+    let rect = item.getBoundingClientRect();
 
-    let borderAdjustedX = itemRect.left - containerRect.left - container.clientLeft;
-    let borderAdjustedY = itemRect.top - containerRect.top - container.clientTop;
+    let borderAdjustedX = rect.left - container.offsetLeft - container.clientLeft;
+    let borderAdjustedY = rect.top - container.offsetTop - container.clientTop;
 
     return {
       x: borderAdjustedX + container.scrollLeft,
       y: borderAdjustedY + container.scrollTop,
-      width: itemRect.width,
-      height: itemRect.height
+      width: rect.width,
+      height: rect.height
     };
   }
 

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -33,8 +33,8 @@ export class DOMLayoutDelegate implements LayoutDelegate {
     let containerRect = container.getBoundingClientRect();
     let itemRect = item.getBoundingClientRect();
 
-    let borderAdjustedX = 2 * itemRect.left - 2 * containerRect.left - container.offsetWidth + container.clientWidth;
-    let borderAdjustedY = 2 * itemRect.top - 2 * containerRect.top - container.offsetHeight + container.clientHeight;
+    let borderAdjustedX = itemRect.left - containerRect.left - container.clientLeft;
+    let borderAdjustedY = itemRect.top - containerRect.top - container.clientTop;
 
     return {
       x: borderAdjustedX + container.scrollLeft,

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -33,9 +33,12 @@ export class DOMLayoutDelegate implements LayoutDelegate {
     let containerRect = container.getBoundingClientRect();
     let itemRect = item.getBoundingClientRect();
 
+    let borderAdjustedX = 2 * itemRect.left - 2 * containerRect.left - container.offsetWidth + container.clientWidth;
+    let borderAdjustedY = 2 * itemRect.top - 2 * containerRect.top - container.offsetHeight + container.clientHeight;
+
     return {
-      x: itemRect.left - containerRect.left + container.scrollLeft,
-      y: itemRect.top - containerRect.top + container.scrollTop,
+      x: borderAdjustedX + container.scrollLeft,
+      y: borderAdjustedY + container.scrollTop,
       width: itemRect.width,
       height: itemRect.height
     };

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -32,12 +32,9 @@ export class DOMLayoutDelegate implements LayoutDelegate {
 
     let rect = item.getBoundingClientRect();
 
-    let borderAdjustedX = rect.left - container.offsetLeft - container.clientLeft;
-    let borderAdjustedY = rect.top - container.offsetTop - container.clientTop;
-
     return {
-      x: borderAdjustedX + container.scrollLeft,
-      y: borderAdjustedY + container.scrollTop,
+      x: rect.left - container.offsetLeft - container.clientLeft
+      y: rect.top - container.offsetTop - container.clientTop,
       width: rect.width,
       height: rect.height
     };

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -54,8 +54,8 @@ export class DOMLayoutDelegate implements LayoutDelegate {
     return {
       x: container?.scrollLeft ?? 0,
       y: container?.scrollTop ?? 0,
-      width: container?.offsetWidth ?? 0,
-      height: container?.offsetHeight ?? 0
+      width: container?.clientWidth ?? 0,
+      height: container?.clientHeight ?? 0
     };
   }
 }

--- a/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
+++ b/packages/@react-aria/selection/src/DOMLayoutDelegate.ts
@@ -30,14 +30,14 @@ export class DOMLayoutDelegate implements LayoutDelegate {
       return null;
     }
 
-    let rect = item.getBoundingClientRect();
     let containerRect = container.getBoundingClientRect();
+    let itemRect = item.getBoundingClientRect();
 
     return {
-      x: rect.left - containerRect.left - container.clientLeft + container.scrollLeft,
-      y: rect.top - containerRect.top - container.clientTop + container.scrollTop,
-      width: rect.width,
-      height: rect.height
+      x: itemRect.left - containerRect.left - container.clientLeft + container.scrollLeft,
+      y: itemRect.top - containerRect.top - container.clientTop + container.scrollTop,
+      width: itemRect.width,
+      height: itemRect.height
     };
   }
 

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -1633,7 +1633,7 @@ describe('Table', () => {
   });
 
   describe('load more spinner', () => {
-    let offsetHeight, scrollHeight;
+    let clientHeight, scrollHeight;
     let DndTable = stories.DndTable;
     let initialItems = [
       {id: '1', type: 'file', name: 'Adobe Photoshop'},
@@ -1641,7 +1641,7 @@ describe('Table', () => {
     ];
     beforeAll(function () {
       scrollHeight = jest.spyOn(window.HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(() => 200);
-      offsetHeight = jest.spyOn(window.HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function () {
+      clientHeight = jest.spyOn(window.HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(function () {
         if (this.getAttribute('role') === 'grid') {
           return 200;
         }
@@ -1651,7 +1651,7 @@ describe('Table', () => {
     });
 
     afterAll(function () {
-      offsetHeight.mockReset();
+      clientHeight.mockReset();
       scrollHeight.mockReset();
     });
 


### PR DESCRIPTION
A [Scrollport](https://developer.mozilla.org/en-US/docs/Glossary/Scroll_container#scrollport) coincides with the padding box, which should not include border offset. We were calculating on `offsetWidth` & bounding boxes instead of `clientWidth` and for some reason shifted the item rect by scroll offset??

With this change, the DOM layout is now consistent with our virtualized ones 👍 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
