### PR TITLE
fix: Dont display disclosure panel content if isDisabled and isExpanded=false

### DIFF
--- a/packages/@react-aria/disclosure/src/useDisclosure.ts
+++ b/packages/@react-aria/disclosure/src/useDisclosure.ts
@@ -155,7 +155,7 @@ export function useDisclosure(props: AriaDisclosureProps, state: DisclosureState
       role: 'group',
       'aria-labelledby': triggerId,
       'aria-hidden': !state.isExpanded,
-      hidden: isSSR ? !state.isExpanded : undefined
+      hidden: (isSSR || isDisabled) ? !state.isExpanded : undefined
     }
   };
 }

--- a/packages/@react-aria/disclosure/src/useDisclosure.ts
+++ b/packages/@react-aria/disclosure/src/useDisclosure.ts
@@ -155,7 +155,7 @@ export function useDisclosure(props: AriaDisclosureProps, state: DisclosureState
       role: 'group',
       'aria-labelledby': triggerId,
       'aria-hidden': !state.isExpanded,
-      hidden: (isSSR || isDisabled) ? !state.isExpanded : undefined
+      hidden: (isSSR || isDisabled) ? (isDisabled || !state.isExpanded) : undefined
     }
   };
 }

--- a/packages/react-aria-components/test/Disclosure.test.js
+++ b/packages/react-aria-components/test/Disclosure.test.js
@@ -78,7 +78,7 @@ describe('Disclosure', () => {
   });
 
   it('should support disabled state', () => {
-    const {getByTestId, getByRole} = render(
+    const {getByTestId, getByRole, queryByText} = render(
       <Disclosure data-testid="disclosure" isDisabled>
         <Heading level={3}>
           <Button slot="trigger">Trigger</Button>
@@ -94,6 +94,8 @@ describe('Disclosure', () => {
     const button = getByRole('button');
     expect(button).toHaveAttribute('disabled');
     expect(button).toHaveAttribute('data-disabled', 'true');
+    const panel = queryByText('Content');
+    expect(panel).not.toBeVisible();
   });
 
   it('should support controlled isExpanded prop', async () => {
@@ -239,7 +241,7 @@ describe('Disclosure', () => {
     const menuTrigger = getByTestId('menu-trigger');
     expect(disclosure).not.toHaveAttribute('data-expanded');
     expect(panel).not.toBeVisible();
-    
+
     await user.click(menuTrigger);
     const menu = getByTestId('menu');
     expect(menu).toBeVisible();

--- a/packages/react-aria-components/test/Disclosure.test.js
+++ b/packages/react-aria-components/test/Disclosure.test.js
@@ -98,6 +98,23 @@ describe('Disclosure', () => {
     expect(panel).not.toBeVisible();
   });
 
+  it('should not expand a disabled disclosure via isExpanded', () => {
+    const {getByTestId,  queryByText} = render(
+      <Disclosure data-testid="disclosure" isDisabled isExpanded>
+        <Heading level={3}>
+          <Button slot="trigger">Trigger</Button>
+        </Heading>
+        <DisclosurePanel>
+          <p>Content</p>
+        </DisclosurePanel>
+      </Disclosure>
+    );
+    const disclosure = getByTestId('disclosure');
+    expect(disclosure).toHaveAttribute('data-disabled', 'true');
+    const panel = queryByText('Content');
+    expect(panel).not.toBeVisible();
+  });
+
   it('should support controlled isExpanded prop', async () => {
     const onExpandedChange = jest.fn();
     const {getByTestId, getByRole, queryByText} = render(


### PR DESCRIPTION
Found via chromatic 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check the RSP Accordion "with disabled disclosure" story, the disabled disclosure shouldn't display its contents. The tests and chromatic should cover the other cases

## 🧢 Your Project:

RSP
