### PR TITLE
fix: S2 Selectbox Updates

### DIFF
--- a/packages/@react-spectrum/s2/src/SelectBoxGroup.tsx
+++ b/packages/@react-spectrum/s2/src/SelectBoxGroup.tsx
@@ -28,7 +28,22 @@ import React, {createContext, forwardRef, ReactNode, useContext, useMemo, useRef
 import {TextContext} from './Content';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
-export interface SelectBoxGroupProps<T> extends StyleProps, Omit<ListBoxProps<T>, keyof GlobalDOMAttributes | 'layout' | 'dragAndDropHooks' | 'renderEmptyState' | 'dependencies' | 'items' | 'children' | 'selectionMode'>{
+type ExcludedListBoxProps = 
+  | keyof GlobalDOMAttributes 
+  | 'layout' 
+  | 'dragAndDropHooks' 
+  | 'renderEmptyState' 
+  | 'dependencies' 
+  | 'items' 
+  | 'onAction'
+  | 'children' 
+  | 'selectionMode' 
+  | 'shouldSelectOnPress' 
+  | 'shouldFocusWrap' 
+  | 'selectionBehavior' 
+  | 'shouldSelectOnFocus';
+
+export interface SelectBoxGroupProps<T> extends StyleProps, Omit<ListBoxProps<T>, ExcludedListBoxProps> {
   /**
    * The SelectBox elements contained within the SelectBoxGroup.
    */
@@ -87,7 +102,7 @@ const selectBoxStyles = style({
   height: {
     default: 170,
     orientation: {
-      horizontal: '100%'
+      horizontal: 'auto'
     }
   },
   minWidth: {
@@ -115,19 +130,19 @@ const selectBoxStyles = style({
     }
   },
   padding: {
-    default: 16,
+    default: 24,
     orientation: {
       horizontal: 16
     }
   },
   paddingStart: {
     orientation: {
-      horizontal: 24
+      horizontal: 32
     }
   },
   paddingEnd: {
     orientation: {
-      horizontal: 32
+      horizontal: 24
     }
   },
   gridTemplateAreas: {
@@ -152,14 +167,14 @@ const selectBoxStyles = style({
     orientation: {
       vertical: ['min-content', 8, 'min-content'],
       horizontal: {
-        default: ['min-content', 'min-content'],
+        default: ['min-content', 2, 'min-content'],
         [noIllustration]: ['min-content']
       }
     }
   },
   gridTemplateColumns: {
     orientation: {
-      horizontal: ['min-content', 12, '1fr']
+      horizontal: 'min-content 10px 1fr'
     }
   },
   alignContent: {
@@ -185,8 +200,7 @@ const selectBoxStyles = style({
     default: 'emphasized',
     isHovered: 'elevated',
     isSelected: 'elevated',
-    forcedColors: 'none',
-    isDisabled: 'emphasized'
+    isDisabled: 'none'
   },
   borderWidth: 2,
   transition: 'default'
@@ -198,7 +212,8 @@ const illustrationContainer = style({
   justifySelf: 'center',
   minSize: 48,
   color: {
-    isDisabled: 'disabled'
+    isDisabled: 'disabled',
+    isHovered: 'gray-900'
   },
   opacity: {
     isDisabled: 0.4
@@ -223,6 +238,7 @@ const descriptionText = style({
   },
   color: {
     default: 'neutral',
+    isHovered: 'gray-900',
     isDisabled: 'disabled'
   }
 });
@@ -254,6 +270,7 @@ const labelText = style({
   },
   color: {
     default: 'neutral',
+    isHovered: 'gray-900',
     isDisabled: 'disabled'
   }
 });
@@ -296,48 +313,46 @@ export function SelectBox(props: SelectBoxProps): ReactNode {
       }, styles)}
       style={pressScale(ref, UNSAFE_style)}
       {...otherProps}>
-      {({isSelected, isHovered, isDisabled}) => {
+      {({isSelected, isDisabled, isHovered}) => {
         return (
           <>
-            {(isSelected || (!isDisabled && isHovered)) && (
             <div 
               className={style({
                 position: 'absolute',
-                top: 12,
-                left: 12,
+                top: 8,
+                left: 8,
                 pointerEvents: 'none'
               })}
               aria-hidden="true">
-              <div
-                className={box({
-                  isSelected,
-                  isDisabled,
-                  size: 'M'
-                } as any)}>
-                {isSelected && (
+              {!isDisabled && (
+                <div
+                  className={box({
+                    isSelected,
+                    isDisabled,
+                    size: 'M'
+                  } as any)}>
                   <Checkmark 
                     size="S" 
                     className={iconStyles} />
-                )}
-              </div>
+                </div>
+              )}
             </div>
-          )}
             <Provider
               values={[
                 [IllustrationContext, {
                   size: 'S',
-                  styles: illustrationContainer({size: 'S', orientation, isDisabled})
+                  styles: illustrationContainer({size: 'S', orientation, isDisabled, isHovered})
                 }],
                 [TextContext, {
                   slots: {
                     [DEFAULT_SLOT]: {
-                      styles: labelText({orientation, isDisabled})
+                      styles: labelText({orientation, isDisabled, isHovered})
                     },
                     label: {
-                      styles: labelText({orientation, isDisabled})
+                      styles: labelText({orientation, isDisabled, isHovered})
                     },
                     description: {
-                      styles: descriptionText({orientation, isDisabled})
+                      styles: descriptionText({orientation, isDisabled, isHovered})
                     }
                   }
                 }]
@@ -381,10 +396,10 @@ export const SelectBoxGroup = /*#__PURE__*/ forwardRef(function SelectBoxGroup<T
   return (
     <ListBox
       selectionMode={selectionMode}
-      {...otherProps}
       layout="grid"
       className={(UNSAFE_className || '') + gridStyles({orientation})}
-      style={UNSAFE_style}>
+      style={UNSAFE_style}
+      {...otherProps}>
       <SelectBoxContext.Provider value={selectBoxContextValue}>
         {children}
       </SelectBoxContext.Provider>

--- a/packages/@react-spectrum/s2/src/SelectBoxGroup.tsx
+++ b/packages/@react-spectrum/s2/src/SelectBoxGroup.tsx
@@ -19,13 +19,13 @@ import {
   ListBoxProps,
   Provider
 } from 'react-aria-components';
-import {DOMRef, DOMRefValue, GlobalDOMAttributes, Orientation, Selection} from '@react-types/shared';
+import {DOMRef, DOMRefValue, GlobalDOMAttributes, Orientation} from '@react-types/shared';
 import {focusRing, style} from '../style' with {type: 'macro'};
 import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {IllustrationContext} from '../src/Icon';
-import React, {createContext, forwardRef, ReactNode, useContext, useMemo} from 'react';
+import {pressScale} from './pressScale';
+import React, {createContext, forwardRef, ReactNode, useContext, useMemo, useRef} from 'react';
 import {TextContext} from './Content';
-import {useControlledState} from '@react-stately/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
 export interface SelectBoxGroupProps<T> extends StyleProps, Omit<ListBoxProps<T>, keyof GlobalDOMAttributes | 'layout' | 'dragAndDropHooks' | 'renderEmptyState' | 'dependencies' | 'items' | 'children' | 'selectionMode'>{
@@ -39,32 +39,9 @@ export interface SelectBoxGroupProps<T> extends StyleProps, Omit<ListBoxProps<T>
    */
   selectionMode?: 'single' | 'multiple',
   /**
-   * The currently selected keys in the collection (controlled).
-   */
-  selectedKeys?: Selection,
-  /**
-   * The initial selected keys in the collection (uncontrolled).
-   */
-  defaultSelectedKeys?: Selection,
-  /**
-   * Number of columns to display the SelectBox elements in.
-   * @default 2
-   */
-  numColumns?: number,
-  /**
-   * Gap between grid items.
-   * @default 'default'
-   */
-  gutterWidth?: 'default' | 'compact' | 'spacious',
-  /**
    * Whether the SelectBoxGroup is disabled.
    */
-  isDisabled?: boolean,
-  /**
-   * Whether to show selection checkboxes for all SelectBoxes.
-   * @default false
-   */
-  showCheckbox?: boolean
+  isDisabled?: boolean
 }
 
 export interface SelectBoxProps extends StyleProps {
@@ -85,10 +62,7 @@ export interface SelectBoxProps extends StyleProps {
 interface SelectBoxContextValue {
   allowMultiSelect?: boolean,
   orientation?: Orientation,
-  isDisabled?: boolean,
-  showCheckbox?: boolean,
-  selectedKeys?: Selection,
-  onSelectionChange?: (keys: Selection) => void
+  isDisabled?: boolean
 }
 
 export const SelectBoxContext = createContext<SelectBoxContextValue>({orientation: 'vertical'});
@@ -98,9 +72,6 @@ const labelOnly = ':has([slot=label]):not(:has([slot=description]))';
 const noIllustration = ':not(:has([slot=illustration]))';
 const selectBoxStyles = style({
   ...focusRing(),
-  outlineOffset: {
-    isFocusVisible: -2
-  },
   display: 'grid',
   gridAutoRows: '1fr',
   position: 'relative',
@@ -144,7 +115,7 @@ const selectBoxStyles = style({
     }
   },
   padding: {
-    default: 24,
+    default: 16,
     orientation: {
       horizontal: 16
     }
@@ -218,11 +189,7 @@ const selectBoxStyles = style({
     isDisabled: 'emphasized'
   },
   borderWidth: 2,
-  transition: 'default',
-  cursor: {
-    default: 'pointer',
-    isDisabled: 'default'
-  }
+  transition: 'default'
 }, getAllowedOverrides());
 
 const illustrationContainer = style({
@@ -291,15 +258,14 @@ const labelText = style({
   }
 });
 
-const gridStyles = style({
+const gridStyles = style<{orientation?: Orientation}>({
   display: 'grid',
-  outline: 'none',
   gridAutoRows: '1fr',
-  gap: {
-    gutterWidth: {
-      default: 16,
-      compact: 8,
-      spacious: 24
+  gap: 16,
+  gridTemplateColumns: {
+    orientation: {
+      horizontal: 'repeat(auto-fit, minmax(368px, 1fr))',
+      vertical: 'repeat(auto-fit, minmax(170px, 1fr))'
     }
   }
 }, getAllowedOverrides());
@@ -308,45 +274,47 @@ const gridStyles = style({
  * SelectBox is a single selectable item in a SelectBoxGroup.
  */
 export function SelectBox(props: SelectBoxProps): ReactNode {
-  let {children, value, isDisabled: individualDisabled = false, UNSAFE_style} = props;
+  let {children, value, isDisabled: individualDisabled = false, UNSAFE_style, UNSAFE_className, styles, ...otherProps} = props;
   
   let {
     orientation = 'vertical',
-    isDisabled: groupDisabled = false,
-    showCheckbox = false
+    isDisabled: groupDisabled = false
   } = useContext(SelectBoxContext);
 
-  const size = 'M';
   const isDisabled = individualDisabled || groupDisabled;
+  const ref = useRef<HTMLDivElement>(null);
 
   return (
     <ListBoxItem
       id={value}
-      isDisabled={isDisabled}
       textValue={value}
-      className={renderProps => (props.UNSAFE_className || '') + selectBoxStyles({
-        size, 
-        orientation, 
-        ...renderProps
-      }, props.styles)}
-      style={UNSAFE_style}>
-      {(renderProps) => (
-        <>
-          {showCheckbox && (renderProps.isSelected || (!renderProps.isDisabled && renderProps.isHovered)) && (
+      isDisabled={isDisabled}
+      ref={ref}
+      className={renderProps => (UNSAFE_className || '') + selectBoxStyles({
+        ...renderProps,
+        orientation
+      }, styles)}
+      style={pressScale(ref, UNSAFE_style)}
+      {...otherProps}>
+      {({isSelected, isHovered, isDisabled}) => {
+        return (
+          <>
+            {(isSelected || (!isDisabled && isHovered)) && (
             <div 
               className={style({
                 position: 'absolute',
                 top: 12,
-                left: 12
+                left: 12,
+                pointerEvents: 'none'
               })}
               aria-hidden="true">
               <div
                 className={box({
-                  isSelected: renderProps.isSelected,
-                  isDisabled: renderProps.isDisabled,
+                  isSelected,
+                  isDisabled,
                   size: 'M'
                 } as any)}>
-                {renderProps.isSelected && (
+                {isSelected && (
                   <Checkmark 
                     size="S" 
                     className={iconStyles} />
@@ -354,35 +322,36 @@ export function SelectBox(props: SelectBoxProps): ReactNode {
               </div>
             </div>
           )}
-          <Provider
-            values={[
-              [IllustrationContext, {
-                size: 'S',
-                styles: illustrationContainer({size: 'S', orientation, isDisabled: renderProps.isDisabled})
-              }],
-              [TextContext, {
-                slots: {
-                  [DEFAULT_SLOT]: {
-                    styles: labelText({orientation, isDisabled: renderProps.isDisabled})
-                  },
-                  label: {
-                    styles: labelText({orientation, isDisabled: renderProps.isDisabled})
-                  },
-                  description: {
-                    styles: descriptionText({orientation, isDisabled: renderProps.isDisabled})
+            <Provider
+              values={[
+                [IllustrationContext, {
+                  size: 'S',
+                  styles: illustrationContainer({size: 'S', orientation, isDisabled})
+                }],
+                [TextContext, {
+                  slots: {
+                    [DEFAULT_SLOT]: {
+                      styles: labelText({orientation, isDisabled})
+                    },
+                    label: {
+                      styles: labelText({orientation, isDisabled})
+                    },
+                    description: {
+                      styles: descriptionText({orientation, isDisabled})
+                    }
                   }
-                }
-              }]
-            ]}>
-            {children}
-          </Provider>
-        </>
-      )}
+                }]
+              ]}>
+              {children}
+            </Provider>
+          </>
+        );
+      }}
     </ListBoxItem>
   );
 }
 
-/**
+/*
  * SelectBoxGroup allows users to select one or more options from a list.
  */
 export const SelectBoxGroup = /*#__PURE__*/ forwardRef(function SelectBoxGroup<T>(props: SelectBoxGroupProps<T>, ref: DOMRef<HTMLDivElement>) {
@@ -390,54 +359,32 @@ export const SelectBoxGroup = /*#__PURE__*/ forwardRef(function SelectBoxGroup<T
 
   let {
     children,
-    onSelectionChange,
-    selectedKeys: controlledSelectedKeys,
-    defaultSelectedKeys,
     selectionMode = 'single',
     orientation = 'vertical',
-    numColumns = 2,
-    gutterWidth = 'default',
     isDisabled = false,
-    showCheckbox = false,
     UNSAFE_className,
-    UNSAFE_style
+    UNSAFE_style,
+    ...otherProps
   } = props;
-
-  const [selectedKeys, setSelectedKeys] = useControlledState(
-    controlledSelectedKeys,
-    defaultSelectedKeys || new Set(),
-    onSelectionChange
-  );
 
   const selectBoxContextValue = useMemo(
     () => {
       const contextValue = {
-        allowMultiSelect: selectionMode === 'multiple',
         orientation,
-        isDisabled,
-        showCheckbox,
-        selectedKeys,
-        onSelectionChange: setSelectedKeys
+        isDisabled
       };
-      
       return contextValue;
     },
-    [selectionMode, orientation, isDisabled, showCheckbox, selectedKeys, setSelectedKeys]
+    [orientation, isDisabled]
   );
 
   return (
     <ListBox
-      layout="grid"
       selectionMode={selectionMode}
-      selectedKeys={selectedKeys}
-      onSelectionChange={setSelectedKeys}
-      className={(UNSAFE_className || '') + gridStyles({gutterWidth, orientation}, props.styles)}
-      aria-label="SelectBoxGroup"
-      aria-labelledby="SelectBoxGroup"
-      style={{
-        gridTemplateColumns: `repeat(${numColumns}, 1fr)`,
-        ...UNSAFE_style
-      }}>
+      {...otherProps}
+      layout="grid"
+      className={(UNSAFE_className || '') + gridStyles({orientation})}
+      style={UNSAFE_style}>
       <SelectBoxContext.Provider value={selectBoxContextValue}>
         {children}
       </SelectBoxContext.Provider>

--- a/packages/@react-spectrum/s2/stories/SelectBoxGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/SelectBoxGroup.stories.tsx
@@ -72,24 +72,13 @@ const meta: Meta<typeof SelectBoxGroup> = {
       control: 'select',
       options: ['vertical', 'horizontal']
     },
-    numColumns: {
-      control: {type: 'number', min: 1, max: 4}
-    },
-    gutterWidth: {
-      control: 'select',
-      options: ['compact', 'default', 'spacious']
-    },
-    showCheckbox: {
-      control: 'boolean'
-    }
+    selectedKeys: {control: false, table: {disable: true}},
+    defaultSelectedKeys: {control: false, table: {disable: true}}
   },
   args: {
     selectionMode: 'single',
     orientation: 'vertical',
-    numColumns: 2,
-    gutterWidth: 'default',
-    isDisabled: false,
-    showCheckbox: false
+    isDisabled: false
   }
 };
 
@@ -97,116 +86,35 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (args) => (
-    <SelectBoxGroup {...args} onSelectionChange={action('onSelectionChange')}>
-      <SelectBox value="aws">
-        <Server />
-        <Text slot="label">Amazon Web Services</Text>
-        <Text slot="description">Reliable cloud infrastructure</Text>
-      </SelectBox>
-      <SelectBox value="azure">
-        <AlertNotice />
-        <Text slot="label">Microsoft Azure</Text>
-      </SelectBox>
-      <SelectBox value="gcp">
-        <PaperAirplane />
-        <Text slot="label">Google Cloud Platform</Text>
-      </SelectBox>
-      <SelectBox value="ibm">
-        <StarFilled1 />
-        <Text slot="label">IBM Cloud</Text>
-        <Text slot="description">Hybrid cloud solutions</Text>
-      </SelectBox>
-    </SelectBoxGroup>
-  )
-};
-
-export const MultipleSelection: Story = {
-  args: {
-    selectionMode: 'multiple',
-    defaultSelectedKeys: new Set(['aws', 'gcp']),
-    numColumns: 3,
-    gutterWidth: 'default'
-  },
-  render: (args) => (
-    <div style={{maxWidth: 800}}>
-      <p style={{marginBottom: 16, fontSize: 14, color: '#666'}}>
-        Focus any item and use arrow keys for grid navigation:
-      </p>
-      <SelectBoxGroup {...args} onSelectionChange={action('onSelectionChange')}>
+  render: (args) => {
+    const {selectionMode, orientation, isDisabled} = args as any;
+    return (
+      <SelectBoxGroup selectionMode={selectionMode} orientation={orientation} isDisabled={isDisabled} UNSAFE_style={{gridTemplateColumns: 'repeat(2, 1fr)'}}>
         <SelectBox value="aws">
           <Server />
           <Text slot="label">Amazon Web Services</Text>
-          {/* <Text slot="description">Reliable cloud infrastructure</Text> */}
+          <Text slot="description">Reliable cloud infrastructure</Text>
         </SelectBox>
         <SelectBox value="azure">
           <AlertNotice />
           <Text slot="label">Microsoft Azure</Text>
-          <Text slot="description">Enterprise cloud solutions</Text>
         </SelectBox>
         <SelectBox value="gcp">
           <PaperAirplane />
           <Text slot="label">Google Cloud Platform</Text>
-          <Text slot="description">Modern cloud services</Text>
-        </SelectBox>
-        <SelectBox value="oracle">
-          <Server />
-          <Text slot="label">Oracle Cloud</Text>
-          <Text slot="description">Database-focused cloud</Text>
         </SelectBox>
         <SelectBox value="ibm">
-          <Server />
+          <StarFilled1 />
           <Text slot="label">IBM Cloud</Text>
           <Text slot="description">Hybrid cloud solutions</Text>
         </SelectBox>
-        <SelectBox value="alibaba">
-          <PaperAirplane />
-          <Text slot="label">Alibaba Cloud</Text>
-          <Text slot="description">Asia-focused services</Text>
-        </SelectBox>
-        <SelectBox value="digitalocean">
-          <Server />
-          <Text slot="label">DigitalOcean</Text>
-          <Text slot="description">Developer-friendly platform</Text>
-        </SelectBox>
-        <SelectBox value="linode">
-          <AlertNotice />
-          <Text slot="label">Linode</Text>
-          <Text slot="description">Simple cloud computing</Text>
-        </SelectBox>
-        <SelectBox value="vultr">
-          <PaperAirplane />
-          <Text slot="label">Vultr</Text>
-          <Text slot="description">High performance cloud</Text>
-        </SelectBox>
       </SelectBoxGroup>
-    </div>
-  )
+    );
+  }
 };
 
-export const DisabledGroup: Story = {
-  args: {
-    isDisabled: true,
-    defaultSelectedKeys: new Set(['option1']),
-    isCheckboxSelection: true
-  },
-  render: (args) => (
-    <SelectBoxGroup {...args} onSelectionChange={action('onSelectionChange')}>
-      <SelectBox value="option1">
-        <Server />
-        <Text slot="label">Selected then Disabled</Text>
-      </SelectBox>
-      <SelectBox value="option2">
-        <AlertNotice />
-        <Text slot="label">Disabled</Text>
-      </SelectBox>
-    </SelectBoxGroup>
-  )
-};
-
-function InteractiveExamplesStory() {
+function InteractiveExamplesStory(args: any) {
   const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set(['enabled1', 'starred2']));
-
   return (
     <div style={{maxWidth: 800}}>
       <h3 className={subheadingStyles}>Interactive Features Combined</h3>
@@ -217,13 +125,12 @@ function InteractiveExamplesStory() {
       <SelectBoxGroup
         selectionMode="multiple"
         selectedKeys={selectedKeys}
-        numColumns={4}
-        gutterWidth="default"
         onSelectionChange={(selection) => {
           setSelectedKeys(selection);
           action('onSelectionChange')(selection);
-        }}>
-        {/* Enabled items with dynamic illustrations */}
+        }}
+        {...args}
+        UNSAFE_style={{gridTemplateColumns: 'repeat(4, 1fr)'}}>
         <SelectBox value="enabled1">
           {selectedKeys !== 'all' && selectedKeys.has('enabled1') ? (
             <StarFilled1 />
@@ -313,7 +220,7 @@ function InteractiveExamplesStory() {
 }
 
 export const InteractiveExamples: Story = {
-  render: () => <InteractiveExamplesStory />
+  render: (args) => <InteractiveExamplesStory {...args} />
 };
 
 export const AllSlotCombinations: Story = {
@@ -331,7 +238,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Text Only</h4>
             <SelectBoxGroup 
               orientation="vertical" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="text-only">
                 <Text slot="label">Simple Text</Text>
@@ -344,7 +250,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Illustration + Text</h4>
             <SelectBoxGroup 
               orientation="vertical" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="illustration-text">
                 <Server />
@@ -358,7 +263,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Text + Description</h4>
             <SelectBoxGroup 
               orientation="vertical" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="text-desc">
                 <Text slot="label">Main Text</Text>
@@ -372,7 +276,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Illustration + Description</h4>
             <SelectBoxGroup 
               orientation="vertical" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="illustration-desc">
                 <PaperAirplane />
@@ -386,7 +289,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Illustration + Text + Description</h4>
             <SelectBoxGroup 
               orientation="vertical" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="all-vertical">
                 <AlertNotice />
@@ -409,7 +311,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Text Only</h4>
             <SelectBoxGroup 
               orientation="horizontal" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="h-text-only">
                 <Text slot="label">Simple Horizontal Text</Text>
@@ -422,7 +323,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Illustration + Text</h4>
             <SelectBoxGroup 
               orientation="horizontal" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="h-illustration-text">
                 <PaperAirplane />
@@ -436,7 +336,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Text + Description</h4>
             <SelectBoxGroup 
               orientation="horizontal" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="h-text-desc">
                 <Text slot="label">Main Horizontal Text</Text>
@@ -450,7 +349,6 @@ export const AllSlotCombinations: Story = {
             <h4 className={sectionHeadingStyles}>Illustration + Text + Description</h4>
             <SelectBoxGroup 
               orientation="horizontal" 
-              numColumns={1}
               onSelectionChange={action('onSelectionChange')}>
               <SelectBox value="h-all">
                 <Server />
@@ -467,8 +365,6 @@ export const AllSlotCombinations: Story = {
       <div style={{marginTop: 40}}>
         <h3 className={subheadingStyles}>Side-by-Side Comparison</h3>
         <SelectBoxGroup 
-          numColumns={5}
-          gutterWidth="spacious"
           onSelectionChange={action('onSelectionChange')}>
           
           {/* Vertical examples */}
@@ -502,8 +398,6 @@ export const AllSlotCombinations: Story = {
         <div style={{marginTop: 20}}>
           <SelectBoxGroup 
             orientation="horizontal"
-            numColumns={5}
-            gutterWidth="spacious"
             onSelectionChange={action('onSelectionChange')}>
             
             {/* Horizontal examples */}
@@ -536,60 +430,6 @@ export const AllSlotCombinations: Story = {
         </div>
       </div>
 
-    </div>
-  )
-};
-
-export const TextSlots: Story = {
-  args: {
-    orientation: 'horizontal'
-  },
-  render: (args) => (
-    <div style={{maxWidth: 600}}>
-      <h3 className={subheadingStyles}>Text Slots Example</h3>
-      <SelectBoxGroup {...args} onSelectionChange={action('onSelectionChange')}>
-        <SelectBox value="aws">
-          <Server />
-          <Text slot="label">Amazon Web Services</Text>
-          <Text slot="description">Reliable cloud infrastructure</Text>
-        </SelectBox>
-        <SelectBox value="azure">
-          <AlertNotice />
-          <Text slot="label">Microsoft Azure</Text>
-          <Text slot="description">Enterprise cloud solutions</Text>
-        </SelectBox>
-        <SelectBox value="gcp">
-          <PaperAirplane />
-          <Text slot="label">Google Cloud Platform</Text>
-          <Text slot="description">Modern cloud services</Text>
-        </SelectBox>
-        <SelectBox value="oracle">
-          <Server />
-          <Text slot="label">Oracle Cloud</Text>
-          <Text slot="description">Database-focused cloud</Text>
-        </SelectBox>
-      </SelectBoxGroup>
-    </div>
-  )
-};
-
-export const WithDescription: Story = {
-  args: {
-    orientation: 'horizontal'
-  },
-  render: (args) => (
-    <div style={{maxWidth: 600}}>
-      <h3 className={subheadingStyles}>With Description</h3>
-      <SelectBoxGroup {...args} onSelectionChange={action('onSelectionChange')}>
-        <SelectBox value="aws">
-          <Server />
-          <Text slot="description">Reliable cloud infrastructure</Text>
-        </SelectBox>
-        <SelectBox value="azure">
-          <AlertNotice />
-          <Text slot="label">Microsoft Azure</Text>
-        </SelectBox>
-      </SelectBoxGroup>
     </div>
   )
 };

--- a/packages/@react-spectrum/s2/stories/SelectBoxGroup.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/SelectBoxGroup.stories.tsx
@@ -17,14 +17,12 @@
 
 import {action} from '@storybook/addon-actions';
 import AlertNotice from '../spectrum-illustrations/linear/AlertNotice';
-import {Button, SelectBox, SelectBoxGroup, Text} from '../src';
 import type {Meta, StoryObj} from '@storybook/react';
 import PaperAirplane from '../spectrum-illustrations/linear/Paperairplane';
-import React, {useState} from 'react';
-import type {Selection} from 'react-aria-components';
+import React from 'react';
+import {SelectBox, SelectBoxGroup, Text} from '../src';
 import Server from '../spectrum-illustrations/linear/Server';
 import StarFilled1 from '../spectrum-illustrations/gradient/generic1/Star';
-import StarFilled2 from '../spectrum-illustrations/gradient/generic2/Star';
 import {style} from '../style' with {type: 'macro'};
 
 const headingStyles = style({
@@ -46,14 +44,6 @@ const sectionHeadingStyles = style({
   color: 'gray-600',
   margin: 0,
   marginBottom: 8
-});
-
-const descriptionStyles = style({
-  font: 'body',
-  fontSize: 'body-sm',
-  color: 'gray-600',
-  margin: 0,
-  marginBottom: 16
 });
 
 const meta: Meta<typeof SelectBoxGroup> = {
@@ -83,144 +73,35 @@ const meta: Meta<typeof SelectBoxGroup> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof SelectBoxGroup>;
 
 export const Default: Story = {
   render: (args) => {
-    const {selectionMode, orientation, isDisabled} = args as any;
     return (
-      <SelectBoxGroup selectionMode={selectionMode} orientation={orientation} isDisabled={isDisabled} UNSAFE_style={{gridTemplateColumns: 'repeat(2, 1fr)'}}>
-        <SelectBox value="aws">
-          <Server />
-          <Text slot="label">Amazon Web Services</Text>
-          <Text slot="description">Reliable cloud infrastructure</Text>
-        </SelectBox>
-        <SelectBox value="azure">
-          <AlertNotice />
-          <Text slot="label">Microsoft Azure</Text>
-        </SelectBox>
-        <SelectBox value="gcp">
-          <PaperAirplane />
-          <Text slot="label">Google Cloud Platform</Text>
-        </SelectBox>
-        <SelectBox value="ibm">
-          <StarFilled1 />
-          <Text slot="label">IBM Cloud</Text>
-          <Text slot="description">Hybrid cloud solutions</Text>
-        </SelectBox>
-      </SelectBoxGroup>
+      <div style={{width: 800}}>
+        <SelectBoxGroup {...args}>
+          <SelectBox value="aws">
+            <Server />
+            <Text slot="label">Amazon Web Services</Text>
+            <Text slot="description">Reliable cloud infrastructure</Text>
+          </SelectBox>
+          <SelectBox value="azure">
+            <AlertNotice />
+            <Text slot="label">Microsoft Azure</Text>
+          </SelectBox>
+          <SelectBox value="gcp">
+            <PaperAirplane />
+            <Text slot="label">Google Cloud Platform</Text>
+          </SelectBox>
+          <SelectBox value="ibm">
+            <StarFilled1 />
+            <Text slot="label">IBM Cloud</Text>
+            <Text slot="description">Hybrid cloud solutions</Text>
+          </SelectBox>
+        </SelectBoxGroup>
+      </div>
     );
   }
-};
-
-function InteractiveExamplesStory(args: any) {
-  const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set(['enabled1', 'starred2']));
-  return (
-    <div style={{maxWidth: 800}}>
-      <h3 className={subheadingStyles}>Interactive Features Combined</h3>
-      <p className={descriptionStyles}>
-        Current selection: {selectedKeys === 'all' ? 'All' : Array.from(selectedKeys).join(', ') || 'None'}
-      </p>
-      
-      <SelectBoxGroup
-        selectionMode="multiple"
-        selectedKeys={selectedKeys}
-        onSelectionChange={(selection) => {
-          setSelectedKeys(selection);
-          action('onSelectionChange')(selection);
-        }}
-        {...args}
-        UNSAFE_style={{gridTemplateColumns: 'repeat(4, 1fr)'}}>
-        <SelectBox value="enabled1">
-          {selectedKeys !== 'all' && selectedKeys.has('enabled1') ? (
-            <StarFilled1 />
-          ) : (
-            <StarFilled2 />
-          )}
-          <Text slot="label">Enabled Item 1</Text>
-          <Text slot="description">Status updates</Text>
-        </SelectBox>
-        <SelectBox value="enabled2">
-          {selectedKeys !== 'all' && selectedKeys.has('enabled2') ? (
-            <StarFilled1 />
-          ) : (
-            <StarFilled2 />
-          )}
-          <Text slot="label">Enabled Item 2</Text>
-          <Text slot="description">Click to toggle</Text>
-        </SelectBox>
-        {/* Disabled item */}
-        <SelectBox value="disabled1" isDisabled>
-          <AlertNotice />
-          <Text slot="label">Disabled Item</Text>
-          <Text slot="description">Cannot select</Text>
-        </SelectBox>
-        <SelectBox value="starred1">
-          {selectedKeys !== 'all' && selectedKeys.has('starred1') ? (
-            <StarFilled1 />
-          ) : (
-            <StarFilled2 />
-          )}
-          <Text slot="label">Starred Item 1</Text>
-          <Text slot="description">Click to star</Text>
-        </SelectBox>
-        <SelectBox value="starred2">
-          {selectedKeys !== 'all' && selectedKeys.has('starred2') ? (
-            <StarFilled1 />
-          ) : (
-            <StarFilled2 />
-          )}
-          <Text slot="label">Starred Item 2</Text>
-          <Text slot="description">Click to star</Text>
-        </SelectBox>
-        <SelectBox value="disabled2" isDisabled>
-          <Server />
-          <Text slot="label">Disabled Service</Text>
-          <Text slot="description">Cannot select</Text>
-        </SelectBox>
-        <SelectBox value="dynamic1">
-          {selectedKeys !== 'all' && selectedKeys.has('dynamic1') ? (
-            <StarFilled1 />
-          ) : (
-            <StarFilled2 />
-          )}
-          <Text slot="label">Dynamic Illustration</Text>
-          <Text slot="description">Click to activate</Text>
-        </SelectBox>
-        <SelectBox value="controllable">
-          {selectedKeys !== 'all' && selectedKeys.has('controllable') ? (
-            <StarFilled1 />
-          ) : (
-            <StarFilled2 />
-          )}
-          <Text slot="label">Controllable</Text>
-          <Text slot="description">External control available</Text>
-        </SelectBox>
-      </SelectBoxGroup>
-      
-      <div style={{marginTop: 20, display: 'flex', gap: 12, flexWrap: 'wrap'}}>
-        <Button 
-          onPress={() => setSelectedKeys(new Set(['starred1', 'starred2', 'dynamic1']))}
-          variant="secondary">
-          Select Favorites
-        </Button>
-        <Button 
-          onPress={() => setSelectedKeys(new Set())}
-          variant="secondary">
-          Clear All
-        </Button>
-        <Button 
-          onPress={() => setSelectedKeys(new Set(['enabled1', 'enabled2', 'controllable']))}
-          variant="secondary">
-          Select Enabled Only
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-export const InteractiveExamples: Story = {
-  render: (args) => <InteractiveExamplesStory {...args} />
 };
 
 export const AllSlotCombinations: Story = {

--- a/packages/@react-spectrum/s2/test/SelectBoxGroup.test.tsx
+++ b/packages/@react-spectrum/s2/test/SelectBoxGroup.test.tsx
@@ -3,6 +3,7 @@ import Calendar from '../spectrum-illustrations/linear/Calendar';
 import React from 'react';
 import {SelectBox, SelectBoxGroup, Text} from '../src';
 import {Selection} from '@react-types/shared';
+import {User} from '@react-aria/test-utils';
 import userEvent from '@testing-library/user-event';
 
 function ControlledSingleSelectBox() {
@@ -85,12 +86,10 @@ function DisabledSelectBox() {
 
 describe('SelectBoxGroup', () => {
   let user;
+  let testUtilUser = new User();
 
   beforeAll(function () {
     jest.useFakeTimers();
-    jest.spyOn(window.HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => 100);
-    jest.spyOn(window.HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(() => 100);
-    jest.spyOn(window.HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(() => 50);
     user = userEvent.setup({delay: null, pointerMap});
   });
 
@@ -122,40 +121,34 @@ describe('SelectBoxGroup', () => {
   describe('Uncontrolled behavior', () => {
     it('handles uncontrolled click selection in single mode', async () => {
       render(<UncontrolledSelectBox selectionMode="single" />);
-      const options = screen.getAllByRole('option');
-      const option1 = options.find(option => option.textContent?.includes('Option 1'))!;
+      let listboxTester = testUtilUser.createTester('ListBox', {root: screen.getByRole('listbox')});
       
-      await user.click(option1);
-      expect(option1).toHaveAttribute('aria-selected', 'true');
+      await listboxTester.toggleOptionSelection({option: 0});
+      expect(listboxTester.options()[0]).toHaveAttribute('aria-selected', 'true');
     });
 
     it('handles uncontrolled click selection in multiple mode', async () => {
       render(<UncontrolledSelectBox selectionMode="multiple" />);
-      const options = screen.getAllByRole('option');
-      const option1 = options.find(option => option.textContent?.includes('Option 1'))!;
-      const option2 = options.find(option => option.textContent?.includes('Option 2'))!;
+      let listboxTester = testUtilUser.createTester('ListBox', {root: screen.getByRole('listbox')});
       
-      await user.click(option1);
-      await user.click(option2);
+      await listboxTester.toggleOptionSelection({option: 0});
+      await listboxTester.toggleOptionSelection({option: 1});
       
-      expect(option1).toHaveAttribute('aria-selected', 'true');
-      expect(option2).toHaveAttribute('aria-selected', 'true');
+      expect(listboxTester.options()[0]).toHaveAttribute('aria-selected', 'true');
+      expect(listboxTester.options()[1]).toHaveAttribute('aria-selected', 'true');
     });
 
     it('handles uncontrolled selection toggle', async () => {
       render(<UncontrolledSelectBox selectionMode="single" />);
-      const options = screen.getAllByRole('option');
-      const option1 = options.find(option => option.textContent?.includes('Option 1'))!;
+      let listboxTester = testUtilUser.createTester('ListBox', {root: screen.getByRole('listbox')});
       
-      // Select
-      await user.click(option1);
-      expect(option1).toHaveAttribute('aria-selected', 'true');
+      await listboxTester.toggleOptionSelection({option: 0});
+      expect(listboxTester.options()[0]).toHaveAttribute('aria-selected', 'true');
       
       // Toggle off in single mode by selecting another
-      const option2 = options.find(option => option.textContent?.includes('Option 2'))!;
-      await user.click(option2);
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'true');
+      await listboxTester.toggleOptionSelection({option: 1});
+      expect(listboxTester.options()[0]).toHaveAttribute('aria-selected', 'false');
+      expect(listboxTester.options()[1]).toHaveAttribute('aria-selected', 'true');
     });
 
     it('handles uncontrolled keyboard selection', async () => {
@@ -178,24 +171,21 @@ describe('SelectBoxGroup', () => {
   describe('Controlled behavior', () => {
     it('handles controlled selection in single mode', async () => {
       render(<ControlledSingleSelectBox />);
-      const options = screen.getAllByRole('option');
-      const option1 = options.find(option => option.textContent?.includes('Option 1'))!;
+      let listboxTester = testUtilUser.createTester('ListBox', {root: screen.getByRole('listbox')});
       
-      await user.click(option1);
-      expect(option1).toHaveAttribute('aria-selected', 'true');
+      await listboxTester.toggleOptionSelection({option: 0});
+      expect(listboxTester.options()[0]).toHaveAttribute('aria-selected', 'true');
     });
 
     it('handles controlled multiple selection', async () => {
       render(<ControlledMultiSelectBox />);
-      const options = screen.getAllByRole('option');
-      const option1 = options.find(option => option.textContent?.includes('Option 1'))!;
-      const option2 = options.find(option => option.textContent?.includes('Option 2'))!;
+      let listboxTester = testUtilUser.createTester('ListBox', {root: screen.getByRole('listbox')});
       
-      await user.click(option1);
-      await user.click(option2);
+      await listboxTester.toggleOptionSelection({option: 0});
+      await listboxTester.toggleOptionSelection({option: 1});
       
-      expect(option1).toHaveAttribute('aria-selected', 'true');
-      expect(option2).toHaveAttribute('aria-selected', 'true');
+      expect(listboxTester.options()[0]).toHaveAttribute('aria-selected', 'true');
+      expect(listboxTester.options()[1]).toHaveAttribute('aria-selected', 'true');
     });
 
     it('calls onSelectionChange when selection changes in controlled mode', async () => {
@@ -418,7 +408,7 @@ describe('SelectBoxGroup', () => {
       expect(checkboxDiv).toBeInTheDocument();
     });
 
-    it('does not show checkbox on hover for disabled items', async () => {
+    it('shows checkbox for disabled items (always show checkboxes)', async () => {
       render(
         <SelectBoxGroup 
           aria-label="Disabled hover test"
@@ -433,12 +423,9 @@ describe('SelectBoxGroup', () => {
 
       const row = screen.getByRole('option', {name: 'Option 1'});
       
-      await user.hover(row);
-      
-      await waitFor(() => {
-        const checkboxDiv = row.querySelector('[aria-hidden="true"]');
-        expect(checkboxDiv).not.toBeInTheDocument();
-      }, {timeout: 1000});
+      // checkbox always present
+      const checkboxDiv = row.querySelector('[aria-hidden="true"]');
+      expect(checkboxDiv).toBeInTheDocument();
     });
   });
 
@@ -483,7 +470,6 @@ describe('SelectBoxGroup', () => {
       
       const listbox = screen.getByRole('listbox');
       expect(listbox).toBeInTheDocument();
-      // Grid template columns are now handled via CSS classes from the style macro
     });
 
     it('auto-fits columns based on orientation (horizontal)', () => {
@@ -507,7 +493,6 @@ describe('SelectBoxGroup', () => {
       
       const listbox = screen.getByRole('listbox');
       expect(listbox).toBeInTheDocument();
-      // Grid template columns are now handled via CSS classes from the style macro
     });
   });
 
@@ -581,11 +566,10 @@ describe('SelectBoxGroup', () => {
       const option1 = screen.getByRole('option', {name: 'Option 1'});
       const option2 = screen.getByRole('option', {name: 'Option 2'});
       
-      // Should start with option1 selected
       expect(option1).toHaveAttribute('aria-selected', 'true');
       expect(option2).toHaveAttribute('aria-selected', 'false');
       
-      // Click should update selection
+      // click should update selection
       await user.click(option2);
       expect(option1).toHaveAttribute('aria-selected', 'false');
       expect(option2).toHaveAttribute('aria-selected', 'true');
@@ -613,18 +597,16 @@ describe('SelectBoxGroup', () => {
       const option2 = screen.getByRole('option', {name: 'Option 2'});
       const option3 = screen.getByRole('option', {name: 'Option 3'});
       
-      // Should start with option1 and option2 selected
       expect(option1).toHaveAttribute('aria-selected', 'true');
       expect(option2).toHaveAttribute('aria-selected', 'true');
       expect(option3).toHaveAttribute('aria-selected', 'false');
       
-      // Click should add to selection
       await user.click(option3);
       expect(option1).toHaveAttribute('aria-selected', 'true');
       expect(option2).toHaveAttribute('aria-selected', 'true');
       expect(option3).toHaveAttribute('aria-selected', 'true');
       
-      // Click should remove from selection
+      // click should remove from selection
       await user.click(option1);
       expect(option1).toHaveAttribute('aria-selected', 'false');
       expect(option2).toHaveAttribute('aria-selected', 'true');
@@ -933,7 +915,7 @@ describe('SelectBoxGroup', () => {
       expect(option1).toHaveAttribute('aria-disabled', 'true');
       expect(option1).toHaveAttribute('aria-selected', 'false');
       
-      // Clicking enabled item should still work
+      // clicking enabled item should still work
       await user.click(option2);
       expect(option2).toHaveAttribute('aria-selected', 'true');
     });


### PR DESCRIPTION
Closes <!-- Github issue # here -->

things to look out for that we discussed when we tested selectbox:
1. selectbox should have cursor: 'default'. right now it has a pointer cursor
2. the focus ring should be a halo since it conflicts with the selection state. i think all you need to do is remove the outlineOffset
3. we're just going to omit the showCheckbox and have checkboxes always rendered. we can change this later
4. when the user presses down on a select box, the select box should scale down (which is what we call press scaling). search pressScale and example of how to use it in S2 should come up. we want it to look similar to how CardView does when you press down on a Card
5. clean up the stories a little bit since some of the various states can be achieved by using the controls (like the Disabled one for example). some of stories might actually be better in chromatic where we take snapshots of the components. lemme know if you need help with getting chromatic to work but that can be follow-up to this new PR if it's easier to separate out
6. spread props onto ListBoxItem/ListBox
7. delete gutterWidth/numColumns 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run the `SelectBoxGroup.test.tsx` file and observe the SelectBox s2 component with `yarn start:s2`

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
