### PR TITLE
docs: Disable scale transition on Select and ComboBox popovers

### DIFF
--- a/packages/react-aria-components/docs/ComboBox.mdx
+++ b/packages/react-aria-components/docs/ComboBox.mdx
@@ -134,6 +134,7 @@ import {ChevronDown} from 'lucide-react';
 
 .react-aria-Popover[data-trigger=ComboBox] {
   width: var(--trigger-width);
+  --starting-scale: scale(1);
 
   .react-aria-ListBox {
     display: block;

--- a/packages/react-aria-components/docs/Popover.mdx
+++ b/packages/react-aria-components/docs/Popover.mdx
@@ -90,6 +90,7 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow, Heading, Switch} f
   outline: none;
   max-width: 250px;
   transition: transform 200ms, opacity 200ms;
+  --starting-scale: scale(0.9);
   transform-origin: var(--trigger-anchor-point);
 
   .react-aria-OverlayArrow svg {
@@ -101,7 +102,7 @@ import {DialogTrigger, Popover, Dialog, Button, OverlayArrow, Heading, Switch} f
 
   &[data-entering],
   &[data-exiting] {
-    transform: scale(0.85) var(--origin);
+    transform: var(--starting-scale) var(--origin);
     opacity: 0;
   }
 

--- a/packages/react-aria-components/docs/Select.mdx
+++ b/packages/react-aria-components/docs/Select.mdx
@@ -134,6 +134,7 @@ import {ChevronDown} from 'lucide-react';
 
 .react-aria-Popover[data-trigger=Select] {
   min-width: var(--trigger-width);
+  --starting-scale: scale(1);
 
   .react-aria-ListBox {
     display: block;


### PR DESCRIPTION
The scale transition looks weird when the width of the popover is supposed to match the trigger.