### PR TITLE
fix: Overlay positioning incorrect when animation starts on first render

### DIFF
--- a/packages/react-aria-components/stories/Popover.stories.tsx
+++ b/packages/react-aria-components/stories/Popover.stories.tsx
@@ -30,6 +30,10 @@ export default {
         'left', 'left top', 'left bottom', 'start', 'start top', 'start bottom',
         'right', 'right top', 'right bottom', 'end', 'end top', 'end bottom'
       ]
+    },
+    animation: {
+      control: 'radio',
+      options: ['transition', 'animation', 'animation-delayed']
     }
   }
 } as Meta<typeof Popover>;
@@ -41,7 +45,7 @@ export const PopoverExample: PopoverStory = (args) => (
     <Button>Open popover</Button>
     <Popover
       {...args}
-      className={styles.popover}
+      className={`${styles['popover-base']} ${styles[(args as any).animation]}`}
       style={{
         background: 'Canvas',
         color: 'CanvasText',

--- a/packages/react-aria-components/stories/Tooltip.stories.tsx
+++ b/packages/react-aria-components/stories/Tooltip.stories.tsx
@@ -30,6 +30,10 @@ export default {
         'left', 'left top', 'left bottom', 'start', 'start top', 'start bottom',
         'right', 'right top', 'right bottom', 'end', 'end top', 'end bottom'
       ]
+    },
+    animation: {
+      control: 'radio',
+      options: ['transition', 'animation', 'animation-delayed']
     }
   }
 } as Meta<typeof Tooltip>;
@@ -42,7 +46,7 @@ export const TooltipExample: TooltipStory = (args) => (
     <Button>Tooltip trigger</Button>
     <Tooltip
       {...args}
-      className={styles.tooltip}
+      className={`${styles['tooltip-base']} ${styles[(args as any).animation]}`}
       offset={5}
       style={{
         background: 'Canvas',

--- a/packages/react-aria-components/stories/styles.css
+++ b/packages/react-aria-components/stories/styles.css
@@ -399,16 +399,9 @@
   }
 }
 
-.popover,
-.tooltip {
-  transition: scale 300ms, opacity 300ms;
+.popover-base,
+.tooltip-base {
   transform-origin: var(--trigger-anchor-point);
-
-  &[data-entering],
-  &[data-exiting] {
-    opacity: 0;
-    scale: 0.85;
-  }
 
   :global(.react-aria-OverlayArrow) {
     &[data-placement=bottom] svg {
@@ -422,5 +415,52 @@
     &[data-placement=right] svg {
       transform: rotate(90deg);
     }
+  }
+}
+
+.popover,
+.tooltip {
+  composes: popover-base transition;
+}
+
+.transition {
+  transition: scale 300ms, opacity 300ms;
+
+  &[data-entering],
+  &[data-exiting] {
+    opacity: 0;
+    scale: 0.85;
+  }
+}
+
+.animation {
+  animation: enter 300ms;
+  &[data-exiting] {
+    animation: exit 300ms;
+  }
+}
+
+.animation-delayed {
+  &[data-entering] {
+    animation: enter 300ms;
+  }
+
+  &[data-exiting] {
+    animation: exit 300ms;
+  }
+}
+
+
+@keyframes enter {
+  from {
+    opacity: 0;
+    scale: 0.85;
+  }
+}
+
+@keyframes exit {
+  to {
+    opacity: 0;
+    scale: 0.85;
   }
 }


### PR DESCRIPTION
Fixes #8781, fixes #8787

When entering animations start on the first render, rather than waiting for the `data-entering` state, overlay positioning never occurs because we skip during animations. This ensures that we always position on the first render. If animations are already occurring, we temporarily pause them and skip to the end during positioning calculations, and then continue the animation after. I would do this approach all the time, but it causes flickering in Safari if we do this in the middle of an animation rather than only on the first frame.