### PR TITLE
fix: Improve behavior of modals on iOS 26

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -20,14 +20,13 @@
 
 .spectrum-Tray-wrapper {
   inset-inline-start: 0;
-  /* Positioned at the top of the window */
-  position: fixed;
+  position: absolute;
   top: 0;
 
   display: flex;
   justify-content: center;
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
 
   /* Don't catch clicks */
   pointer-events: none;
@@ -55,10 +54,12 @@
   max-height: calc(var(--spectrum-visual-viewport-height) - var(--spectrum-tray-margin-top));
   /* Add padding at the bottom to account for the rest of the viewport height behind the keyboard.
    * This is necessary so that there isn't a visible gap that appears while the keyboard is animating
-   * in and out. Fall back to the safe area inset to account for things like iOS home indicator. */
-  padding-bottom: max(calc(100vh - var(--spectrum-visual-viewport-height)), env(safe-area-inset-bottom));
+   * in and out. Fall back to the safe area inset to account for things like iOS home indicator.
+     We also add an additional 100vh of padding (offset by the bottom position below) so the tray 
+     extends behind Safari's address bar and keyboard in iOS 26. */
+  padding-bottom: calc(max(calc(100dvh - var(--spectrum-visual-viewport-height)), env(safe-area-inset-bottom)) + 100vh);
   position: absolute;
-  bottom: 0;
+  bottom: -100vh;
   outline: none;
   display: flex;
   flex-direction: column;

--- a/packages/@adobe/spectrum-css-temp/components/underlay/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/underlay/index.css
@@ -23,7 +23,8 @@ governing permissions and limitations under the License.
 .spectrum-Underlay {
   composes: spectrum-overlay;
 
-  position: fixed;
+  /* Use position: absolute instead of fixed to avoid being clipped to the "inner" viewport in iOS 26 */
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;

--- a/packages/@react-aria/dialog/docs/useDialog.mdx
+++ b/packages/@react-aria/dialog/docs/useDialog.mdx
@@ -131,6 +131,7 @@ The `Modal` and `ModalTrigger` components render the dialog within a typical mod
 ```tsx example export=true render=false
 import {useOverlayTriggerState} from '@react-stately/overlays';
 import {Overlay, useModalOverlay, useOverlayTrigger} from '@react-aria/overlays';
+import {useViewportSize} from '@react-aria/utils';
 
 function Modal({state, children, ...props}) {
   let ref = React.useRef(null);
@@ -140,18 +141,27 @@ function Modal({state, children, ...props}) {
     <Overlay>
       <div
         style={{
-          position: 'fixed',
+          position: 'absolute',
           zIndex: 100,
           top: 0,
           left: 0,
-          bottom: 0,
-          right: 0,
-          background: 'rgba(0, 0, 0, 0.5)',
+          width: '100%',
+          height: document.body.clientHeight,
+          background: 'rgba(0, 0, 0, 0.5)'
+        }}
+        {...underlayProps} />
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: useViewportSize().height + 'px',
+          zIndex: 101,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center'
-        }}
-        {...underlayProps}>
+        }}>
         <div
           {...modalProps}
           ref={ref}

--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -40,7 +40,12 @@ export function useDialog(props: AriaDialogProps, ref: RefObject<FocusableElemen
 
   // Focus the dialog itself on mount, unless a child element is already focused.
   useEffect(() => {
-    if (ref.current && !ref.current.contains(document.activeElement)) {
+    if (
+      ref.current &&
+      !ref.current.contains(document.activeElement) &&
+      // Ignore scroll stopper input element on iOS (see usePreventScroll).
+      !(document.activeElement as any).reactAriaScrollStopper
+    ) {
       focusSafely(ref.current);
 
       // Safari on iOS does not move the VoiceOver cursor to the dialog

--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -40,12 +40,7 @@ export function useDialog(props: AriaDialogProps, ref: RefObject<FocusableElemen
 
   // Focus the dialog itself on mount, unless a child element is already focused.
   useEffect(() => {
-    if (
-      ref.current &&
-      !ref.current.contains(document.activeElement) &&
-      // Ignore scroll stopper input element on iOS (see usePreventScroll).
-      !(document.activeElement as any).reactAriaScrollStopper
-    ) {
+    if (ref.current && !ref.current.contains(document.activeElement)) {
       focusSafely(ref.current);
 
       // Safari on iOS does not move the VoiceOver cursor to the dialog

--- a/packages/@react-aria/overlays/docs/useModalOverlay.mdx
+++ b/packages/@react-aria/overlays/docs/useModalOverlay.mdx
@@ -75,6 +75,7 @@ The `Modal` component uses an &lt;<TypeLink links={docs.links} type={docs.export
 
 ```tsx example export=true render=false
 import {Overlay, useModalOverlay} from '@react-aria/overlays';
+import {useViewportSize} from '@react-aria/utils';
 
 function Modal({state, children, ...props}) {
   let ref = React.useRef(null);
@@ -84,18 +85,27 @@ function Modal({state, children, ...props}) {
     <Overlay>
       <div
         style={{
-          position: 'fixed',
+          position: 'absolute',
           zIndex: 100,
           top: 0,
           left: 0,
-          bottom: 0,
-          right: 0,
-          background: 'rgba(0, 0, 0, 0.5)',
+          width: '100%',
+          height: document.body.clientHeight,
+          background: 'rgba(0, 0, 0, 0.5)'
+        }}
+        {...underlayProps} />
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: useViewportSize().height + 'px',
+          zIndex: 101,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center'
-        }}
-        {...underlayProps}>
+        }}>
         <div
           {...modalProps}
           ref={ref}

