### PR TITLE
fix: Normalize literal before dayPeriod in formatToParts

### DIFF
--- a/packages/@internationalized/date/src/DateFormatter.ts
+++ b/packages/@internationalized/date/src/DateFormatter.ts
@@ -34,7 +34,18 @@ export class DateFormatter implements Intl.DateTimeFormat {
 
   /** Formats a date to an array of parts such as separators, numbers, punctuation, and more. */
   formatToParts(value: Date): Intl.DateTimeFormatPart[] {
-    return this.formatter.formatToParts(value);
+    const parts = this.formatter.formatToParts(value);
+
+    const literalBeforeDayPeriodIndex =
+      parts.findIndex((p) => p.type === 'dayPeriod') - 1;
+    if (literalBeforeDayPeriodIndex >= 0) {
+      const normalizedParts = parts.map((p, i) =>
+        i === literalBeforeDayPeriodIndex ? {...p, value: ' '} : p
+      );
+      return normalizedParts;
+    }
+
+    return parts;
   }
 
   /** Formats a date range as a string. */

--- a/packages/@internationalized/date/tests/DateFormatter.test.js
+++ b/packages/@internationalized/date/tests/DateFormatter.test.js
@@ -42,6 +42,17 @@ describe('DateFormatter', function () {
     ]);
   });
 
