### PR TITLE
fix: store scroll pos when virtualized

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -325,7 +325,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
   // Store the scroll position so we can restore it later.
   /// TODO: should this happen all the time??
   let scrollPos = useRef({top: 0, left: 0});
-  useEvent(scrollRef, 'scroll', isVirtualized ? undefined : () => {
+  useEvent(scrollRef, 'scroll', () => {
     scrollPos.current = {
       top: scrollRef.current?.scrollTop ?? 0,
       left: scrollRef.current?.scrollLeft ?? 0
@@ -366,7 +366,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
       } else {
         navigateToKey(manager.firstSelectedKey ?? delegate.getFirstKey?.());
       }
-    } else if (!isVirtualized && scrollRef.current) {
+    } else if (scrollRef.current) {
       // Restore the scroll position to what it was before.
       scrollRef.current.scrollTop = scrollPos.current.top;
       scrollRef.current.scrollLeft = scrollPos.current.left;
@@ -585,7 +585,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
   // This will be marshalled to either the first or last item depending on where focus came from.
   let tabIndex: number | undefined = undefined;
   if (!shouldUseVirtualFocus) {
-    tabIndex = manager.focusedKey == null ? 0 : -1;
+    tabIndex = manager.isFocused ? -1 : 0;
   }
 
   let collectionId = useCollectionId(manager.collection);


### PR DESCRIPTION
Closes [#8234](https://github.com/adobe/react-spectrum/issues/8234)

This PR makes three changes:

**1. Use isFocused instead of focusedKey for tabIndex** 
Previously, the tabIndex was determined by whether focusedKey was null. However, focusedKey persists even after tabbing out of the collection. This caused the collection root to remain non-tabbable, and as a result the browser would default to focusing the first or last focusable element inside the collection (e.g., a button) when tabbing back in. Once the browser focused that button, the focus logic ran and scrolled the focusedKey item into view — which led to the “jump” that was observed. By switching the condition to use isFocused instead, the collection root becomes tabbable whenever the collection itself is not focused. This prevents the browser from landing on inner focusable elements and eliminates the initial jump when tabbing back into the collection.

**2. Always track scroll position**
The useEvent(scrollRef, 'scroll', ...) handler is now always active, rather than being disabled for virtualized collections. This ensures the current scroll position is always stored, even when virtualization is used.

**3. Always restore scroll position on focus**
Similarly, the scroll position is now restored whenever the collection regains focus, regardless of whether it is virtualized. This prevents jumps when shift+tabbing back into the collection. I guess the issue [#2233](https://github.com/adobe/react-spectrum/pull/2233) is connected to the problem.


I am still curious why scroll position saving/restoring was originally disabled for virtualized collections. My assumption is that it may have been excluded to avoid interfering with virtualization behavior or for performance reasons.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

## 🧢 Your Project:

<!--- Company/project for pull request -->
