### PR TITLE
docs: Improve styling API docs

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Breadcrumbs.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Breadcrumbs.mdx
@@ -93,5 +93,3 @@ function Example() {
 ### Breadcrumb
 
 <PropTable component={docs.exports.Breadcrumb} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Breadcrumb" properties={docs.exports.BreadcrumbRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Button.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Button.mdx
@@ -122,5 +122,3 @@ import {Link} from 'react-aria-components';
 ## API
 
 <PropTable component={docs.exports.Button} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Button" properties={docs.exports.ButtonRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Calendar.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Calendar.mdx
@@ -312,34 +312,22 @@ import {Button} from 'vanilla-starter/Button';
 
 <PropTable component={docs.exports.Calendar} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Calendar" properties={docs.exports.CalendarRenderProps.properties} />
-
 ### CalendarGrid
 
 <PropTable component={docs.exports.CalendarGrid} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-CalendarGrid" properties={docs.exports.CalendarGridRenderProps.properties} /> */}
 
 ### CalendarGridHeader
 
 <PropTable component={docs.exports.CalendarGridHeader} links={docs.links} showDescription />
 
-{/* <StateTable defaultClassName="react-aria-CalendarGridHeader" properties={docs.exports.CalendarGridHeaderRenderProps.properties} /> */}
-
 ### CalendarHeaderCell
 
 <PropTable component={docs.exports.CalendarHeaderCell} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-CalendarHeaderCell" properties={docs.exports.CalendarHeaderCellRenderProps.properties} /> */}
 
 ### CalendarGridBody
 
 <PropTable component={docs.exports.CalendarGridBody} links={docs.links} showDescription />
 
-{/* <StateTable defaultClassName="react-aria-CalendarGridBody" properties={docs.exports.CalendarGridBodyRenderProps.properties} /> */}
-
 ### CalendarCell
 
 <PropTable component={docs.exports.CalendarCell} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-CalendarCell" properties={docs.exports.CalendarCellRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Checkbox.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Checkbox.mdx
@@ -96,5 +96,3 @@ import {Form} from 'react-aria-components';
 ### Checkbox
 
 <PropTable component={docs.exports.Checkbox} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Checkbox" properties={docs.exports.CheckboxRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/CheckboxGroup.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/CheckboxGroup.mdx
@@ -120,5 +120,3 @@ import {Form} from 'react-aria-components';
 ### CheckboxGroup
 
 <PropTable component={docs.exports.CheckboxGroup} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-CheckboxGroup" properties={docs.exports.CheckboxGroupRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ColorArea.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ColorArea.mdx
@@ -83,10 +83,6 @@ function Example() {
 
 <PropTable component={docs.exports.ColorArea} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ColorArea" properties={docs.exports.ColorAreaRenderProps.properties} />
-
 ### ColorThumb
 
 <PropTable component={docs.exports.ColorThumb} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-ColorThumb" properties={docs.exports.ColorThumbRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ColorPicker.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ColorPicker.mdx
@@ -189,5 +189,3 @@ import {ColorSwatchPicker, ColorSwatchPickerItem} from 'vanilla-starter/ColorSwa
 ## API
 
 <PropTable component={docs.exports.ColorPicker} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-ColorPicker" properties={docs.exports.ColorPickerRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ColorSlider.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ColorSlider.mdx
@@ -87,10 +87,6 @@ function Example() {
 
 <PropTable component={docs.exports.ColorSlider} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ColorSlider" properties={docs.exports.ColorSliderRenderProps.properties} />
-
 ### ColorThumb
 
 <PropTable component={docs.exports.ColorThumb} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-ColorThumb" properties={docs.exports.ColorThumbRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ColorWheel.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ColorWheel.mdx
@@ -80,16 +80,10 @@ function Example() {
 
 <PropTable component={docs.exports.ColorWheel} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ColorWheel" properties={docs.exports.ColorWheelRenderProps.properties} />
-
 ### ColorWheelTrack
 
 <PropTable component={docs.exports.ColorWheelTrack} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ColorWheelTrack" properties={docs.exports.ColorWheelTrackRenderProps.properties} />
-
 ### ColorThumb
 
 <PropTable component={docs.exports.ColorThumb} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-ColorThumb" properties={docs.exports.ColorThumbRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ComboBox.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ComboBox.mdx
@@ -343,5 +343,3 @@ import {ComboBox, ComboBoxItem} from 'vanilla-starter/ComboBox';
 ### ComboBox
 
 <PropTable component={docs.exports.ComboBox} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-ComboBox" properties={docs.exports.ComboBoxRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/DateField.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/DateField.mdx
@@ -133,16 +133,10 @@ import {Form} from 'react-aria-components';
 
 <PropTable component={docs.exports.DateField} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-DateField" properties={docs.exports.DateFieldRenderProps.properties} />
-
 ### DateInput
 
 <PropTable component={docs.exports.DateInput} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-DateInput" properties={docs.exports.DateInputRenderProps.properties} />
-
 ### DateSegment
 
 <PropTable component={docs.exports.DateSegment} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-DateSegment" properties={docs.exports.DateSegmentRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/DatePicker.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/DatePicker.mdx
@@ -157,5 +157,3 @@ function Example() {
 ### DatePicker
 
 <PropTable component={docs.exports.DatePicker} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-DatePicker" properties={docs.exports.DatePickerRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/DateRangePicker.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/DateRangePicker.mdx
@@ -174,5 +174,3 @@ function Example(props) {
 ### DateRangePicker
 
 <PropTable component={docs.exports.DateRangePicker} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-DateRangePicker" properties={docs.exports.DateRangePickerRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Disclosure.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Disclosure.mdx
@@ -97,15 +97,12 @@ import {Settings} from 'lucide-react';
 
 <PropTable component={docs.exports.Disclosure} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Disclosure" properties={docs.exports.DisclosureRenderProps.properties} />
-
 ### DisclosurePanel
 
-<PropTable component={docs.exports.DisclosurePanel} links={docs.links} showDescription />
-
-<StateTable
-  defaultClassName="react-aria-DisclosurePanel"
-  properties={docs.exports.DisclosurePanelRenderProps.properties}
+<PropTable
+  component={docs.exports.DisclosurePanel}
+  links={docs.links}
+  showDescription
   cssVariables={{
     '--disclosure-panel-width': "The disclosure panel's intrinsic width in pixels. Useful for animations.",
     '--disclosure-panel-height': "The disclosure panel's intrinsic height in pixels. Useful for animations."

--- a/packages/dev/s2-docs/pages/react-aria/Disclosure.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Disclosure.mdx
@@ -103,4 +103,10 @@ import {Settings} from 'lucide-react';
 
 <PropTable component={docs.exports.DisclosurePanel} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-DisclosurePanel" properties={docs.exports.DisclosurePanelRenderProps.properties} />
+<StateTable
+  defaultClassName="react-aria-DisclosurePanel"
+  properties={docs.exports.DisclosurePanelRenderProps.properties}
+  cssVariables={{
+    '--disclosure-panel-width': "The disclosure panel's intrinsic width in pixels. Useful for animations.",
+    '--disclosure-panel-height': "The disclosure panel's intrinsic height in pixels. Useful for animations."
+  }} />

--- a/packages/dev/s2-docs/pages/react-aria/DisclosureGroup.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/DisclosureGroup.mdx
@@ -97,5 +97,3 @@ function Example() {
 ### DisclosureGroup
 
 <PropTable component={docs.exports.DisclosureGroup} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-DisclosureGroup" properties={docs.exports.DisclosureGroupRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/DropZone.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/DropZone.mdx
@@ -100,5 +100,3 @@ export const tags = ['file', 'drag', 'dnd', 'upload'];
 ### DropZone
 
 <PropTable component={docs.exports.DropZone} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-DropZone" properties={docs.exports.DropZoneRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/GridList.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/GridList.mdx
@@ -279,16 +279,10 @@ function Example() {
 
 <PropTable component={docs.exports.GridList} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-GridList" properties={docs.exports.GridListRenderProps.properties} />
-
 ### GridListItem
 
 <PropTable component={docs.exports.GridListItem} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-GridListItem" properties={docs.exports.GridListItemRenderProps.properties} />
-
 ### GridListLoadMoreItem
 
 <PropTable component={docs.exports.GridListLoadMoreItem} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-GridListLoadMoreItem" properties={docs.exports.GridListLoadMoreItemRenderProps.properties} /> */}

--- a/packages/dev/s2-docs/pages/react-aria/Group.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Group.mdx
@@ -40,5 +40,3 @@ import {Input} from 'react-aria-components';
 ## API
 
 <PropTable component={docs.exports.Group} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Group" properties={docs.exports.GroupRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Link.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Link.mdx
@@ -46,5 +46,3 @@ import {Link} from 'vanilla-starter/Link';
 ## API
 
 <PropTable component={docs.exports.Link} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Link" properties={docs.exports.LinkRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ListBox.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ListBox.mdx
@@ -393,22 +393,14 @@ function Example() {
 
 <PropTable component={docs.exports.ListBox} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ListBox" properties={docs.exports.ListBoxRenderProps.properties} />
-
 ### ListBoxItem
 
 <PropTable component={docs.exports.ListBoxItem} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-ListBoxItem" properties={docs.exports.ListBoxItemRenderProps.properties} />
 
 ### ListBoxSection
 
 <PropTable component={docs.exports.ListBoxSection} links={docs.links} showDescription />
 
-{/* <StateTable defaultClassName="react-aria-ListBoxSection" properties={docs.exports.ListBoxSectionRenderProps.properties} /> */}
-
 ### ListBoxLoadMoreItem
 
 <PropTable component={docs.exports.ListBoxLoadMoreItem} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-ListBoxLoadMoreItem" properties={docs.exports.ListBoxLoadMoreItemRenderProps.properties} /> */}

--- a/packages/dev/s2-docs/pages/react-aria/Menu.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Menu.mdx
@@ -506,19 +506,13 @@ import {MenuTrigger, Menu, MenuItem, Button, Popover} from 'react-aria-component
 
 <PropTable component={docs.exports.Menu} links={docs.links} showDescription />
 
-{/* <StateTable defaultClassName="react-aria-Menu" properties={docs.exports.MenuRenderProps.properties} /> */}
-
 ### MenuItem
 
 <PropTable component={docs.exports.MenuItem} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-MenuItem" properties={docs.exports.MenuItemRenderProps.properties} />
-
 ### MenuSection
 
 <PropTable component={docs.exports.MenuSection} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-MenuSection" properties={docs.exports.MenuSectionRenderProps.properties} /> */}
 
 ### SubmenuTrigger
 

--- a/packages/dev/s2-docs/pages/react-aria/Meter.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Meter.mdx
@@ -68,5 +68,3 @@ By default, the `value` prop is a percentage between 0 and 100. Use the `minValu
 ### Meter
 
 <PropTable component={docs.exports.Meter} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-Meter" properties={docs.exports.MeterRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Modal.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Modal.mdx
@@ -182,15 +182,12 @@ const CustomTrigger = React.forwardRef((props, ref) => (
 
 <PropTable component={docs.exports.Modal} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Modal" properties={docs.exports.ModalRenderProps.properties} />
-
 ### ModalOverlay
 
-<PropTable component={docs.exports.ModalOverlay} links={docs.links} showDescription />
-
-<StateTable
-  defaultClassName="react-aria-ModalOverlay"
-  properties={docs.exports.ModalRenderProps.properties}
+<PropTable
+  component={docs.exports.ModalOverlay}
+  links={docs.links}
+  showDescription
   cssVariables={{
     '--visual-viewport-height': 'The height of the [Visual Viewport](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API), i.e. space above the software keyboard.',
     '--page-height': 'The height of the `<body>` element. Useful for sizing the modal backdrop.'
@@ -199,5 +196,3 @@ const CustomTrigger = React.forwardRef((props, ref) => (
 ### Dialog
 
 <PropTable component={docs.exports.Dialog} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-Dialog" properties={docs.exports.DialogRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Modal.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Modal.mdx
@@ -188,7 +188,13 @@ const CustomTrigger = React.forwardRef((props, ref) => (
 
 <PropTable component={docs.exports.ModalOverlay} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ModalOverlay" properties={docs.exports.ModalRenderProps.properties} />
+<StateTable
+  defaultClassName="react-aria-ModalOverlay"
+  properties={docs.exports.ModalRenderProps.properties}
+  cssVariables={{
+    '--visual-viewport-height': 'The height of the [Visual Viewport](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API), i.e. space above the software keyboard.',
+    '--page-height': 'The height of the `<body>` element. Useful for sizing the modal backdrop.'
+  }} />
 
 ### Dialog
 

--- a/packages/dev/s2-docs/pages/react-aria/NumberField.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/NumberField.mdx
@@ -144,5 +144,3 @@ import {Form} from 'react-aria-components';
 ### NumberField
 
 <PropTable component={docs.exports.NumberField} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-NumberField" properties={docs.exports.NumberFieldRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Popover.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Popover.mdx
@@ -152,7 +152,13 @@ function Example() {
 
 <PropTable component={docs.exports.Popover} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Popover" properties={docs.exports.PopoverRenderProps.properties} />
+<StateTable
+  defaultClassName="react-aria-Popover"
+  properties={docs.exports.PopoverRenderProps.properties}
+  cssVariables={{
+    '--trigger-width': 'The width of the popover trigger element.',
+    '--trigger-anchor-point': 'The position of the trigger relative to the popover. Use with `transform-origin` when applying scale transitions.'
+  }} />
 
 ### OverlayArrow
 

--- a/packages/dev/s2-docs/pages/react-aria/Popover.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Popover.mdx
@@ -150,11 +150,10 @@ function Example() {
 
 ### Popover
 
-<PropTable component={docs.exports.Popover} links={docs.links} showDescription />
-
-<StateTable
-  defaultClassName="react-aria-Popover"
-  properties={docs.exports.PopoverRenderProps.properties}
+<PropTable
+  component={docs.exports.Popover}
+  links={docs.links}
+  showDescription
   cssVariables={{
     '--trigger-width': 'The width of the popover trigger element.',
     '--trigger-anchor-point': 'The position of the trigger relative to the popover. Use with `transform-origin` when applying scale transitions.'
@@ -163,5 +162,3 @@ function Example() {
 ### OverlayArrow
 
 <PropTable component={docs.exports.OverlayArrow} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-OverlayArrow" properties={docs.exports.OverlayArrowRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ProgressBar.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ProgressBar.mdx
@@ -80,5 +80,3 @@ Use SVG within a `<ProgressBar>` to build a circular progress indicator or spinn
 ### ProgressBar
 
 <PropTable component={docs.exports.ProgressBar} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-ProgressBar" properties={docs.exports.ProgressBarRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/RadioGroup.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/RadioGroup.mdx
@@ -110,10 +110,6 @@ import {Form} from 'react-aria-components';
 
 <PropTable component={docs.exports.RadioGroup} links={docs.links} />
 
-<StateTable defaultClassName="react-aria-RadioGroup" properties={docs.exports.RadioGroupRenderProps.properties} />
-
 ### Radio
 
 <PropTable component={docs.exports.Radio} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Radio" properties={docs.exports.RadioRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/RangeCalendar.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/RangeCalendar.mdx
@@ -330,34 +330,22 @@ import {Button} from 'vanilla-starter/Button';
 
 <PropTable component={docs.exports.RangeCalendar} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-RangeCalendar" properties={docs.exports.RangeCalendarRenderProps.properties} />
-
 ### CalendarGrid
 
 <PropTable component={docs.exports.CalendarGrid} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-CalendarGrid" properties={docs.exports.CalendarGridRenderProps.properties} /> */}
 
 ### CalendarGridHeader
 
 <PropTable component={docs.exports.CalendarGridHeader} links={docs.links} showDescription />
 
-{/* <StateTable defaultClassName="react-aria-CalendarGridHeader" properties={docs.exports.CalendarGridHeaderRenderProps.properties} /> */}
-
 ### CalendarHeaderCell
 
 <PropTable component={docs.exports.CalendarHeaderCell} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-CalendarHeaderCell" properties={docs.exports.CalendarHeaderCellRenderProps.properties} /> */}
 
 ### CalendarGridBody
 
 <PropTable component={docs.exports.CalendarGridBody} links={docs.links} showDescription />
 
-{/* <StateTable defaultClassName="react-aria-CalendarGridBody" properties={docs.exports.CalendarGridBodyRenderProps.properties} /> */}
-
 ### CalendarCell
 
 <PropTable component={docs.exports.CalendarCell} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-CalendarCell" properties={docs.exports.CalendarCellRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/SearchField.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/SearchField.mdx
@@ -108,5 +108,3 @@ function Example(props) {
 ### SearchField
 
 <PropTable component={docs.exports.SearchField} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-SearchField" properties={docs.exports.SearchFieldRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Select.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Select.mdx
@@ -224,10 +224,6 @@ import {Form} from 'react-aria-components';
 
 <PropTable component={docs.exports.Select} links={docs.links} />
 
-<StateTable defaultClassName="react-aria-Select" properties={docs.exports.SelectRenderProps.properties} />
-
 ### SelectValue
 
 <PropTable component={docs.exports.SelectValue} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-SelectValue" properties={docs.exports.SelectValueRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Slider.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Slider.mdx
@@ -115,22 +115,14 @@ By default, slider values are percentages between 0 and 100. Use the `minValue`,
 
 <PropTable component={docs.exports.Slider} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Slider" properties={docs.exports.SliderRenderProps.properties} />
-
 ### SliderOutput
 
 <PropTable component={docs.exports.SliderOutput} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-SliderOutput" properties={docs.exports.SliderRenderProps.properties} />
 
 ### SliderTrack
 
 <PropTable component={docs.exports.SliderTrack} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-SliderTrack" properties={docs.exports.SliderTrackRenderProps.properties} />
-
 ### SliderThumb
 
 <PropTable component={docs.exports.SliderThumb} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-SliderThumb" properties={docs.exports.SliderThumbRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Switch.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Switch.mdx
@@ -90,5 +90,3 @@ import {Form} from 'react-aria-components';
 ### Switch
 
 <PropTable component={docs.exports.Switch} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Switch" properties={docs.exports.SwitchRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Table.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Table.mdx
@@ -687,37 +687,25 @@ function ReorderableTable() {
 
 <PropTable component={docs.exports.Table} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Table" properties={docs.exports.TableRenderProps.properties} />
-
 ### TableHeader
 
 <PropTable component={docs.exports.TableHeader} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-TableHeader" properties={docs.exports.TableHeaderRenderProps.properties} /> */}
 
 ### Column
 
 <PropTable component={docs.exports.Column} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Column" properties={docs.exports.ColumnRenderProps.properties} />
-
 ### TableBody
 
 <PropTable component={docs.exports.TableBody} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-TableBody" properties={docs.exports.TableBodyRenderProps.properties} /> */}
 
 ### Row
 
 <PropTable component={docs.exports.Row} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Row" properties={docs.exports.RowRenderProps.properties} />
-
 ### Cell
 
 <PropTable component={docs.exports.Cell} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-Cell" properties={docs.exports.CellRenderProps.properties} />
 
 ### ResizableTableContainer
 
@@ -727,10 +715,6 @@ function ReorderableTable() {
 
 <PropTable component={docs.exports.ColumnResizer} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-ColumnResizer" properties={docs.exports.ColumnResizerRenderProps.properties} />
-
 ### TableLoadMoreItem
 
 <PropTable component={docs.exports.TableLoadMoreItem} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-TableLoadMoreItem" properties={docs.exports.TableLoadMoreItemRenderProps.properties} /> */}

--- a/packages/dev/s2-docs/pages/react-aria/Tabs.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tabs.mdx
@@ -255,22 +255,14 @@ function Example() {
 
 <PropTable component={docs.exports.Tabs} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Tabs" properties={docs.exports.TabsRenderProps.properties} />
-
 ### TabList
 
 <PropTable component={docs.exports.TabList} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-TabList" properties={docs.exports.TabListRenderProps.properties} />
 
 ### Tab
 
 <PropTable component={docs.exports.Tab} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Tab" properties={docs.exports.TabRenderProps.properties} />
-
 ### TabPanel
 
 <PropTable component={docs.exports.TabPanel} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-TabPanel" properties={docs.exports.TabPanelRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/TagGroup.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/TagGroup.mdx
@@ -155,10 +155,6 @@ function Example(props) {
 
 <PropTable component={docs.exports.TagList} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-TagList" properties={docs.exports.TagListRenderProps.properties} />
-
 ### Tag
 
 <PropTable component={docs.exports.Tag} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-Tag" properties={docs.exports.TagRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/TextField.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/TextField.mdx
@@ -116,5 +116,3 @@ import {TextField, Label, TextArea} from 'react-aria-components';
 ### TextField
 
 <PropTable component={docs.exports.TextField} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-TextField" properties={docs.exports.TextFieldRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/TimeField.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/TimeField.mdx
@@ -118,16 +118,10 @@ import {Form} from 'react-aria-components';
 
 <PropTable component={docs.exports.TimeField} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-TimeField" properties={docs.exports.DateFieldRenderProps.properties} />
-
 ### DateInput
 
 <PropTable component={docs.exports.DateInput} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-DateInput" properties={docs.exports.DateInputRenderProps.properties} />
-
 ### DateSegment
 
 <PropTable component={docs.exports.DateSegment} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-DateSegment" properties={docs.exports.DateSegmentRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ToggleButton.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ToggleButton.mdx
@@ -65,5 +65,3 @@ function Example(props) {
 ## API
 
 <PropTable component={docs.exports.ToggleButton} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-ToggleButton" properties={docs.exports.ToggleButtonRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/ToggleButtonGroup.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ToggleButtonGroup.mdx
@@ -127,5 +127,3 @@ function SegmentedControlItem(props: ToggleButtonProps) {
 ### ToggleButtonGroup
 
 <PropTable component={docs.exports.ToggleButtonGroup} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-ToggleButtonGroup" properties={docs.exports.ToggleButtonGroupRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Toolbar.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Toolbar.mdx
@@ -118,5 +118,3 @@ export const tags = ['group'];
 ### Toolbar
 
 <PropTable component={docs.exports.Toolbar} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-Toolbar" properties={docs.exports.ToolbarRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Tooltip.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tooltip.mdx
@@ -157,7 +157,12 @@ const CustomTrigger = React.forwardRef((props, ref) => (
 
 <PropTable component={docs.exports.Tooltip} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Tooltip" properties={docs.exports.TooltipRenderProps.properties} />
+<StateTable
+  defaultClassName="react-aria-Tooltip"
+  properties={docs.exports.TooltipRenderProps.properties}
+  cssVariables={{
+    '--trigger-anchor-point': 'The position of the trigger relative to the tooltip. Use with `transform-origin` when applying scale transitions.'
+  }} />
 
 ### OverlayArrow
 

--- a/packages/dev/s2-docs/pages/react-aria/Tooltip.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tooltip.mdx
@@ -155,11 +155,10 @@ const CustomTrigger = React.forwardRef((props, ref) => (
 
 ### Tooltip
 
-<PropTable component={docs.exports.Tooltip} links={docs.links} showDescription />
-
-<StateTable
-  defaultClassName="react-aria-Tooltip"
-  properties={docs.exports.TooltipRenderProps.properties}
+<PropTable
+  component={docs.exports.Tooltip}
+  links={docs.links}
+  showDescription
   cssVariables={{
     '--trigger-anchor-point': 'The position of the trigger relative to the tooltip. Use with `transform-origin` when applying scale transitions.'
   }} />
@@ -167,5 +166,3 @@ const CustomTrigger = React.forwardRef((props, ref) => (
 ### OverlayArrow
 
 <PropTable component={docs.exports.OverlayArrow} links={docs.links} showDescription />
-
-<StateTable defaultClassName="react-aria-OverlayArrow" properties={docs.exports.OverlayArrowRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/Tree.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tree.mdx
@@ -377,25 +377,26 @@ function Example() {
 
 <PropTable component={docs.exports.Tree} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-Tree" properties={docs.exports.TreeRenderProps.properties} />
-
 ### TreeItem
 
-<PropTable component={docs.exports.TreeItem} links={docs.links} showDescription />
-
-<StateTable
-  defaultClassName="react-aria-TreeItem"
-  properties={docs.exports.TreeItemRenderProps.properties}
+<PropTable
+  component={docs.exports.TreeItem}
+  links={docs.links}
+  showDescription
   cssVariables={{
     '--tree-item-level': "The depth of the item within the tree. Useful to calculate indentation."
   }} />
 
 ### TreeItemContent
 
-<PropTable component={docs.exports.TreeItemContent} links={docs.links} showDescription />
+<PropTable component={docs.exports.TreeItemContent} links={docs.links} showDescription hideRenderProps />
 
 ### TreeLoadMoreItem
 
-<PropTable component={docs.exports.TreeLoadMoreItem} links={docs.links} showDescription />
-
-{/* <StateTable defaultClassName="react-aria-TreeLoadMoreItem" properties={docs.exports.TreeLoadMoreItemRenderProps.properties} /> */}
+<PropTable
+  component={docs.exports.TreeLoadMoreItem}
+  links={docs.links}
+  showDescription
+  cssVariables={{
+    '--tree-item-level': "The depth of the item within the tree. Useful to calculate indentation."
+  }} />

--- a/packages/dev/s2-docs/pages/react-aria/Tree.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tree.mdx
@@ -383,7 +383,12 @@ function Example() {
 
 <PropTable component={docs.exports.TreeItem} links={docs.links} showDescription />
 
-<StateTable defaultClassName="react-aria-TreeItem" properties={docs.exports.TreeItemRenderProps.properties} />
+<StateTable
+  defaultClassName="react-aria-TreeItem"
+  properties={docs.exports.TreeItemRenderProps.properties}
+  cssVariables={{
+    '--tree-item-level': "The depth of the item within the tree. Useful to calculate indentation."
+  }} />
 
 ### TreeItemContent
 

--- a/packages/dev/s2-docs/pages/react-aria/dnd.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/dnd.mdx
@@ -942,5 +942,3 @@ Note that because mouse and touch drag and drop interactions utilize the native 
 ### DropIndicator
 
 <PropTable component={docs.exports.DropIndicator} links={docs.links} />
-
-<StateTable defaultClassName="react-aria-DropIndicator" properties={docs.exports.DropIndicatorRenderProps.properties} />

--- a/packages/dev/s2-docs/pages/react-aria/selection.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/selection.mdx
@@ -528,7 +528,7 @@ function SelectableItem({id, children}) {
 </GridList>
 ```
 
-<StateTable defaultClassName="react-aria-SelectionIndicator" properties={docs.exports.SharedElementRenderProps.properties} links={docs.links} />
+<PropTable component={docs.exports.SelectionIndicator} links={docs.links} />
 
 ## Item actions
 

--- a/packages/dev/s2-docs/src/PropTable.tsx
+++ b/packages/dev/s2-docs/src/PropTable.tsx
@@ -1,7 +1,8 @@
 import {Code, styles as codeStyles} from './Code';
 import {DisclosureRow} from './DisclosureRow';
 import React from 'react';
-import {renderHTMLfromMarkdown, setLinks, TComponent, TInterface, Type} from './types';
+import {renderHTMLfromMarkdown, setLinks, TComponent, TInterface, TType, Type} from './types';
+import {StateTable} from './StateTable';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from './Table';
 
@@ -55,13 +56,38 @@ const codeStyle = style({font: {default: 'code-xs', lg: 'code-sm'}});
 interface PropTableProps {
   component: TComponent,
   links: any,
-  showDescription?: boolean
+  showDescription?: boolean,
+  hideRenderProps?: boolean,
+  showOptionalRenderProps?: boolean,
+  hideSelector?: boolean,
+  cssVariables?: {[name: string]: string}
 }
 
-export function PropTable({component, links, showDescription}: PropTableProps) {
+export function PropTable({component, links, showDescription, hideRenderProps, showOptionalRenderProps, hideSelector, cssVariables}: PropTableProps) {
   let properties = component?.props?.type === 'interface' ? component.props.properties : null;
   if (!properties) {
     return null;
+  }
+
+  let defaultClassName = properties.className?.default?.slice(1, -1);
+  let renderProps: TType | null = null;
+  let renderPropProperty = properties.className || properties.children;
+  if (!hideRenderProps && renderPropProperty?.type === 'property') {
+    if (renderPropProperty.value.type === 'union') {
+      let func = renderPropProperty.value.elements.find(e => e.type === 'function');
+      if (func) {
+        renderProps = func.parameters[0]?.value;
+      }
+    } else if (renderPropProperty.value.type === 'application') {
+      let application = renderPropProperty.value;
+      if (application.base.type === 'link' && /ClassNameOrFunction|ChildrenOrFunction/.test(links[application.base.id]?.name)) {
+        renderProps = application.typeParameters[0];
+      }
+    }
+
+    if (renderProps?.type === 'link') {
+      renderProps = links[renderProps.id];
+    }
   }
 
   return (
@@ -72,6 +98,15 @@ export function PropTable({component, links, showDescription}: PropTableProps) {
         links={links}
         propGroups={GROUPS}
         defaultExpanded={DEFAULT_EXPANDED} />
+      {defaultClassName ? <DefaultClassName defaultClassName={defaultClassName} /> : null}
+      {renderProps && renderProps.type === 'interface' ? (
+        <StateTable
+          style={!defaultClassName ? {marginTop: 16} : undefined}
+          properties={renderProps.properties}
+          showOptional={showOptionalRenderProps}
+          hideSelector={hideSelector}
+          cssVariables={cssVariables} />
+       ) : null}
     </>
   );
 }
@@ -215,4 +250,13 @@ function groupProps(
   }
 
   return [props, groups];
+}
+
+function DefaultClassName({defaultClassName}: {defaultClassName: string}) {
+  return (
+    <p className={style({font: 'ui'})}>
+      <span className={style({fontWeight: 'bold'})}>Default className: </span>
+      <span className={style({font: 'code-xs', backgroundColor: 'layer-1', paddingX: 4, borderWidth: 1, borderColor: 'gray-100', borderStyle: 'solid', borderRadius: 'sm'})}>{defaultClassName}</span>
+    </p>
+  );
 }

--- a/packages/dev/s2-docs/src/StateTable.tsx
+++ b/packages/dev/s2-docs/src/StateTable.tsx
@@ -11,10 +11,11 @@ interface StateTableProps {
   links?: any,
   showOptional?: boolean,
   hideSelector?: boolean,
-  defaultClassName?: string
+  defaultClassName?: string,
+  cssVariables?: {[name: string]: string}
 }
 
-export function StateTable({properties, links, showOptional, hideSelector, defaultClassName}: StateTableProps) {
+export function StateTable({properties, links, showOptional, hideSelector, defaultClassName, cssVariables}: StateTableProps) {
   if (links) {
     setLinks(links);
   }
@@ -61,6 +62,37 @@ export function StateTable({properties, links, showOptional, hideSelector, defau
       <>
         <DefaultClassName defaultClassName={defaultClassName} />
         {table}
+      </>
+    );
+  }
+
+  if (cssVariables) {
+    table = (
+      <>
+        {table}
+        <Table style={{marginTop: 16}}>
+          <TableHeader>
+            <TableRow>
+              <TableColumn role="columnheader">CSS Variable</TableColumn>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Object.entries(cssVariables).map(([name, description]) => (
+              <Fragment key={name}>
+                <TableRow>
+                  <TableCell role="rowheader" hideBorder>
+                    <code className={codeStyle}>
+                      <span className={codeStyles.property}>{name}</span>
+                    </code>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{renderHTMLfromMarkdown(description, {forceInline: true})}</TableCell>
+                </TableRow>
+              </Fragment>
+            ))}
+          </TableBody>
+        </Table>
       </>
     );
   }

--- a/packages/dev/s2-docs/src/StateTable.tsx
+++ b/packages/dev/s2-docs/src/StateTable.tsx
@@ -1,5 +1,5 @@
 import {Code, styles as codeStyles} from './Code';
-import {Fragment} from 'react';
+import {CSSProperties, Fragment} from 'react';
 import {renderHTMLfromMarkdown, setLinks, TInterface} from './types';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from './Table';
@@ -11,11 +11,11 @@ interface StateTableProps {
   links?: any,
   showOptional?: boolean,
   hideSelector?: boolean,
-  defaultClassName?: string,
-  cssVariables?: {[name: string]: string}
+  cssVariables?: {[name: string]: string},
+  style?: CSSProperties
 }
 
-export function StateTable({properties, links, showOptional, hideSelector, defaultClassName, cssVariables}: StateTableProps) {
+export function StateTable({properties, links, showOptional, hideSelector, cssVariables, style: styleProp}: StateTableProps) {
   if (links) {
     setLinks(links);
   }
@@ -27,7 +27,7 @@ export function StateTable({properties, links, showOptional, hideSelector, defau
   let showSelector = !hideSelector && props.some(prop => prop.type === 'property' && prop.selector);
 
   let table =  (
-    <Table>
+    <Table style={styleProp}>
       <TableHeader>
         <TableRow>
           <TableColumn role="columnheader">Render Prop</TableColumn>
@@ -56,15 +56,6 @@ export function StateTable({properties, links, showOptional, hideSelector, defau
       </TableBody>
     </Table>
   );
-
-  if (defaultClassName) {
-    table = (
-      <>
-        <DefaultClassName defaultClassName={defaultClassName} />
-        {table}
-      </>
-    );
-  }
 
   if (cssVariables) {
     table = (
@@ -98,13 +89,4 @@ export function StateTable({properties, links, showOptional, hideSelector, defau
   }
 
   return table;
-}
-
-export function DefaultClassName({defaultClassName}: {defaultClassName: string}) {
-  return (
-    <p className={style({font: 'ui'})}>
-      <span className={style({fontWeight: 'bold'})}>Default className: </span>
-      <span className={style({font: 'code-xs', backgroundColor: 'layer-1', paddingX: 4, borderWidth: 1, borderColor: 'gray-100', borderStyle: 'solid', borderRadius: 'sm'})}>{defaultClassName}</span>
-    </p>
-  );
 }

--- a/packages/react-aria-components/docs/ColorPicker.mdx
+++ b/packages/react-aria-components/docs/ColorPicker.mdx
@@ -213,7 +213,7 @@ import {MyColorArea} from './ColorArea';
 import {MyColorSlider} from './ColorSlider';
 import {MyColorField} from './ColorField';
 
-interface MyColorPickerProps extends ColorPickerProps {
+interface MyColorPickerProps extends Omit<ColorPickerProps, 'children'> {
   label?: string,
   children?: React.ReactNode
 }

--- a/packages/react-aria-components/src/Breadcrumbs.tsx
+++ b/packages/react-aria-components/src/Breadcrumbs.tsx
@@ -10,9 +10,18 @@
  * governing permissions and limitations under the License.
  */
 import {AriaBreadcrumbsProps, useBreadcrumbs} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  StyleProps,
+  useContextProps,
+  useRenderProps,
+  useSlottedContext
+} from './utils';
 import {Collection, CollectionBuilder, CollectionNode, createLeafComponent} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext} from './Collection';
-import {ContextValue, RenderProps, SlotProps, StyleProps, useContextProps, useRenderProps, useSlottedContext} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, Key} from '@react-types/shared';
 import {LinkContext} from './Link';
@@ -20,6 +29,11 @@ import {Node} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, useContext} from 'react';
 
 export interface BreadcrumbsProps<T> extends Omit<CollectionProps<T>, 'disabledKeys'>, AriaBreadcrumbsProps, StyleProps, SlotProps, GlobalDOMAttributes<HTMLOListElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-Breadcrumbs'
+   */
+  className?: string,
   /** Whether the breadcrumbs are disabled. */
   isDisabled?: boolean,
   /** Handler that is called when a breadcrumb is clicked. */
@@ -69,6 +83,11 @@ export interface BreadcrumbRenderProps {
 }
 
 export interface BreadcrumbProps extends RenderProps<BreadcrumbRenderProps>, GlobalDOMAttributes<HTMLLIElement>  {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Breadcrumb'
+   */
+  className?: ClassNameOrFunction<BreadcrumbRenderProps>,
   /** A unique id for the breadcrumb, which will be passed to `onAction` when the breadcrumb is pressed. */
   id?: Key
 }

--- a/packages/react-aria-components/src/Button.tsx
+++ b/packages/react-aria-components/src/Button.tsx
@@ -21,6 +21,7 @@ import {
   useId
 } from 'react-aria';
 import {
+  ClassNameOrFunction,
   ContextValue,
   RenderProps,
   SlotProps,
@@ -67,6 +68,11 @@ export interface ButtonRenderProps {
 }
 
 export interface ButtonProps extends Omit<AriaButtonProps, 'children' | 'href' | 'target' | 'rel' | 'elementType'>, HoverEvents, SlotProps, RenderProps<ButtonRenderProps>, Omit<GlobalDOMAttributes<HTMLButtonElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Button'
+   */
+  className?: ClassNameOrFunction<ButtonRenderProps>,
   /**
    * Whether the button is in a pending state. This disables press and hover events
    * while retaining focusability, and announces the pending state to screen readers.

--- a/packages/react-aria-components/src/Calendar.tsx
+++ b/packages/react-aria-components/src/Calendar.tsx
@@ -26,7 +26,18 @@ import {
 import {ButtonContext} from './Button';
 import {CalendarDate, CalendarIdentifier, createCalendar, DateDuration, endOfMonth, Calendar as ICalendar, isSameDay, isSameMonth, isToday} from '@internationalized/date';
 import {CalendarState, RangeCalendarState, useCalendarState, useRangeCalendarState} from 'react-stately';
-import {ContextValue, DOMProps, Provider, RenderProps, SlotProps, StyleProps, useContextProps, useRenderProps, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DOMProps,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleProps,
+  useContextProps,
+  useRenderProps,
+  useSlottedContext
+} from './utils';
 import {DOMAttributes, FocusableElement, forwardRefType, GlobalDOMAttributes, HoverEvents} from '@react-types/shared';
 import {filterDOMProps} from '@react-aria/utils';
 import {HeadingContext} from './RSPContexts';
@@ -59,11 +70,15 @@ export interface RangeCalendarRenderProps extends Omit<CalendarRenderProps, 'sta
 
 export interface CalendarProps<T extends DateValue> extends Omit<AriaCalendarProps<T>, 'errorMessage' | 'validationState'>, RenderProps<CalendarRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
   /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Calendar'
+   */
+  className?: ClassNameOrFunction<CalendarRenderProps>,
+  /**
    * The amount of days that will be displayed at once. This affects how pagination works.
    * @default {months: 1}
    */
   visibleDuration?: DateDuration,
-
   /**
    * A function to create a new [Calendar](https://react-spectrum.adobe.com/internationalized/date/Calendar.html)
    * object for a given calendar identifier. If not provided, the `createCalendar` function
@@ -74,11 +89,15 @@ export interface CalendarProps<T extends DateValue> extends Omit<AriaCalendarPro
 
 export interface RangeCalendarProps<T extends DateValue> extends Omit<AriaRangeCalendarProps<T>, 'errorMessage' | 'validationState'>, RenderProps<RangeCalendarRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
   /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-RangeCalendar'
+   */
+  className?: ClassNameOrFunction<RangeCalendarRenderProps>,
+  /**
    * The amount of days that will be displayed at once. This affects how pagination works.
    * @default {months: 1}
    */
   visibleDuration?: DateDuration,
-
   /**
    * A function to create a new [Calendar](https://react-spectrum.adobe.com/internationalized/date/Calendar.html)
    * object for a given calendar identifier. If not provided, the `createCalendar` function
@@ -327,6 +346,11 @@ export interface CalendarCellRenderProps {
 
 export interface CalendarGridProps extends StyleProps, GlobalDOMAttributes<HTMLTableElement> {
   /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-CalendarGrid'
+   */
+  className?: string,
+  /**
    * Either a function to render calendar cells for each date in the month,
    * or children containing a `<CalendarGridHeader>`` and `<CalendarGridBody>`
    * when additional customization is needed.
@@ -406,6 +430,11 @@ export const CalendarGrid = /*#__PURE__*/ (forwardRef as forwardRefType)(functio
 });
 
 export interface CalendarGridHeaderProps extends StyleProps, GlobalDOMAttributes<HTMLTableSectionElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-CalendarGridHeader'
+   */
+  className?: string,
   /** A function to render a `<CalendarHeaderCell>` for a weekday name. */
   children: (day: string) => ReactElement
 }
@@ -434,7 +463,13 @@ function CalendarGridHeader(props: CalendarGridHeaderProps, ref: ForwardedRef<HT
 const CalendarGridHeaderForwardRef = /*#__PURE__*/ (forwardRef as forwardRefType)(CalendarGridHeader);
 export {CalendarGridHeaderForwardRef as CalendarGridHeader};
 
-export interface CalendarHeaderCellProps extends DOMProps, GlobalDOMAttributes<HTMLTableHeaderCellElement> {}
+export interface CalendarHeaderCellProps extends DOMProps, GlobalDOMAttributes<HTMLTableHeaderCellElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-CalendarHeaderCell'
+   */
+  className?: string
+}
 
 function CalendarHeaderCell(props: CalendarHeaderCellProps, ref: ForwardedRef<HTMLTableCellElement>) {
   let {children, style, className} = props;
@@ -457,6 +492,11 @@ const CalendarHeaderCellForwardRef = forwardRef(CalendarHeaderCell);
 export {CalendarHeaderCellForwardRef as CalendarHeaderCell};
 
 export interface CalendarGridBodyProps extends StyleProps, GlobalDOMAttributes<HTMLTableSectionElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-CalendarGridBody'
+   */
+  className?: string,
   /** A function to render a `<CalendarCell>` for a given date. */
   children: (date: CalendarDate) => ReactElement
 }
@@ -495,6 +535,11 @@ const CalendarGridBodyForwardRef = /*#__PURE__*/ (forwardRef as forwardRefType)(
 export {CalendarGridBodyForwardRef as CalendarGridBody};
 
 export interface CalendarCellProps extends RenderProps<CalendarCellRenderProps>, HoverEvents, GlobalDOMAttributes<HTMLTableCellElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-CalendarCell'
+   */
+  className?: ClassNameOrFunction<CalendarCellRenderProps>,
   /** The date to render in the cell. */
   date: CalendarDate
 }

--- a/packages/react-aria-components/src/Checkbox.tsx
+++ b/packages/react-aria-components/src/Checkbox.tsx
@@ -12,7 +12,19 @@
 import {AriaCheckboxGroupProps, AriaCheckboxProps, HoverEvents, mergeProps, useCheckbox, useCheckboxGroup, useCheckboxGroupItem, useFocusRing, useHover, VisuallyHidden} from 'react-aria';
 import {CheckboxContext} from './RSPContexts';
 import {CheckboxGroupState, useCheckboxGroupState, useToggleState} from 'react-stately';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps, mergeRefs, useObjectRef} from '@react-aria/utils';
 import {FormContext} from './Form';
@@ -21,8 +33,19 @@ import {LabelContext} from './Label';
 import React, {createContext, ForwardedRef, forwardRef, useContext, useMemo} from 'react';
 import {TextContext} from './Text';
 
-export interface CheckboxGroupProps extends Omit<AriaCheckboxGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<CheckboxGroupRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface CheckboxGroupProps extends Omit<AriaCheckboxGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<CheckboxGroupRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-CheckboxGroup'
+   */
+  className?: ClassNameOrFunction<CheckboxGroupRenderProps>
+}
 export interface CheckboxProps extends Omit<AriaCheckboxProps, 'children' | 'validationState' | 'validationBehavior'>, HoverEvents, RACValidation, RenderProps<CheckboxRenderProps>, SlotProps, Omit<GlobalDOMAttributes<HTMLLabelElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Checkbox'
+   */
+  className?: ClassNameOrFunction<CheckboxRenderProps>,
   /**
    * A ref for the HTML input element.
    */

--- a/packages/react-aria-components/src/ColorArea.tsx
+++ b/packages/react-aria-components/src/ColorArea.tsx
@@ -1,10 +1,17 @@
 import {AriaColorAreaProps, useColorArea} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  Provider,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {ColorAreaContext} from './RSPContexts';
 import {ColorAreaState, useColorAreaState} from 'react-stately';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {GlobalDOMAttributes} from '@react-types/shared';
 import {InternalColorThumbContext} from './ColorThumb';
-import {Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
 import React, {createContext, ForwardedRef, forwardRef, useRef} from 'react';
 
 export interface ColorAreaRenderProps {
@@ -19,7 +26,13 @@ export interface ColorAreaRenderProps {
   state: ColorAreaState
 }
 
-export interface ColorAreaProps extends AriaColorAreaProps, RenderProps<ColorAreaRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ColorAreaProps extends AriaColorAreaProps, RenderProps<ColorAreaRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorArea'
+   */
+  className?: ClassNameOrFunction<ColorAreaRenderProps>
+}
 
 export const ColorAreaStateContext = createContext<ColorAreaState | null>(null);
 

--- a/packages/react-aria-components/src/ColorField.tsx
+++ b/packages/react-aria-components/src/ColorField.tsx
@@ -11,6 +11,17 @@
  */
 
 import {AriaColorFieldProps, useColorChannelField, useColorField, useLocale} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot
+} from './utils';
 import {ColorChannel, ColorFieldState, ColorSpace, useColorChannelFieldState, useColorFieldState} from 'react-stately';
 import {ColorFieldContext} from './RSPContexts';
 import {FieldErrorContext} from './FieldError';
@@ -19,7 +30,6 @@ import {GlobalDOMAttributes, InputDOMProps, ValidationResult} from '@react-types
 import {GroupContext} from './Group';
 import {InputContext} from './Input';
 import {LabelContext} from './Label';
-import {Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, InputHTMLAttributes, LabelHTMLAttributes, Ref, useRef} from 'react';
 import {TextContext} from './Text';
 
@@ -46,6 +56,11 @@ export interface ColorFieldRenderProps {
 }
 
 export interface ColorFieldProps extends Omit<AriaColorFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, InputDOMProps, RenderProps<ColorFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorField'
+   */
+  className?: ClassNameOrFunction<ColorFieldRenderProps>,
   /**
    * The color channel that this field edits. If not provided, 
    * the color is edited as a hex value.

--- a/packages/react-aria-components/src/ColorPicker.tsx
+++ b/packages/react-aria-components/src/ColorPicker.tsx
@@ -10,12 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+import {ChildrenOrFunction, Provider, SlotProps, SlottedContextValue, useRenderProps, useSlottedContext} from './utils';
 import {Color, ColorPickerState, ColorPickerProps as StatelyColorPickerProps, useColorPickerState} from 'react-stately';
 import {ColorAreaContext, ColorFieldContext, ColorSliderContext, ColorWheelContext} from './RSPContexts';
 import {ColorSwatchContext} from './ColorSwatch';
 import {ColorSwatchPickerContext} from './ColorSwatchPicker';
 import {mergeProps} from 'react-aria';
-import {Provider, RenderProps, SlotProps, SlottedContextValue, useRenderProps, useSlottedContext} from './utils';
 import React, {createContext, JSX} from 'react';
 
 export interface ColorPickerRenderProps {
@@ -23,7 +23,10 @@ export interface ColorPickerRenderProps {
   color: Color
 }
 
-export interface ColorPickerProps extends StatelyColorPickerProps, SlotProps, Pick<RenderProps<ColorPickerRenderProps>, 'children'> {}
+export interface ColorPickerProps extends StatelyColorPickerProps, SlotProps {
+  /** The children of the component. A function may be provided to alter the children based on component state. */
+  children: ChildrenOrFunction<ColorPickerRenderProps>
+}
 
 export const ColorPickerContext = createContext<SlottedContextValue<ColorPickerProps>>(null);
 export const ColorPickerStateContext = createContext<ColorPickerState | null>(null);

--- a/packages/react-aria-components/src/ColorSlider.tsx
+++ b/packages/react-aria-components/src/ColorSlider.tsx
@@ -1,11 +1,19 @@
 import {AriaColorSliderProps, Orientation, useColorSlider, useLocale} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  Provider,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot
+} from './utils';
 import {ColorSliderContext} from './RSPContexts';
 import {ColorSliderState, useColorSliderState} from 'react-stately';
 import {filterDOMProps} from '@react-aria/utils';
 import {GlobalDOMAttributes} from '@react-types/shared';
 import {InternalColorThumbContext} from './ColorThumb';
 import {LabelContext} from './Label';
-import {Provider, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
 import {SliderOutputContext, SliderStateContext, SliderTrackContext} from './Slider';
 
@@ -26,7 +34,13 @@ export interface ColorSliderRenderProps {
   state: ColorSliderState
 }
 
-export interface ColorSliderProps extends Omit<AriaColorSliderProps, 'label'>, RenderProps<ColorSliderRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ColorSliderProps extends Omit<AriaColorSliderProps, 'label'>, RenderProps<ColorSliderRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorSlider'
+   */
+  className?: ClassNameOrFunction<ColorSliderRenderProps>
+}
 
 export const ColorSliderStateContext = createContext<ColorSliderState | null>(null);
 

--- a/packages/react-aria-components/src/ColorSwatch.tsx
+++ b/packages/react-aria-components/src/ColorSwatch.tsx
@@ -1,6 +1,13 @@
 import {AriaColorSwatchProps, useColorSwatch} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {Color} from 'react-stately';
-import {ContextValue, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {GlobalDOMAttributes} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
@@ -10,7 +17,13 @@ export interface ColorSwatchRenderProps {
   color: Color
 }
 
-export interface ColorSwatchProps extends AriaColorSwatchProps, StyleRenderProps<ColorSwatchRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ColorSwatchProps extends AriaColorSwatchProps, StyleRenderProps<ColorSwatchRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorSwatch'
+   */
+  className?: ClassNameOrFunction<ColorSwatchRenderProps>
+}
 
 export const ColorSwatchContext = createContext<ContextValue<ColorSwatchProps, HTMLDivElement>>(null);
 

--- a/packages/react-aria-components/src/ColorSwatchPicker.tsx
+++ b/packages/react-aria-components/src/ColorSwatchPicker.tsx
@@ -1,7 +1,14 @@
 import {AriaLabelingProps, GlobalDOMAttributes, HoverEvents, PressEvents, ValueBase} from '@react-types/shared';
+import {
+  ClassNameOrFunction,
+  composeRenderProps,
+  ContextValue,
+  RenderProps,
+  StyleRenderProps,
+  useContextProps
+} from './utils';
 import {Color, parseColor, useColorPickerState} from 'react-stately';
 import {ColorSwatchContext} from './ColorSwatch';
-import {composeRenderProps, ContextValue, RenderProps, StyleRenderProps, useContextProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -11,6 +18,11 @@ import {useLocale, useLocalizedStringFormatter} from 'react-aria';
 
 export interface ColorSwatchPickerRenderProps extends Omit<ListBoxRenderProps, 'isDropTarget'> {}
 export interface ColorSwatchPickerProps extends ValueBase<string | Color, Color>, AriaLabelingProps, StyleRenderProps<ColorSwatchPickerRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorSwatchPicker'
+   */
+  className?: ClassNameOrFunction<ColorSwatchPickerRenderProps>,
   /** The children of the ColorSwatchPicker. */
   children?: ReactNode,
   /**
@@ -62,6 +74,11 @@ export interface ColorSwatchPickerItemRenderProps extends Omit<ListBoxItemRender
 }
 
 export interface ColorSwatchPickerItemProps extends RenderProps<ColorSwatchPickerItemRenderProps>, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorSwatchPickerItem'
+   */
+  className?: ClassNameOrFunction<ColorSwatchPickerItemRenderProps>,
   /** The color of the swatch. */
   color: string | Color,
   /** Whether the color swatch is disabled. */

--- a/packages/react-aria-components/src/ColorThumb.tsx
+++ b/packages/react-aria-components/src/ColorThumb.tsx
@@ -1,9 +1,9 @@
+import {ClassNameOrFunction, RenderProps, useRenderProps} from './utils';
 import {Color} from 'react-stately';
 import {filterDOMProps} from '@react-aria/utils';
 import {GlobalDOMAttributes, HoverEvents, RefObject} from '@react-types/shared';
 import {mergeProps, useFocusRing, useHover} from 'react-aria';
 import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, InputHTMLAttributes, useContext} from 'react';
-import {RenderProps, useRenderProps} from './utils';
 
 interface ColorState {
   getDisplayColor(): Color,
@@ -54,7 +54,13 @@ export interface ColorThumbRenderProps {
   isDisabled: boolean
 }
 
-export interface ColorThumbProps extends HoverEvents, RenderProps<ColorThumbRenderProps>, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ColorThumbProps extends HoverEvents, RenderProps<ColorThumbRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorThumb'
+   */
+  className?: ClassNameOrFunction<ColorThumbRenderProps>
+}
 
 /**
  * A color thumb appears within a ColorArea, ColorSlider, or ColorWheel and allows a user to drag to adjust the color value.

--- a/packages/react-aria-components/src/ColorWheel.tsx
+++ b/packages/react-aria-components/src/ColorWheel.tsx
@@ -1,7 +1,16 @@
 import {AriaColorWheelOptions, useColorWheel} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {ColorWheelContext} from './RSPContexts';
 import {ColorWheelState, useColorWheelState} from 'react-stately';
-import {ContextValue, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {GlobalDOMAttributes} from '@react-types/shared';
 import {InternalColorThumbContext} from './ColorThumb';
@@ -19,7 +28,13 @@ export interface ColorWheelRenderProps {
   state: ColorWheelState
 }
 
-export interface ColorWheelProps extends AriaColorWheelOptions, RenderProps<ColorWheelRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ColorWheelProps extends AriaColorWheelOptions, RenderProps<ColorWheelRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorWheel'
+   */
+  className?: ClassNameOrFunction<ColorWheelRenderProps>
+}
 
 export const ColorWheelStateContext = createContext<ColorWheelState | null>(null);
 
@@ -67,7 +82,13 @@ export const ColorWheel = forwardRef(function ColorWheel(props: ColorWheelProps,
 });
 
 export interface ColorWheelTrackRenderProps extends ColorWheelRenderProps {}
-export interface ColorWheelTrackProps extends StyleRenderProps<ColorWheelTrackRenderProps>, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ColorWheelTrackProps extends StyleRenderProps<ColorWheelTrackRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColorWheelTrack'
+   */
+  className?: ClassNameOrFunction<ColorWheelTrackRenderProps>
+}
 interface ColorWheelTrackContextValue extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'>, StyleRenderProps<ColorWheelTrackRenderProps> {}
 
 export const ColorWheelTrackContext = createContext<ContextValue<ColorWheelTrackContextValue, HTMLDivElement>>(null);

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -11,9 +11,21 @@
  */
 import {AriaComboBoxProps, useComboBox, useFilter} from 'react-aria';
 import {ButtonContext} from './Button';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {Collection, ComboBoxState, Node, useComboBoxState} from 'react-stately';
 import {CollectionBuilder} from '@react-aria/collections';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps, useResizeObserver} from '@react-aria/utils';
 import {FormContext} from './Form';
@@ -51,6 +63,11 @@ export interface ComboBoxRenderProps {
 }
 
 export interface ComboBoxProps<T extends object> extends Omit<AriaComboBoxProps<T>, 'children' | 'placeholder' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<ComboBoxRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ComboBox'
+   */
+  className?: ClassNameOrFunction<ComboBoxRenderProps>,
   /** The filter function used to determine if a option should be included in the combo box list. */
   defaultFilter?: (textValue: string, inputValue: string) => boolean,
   /**

--- a/packages/react-aria-components/src/DateField.tsx
+++ b/packages/react-aria-components/src/DateField.tsx
@@ -10,7 +10,20 @@
  * governing permissions and limitations under the License.
  */
 import {AriaDateFieldProps, AriaTimeFieldProps, DateValue, HoverEvents, mergeProps, TimeValue, useDateField, useDateSegment, useFocusRing, useHover, useLocale, useTimeField} from 'react-aria';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {createCalendar} from '@internationalized/date';
 import {DateFieldState, DateSegmentType, DateSegment as IDateSegment, TimeFieldState, useDateFieldState, useTimeFieldState} from 'react-stately';
 import {FieldErrorContext} from './FieldError';
@@ -45,8 +58,20 @@ export interface DateFieldRenderProps {
    */
   isReadOnly: boolean
 }
-export interface DateFieldProps<T extends DateValue> extends Omit<AriaDateFieldProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<DateFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
-export interface TimeFieldProps<T extends TimeValue> extends Omit<AriaTimeFieldProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<DateFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface DateFieldProps<T extends DateValue> extends Omit<AriaDateFieldProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<DateFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DateField'
+   */
+  className?: ClassNameOrFunction<DateFieldRenderProps>
+}
+export interface TimeFieldProps<T extends TimeValue> extends Omit<AriaTimeFieldProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<DateFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TimeField'
+   */
+  className?: ClassNameOrFunction<DateFieldRenderProps>
+}
 
 export const DateFieldContext = createContext<ContextValue<DateFieldProps<any>, HTMLDivElement>>(null);
 export const TimeFieldContext = createContext<ContextValue<TimeFieldProps<any>, HTMLDivElement>>(null);
@@ -225,6 +250,11 @@ export interface DateInputRenderProps {
 }
 
 export interface DateInputProps extends SlotProps, StyleRenderProps<DateInputRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DateInput'
+   */
+  className?: ClassNameOrFunction<DateInputRenderProps>,
   children: (segment: IDateSegment) => ReactElement
 }
 
@@ -332,6 +362,11 @@ export interface DateSegmentRenderProps extends Omit<IDateSegment, 'isEditable'>
 }
 
 export interface DateSegmentProps extends RenderProps<DateSegmentRenderProps>, HoverEvents, GlobalDOMAttributes<HTMLSpanElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DateSegment'
+   */
+  className?: ClassNameOrFunction<DateSegmentRenderProps>,
   segment: IDateSegment
 }
 

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -12,7 +12,19 @@
 import {AriaDatePickerProps, AriaDateRangePickerProps, DateValue, useDatePicker, useDateRangePicker, useFocusRing} from 'react-aria';
 import {ButtonContext} from './Button';
 import {CalendarContext, RangeCalendarContext} from './Calendar';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {DateFieldContext} from './DateField';
 import {DatePickerState, DatePickerStateOptions, DateRangePickerState, DateRangePickerStateOptions, useDatePickerState, useDateRangePickerState} from 'react-stately';
 import {DialogContext, OverlayTriggerStateContext} from './Dialog';
@@ -70,8 +82,20 @@ export interface DateRangePickerRenderProps extends Omit<DatePickerRenderProps, 
   state: DateRangePickerState
 }
 
-export interface DatePickerProps<T extends DateValue> extends Omit<AriaDatePickerProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, Pick<DatePickerStateOptions<T>, 'shouldCloseOnSelect'>, RACValidation, RenderProps<DatePickerRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
-export interface DateRangePickerProps<T extends DateValue> extends Omit<AriaDateRangePickerProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, Pick<DateRangePickerStateOptions<T>, 'shouldCloseOnSelect'>, RACValidation, RenderProps<DateRangePickerRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface DatePickerProps<T extends DateValue> extends Omit<AriaDatePickerProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, Pick<DatePickerStateOptions<T>, 'shouldCloseOnSelect'>, RACValidation, RenderProps<DatePickerRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DatePicker'
+   */
+  className?: ClassNameOrFunction<DatePickerRenderProps>
+}
+export interface DateRangePickerProps<T extends DateValue> extends Omit<AriaDateRangePickerProps<T>, 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, Pick<DateRangePickerStateOptions<T>, 'shouldCloseOnSelect'>, RACValidation, RenderProps<DateRangePickerRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DateRangePicker'
+   */
+  className?: ClassNameOrFunction<DateRangePickerRenderProps>
+}
 
 export const DatePickerContext = createContext<ContextValue<DatePickerProps<any>, HTMLDivElement>>(null);
 export const DateRangePickerContext = createContext<ContextValue<DateRangePickerProps<any>, HTMLDivElement>>(null);

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -30,6 +30,11 @@ export interface DialogRenderProps {
 }
 
 export interface DialogProps extends AriaDialogProps, StyleProps, SlotProps, GlobalDOMAttributes<HTMLElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-Dialog'
+   */
+  className?: string,
   /** Children of the dialog. A function may be provided to access a function to close the dialog. */
   children?: ReactNode | ((opts: DialogRenderProps) => ReactNode)
 }

--- a/packages/react-aria-components/src/Disclosure.tsx
+++ b/packages/react-aria-components/src/Disclosure.tsx
@@ -12,13 +12,28 @@
 
 import {AriaDisclosureProps, useDisclosure, useFocusRing} from 'react-aria';
 import {ButtonContext} from './Button';
-import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  Provider,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {DisclosureGroupState, DisclosureState, DisclosureGroupProps as StatelyDisclosureGroupProps, useDisclosureGroupState, useDisclosureState} from 'react-stately';
 import {DOMProps, forwardRefType, GlobalDOMAttributes, Key} from '@react-types/shared';
 import {filterDOMProps, mergeProps, mergeRefs, useId} from '@react-aria/utils';
 import React, {createContext, DOMAttributes, ForwardedRef, forwardRef, ReactNode, useContext} from 'react';
 
-export interface DisclosureGroupProps extends StatelyDisclosureGroupProps, RenderProps<DisclosureGroupRenderProps>, DOMProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface DisclosureGroupProps extends StatelyDisclosureGroupProps, RenderProps<DisclosureGroupRenderProps>, DOMProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DisclosureGroup'
+   */
+  className?: ClassNameOrFunction<DisclosureGroupRenderProps>
+}
 
 export interface DisclosureGroupRenderProps {
   /**
@@ -66,6 +81,11 @@ export const DisclosureGroup = forwardRef(function DisclosureGroup(props: Disclo
 });
 
 export interface DisclosureProps extends Omit<AriaDisclosureProps, 'children'>, RenderProps<DisclosureRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Disclosure'
+   */
+  className?: ClassNameOrFunction<DisclosureRenderProps>,
   /** An id for the disclosure when used within a DisclosureGroup, matching the id used in `expandedKeys`. */
   id?: Key
 }
