### PR TITLE
fix: position ColorLoupe relative to ColorHandle in V3 ColorWheel

### DIFF
--- a/packages/@react-spectrum/color/src/ColorThumb.tsx
+++ b/packages/@react-spectrum/color/src/ColorThumb.tsx
@@ -50,7 +50,7 @@ function ColorThumb(props: ColorThumbProps): JSX.Element {
 }
 
 // ColorLoupe is rendered in a portal so that it breaks out of clipped/scrolling containers (e.g. popovers).
-function ColorLoupe({isOpen, valueCSS, containerRef, loupeRef, style, getPosition}: any) {
+function ColorLoupe({isOpen, valueCSS, containerRef, loupeRef, style}: any) {
   let patternId = useId();
 
   // Get the bounding rectangle of the container (e.g. ColorArea/ColorSlider).
@@ -76,7 +76,7 @@ function ColorLoupe({isOpen, valueCSS, containerRef, loupeRef, style, getPositio
   let thumbLeft = style.left || '50%';
   if (typeof thumbLeft === 'string' && thumbLeft.endsWith('%')) {
     thumbLeft = parseFloat(thumbLeft || '50%') / 100 * containerRect.width;
-  } else if (typeof thumbLeft=== 'string' && thumbLeft.endsWith('px')) {
+  } else if (typeof thumbLeft === 'string' && thumbLeft.endsWith('px')) {
     thumbLeft = parseFloat(thumbLeft);
   }
 

--- a/packages/@react-spectrum/color/src/ColorThumb.tsx
+++ b/packages/@react-spectrum/color/src/ColorThumb.tsx
@@ -50,7 +50,7 @@ function ColorThumb(props: ColorThumbProps): JSX.Element {
 }
 
 // ColorLoupe is rendered in a portal so that it breaks out of clipped/scrolling containers (e.g. popovers).
-function ColorLoupe({isOpen, valueCSS, containerRef, loupeRef, style}: any) {
+function ColorLoupe({isOpen, valueCSS, containerRef, loupeRef, style, getPosition}: any) {
   let patternId = useId();
 
   // Get the bounding rectangle of the container (e.g. ColorArea/ColorSlider).
@@ -69,11 +69,15 @@ function ColorLoupe({isOpen, valueCSS, containerRef, loupeRef, style}: any) {
   let thumbTop = style.top || '50%';
   if (typeof thumbTop === 'string' && thumbTop.endsWith('%')) {
     thumbTop = parseFloat(style.top || '50%') / 100 * containerRect.height;
+  } else if (typeof thumbTop === 'string' && thumbTop.endsWith('px')) {
+    thumbTop = parseFloat(thumbTop);
   }
 
   let thumbLeft = style.left || '50%';
   if (typeof thumbLeft === 'string' && thumbLeft.endsWith('%')) {
     thumbLeft = parseFloat(thumbLeft || '50%') / 100 * containerRect.width;
+  } else if (typeof thumbLeft=== 'string' && thumbLeft.endsWith('px')) {
+    thumbLeft = parseFloat(thumbLeft);
   }
 
   return (


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
