### PR TITLE
chore: revert adjust browserslist to compile optional chaining

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
-chrome >= 79
+chrome >= 88
 firefox >= 85
 safari >= 13
 edge >= 88


### PR DESCRIPTION
This reverts #2860 to reduce bundle sizes and improve runtime performance. This change was originally [scheduled for July 2022](https://github.com/adobe/react-spectrum/issues/2857#issuecomment-1042411379) so this should not come unexpected by now 😅

Noteworthy: Chrome 85+ addressed `scrollLeft` RTL compatibility [issues](https://issuetracker.google.com/issues/41319147), currently normalized by our virtualization utils, but simultaneously introduced new direction [issues](https://issuetracker.google.com/issues/40718740) with `scrollTop` 🫠 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