@@ -187,6 +207,11 @@ export interface DisclosurePanelRenderProps {
 }
 
 export interface DisclosurePanelProps extends RenderProps<DisclosurePanelRenderProps>, DOMProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DisclosurePanel'
+   */
+  className?: ClassNameOrFunction<DisclosurePanelRenderProps>,
   /**
    * The accessibility role for the disclosure's panel.
    * @default 'group'

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 import type {DropIndicatorProps as AriaDropIndicatorProps, ItemDropTarget, Key} from 'react-aria';
+import type {ClassNameOrFunction, RenderProps} from './utils';
 import type {DragAndDropHooks} from './useDragAndDrop';
 import type {DraggableCollectionState, DroppableCollectionState, MultipleSelectionManager} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, JSX, ReactNode, useCallback, useContext, useMemo} from 'react';
-import type {RenderProps} from './utils';
 
 export interface DragAndDropContextValue {
   dragAndDropHooks?: DragAndDropHooks,
@@ -32,7 +32,13 @@ export interface DropIndicatorRenderProps {
   isDropTarget: boolean
 }
 
-export interface DropIndicatorProps extends Omit<AriaDropIndicatorProps, 'activateButtonRef'>, RenderProps<DropIndicatorRenderProps> { }
+export interface DropIndicatorProps extends Omit<AriaDropIndicatorProps, 'activateButtonRef'>, RenderProps<DropIndicatorRenderProps> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DropIndicator'
+   */
+  className?: ClassNameOrFunction<DropIndicatorRenderProps>
+}
 interface DropIndicatorContextValue {
   render: (props: DropIndicatorProps, ref: ForwardedRef<HTMLElement>) => ReactNode
 }

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -11,7 +11,15 @@
  */
 
 import {AriaLabelingProps, GlobalDOMAttributes, HoverEvents} from '@react-types/shared';
