### PR TITLE
fix(Autocomplete): links not opening in new tab on meta key modifier

### DIFF
--- a/packages/@react-aria/autocomplete/src/useAutocomplete.ts
+++ b/packages/@react-aria/autocomplete/src/useAutocomplete.ts
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, BaseEvent, DOMProps, FocusableElement, FocusEvents, KeyboardEvents, Node, RefObject, ValueBase} from '@react-types/shared';
 import {AriaTextFieldProps} from '@react-aria/textfield';
 import {AutocompleteProps, AutocompleteState} from '@react-stately/autocomplete';
-import {CLEAR_FOCUS_EVENT, FOCUS_EVENT, getActiveElement, getOwnerDocument, isAndroid, isCtrlKeyPressed, isIOS, mergeProps, mergeRefs, useEffectEvent, useEvent, useId, useLabels, useObjectRef} from '@react-aria/utils';
+import {CLEAR_FOCUS_EVENT, FOCUS_EVENT, getActiveElement, getOwnerDocument, isAndroid, isCtrlKeyPressed, isIOS, mergeProps, mergeRefs, openLink, useEffectEvent, useEvent, useId, useLabels, useObjectRef} from '@react-aria/utils';
 import {dispatchVirtualBlur, dispatchVirtualFocus, getVirtuallyFocusedElement, moveVirtualFocus} from '@react-aria/focus';
 import {getInteractionModality} from '@react-aria/interactions';
 // @ts-ignore
@@ -311,7 +311,11 @@ export function useAutocomplete<T>(props: AriaAutocompleteOptions<T>, state: Aut
           // Trigger click action on item when Enter key was pressed.
           if (focusedNodeId != null) {
             let item = document.getElementById(focusedNodeId);
-            item?.click();
+            if (item instanceof HTMLAnchorElement && item.href) {
+              openLink(item, e.nativeEvent);
+            } else if (item) {
+              item.click();
+            }
           }
           break;
       }


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/8992

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to an Autocomplete story, keyboard navigate down to 'Google', press `⌘+Enter`, and verify that the link is opened in a new tab.

## 🧢 Your Project:

<!--- Company/project for pull request -->
