### PR TITLE
fix: Styles on Group example to be more consistent

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Group.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Group.mdx
@@ -18,19 +18,19 @@ import {Input} from 'react-aria-components';
 
 <InputGroup/* PROPS */>
   <Input
-    size={3}
+    style={{width: '3ch', boxSizing: 'content-box'}}
     maxLength={3}
     aria-label="First 3 digits"
     placeholder="000" />
   –
   <Input
-    size={2}
+    style={{width: '2ch', boxSizing: 'content-box'}}
     maxLength={2}
     aria-label="Middle 2 digits"
     placeholder="00" />
   –
   <Input
-    size={4}
+    style={{width: '4ch', boxSizing: 'content-box'}}
     maxLength={4}
     aria-label="Last 4 digits"
     placeholder="0000" />


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Previously
<img width="168" height="84" alt="Screenshot 2025-10-21 at 1 00 06 pm" src="https://github.com/user-attachments/assets/5e2556b6-a3c4-462b-842d-31f6835c5fbe" />

Now
<img width="174" height="86" alt="Screenshot 2025-10-21 at 12 59 27 pm" src="https://github.com/user-attachments/assets/fb0a688f-2787-4380-9fcf-30beda050248" />

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