-import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {DropOptions, mergeProps, useButton, useClipboard, useDrop, useFocusRing, useHover, useLocalizedStringFormatter, VisuallyHidden} from 'react-aria';
 import {filterDOMProps, isFocusable, useLabels, useObjectRef, useSlotId} from '@react-aria/utils';
 // @ts-ignore
@@ -47,7 +55,13 @@ export interface DropZoneRenderProps {
   isDisabled: boolean
 }
 
-export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface DropZoneProps extends Omit<DropOptions, 'getDropOperationForPoint' | 'ref' | 'hasDropButton'>, HoverEvents, RenderProps<DropZoneRenderProps>, SlotProps, AriaLabelingProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-DropZone'
+   */
+  className?: ClassNameOrFunction<DropZoneRenderProps>
+}
 
 export const DropZoneContext = createContext<ContextValue<DropZoneProps, HTMLDivElement>>(null);
 

--- a/packages/react-aria-components/src/FieldError.tsx
+++ b/packages/react-aria-components/src/FieldError.tsx
@@ -10,16 +10,22 @@
  * governing permissions and limitations under the License.
  */
 
+import {ClassNameOrFunction, RenderProps, useRenderProps} from './utils';
 import {DOMProps, GlobalDOMAttributes, ValidationResult} from '@react-types/shared';
 import {filterDOMProps} from '@react-aria/utils';
 import React, {createContext, ForwardedRef, forwardRef, useContext} from 'react';
