### PR TITLE
fix(scrollIntoViewport): add root to scrollParents

### DIFF
--- a/packages/@react-aria/utils/src/scrollIntoView.ts
+++ b/packages/@react-aria/utils/src/scrollIntoView.ts
@@ -151,6 +151,9 @@ export function scrollIntoViewport(targetElement: Element | null, opts?: ScrollI
     } else {
       let scrollParents = getScrollParents(targetElement);
       // If scrolling is prevented, we don't want to scroll the body since it might move the overlay partially offscreen and the user can't scroll it back into view.
+      if (!isScrollPrevented) {
+        scrollParents.push(root);
+      }
       for (let scrollParent of scrollParents) {
         scrollIntoView(scrollParent as HTMLElement, targetElement as HTMLElement);
       }


### PR DESCRIPTION
Closes #8977

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

For people on the team trying to test this, you can use the "Table with React Transition" RAC story, just make sure to shrink your window in such a way that the body is now scrollable. See https://reactspectrum.blob.core.windows.net/reactspectrum/9bf119be79af2a2d2b2605c23f67e0e10628fa76/storybook/index.html?path=/story/react-aria-components-table--table-with-react-transition&providerSwitcher-express=false on main for an example of the broken case

## 🧢 Your Project:

<!--- Company/project for pull request -->
