### PR TITLE
fix: Ensure Tray always uses `box-sizing: content-box` so it isn't affected by global css resets

### DIFF
--- a/examples/rsp-next-ts/styles/globals.css
+++ b/examples/rsp-next-ts/styles/globals.css
@@ -10,7 +10,3 @@ a {
   color: inherit;
   text-decoration: none;
 }
-
-* {
-  box-sizing: border-box;
-}

--- a/examples/rsp-next-ts/styles/globals.css
+++ b/examples/rsp-next-ts/styles/globals.css
@@ -10,3 +10,7 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+* {
+  box-sizing: border-box;
+}

--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -55,7 +55,7 @@
   /* Add padding at the bottom to account for the rest of the viewport height behind the keyboard.
    * This is necessary so that there isn't a visible gap that appears while the keyboard is animating
    * in and out. Fall back to the safe area inset to account for things like iOS home indicator.
-     We also add an additional 100vh of padding (offset by the bottom position below) so the tray 
+     We also add an additional 100vh of padding (offset by the bottom position below) so the tray
      extends behind Safari's address bar and keyboard in iOS 26. */
   padding-bottom: calc(max(calc(100dvh - var(--spectrum-visual-viewport-height)), env(safe-area-inset-bottom)) + 100vh);
   position: absolute;
@@ -75,6 +75,8 @@
   /* Exit animations */
   transition: opacity var(--spectrum-dialog-exit-animation-duration) cubic-bezier(0.5, 0, 1, 1) var(--spectrum-dialog-exit-animation-delay),
     transform var(--spectrum-dialog-exit-animation-duration) cubic-bezier(0.5, 0, 1, 1) var(--spectrum-dialog-exit-animation-delay);
+
+  box-sizing: content-box;
 }
 
 .is-open {


### PR DESCRIPTION
This prevents the content box of the Tray from being reduced to 0 due to the extra 100vh padding we apply for iOS 26

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Will need to merge in order to test the NextJS test app, but locally you can try applying a global `box-sizing: border-box` in the V3 storybook and make sure it doesn't cause the ComboBox/Menu/etc tray to hide its contents

## 🧢 Your Project:

RSP