-import {RenderProps, useRenderProps} from './utils';
 import {Text} from './Text';
 
 export const FieldErrorContext = createContext<ValidationResult | null>(null);
 
 export interface FieldErrorRenderProps extends ValidationResult {}
-export interface FieldErrorProps extends RenderProps<FieldErrorRenderProps>, DOMProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface FieldErrorProps extends RenderProps<FieldErrorRenderProps>, DOMProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-FieldError'
+   */
+  className?: ClassNameOrFunction<FieldErrorRenderProps>
+}
 
 /**
  * A FieldError displays validation errors for a form field.

--- a/packages/react-aria-components/src/Form.tsx
+++ b/packages/react-aria-components/src/Form.tsx
@@ -18,6 +18,11 @@ import {FormProps as SharedFormProps} from '@react-types/form';
 
 export interface FormProps extends SharedFormProps, DOMProps, GlobalDOMAttributes<HTMLFormElement> {
   /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-Form'
+   */
+  className?: string,
+  /**
    * Whether to use native HTML form validation to prevent form submission
    * when a field value is missing or invalid, or mark fields as required
    * or invalid via ARIA.

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -12,9 +12,20 @@
 import {AriaGridListProps, DraggableItemResult, DragPreviewRenderer, DropIndicatorAria, DroppableCollectionResult, FocusScope, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing, useGridList, useGridListItem, useGridListSection, useGridListSelectionCheckbox, useHover, useLocale, useVisuallyHidden} from 'react-aria';
 import {ButtonContext} from './Button';
 import {CheckboxContext, FieldInputContext, SelectableCollectionContext, SelectableCollectionContextValue} from './RSPContexts';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {Collection, CollectionBuilder, createBranchComponent, createLeafComponent, HeaderNode, ItemNode, LoaderNode, SectionNode} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps, SectionProps} from './Collection';
-import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {DragAndDropContext, DropIndicatorContext, DropIndicatorProps, useDndPersistedKeys, useRenderDropIndicator} from './DragAndDrop';
 import {DragAndDropHooks} from './useDragAndDrop';
 import {DraggableCollectionState, DroppableCollectionState, Collection as ICollection, ListState, Node, SelectionBehavior, UNSTABLE_useFilteredListState, useListState} from 'react-stately';
@@ -59,6 +70,11 @@ export interface GridListRenderProps {
 }
 
 export interface GridListProps<T> extends Omit<AriaGridListProps<T>, 'children'>, CollectionProps<T>, StyleRenderProps<GridListRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-GridList'
+   */
+  className?: ClassNameOrFunction<GridListRenderProps>,
   /**
    * Whether typeahead navigation is disabled.
    * @default false
@@ -272,6 +288,11 @@ function GridListInner<T extends object>({props, collection, gridListRef: ref}: 
 export interface GridListItemRenderProps extends ItemRenderProps {}
 
 export interface GridListItemProps<T = object> extends RenderProps<GridListItemRenderProps>, LinkDOMProps, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-GridListItem'
+   */
+  className?: ClassNameOrFunction<GridListItemRenderProps>,
   /** The unique id of the item. */
   id?: Key,
   /** The object value that this item represents. When using dynamic collections, this is set automatically. */
