### PR TITLE
chore: export SelectBoxGroupContext

### DIFF
--- a/packages/@react-spectrum/s2/src/SelectBoxGroup.tsx
+++ b/packages/@react-spectrum/s2/src/SelectBoxGroup.tsx
@@ -65,7 +65,7 @@ interface SelectBoxContextValue {
   isDisabled?: boolean
 }
 
-export const SelectBoxContext = createContext<SelectBoxContextValue>({orientation: 'vertical'});
+const SelectBoxContext = createContext<SelectBoxContextValue>({orientation: 'vertical'});
 export const SelectBoxGroupContext = createContext<ContextValue<Partial<SelectBoxGroupProps<any>>, DOMRefValue<HTMLDivElement>>>(null);
 
 const labelOnly = ':has([slot=label]):not(:has([slot=description]))';

--- a/packages/@react-spectrum/s2/src/index.ts
+++ b/packages/@react-spectrum/s2/src/index.ts
@@ -72,7 +72,7 @@ export {RangeCalendar, RangeCalendarContext} from './RangeCalendar';
 export {RangeSlider, RangeSliderContext} from './RangeSlider';
 export {SearchField, SearchFieldContext} from './SearchField';
 export {SegmentedControl, SegmentedControlItem, SegmentedControlContext} from './SegmentedControl';
-export {SelectBox, SelectBoxContext, SelectBoxGroup} from './SelectBoxGroup';
+export {SelectBox, SelectBoxGroup, SelectBoxGroupContext} from './SelectBoxGroup';
 export {Slider, SliderContext} from './Slider';
 export {Skeleton, useIsSkeleton} from './Skeleton';
 export {SkeletonCollection} from './SkeletonCollection';


### PR DESCRIPTION
just something i remember when i was looking at SelectBox

also personally felt like SelctBoxContext was more of an internal context thing so i removed it from being exported

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
