### PR TITLE
wip: Use stacking contexts to determine non-inert elements outside modals

### DIFF
--- a/packages/@react-aria/overlays/src/Overlay.tsx
+++ b/packages/@react-aria/overlays/src/Overlay.tsx
@@ -52,7 +52,7 @@ export const OverlayContext: React.Context<{contain: boolean, setContain: React.
  */
 export function Overlay(props: OverlayProps): React.ReactPortal | null {
   let isSSR = useIsSSR();
-  let {portalContainer = isSSR ? null : document.body, isExiting} = props;
+  let {portalContainer = isSSR ? null : document.body} = props;
   let [contain, setContain] = useState(false);
   let contextValue = useMemo(() => ({contain, setContain}), [contain, setContain]);
 
@@ -68,7 +68,7 @@ export function Overlay(props: OverlayProps): React.ReactPortal | null {
   let contents = props.children;
   if (!props.disableFocusManagement) {
     contents = (
-      <FocusScope restoreFocus contain={(props.shouldContainFocus || contain) && !isExiting}>
+      <FocusScope restoreFocus>
         {contents}
       </FocusScope>
     );

--- a/packages/@react-aria/overlays/src/ariaHideOutside.ts
+++ b/packages/@react-aria/overlays/src/ariaHideOutside.ts
@@ -15,7 +15,8 @@ const supportsInert = typeof HTMLElement !== 'undefined' && 'inert' in HTMLEleme
 
 interface AriaHideOutsideOptions {
   root?: Element,
-  shouldUseInert?: boolean
+  shouldUseInert?: boolean,
+  getVisibleNodes?: (element: Element) => Element[]
 }
 
 // Keeps a ref count of all hidden elements. Added to when hiding an element, and
@@ -42,6 +43,7 @@ export function ariaHideOutside(targets: Element[], options?: AriaHideOutsideOpt
   let opts = options instanceof windowObj.Element ? {root: options} : options;
   let root = opts?.root ?? document.body;
   let shouldUseInert = opts?.shouldUseInert && supportsInert;
+  let getVisibleNodes = opts?.getVisibleNodes;
   let visibleNodes = new Set<Element>(targets);
   let hiddenNodes = new Set<Element>();
 
@@ -68,6 +70,12 @@ export function ariaHideOutside(targets: Element[], options?: AriaHideOutsideOpt
     // Keep live announcer and top layer elements (e.g. toasts) visible.
     for (let element of root.querySelectorAll('[data-live-announcer], [data-react-aria-top-layer]')) {
       visibleNodes.add(element);
+    }
+
+    if (getVisibleNodes) {
+      for (let element of getVisibleNodes(root)) {
+        visibleNodes.add(element);
+      }
     }
 
     let acceptNode = (node: Element) => {

--- a/packages/@react-aria/overlays/src/useModalOverlay.ts
+++ b/packages/@react-aria/overlays/src/useModalOverlay.ts
@@ -13,6 +13,7 @@
 import {ariaHideOutside} from './ariaHideOutside';
 import {AriaOverlayProps, useOverlay} from './useOverlay';
 import {DOMAttributes, RefObject} from '@react-types/shared';
+import {isElementVisible} from '../../utils/src/isElementVisible';
 import {mergeProps} from '@react-aria/utils';
 import {OverlayTriggerState} from '@react-stately/overlays';
 import {useEffect} from 'react';
@@ -58,7 +59,7 @@ export function useModalOverlay(props: AriaModalOverlayProps, state: OverlayTrig
 
   useEffect(() => {
     if (state.isOpen && ref.current) {
-      return ariaHideOutside([ref.current], {shouldUseInert: true});
+      return hideElementsBehind(ref.current);
     }
   }, [state.isOpen, ref]);
 
@@ -66,4 +67,121 @@ export function useModalOverlay(props: AriaModalOverlayProps, state: OverlayTrig
     modalProps: mergeProps(overlayProps),
     underlayProps
   };
+}
+
+function hideElementsBehind(element: Element, root = document.body) {
+  // TODO: automatically determine root based on parent stacking context of element?
+  let roots = getStackingContextRoots(root);
+  let rootStackingContext = roots.find(r => r.contains(element)) || document.documentElement;
+  let elementZIndex = getZIndex(rootStackingContext);
+
+  return ariaHideOutside([element], {
+    shouldUseInert: true,
+    getVisibleNodes: el => {
+      let node: Element | null = el;
+      let ancestors: Element[] = [];
+      while (node && node !== root) {
+        ancestors.unshift(node);
+        node = node.parentElement;
+      }
+      
+      // If an ancestor element of the added target is a stacking context root,
+      // use that to determine if the element should be preserved.
+      let stackingContext = ancestors.find(el => isStackingContext(el));
+      if (stackingContext) {
+        if (shouldPreserve(element, elementZIndex, stackingContext)) {
+          return [el];
+        }
+        return [];
+      } else {
+        // Otherwise, find stacking context roots within the added element, and compare with the modal element.
+        let roots = getStackingContextRoots(el);
+        let preservedElements: Element[] = [];
+        for (let root of roots) {
+          if (shouldPreserve(element, elementZIndex, root)) {
+            preservedElements.push(root);
+          }
+        }
+        return preservedElements;
+      }
+    }
+  });
+}
+
+function shouldPreserve(baseElement: Element, baseZIndex: number, element: Element) {
+  if (baseElement.contains(element)) {
+    return true;
+  }
+
+  let zIndex = getZIndex(element);
+  if (zIndex === baseZIndex) {
+    // If two elements have the same z-index, compare their document order.
+    if (baseElement.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING) {
+      return true;
+    }
+  } else if (zIndex > baseZIndex) {
+    return true;
+  }
+
+  return false;
+}
+
+function isStackingContext(el: Element) {
+  let style = getComputedStyle(el);
+
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context#features_creating_stacking_contexts
+  return (
+    el === document.documentElement ||
+    (style.position !== 'static' && style.zIndex !== 'auto') ||
+    ('containerType' in style && style.containerType.includes('size')) ||
+    (style.zIndex !== 'auto' && isFlexOrGridItem(el)) ||
+    parseFloat(style.opacity) < 1 ||
+    ('mixBlendMode' in style && style.mixBlendMode !== 'normal') ||
+    ('transform' in style && style.transform !== 'none') ||
+    ('webkitTransform' in style && style.webkitTransform !== 'none') ||
+    ('scale' in style && style.scale !== 'none') ||
+    ('rotate' in style && style.rotate !== 'none') ||
+    ('translate' in style && style.translate !== 'none') ||
+    ('filter' in style && style.filter !== 'none') ||
+    ('webkitFilter' in style && style.webkitFilter !== 'none') ||
+    ('backdropFilter' in style && style.backdropFilter !== 'none') ||
+    ('perspective' in style && style.perspective !== 'none') ||
+    ('clipPath' in style && style.clipPath !== 'none') ||
+    ('mask' in style && style.mask !== 'none') ||
+    ('maskImage' in style && style.maskImage !== 'none') ||
+    ('maskBorder' in style && style.maskBorder !== 'none') ||
+    style.isolation === 'isolate' ||
+    /position|z-index|opacity|mix-blend-mode|transform|webkit-transform|scale|rotate|translate|filter|webkit-filter|backdrop-filter|perspective|clip-path|mask|mask-image|mask-border|isolation/.test(style.willChange) ||
+    /layout|paint|strict|content/.test(style.contain)
+  );
+}
+
+function getStackingContextRoots(root: Element = document.body) {
+  let roots: Element[] = [];
+
+  function walk(el: Element) {
+    if (!isElementVisible(el)) {
+      return;
+    }
+
+    if (isStackingContext(el)) {
+      roots.push(el);
+    } else {
+      for (const child of el.children) {
+        walk(child);
+      }
+    }
+  }
+
+  walk(root);
+  return roots;
+}
+
+function getZIndex(element: Element) {
+  return Number(getComputedStyle(element).zIndex) || 0;
+}
+
+function isFlexOrGridItem(element: Element) {
+  let parent = element.parentElement;
+  return parent && /flex|grid/.test(getComputedStyle(parent).display);
 }

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -13,7 +13,7 @@
 import {DOMAttributes, RefObject} from '@react-types/shared';
 import {isElementInChildOfActiveScope} from '@react-aria/focus';
 import {useEffect} from 'react';
-import {useFocusWithin, useInteractOutside} from '@react-aria/interactions';
+import {useFocusWithin} from '@react-aria/interactions';
 
 export interface AriaOverlayProps {
   /** Whether the overlay is currently open. */
@@ -119,7 +119,7 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   };
 
   // Handle clicking outside the overlay to close it
-  useInteractOutside({ref, onInteractOutside: isDismissable && isOpen ? onInteractOutside : undefined, onInteractOutsideStart});
+  // useInteractOutside({ref, onInteractOutside: isDismissable && isOpen ? onInteractOutside : undefined, onInteractOutsideStart});
 
   let {focusWithinProps} = useFocusWithin({
     isDisabled: !shouldCloseOnBlur,
@@ -147,6 +147,9 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
     // fixes a firefox issue that starts text selection https://bugzilla.mozilla.org/show_bug.cgi?id=1675846
     if (e.target === e.currentTarget) {
       e.preventDefault();
+      if (isDismissable) {
+        onInteractOutsideStart(e);
+      }
     }
   };
 
@@ -156,7 +159,12 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
       ...focusWithinProps
     },
     underlayProps: {
-      onPointerDown: onPointerDownUnderlay
+      onPointerDown: onPointerDownUnderlay,
+      onClick(e) {
+        if (isDismissable && isOpen && e.target === e.currentTarget) {
+          onInteractOutside(e.nativeEvent as PointerEvent);
+        }
+      }
     }
   };
 }

--- a/packages/@react-aria/toast/src/useToastRegion.ts
+++ b/packages/@react-aria/toast/src/useToastRegion.ts
@@ -186,7 +186,7 @@ export function useToastRegion<T>(props: AriaToastRegionProps, state: ToastState
       //   - allows focus even outside a containing focus scope
       //   - doesn’t dismiss overlays when clicking on it, even though it is outside
       // @ts-ignore
-      'data-react-aria-top-layer': true,
+      // 'data-react-aria-top-layer': true,
       // listen to focus events separate from focuswithin because that will only fire once
       // and we need to follow all focus changes
       onFocus: (e) => {


### PR DESCRIPTION
https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=126270389

Related issues:
* https://github.com/adobe/react-spectrum/issues/8784
* https://github.com/adobe/react-spectrum/issues/7397
* https://github.com/adobe/react-spectrum/issues/5314
* https://github.com/adobe/react-spectrum/issues/5799
* https://github.com/adobe/react-spectrum/issues/6729
* https://github.com/adobe/react-spectrum/issues/7954
* https://github.com/adobe/react-spectrum/issues/6774
* https://github.com/adobe/react-spectrum/discussions/8661
* https://github.com/adobe/react-spectrum/discussions/6000
* https://github.com/adobe/react-spectrum/discussions/6498
* https://github.com/adobe/react-spectrum/discussions/7981
* https://github.com/adobe/react-spectrum/discussions/5981
* https://github.com/adobe/react-spectrum/discussions/4364

Currently, our dialogs mark all elements outside them as `inert`. This makes it difficult to use them with third party components that use portals, such as external dialogs, menus, browser extensions, embedded widgets like cookie consents, toasts, support chats, etc. Even before we switched to `inert` from `aria-hidden`, FocusScope would steal focus back to the dialog and screen readers could not access these elements. We have `data-react-aria-top-layer` as an opt out, but you must manually apply it which can be difficult.

This PR is an attempt to make this work automatically. Instead of marking all elements outside dialogs as inert (with a few exceptions), it compares their z-indexes with the modal. Any elements that are visually above the modal get preserved. This works by traversing down from the document body to find the root stacking contexts, and then comparing these with the root stacking context of the modal itself. When a new element such as a toast comes in after the dialog opens the same process occurs.

Since we use inert, we don't need FocusScope to contain focus for the most part. This will also mean the browser will handle tabbing, which should fix some issues with shadow DOM and native elements. Some exceptions to handle still:

1. Inert does not prevent tabbing out of a dialog into the browser chrome like our current dialog does. Accessibility experts are divided on that issue. The native <dialog> element does not prevent this, but the ARIA practices guide says it should. See https://github.com/w3c/aria-practices/issues/1772
2. Inert does not prevent tabbing out of a dialog within an iframe to the parent page. This seems like a major issue especially for unified shell.

Perhaps we could do a more limited focus trap just within the window/iframe instead of only within the dialog. That would allow tabbing to other elements on top of the dialog, but not out of the window.

To do

- [ ] Fix tests (JSDOM doesn't support inert so this will be interesting)
- [ ] Do the same for popovers
- [ ] Handle above cases