@@ -515,6 +536,11 @@ function RootDropIndicator() {
 
 export interface GridListLoadMoreItemProps extends Omit<LoadMoreSentinelProps, 'collection'>, StyleProps, GlobalDOMAttributes<HTMLDivElement> {
   /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-GridListLoadMoreItem'
+   */
+  className?: string,
+  /**
    * The load more spinner to render when loading additional items.
    */
   children?: ReactNode,
@@ -573,7 +599,13 @@ export const GridListLoadMoreItem = createLeafComponent(LoaderNode, function Gri
   );
 });
 
-export interface GridListSectionProps<T> extends SectionProps<T> {}
+export interface GridListSectionProps<T> extends SectionProps<T> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-GridListSection'
+   */
+  className?: string
+}
 
 /**
  * A GridListSection represents a section within a GridList.

--- a/packages/react-aria-components/src/Group.tsx
+++ b/packages/react-aria-components/src/Group.tsx
@@ -11,7 +11,14 @@
  */
 
 import {AriaLabelingProps, DOMProps, forwardRefType} from '@react-types/shared';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+ ClassNameOrFunction,
+ ContextValue,
+ RenderProps,
+ SlotProps,
+ useContextProps,
+ useRenderProps
+} from './utils';
 import {HoverProps, mergeProps, useFocusRing, useHover} from 'react-aria';
 import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes} from 'react';
 
@@ -44,20 +51,25 @@ export interface GroupRenderProps {
 }
 
 export interface GroupProps extends AriaLabelingProps, Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style' | 'role' | 'slot'>, DOMProps, HoverProps, RenderProps<GroupRenderProps>, SlotProps {
-  /** Whether the group is disabled. */
-  isDisabled?: boolean,
-  /** Whether the group is invalid. */
-  isInvalid?: boolean,
-  /** Whether the group is read only. */
-  isReadOnly?: boolean,
-  /**
-   * An accessibility role for the group. By default, this is set to `'group'`.
-   * Use `'region'` when the contents of the group is important enough to be
-   * included in the page table of contents. Use `'presentation'` if the group
-   * is visual only and does not represent a semantic grouping of controls.
-   * @default 'group'
-   */
-  role?: 'group' | 'region' | 'presentation'
+ /**
+  * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+  * @default 'react-aria-Group'
+  */
+ className?: ClassNameOrFunction<GroupRenderProps>,
+ /** Whether the group is disabled. */
+ isDisabled?: boolean,
+ /** Whether the group is invalid. */
+ isInvalid?: boolean,
+ /** Whether the group is read only. */
+ isReadOnly?: boolean,
+ /**
+  * An accessibility role for the group. By default, this is set to `'group'`.
+  * Use `'region'` when the contents of the group is important enough to be
+  * included in the page table of contents. Use `'presentation'` if the group
+  * is visual only and does not represent a semantic grouping of controls.
+  * @default 'group'
+  */
+ role?: 'group' | 'region' | 'presentation'
 }
 
 export const GroupContext = createContext<ContextValue<GroupProps, HTMLDivElement>>({});

--- a/packages/react-aria-components/src/Input.tsx
+++ b/packages/react-aria-components/src/Input.tsx
@@ -10,7 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {ContextValue, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {
+ ClassNameOrFunction,
+ ContextValue,
+ StyleRenderProps,
+ useContextProps,
+ useRenderProps
+} from './utils';
 import {createHideableComponent} from '@react-aria/collections';
 import {HoverEvents, mergeProps, useFocusRing, useHover} from 'react-aria';
 import React, {createContext, ForwardedRef, InputHTMLAttributes} from 'react';
@@ -44,11 +50,16 @@ export interface InputRenderProps {
 }
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className' | 'style'>, HoverEvents, StyleRenderProps<InputRenderProps> {
-  /**
-   * Temporary text that occupies the text input when it is empty.
-   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/placeholder).
-   */
-  placeholder?: string
+ /**
+  * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+  * @default 'react-aria-Input'
+  */
+ className?: ClassNameOrFunction<InputRenderProps>,
+ /**
+  * Temporary text that occupies the text input when it is empty.
+  * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/placeholder).
+  */
+ placeholder?: string
 }
 
 export const InputContext = createContext<ContextValue<InputProps, HTMLInputElement>>({});

--- a/packages/react-aria-components/src/Link.tsx
+++ b/packages/react-aria-components/src/Link.tsx
@@ -11,12 +11,25 @@
  */
 
 import {AriaLinkOptions, HoverEvents, mergeProps, useFocusRing, useHover, useLink} from 'react-aria';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+ ClassNameOrFunction,
+ ContextValue,
+ RenderProps,
+ SlotProps,
+ useContextProps,
+ useRenderProps
+} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
 import React, {createContext, ElementType, ForwardedRef, forwardRef} from 'react';
 
-export interface LinkProps extends Omit<AriaLinkOptions, 'elementType'>, HoverEvents, RenderProps<LinkRenderProps>, SlotProps, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {}
+export interface LinkProps extends Omit<AriaLinkOptions, 'elementType'>, HoverEvents, RenderProps<LinkRenderProps>, SlotProps, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+ /**
+  * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+  * @default 'react-aria-Link'
+  */
+ className?: ClassNameOrFunction<LinkRenderProps>
+}
 
 export interface LinkRenderProps {
   /**

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -11,9 +11,21 @@
  */
 
 import {AriaListBoxOptions, AriaListBoxProps, DraggableItemResult, DragPreviewRenderer, DroppableCollectionResult, DroppableItemResult, FocusScope, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing, useHover, useListBox, useListBoxSection, useLocale, useOption} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps,
+  useSlot
+} from './utils';
 import {Collection, CollectionBuilder, createBranchComponent, createLeafComponent, ItemNode, LoaderNode, SectionNode} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, ItemRenderProps, SectionContext, SectionProps} from './Collection';
-import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {DragAndDropContext, DropIndicatorContext, DropIndicatorProps, useDndPersistedKeys, useRenderDropIndicator} from './DragAndDrop';
 import {DragAndDropHooks} from './useDragAndDrop';
 import {DraggableCollectionState, DroppableCollectionState, ListState, Node, Orientation, SelectionBehavior, UNSTABLE_useFilteredListState, useListState} from 'react-stately';
@@ -60,6 +72,11 @@ export interface ListBoxRenderProps {
 }
 
 export interface ListBoxProps<T> extends Omit<AriaListBoxProps<T>, 'children' | 'label'>, CollectionProps<T>, StyleRenderProps<ListBoxRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ListBox'
