### PR TITLE
fix(Toast): remove types from view transition

### DIFF
--- a/packages/@react-spectrum/s2/src/Toast.tsx
+++ b/packages/@react-spectrum/s2/src/Toast.tsx
@@ -68,10 +68,7 @@ function startViewTransition(fn: () => void, type: string) {
   if ('startViewTransition' in document) {
     // Safari doesn't support :active-view-transition-type() yet, so we fall back to a class on the html element.
     document.documentElement.classList.add(toastCss[type]);
-    let viewTransition = document.startViewTransition({
-      update: () => flushSync(fn),
-      types: [toastCss[type]]
-    });
+    let viewTransition = document.startViewTransition(() => flushSync(fn));
 
     viewTransition.ready.catch(() => {});
     viewTransition.finished.then(() => {


### PR DESCRIPTION
[Firefox Release 144.0](https://www.firefox.com/en-US/firefox/144.0/releasenotes/) added support for the View Transitions API, however it does not support the [callbackOptions](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition#browser_compatibility) parameter, so it would throw an error and not show the toast at all.

This PR updates the `startViewTransition` call to just pass the `updateCallback` in.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test S2 Toast in all major browser and confirm that toast is shown and removed with view transition.

## 🧢 Your Project:

<!--- Company/project for pull request -->
