### PR TITLE
fix: Fix collection dirty node tracking with suspense

### DIFF
--- a/packages/@react-aria/collections/src/Document.ts
+++ b/packages/@react-aria/collections/src/Document.ts
@@ -461,16 +461,14 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
   }
 
   private removeNode(node: ElementNode<T>): void {
-    if (node.node == null) {
-      return;
-    }
-
     for (let child of node) {
       this.removeNode(child);
     }
 
-    let collection = this.getMutableCollection();
-    collection.removeNode(node.node.key);
+    if (node.node) {
+      let collection = this.getMutableCollection();
+      collection.removeNode(node.node.key);
+    }
   }
 
   /** Finalizes the collection update, updating all nodes and freezing the collection. */
@@ -508,11 +506,15 @@ export class Document<T, C extends BaseCollection<T> = BaseCollection<T>> extend
           this.addNode(element);
         }
 
+        if (element.node) {
+          this.dirtyNodes.delete(element);
+        }
+
         element.isMutated = false;
+      } else {
+        this.dirtyNodes.delete(element);
       }
     }
-
-    this.dirtyNodes.clear();
 
     // Finally, update the collection.
     if (this.nextCollection) {


### PR DESCRIPTION
Fixes #8885, fixes #8865

With suspense, React can create elements without setting their props, leading to elements that don't have collection nodes yet. These were tracked in `dirtyNodes`, which was cleared at the end of each collection update. However, since these elements don't have nodes, they actually should still be dirty because we haven't added them to the collection yet. This way, on the next render they will be updated.