### PR TITLE
docs: Make component card heights match

### DIFF
--- a/packages/dev/s2-docs/src/ComponentCardView.tsx
+++ b/packages/dev/s2-docs/src/ComponentCardView.tsx
@@ -160,10 +160,36 @@ const componentIllustrations: Record<string, React.ComponentType | undefined> = 
   'usePress': usePressSvg
 };
 
-const illustrationStyles = style({
+// Overrides for specific illustrations so they fit within the cards.
+const propOverrides = {
+  DateField: {
+    viewBox: '0 -56 276 276'
+  },
+  TimeField: {
+    viewBox: '0 -56 276 276'
+  },
+  DatePicker: {
+    style: {alignSelf: 'end'}
+  },
+  DateRangePicker: {
+    style: {alignSelf: 'end'}
+  },
+  DropZone: {
+    viewBox: '0 0 290 220'
+  }
+};
+
+const illustrationContainer = style({
   width: 'full',
   aspectRatio: '3/2',
-  objectFit: 'cover',
+  backgroundColor: '--anatomy-gray-100',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
+});
+
+const illustrationStyles = style({
+  width: 'calc(100% - 16px)',
   userSelect: 'none',
   pointerEvents: 'none'
 });
@@ -183,13 +209,21 @@ export function ComponentCardView({items, ariaLabel = 'Items', size = 'S', onAct
       <Collection items={items}>
         {(item) => {
           let IllustrationComponent = componentIllustrations[item.name] || ComingSoonSvg;
+          let overrides = propOverrides[item.name] || {};
           return (
             <Card key={item.id} id={item.id} href={item.href} size={size} textValue={item.name}>
               <CardPreview>
-                <IllustrationComponent
-                  aria-hidden="true"
-                  // @ts-ignore
-                  className={illustrationStyles} />
+                <div className={illustrationContainer}>
+                  <IllustrationComponent
+                    {...overrides}
+                    aria-hidden="true"
+                    // @ts-ignore
+                    className={illustrationStyles}
+                    style={{
+                      ...overrides.style,
+                      maxHeight: 'calc(100% - 16px)'
+                    }} />
+                </div>
               </CardPreview>
               <Content>
                 <Text slot="title">{item.name}</Text>

--- a/packages/dev/s2-docs/src/ComponentCardView.tsx
+++ b/packages/dev/s2-docs/src/ComponentCardView.tsx
@@ -169,13 +169,24 @@ const propOverrides = {
     viewBox: '0 -56 276 276'
   },
   DatePicker: {
-    style: {alignSelf: 'end'}
+    style: {alignSelf: 'end', height: 'calc(100% - 16px)'}
   },
   DateRangePicker: {
-    style: {alignSelf: 'end'}
+    style: {alignSelf: 'end', height: 'calc(100% - 16px)'}
   },
   DropZone: {
-    viewBox: '0 0 290 220'
+    viewBox: '0 0 290 220',
+    style: {height: 'calc(100% - 16px)'}
+  },
+  Select: {
+    // Safari doesn't calculate the max-height correctly with the aspect-ratio.
+    style: {height: 'calc(100% - 16px)'}
+  },
+  Picker: {
+    style: {height: 'calc(100% - 16px)'}
+  },
+  ComboBox: {
+    style: {height: 'calc(100% - 16px)'}
   }
 };
 
@@ -185,11 +196,12 @@ const illustrationContainer = style({
   backgroundColor: '--anatomy-gray-100',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center'
+  justifyContent: 'center',
+  minHeight: 0
 });
 
 const illustrationStyles = style({
-  width: 'calc(100% - 16px)',
+  maxWidth: 'calc(100% - 16px)',
   userSelect: 'none',
   pointerEvents: 'none'
 });
@@ -220,8 +232,8 @@ export function ComponentCardView({items, ariaLabel = 'Items', size = 'S', onAct
                     // @ts-ignore
                     className={illustrationStyles}
                     style={{
-                      ...overrides.style,
-                      maxHeight: 'calc(100% - 16px)'
+                      maxHeight: 'calc(100% - 16px)',
+                      ...overrides.style
                     }} />
                 </div>
               </CardPreview>


### PR DESCRIPTION
Makes all the image heights match in the component cards. Needed a few overrides for certain SVGs which have hard coded dimensions for the old site. Eventually we'll replace all these images with new ones anyway, but this is better for now.