### PR TITLE
fix: tag collapse calculation for removable tags

### DIFF
--- a/packages/@react-spectrum/s2/src/TagGroup.tsx
+++ b/packages/@react-spectrum/s2/src/TagGroup.tsx
@@ -323,7 +323,45 @@ function TagGroupInner<T>({
                       style={item.props.UNSAFE_style}
                       key={item.key}
                       className={item.props.className({size, allowsRemoving: Boolean(onRemove)})}>
-                      {item.props.children({size, allowsRemoving: Boolean(onRemove), isInCtx: true})}
+                      <div
+                        className={style({
+                          display: 'flex',
+                          minWidth: 0,
+                          alignItems: 'center',
+                          gap: 'text-to-visual',
+                          forcedColorAdjust: 'none',
+                          backgroundColor: 'transparent'
+                        })}>
+                        <Provider
+                          values={[
+                            [TextContext, {styles: style({order: 1, truncate: true})}],
+                            [IconContext, {
+                              render: centerBaseline({slot: 'icon', styles: style({order: 0})}),
+                              styles: style({size: fontRelative(20), marginStart: '--iconMargin', flexShrink: 0})
+                            }],
+                            [AvatarContext, {
+                              size: avatarSize[size],
+                              styles: style({order: 0})
+                            }],
+                            [ImageContext, {
+                              styles: style({
+                                size: fontRelative(20),
+                                flexShrink: 0,
+                                order: 0,
+                                aspectRatio: 'square',
+                                objectFit: 'contain',
+                                borderRadius: 'sm'
+                              })
+                            }]
+                          ]}>
+                          {item.props.children({size, allowsRemoving: Boolean(onRemove), isInCtx: true})}
+                        </Provider>
+                      </div>
+                      {Boolean(onRemove) && (
+                        <ClearButton
+                          slot="remove"
+                          size={size} />
+                      )}
                     </div>
                   );
                 })}
@@ -516,41 +554,41 @@ function TagWrapper({children, isDisabled, allowsRemoving, isInRealDOM, isEmphas
   return (
     <>
       {isInRealDOM && (
-      <div
-        className={style({
-          display: 'flex',
-          minWidth: 0,
-          alignItems: 'center',
-          gap: 'text-to-visual',
-          forcedColorAdjust: 'none',
-          backgroundColor: 'transparent'
-        })}>
-        <Provider
-          values={[
-            [TextContext, {styles: style({order: 1, truncate: true})}],
-            [IconContext, {
-              render: centerBaseline({slot: 'icon', styles: style({order: 0})}),
-              styles: style({size: fontRelative(20), marginStart: '--iconMargin', flexShrink: 0})
-            }],
-            [AvatarContext, {
-              size: avatarSize[size],
-              styles: style({order: 0})
-            }],
-            [ImageContext, {
-              styles: style({
-                size: fontRelative(20),
-                flexShrink: 0,
-                order: 0,
-                aspectRatio: 'square',
-                objectFit: 'contain',
-                borderRadius: 'sm'
-              })
-            }]
-          ]}>
-          {children}
-        </Provider>
-      </div>
-        )}
+        <div
+          className={style({
+            display: 'flex',
+            minWidth: 0,
+            alignItems: 'center',
+            gap: 'text-to-visual',
+            forcedColorAdjust: 'none',
+            backgroundColor: 'transparent'
+          })}>
+          <Provider
+            values={[
+              [TextContext, {styles: style({order: 1, truncate: true})}],
+              [IconContext, {
+                render: centerBaseline({slot: 'icon', styles: style({order: 0})}),
+                styles: style({size: fontRelative(20), marginStart: '--iconMargin', flexShrink: 0})
+              }],
+              [AvatarContext, {
+                size: avatarSize[size],
+                styles: style({order: 0})
+              }],
+              [ImageContext, {
+                styles: style({
+                  size: fontRelative(20),
+                  flexShrink: 0,
+                  order: 0,
+                  aspectRatio: 'square',
+                  objectFit: 'contain',
+                  borderRadius: 'sm'
+                })
+              }]
+            ]}>
+            {children}
+          </Provider>
+        </div>
+      )}
       {!isInRealDOM && children}
       {allowsRemoving && isInRealDOM && (
         <ClearButton


### PR DESCRIPTION
Closes <!-- Github issue # here -->

originally found in https://github.com/adobe/react-spectrum/pull/8653/files

Removable tags would exceed the number of specified maxRows

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Go to storybook, turn on removable, set maxRows to 1 or 2

## 🧢 Your Project:

<!--- Company/project for pull request -->
