### PR TITLE
docs: fix import copied from illustrations

### DIFF
--- a/.storybook-s2/docs/Illustrations.jsx
+++ b/.storybook-s2/docs/Illustrations.jsx
@@ -35,7 +35,7 @@ export function Illustrations() {
                     size="XS"
                     isQuiet
                     aria-label="Copy"
-                    onPress={() => navigator.clipboard.writeText(`import ${name} from '@react-spectrum/s2/illustrations/gradient/${gradientStyle}/${icon}';`)}>
+                     onPress={() => navigator.clipboard.writeText(`import ${icon} from '@react-spectrum/s2/illustrations/gradient/${gradientStyle}/${icon}';`)}>
                     <Paste />
                   </ActionButton>
                 </span>

--- a/.storybook-s2/docs/Illustrations.jsx
+++ b/.storybook-s2/docs/Illustrations.jsx
@@ -35,7 +35,7 @@ export function Illustrations() {
                     size="XS"
                     isQuiet
                     aria-label="Copy"
-                     onPress={() => navigator.clipboard.writeText(`import ${icon} from '@react-spectrum/s2/illustrations/gradient/${gradientStyle}/${icon}';`)}>
+                    onPress={() => navigator.clipboard.writeText(`import ${icon} from '@react-spectrum/s2/illustrations/gradient/${gradientStyle}/${icon}';`)}>
                     <Paste />
                   </ActionButton>
                 </span>


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Copy an import and check the content: https://reactspectrum.blob.core.windows.net/reactspectrum/727c206ab4134607fb781bac2e0b7842e6d831be/storybook-s2/index.html?path=/docs/illustrations--docs

## 🧢 Your Project:

<!--- Company/project for pull request -->
