### PR TITLE
fix(Menu): show checkboxes for selected items with ContextualHelpTrigger isUnavailable={false}

### DIFF
--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -64,7 +64,11 @@ export function MenuItem<T>(props: MenuItemProps<T>): JSX.Element {
   }
 
   let isDisabled = state.disabledKeys.has(key);
-  let isSelectable = !isSubmenuTrigger && state.selectionManager.selectionMode !== 'none';
+  let isContextualHelpTrigger = isSubmenuTrigger && isUnavailable !== undefined;
+  let isSelectable = (
+    (isContextualHelpTrigger ? !isUnavailable : !isSubmenuTrigger) &&
+    state.selectionManager.selectionMode !== 'none'
+  );
   let isSelected = isSelectable && state.selectionManager.isSelected(key);
   let itemref = useRef<any>(null);
   let ref = useObjectRef(useMemo(() => mergeRefs(itemref, triggerRef), [itemref, triggerRef]));

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -786,6 +786,41 @@ export let MenuItemUnavailable: StoryObj<typeof Menu> = {
   )
 };
 
+export let MenuItemUnavailableWithSelection: StoryObj<typeof Menu> = {
+  render: () => render(
+    <Menu selectionMode="multiple">
+      <Item key="1">One</Item>
+      <ContextualHelpTrigger isUnavailable>
+        <Item key="foo">Two</Item>
+        <Dialog>
+          <Heading>hello</Heading>
+          <Content>Is it me you're looking for?</Content>
+        </Dialog>
+      </ContextualHelpTrigger>
+      <ContextualHelpTrigger isUnavailable={false}>
+        <Item key="baz">Two point five</Item>
+        <Dialog>
+          <Heading>hello</Heading>
+          <Content>Is it me you're looking for?</Content>
+        </Dialog>
+      </ContextualHelpTrigger>
+      <Item key="3">Three</Item>
+      <ContextualHelpTrigger isUnavailable={false}>
+        <Item key="bar" textValue="Four">
+          <Text>Four</Text>
+          <Text slot={'description'}>Shut the door</Text>
+        </Item>
+        <Dialog>
+          <Heading>hello</Heading>
+          <Content>Is it me you're looking for?</Content>
+          <Footer><Link>Learn more</Link></Footer>
+        </Dialog>
+      </ContextualHelpTrigger>
+      <Item key="5">Five</Item>
+    </Menu>
+  )
+};
+
 export let MenuItemUnavailableDynamic: StoryObj<typeof Menu> = {
   render: () => render(
     <Menu items={flatMenu} onAction={action('onAction')}>

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -646,14 +646,10 @@ describe('MenuTrigger', function () {
 
         expect(availableItem).toBeVisible();
         expect(availableItem).toHaveAttribute('aria-checked', 'false');
-        expect(availableItem).not.toHaveClass('is-selected');
         fireEvent.click(availableItem);
         act(() => {jest.runAllTimers();});
 
         expect(availableItem).toHaveAttribute('aria-checked', 'true');
-        expect(availableItem).toHaveClass('is-selected');
-        expect(within(availableItem).getByRole('img', {hidden: true})).toHaveClass('spectrum-Menu-checkmark');
-        expect(within(availableItem).queryByLabelText('Unavailable')).toBeNull();
         expect(availableItem).not.toHaveAttribute('aria-haspopup', 'dialog');
       });
 

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -617,6 +617,46 @@ describe('MenuTrigger', function () {
         expect(tree.queryByRole('dialog')).toBeNull();
       });
 
+      it('shows selection state for available ContextualHelpTrigger items', async function () {
+        render(
+          <Provider theme={theme}>
+            <MenuTrigger defaultOpen>
+              <ActionButton>Menu</ActionButton>
+              <Menu selectionMode="single">
+                <Item key="1">One</Item>
+                <ContextualHelpTrigger>
+                  <Item key="foo" textValue="Hello">
+                    <Text>Hello</Text>
+                    <Text slot="description">Is it me you're looking for?</Text>
+                  </Item>
+                  <Dialog>
+                    <Heading>Lionel Richie says:</Heading>
+                    <Content>I can see it in your eyes</Content>
+                  </Dialog>
+                </ContextualHelpTrigger>
+              </Menu>
+            </MenuTrigger>
+          </Provider>
+        );
+
+        act(() => {jest.runAllTimers();});
+
+        let menu = screen.getByRole('menu');
+        let availableItem = within(menu).getByRole('menuitemradio', {name: 'Hello'});
+
+        expect(availableItem).toBeVisible();
+        expect(availableItem).toHaveAttribute('aria-checked', 'false');
+        expect(availableItem).not.toHaveClass('is-selected');
+        fireEvent.click(availableItem);
+        act(() => {jest.runAllTimers();});
+
+        expect(availableItem).toHaveAttribute('aria-checked', 'true');
+        expect(availableItem).toHaveClass('is-selected');
+        expect(within(availableItem).getByRole('img', {hidden: true})).toHaveClass('spectrum-Menu-checkmark');
+        expect(within(availableItem).queryByLabelText('Unavailable')).toBeNull();
+        expect(availableItem).not.toHaveAttribute('aria-haspopup', 'dialog');
+      });
+
       it('can open a sub dialog with keyboard', async function () {
         renderTree();
         let menu = await openMenu();


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8871

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test new story: https://reactspectrum.blob.core.windows.net/reactspectrum/a205e07eb8f1f9b0b1d77d98fe70c2da574b41d3/storybook/index.html?path=/story/menutrigger--menu-item-unavailable-with-selection&providerSwitcher-express=false

## 🧢 Your Project:

<!--- Company/project for pull request -->
