### PR TITLE
fix: iso8601 week start and use intl.locale when possible for week start

### DIFF
--- a/packages/@internationalized/date/src/queries.ts
+++ b/packages/@internationalized/date/src/queries.ts
@@ -267,11 +267,29 @@ function getWeekStart(locale: string): number {
       }
     }
     let region = getRegion(locale);
-    if (locale.includes('u-ca-iso8601')) {
+    if (locale.includes('-fw-')) {
+      let day = locale.split('-fw-')[1];
+      if (day === 'mon') {
+        weekInfo = {firstDay: 1};
+      } else if (day === 'tue') {
+        weekInfo = {firstDay: 2};
+      } else if (day === 'wed') {
+        weekInfo = {firstDay: 3};
+      } else if (day === 'thu') {
+        weekInfo = {firstDay: 4};
+      } else if (day === 'fri') {
+        weekInfo = {firstDay: 5};
+      } else if (day === 'sat') {
+        weekInfo = {firstDay: 6};
+      } else {
+        weekInfo = {firstDay: 0};
+      }
+    } else if (locale.includes('u-ca-iso8601')) {
       weekInfo = {firstDay: 1};
     } else {
       weekInfo = {firstDay: region ? weekStartData[region] || 0 : 0};
     }
+    cachedWeekInfo.set(locale, weekInfo);
   }
 
   return weekInfo.firstDay;

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -278,6 +278,9 @@ describe('queries', function () {
       // start of week is monday
       expect(startOfWeek(new CalendarDate(2021, 8, 4), 'en-US-u-ca-iso8601')).toEqual(new CalendarDate(2021, 8, 2));
       expect(startOfWeek(new CalendarDate(2021, 8, 4), 'fr-FR-u-ca-iso8601')).toEqual(new CalendarDate(2021, 8, 2));
+
+      // override first day of week
+      expect(startOfWeek(new CalendarDate(2021, 8, 4), 'en-US-u-ca-iso8601-fw-tue')).toEqual(new CalendarDate(2021, 8, 3));
     });
   });
 

--- a/packages/@internationalized/date/tests/queries.test.js
+++ b/packages/@internationalized/date/tests/queries.test.js
@@ -273,6 +273,12 @@ describe('queries', function () {
       expect(startOfWeek(new CalendarDate(2021, 8, 4), 'fr-FR', 'sun')).toEqual(new CalendarDate(2021, 8, 1));
       expect(startOfWeek(new CalendarDate(2021, 8, 4), 'en-US', 'thu')).toEqual(new CalendarDate(2021, 7, 29));
     });