+  it('should format to parts with space as literal before am/pm', function () {
+    let formatter = new DateFormatter('en-US', {timeStyle: 'short'});
+    expect(formatter.formatToParts(new Date(2020, 1, 3, 13, 0))).toEqual([
+      {type: 'hour', value: '1'},
+      {type: 'literal', value: ':'},
+      {type: 'minute', value: '00'},
+      {type: 'literal', value: ' '},
+      {type: 'dayPeriod', value: 'PM'}
+    ]);
+  });
+
   it('should format a range', function () {
     let formatter = new DateFormatter('en-US');
     // Test fallback

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -437,7 +437,7 @@ describe('DatePicker', function () {
       );
 
       let combobox = getAllByRole('group')[0];
-      expect(getTextValue(combobox)).toBe('2/3/2019, 8:45 AM');
+      expect(getTextValue(combobox)).toBe('2/3/2019, 8:45 AM');
 
       let button = getByRole('button');
       await user.click(button);
@@ -450,7 +450,7 @@ describe('DatePicker', function () {
       expect(selected.children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
 
       let timeField = getAllByLabelText('Time')[0];
-      expect(getTextValue(timeField)).toBe('8:45 AM');
+      expect(getTextValue(timeField)).toBe('8:45 AM');
 
       // selecting a date should not close the popover
       await user.click(selected.nextSibling.children[0]);
@@ -458,7 +458,7 @@ describe('DatePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(new CalendarDateTime(2019, 2, 4, 8, 45));
-      expect(getTextValue(combobox)).toBe('2/4/2019, 8:45 AM');
+      expect(getTextValue(combobox)).toBe('2/4/2019, 8:45 AM');
 
       let hour = within(timeField).getByLabelText('hour,');
       expect(hour).toHaveAttribute('role', 'spinbutton');
@@ -472,7 +472,7 @@ describe('DatePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(new CalendarDateTime(2019, 2, 4, 9, 45));
-      expect(getTextValue(combobox)).toBe('2/4/2019, 9:45 AM');
+      expect(getTextValue(combobox)).toBe('2/4/2019, 9:45 AM');
     });
 
     it('should not throw error when deleting values from time field when CalendarDateTime value is used', async function () {
@@ -484,7 +484,7 @@ describe('DatePicker', function () {
       );
 
       let combobox = getAllByRole('group')[0];
-      expect(getTextValue(combobox)).toBe('2/3/2019, 10:45 AM');
+      expect(getTextValue(combobox)).toBe('2/3/2019, 10:45 AM');
 
       let button = getByRole('button');
       await user.click(button);
@@ -497,7 +497,7 @@ describe('DatePicker', function () {
       expect(selected.children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
 
       let timeField = getAllByLabelText('Time')[0];
-      expect(getTextValue(timeField)).toBe('10:45 AM');
+      expect(getTextValue(timeField)).toBe('10:45 AM');
 
       // selecting a date should not close the popover
       await user.click(selected.nextSibling.children[0]);
@@ -505,7 +505,7 @@ describe('DatePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(new CalendarDateTime(2019, 2, 4, 10, 45));
-      expect(getTextValue(combobox)).toBe('2/4/2019, 10:45 AM');
+      expect(getTextValue(combobox)).toBe('2/4/2019, 10:45 AM');
 
       let hour = within(timeField).getByLabelText('hour,');
       expect(hour).toHaveAttribute('role', 'spinbutton');
@@ -521,7 +521,7 @@ describe('DatePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(new CalendarDateTime(2019, 2, 4, 1, 45));
-      expect(getTextValue(combobox)).toBe('2/4/2019, 1:45 AM');
+      expect(getTextValue(combobox)).toBe('2/4/2019, 1:45 AM');
     });
 
     it('should fire onChange until both date and time are selected', async function () {

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -492,8 +492,8 @@ describe('DateRangePicker', function () {
 
       let startDate = getByTestId('start-date');
       let endDate = getByTestId('end-date');
-      expect(getTextValue(startDate)).toBe('2/3/2019, 8:45 AM');
-      expect(getTextValue(endDate)).toBe('5/6/2019, 10:45 AM');
+      expect(getTextValue(startDate)).toBe('2/3/2019, 8:45 AM');
+      expect(getTextValue(endDate)).toBe('5/6/2019, 10:45 AM');
 
       let button = getByRole('button');
       await user.click(button);
@@ -506,10 +506,10 @@ describe('DateRangePicker', function () {
       expect(selected.children[0]).toHaveAttribute('aria-label', 'Selected Range: Sunday, February 3 to Monday, May 6, 2019, Sunday, February 3, 2019 selected');
 
       let startTimeField = getAllByLabelText('Start time')[0];
-      expect(getTextValue(startTimeField)).toBe('8:45 AM');
+      expect(getTextValue(startTimeField)).toBe('8:45 AM');
 
       let endTimeField = getAllByLabelText('End time')[0];
-      expect(getTextValue(endTimeField)).toBe('10:45 AM');
+      expect(getTextValue(endTimeField)).toBe('10:45 AM');
 
       // selecting a date should not close the popover
       await user.click(getByLabelText('Sunday, February 10, 2019 selected'));
@@ -518,8 +518,8 @@ describe('DateRangePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDateTime(2019, 2, 10, 8, 45), end: new CalendarDateTime(2019, 2, 17, 10, 45)});
-      expect(getTextValue(startDate)).toBe('2/10/2019, 8:45 AM');
-      expect(getTextValue(endDate)).toBe('2/17/2019, 10:45 AM');
+      expect(getTextValue(startDate)).toBe('2/10/2019, 8:45 AM');
+      expect(getTextValue(endDate)).toBe('2/17/2019, 10:45 AM');
 
       let hour = within(startTimeField).getByLabelText('hour,');
       expect(hour).toHaveAttribute('role', 'spinbutton');
@@ -534,8 +534,8 @@ describe('DateRangePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDateTime(2019, 2, 10, 9, 45), end: new CalendarDateTime(2019, 2, 17, 10, 45)});
-      expect(getTextValue(startDate)).toBe('2/10/2019, 9:45 AM');
-      expect(getTextValue(endDate)).toBe('2/17/2019, 10:45 AM');
+      expect(getTextValue(startDate)).toBe('2/10/2019, 9:45 AM');
+      expect(getTextValue(endDate)).toBe('2/17/2019, 10:45 AM');
 
       hour = within(endTimeField).getByLabelText('hour,');
       expect(hour).toHaveAttribute('role', 'spinbutton');
@@ -550,8 +550,8 @@ describe('DateRangePicker', function () {
       expect(dialog).toBeVisible();
       expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith({start: new CalendarDateTime(2019, 2, 10, 9, 45), end: new CalendarDateTime(2019, 2, 17, 11, 45)});
-      expect(getTextValue(startDate)).toBe('2/10/2019, 9:45 AM');
-      expect(getTextValue(endDate)).toBe('2/17/2019, 11:45 AM');
+      expect(getTextValue(startDate)).toBe('2/10/2019, 9:45 AM');
+      expect(getTextValue(endDate)).toBe('2/17/2019, 11:45 AM');
     });
 
     it('should not fire onChange until both date range and time range are selected', async function () {


### PR DESCRIPTION
Closes #7169 

Node's and Chromium's `formatToParts` return `NARROW NO-BREAK SPACE` for the literal before `dayPeriod`. This causes hydration errors in Firefox and Safari, which use regular space for the same literal.

Since `format` returns regular space, it makes sense to standardize `formatToParts` to also use regular space.

I would've liked to refer to an issue in v8, but there was already one open and they claimed it's in-actionable for them. https://github.com/nodejs/node/issues/49222

At present, it's not clear when Chromium and Node (if ever) are going to fix the inconsistency between `formatToParts` and `format`.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
