### PR TITLE
fix: add role to react aria taggroup when empty

### DIFF
--- a/packages/@react-aria/tag/src/useTagGroup.ts
+++ b/packages/@react-aria/tag/src/useTagGroup.ts
@@ -114,7 +114,7 @@ export function useTagGroup<T>(props: AriaTagGroupOptions<T>, state: ListState<T
 
   return {
     gridProps: mergeProps(gridProps, domProps, {
-      role: state.collection.size ? 'grid' : null,
+      role: state.collection.size ? 'grid' : 'group',
       'aria-atomic': false,
       'aria-relevant': 'additions',
       'aria-live': isFocusWithin ? 'polite' : 'off',

--- a/packages/react-aria-components/stories/TagGroup.stories.tsx
+++ b/packages/react-aria-components/stories/TagGroup.stories.tsx
@@ -111,3 +111,13 @@ export const TagGroupExampleWithRemove: Story = {
     </TagGroup>
   )
 };
+
+export const EmptyTagGroup: Story = {
+  render: (props: TagGroupProps) => (
+    <TagGroup {...props} aria-label="Categories" >
+      <TagList renderEmptyState={() => 'No categories.'}>
+        {[]}
+      </TagList>
+    </TagGroup>
+  )
+};

--- a/packages/react-aria-components/test/TagGroup.test.js
+++ b/packages/react-aria-components/test/TagGroup.test.js
@@ -306,6 +306,7 @@ describe('TagGroup', () => {
     let grid = getByTestId('list');
     expect(grid).toHaveAttribute('data-empty', 'true');
     expect(grid).toHaveTextContent('No results');
+    expect(grid).toHaveAttribute('role', 'group');
   });
 
   it('supports tooltips', async function () {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8354

Tested it with VO before and after this change and it didn't really make a difference in terms of announcement. It always seemed to announce it as a group so I feel like this change is fine and now won't violate accessibility.  

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
