### PR TITLE
fix: properly focus text area when tapping on invalid icon on mobile

### DIFF
--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -200,8 +200,8 @@ export const FieldGroup = forwardRef(function FieldGroup(props: FieldGroupProps,
           (e.currentTarget.querySelector('input, textarea') as HTMLElement)?.focus();
         }
       }}
-      onClick={e => {
-        if ((e.nativeEvent as PointerEvent).pointerType !== 'mouse' && !(e.target as Element).closest('button,input,textarea')) {
+      onTouchEnd={e => {
+        if (!(e.target as Element).closest('button,input,textarea')) {
           e.preventDefault();
           (e.currentTarget.querySelector('input, textarea') as HTMLElement)?.focus();
         }


### PR DESCRIPTION
From testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Try tapping on a S2 TextArea's invalid icon via a mobile device and verify that your virtual keyboard appears and you can then type into the field.

## 🧢 Your Project:

RSP
