### PR TITLE
fix: Picker default text display

### DIFF
--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -532,7 +532,7 @@ const PickerButton = createHideableComponent(function PickerButton<T extends obj
         })}>
         {(renderProps) => (
           <>
-            <SelectValue className={valueStyles({isQuiet}) + ' ' + raw('&> :not([slot=icon], [slot=avatar], [slot=label]) {display: none;}')}>
+            <SelectValue className={valueStyles({isQuiet}) + ' ' + raw('&> :not([slot=icon], [slot=avatar], [slot=label], [data-slot=label]) {display: none;}')}>
               {({selectedItems, defaultChildren}) => {
                 return (
                   <Provider
@@ -556,16 +556,24 @@ const PickerButton = createHideableComponent(function PickerButton<T extends obj
                       [TextContext, {
                         slots: {
                           description: {},
-                          [DEFAULT_SLOT]: {styles: style({
-                            display: 'block',
-                            flexGrow: 1,
-                            truncate: true
-                          })},
-                          label: {styles: style({
-                            display: 'block',
-                            flexGrow: 1,
-                            truncate: true
-                          })}
+                          [DEFAULT_SLOT]: {
+                            styles: style({
+                              display: 'block',
+                              flexGrow: 1,
+                              truncate: true
+                            }),
+                            // @ts-ignore
+                            'data-slot': 'label'
+                          },
+                          label: {
+                            styles: style({
+                              display: 'block',
+                              flexGrow: 1,
+                              truncate: true
+                            }),
+                            // @ts-ignore not technically necessary, but good for consistency
+                            'data-slot': 'label'
+                          }
                         }
                       }],
                       [InsideSelectValueContext, true]

--- a/packages/@react-spectrum/s2/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/Picker.stories.tsx
@@ -153,17 +153,17 @@ export const WithAvatars: Story = {
     <Picker {...args}>
       <PickerItem textValue="User One">
         <Avatar slot="avatar" src={SRC_URL_1} />
-        <Text slot="label">User One</Text>
+        <Text>User One</Text>
         <Text slot="description">user.one@example.com</Text>
       </PickerItem>
       <PickerItem textValue="User Two">
         <Avatar slot="avatar" src={SRC_URL_2} />
-        <Text slot="label">User Two</Text>
+        <Text>User Two</Text>
         <Text slot="description">user.two@example.com<br />123-456-7890</Text>
       </PickerItem>
       <PickerItem textValue="User Three">
         <Avatar slot="avatar" src={SRC_URL_2} />
-        <Text slot="label">User Three</Text>
+        <Text>User Three</Text>
       </PickerItem>
     </Picker>
   ),


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Found while working on another branch after merging in main

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
First comment should show the broken behaviour when you select an item in the S2 Picker Avatar story
Second comment should show it fixed


## 🧢 Your Project:

<!--- Company/project for pull request -->
