### PR TITLE
fix: S2 Tabs collapsing with a single word

### DIFF
--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -213,7 +213,7 @@ const tablist = style({
 
 const tablistWrapper = style({
   position: 'relative',
-  minWidth: 'min',
+  minWidth: 0,
   flexShrink: 0,
   flexGrow: 0
 }, getAllowedOverrides());

--- a/packages/@react-spectrum/s2/stories/Tabs.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Tabs.stories.tsx
@@ -47,9 +47,9 @@ export const Example: Story = {
     <div className={style({width: 700, maxWidth: 'calc(100vw - 60px)', height: 256, resize: 'horizontal', overflow: 'hidden', padding: 8})}>
       <Tabs {...args} styles={tabs} aria-label="History of Ancient Rome">
         <TabList styles={tabList({orientation: args.orientation})}>
-          <Tab id="FoR">Founding of Rome</Tab>
-          <Tab id="MaR">Monarchy and Republic</Tab>
-          <Tab id="Emp">Empire</Tab>
+          <Tab id="FoR">Home</Tab>
+          <Tab id="MaR">Search</Tab>
+          <Tab id="Emp">Settings</Tab>
         </TabList>
         <TabPanel id="FoR">
           <div className={style({overflow: 'auto', height: 'full'})}>


### PR DESCRIPTION
When S2 Tabs have only a single word in each tab they would never collapse due to the `min-width: min-content`. Setting this to zero fixes the issue. Updated one of the stories to test.