### PR TITLE
docs: Update dnd docs for new getItems API

### DIFF
--- a/packages/react-aria-components/docs/GridList.mdx
+++ b/packages/react-aria-components/docs/GridList.mdx
@@ -859,6 +859,11 @@ This uses [useListData](../react-stately/useListData.html) from React Stately to
 import {useListData} from 'react-stately';
 import {useDragAndDrop} from 'react-aria-components';
 
+interface Item {
+  id: number,
+  name: string
+}
+
 function Example() {
   let list = useListData({
     initialItems: [
@@ -871,8 +876,8 @@ function Example() {
   });
 
   ///- begin highlight -///
-  let {dragAndDropHooks} = useDragAndDrop({
-    getItems: (keys) => [...keys].map(key => ({'text/plain': list.getItem(key).name})),
+  let {dragAndDropHooks} = useDragAndDrop<Item>({
+    getItems: (keys, items) => items.map(item => ({'text/plain': item.name})),
     onReorder(e) {
       if (e.target.dropPosition === 'before') {
         list.moveBefore(e.target.key, e.keys);
@@ -948,11 +953,18 @@ This example renders a custom drag preview which shows the number of items being
 import {useListData} from 'react-stately';
 import {useDragAndDrop} from 'react-aria-components';
 
+///- begin collapse -///
+interface Item {
+  id: number,
+  name: string
+}
+///- end collapse -///
+
 function Example() {
-  let {dragAndDropHooks} = useDragAndDrop({
+  let {dragAndDropHooks} = useDragAndDrop<Item>({
     // ...
     ///- begin collapse -///
-    getItems: (keys) => [...keys].map(key => ({'text/plain': list.getItem(key).name})),
+    getItems: (keys, items) => items.map(item => ({'text/plain': item.name})),
     onReorder(e) {
       if (e.target.dropPosition === 'before') {
         list.moveBefore(e.target.key, e.keys);
@@ -1029,16 +1041,22 @@ This can be done by returning multiple keys for an item from the `getItems` func
 This example provides representations of each item as plain text, HTML, and a custom app-specific data format. Dropping on the drop targets in this page will use the custom data format to render formatted items. If you drop in an external application supporting rich text, the HTML representation will be used. Dropping in a text editor will use the plain text format.
 
 ```tsx example export=true
-function DraggableGridList() {
-  let items = new Map([
-    ['ps', {name: 'Photoshop', style: 'strong'}],
-    ['xd', {name: 'XD', style: 'strong'}],
-    ['id', {name: 'InDesign', style: 'strong'}],
-    ['dw', {name: 'Dreamweaver', style: 'em'}],
-    ['co', {name: 'Connect', style: 'em'}]
-  ]);
+interface RichTextItem {
+  id: string,
+  name: string,
+  style: string
+}
 
-  let { dragAndDropHooks } = useDragAndDrop({
+function DraggableGridList() {
+  let items: RichTextItem[] = [
+    {id: 'ps', name: 'Photoshop', style: 'strong'},
+    {id: 'xd', name: 'XD', style: 'strong'},
+    {id: 'id', name: 'InDesign', style: 'strong'},
+    {id: 'dw', name: 'Dreamweaver', style: 'em'},
+    {id: 'co', name: 'Connect', style: 'em'}
+  ];
+
+  let { dragAndDropHooks } = useDragAndDrop<RichTextItem>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1050,13 +1068,12 @@ function DraggableGridList() {
     },
     ///- end collapse -///
     /*- begin highlight -*/
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = items.get(key as string)!;
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'text/html': `<${item.style}>${item.name}</${item.style}>`,
-          'custom-app-type': JSON.stringify({id: key, ...item})
+          'custom-app-type': JSON.stringify(item)
         };
       });
     },
@@ -1065,7 +1082,7 @@ function DraggableGridList() {
 
   return (
     <MyGridList aria-label="Draggable list" selectionMode="multiple" items={items} dragAndDropHooks={dragAndDropHooks}>
-      {([id, item]) => <MyItem id={id} textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</MyItem>}
+      {item => <MyItem textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</MyItem>}
     </MyGridList>
   );
 }
@@ -1082,15 +1099,17 @@ function DraggableGridList() {
 Dropping on the GridList as a whole can be enabled using the `onRootDrop` event. When a valid drag hovers over the GridList, it receives the `isDropTarget` state and can be styled using the `[data-drop-target]` CSS selector.
 
 ```tsx example
+///- begin collapse -///
 interface Item {
   id: number,
   name: string
 }
+///- end collapse -///
 
 function Example() {
   let [items, setItems] = React.useState<Item[]>([]);
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Item>({
     /*- begin highlight -*/
     async onRootDrop(e) {
       let items = await Promise.all(e.items.map(async (item, i) => {
@@ -1528,6 +1547,13 @@ The `onDragEnd` event allows the drag source to respond when a drag that it init
 This example removes the dragged items from the UI when a move operation is completed. Try holding the <Keyboard>Option</Keyboard> or <Keyboard>Alt</Keyboard> keys to change the operation to copy, and see how the behavior changes.
 
 ```tsx example
+///- begin collapse -///
+interface Item {
+  id: number,
+  name: string
+}
+///- end collapse -///
+
 function Example() {
   let list = useListData({
     initialItems: [
@@ -1539,7 +1565,7 @@ function Example() {
     ]
   });
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Item>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1549,9 +1575,8 @@ function Example() {
         </div>
       );
     },
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'custom-app-type': JSON.stringify(item)
@@ -1585,6 +1610,13 @@ function Example() {
 The drag source can also control which drop operations are allowed for the data. For example, if moving data is not allowed, and only copying is supported, the `getAllowedDropOperations` function could be implemented to indicate this. When you drag the element below, the cursor now shows the copy affordance by default, and pressing a modifier to switch drop operations results in the drop being canceled.
 
 ```tsx example
+///- begin collapse -///
+interface Item {
+  id: number,
+  name: string
+}
+///- end collapse -///
+
 function Example() {
   ///- begin collapse -///
   let list = useListData({
@@ -1599,7 +1631,7 @@ function Example() {
   ///- end collapse -///
   // ...
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Item>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1609,9 +1641,8 @@ function Example() {
         </div>
       );
     },
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'custom-app-type': JSON.stringify(item)
@@ -1737,7 +1768,7 @@ function DndGridList(props: DndGridListProps) {
     initialItems: props.initialItems
   });
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<FileItem>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1749,9 +1780,8 @@ function DndGridList(props: DndGridListProps) {
     },
     ///- end collapse -///
     // Provide drag data in a custom format as well as plain text.
-    getItems(keys) {
-      return [...keys].map((key) => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'custom-app-type': JSON.stringify(item),
           'text/plain': item.name

--- a/packages/react-aria-components/docs/ListBox.mdx
+++ b/packages/react-aria-components/docs/ListBox.mdx
@@ -976,6 +976,11 @@ This uses [useListData](../react-stately/useListData.html) from React Stately to
 import {useListData} from 'react-stately';
 import {useDragAndDrop} from 'react-aria-components';
 
+interface Item {
+  id: number,
+  name: string
+}
+
 function Example() {
   let list = useListData({
     initialItems: [
@@ -988,8 +993,8 @@ function Example() {
   });
 
   ///- begin highlight -///
-  let {dragAndDropHooks} = useDragAndDrop({
-    getItems: (keys) => [...keys].map(key => ({'text/plain': list.getItem(key).name})),
+  let {dragAndDropHooks} = useDragAndDrop<Item>({
+    getItems: (keys, items) => items.map(item => ({'text/plain': item.name})),
     onReorder(e) {
       if (e.target.dropPosition === 'before') {
         list.moveBefore(e.target.key, e.keys);
@@ -1042,11 +1047,18 @@ This example renders a custom drag preview which shows the number of items being
 import {useListData} from 'react-stately';
 import {useDragAndDrop} from 'react-aria-components';
 
+///- begin collapse -///
+interface Item {
+  id: number,
+  name: string
+}
+///- end collapse -///
+
 function Example() {
-  let {dragAndDropHooks} = useDragAndDrop({
+  let {dragAndDropHooks} = useDragAndDrop<Item>({
     // ...
     ///- begin collapse -///
-    getItems: (keys) => [...keys].map(key => ({'text/plain': list.getItem(key).name})),
+    getItems: (keys, items) => items.map(item => ({'text/plain': item.name})),
     onReorder(e) {
       if (e.target.dropPosition === 'before') {
         list.moveBefore(e.target.key, e.keys);
@@ -1123,16 +1135,22 @@ This can be done by returning multiple keys for an item from the `getItems` func
 This example provides representations of each item as plain text, HTML, and a custom app-specific data format. Dropping on the drop targets in this page will use the custom data format to render formatted items. If you drop in an external application supporting rich text, the HTML representation will be used. Dropping in a text editor will use the plain text format.
 
 ```tsx example export=true
-function DraggableListBox() {
-  let items = new Map([
-    ['ps', {name: 'Photoshop', style: 'strong'}],
-    ['xd', {name: 'XD', style: 'strong'}],
-    ['id', {name: 'InDesign', style: 'strong'}],
-    ['dw', {name: 'Dreamweaver', style: 'em'}],
-    ['co', {name: 'Connect', style: 'em'}]
-  ]);
+interface RichTextItem {
+  id: string,
+  name: string,
+  style: string
+}
 
-  let { dragAndDropHooks } = useDragAndDrop({
+function DraggableListBox() {
+  let items: RichTextItem[] = [
+    {id: 'ps', name: 'Photoshop', style: 'strong'},
+    {id: 'xd', name: 'XD', style: 'strong'},
+    {id: 'id', name: 'InDesign', style: 'strong'},
+    {id: 'dw', name: 'Dreamweaver', style: 'em'},
+    {id: 'co', name: 'Connect', style: 'em'}
+  ];
+
+  let { dragAndDropHooks } = useDragAndDrop<RichTextItem>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1144,13 +1162,12 @@ function DraggableListBox() {
     },
     ///- end collapse -///
     /*- begin highlight -*/
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = items.get(key as string)!;
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'text/html': `<${item.style}>${item.name}</${item.style}>`,
-          'custom-app-type': JSON.stringify({id: key, ...item})
+          'custom-app-type': JSON.stringify(item)
         };
       });
     },
@@ -1159,7 +1176,7 @@ function DraggableListBox() {
 
   return (
     <ListBox aria-label="Draggable list" selectionMode="multiple" items={items} dragAndDropHooks={dragAndDropHooks}>
-      {([id, item]) => <ListBoxItem id={id} textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</ListBoxItem>}
+      {item => <ListBoxItem textValue={item.name}>{React.createElement(item.style || 'span', null, item.name)}</ListBoxItem>}
     </ListBox>
   );
 }
@@ -1176,10 +1193,12 @@ function DraggableListBox() {
 Dropping on the ListBox as a whole can be enabled using the `onRootDrop` event. When a valid drag hovers over the ListBox, it receives the `isDropTarget` state and can be styled using the `[data-drop-target]` CSS selector.
 
 ```tsx example
+///- begin collapse -///
 interface Item {
   id: number,
   name: string
 }
+///- end collapse -///
 
 function Example() {
   let [items, setItems] = React.useState<Item[]>([]);
@@ -1608,6 +1627,13 @@ The `onDragEnd` event allows the drag source to respond when a drag that it init
 This example removes the dragged items from the UI when a move operation is completed. Try holding the <Keyboard>Option</Keyboard> or <Keyboard>Alt</Keyboard> keys to change the operation to copy, and see how the behavior changes.
 
 ```tsx example
+///- begin collapse -///
+interface Item {
+  id: number,
+  name: string
+}
+///- end collapse -///
+
 function Example() {
   let list = useListData({
     initialItems: [
@@ -1619,7 +1645,7 @@ function Example() {
     ]
   });
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Item>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1629,9 +1655,8 @@ function Example() {
         </div>
       );
     },
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'custom-app-type': JSON.stringify(item)
@@ -1665,6 +1690,13 @@ function Example() {
 The drag source can also control which drop operations are allowed for the data. For example, if moving data is not allowed, and only copying is supported, the `getAllowedDropOperations` function could be implemented to indicate this. When you drag the element below, the cursor now shows the copy affordance by default, and pressing a modifier to switch drop operations results in the drop being canceled.
 
 ```tsx example
+///- begin collapse -///
+interface Item {
+  id: number,
+  name: string
+}
+///- end collapse -///
+
 function Example() {
   ///- begin collapse -///
   let list = useListData({
@@ -1679,7 +1711,7 @@ function Example() {
   ///- end collapse -///
   // ...
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Item>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1689,9 +1721,8 @@ function Example() {
         </div>
       );
     },
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'custom-app-type': JSON.stringify(item)
@@ -1817,7 +1848,7 @@ function DndListBox(props: DndListBoxProps) {
     initialItems: props.initialItems
   });
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<FileItem>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1829,9 +1860,8 @@ function DndListBox(props: DndListBoxProps) {
     },
     ///- end collapse -///
     // Provide drag data in a custom format as well as plain text.
-    getItems(keys) {
-      return [...keys].map((key) => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'custom-app-type': JSON.stringify(item),
           'text/plain': item.name

--- a/packages/react-aria-components/docs/Table.mdx
+++ b/packages/react-aria-components/docs/Table.mdx
@@ -1393,6 +1393,13 @@ import {useListData} from 'react-stately';
 import {useDragAndDrop, Button} from 'react-aria-components';
 import {GripVertical} from 'lucide-react';
 
+interface FileItem {
+  id: number,
+  name: string,
+  date: string,
+  type: string
+}
+
 function Example() {
   let list = useListData({
     initialItems: [
@@ -1404,9 +1411,9 @@ function Example() {
   });
 
   ///- begin highlight -///
-  let {dragAndDropHooks} = useDragAndDrop({
-    getItems: (keys) => [...keys].map(key => ({
-      'text/plain': list.getItem(key).name
+  let {dragAndDropHooks} = useDragAndDrop<FileItem>({
+    getItems: (keys, items) => items.map(item => ({
+      'text/plain': item.name
     })),
     onReorder(e) {
       if (e.target.dropPosition === 'before') {
@@ -1495,12 +1502,21 @@ This example renders a custom drag preview which shows the number of items being
 import {useListData} from 'react-stately';
 import {useDragAndDrop} from 'react-aria-components';
 
+///- begin collapse -///
+interface FileItem {
+  id: number,
+  name: string,
+  date: string,
+  type: string
+}
+///- end collapse -///
+
 function Example() {
-  let {dragAndDropHooks} = useDragAndDrop({
+  let {dragAndDropHooks} = useDragAndDrop<FileItem>({
     // ...
     ///- begin collapse -///
-    getItems: (keys) => [...keys].map(key => ({
-      'text/plain': list.getItem(key).name
+    getItems: (keys, items) => items.map(item => ({
+      'text/plain': item.name
     })),
     onReorder(e) {
       if (e.target.dropPosition === 'before') {
@@ -1605,7 +1621,7 @@ function DraggableTable() {
     {id: 4, name: 'Pikachu', type: 'Electric', level: '100'}
   ];
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Pokemon>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -1617,9 +1633,8 @@ function DraggableTable() {
     },
     ///- end collapse -///
     /*- begin highlight -*/
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = items.find(item => item.id === key)!;
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': `${item.name} – ${item.type}`,
           'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
@@ -2078,7 +2093,7 @@ function Example() {
     ]
   });
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Pokemon>({
     // ...
     ///- begin collapse -///
     renderDragPreview(items) {
@@ -2089,9 +2104,8 @@ function Example() {
         </div>
       );
     },
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'pokemon': JSON.stringify(item)
@@ -2137,7 +2151,7 @@ function Example() {
     ]
   });
   ///- end collapse -///
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<Pokemon>({
     // ...
     ///- begin collapse -///
     renderDragPreview(items) {
@@ -2148,9 +2162,8 @@ function Example() {
         </div>
       );
     },
-    getItems(keys) {
-      return [...keys].map(key => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'text/plain': item.name,
           'pokemon': JSON.stringify(item)
@@ -2293,7 +2306,7 @@ function DndTable(props: DndTableProps) {
     initialItems: props.initialItems
   });
 
-  let { dragAndDropHooks } = useDragAndDrop({
+  let { dragAndDropHooks } = useDragAndDrop<FileItem>({
     ///- begin collapse -///
     renderDragPreview(items) {
       return (
@@ -2305,9 +2318,8 @@ function DndTable(props: DndTableProps) {
     },
     ///- end collapse -///
     // Provide drag data in a custom format as well as plain text.
-    getItems(keys) {
-      return [...keys].map((key) => {
-        let item = list.getItem(key);
+    getItems(keys, items) {
+      return items.map(item => {
         return {
           'custom-app-type': JSON.stringify(item),
           'text/plain': item.name


### PR DESCRIPTION
Skipped Tree for now since it's a little more complicated due to the `useTreeData` wrapper objects.