+
+    it('should return the start of the week in en-US-u-ca-iso8601', function () {
+      // start of week is monday
+      expect(startOfWeek(new CalendarDate(2021, 8, 4), 'en-US-u-ca-iso8601')).toEqual(new CalendarDate(2021, 8, 2));
+      expect(startOfWeek(new CalendarDate(2021, 8, 4), 'fr-FR-u-ca-iso8601')).toEqual(new CalendarDate(2021, 8, 2));
+    });
   });
 
   describe('endOfWeek', function () {

--- a/packages/react-aria-components/stories/Calendar.stories.tsx
+++ b/packages/react-aria-components/stories/Calendar.stories.tsx
@@ -10,10 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, Calendar, CalendarCell, CalendarGrid, CalendarStateContext, Heading, I18nProvider, RangeCalendar} from 'react-aria-components';
+import {Button, Calendar, CalendarCell, CalendarGrid, CalendarStateContext, DateValue, Heading, I18nProvider, RangeCalendar} from 'react-aria-components';
 import {Meta, StoryObj} from '@storybook/react';
 import React, {useContext} from 'react';
 import './styles.css';
+import { CalendarProps } from 'react-aria';
 
 export default {
   title: 'React Aria Components/Calendar',
@@ -43,36 +44,18 @@ function Footer() {
 }
 
 export const CalendarExample: CalendarStory = {
-  render: function Example() {
-    let locale = 'en-US-u-ca-iso8601';
-    return (
-      <>
-        <I18nProvider locale={locale}>
-          <Calendar style={{width: 220}}>
-            <div style={{display: 'flex', alignItems: 'center'}}>
-              <Button slot="previous">&lt;</Button>
-              <Heading style={{flex: 1, textAlign: 'center'}} />
-              <Button slot="next">&gt;</Button>
-            </div>
-            <CalendarGrid style={{width: '100%'}}>
-              {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
-            </CalendarGrid>
-          </Calendar>
-        </I18nProvider>
-
-        <Calendar style={{width: 220}}>
-          <div style={{display: 'flex', alignItems: 'center'}}>
-            <Button slot="previous">&lt;</Button>
-            <Heading style={{flex: 1, textAlign: 'center'}} />
-            <Button slot="next">&gt;</Button>
-          </div>
-          <CalendarGrid style={{width: '100%'}}>
-            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
-          </CalendarGrid>
-        </Calendar>
-      </>
-    );
-  }
+  render: () => (
+    <Calendar style={{width: 220}}>
+      <div style={{display: 'flex', alignItems: 'center'}}>
+        <Button slot="previous">&lt;</Button>
+        <Heading style={{flex: 1, textAlign: 'center'}} />
+        <Button slot="next">&gt;</Button>
+      </div>
+      <CalendarGrid style={{width: '100%'}}>
+        {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+      </CalendarGrid>
+    </Calendar>
+  )
 };
 
 export const CalendarResetValue: CalendarStory = {
@@ -109,6 +92,40 @@ export const CalendarMultiMonth: CalendarStory = {
       </div>
     </Calendar>
   )
+};
+
+interface CalendarFirstDayOfWeekExampleProps extends CalendarProps<DateValue> {
+  locale: string;
+}
+
+export const CalendarFirstDayOfWeekExample: StoryObj<CalendarFirstDayOfWeekExampleProps> = {
+  render: function Example(args) {
+    return (
+      <div>
+        <I18nProvider locale={args.locale}>
+          <Calendar style={{width: 220}}>
+            <div style={{display: 'flex', alignItems: 'center'}}>
+              <Button slot="previous">&lt;</Button>
+              <Heading style={{flex: 1, textAlign: 'center'}} />
+              <Button slot="next">&gt;</Button>
+            </div>
+            <CalendarGrid style={{width: '100%'}}>
+              {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+            </CalendarGrid>
+          </Calendar>
+        </I18nProvider>
+      </div>
+    );
+  },
+  args: {
+    locale: 'en-US-u-ca-iso8601-fw-tue'
+  },
+  argTypes: {
+    locale: {
+      control: 'select',
+      options: ['en-US-u-ca-iso8601-fw-tue', 'en-US-u-ca-iso8601', 'en-US', 'fr-FR-u-ca-iso8601-fw-tue', 'fr-FR-u-ca-iso8601', 'fr-FR']
+    }
+  }
 };
 
 export const RangeCalendarExample: CalendarStory = {

--- a/packages/react-aria-components/stories/Calendar.stories.tsx
+++ b/packages/react-aria-components/stories/Calendar.stories.tsx
@@ -10,8 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Button, Calendar, CalendarCell, CalendarGrid, CalendarStateContext, Heading, RangeCalendar} from 'react-aria-components';
-import {CalendarDate, parseDate} from '@internationalized/date';
+import {Button, Calendar, CalendarCell, CalendarGrid, CalendarStateContext, Heading, I18nProvider, RangeCalendar} from 'react-aria-components';
 import {Meta, StoryObj} from '@storybook/react';
 import React, {useContext} from 'react';
 import './styles.css';
@@ -22,7 +21,7 @@ export default {
 } as Meta<typeof Calendar>;
 
 export type CalendarStory = StoryObj<typeof Calendar>;
-export type RangeCalendarStory = StoryObj<typeof RangeCalendar>;
+
 
 function Footer() {
   const state = useContext(CalendarStateContext);
@@ -44,18 +43,36 @@ function Footer() {
 }
 
 export const CalendarExample: CalendarStory = {
-  render: () => (
-    <Calendar style={{width: 220}}>
-      <div style={{display: 'flex', alignItems: 'center'}}>
-        <Button slot="previous">&lt;</Button>
-        <Heading style={{flex: 1, textAlign: 'center'}} />
-        <Button slot="next">&gt;</Button>
-      </div>
-      <CalendarGrid style={{width: '100%'}}>
-        {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
-      </CalendarGrid>
-    </Calendar>
-  )
+  render: function Example() {
+    let locale = 'en-US-u-ca-iso8601';
+    return (
+      <>
+        <I18nProvider locale={locale}>
+          <Calendar style={{width: 220}}>
+            <div style={{display: 'flex', alignItems: 'center'}}>
+              <Button slot="previous">&lt;</Button>
+              <Heading style={{flex: 1, textAlign: 'center'}} />
+              <Button slot="next">&gt;</Button>
+            </div>
+            <CalendarGrid style={{width: '100%'}}>
+              {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+            </CalendarGrid>
+          </Calendar>
+        </I18nProvider>
+
+        <Calendar style={{width: 220}}>
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            <Button slot="previous">&lt;</Button>
+            <Heading style={{flex: 1, textAlign: 'center'}} />
+            <Button slot="next">&gt;</Button>
+          </div>
+          <CalendarGrid style={{width: '100%'}}>
+            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
+          </CalendarGrid>
+        </Calendar>
+      </>
+    );
+  }
 };
 
 export const CalendarResetValue: CalendarStory = {
@@ -74,53 +91,27 @@ export const CalendarResetValue: CalendarStory = {
   )
 };
 
-function CalendarMultiMonthExample(args) {
-  let defaultDate = new CalendarDate(2021, 7, 1);
-  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
-
-  return (
-    <>
-      <button
-        style={{marginBottom: 20}}
-        onClick={() => setFocusedDate(defaultDate)}>
-        Reset focused date
-      </button>
-      <Calendar style={{width: 500}} visibleDuration={{months: 3}} focusedValue={focusedDate} onFocusChange={setFocusedDate} defaultValue={defaultDate} {...args}>
-        <div style={{display: 'flex', alignItems: 'center'}}>
-          <Button slot="previous">&lt;</Button>
-          <Heading style={{flex: 1, textAlign: 'center'}} />
-          <Button slot="next">&gt;</Button>
-        </div>
-        <div style={{display: 'flex', gap: 20}}>
-          <CalendarGrid style={{flex: 1}}>
-            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({opacity: isOutsideMonth ? '0.5' : '', textAlign: 'center', cursor: 'default', background: isSelected && !isOutsideMonth ? 'blue' : ''})} />}
-          </CalendarGrid>
-          <CalendarGrid style={{flex: 1}} offset={{months: 1}}>
-            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({opacity: isOutsideMonth ? '0.5' : '', textAlign: 'center', cursor: 'default', background: isSelected && !isOutsideMonth ? 'blue' : ''})} />}
-          </CalendarGrid>
-          <CalendarGrid style={{flex: 1}} offset={{months: 2}}>
-            {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({opacity: isOutsideMonth ? '0.5' : '', textAlign: 'center', cursor: 'default', background: isSelected && !isOutsideMonth ? 'blue' : ''})} />}
-          </CalendarGrid>
-        </div>
-      </Calendar>
-    </>
-  );
-};
-
 export const CalendarMultiMonth: CalendarStory = {
-  render: (args) => <CalendarMultiMonthExample {...args} />,
-  args: {
-    selectionAlignment: 'center'
-  },
-  argTypes: {
-    selectionAlignment: {
-      control: 'select',
-      options: ['start', 'center', 'end']
-    }
-  }
+  render: () => (
+    <Calendar style={{width: 500}} visibleDuration={{months: 2}}>
+      <div style={{display: 'flex', alignItems: 'center'}}>
+        <Button slot="previous">&lt;</Button>
+        <Heading style={{flex: 1, textAlign: 'center'}} />
+        <Button slot="next">&gt;</Button>
+      </div>
+      <div style={{display: 'flex', gap: 20}}>
+        <CalendarGrid style={{flex: 1}}>
+          {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({opacity: isOutsideMonth ? '0.5' : '', textAlign: 'center', cursor: 'default', background: isSelected && !isOutsideMonth ? 'blue' : ''})} />}
+        </CalendarGrid>
+        <CalendarGrid style={{flex: 1}} offset={{months: 1}}>
+          {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({opacity: isOutsideMonth ? '0.5' : '', textAlign: 'center', cursor: 'default', background: isSelected && !isOutsideMonth ? 'blue' : ''})} />}
+        </CalendarGrid>
+      </div>
+    </Calendar>
+  )
 };
 
-export const RangeCalendarExample: RangeCalendarStory = {
+export const RangeCalendarExample: CalendarStory = {
   render: () => (
     <RangeCalendar style={{width: 220}}>
       <div style={{display: 'flex', alignItems: 'center'}}>
@@ -133,37 +124,4 @@ export const RangeCalendarExample: RangeCalendarStory = {
       </CalendarGrid>
     </RangeCalendar>
   )
-};
-
-
-export const RangeCalendarMultiMonthExample: RangeCalendarStory = {
-  render: (args) => (
-    <RangeCalendar style={{width: 500}} visibleDuration={{months: 3}} defaultValue={{start: parseDate('2025-08-04'), end: parseDate('2025-08-10')}} {...args} >
-      <div style={{display: 'flex', alignItems: 'center'}}>
-        <Button slot="previous">&lt;</Button>
-        <Heading style={{flex: 1, textAlign: 'center'}} />
-        <Button slot="next">&gt;</Button>
-      </div>
-      <div style={{display: 'flex', gap: 20}}>
-        <CalendarGrid style={{flex: 1}}>
-          {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
-        </CalendarGrid>
-        <CalendarGrid style={{flex: 1}} offset={{months: 1}}>
-          {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
-        </CalendarGrid>
-        <CalendarGrid style={{flex: 1}} offset={{months: 2}}>
-          {date => <CalendarCell date={date} style={({isSelected, isOutsideMonth}) => ({display: isOutsideMonth ? 'none' : '', textAlign: 'center', cursor: 'default', background: isSelected ? 'blue' : ''})} />}
-        </CalendarGrid>
-      </div>
-    </RangeCalendar>
-  ),
-  args: {
-    selectionAlignment: 'center'
-  },
-  argTypes: {
-    selectionAlignment: {
-      control: 'select',
-      options: ['start', 'center', 'end']
-    }
-  }
 };


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8810

Running `new Intl.Locale('en-US-u-ca-iso8601').getWeekInfo()` in supported browsers does return Monday
iso8601 means that the region does not matter https://www.unicode.org/reports/tr35/tr35-72/tr35-dates.html#Week_Data

Technically, the first day is also overridable via `fw-tue` for example. I've included some parsing for that in browsers that don't support Intl.Locale yet. Is this something we want?

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
