### PR TITLE
fix: Allow pinch zooming and text selection in modals on iOS

### DIFF
--- a/packages/@react-aria/utils/src/useViewportSize.ts
+++ b/packages/@react-aria/utils/src/useViewportSize.ts
@@ -28,6 +28,11 @@ export function useViewportSize(): ViewportSize {
   useEffect(() => {
     // Use visualViewport api to track available height even on iOS virtual keyboard opening
     let onResize = () => {
+      // Ignore updates when zoomed.
+      if (visualViewport && visualViewport.scale > 1) {
+        return;
+      }
+
       setSize(size => {
         let newSize = getViewportSize();
         if (newSize.width === size.width && newSize.height === size.height) {
@@ -41,6 +46,10 @@ export function useViewportSize(): ViewportSize {
     // We can anticipate this and resize early by handling the blur event and using the layout size.
     let frame: number;
     let onBlur = (e: FocusEvent) => {
+      if (visualViewport && visualViewport.scale > 1) {
+        return;
+      }
+
       if (willOpenKeyboard(e.target as Element)) {
         // Wait one frame to see if a new element gets focused.
         frame = requestAnimationFrame(() => {
@@ -81,7 +90,8 @@ export function useViewportSize(): ViewportSize {
 
 function getViewportSize(): ViewportSize {
   return {
-    width: (visualViewport && visualViewport?.width) || window.innerWidth,
-    height: (visualViewport && visualViewport?.height) || window.innerHeight
+    // Multiply by the visualViewport scale to get the "natural" size, unaffected by pinch zooming.
+    width: visualViewport ? visualViewport.width * visualViewport.scale : window.innerWidth,
+    height: visualViewport ? visualViewport.height * visualViewport.scale : window.innerHeight
   };
 }


### PR DESCRIPTION
Fixes #1898, fixes #8324

This fixes two issues with `usePreventScroll` on iOS

* Pinch zooming was prevented by the `preventDefault` in `touchmove`, which was only intended to prevent scrolling.
* It was impossible to modify a text selection by dragging the little handles for the same reason.

We now skip the `preventDefault` when using two fingers to allow zooming. Once zoomed, you are allowed to pan around within the zoomed region using two fingers as well. In addition `useViewportSize` now no longer updates when the page is zoomed (similar to what we do for overlay positioning), so that the dialog doesn't resize unexpectedly.

We now also detect whether the target element contains text selection, and allow touchmove events to go through. This means it is also possible to scroll the page behind a dialog by starting from a selected element, but this seems better than preventing text selection so it's a best effort. I'm not sure there's another way to allow dragging the text selection but not scrolling unfortunately.