### PR TITLE
Update package.json

### DIFF
--- a/starters/docs/package.json
+++ b/starters/docs/package.json
@@ -4,7 +4,9 @@
     "build-storybook": "storybook build"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.24.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/addon-links": "^8.6.14",


### PR DESCRIPTION
Without these dependencies yarn storybook won't launch out of the box


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
Couldn't find an open issue
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
Non applicable
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
Non applicable
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
Non applicable

## 📝 Test Instructions:

- Clone the repo
- Jump to presets/docs folder
- Open in vscode or other editor
- run `yarn install`
- run `yarn storybook`
- storybook build crashes:
`SB_BUILDER-WEBPACK5_0003 (WebpackCompilationError): There were problems when compiling your code with Webpack`
- now run `yarn add -D @babel/preset-typescript @babel/preset-env`
- `yarn storybook` executes successfully and you're redirected to browser