--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -227,9 +227,12 @@ function scrollIntoView(target: Element) {
         if (visualViewport) {
           bottom = Math.min(bottom, visualViewport.offsetTop + visualViewport.height);
         }
-        scrollable.scrollBy({
-          // Center within the viewport.
-          top: (targetRect.top - scrollableRect.top) - ((bottom - scrollableRect.top) / 2 - targetRect.height / 2),
+
+        // Center within the viewport.
+        let adjustment = (targetRect.top - scrollableRect.top) - ((bottom - scrollableRect.top) / 2 - targetRect.height / 2);
+        scrollable.scrollTo({
+          // Clamp to the valid range to prevent over-scrolling.
+          top: Math.max(0, Math.min(scrollable.scrollHeight - scrollable.clientHeight, scrollable.scrollTop + adjustment)),
           behavior: 'smooth'
         });
       }

--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -144,6 +144,12 @@ function preventScrollMobileSafari() {
       scrollStopper.style.left = '0px';
       scrollStopper.style.top = '0px';
       scrollStopper.style.transform = 'translateY(-3000px) scale(0)';
+      // Copy keyboard-related attributes for we get the correct size.
+      for (let attr of ['autocorrect', 'autocomplete', 'autocapitalize', 'inputmode', 'spellcheck', 'type', 'pattern', 'enterkeyhint']) {
+        if (relatedTarget.hasAttribute(attr)) {
+          scrollStopper.setAttribute(attr, relatedTarget.getAttribute(attr)!);
+        }
+      }
       document.body.appendChild(scrollStopper);
       scrollStopper.focus({preventScroll: true});
 

--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -144,7 +144,7 @@ function preventScrollMobileSafari() {
       scrollStopper.style.left = '0px';
       scrollStopper.style.top = '0px';
       scrollStopper.style.transform = 'translateY(-3000px) scale(0)';
-      // Copy keyboard-related attributes for we get the correct size.
+      // Copy keyboard-related attributes so we get the correct size.
       for (let attr of ['autocorrect', 'autocomplete', 'autocapitalize', 'inputmode', 'spellcheck', 'type', 'pattern', 'enterkeyhint']) {
         if (relatedTarget.hasAttribute(attr)) {
           scrollStopper.setAttribute(attr, relatedTarget.getAttribute(attr)!);

--- a/packages/@react-aria/utils/src/index.ts
+++ b/packages/@react-aria/utils/src/index.ts
@@ -48,7 +48,7 @@ export {useLoadMore} from './useLoadMore';
 export {useLoadMoreSentinel, useLoadMoreSentinel as UNSTABLE_useLoadMoreSentinel} from './useLoadMoreSentinel';
 export {inertValue} from './inertValue';
 export {CLEAR_FOCUS_EVENT, FOCUS_EVENT} from './constants';
-export {isCtrlKeyPressed} from './keyboard';
+export {isCtrlKeyPressed, willOpenKeyboard} from './keyboard';
 export {useEnterAnimation, useExitAnimation} from './animation';
 export {isFocusable, isTabbable} from './isFocusable';
 

--- a/packages/@react-aria/utils/src/keyboard.tsx
+++ b/packages/@react-aria/utils/src/keyboard.tsx
@@ -25,3 +25,24 @@ export function isCtrlKeyPressed(e: Event): boolean {
 
   return e.ctrlKey;
 }
+
+// HTML input types that do not cause the software keyboard to appear.
+const nonTextInputTypes = new Set([
+  'checkbox',
+  'radio',
+  'range',
+  'color',
+  'file',
+  'image',
+  'button',
+  'submit',
+  'reset'
+]);
+
+export function willOpenKeyboard(target: Element) {
+  return (
+    (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type)) ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}

--- a/packages/@react-aria/utils/src/useViewportSize.ts
+++ b/packages/@react-aria/utils/src/useViewportSize.ts
@@ -12,6 +12,7 @@
 
 import {useEffect, useState} from 'react';
 import {useIsSSR} from '@react-aria/ssr';
+import {willOpenKeyboard} from './keyboard';
 
 interface ViewportSize {
   width: number,
@@ -36,6 +37,25 @@ export function useViewportSize(): ViewportSize {
       });
     };
 
+    // When closing the keyboard, iOS does not fire the visual viewport resize event until the animation is complete.
+    // We can anticipate this and resize early by handling the blur event and using the layout size.
+    let onBlur = (e: FocusEvent) => {
+      if (
+        willOpenKeyboard(e.target as Element) && 
+        (!e.relatedTarget || !willOpenKeyboard(e.relatedTarget as Element))
+      ) {
+        setSize(size => {
+          let newSize = {width: window.innerWidth, height: window.innerHeight};
+          if (newSize.width === size.width && newSize.height === size.height) {
+            return size;
+          }
+          return newSize;
+        });
+      }
+    };
+
+    window.addEventListener('blur', onBlur, true);
+
     if (!visualViewport) {
       window.addEventListener('resize', onResize);
     } else {
@@ -43,6 +63,7 @@ export function useViewportSize(): ViewportSize {
     }
 
     return () => {
+      window.removeEventListener('blur', onBlur);
       if (!visualViewport) {
         window.removeEventListener('resize', onResize);
       } else {

--- a/packages/@react-aria/utils/src/useViewportSize.ts
+++ b/packages/@react-aria/utils/src/useViewportSize.ts
@@ -63,7 +63,7 @@ export function useViewportSize(): ViewportSize {
     }
 
     return () => {
-      window.removeEventListener('blur', onBlur);
+      window.removeEventListener('blur', onBlur, true);
       if (!visualViewport) {
         window.removeEventListener('resize', onResize);
       } else {

--- a/packages/@react-spectrum/overlays/src/Tray.tsx
+++ b/packages/@react-spectrum/overlays/src/Tray.tsx
@@ -72,7 +72,11 @@ let TrayWrapper = forwardRef(function (props: TrayWrapperProps, ref: ForwardedRe
   // is up, so use the VisualViewport API to ensure the tray is displayed above the keyboard.
   let viewport = useViewportSize();
   let wrapperStyle: any = {
-    '--spectrum-visual-viewport-height': viewport.height + 'px'
+    '--spectrum-visual-viewport-height': viewport.height + 'px',
+    // position: fixed elements are clipped by Safari on iOS 26, so we use
+    // position: absolute and manually set the top to the scrollY.
+    // The page can't scroll while the tray is open so this doesn't need to update.
+    top: typeof window !== 'undefined' ? window.scrollY : 0
   };
 
   let wrapperClassName = classNames(

--- a/packages/@react-spectrum/overlays/src/Underlay.tsx
+++ b/packages/@react-spectrum/overlays/src/Underlay.tsx
@@ -21,6 +21,14 @@ interface UnderlayProps {
 
 export function Underlay({isOpen, isTransparent, ...otherProps}: UnderlayProps): JSX.Element {
   return (
-    <div data-testid="underlay" {...otherProps} className={classNames(underlayStyles, 'spectrum-Underlay', {'is-open': isOpen, 'spectrum-Underlay--transparent': isTransparent})} />
+    <div
+      data-testid="underlay"
+      {...otherProps}
+      // Cover the entire document so iOS 26 Safari doesn't clip the underlay to the inner viewport.
+      style={{height: isOpen && typeof document !== 'undefined' ? document.body.clientHeight : undefined}}
+      className={classNames(underlayStyles, 'spectrum-Underlay', {
+        'is-open': isOpen,
+        'spectrum-Underlay--transparent': isTransparent
+      })} />
   );
 }

--- a/packages/@react-spectrum/s2/src/Dialog.tsx
+++ b/packages/@react-spectrum/s2/src/Dialog.tsx
@@ -57,10 +57,13 @@ const header = style({
 
 const content =  style({
   flexGrow: 1,
+  flexShrink: {
+    [`@container (height < ${500 / 16}rem)`]: 0
+  },
   overflowY: {
     default: 'auto',
-    // Make the whole dialog scroll rather than only the content when the height it small.
-    [`@media (height < ${400 / 16}rem)`]: 'visible'
+    // Make the whole dialog scroll rather than only the content when the height is small.
+    [`@container (height < ${500 / 16}rem)`]: 'visible'
   },
   font: 'body',
   // TODO: adjust margin on mobile?

--- a/packages/@react-spectrum/s2/src/FullscreenDialog.tsx
+++ b/packages/@react-spectrum/s2/src/FullscreenDialog.tsx
@@ -52,7 +52,7 @@ const content =  style({
   overflowY: {
     default: 'auto',
     // Make the whole dialog scroll rather than only the content when the height it small.
-    [`@media (height < ${400 / 16}rem)`]: 'visible'
+    [`@container (height < ${400 / 16}rem)`]: 'visible'
   },
   font: 'body'
 });

--- a/packages/@react-spectrum/s2/src/Modal.tsx
+++ b/packages/@react-spectrum/s2/src/Modal.tsx
@@ -29,13 +29,13 @@ interface ModalProps extends ModalOverlayProps {
 
 const modalOverlayStyles = style({
   ...colorScheme(),
-  position: 'fixed',
-  inset: 0,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: 'full',
+  height: '--page-height',
   isolation: 'isolate',
   backgroundColor: 'transparent-black-500',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
   opacity: {
     isEntering: 0,
     isExiting: 0
@@ -45,6 +45,22 @@ const modalOverlayStyles = style({
     default: 250,
     isExiting: 130
   }
+});
+
+const modalWrapper = style({
+  position: 'sticky',
+  top: 0,
+  left: 0,
+  width: 'full',
+  height: '--visual-viewport-height',
+  display: 'flex',
+  alignItems: {
+    default: 'center',
+    size: {
+      fullscreenTakeover: 'start'
+    }
+  },
+  justifyContent: 'center'
 });
 
 /**
@@ -68,74 +84,82 @@ export const Modal = forwardRef(function Modal(props: ModalProps, ref: DOMRef<HT
     <ModalOverlay
       {...props}
       className={renderProps => modalOverlayStyles({...renderProps, colorScheme})}>
-      <RACModal
-        {...props}
-        ref={modalRef}
-        className={renderProps => style({
-          display: 'flex',
-          flexDirection: 'column',
-          borderRadius: {
-            default: 'xl',
-            size: {
-              fullscreenTakeover: 'none'
-            }
-          },
-          width: {
-            size: {
-              // Copied from designs, not sure if correct.
-              S: 400,
-              M: 480,
-              L: 640,
-              fullscreen: 'calc(100% - 40px)',
-              fullscreenTakeover: 'full'
-            }
-          },
-          height: {
-            size: {
-              fullscreen: 'calc(100% - 40px)',
-              fullscreenTakeover: 'full'
-            }
-          },
-          maxWidth: {
-            default: '90vw',
-            size: {
-              fullscreen: 'none',
-              fullscreenTakeover: 'none'
-            }
-          },
-          maxHeight: {
-            default: '90vh',
-            size: {
-              fullscreen: 'none',
-              fullscreenTakeover: 'none'
-            }
-          },
-          '--s2-container-bg': {
-            type: 'backgroundColor',
-            value: 'layer-2'
-          },
-          backgroundColor: '--s2-container-bg',
-          opacity: {
-            isEntering: 0,
-            isExiting: 0
-          },
-          translateY: {
-            isEntering: 20
-          },
-          transition: '[opacity, translate]',
-          transitionDuration: {
-            default: 250,
-            isExiting: 130
-          },
-          transitionDelay: {
-            default: 160,
-            isExiting: 0
-          },
-          // Transparent outline for WHCM.
-          outlineStyle: 'solid',
-          outlineWidth: 1,
-          outlineColor: 'transparent'
-        })({...renderProps, size: props.size})} />
+      <div className={modalWrapper({size: props.size})} style={{containerType: 'size'} as any}>
+        <RACModal
+          {...props}
+          ref={modalRef}
+          className={renderProps => style({
+            display: 'flex',
+            flexDirection: 'column',
+            borderRadius: {
+              default: 'xl',
+              size: {
+                fullscreenTakeover: 'none'
+              }
+            },
+            width: {
+              size: {
+                // Copied from designs, not sure if correct.
+                S: 400,
+                M: 480,
+                L: 640,
+                fullscreen: 'calc(100% - 40px)',
+                fullscreenTakeover: 'full'
+              }
+            },
+            height: {
+              size: {
+                fullscreen: 'calc(100% - 40px)',
+                fullscreenTakeover: 'full'
+              }
+            },
+            maxWidth: {
+              default: '90vw',
+              size: {
+                fullscreen: 'none',
+                fullscreenTakeover: 'none'
+              }
+            },
+            maxHeight: {
+              default: '90%',
+              size: {
+                fullscreen: 'none',
+                fullscreenTakeover: 'none'
+              }
+            },
+            paddingBottom: {
+              size: {
+                // Extend background behind the iOS Safari toolbar and keyboard.
+                fullscreenTakeover: '[100vh]'
+              }
+            },
+            '--s2-container-bg': {
+              type: 'backgroundColor',
+              value: 'layer-2'
+            },
+            backgroundColor: '--s2-container-bg',
+            opacity: {
+              isEntering: 0,
+              isExiting: 0
+            },
+            translateY: {
+              isEntering: 20
+            },
+            transition: '[opacity, translate]',
+            transitionDuration: {
+              default: 250,
+              isExiting: 130
+            },
+            transitionDelay: {
+              default: 160,
+              isExiting: 0
+            },
+            // Transparent outline for WHCM.
+            outlineStyle: 'solid',
+            outlineWidth: 1,
+            outlineColor: 'transparent'
+          })({...renderProps, size: props.size})} />
+      </div>
     </ModalOverlay>
   );
 });

--- a/packages/dev/docs/pages/react-aria/home/ExampleApp.tsx
+++ b/packages/dev/docs/pages/react-aria/home/ExampleApp.tsx
@@ -505,7 +505,7 @@ function PlantModal(props: ModalOverlayProps) {
       // Use position: absolute instead of fixed to avoid
       // being clipped to the "inner" viewport in iOS 26
       className={({isEntering, isExiting}) => `
-      absolute inset-0 h-(--page-height) isolate z-20 bg-black/[15%] backdrop-blur-lg
+      absolute top-0 left-0 w-full h-(--page-height) isolate z-20 bg-black/[15%] backdrop-blur-lg
       ${isEntering ? 'animate-in fade-in duration-200 ease-out' : ''}
       ${isExiting ? 'animate-out fade-out duration-200 ease-in' : ''}
     `}>

--- a/packages/dev/docs/pages/react-aria/home/ExampleApp.tsx
+++ b/packages/dev/docs/pages/react-aria/home/ExampleApp.tsx
@@ -502,8 +502,10 @@ function PlantModal(props: ModalOverlayProps) {
   return (
     <ModalOverlay
       {...props}
+      // Use position: absolute instead of fixed to avoid
+      // being clipped to the "inner" viewport in iOS 26
       className={({isEntering, isExiting}) => `
-      fixed top-0 left-0 w-full h-(--visual-viewport-height) isolate z-20 bg-black/[15%] flex items-center justify-center p-4 text-center backdrop-blur-lg
+      absolute inset-0 h-(--page-height) isolate z-20 bg-black/[15%] backdrop-blur-lg
       ${isEntering ? 'animate-in fade-in duration-200 ease-out' : ''}
       ${isExiting ? 'animate-out fade-out duration-200 ease-in' : ''}
     `}>
@@ -526,14 +528,21 @@ function PlantModal(props: ModalOverlayProps) {
             </svg>
           </div>
         }
-        <RACModal
-          {...props}
-          ref={ref}
-          className={({isEntering, isExiting}) => `
-          w-full max-w-md max-h-full overflow-auto rounded-2xl bg-white dark:bg-zinc-800/70 dark:backdrop-blur-2xl dark:backdrop-saturate-200 forced-colors:!bg-[Canvas] p-6 text-left align-middle shadow-2xl bg-clip-padding border border-black/10 dark:border-white/10
-          ${isEntering ? 'animate-in zoom-in-105 ease-out duration-200' : ''}
-          ${isExiting ? 'animate-out zoom-out-95 ease-in duration-200' : ''}
-        `} />
+        {/* Inner position: sticky div sized to the visual viewport
+            height so the modal appears in view.
+            Note that position: fixed will not work here because this
+            is positioned relative to the containing block, which is
+            the ModalOverlay in this case due to backdrop-blur. */}
+        <div className="sticky top-0 left-0 w-full h-(--visual-viewport-height) flex items-center justify-center p-4 text-center">
+          <RACModal
+            {...props}
+            ref={ref}
+            className={({isEntering, isExiting}) => `
+            w-full max-w-md max-h-full overflow-auto rounded-2xl bg-white dark:bg-zinc-800/70 dark:backdrop-blur-2xl dark:backdrop-saturate-200 forced-colors:!bg-[Canvas] p-6 text-left align-middle shadow-2xl bg-clip-padding border border-black/10 dark:border-white/10
+            ${isEntering ? 'animate-in zoom-in-105 ease-out duration-200' : ''}
+            ${isExiting ? 'animate-out zoom-out-95 ease-in duration-200' : ''}
+          `} />
+        </div>
       </>)}
     </ModalOverlay>
   );

--- a/packages/dev/s2-docs/src/Layout.tsx
+++ b/packages/dev/s2-docs/src/Layout.tsx
@@ -87,91 +87,98 @@ export function Layout(props: PageProps & {children: ReactElement<any>}) {
       </head>
       <body
         className={style({
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          maxWidth: {
-            default: 'full',
-            lg: 1280
-          },
-          marginX: 'auto',
-          marginY: 0,
-          padding: {
-            default: 0,
-            lg: 12
-          },
-          paddingBottom: 0,
-          gap: {
-            default: 0,
-            lg: 12
-          },
+          margin: 0,
+          padding: 0,
           overscrollBehavior: {
             default: 'auto',
             lg: 'none'
           }
         })}>
-        <Header pages={pages} currentPage={currentPage} />
-        <MobileHeader
-          toc={<MobileToc key="toc" toc={currentPage.tableOfContents ?? []} />}
-          nav={<MobileNav key="nav" pages={pages} currentPage={currentPage} />} />
-        <div className={style({display: 'flex', width: 'full'})}>
-          <Nav pages={pages} currentPage={currentPage} />
-          <main 
-            key={currentPage.url}
-            style={{borderBottomLeftRadius: 0, borderBottomRightRadius: 0}}
-            className={style({
-              isolation: 'isolate',
-              backgroundColor: 'base',
-              padding: {
-                default: 12,
-                lg: 40
-              },
-              borderRadius: {
-                default: 'none',
-                lg: 'xl'
-              },
-              boxShadow: {
-                lg: 'emphasized'
-              },
-              width: 'full',
-              boxSizing: 'border-box',
-              flexGrow: 1,
-              display: 'flex',
-              justifyContent: 'space-between',
-              position: 'relative',
-              height: {
-                lg: '[calc(100vh - 72px)]'
-              },
-              overflow: {
-                lg: 'auto'
-              }
-            })}>
-            <article
+        <div
+          className={style({
+            isolation: 'isolate',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            maxWidth: {
+              default: 'full',
+              lg: 1280
+            },
+            marginX: 'auto',
+            marginY: 0,
+            padding: {
+              default: 0,
+              lg: 12
+            },
+            paddingBottom: 0,
+            gap: {
+              default: 0,
+              lg: 12
+            }
+          })}>
+          <Header pages={pages} currentPage={currentPage} />
+          <MobileHeader
+            toc={<MobileToc key="toc" toc={currentPage.tableOfContents ?? []} />}
+            nav={<MobileNav key="nav" pages={pages} currentPage={currentPage} />} />
+          <div className={style({display: 'flex', width: 'full'})}>
+            <Nav pages={pages} currentPage={currentPage} />
+            <main 
+              key={currentPage.url}
+              style={{borderBottomLeftRadius: 0, borderBottomRightRadius: 0}}
               className={style({
-                maxWidth: 768,
-                width: 'full',
-                height: 'fit'
-              })}>
-              {React.cloneElement(children, {components})}
-            </article>
-            <aside
-              className={style({
-                position: 'sticky',
-                top: 0,
-                height: 'fit',
-                maxHeight: 'screen',
-                overflow: 'auto',
-                paddingY: 32,
-                boxSizing: 'border-box',
-                display: {
+                isolation: 'isolate',
+                backgroundColor: 'base',
+                padding: {
+                  default: 12,
+                  lg: 40
+                },
+                borderRadius: {
                   default: 'none',
-                  lg: 'block'
+                  lg: 'xl'
+                },
+                boxShadow: {
+                  lg: 'emphasized'
+                },
+                width: 'full',
+                boxSizing: 'border-box',
+                flexGrow: 1,
+                display: 'flex',
+                justifyContent: 'space-between',
+                position: 'relative',
+                height: {
+                  lg: '[calc(100vh - 72px)]'
+                },
+                overflow: {
+                  lg: 'auto'
                 }
               })}>
-              <div className={style({font: 'title', minHeight: 32, paddingX: 12, display: 'flex', alignItems: 'center'})}>Contents</div>
-              <Toc toc={currentPage.tableOfContents?.[0]?.children ?? []} />
-            </aside>
-          </main>
+              <article
+                className={style({
+                  maxWidth: 768,
+                  width: 'full',
+                  height: 'fit'
+                })}>
+                {React.cloneElement(children, {components})}
+              </article>
+              <aside
+                className={style({
+                  position: 'sticky',
+                  top: 0,
+                  height: 'fit',
+                  maxHeight: 'screen',
+                  overflow: 'auto',
+                  paddingY: 32,
+                  boxSizing: 'border-box',
+                  display: {
+                    default: 'none',
+                    lg: 'block'
+                  }
+                })}>
+                <div className={style({font: 'title', minHeight: 32, paddingX: 12, display: 'flex', alignItems: 'center'})}>Contents</div>
+                <Toc toc={currentPage.tableOfContents?.[0]?.children ?? []} />
+              </aside>
+            </main>
+          </div>
         </div>
       </body>
     </Provider>

--- a/packages/react-aria-components/docs/Modal.mdx
+++ b/packages/react-aria-components/docs/Modal.mdx
@@ -80,15 +80,12 @@ import {DialogTrigger, Modal, Dialog, Button, Heading, TextField, Label, Input} 
 @import "@react-aria/example-theme";
 
 .react-aria-ModalOverlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100vw;
-  height: var(--visual-viewport-height);
+  height: var(--page-height);
   background: rgba(0 0 0 / .5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 100;
 
   &[data-entering] {
@@ -101,12 +98,18 @@ import {DialogTrigger, Modal, Dialog, Button, Heading, TextField, Label, Input} 
 }
 
 .react-aria-Modal {
+  position: fixed;
+  max-height: var(--visual-viewport-height);
+  top: calc(var(--visual-viewport-height) / 2);
+  left: 50%;
+  translate: -50% -50%;
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
   border-radius: 6px;
   background: var(--overlay-background);
   color: var(--text-color);
   border: 1px solid var(--gray-400);
   outline: none;
+  width: max-content;
   max-width: 300px;
 
   &[data-entering] {
@@ -241,8 +244,11 @@ import {ModalOverlay} from 'react-aria-components';
 
 ```css
 .my-overlay {
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--page-height);
   background: rgba(45 0 0 / .3);
   backdrop-filter: blur(10px);
 
@@ -256,11 +262,14 @@ import {ModalOverlay} from 'react-aria-components';
 }
 
 .my-modal {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  position: sticky;
+  left: 0;
   width: 300px;
+  /* Extra padding to account for iOS floating browser UI. */
+  top: -100px;
+  height: calc(100dvh + 200px);
+  padding: 100px 0;
+  margin-left: auto;
   background: var(--overlay-background);
   outline: none;
   border-left: 1px solid var(--border-color);

--- a/packages/react-aria-components/docs/examples/command-palette.mdx
+++ b/packages/react-aria-components/docs/examples/command-palette.mdx
@@ -101,40 +101,42 @@ function CommandPaletteExample() {
         <ModalOverlay
           isDismissable
           className={({ isEntering, isExiting }) => `
-          fixed inset-0 z-10 overflow-y-auto bg-black/25 flex min-h-full items-start sm:items-center justify-center p-4 text-center
+          absolute top-0 left-0 w-full h-(--page-height) z-10 bg-black/25
           ${isEntering ? 'animate-in fade-in duration-300 ease-out' : ''}
           ${isExiting ? 'animate-out fade-out duration-200 ease-in' : ''}
         `}
         >
-          <Modal
-            className={({ isEntering, isExiting }) => `
-            ${isEntering ? 'animate-in zoom-in-95 ease-out duration-300' : ''}
-            ${isExiting ? 'animate-out zoom-out-95 ease-in duration-200' : ''}
-          `}
-          >
-            <Dialog className="outline-hidden relative">
-              <div className="flex flex-col gap-1 w-[95vw] sm:w-[500px] max-w-full rounded-xl bg-white shadow-lg p-2">
-                <Autocomplete filter={contains}>
-                  <TextField
-                    aria-label="Search commands"
-                    className="flex flex-col px-3 py-2 rounded-md outline-none placeholder-white/70"
-                  >
-                    <Input
-                      autoFocus
-                      placeholder="Search commands…"
-                      className="border-none py-2 px-3 leading-5 text-gray-900 bg-transparent outline-hidden text-base focus-visible:ring-2 focus-visible:ring-violet-500 rounded-lg"
-                    />
-                  </TextField>
-                  <Menu
-                    items={commands}
-                    className="mt-2 p-1 max-h-44 overflow-auto"
-                  >
-                    {({ label }) => <CommandItem>{label}</CommandItem>}
-                  </Menu>
-                </Autocomplete>
-              </div>
-            </Dialog>
-          </Modal>
+          <div className="sticky top-0 left-0 w-full h-(--visual-viewport-height) flex items-start sm:items-center justify-center p-4 box-border text-center">
+            <Modal
+              className={({ isEntering, isExiting }) => `
+              ${isEntering ? 'animate-in zoom-in-95 ease-out duration-300' : ''}
+              ${isExiting ? 'animate-out zoom-out-95 ease-in duration-200' : ''}
+            `}
+            >
+              <Dialog className="outline-hidden relative">
+                <div className="flex flex-col gap-1 w-[95vw] sm:w-[500px] max-w-full rounded-xl bg-white shadow-lg p-2">
+                  <Autocomplete filter={contains}>
+                    <TextField
+                      aria-label="Search commands"
+                      className="flex flex-col px-3 py-2 rounded-md outline-none placeholder-white/70"
+                    >
+                      <Input
+                        autoFocus
+                        placeholder="Search commands…"
+                        className="border-none py-2 px-3 leading-5 text-gray-900 bg-transparent outline-hidden text-base focus-visible:ring-2 focus-visible:ring-violet-500 rounded-lg"
+                      />
+                    </TextField>
+                    <Menu
+                      items={commands}
+                      className="mt-2 p-1 max-h-44 overflow-auto"
+                    >
+                      {({ label }) => <CommandItem>{label}</CommandItem>}
+                    </Menu>
+                  </Autocomplete>
+                </div>
+              </Dialog>
+            </Modal>
+          </div>
         </ModalOverlay>
       </DialogTrigger>
     </div>

--- a/packages/react-aria-components/docs/examples/destructive-dialog.mdx
+++ b/packages/react-aria-components/docs/examples/destructive-dialog.mdx
@@ -46,19 +46,19 @@ function ModalExample() {
       <DialogTrigger>
         <Button className="inline-flex items-center justify-center rounded-md bg-black/20 bg-clip-padding border border-white/20 px-3.5 py-2 font-medium font-[inherit] text-base text-white hover:bg-black/30 pressed:bg-black/40 transition-colors cursor-default outline-hidden focus-visible:ring-2 focus-visible:ring-white/75">Delete…</Button>
         <ModalOverlay className={({isEntering, isExiting}) => `
-          fixed inset-0 z-10 overflow-y-auto bg-black/25 flex min-h-full items-center justify-center p-4 text-center backdrop-blur
+          absolute top-0 left-0 w-full h-(--page-height) z-10 bg-black/25 backdrop-blur isolate
           ${isEntering ? 'animate-in fade-in duration-300 ease-out' : ''}
           ${isExiting ? 'animate-out fade-out duration-200 ease-in' : ''}
         `}>
           <Modal className={({isEntering, isExiting}) => `
-            w-full max-w-md overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl
+            sticky top-0 left-0 w-full h-(--visual-viewport-height) flex items-center justify-center p-4 box-border text-center
             ${isEntering ? 'animate-in zoom-in-95 ease-out duration-300' : ''}
             ${isExiting ? 'animate-out zoom-out-95 ease-in duration-200' : ''}
           `}>
-            <Dialog role="alertdialog" className="outline-hidden relative">
+            <Dialog role="alertdialog" className="max-w-md max-h-full overflow-hidden rounded-2xl bg-white p-6 box-border text-left align-middle shadow-xl outline-hidden relative">
               {({ close }) => (<>
                 <Heading slot="title" className="text-xxl font-semibold leading-6 my-0 text-slate-700">Delete folder</Heading>
-                <div className="w-6 h-6 text-red-500 absolute right-0 top-0 stroke-2"><AlertTriangle className="w-6 h-6" /></div>
+                <div className="w-6 h-6 text-red-500 absolute right-6 top-6 stroke-2"><AlertTriangle className="w-6 h-6" /></div>
                 <p className="mt-3 text-slate-500">
                   Are you sure you want to delete "Documents"? All contents will be permanently destroyed.
                 </p>

--- a/packages/react-aria-components/src/Modal.tsx
+++ b/packages/react-aria-components/src/Modal.tsx
@@ -173,7 +173,8 @@ function ModalOverlayInner({UNSTABLE_portalContainer, ...props}: ModalOverlayInn
   let viewport = useViewportSize();
   let style = {
     ...renderProps.style,
-    '--visual-viewport-height': viewport.height + 'px'
+    '--visual-viewport-height': viewport.height + 'px',
+    '--page-height': typeof document !== 'undefined' ? document.body.clientHeight + 'px' : undefined
   };
 
   return (

--- a/starters/docs/src/Modal.css
+++ b/starters/docs/src/Modal.css
@@ -1,15 +1,12 @@
 @import "./theme.css";
 
 .react-aria-ModalOverlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100vw;
-  height: var(--visual-viewport-height);
+  height: var(--page-height);
   background: rgba(0 0 0 / .5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 100;
   font-family: system-ui;
   font-size: 0.875rem;
@@ -24,12 +21,18 @@
 }
 
 .react-aria-Modal {
+  position: sticky;
+  max-height: var(--visual-viewport-height);
+  top: calc(var(--visual-viewport-height) / 2);
+  margin-left: 50vw;
+  translate: -50% -50%;
   box-shadow: 0 8px 20px rgba(0 0 0 / 0.1);
   border-radius: 6px;
   background: var(--overlay-background);
   color: var(--text-color);
   border: 1px solid var(--gray-400);
   outline: none;
+  width: max-content;
   max-width: 300px;
 
   &[data-entering] {

--- a/starters/docs/src/Sheet.css
+++ b/starters/docs/src/Sheet.css
@@ -1,8 +1,12 @@
 .sheet-overlay {
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--page-height);
   background: rgba(0 0 0 / .3);
   backdrop-filter: blur(10px);
+  z-index: 100;
 
   &[data-entering] {
     animation: sheet-blur 300ms;
@@ -14,11 +18,14 @@
 }
 
 .sheet {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  position: sticky;
+  left: 0;
   width: 300px;
+  /* Extra padding to account for iOS floating browser UI. */
+  top: -100px;
+  height: calc(100dvh + 200px);
+  padding: 100px 0;
+  margin-left: auto;
   background: var(--overlay-background);
   outline: none;
   border-left: 1px solid var(--border-color);

--- a/starters/tailwind/src/Modal.tsx
+++ b/starters/tailwind/src/Modal.tsx
@@ -4,7 +4,7 @@ import { ModalOverlay, ModalOverlayProps, Modal as RACModal } from 'react-aria-c
 import { tv } from 'tailwind-variants';
 
 const overlayStyles = tv({
-  base: 'fixed top-0 left-0 w-full h-(--visual-viewport-height) isolate z-20 bg-black/[15%] flex items-center justify-center p-4 text-center backdrop-blur-lg',
+  base: 'absolute top-0 left-0 w-full h-(--page-height) isolate z-20 bg-black/[50%] text-center backdrop-blur-lg',
   variants: {
     isEntering: {
       true: 'animate-in fade-in duration-200 ease-out'
@@ -30,7 +30,9 @@ const modalStyles = tv({
 export function Modal(props: ModalOverlayProps) {
   return (
     <ModalOverlay {...props} className={overlayStyles}>
-      <RACModal {...props} className={modalStyles} />
+      <div className="sticky top-0 left-0 w-full h-(--visual-viewport-height) flex items-center justify-center p-4 box-border">
+        <RACModal {...props} className={modalStyles} />
+      </div>
     </ModalOverlay>
   );
 }


### PR DESCRIPTION
Fixes #7902, fixes #7972, fixes #5926

## iOS 26 viewport changes

iOS Safari 26 significantly changes how the visual viewport works due to the controls that now overlay on top of the page. `position: fixed` elements are clipped to the viewport below the status bar and above the address bar, but other content continues to scroll behind them. This means that the modal backdrop will not fill the entire visible viewport, which looks strange.

<img height="400" alt="React Aria" src="https://github.com/user-attachments/assets/190a03cf-45b3-4663-a813-74636463971b" />

To fix this, we can use `position: absolute` for the backdrop instead of `fixed`, and make it cover the entire page instead of just the visual viewport. The actual modal is still sized within the visual viewport. For trays, we add additional padding that extends behind the address bar so it looks seamless.

I also made `useViewportSize` update during the `blur` event instead of waiting for the `resize` event, which occurs after the keyboard animation is complete. This makes it feel a bit faster.

## usePreventScroll improvements

The usePreventScroll logic on iOS sometimes causes flickering when tapping on an input as we temporarily applied a transform to trick safari into not scrolling. Turns out we can avoid this by preemptively calling `relatedTarget.focus({preventScroll: true})` during the `blur` event, and then scrolling ourselves.

In iOS 26, we can also no longer apply `overscroll-behavior: contain` during the `touchstart` event, it must be applied before that. So now we inject a small `<style>` element to ensure this is applied everywhere while `usePreventScroll` is active.

I also improved the scroll into view logic so that it centers the input within the viewport, and smoothly animates into view just like the native implementation does (just without scrolling the entire page).

https://github.com/user-attachments/assets/fda6221a-78ba-47f1-ac32-0de4051cf7ee