+   */
+  className?: ClassNameOrFunction<ListBoxRenderProps>,
   /**
    * How multiple selection should behave in the collection.
    * @default "toggle"
@@ -271,7 +288,13 @@ function ListBoxInner<T extends object>({state: inputState, props, listBoxRef}: 
   );
 }
 
-export interface ListBoxSectionProps<T> extends SectionProps<T> {}
+export interface ListBoxSectionProps<T> extends SectionProps<T> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-ListBoxSection'
+   */
+  className?: string
+}
 
 function ListBoxSectionInner<T extends object>(props: ListBoxSectionProps<T>, ref: ForwardedRef<HTMLElement>, section: Node<T>, className = 'react-aria-ListBoxSection') {
   let state = useContext(ListStateContext)!;
@@ -314,6 +337,11 @@ export const ListBoxSection = /*#__PURE__*/ createBranchComponent(SectionNode, L
 export interface ListBoxItemRenderProps extends ItemRenderProps {}
 
 export interface ListBoxItemProps<T = object> extends RenderProps<ListBoxItemRenderProps>, LinkDOMProps, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ListBoxItem'
+   */
+  className?: ClassNameOrFunction<ListBoxItemRenderProps>,
   /** The unique id of the item. */
   id?: Key,
   /** The object value that this item represents. When using dynamic collections, this is set automatically. */
@@ -475,6 +503,11 @@ function ListBoxDropIndicator(props: ListBoxDropIndicatorProps, ref: ForwardedRe
 const ListBoxDropIndicatorForwardRef = forwardRef(ListBoxDropIndicator);
 
 export interface ListBoxLoadMoreItemProps extends Omit<LoadMoreSentinelProps, 'collection'>, StyleProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-ListBoxLoadMoreItem'
+   */
+  className?: string,
   /**
    * The load more spinner to render when loading additional items.
    */

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -13,8 +13,20 @@
 import {AriaMenuProps, FocusScope, mergeProps, useHover, useMenu, useMenuItem, useMenuSection, useMenuTrigger, useSubmenuTrigger} from 'react-aria';
 import {BaseCollection, Collection, CollectionBuilder, CollectionNode, createBranchComponent, createLeafComponent, ItemNode, SectionNode} from '@react-aria/collections';
 import {MenuTriggerProps as BaseMenuTriggerProps, Collection as ICollection, Node, RootMenuTriggerState, TreeState, useMenuTriggerState, useSubmenuTriggerState, useTreeState} from 'react-stately';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {CollectionProps, CollectionRendererContext, ItemRenderProps, SectionContext, SectionProps, usePersistedKeys} from './Collection';
-import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
 import {FieldInputContext, SelectableCollectionContext, SelectableCollectionContextValue} from './RSPContexts';
 import {filterDOMProps, useObjectRef, useResizeObserver} from '@react-aria/utils';
 import {FocusStrategy, forwardRefType, GlobalDOMAttributes, HoverEvents, Key, LinkDOMProps, MultipleSelection, PressEvents} from '@react-types/shared';
@@ -176,6 +188,11 @@ export interface MenuRenderProps {
 }
 
 export interface MenuProps<T> extends Omit<AriaMenuProps<T>, 'children'>, CollectionProps<T>, StyleRenderProps<MenuRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Menu'
+   */
+  className?: ClassNameOrFunction<MenuRenderProps>,
   /** Provides content to display when there are no items in the list. */
   renderEmptyState?: () => ReactNode
 }
@@ -272,7 +289,13 @@ function MenuInner<T extends object>({props, collection, menuRef: ref}: MenuInne
   );
 }
 
-export interface MenuSectionProps<T> extends SectionProps<T>, MultipleSelection {}
+export interface MenuSectionProps<T> extends SectionProps<T>, MultipleSelection {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-MenuSection'
+   */
+  className?: string
+}
 
 // A subclass of SelectionManager that forwards focus-related properties to the parent,
 // but has its own local selection state.
@@ -363,6 +386,11 @@ export interface MenuItemRenderProps extends ItemRenderProps {
 }
 
 export interface MenuItemProps<T = object> extends RenderProps<MenuItemRenderProps>, LinkDOMProps, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-MenuItem'
+   */
+  className?: ClassNameOrFunction<MenuItemRenderProps>,
   /** The unique id of the item. */
   id?: Key,
   /** The object value that this item represents. When using dynamic collections, this is set automatically. */

--- a/packages/react-aria-components/src/Meter.tsx
+++ b/packages/react-aria-components/src/Meter.tsx
@@ -12,13 +12,27 @@
 
 import {AriaMeterProps, useMeter} from 'react-aria';
 import {clamp} from '@react-stately/utils';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot
+} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
 import {LabelContext} from './Label';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
 
-export interface MeterProps extends Omit<AriaMeterProps, 'label'>, RenderProps<MeterRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface MeterProps extends Omit<AriaMeterProps, 'label'>, RenderProps<MeterRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Meter'
+   */
+  className?: ClassNameOrFunction<MeterRenderProps>
+}
 
 export interface MeterRenderProps {
   /**

--- a/packages/react-aria-components/src/Modal.tsx
+++ b/packages/react-aria-components/src/Modal.tsx
@@ -11,7 +11,15 @@
  */
 
 import {AriaModalOverlayProps, DismissButton, Overlay, useIsSSR, useModalOverlay} from 'react-aria';
-import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {DOMAttributes, forwardRefType, GlobalDOMAttributes, RefObject} from '@react-types/shared';
 import {filterDOMProps, isScrollable, mergeProps, mergeRefs, useEnterAnimation, useExitAnimation, useObjectRef, useViewportSize} from '@react-aria/utils';
 import {OverlayTriggerProps, OverlayTriggerState, useOverlayTriggerState} from 'react-stately';
@@ -19,6 +27,11 @@ import {OverlayTriggerStateContext} from './Dialog';
 import React, {createContext, ForwardedRef, forwardRef, useContext, useMemo, useRef} from 'react';
 
 export interface ModalOverlayProps extends AriaModalOverlayProps, OverlayTriggerProps, RenderProps<ModalRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ModalOverlay'
+   */
+  className?: ClassNameOrFunction<ModalRenderProps>,
   /**
    * Whether the modal is currently performing an entry animation.
    */
@@ -207,6 +220,11 @@ function ModalOverlayInner({UNSTABLE_portalContainer, ...props}: ModalOverlayInn
 }
 
 interface ModalContentProps extends RenderProps<ModalRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ModalContent'
+   */
+  className?: ClassNameOrFunction<ModalRenderProps>,
   modalRef: ForwardedRef<HTMLDivElement>
 }
 

--- a/packages/react-aria-components/src/NumberField.tsx
+++ b/packages/react-aria-components/src/NumberField.tsx
@@ -12,7 +12,19 @@
 
 import {AriaNumberFieldProps, useLocale, useNumberField} from 'react-aria';
 import {ButtonContext} from './Button';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps} from '@react-aria/utils';
 import {FormContext} from './Form';
@@ -46,7 +58,13 @@ export interface NumberFieldRenderProps {
   state: NumberFieldState
 }
 
-export interface NumberFieldProps extends Omit<AriaNumberFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, InputDOMProps, RenderProps<NumberFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface NumberFieldProps extends Omit<AriaNumberFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, InputDOMProps, RenderProps<NumberFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-NumberField'
+   */
+  className?: ClassNameOrFunction<NumberFieldRenderProps>
+}
 
 export const NumberFieldContext = createContext<ContextValue<NumberFieldProps, HTMLDivElement>>(null);
 export const NumberFieldStateContext = createContext<NumberFieldState | null>(null);

--- a/packages/react-aria-components/src/OverlayArrow.tsx
+++ b/packages/react-aria-components/src/OverlayArrow.tsx
@@ -10,7 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {ContextValue, RenderProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {DOMProps, forwardRefType} from '@react-types/shared';
 import {filterDOMProps} from '@react-aria/utils';
 import {PlacementAxis} from 'react-aria';
@@ -24,7 +30,13 @@ export const OverlayArrowContext = createContext<ContextValue<OverlayArrowContex
   placement: 'bottom'
 });
 
-export interface OverlayArrowProps extends Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style' | 'children'>, RenderProps<OverlayArrowRenderProps>, DOMProps {}
+export interface OverlayArrowProps extends Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style' | 'children'>, RenderProps<OverlayArrowRenderProps>, DOMProps {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-OverlayArrow'
+   */
+  className?: ClassNameOrFunction<OverlayArrowRenderProps>
+}
 
 export interface OverlayArrowRenderProps {
   /**

--- a/packages/react-aria-components/src/Popover.tsx
+++ b/packages/react-aria-components/src/Popover.tsx
@@ -12,7 +12,14 @@
 
 import {AriaLabelingProps, forwardRefType, GlobalDOMAttributes, RefObject} from '@react-types/shared';
 import {AriaPopoverProps, DismissButton, Overlay, PlacementAxis, PositionProps, useLocale, usePopover} from 'react-aria';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {filterDOMProps, mergeProps, useEnterAnimation, useExitAnimation, useLayoutEffect} from '@react-aria/utils';
 import {focusSafely} from '@react-aria/interactions';
 import {OverlayArrowContext} from './OverlayArrow';
@@ -22,6 +29,11 @@ import React, {Context, createContext, ForwardedRef, forwardRef, useContext, use
 import {useIsHidden} from '@react-aria/collections';
 
 export interface PopoverProps extends Omit<PositionProps, 'isOpen'>, Omit<AriaPopoverProps, 'popoverRef' | 'triggerRef' | 'groupRef' | 'offset' | 'arrowSize'>, OverlayTriggerProps, RenderProps<PopoverRenderProps>, SlotProps, AriaLabelingProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Popover'
+   */
+  className?: ClassNameOrFunction<PopoverRenderProps>,
   /**
    * The name of the component that triggered the popover. This is reflected on the element
    * as the `data-trigger` attribute, and can be used to provide specific

--- a/packages/react-aria-components/src/ProgressBar.tsx
+++ b/packages/react-aria-components/src/ProgressBar.tsx
@@ -12,13 +12,27 @@
 
 import {AriaProgressBarProps, useProgressBar} from 'react-aria';
 import {clamp} from '@react-stately/utils';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot
+} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {GlobalDOMAttributes} from '@react-types/shared';
 import {LabelContext} from './Label';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
 
-export interface ProgressBarProps extends Omit<AriaProgressBarProps, 'label'>, RenderProps<ProgressBarRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ProgressBarProps extends Omit<AriaProgressBarProps, 'label'>, RenderProps<ProgressBarRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ProgressBar'
+   */
+  className?: ClassNameOrFunction<ProgressBarRenderProps>
+}
 
 export interface ProgressBarRenderProps {
   /**

--- a/packages/react-aria-components/src/RadioGroup.tsx
+++ b/packages/react-aria-components/src/RadioGroup.tsx
@@ -11,7 +11,19 @@
  */
 
 import {AriaRadioGroupProps, AriaRadioProps, HoverEvents, Orientation, useFocusRing, useHover, useRadio, useRadioGroup, VisuallyHidden} from 'react-aria';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps, mergeProps, mergeRefs, useObjectRef} from '@react-aria/utils';
 import {FormContext} from './Form';
@@ -23,8 +35,19 @@ import {SelectionIndicatorContext} from './SelectionIndicator';
 import {SharedElementTransition} from './SharedElementTransition';
 import {TextContext} from './Text';
 
-export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface RadioGroupProps extends Omit<AriaRadioGroupProps, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<RadioGroupRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-RadioGroup'
+   */
+  className?: ClassNameOrFunction<RadioGroupRenderProps>
+}
 export interface RadioProps extends Omit<AriaRadioProps, 'children'>, HoverEvents, RenderProps<RadioRenderProps>, SlotProps, Omit<GlobalDOMAttributes<HTMLLabelElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Radio'
+   */
+  className?: ClassNameOrFunction<RadioRenderProps>,
   /**
    * A ref for the HTML input element.
    */

--- a/packages/react-aria-components/src/SearchField.tsx
+++ b/packages/react-aria-components/src/SearchField.tsx
@@ -12,7 +12,19 @@
 
 import {AriaSearchFieldProps, useSearchField} from 'react-aria';
 import {ButtonContext} from './Button';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {createHideableComponent} from '@react-aria/collections';
 import {FieldErrorContext} from './FieldError';
 import {FieldInputContext} from './RSPContexts';
@@ -48,7 +60,13 @@ export interface SearchFieldRenderProps {
   state: SearchFieldState
 }
 
-export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<SearchFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface SearchFieldProps extends Omit<AriaSearchFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, RenderProps<SearchFieldRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-SearchField'
+   */
+  className?: ClassNameOrFunction<SearchFieldRenderProps>
+}
 
 export const SearchFieldContext = createContext<ContextValue<SearchFieldProps, HTMLDivElement>>(null);
 

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -12,9 +12,21 @@
 
 import {AriaSelectProps, HiddenSelect, useFocusRing, useListFormatter, useLocalizedStringFormatter, useSelect} from 'react-aria';
 import {ButtonContext} from './Button';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {Collection, Node, SelectState, useSelectState} from 'react-stately';
 import {CollectionBuilder, createHideableComponent} from '@react-aria/collections';
-import {ContextValue, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps, mergeProps, useResizeObserver} from '@react-aria/utils';
 import {FormContext} from './Form';
@@ -65,6 +77,11 @@ export interface SelectRenderProps {
 }
 
 export interface SelectProps<T extends object = {}, M extends SelectionMode = 'single'> extends Omit<AriaSelectProps<T, M>, 'children' | 'label' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior' | 'items'>, RACValidation, RenderProps<SelectRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Select'
+   */
+  className?: ClassNameOrFunction<SelectRenderProps>,
   /**
    * Temporary text that occupies the select when it is empty.
    * @default 'Select an item' (localized)
@@ -243,7 +260,13 @@ export interface SelectValueRenderProps<T> {
   state: SelectState<T, 'single' | 'multiple'>
 }
 
-export interface SelectValueProps<T extends object> extends Omit<HTMLAttributes<HTMLElement>, keyof RenderProps<unknown>>, RenderProps<SelectValueRenderProps<T>> {}
+export interface SelectValueProps<T extends object> extends Omit<HTMLAttributes<HTMLElement>, keyof RenderProps<unknown>>, RenderProps<SelectValueRenderProps<T>> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-SelectValue'
+   */
+  className?: ClassNameOrFunction<SelectValueRenderProps<T>>
+}
 
 export const SelectValueContext = createContext<ContextValue<SelectValueProps<any>, HTMLSpanElement>>(null);
 

--- a/packages/react-aria-components/src/SelectionIndicator.tsx
+++ b/packages/react-aria-components/src/SelectionIndicator.tsx
@@ -10,11 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import {ContextValue, useContextProps} from './utils';
+import {ClassNameOrFunction, ContextValue, useContextProps} from './utils';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
-import {SharedElement, SharedElementPropsBase} from './SharedElementTransition';
+import {SharedElement, SharedElementPropsBase, SharedElementRenderProps} from './SharedElementTransition';
 
 export interface SelectionIndicatorProps extends SharedElementPropsBase {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-SelectionIndicator'
+   */
+  className?: ClassNameOrFunction<SharedElementRenderProps>,
+  /** Whether the SelectionIndicator is visible. This is usually set automatically by the parent component. */
   isSelected?: boolean
 }
 

--- a/packages/react-aria-components/src/Separator.tsx
+++ b/packages/react-aria-components/src/Separator.tsx
@@ -17,7 +17,13 @@ import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {GlobalDOMAttributes} from '@react-types/shared';
 import React, {createContext, ElementType, ForwardedRef} from 'react';
 
-export interface SeparatorProps extends AriaSeparatorProps, StyleProps, SlotProps, GlobalDOMAttributes<HTMLElement> {}
+export interface SeparatorProps extends AriaSeparatorProps, StyleProps, SlotProps, GlobalDOMAttributes<HTMLElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-Separator'
+   */
+  className?: string
+}
 
 export const SeparatorContext = createContext<ContextValue<SeparatorProps, HTMLElement>>({});
 

--- a/packages/react-aria-components/src/Slider.tsx
+++ b/packages/react-aria-components/src/Slider.tsx
@@ -11,7 +11,17 @@
  */
 
 import {AriaSliderProps, AriaSliderThumbProps, HoverEvents, mergeProps, Orientation, useFocusRing, useHover, useNumberFormatter, useSlider, useSliderThumb, VisuallyHidden} from 'react-aria';
-import {ContextValue, Provider, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, RefObject} from '@react-types/shared';
 import {LabelContext} from './Label';
