### PR TITLE
feat: Add support for animated selection indicators

### DIFF
--- a/packages/@react-spectrum/s2/src/SegmentedControl.tsx
+++ b/packages/@react-spectrum/s2/src/SegmentedControl.tsx
@@ -13,13 +13,13 @@
 import {AriaLabelingProps, DOMRef, DOMRefValue, FocusableRef, Key} from '@react-types/shared';
 import {baseColor, focusRing, style} from '../style' with {type: 'macro'};
 import {centerBaseline} from './CenterBaseline';
-import {ContextValue, DEFAULT_SLOT, Provider, TextContext as RACTextContext, SlotProps, ToggleButton, ToggleButtonGroup, ToggleButtonRenderProps, ToggleGroupStateContext} from 'react-aria-components';
+import {ContextValue, DEFAULT_SLOT, Provider, TextContext as RACTextContext, SelectionIndicator, SlotProps, ToggleButton, ToggleButtonGroup, ToggleButtonRenderProps, ToggleGroupStateContext} from 'react-aria-components';
 import {control, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
-import {createContext, forwardRef, ReactNode, RefObject, useCallback, useContext, useRef} from 'react';
+import {createContext, forwardRef, ReactNode, useCallback, useContext, useRef} from 'react';
 import {IconContext} from './Icon';
 import {pressScale} from './pressScale';
 import {Text, TextContext} from './Content';
-import {useDOMRef, useFocusableRef, useMediaQuery} from '@react-spectrum/utils';
+import {useDOMRef, useFocusableRef} from '@react-spectrum/utils';
 import {useLayoutEffect} from '@react-aria/utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
 
@@ -113,6 +113,13 @@ const slider = style<{isDisabled: boolean}>({
   left: 0,
   width: 'full',
   height: 'full',
+  contain: 'strict',
+  transition: {
+    default: '[translate,width]',
+    '@media (prefers-reduced-motion: reduce)': 'none'
+  },
+  transitionDuration: 200,
+  transitionTimingFunction: 'out',
   position: 'absolute',
   boxSizing: 'border-box',
   borderStyle: 'solid',
@@ -130,8 +137,6 @@ const slider = style<{isDisabled: boolean}>({
 
 interface InternalSegmentedControlContextProps {
   register?: (value: Key, isDisabled?: boolean) => void,
-  prevRef?: RefObject<DOMRect | null>,
-  currentSelectedRef?: RefObject<HTMLDivElement | null>,
   isJustified?: boolean
 }
 
@@ -139,8 +144,6 @@ interface DefaultSelectionTrackProps {
   defaultValue?: Key | null,
   value?: Key | null,
   children: ReactNode,
-  prevRef: RefObject<DOMRect | null>,
-  currentSelectedRef: RefObject<HTMLDivElement | null>,
   isJustified?: boolean
 }
 
@@ -158,14 +161,7 @@ export const SegmentedControl = /*#__PURE__*/ forwardRef(function SegmentedContr
   } = props;
   let domRef = useDOMRef(ref);
 
-  let prevRef = useRef<DOMRect>(null);
-  let currentSelectedRef = useRef<HTMLDivElement>(null);
-
   let onChange = (values: Set<Key>) => {
-    if (currentSelectedRef.current) {
-      prevRef.current = currentSelectedRef?.current.getBoundingClientRect();
-    }
-
     if (onSelectionChange) {
       let firstKey = values.values().next().value;
       if (firstKey != null) {
@@ -186,7 +182,7 @@ export const SegmentedControl = /*#__PURE__*/ forwardRef(function SegmentedContr
       onSelectionChange={onChange}
       className={(props.UNSAFE_className || '') + segmentedControl(null, props.styles)}
       aria-label={props['aria-label']}>
-      <DefaultSelectionTracker defaultValue={defaultSelectedKey} value={selectedKey} prevRef={prevRef} currentSelectedRef={currentSelectedRef} isJustified={props.isJustified}>
+      <DefaultSelectionTracker defaultValue={defaultSelectedKey} value={selectedKey} isJustified={props.isJustified}>
         {props.children}
       </DefaultSelectionTracker>
     </ToggleButtonGroup>
@@ -209,7 +205,7 @@ function DefaultSelectionTracker(props: DefaultSelectionTrackProps) {
   return (
     <Provider
       values={[
-        [InternalSegmentedControlContext, {register: register, prevRef: props.prevRef, currentSelectedRef: props.currentSelectedRef, isJustified: props.isJustified}]
+        [InternalSegmentedControlContext, {register: register, isJustified: props.isJustified}]
       ]}>
       {props.children}
     </Provider>
@@ -222,36 +218,11 @@ function DefaultSelectionTracker(props: DefaultSelectionTrackProps) {
 export const SegmentedControlItem = /*#__PURE__*/ forwardRef(function SegmentedControlItem(props: SegmentedControlItemProps, ref: FocusableRef<HTMLButtonElement>) {
   let domRef = useFocusableRef(ref);
   let divRef = useRef<HTMLDivElement>(null);
-  let {register, prevRef, currentSelectedRef, isJustified} = useContext(InternalSegmentedControlContext);
-  let state = useContext(ToggleGroupStateContext);
-  let isSelected = state?.selectedKeys.has(props.id);
-  // do not apply animation if a user has the prefers-reduced-motion setting
-  let reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  let {register, isJustified} = useContext(InternalSegmentedControlContext);
 
   useLayoutEffect(() => {
     register?.(props.id);
   }, [register, props.id]);
-
-  useLayoutEffect(() => {
-    if (isSelected && prevRef?.current && currentSelectedRef?.current && !reduceMotion) {
-      let currentItem = currentSelectedRef?.current.getBoundingClientRect();
-
-      let deltaX = prevRef?.current.left - currentItem?.left;
-
-      currentSelectedRef.current.animate(
-        [
-          {transform: `translateX(${deltaX}px)`, width: `${prevRef?.current.width}px`},
-          {transform: 'translateX(0px)', width: `${currentItem.width}px`}
-        ],
-        {
-          duration: 200,
-          easing: 'ease-out'
-        }
-      );
-
-      prevRef.current = null;
-    }
-  }, [isSelected, reduceMotion, prevRef, currentSelectedRef]);
 
   return (
     <ToggleButton
@@ -259,9 +230,9 @@ export const SegmentedControlItem = /*#__PURE__*/ forwardRef(function SegmentedC
       ref={domRef}
       style={props.UNSAFE_style}
       className={renderProps => (props.UNSAFE_className || '') + controlItem({...renderProps, isJustified}, props.styles)} >
-      {({isSelected, isPressed, isDisabled}) => (
+      {({isPressed, isDisabled}) => (
         <>
-          {isSelected && <div className={slider({isDisabled})} ref={currentSelectedRef} />}
+          <SelectionIndicator className={slider({isDisabled})} />
           <Provider
             values={[
               [IconContext, {

--- a/packages/dev/s2-docs/pages/react-aria/SegmentedControl.css
+++ b/packages/dev/s2-docs/pages/react-aria/SegmentedControl.css
@@ -1,0 +1,51 @@
+.segmented-control {
+  display: flex;
+  background: var(--gray-100);
+  width: fit-content;
+  padding: 2px;
+  border-radius: 8px;
+
+  .react-aria-SelectionIndicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    transition-property: translate, width;
+    transition-duration: 200ms;
+    border-radius: 8px;
+    background: var(--gray-50);
+    outline: 2px solid var(--gray-600);
+  }
+
+  .segmented-control-item {
+    all: unset;
+    display: block;
+    color: var(--text-color);
+    font-size: 1rem;
+    outline: none;
+    padding: 6px 16px;
+    position: relative;
+    z-index: 1;
+    border-radius: 8px;
+
+    span {
+      display: inline-block;
+      transition: scale 200ms;
+    }
+
+     &[data-pressed] span {
+      scale: 0.95;
+    }
+
+    &[data-selected] {
+      z-index: 0;
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--focus-ring-color);
+      outline-offset: 4px;
+    }
+  }
+}

--- a/packages/dev/s2-docs/pages/react-aria/Tabs.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tabs.mdx
@@ -14,7 +14,7 @@ import Anatomy from '@react-aria/tabs/docs/anatomy.svg';
 <ExampleSwitcher>
   ```tsx render docs={docs.exports.Tabs} links={docs.links} props={['orientation', 'keyboardActivation', 'isDisabled']} type="vanilla" files={["starters/docs/src/Tabs.tsx", "starters/docs/src/Tabs.css"]}
   "use client";
-  import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
+  import {Tabs, TabList, Tab, TabPanel} from 'vanilla-starter/Tabs';
   import Home from '@react-spectrum/s2/illustrations/gradient/generic2/Home';
   import Folder from '@react-spectrum/s2/illustrations/gradient/generic2/FolderOpen';
   import Search from '@react-spectrum/s2/illustrations/gradient/generic2/Search';
@@ -80,7 +80,9 @@ import Anatomy from '@react-aria/tabs/docs/anatomy.svg';
 
 ```tsx render
 "use client";
-import {Tabs, TabList, Tab, TabPanel, Collection, Button} from 'react-aria-components';
+import {Tabs, TabList, Tab, TabPanel} from 'vanilla-starter/Tabs';
+import {Button} from 'vanilla-starter/Button';
+import {Collection} from 'react-aria-components';
 import {useState} from 'react';
 
 function Example() {
@@ -146,7 +148,7 @@ Use the `href` prop on a `<Tab>` to create a link. See the **client side routing
 
 ```tsx render
 "use client";
-import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
+import {Tabs, TabList, Tab, TabPanel} from 'vanilla-starter/Tabs';
 import {useSyncExternalStore} from 'react';
 
 export default function Example() {
@@ -189,7 +191,7 @@ Use the `defaultSelectedKey` or `selectedKey` prop to set the selected tab. The 
 ```tsx render
 "use client";
 import type {Key} from 'react-aria-components';
-import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
+import {Tabs, TabList, Tab, TabPanel} from 'vanilla-starter/Tabs';
 import Home from '@react-spectrum/s2/illustrations/gradient/generic2/Home';
 import Folder from '@react-spectrum/s2/illustrations/gradient/generic2/FolderOpen';
 import Search from '@react-spectrum/s2/illustrations/gradient/generic2/Search';
@@ -239,7 +241,9 @@ function Example() {
 ```tsx links={{Tabs: '#tabs', TabList: '#tablist', Tab: '#tab', TabPanel: '#tabpanel'}}
 <Tabs>
   <TabList>
-    <Tab />
+    <Tab>
+      <SelectionIndicator />
+    </Tab>
   </TabList>
   <TabPanel />
 </Tabs>

--- a/packages/dev/s2-docs/pages/react-aria/ToggleButtonGroup.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ToggleButtonGroup.mdx
@@ -79,6 +79,37 @@ function Example(props) {
 }
 ```
 
+### Animation
+
+Render a `SelectionIndicator` within each `ToggleButton` to animate selection changes.
+
+```tsx render files={['packages/dev/s2-docs/pages/react-aria/SegmentedControl.css']}
+"use client";
+import {ToggleButtonGroup, ToggleButton, ToggleButtonProps, SelectionIndicator} from 'react-aria-components';
+import './SegmentedControl.css';
+
+function SegmentedControlItem(props: ToggleButtonProps) {
+  return (
+    <ToggleButton {...props} className="segmented-control-item">
+      {/*- begin highlight -*/}
+      <SelectionIndicator />
+      {/*- end highlight -*/}
+      <span>{props.children}</span>
+    </ToggleButton>
+  );
+}
+
+<ToggleButtonGroup
+  className="segmented-control"
+  defaultSelectedKeys={['day']}
+  disallowEmptySelection>
+  <SegmentedControlItem id="day">Day</SegmentedControlItem>
+  <SegmentedControlItem id="week">Week</SegmentedControlItem>
+  <SegmentedControlItem id="month">Month</SegmentedControlItem>
+  <SegmentedControlItem id="year">Year</SegmentedControlItem>
+</ToggleButtonGroup>
+```
+
 ## API
 
 <Anatomy />

--- a/packages/react-aria-components/docs/Tabs.mdx
+++ b/packages/react-aria-components/docs/Tabs.mdx
@@ -46,13 +46,22 @@ type: component
 ## Example
 
 ```tsx example
-import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
+import {Tabs, TabList, Tab, TabPanel, SelectionIndicator} from 'react-aria-components';
 
 <Tabs>
   <TabList aria-label="History of Ancient Rome">
-    <Tab id="FoR">Founding of Rome</Tab>
-    <Tab id="MaR">Monarchy and Republic</Tab>
-    <Tab id="Emp">Empire</Tab>
+    <Tab id="FoR">
+      <span>Founding of Rome</span>
+      <SelectionIndicator />
+    </Tab>
+    <Tab id="MaR">
+      <span>Monarchy and Republic</span>
+      <SelectionIndicator />
+    </Tab>
+    <Tab id="Emp">
+      <span>Empire</span>
+      <SelectionIndicator />
+    </Tab>
   </TabList>
   <TabPanel id="FoR">
     Arma virumque cano, Troiae qui primus ab oris.
@@ -91,7 +100,10 @@ import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
   &[data-orientation=horizontal] {
     border-bottom: 1px solid var(--border-color);
 
-    .react-aria-Tab {
+    .react-aria-SelectionIndicator {
+      left: 0;
+      bottom: 0;
+      width: 100%;
       border-bottom: 3px solid var(--border-color);
     }
   }
@@ -106,6 +118,12 @@ import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
   transition: color 200ms;
   --border-color: transparent;
   forced-color-adjust: none;
+
+  .react-aria-SelectionIndicator {
+    position: absolute;
+    transition-property: translate, width, height;
+    transition-duration: 200ms;
+  }
 
   &[data-hovered],
   &[data-focused] {
@@ -164,11 +182,13 @@ Tabs consist of a tab list with one or more visually separated tabs. Each tab ha
 Each tab can be clicked, tapped, or navigated to via arrow keys. Depending on the `keyboardActivation` prop, the tab can be selected by receiving keyboard focus, or it can be selected with the <Keyboard>Enter</Keyboard> key.
 
 ```tsx
-import {Tabs, TabList, Tab, TabPanel} from 'react-aria-components';
+import {Tabs, TabList, Tab, TabPanel, SelectionIndicator} from 'react-aria-components';
 
 <Tabs>
   <TabList>
-    <Tab />
+    <Tab>
+      <SelectionIndicator />
+    </Tab>
   </TabList>
   <TabPanel />
 </Tabs>
@@ -206,6 +226,36 @@ To help kick-start your project, we offer starter kits that include example impl
 
 <StarterKits component="tabs" />
 
+## Reusable wrappers
+
+This example wraps the `Tab` component to include a `SelectionIndicator`, which enables animating the tab selection state.
+
+```tsx example export=true
+import {Tabs, TabList, Tab, TabProps, TabPanel, SelectionIndicator, composeRenderProps} from 'react-aria-components';
+
+function MyTab(props: TabProps) {
+  return (
+    <Tab {...props}>
+      {composeRenderProps(props.children, children => (<>
+        {children}
+        <SelectionIndicator />
+      </>))}
+    </Tab>
+  );
+}
+
+<Tabs>
+  <TabList aria-label="History of Ancient Rome">
+    <MyTab id="home">Home</MyTab>
+    <MyTab id="search">Search</MyTab>
+    <MyTab id="notifications">Notifications</MyTab>
+  </TabList>
+  <TabPanel id="home">Home content</TabPanel>
+  <TabPanel id="search">Search content</TabPanel>
+  <TabPanel id="notifications">Notifications content</TabPanel>
+</Tabs>
+```
+
 ## Selection
 
 ### Default selection
@@ -217,9 +267,9 @@ See the [Selection](selection.html) guide for more details.
 ```tsx example
 <Tabs defaultSelectedKey="keyboard">
   <TabList aria-label="Input settings">
-    <Tab id="mouse">Mouse Settings</Tab>
-    <Tab id="keyboard">Keyboard Settings</Tab>
-    <Tab id="gamepad">Gamepad Settings</Tab>
+    <MyTab id="mouse">Mouse Settings</MyTab>
+    <MyTab id="keyboard">Keyboard Settings</MyTab>
+    <MyTab id="gamepad">Gamepad Settings</MyTab>
   </TabList>
   <TabPanel id="mouse">Mouse Settings</TabPanel>
   <TabPanel id="keyboard">Keyboard Settings</TabPanel>
@@ -242,9 +292,9 @@ function Example() {
       <p>Selected time period: {timePeriod}</p>
       <Tabs selectedKey={timePeriod} onSelectionChange={setTimePeriod}>
         <TabList aria-label="Mesozoic time periods">
-          <Tab id="triassic">Triassic</Tab>
-          <Tab id="jurassic">Jurassic</Tab>
-          <Tab id="cretaceous">Cretaceous</Tab>
+          <MyTab id="triassic">Triassic</MyTab>
+          <MyTab id="jurassic">Jurassic</MyTab>
+          <MyTab id="cretaceous">Cretaceous</MyTab>
         </TabList>
         <TabPanel id="triassic">
           The Triassic ranges roughly from 252 million to 201 million years ago, preceding the Jurassic Period.
@@ -270,9 +320,9 @@ tab selection.
 ```tsx example
 <Tabs keyboardActivation="manual">
   <TabList aria-label="Input settings">
-    <Tab id="mouse">Mouse Settings</Tab>
-    <Tab id="keyboard">Keyboard Settings</Tab>
-    <Tab id="gamepad">Gamepad Settings</Tab>
+    <MyTab id="mouse">Mouse Settings</MyTab>
+    <MyTab id="keyboard">Keyboard Settings</MyTab>
+    <MyTab id="gamepad">Gamepad Settings</MyTab>
   </TabList>
   <TabPanel id="mouse">Mouse Settings</TabPanel>
   <TabPanel id="keyboard">Keyboard Settings</TabPanel>
@@ -291,9 +341,9 @@ This example uses the same `Tabs` component from above. Try navigating from the 
 ```tsx example
 <Tabs>
   <TabList aria-label="Notes app">
-    <Tab id="1">Jane Doe</Tab>
-    <Tab id="2">John Doe</Tab>
-    <Tab id="3">Joe Bloggs</Tab>
+    <MyTab id="1">Jane Doe</MyTab>
+    <MyTab id="2">John Doe</MyTab>
+    <MyTab id="3">Joe Bloggs</MyTab>
   </TabList>
   <TabPanel id="1">
     <label>Leave a note for Jane: <input type="text" /></label>
@@ -340,7 +390,7 @@ function Example() {
     <Tabs>
       <div style={{display: 'flex'}}>
         <TabList aria-label="Dynamic tabs" items={tabs} style={{flex: 1}}>
-          {item => <Tab>{item.title}</Tab>}
+          {item => <MyTab>{item.title}</MyTab>}
         </TabList>
         <div className="button-group">
           <Button onPress={addTab}>Add tab</Button>
@@ -376,9 +426,9 @@ By default, tabs are horizontally oriented. The `orientation` prop can be set to
 ```tsx example
 <Tabs orientation="vertical">
   <TabList aria-label="Chat log orientation example">
-    <Tab id="1">John Doe</Tab>
-    <Tab id="2">Jane Doe</Tab>
-    <Tab id="3">Joe Bloggs</Tab>
+    <MyTab id="1">John Doe</MyTab>
+    <MyTab id="2">Jane Doe</MyTab>
+    <MyTab id="3">Joe Bloggs</MyTab>
   </TabList>
   <TabPanel id="1">There is no prior chat history with John Doe.</TabPanel>
   <TabPanel id="2">There is no prior chat history with Jane Doe.</TabPanel>
@@ -402,7 +452,10 @@ By default, tabs are horizontally oriented. The `orientation` prop can be set to
     flex-direction: column;
     border-inline-end: 1px solid gray;
 
-    .react-aria-Tab {
+    .react-aria-SelectionIndicator {
+      top: 0;
+      right: 0;
+      height: 100%;
       border-inline-end: 3px solid var(--border-color, transparent);
     }
   }
@@ -418,9 +471,9 @@ All tabs can be disabled using the `isDisabled` prop.
 ```tsx example
 <Tabs isDisabled>
   <TabList aria-label="Input settings">
-    <Tab id="mouse">Mouse Settings</Tab>
-    <Tab id="keyboard">Keyboard Settings</Tab>
-    <Tab id="gamepad">Gamepad Settings</Tab>
+    <MyTab id="mouse">Mouse Settings</MyTab>
+    <MyTab id="keyboard">Keyboard Settings</MyTab>
+    <MyTab id="gamepad">Gamepad Settings</MyTab>
   </TabList>
   <TabPanel id="mouse">Mouse Settings</TabPanel>
   <TabPanel id="keyboard">Keyboard Settings</TabPanel>
@@ -451,10 +504,10 @@ An individual `Tab` can be disabled with the `isDisabled` prop. Disabled tabs ar
 ```tsx example
 <Tabs>
   <TabList aria-label="Input settings">
-    <Tab id="mouse">Mouse Settings</Tab>
-    <Tab id="keyboard">Keyboard Settings</Tab>
+    <MyTab id="mouse">Mouse Settings</MyTab>
+    <MyTab id="keyboard">Keyboard Settings</MyTab>
     {/*- begin highlight -*/}
-    <Tab id="gamepad" isDisabled>Gamepad Settings</Tab>
+    <MyTab id="gamepad" isDisabled>Gamepad Settings</MyTab>
     {/*- end highlight -*/}
   </TabList>
   <TabPanel id="mouse">Mouse Settings</TabPanel>
@@ -478,7 +531,7 @@ function Example() {
   return (
     <Tabs disabledKeys={[2]}>
       <TabList aria-label="Input settings" items={tabs}>
-        {item => <Tab>{item.title}</Tab>}
+        {item => <MyTab>{item.title}</MyTab>}
       </TabList>
       <Collection items={tabs}>
         {item => <TabPanel>{item.title}</TabPanel>}
@@ -507,9 +560,9 @@ function AppTabs() {
   return (
     <Tabs selectedKey={pathname}>
       <TabList aria-label="Tabs">
-        <Tab id="/" href="/">Home</Tab>
-        <Tab id="/shared" href="/shared">Shared</Tab>
-        <Tab id="/deleted" href="/deleted">Deleted</Tab>
+        <MyTab id="/" href="/">Home</MyTab>
+        <MyTab id="/shared" href="/shared">Shared</MyTab>
+        <MyTab id="/deleted" href="/deleted">Deleted</MyTab>
       </TabList>
       <TabPanel id={pathname}>
         <Routes>

--- a/packages/react-aria-components/docs/ToggleButtonGroup.mdx
+++ b/packages/react-aria-components/docs/ToggleButtonGroup.mdx
@@ -116,10 +116,12 @@ There is no built in element for toggle button groups in HTML. `ToggleButtonGrou
 A toggle button group consists of a set of toggle buttons, and coordinates the selection state between them. Users can navigate between buttons with the arrow keys in either horizontal or vertical orientations.
 
 ```tsx
-import {ToggleButtonGroup, ToggleButton} from 'react-aria-components';
+import {ToggleButtonGroup, ToggleButton, SelectionIndicator} from 'react-aria-components';
 
 <ToggleButtonGroup>
-  <ToggleButton />
+  <ToggleButton>
+    <SelectionIndicator />
+  </ToggleButton>
 </ToggleButtonGroup>
 ```
 
@@ -186,6 +188,94 @@ function Example() {
   );
 }
 ```
+
+### Animation
+
+Use the `SelectionIndicator` component to animate selection changes.
+
+```tsx example
+import {ToggleButtonGroup, ToggleButton, SelectionIndicator} from 'react-aria-components';
+
+<ToggleButtonGroup
+  className="segmented-control"
+  defaultSelectedKeys={['day']}
+  disallowEmptySelection>
+  <ToggleButton id="day">
+    <SelectionIndicator />
+    <span>Day</span>
+  </ToggleButton>
+  <ToggleButton id="week">
+    <SelectionIndicator />
+    <span>Week</span>
+  </ToggleButton>
+  <ToggleButton id="month">
+    <SelectionIndicator />
+    <span>Month</span>
+  </ToggleButton>
+  <ToggleButton id="year">
+    <SelectionIndicator />
+    <span>Year</span>
+  </ToggleButton>
+</ToggleButtonGroup>
+```
+
+<details>
+  <summary style={{fontWeight: 'bold'}}><ChevronRight size="S" /> Show CSS</summary>
+
+```css
+.segmented-control {
+  display: flex;
+  background: var(--gray-100);
+  width: fit-content;
+  padding: 2px;
+  border-radius: 8px;
+
+  .react-aria-SelectionIndicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    transition-property: translate, width;
+    transition-duration: 200ms;
+    border-radius: 8px;
+    background: var(--gray-50);
+    outline: 2px solid var(--gray-600);
+  }
+
+  .react-aria-ToggleButton {
+    all: unset;
+    color: var(--text-color);
+    font-size: 1rem;
+    outline: none;
+    padding: 4px 16px;
+    position: relative;
+    z-index: 1;
+    border-radius: 8px;
+
+    span {
+      display: inline-block;
+      transition: scale 200ms;
+    }
+
+     &[data-pressed] span {
+      scale: 0.95;
+    }
+
+    &[data-selected] {
+      z-index: 0;
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--focus-ring-color);
+      outline-offset: 4px;
+    }
+  }
+}
+```
+
+</details>
 
 ## Disabled
 

--- a/packages/react-aria-components/src/SharedElementTransition.tsx
+++ b/packages/react-aria-components/src/SharedElementTransition.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {flushSync} from 'react-dom';
+import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, ReactNode, RefObject, useContext, useRef, useState} from 'react';
+import {RenderProps, useRenderProps} from './utils';
+import {useLayoutEffect} from '@react-aria/utils';
+import {useObjectRef} from 'react-aria';
+
+interface Snapshot {
+  rect: DOMRect,
+  style: [string, string][]
+}
+
+const SharedElementContext = createContext<RefObject<{[name: string]: Snapshot}> | null>(null);
+
+export interface SharedElementTransitionProps {
+  children: ReactNode
+}
+
+/**
+ * A scope for SharedElements, which animate between parents.
+ */
+export function SharedElementTransition(props: SharedElementTransitionProps) {
+  let ref = useRef({});
+  return (
+    <SharedElementContext.Provider value={ref}>
+      {props.children}
+    </SharedElementContext.Provider>
+  );
+}
+
+export interface SharedElementRenderProps {
+  isEntering?: boolean,
+  isExiting?: boolean
+}
+
+interface SharedElementPropsBase extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'className' | 'style'>, RenderProps<SharedElementRenderProps> {}
+
+export interface SharedElementProps extends SharedElementPropsBase {
+  name: string,
+  isVisible?: boolean
+}
+
+/**
+ * An element that animates between its old and new position when moving between parents.
+ */
+export const SharedElement = forwardRef(function SharedElement(props: SharedElementProps, ref: ForwardedRef<HTMLDivElement>) {
+  let {name, isVisible = true, children, className, style, ...divProps} = props;
+  let [state, setState] = useState(isVisible ? 'visible' : 'hidden');
+  let scopeRef = useContext(SharedElementContext);
+  if (!scopeRef) {
+    throw new Error('<SharedElement> must be rendered inside a <SharedElementTransition>');
+  }
+
+  if (isVisible && state === 'hidden') {
+    setState('visible');
+  }
+
+  ref = useObjectRef(ref);
+  useLayoutEffect(() => {
+    let element = ref.current;
+    let scope = scopeRef.current;
+    let prevSnapshot = scope[name];
+    let frame: number | null = null;
+
+    if (element && isVisible && prevSnapshot) {
+      // Element is transitioning from a previous instance.
+      setState('visible');
+      let animations = element.getAnimations();
+
+      // Set properties to animate from.
+      let values = prevSnapshot.style.map(([property, prevValue]) => {
+        let value = element.style[property];
+        if (property === 'translate') {
+          let prevRect = prevSnapshot.rect;
+          let currentItem = element.getBoundingClientRect();
+          let deltaX = prevRect.left - currentItem?.left;
+          let deltaY = prevRect.top - currentItem?.top;
+          element.style.translate = `${deltaX}px ${deltaY}px`;
+        } else {
+          element.style[property] = prevValue;
+        }
+        return [property, value];
+      });
+
+      // Cancel any new animations triggered by these properties.
+      for (let a of element.getAnimations()) {
+        if (!animations.includes(a)) {
+          a.cancel();
+        }
+      }
+
+      // Remove overrides after one frame to animate to the current values.
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        for (let [property, value] of values) {
+          element.style[property] = value;
+        }
+      });
+
+      delete scope[name];
+    } else if (element && isVisible && !prevSnapshot) {
+      // No previous instance exists, apply the entering state.
+      queueMicrotask(() => flushSync(() => setState('entering')));
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        setState('visible');
+      });
+    } else if (element && !isVisible) {
+      // Wait until layout effects finish, and check if a snapshot still exists.
+      // If so, no new SharedElement consumed it, so enter the exiting state.
+      queueMicrotask(() => {
+        if (scope[name]) {
+          delete scope[name];
+          flushSync(() => setState('exiting'));
+          Promise.all(element.getAnimations().map(a => a.finished))
+            .then(() => setState('hidden'))
+            .catch(() => {});
+        } else {
+          // Snapshot was consumed by another instance, unmount.
+          setState('hidden');
+        }
+      });
+    }
+
+    return () => {
+      if (frame != null) {
+        cancelAnimationFrame(frame);
+      }
+
+      if (element && element.isConnected && !element.hasAttribute('data-exiting')) {
+        // On unmount, store a snapshot of the rectangle and computed style for transitioning properties.
+        let style = window.getComputedStyle(element);
+        if (style.transitionProperty !== 'none') {
+          let transitionProperty = style.transitionProperty.split(/\s*,\s*/);
+          scope[name] = {
+            rect: element.getBoundingClientRect(),
+            style: transitionProperty.map(p => [p, style[p]])
+          };
+        }
+      }
+    };
+  }, [ref, scopeRef, name, isVisible]);
+
+  let renderProps = useRenderProps({
+    children,
+    className,
+    style,
+    values: {
+      isEntering: state === 'entering',
+      isExiting: state === 'exiting'
+    }
+  });
+
+  if (state === 'hidden') {
+    return null;
+  }
+
+  return (
+    <div
+      {...divProps}
+      {...renderProps}
+      ref={ref}
+      data-entering={state === 'entering' || undefined}
+      data-exiting={state === 'exiting' || undefined} />
+  );
+});
+
+export const SelectionIndicatorContext = createContext({isSelected: false});
+
+export interface SelectionIndicatorProps extends SharedElementPropsBase {}
+
+/**
+ * An animated indicator of selection state within a group of items.
+ */
+export const SelectionIndicator = forwardRef(function SelectionIndicator(props: SelectionIndicatorProps, ref: ForwardedRef<HTMLDivElement>) {
+  let {isSelected} = useContext(SelectionIndicatorContext);
+  return (
+    <SharedElement
+      {...props}
+      ref={ref}
+      className={props.className || 'react-aria-SelectionIndicator'}
+      name="SelectionIndicator"
+      isVisible={isSelected} />
+  );
+});

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -18,6 +18,7 @@ import {ContextValue, Provider, RenderProps, SlotProps, StyleRenderProps, useCon
 import {filterDOMProps, inertValue, useObjectRef} from '@react-aria/utils';
 import {Collection as ICollection, Node, TabListState, useTabListState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, JSX, useContext, useMemo} from 'react';
+import {SelectionIndicatorContext, SharedElementTransition} from './SharedElementTransition';
 
 export interface TabsProps extends Omit<AriaTabListProps<any>, 'items' | 'children'>, RenderProps<TabsRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
 
@@ -230,7 +231,9 @@ function TabListInner<T extends object>({props, forwardedRef: ref}: TabListInner
       {...mergeProps(DOMProps, renderProps, tabListProps)}
       ref={objectRef}
       data-orientation={orientation || undefined}>
-      <CollectionRoot collection={state.collection} persistedKeys={usePersistedKeys(state.selectionManager.focusedKey)} />
+      <SharedElementTransition>
+        <CollectionRoot collection={state.collection} persistedKeys={usePersistedKeys(state.selectionManager.focusedKey)} />
+      </SharedElementTransition>
     </div>
   );
 }
@@ -284,7 +287,9 @@ export const Tab = /*#__PURE__*/ createLeafComponent(TabItemNode, (props: TabPro
       data-focus-visible={isFocusVisible || undefined}
       data-pressed={isPressed || undefined}
       data-hovered={isHovered || undefined}>
-      {renderProps.children}
+      <SelectionIndicatorContext.Provider value={{isSelected}}>
+        {renderProps.children}
+      </SelectionIndicatorContext.Provider>
     </ElementType>
   );
 });

--- a/packages/react-aria-components/src/ToggleButton.tsx
+++ b/packages/react-aria-components/src/ToggleButton.tsx
@@ -16,6 +16,7 @@ import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} f
 import {filterDOMProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, Key} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef, useContext} from 'react';
+import {SelectionIndicatorContext} from './SharedElementTransition';
 import {ToggleGroupStateContext} from './ToggleButtonGroup';
 import {ToggleState, useToggleState} from 'react-stately';
 
@@ -80,6 +81,10 @@ export const ToggleButton = /*#__PURE__*/ (forwardRef as forwardRefType)(functio
       data-pressed={isPressed || undefined}
       data-selected={isSelected || undefined}
       data-hovered={isHovered || undefined}
-      data-focus-visible={isFocusVisible || undefined} />
+      data-focus-visible={isFocusVisible || undefined}>
+      <SelectionIndicatorContext.Provider value={{isSelected}}>
+        {renderProps.children}
+      </SelectionIndicatorContext.Provider>
+    </button>
   );
 });

--- a/packages/react-aria-components/src/ToggleButtonGroup.tsx
+++ b/packages/react-aria-components/src/ToggleButtonGroup.tsx
@@ -14,6 +14,7 @@ import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} f
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
+import {SharedElementTransition} from './SharedElementTransition';
 import {ToggleGroupState, useToggleGroupState} from 'react-stately';
 
 export interface ToggleButtonGroupRenderProps {
@@ -60,7 +61,9 @@ export const ToggleButtonGroup = /*#__PURE__*/ (forwardRef as forwardRefType)(fu
       data-orientation={props.orientation || 'horizontal'}
       data-disabled={props.isDisabled || undefined}>
       <ToggleGroupStateContext.Provider value={state}>
-        {renderProps.children}
+        <SharedElementTransition>
+          {renderProps.children}
+        </SharedElementTransition>
       </ToggleGroupStateContext.Provider>
     </div>
   );

--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -61,6 +61,7 @@ export {RadioGroup, Radio, RadioGroupContext, RadioContext, RadioGroupStateConte
 export {SearchField, SearchFieldContext} from './SearchField';
 export {Select, SelectValue, SelectContext, SelectValueContext, SelectStateContext} from './Select';
 export {Separator, SeparatorContext} from './Separator';
+export {SharedElementTransition, SharedElement, SelectionIndicator, SelectionIndicatorContext} from './SharedElementTransition';
 export {Slider, SliderOutput, SliderTrack, SliderThumb, SliderContext, SliderOutputContext, SliderTrackContext, SliderStateContext} from './Slider';
 export {Switch, SwitchContext} from './Switch';
 export {TableLoadMoreItem, Table, Row, Cell, Column, ColumnResizer, TableHeader, TableBody, TableContext, ResizableTableContainer, useTableOptions, TableStateContext, TableColumnResizeStateContext} from './Table';
@@ -125,6 +126,7 @@ export type {ProgressBarProps, ProgressBarRenderProps} from './ProgressBar';
 export type {RadioGroupProps, RadioGroupRenderProps, RadioProps, RadioRenderProps} from './RadioGroup';
 export type {SearchFieldProps, SearchFieldRenderProps} from './SearchField';
 export type {SelectProps, SelectValueProps, SelectValueRenderProps, SelectRenderProps} from './Select';
+export type {SharedElementTransitionProps, SharedElementProps, SharedElementRenderProps, SelectionIndicatorProps} from './SharedElementTransition';
 export type {SeparatorProps} from './Separator';
 export type {SliderOutputProps, SliderProps, SliderRenderProps, SliderThumbProps, SliderTrackProps, SliderTrackRenderProps, SliderThumbRenderProps} from './Slider';
 export type {SwitchProps, SwitchRenderProps} from './Switch';

--- a/starters/docs/src/Tabs.css
+++ b/starters/docs/src/Tabs.css
@@ -7,6 +7,10 @@
   &[data-orientation=horizontal] {
     flex-direction: column;
   }
+
+  &[data-orientation=vertical] {
+    flex-direction: row;
+  }
 }
 
 .react-aria-TabList {
@@ -15,8 +19,23 @@
   &[data-orientation=horizontal] {
     border-bottom: 1px solid var(--border-color);
 
-    .react-aria-Tab {
+    .react-aria-SelectionIndicator {
+      left: 0;
+      bottom: 0;
+      width: 100%;
       border-bottom: 3px solid var(--border-color);
+    }
+  }
+
+  &[data-orientation=vertical] {
+    flex-direction: column;
+    border-inline-end: 1px solid gray;
+
+    .react-aria-SelectionIndicator {
+      top: 0;
+      right: 0;
+      height: 100%;
+      border-inline-end: 3px solid var(--border-color, transparent);
     }
   }
 }
@@ -34,6 +53,12 @@
   &[data-hovered],
   &[data-focused] {
     color: var(--text-color-hover);
+  }
+
+  .react-aria-SelectionIndicator {
+    position: absolute;
+    transition-property: translate, width, height;
+    transition-duration: 200ms;
   }
 
   &[data-selected] {
@@ -65,32 +90,6 @@
 
   &[data-focus-visible] {
     outline: 2px solid var(--focus-ring-color);
-  }
-}
-
-.react-aria-Tabs {
-  &[data-orientation=vertical] {
-    flex-direction: row;
-  }
-}
-
-.react-aria-TabList {
-  &[data-orientation=vertical] {
-    flex-direction: column;
-    border-inline-end: 1px solid gray;
-
-    .react-aria-Tab {
-      border-inline-end: 3px solid var(--border-color, transparent);
-    }
-  }
-}
-
-.react-aria-Tab {
-  &[data-disabled] {
-    color: var(--text-color-disabled);
-    &[data-selected] {
-      --border-color: var(--border-color-disabled);
-    }
   }
 }
 

--- a/starters/docs/src/Tabs.tsx
+++ b/starters/docs/src/Tabs.tsx
@@ -7,7 +7,10 @@ import {
   Tab as RACTab,
   TabsProps,
   TabPanelProps,
-  TabPanel as RACTabPanel} from 'react-aria-components';
+  TabPanel as RACTabPanel,
+  composeRenderProps,
+  SelectionIndicator
+} from 'react-aria-components';
 import './Tabs.css';
 
 export function Tabs(props: TabsProps) {
@@ -19,7 +22,14 @@ export function TabList<T extends object>(props: TabListProps<T>) {
 }
 
 export function Tab(props: TabProps) {
-  return <RACTab {...props} />;
+  return (
+    <RACTab {...props}>
+      {composeRenderProps(props.children, children => (<>
+        {children}
+        <SelectionIndicator />
+      </>))}
+    </RACTab>
+  );
 }
 
 export function TabPanel(props: TabPanelProps) {

--- a/starters/tailwind/src/Tabs.tsx
+++ b/starters/tailwind/src/Tabs.tsx
@@ -5,6 +5,7 @@ import {
   TabList as RACTabList,
   TabPanel as RACTabPanel,
   Tabs as RACTabs,
+  SelectionIndicator,
   TabListProps,
   TabPanelProps,
   TabProps,
@@ -58,12 +59,8 @@ export function TabList<T extends object>(props: TabListProps<T>) {
 
 const tabProps = tv({
   extend: focusRing,
-  base: 'flex items-center cursor-default rounded-full px-4 py-1.5 text-sm font-medium transition forced-color-adjust-none',
+  base: 'relative flex items-center cursor-default rounded-full px-4 py-1.5 text-sm font-medium transition forced-color-adjust-none',
   variants: {
-    isSelected: {
-      false: 'text-gray-600 dark:text-zinc-300 hover:text-gray-700 pressed:text-gray-700 dark:hover:text-zinc-200 dark:pressed:text-zinc-200 hover:bg-gray-200 dark:hover:bg-zinc-800 pressed:bg-gray-200 dark:pressed:bg-zinc-800',
-      true: 'text-white dark:text-black forced-colors:text-[HighlightText] bg-gray-800 dark:bg-zinc-200 forced-colors:bg-[Highlight]'
-    },
     isDisabled: {
       true: 'text-gray-200 dark:text-zinc-600 forced-colors:text-[GrayText] selected:text-gray-300 dark:selected:text-zinc-500 forced-colors:selected:text-[HighlightText] selected:bg-gray-200 dark:selected:bg-zinc-600 forced-colors:selected:bg-[GrayText]'
     }
@@ -77,7 +74,12 @@ export function Tab(props: TabProps) {
       className={composeRenderProps(
         props.className,
         (className, renderProps) => tabProps({...renderProps, className})
-      )} />
+      )}>
+      {composeRenderProps(props.children, children => (<>
+        {children}
+        <SelectionIndicator className="absolute top-0 left-0 w-full h-full z-10 bg-white rounded-full mix-blend-difference transition-[translate,width,height]" />
+      </>))}
+    </RACTab>
   );
 }
 


### PR DESCRIPTION
This generalizes the animation code from S2 Tabs and SegmentedControl into a reusable `SelectionIndicator` component. This is rendered within a selectable item, and only mounts when that item is selected. When the selection changes, we store a snapshot of the previous item's rectangle and style attributes, and the new item animates from this state to its current state. This supports any CSS property listed in `transition-property`.

Currently it's built into Tabs and ToggleButtonGroup. Which other components should we support?

`SelectionIndicator` is actually a shorthand for an even more general pattern called a `SharedElementTransition`. This creates a scope within which one or more `SharedElement` components can be rendered, each with a unique `name`. When a `SharedElement` moves to a different parent within the same scope, it is automatically animated. `SharedElement` also supports enter and exit transitions when the first instance mounts or the last instance unmounts.