### PR TITLE
Fix: Update description for ActionButtonGroup staticColor prop in S2

### DIFF
--- a/packages/@react-spectrum/s2/src/ActionButtonGroup.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButtonGroup.tsx
@@ -36,7 +36,7 @@ export interface ActionButtonGroupProps extends AriaLabelingProps, UnsafeStyles,
   isQuiet?: boolean,
   /** Whether the buttons should divide the container width equally. */
   isJustified?: boolean,
-  /** Whether the button should be displayed with an [emphasized style](https://spectrum.adobe.com/page/action-button/#Emphasis). */
+  /** The static color style to apply. Useful when the ActionButtonGroup appears over a color background. */
   staticColor?: 'white' | 'black' | 'auto',
   /**
    * The axis the group should align with.


### PR DESCRIPTION

## ✅ Pull Request Checklist:

- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).

## 📝 Test Instructions:

Check ActionButtonGroup staticColor prop description in docs

