### PR TITLE
fix(useViewportSize): update size after hydration

### DIFF
--- a/packages/@react-aria/utils/src/useViewportSize.ts
+++ b/packages/@react-aria/utils/src/useViewportSize.ts
@@ -68,6 +68,7 @@ export function useViewportSize(): ViewportSize {
 
     window.addEventListener('blur', onBlur, true);
 
+    onResize();
     if (!visualViewport) {
       window.addEventListener('resize', onResize);
     } else {

--- a/packages/@react-aria/utils/test/useViewportSize.ssr.test.tsx
+++ b/packages/@react-aria/utils/test/useViewportSize.ssr.test.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {testSSR} from '@react-spectrum/test-utils-internal';
+import {testSSR, screen} from '@react-spectrum/test-utils-internal';
 
 describe('useViewportSize SSR', () => {
   it('should render without errors', async () => {
@@ -24,5 +24,22 @@ describe('useViewportSize SSR', () => {
 
       <Viewport />
     `);
+  });
+
+  it('should update dimensions after hydration', async () => {
+    await testSSR(__filename, `
+      import {useViewportSize} from '../src';
+
+      function Viewport() {
+        let size = useViewportSize();
+        return <div data-testid="viewport">{size.width}x{size.height}</div>;
+      }
+
+      <Viewport />
+    `, () => {
+      expect(screen.getByTestId('viewport')).toHaveTextContent('0x0');
+    });
+
+    expect(screen.getByTestId('viewport')).not.toHaveTextContent('0x0');
   });
 });


### PR DESCRIPTION
## Before

In the `useViewportSize` hook, nothing is updating the `size` state after hydration is run. This was causing `useViewport` size to get stuck on `0x0` until the window is resized, just like in the screen recording below:

https://github.com/user-attachments/assets/57d78c17-4c2f-4ba0-b94b-9318fdd6ab2b

## After

The `onResize` function is run within the `useEffect` just as the `resize` listener is attached. I have written a test that fails without this call.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
