### PR TITLE
fix(S2): XL avatar size in ActionButton

### DIFF
--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -251,12 +251,12 @@ export const btnStyles = style<ButtonRenderProps & ActionButtonStyleProps & Togg
 }, getAllowedOverrides());
 
 // Matching icon sizes. TBD.
-const avatarSize = {
+const avatarSize: Record<NonNullable<ActionButtonStyleProps['size']>, number> = {
   XS: 14,
   S: 16,
   M: 20,
   L: 22,
-  X: 26
+  XL: 26
 } as const;
 
 export const ActionButtonContext = createContext<ContextValue<Partial<ActionButtonProps>, FocusableRefValue<HTMLButtonElement>>>(null);


### PR DESCRIPTION
Avatar size for XL ActionButton should now be 26 instead of previously using default size of 24.  

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Verify in [story](https://reactspectrum.blob.core.windows.net/reactspectrum/0be05f8e426cc6e74aa6125715d304d94cd9f532/storybook-s2/index.html?path=/story/actionbutton--avatars&args=size:XL) that the avatar is 26x26.

## 🧢 Your Project:

<!--- Company/project for pull request -->