@@ -19,6 +29,11 @@ import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, OutputHT
 import {SliderState, useSliderState} from 'react-stately';
 
 export interface SliderProps<T = number | number[]> extends Omit<AriaSliderProps<T>, 'label'>, RenderProps<SliderRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Slider'
+   */
+  className?: ClassNameOrFunction<SliderRenderProps>,
   /**
    * The display format of the value label.
    */
@@ -96,7 +111,13 @@ export const Slider = /*#__PURE__*/ (forwardRef as forwardRefType)(function Slid
   );
 });
 
-export interface SliderOutputProps extends RenderProps<SliderRenderProps>, GlobalDOMAttributes<HTMLOutputElement> {}
+export interface SliderOutputProps extends RenderProps<SliderRenderProps>, GlobalDOMAttributes<HTMLOutputElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-SliderOutput'
+   */
+  className?: ClassNameOrFunction<SliderRenderProps>
+}
 interface SliderOutputContextValue extends Omit<OutputHTMLAttributes<HTMLOutputElement>, 'children' | 'className' | 'style'>, SliderOutputProps {}
 
 /**
@@ -137,7 +158,13 @@ export interface SliderTrackRenderProps extends SliderRenderProps {
   isHovered: boolean
 }
 
-export interface SliderTrackProps extends HoverEvents, RenderProps<SliderTrackRenderProps>, GlobalDOMAttributes<HTMLDivElement> {}
+export interface SliderTrackProps extends HoverEvents, RenderProps<SliderTrackRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-SliderTrack'
+   */
+  className?: ClassNameOrFunction<SliderTrackRenderProps>
+}
 interface SliderTrackContextValue extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'className' | 'style'>, SliderTrackProps {}
 
 /**
@@ -203,6 +230,11 @@ export interface SliderThumbRenderProps {
 }
 
 export interface SliderThumbProps extends Omit<AriaSliderThumbProps, 'label' | 'validationState'>, HoverEvents, RenderProps<SliderThumbRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-SliderThumb'
+   */
+  className?: ClassNameOrFunction<SliderThumbRenderProps>,
   /**
    * A ref for the HTML input element.
    */

--- a/packages/react-aria-components/src/Switch.tsx
+++ b/packages/react-aria-components/src/Switch.tsx
@@ -11,17 +11,30 @@
  */
 
 import {AriaSwitchProps, HoverEvents, mergeProps, useFocusRing, useHover, useSwitch, VisuallyHidden} from 'react-aria';
-import {ContextValue, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+ ClassNameOrFunction,
+ ContextValue,
+ removeDataAttributes,
+ RenderProps,
+ SlotProps,
+ useContextProps,
+ useRenderProps
+} from './utils';
 import {filterDOMProps, mergeRefs, useObjectRef} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, RefObject} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
 import {ToggleState, useToggleState} from 'react-stately';
 
 export interface SwitchProps extends Omit<AriaSwitchProps, 'children'>, HoverEvents, RenderProps<SwitchRenderProps>, SlotProps, Omit<GlobalDOMAttributes<HTMLLabelElement>, 'onClick'> {
-  /**
-   * A ref for the HTML input element.
-   */
-  inputRef?: RefObject<HTMLInputElement | null>
+ /**
+  * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+  * @default 'react-aria-Switch'
+  */
+ className?: ClassNameOrFunction<SwitchRenderProps>,
+ /**
+  * A ref for the HTML input element.
+  */
+ inputRef?: RefObject<HTMLInputElement | null>
 }
 
 export interface SwitchRenderProps {

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -3,9 +3,21 @@ import {BaseCollection, Collection, CollectionBuilder, CollectionNode, createBra
 import {buildHeaderRows, TableColumnResizeState} from '@react-stately/table';
 import {ButtonContext} from './Button';
 import {CheckboxContext, FieldInputContext, SelectableCollectionContext, SelectableCollectionContextValue} from './RSPContexts';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  DOMProps,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps} from './Collection';
 import {ColumnSize, ColumnStaticSize, TableCollection as ITableCollection, TableProps as SharedTableProps} from '@react-types/table';
-import {ContextValue, DEFAULT_SLOT, DOMProps, Provider, RenderProps, SlotProps, StyleProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
 import {DisabledBehavior, DraggableCollectionState, DroppableCollectionState, MultipleSelectionState, Node, SelectionBehavior, SelectionMode, SortDirection, TableState, UNSTABLE_useFilteredTableState, useMultipleSelectionState, useTableColumnResizeState, useTableState} from 'react-stately';
 import {DragAndDropContext, DropIndicatorContext, DropIndicatorProps, useDndPersistedKeys, useRenderDropIndicator} from './DragAndDrop';
 import {DragAndDropHooks} from './useDragAndDrop';
@@ -208,6 +220,11 @@ const ResizableTableContainerContext = createContext<ResizableTableContainerCont
 
 export interface ResizableTableContainerProps extends DOMProps, GlobalDOMAttributes<HTMLDivElement> {
   /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-ResizableTableContainer'
+   */
+  className?: string,
+  /**
    * Handler that is called when a user starts a column resize.
    */
   onResizeStart?: (widths: Map<Key, ColumnSize>) => void,
@@ -306,6 +323,11 @@ export interface TableRenderProps {
 }
 
 export interface TableProps extends Omit<SharedTableProps<any>, 'children'>, StyleRenderProps<TableRenderProps>, SlotProps, AriaLabelingProps, GlobalDOMAttributes<HTMLTableElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Table'
+   */
+  className?: ClassNameOrFunction<TableRenderProps>,
   /** The elements that make up the table. Includes the TableHeader, TableBody, Columns, and Rows. */
   children?: ReactNode,
   /**
@@ -545,6 +567,11 @@ export interface TableHeaderRenderProps {
 }
 
 export interface TableHeaderProps<T> extends StyleRenderProps<TableHeaderRenderProps>, HoverEvents, GlobalDOMAttributes<HTMLTableSectionElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TableHeader'
+   */
+  className?: ClassNameOrFunction<TableHeaderRenderProps>,
   /** A list of table columns. */
   columns?: Iterable<T>,
   /** A list of `Column(s)` or a function. If the latter, a list of columns must be provided using the `columns` prop. */
@@ -676,6 +703,11 @@ export interface ColumnRenderProps {
 }
 
 export interface ColumnProps extends RenderProps<ColumnRenderProps>, GlobalDOMAttributes<HTMLTableHeaderCellElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Column'
+   */
+  className?: ClassNameOrFunction<ColumnRenderProps>,
   /** The unique id of the column. */
   id?: Key,
   /** Whether the column allows sorting. */
@@ -814,6 +846,11 @@ export interface ColumnResizerRenderProps {
 }
 
 export interface ColumnResizerProps extends HoverEvents, RenderProps<ColumnResizerRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ColumnResizer'
+   */
+  className?: ClassNameOrFunction<ColumnResizerRenderProps>,
   /** A custom accessibility label for the resizer. */
   'aria-label'?: string
 }
@@ -930,6 +967,11 @@ export interface TableBodyRenderProps {
 }
 
 export interface TableBodyProps<T> extends Omit<CollectionProps<T>, 'disabledKeys'>, StyleRenderProps<TableBodyRenderProps>, GlobalDOMAttributes<HTMLTableSectionElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TableBody'
+   */
+  className?: ClassNameOrFunction<TableBodyRenderProps>,
   /** Provides content to display when there are no rows in the table. */
   renderEmptyState?: (props: TableBodyRenderProps) => ReactNode
 }
@@ -1018,6 +1060,11 @@ export interface RowRenderProps extends ItemRenderProps {
 }
 
 export interface RowProps<T> extends StyleRenderProps<RowRenderProps>, LinkDOMProps, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLTableRowElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Row'
+   */
+  className?: ClassNameOrFunction<RowRenderProps>,
   /** A list of columns used when dynamically rendering cells. */
   columns?: Iterable<T>,
   /** The cells within the row. Supports static items or a function for dynamic rendering. */
@@ -1233,6 +1280,11 @@ export interface CellRenderProps {
 }
 
 export interface CellProps extends RenderProps<CellRenderProps>, GlobalDOMAttributes<HTMLTableCellElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Cell'
+   */
+  className?: ClassNameOrFunction<CellRenderProps>,
   /** The unique id of the cell. */
   id?: Key,
   /** A string representation of the cell's contents, used for features like typeahead. */
@@ -1393,6 +1445,11 @@ function RootDropIndicator() {
 }
 
 export interface TableLoadMoreItemProps extends Omit<LoadMoreSentinelProps, 'collection'>, StyleProps, GlobalDOMAttributes<HTMLTableRowElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-TableLoadMoreItem'
+   */
+  className?: string,
   /**
    * The load more spinner to render when loading additional items.
    */

--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -12,16 +12,32 @@
 
 import {AriaLabelingProps, forwardRefType, GlobalDOMAttributes, HoverEvents, Key, LinkDOMProps, PressEvents, RefObject} from '@react-types/shared';
 import {AriaTabListProps, AriaTabPanelProps, mergeProps, Orientation, useFocusRing, useHover, useTab, useTabList, useTabPanel} from 'react-aria';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps,
+  useSlottedContext
+} from './utils';
 import {Collection, CollectionBuilder, CollectionNode, createHideableComponent, createLeafComponent} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, usePersistedKeys} from './Collection';
-import {ContextValue, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlottedContext} from './utils';
 import {filterDOMProps, inertValue, useObjectRef} from '@react-aria/utils';
 import {Collection as ICollection, Node, TabListState, useTabListState} from 'react-stately';
 import React, {createContext, ForwardedRef, forwardRef, JSX, useContext, useMemo} from 'react';
 import {SelectionIndicatorContext} from './SelectionIndicator';
 import {SharedElementTransition} from './SharedElementTransition';
 
-export interface TabsProps extends Omit<AriaTabListProps<any>, 'items' | 'children'>, RenderProps<TabsRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface TabsProps extends Omit<AriaTabListProps<any>, 'items' | 'children'>, RenderProps<TabsRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Tabs'
+   */
+  className?: ClassNameOrFunction<TabsRenderProps>
+}
 
 export interface TabsRenderProps {
   /**
@@ -31,7 +47,13 @@ export interface TabsRenderProps {
   orientation: Orientation
 }
 
-export interface TabListProps<T> extends StyleRenderProps<TabListRenderProps>, AriaLabelingProps, Omit<CollectionProps<T>, 'disabledKeys'>, GlobalDOMAttributes<HTMLDivElement> {}
+export interface TabListProps<T> extends StyleRenderProps<TabListRenderProps>, AriaLabelingProps, Omit<CollectionProps<T>, 'disabledKeys'>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TabList'
+   */
+  className?: ClassNameOrFunction<TabListRenderProps>
+}
 
 export interface TabListRenderProps {
   /**
@@ -46,6 +68,11 @@ export interface TabListRenderProps {
 }
 
 export interface TabProps extends RenderProps<TabRenderProps>, AriaLabelingProps, LinkDOMProps, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Tab'
+   */
+  className?: ClassNameOrFunction<TabRenderProps>,
   /** The unique id of the tab. */
   id?: Key,
   /** Whether the tab is disabled. */
@@ -86,6 +113,11 @@ export interface TabRenderProps {
 }
 
 export interface TabPanelProps extends AriaTabPanelProps, RenderProps<TabPanelRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TabPanel'
+   */
+  className?: ClassNameOrFunction<TabPanelRenderProps>,
   /**
    * Whether to mount the tab panel in the DOM even when it is not currently selected.
    * Inactive tab panels are inert and cannot be interacted with. They must be styled appropriately so this is clear to the user visually.

--- a/packages/react-aria-components/src/TagGroup.tsx
+++ b/packages/react-aria-components/src/TagGroup.tsx
@@ -12,9 +12,20 @@
 
 import {AriaTagGroupProps, useFocusRing, useHover, useTag, useTagGroup} from 'react-aria';
 import {ButtonContext} from './Button';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DOMProps,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps,
+  useSlot
+} from './utils';
 import {Collection, CollectionBuilder, createLeafComponent, ItemNode} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps, usePersistedKeys} from './Collection';
-import {ContextValue, DOMProps, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps, useSlot} from './utils';
 import {filterDOMProps, mergeProps, useObjectRef} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, HoverEvents, Key, LinkDOMProps, PressEvents, RefObject} from '@react-types/shared';
 import {LabelContext} from './Label';
@@ -26,7 +37,13 @@ import {SelectionIndicatorContext} from './SelectionIndicator';
 import {SharedElementTransition} from './SharedElementTransition';
 import {TextContext} from './Text';
 
-export interface TagGroupProps extends Omit<AriaTagGroupProps<unknown>, 'children' | 'items' | 'label' | 'description' | 'errorMessage' | 'keyboardDelegate'>, DOMProps, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface TagGroupProps extends Omit<AriaTagGroupProps<unknown>, 'children' | 'items' | 'label' | 'description' | 'errorMessage' | 'keyboardDelegate'>, DOMProps, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element.
+   * @default 'react-aria-TagGroup'
+   */
+  className?: string
+}
 
 export interface TagListRenderProps {
   /**
@@ -51,6 +68,11 @@ export interface TagListRenderProps {
 }
 
 export interface TagListProps<T> extends Omit<CollectionProps<T>, 'disabledKeys'>, StyleRenderProps<TagListRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TagList'
+   */
+  className?: ClassNameOrFunction<TagListRenderProps>,
   /** Provides content to display when there are no items in the tag list. */
   renderEmptyState?: (props: TagListRenderProps) => ReactNode
 }
@@ -198,6 +220,11 @@ export interface TagRenderProps extends Omit<ItemRenderProps, 'allowsDragging' |
 }
 
 export interface TagProps extends RenderProps<TagRenderProps>, LinkDOMProps, HoverEvents, PressEvents, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Tag'
+   */
+  className?: ClassNameOrFunction<TagRenderProps>,
   /** A unique id for the tag. */
   id?: Key,
   /**

--- a/packages/react-aria-components/src/TextArea.tsx
+++ b/packages/react-aria-components/src/TextArea.tsx
@@ -1,9 +1,21 @@
-import {ContextValue, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {HoverEvents, mergeProps, useFocusRing, useHover} from 'react-aria';
 import {InputRenderProps} from './Input';
 import React, {createContext, ForwardedRef, forwardRef, TextareaHTMLAttributes} from 'react';
 
-export interface TextAreaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'className' | 'style'>, HoverEvents, StyleRenderProps<InputRenderProps> {}
+export interface TextAreaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'className' | 'style'>, HoverEvents, StyleRenderProps<InputRenderProps> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TextArea'
+   */
+  className?: ClassNameOrFunction<InputRenderProps>
+}
 
 export const TextAreaContext = createContext<ContextValue<TextAreaProps, HTMLTextAreaElement>>({});
 

--- a/packages/react-aria-components/src/TextField.tsx
+++ b/packages/react-aria-components/src/TextField.tsx
@@ -11,7 +11,20 @@
  */
 
 import {AriaTextFieldProps, useTextField} from 'react-aria';
-import {ContextValue, DOMProps, Provider, RACValidation, removeDataAttributes, RenderProps, SlotProps, useContextProps, useRenderProps, useSlot, useSlottedContext} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DOMProps,
+  Provider,
+  RACValidation,
+  removeDataAttributes,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps,
+  useSlot,
+  useSlottedContext
+} from './utils';
 import {createHideableComponent} from '@react-aria/collections';
 import {FieldErrorContext} from './FieldError';
 import {FieldInputContext} from './RSPContexts';
