### PR TITLE
docs: Add trigger-anchor-point example

### DIFF
--- a/packages/react-aria-components/docs/Popover.mdx
+++ b/packages/react-aria-components/docs/Popover.mdx
@@ -90,6 +90,7 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow, Heading, Switch} f
   outline: none;
   max-width: 250px;
   transition: transform 200ms, opacity 200ms;
+  transform-origin: var(--trigger-anchor-point);
 
   .react-aria-OverlayArrow svg {
     display: block;
@@ -100,7 +101,7 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow, Heading, Switch} f
 
   &[data-entering],
   &[data-exiting] {
-    transform: var(--origin);
+    transform: scale(0.85) var(--origin);
     opacity: 0;
   }
 

--- a/packages/react-aria-components/docs/Tooltip.mdx
+++ b/packages/react-aria-components/docs/Tooltip.mdx
@@ -77,10 +77,11 @@ import {Edit} from 'lucide-react';
   /* fixes FF gap */
   transform: translate3d(0, 0, 0);
   transition: transform 200ms, opacity 200ms;
+  transform-origin: var(--trigger-anchor-point);
 
   &[data-entering],
   &[data-exiting] {
-    transform: var(--origin);
+    transform: scale(0.9) var(--origin);
     opacity: 0;
   }
 


### PR DESCRIPTION
Use `var(--trigger-anchor-point)` in the popover/tooltip examples so we have an example of origin-aware animations to point to.