### PR TITLE
fix: add @babel/runtime to @spectrum-icons/ui dependencies

### DIFF
--- a/packages/@spectrum-icons/ui/package.json
+++ b/packages/@spectrum-icons/ui/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@adobe/react-spectrum-ui": "1.2.1",
     "@react-spectrum/icon": "^3.8.8",
+    "@babel/runtime": "^7.24.4",
     "@swc/helpers": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8833

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