@@ -49,6 +62,11 @@ export interface TextFieldRenderProps {
 }
 
 export interface TextFieldProps extends Omit<AriaTextFieldProps, 'label' | 'placeholder' | 'description' | 'errorMessage' | 'validationState' | 'validationBehavior'>, RACValidation, Omit<DOMProps, 'style' | 'className' | 'children'>, SlotProps, RenderProps<TextFieldRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TextField'
+   */
+  className?: ClassNameOrFunction<TextFieldRenderProps>,
   /** Whether the value is invalid. */
   isInvalid?: boolean
 }

--- a/packages/react-aria-components/src/Toast.tsx
+++ b/packages/react-aria-components/src/Toast.tsx
@@ -12,7 +12,16 @@
 
 import {AriaToastProps, AriaToastRegionProps, mergeProps, useFocusRing, useHover, useLocale, useToast, useToastRegion} from 'react-aria';
 import {ButtonContext} from './Button';
-import {ContextValue, DEFAULT_SLOT, Provider, RenderProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  Provider,
+  RenderProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {createPortal} from 'react-dom';
 import {filterDOMProps, useObjectRef} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
@@ -45,6 +54,11 @@ export interface ToastRegionRenderProps<T> {
 }
 
 export interface ToastRegionProps<T> extends AriaToastRegionProps, StyleRenderProps<ToastRegionRenderProps<T>>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ToastRegion'
+   */
+  className?: ClassNameOrFunction<ToastRegionRenderProps<T>>,
   /** The queue of toasts to display. */
   queue: ToastQueue<T>,
   /** A function to render each toast, or children containing a `<ToastList>`. */
@@ -153,7 +167,13 @@ export interface ToastRenderProps<T> {
   isFocusVisible: boolean
 }
 
-export interface ToastProps<T> extends AriaToastProps<T>, RenderProps<ToastRenderProps<T>>, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ToastProps<T> extends AriaToastProps<T>, RenderProps<ToastRenderProps<T>>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Toast'
+   */
+  className?: ClassNameOrFunction<ToastRenderProps<T>>
+}
 
 /**
  * A Toast displays a brief, temporary notification of actions, errors, or other events in an application.

--- a/packages/react-aria-components/src/ToggleButton.tsx
+++ b/packages/react-aria-components/src/ToggleButton.tsx
@@ -12,7 +12,14 @@
 
 import {AriaToggleButtonProps, HoverEvents, mergeProps, useFocusRing, useHover, useToggleButton, useToggleButtonGroupItem} from 'react-aria';
 import {ButtonRenderProps} from './Button';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {filterDOMProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, Key} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef, useContext} from 'react';
@@ -33,6 +40,11 @@ export interface ToggleButtonRenderProps extends Omit<ButtonRenderProps, 'isPend
 }
 
 export interface ToggleButtonProps extends Omit<AriaToggleButtonProps, 'children' | 'elementType' | 'id'>, HoverEvents, SlotProps, RenderProps<ToggleButtonRenderProps>, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ToggleButton'
+   */
+  className?: ClassNameOrFunction<ToggleButtonRenderProps>,
   /** When used in a ToggleButtonGroup, an identifier for the item in `selectedKeys`. When used standalone, a DOM id. */
   id?: Key
 }

--- a/packages/react-aria-components/src/ToggleButtonGroup.tsx
+++ b/packages/react-aria-components/src/ToggleButtonGroup.tsx
@@ -10,7 +10,14 @@
  * governing permissions and limitations under the License.
  */
 import {AriaToggleButtonGroupProps, useToggleButtonGroup} from 'react-aria';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
@@ -29,7 +36,13 @@ export interface ToggleButtonGroupRenderProps {
   state: ToggleGroupState
 }
 
-export interface ToggleButtonGroupProps extends AriaToggleButtonGroupProps, RenderProps<ToggleButtonGroupRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {}
+export interface ToggleButtonGroupProps extends AriaToggleButtonGroupProps, RenderProps<ToggleButtonGroupRenderProps>, SlotProps, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-ToggleButtonGroup'
+   */
+  className?: ClassNameOrFunction<ToggleButtonGroupRenderProps>
+}
 
 export const ToggleButtonGroupContext = createContext<ContextValue<ToggleButtonGroupProps, HTMLDivElement>>({});
 export const ToggleGroupStateContext = createContext<ToggleGroupState | null>(null);

--- a/packages/react-aria-components/src/Toolbar.tsx
+++ b/packages/react-aria-components/src/Toolbar.tsx
@@ -11,7 +11,14 @@
  */
 
 import {AriaToolbarProps, useToolbar} from '@react-aria/toolbar';
-import {ContextValue, RenderProps, SlotProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  RenderProps,
+  SlotProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {filterDOMProps, mergeProps} from '@react-aria/utils';
 import {forwardRefType, GlobalDOMAttributes, Orientation} from '@react-types/shared';
 import React, {createContext, ForwardedRef, forwardRef} from 'react';
@@ -25,6 +32,11 @@ export interface ToolbarRenderProps {
 }
 
 export interface ToolbarProps extends AriaToolbarProps, SlotProps, RenderProps<ToolbarRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Toolbar'
+   */
+  className?: ClassNameOrFunction<ToolbarRenderProps>
 }
 
 export const ToolbarContext = createContext<ContextValue<ToolbarProps, HTMLDivElement>>({});

--- a/packages/react-aria-components/src/Tooltip.tsx
+++ b/packages/react-aria-components/src/Tooltip.tsx
@@ -12,7 +12,14 @@
 
 import {AriaLabelingProps, FocusableElement, forwardRefType, GlobalDOMAttributes, RefObject} from '@react-types/shared';
 import {AriaPositionProps, mergeProps, OverlayContainer, Placement, PlacementAxis, PositionProps, useOverlayPosition, useTooltip, useTooltipTrigger} from 'react-aria';
-import {ContextValue, Provider, RenderProps, useContextProps, useRenderProps} from './utils';
+import {
+  ClassNameOrFunction,
+  ContextValue,
+  Provider,
+  RenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {filterDOMProps, useEnterAnimation, useExitAnimation} from '@react-aria/utils';
 import {FocusableProvider} from '@react-aria/focus';
 import {OverlayArrowContext} from './OverlayArrow';
@@ -24,6 +31,11 @@ export interface TooltipTriggerComponentProps extends TooltipTriggerProps {
 }
 
 export interface TooltipProps extends PositionProps, Pick<AriaPositionProps, 'arrowBoundaryOffset'>, OverlayTriggerProps, AriaLabelingProps, RenderProps<TooltipRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Tooltip'
+   */
+  className?: ClassNameOrFunction<TooltipRenderProps>,
   /**
    * The ref for the element which the tooltip positions itself with respect to.
    *

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -13,7 +13,18 @@
 import {AriaTreeItemOptions, AriaTreeProps, DraggableItemResult, DropIndicatorAria, DropIndicatorProps, DroppableCollectionResult, FocusScope, ListKeyboardDelegate, mergeProps, useCollator, useFocusRing,  useGridListSelectionCheckbox, useHover, useId, useLocale, useTree, useTreeItem, useVisuallyHidden} from 'react-aria';
 import {ButtonContext} from './Button';
 import {CheckboxContext} from './RSPContexts';
-import {ChildrenOrFunction, ContextValue, DEFAULT_SLOT, Provider, RenderProps, SlotProps, StyleRenderProps, useContextProps, useRenderProps} from './utils';
+import {
+  ChildrenOrFunction,
+  ClassNameOrFunction,
+  ContextValue,
+  DEFAULT_SLOT,
+  Provider,
+  RenderProps,
+  SlotProps,
+  StyleRenderProps,
+  useContextProps,
+  useRenderProps
+} from './utils';
 import {Collection, CollectionBuilder, CollectionNode, createBranchComponent, createLeafComponent, LoaderNode, useCachedChildren} from '@react-aria/collections';
 import {CollectionProps, CollectionRendererContext, DefaultCollectionRenderer, ItemRenderProps} from './Collection';
 import {DisabledBehavior, DragPreviewRenderer, Expandable, forwardRefType, GlobalDOMAttributes, HoverEvents, Key, LinkDOMProps, MultipleSelection, PressEvents, RefObject, SelectionMode} from '@react-types/shared';
@@ -137,6 +148,11 @@ export interface TreeRenderProps {
 export interface TreeEmptyStateRenderProps extends Omit<TreeRenderProps, 'isEmpty'> {}
 
 export interface TreeProps<T> extends Omit<AriaTreeProps<T>, 'children'>, MultipleSelection, CollectionProps<T>, StyleRenderProps<TreeRenderProps>, SlotProps, Expandable, GlobalDOMAttributes<HTMLDivElement> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-Tree'
+   */
+  className?: ClassNameOrFunction<TreeRenderProps>,
   /**
    * How multiple selection should behave in the tree.
    * @default "toggle"
@@ -450,7 +466,10 @@ export interface TreeItemContentRenderProps extends TreeItemRenderProps {}
 
 // The TreeItemContent is the one that accepts RenderProps because we would get much more complicated logic in TreeItem otherwise since we'd
 // need to do a bunch of check to figure out what is the Content and what are the actual collection elements (aka child rows) of the TreeItem
-export interface TreeItemContentProps extends Pick<RenderProps<TreeItemContentRenderProps>, 'children'> {}
+export interface TreeItemContentProps {
+  /** The children of the component. A function may be provided to alter the children based on component state. */
+  children: ChildrenOrFunction<TreeItemContentRenderProps>
+}
 
 class TreeContentNode extends CollectionNode<any> {
   static readonly type = 'content';
@@ -472,6 +491,11 @@ export const TreeItemContent = /*#__PURE__*/ createLeafComponent(TreeContentNode
 export const TreeItemContentContext = createContext<TreeItemContentRenderProps | null>(null);
 
 export interface TreeItemProps<T = object> extends StyleRenderProps<TreeItemRenderProps>, LinkDOMProps, HoverEvents, PressEvents, Pick<AriaTreeItemOptions, 'hasChildItems'>, Omit<GlobalDOMAttributes<HTMLDivElement>, 'onClick'> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TreeItem'
+   */
+  className?: ClassNameOrFunction<TreeItemRenderProps>,
   /** The unique id of the tree row. */
   id?: Key,
   /** The object value that this tree item represents. When using dynamic collections, this is set automatically. */
@@ -628,39 +652,39 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent(TreeItemNode, <T ext
   return (
     <>
       {dropIndicator && !dropIndicator.isHidden && (
-        <div
-          role="row"
-          aria-level={rowProps['aria-level']}
-          aria-expanded={rowProps['aria-expanded']}
-          aria-label={dropIndicator.dropIndicatorProps['aria-label']}>
-          <div role="gridcell" aria-colindex={1} style={{display: 'contents'}}>
-            <div role="button" {...visuallyHiddenProps} {...dropIndicator.dropIndicatorProps} ref={dropIndicatorRef} />
-            {rowProps['aria-expanded'] != null ? (
-              // Button to allow touch screen reader users to expand the item while dragging.
-              <div
-                role="button"
-                {...visuallyHiddenProps}
-                id={activateButtonId}
-                aria-label={expandButtonProps['aria-label']}
-                aria-labelledby={`${activateButtonId} ${rowProps.id}`}
-                tabIndex={-1}
-                ref={activateButtonRef} />
-            ) : null}
-          </div>
+      <div
+        role="row"
+        aria-level={rowProps['aria-level']}
+        aria-expanded={rowProps['aria-expanded']}
+        aria-label={dropIndicator.dropIndicatorProps['aria-label']}>
+        <div role="gridcell" aria-colindex={1} style={{display: 'contents'}}>
+          <div role="button" {...visuallyHiddenProps} {...dropIndicator.dropIndicatorProps} ref={dropIndicatorRef} />
+          {rowProps['aria-expanded'] != null ? (
+            // Button to allow touch screen reader users to expand the item while dragging.
+            <div
+              role="button"
+              {...visuallyHiddenProps}
+              id={activateButtonId}
+              aria-label={expandButtonProps['aria-label']}
+              aria-labelledby={`${activateButtonId} ${rowProps.id}`}
+              tabIndex={-1}
+              ref={activateButtonRef} />
+          ) : null}
         </div>
-      )}
+      </div>
+    )}
       <div
         {...mergeProps(
-          DOMProps,
-          rowProps,
-          focusProps,
-          hoverProps,
-          focusWithinProps,
-          draggableItem?.dragProps
-        )}
+        DOMProps,
+        rowProps,
+        focusProps,
+        hoverProps,
+        focusWithinProps,
+        draggableItem?.dragProps
+      )}
         {...renderProps}
         ref={ref}
-        // TODO: missing selectionBehavior, hasAction and allowsSelection data attribute equivalents (available in renderProps). Do we want those?
+      // TODO: missing selectionBehavior, hasAction and allowsSelection data attribute equivalents (available in renderProps). Do we want those?
         data-expanded={(hasChildItems && isExpanded) || undefined}
         data-has-child-items={hasChildItems || undefined}
         data-level={level}
@@ -682,8 +706,8 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent(TreeItemNode, <T ext
                   selection: checkboxProps
                 }
               }],
-              // TODO: support description in the tree row
-              // TODO: don't think I need to pass isExpanded to the button here since it can be sourced from the renderProps? Might be worthwhile passing it down?
+            // TODO: support description in the tree row
+            // TODO: don't think I need to pass isExpanded to the button here since it can be sourced from the renderProps? Might be worthwhile passing it down?
               [ButtonContext, {
                 slots: {
                   [DEFAULT_SLOT]: {},
@@ -703,7 +727,7 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent(TreeItemNode, <T ext
               [TreeItemContentContext, {
                 ...renderPropValues
               }],
-              [SelectionIndicatorContext, {isSelected: states.isSelected}]
+            [SelectionIndicatorContext, {isSelected: states.isSelected}]
             ]}>
             {children}
           </Provider>
@@ -722,6 +746,11 @@ export interface TreeLoadMoreItemRenderProps {
 }
 
 export interface TreeLoadMoreItemProps extends Omit<LoadMoreSentinelProps, 'collection'>, RenderProps<TreeLoadMoreItemRenderProps> {
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state.
+   * @default 'react-aria-TreeLoadMoreItem'
+   */
+  className?: ClassNameOrFunction<TreeLoadMoreItemRenderProps>,
   /**
    * The load more spinner to render when loading additional items.
    */

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -63,7 +63,7 @@ export interface DOMProps extends StyleProps, SharedDOMProps {
   children?: ReactNode
 }
 
-type ClassNameOrFunction<T> = string | ((values: T & {defaultClassName: string | undefined}) => string);
+export type ClassNameOrFunction<T> = string | ((values: T & {defaultClassName: string | undefined}) => string);
 type StyleOrFunction<T> = CSSProperties | ((values: T & {defaultStyle: CSSProperties}) => CSSProperties | undefined);
 
 export interface StyleRenderProps<T> {


### PR DESCRIPTION
Adds a table for CSS variables exposed by each component, and ensures that all components have a default class name and render props table. This is now automatically generated by the `PropTable` component by extracting the default class name from the JS docs, and the render props from the types. So now you don't need to manually render a `StateTable` as well.