### PR TITLE
docs: add supported locales to provider docs

### DIFF
--- a/packages/dev/s2-docs/pages/s2/Provider.mdx
+++ b/packages/dev/s2-docs/pages/s2/Provider.mdx
@@ -2,7 +2,7 @@ import {Layout} from '../../src/Layout';
 import {InstallCommand} from '../../src/InstallCommand';
 import {BundlerSwitcher, BundlerSwitcherItem} from '../../src/BundlerSwitcher';
 export default Layout;
-import {SegmentedControl, SegmentedControlItem} from '@react-spectrum/s2';
+import {Disclosure, DisclosureTitle, DisclosurePanel} from '@react-spectrum/s2';
 
 export const section = 'Components';
 import docs from 'docs:@react-spectrum/s2';
@@ -28,13 +28,57 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 ```
 
 ## Locales
-By default, React Spectrum chooses the locale matching the user’s browser/operating system language, but this can be overridden with the locale prop if you have an application specific setting. This prop accepts a [BCP 47](https://www.ietf.org/rfc/bcp/bcp47.txt) language code. A list of supported locales is available [here](Concepts.html#supported-locales)
+By default, React Spectrum chooses the locale matching the user’s browser/operating system language, but this can be overridden with the locale prop if you have an application specific setting. This prop accepts a [BCP 47](https://www.ietf.org/rfc/bcp/bcp47.txt) language code.
 
 ```tsx
 <Provider locale="en-US">
   <YourApp />
 </Provider>
 ```
+
+<Disclosure isQuiet>
+  <DisclosureTitle>Supported Locales</DisclosureTitle>
+  <DisclosurePanel>
+  <ul style={{columnWidth: 200, paddingLeft: 16, fontFamily: 'adobe-clean-spectrum-vf'}}>
+    <li>Arabic (United Arab Emirates)</li>
+    <li>Bulgarian (Bulgaria)</li>
+    <li>Chinese (Simplified)</li>
+    <li>Chinese (Traditional)</li>
+    <li>Croatian (Croatia)</li>
+    <li>Czech (Czech Republic)</li>
+    <li>Danish (Denmark)</li>
+    <li>Dutch (Netherlands)</li>
+    <li>English (Great Britain)</li>
+    <li>English (United States)</li>
+    <li>Estonian (Estonia)</li>
+    <li>Finnish (Finland)</li>
+    <li>French (Canada)</li>
+    <li>French (France)</li>
+    <li>German (Germany)</li>
+    <li>Greek (Greece)</li>
+    <li>Hebrew (Israel)</li>
+    <li>Hungarian (Hungary)</li>
+    <li>Italian (Italy)</li>
+    <li>Japanese (Japan)</li>
+    <li>Korean (Korea)</li>
+    <li>Latvian (Latvia)</li>
+    <li>Lithuanian (Lithuania)</li>
+    <li>Norwegian (Norway)</li>
+    <li>Polish (Poland)</li>
+    <li>Portuguese (Brazil)</li>
+    <li>Romanian (Romania)</li>
+    <li>Russian (Russia)</li>
+    <li>Serbian (Serbia)</li>
+    <li>Slovakian (Slovakia)</li>
+    <li>Slovenian (Slovenia)</li>
+    <li>Spanish (Spain)</li>
+    <li>Swedish (Sweden)</li>
+    <li>Turkish (Turkey)</li>
+    <li>Ukrainian (Ukraine)</li>
+  </ul>
+  </DisclosurePanel>
+</Disclosure>
+
 
 ## Client side routing
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to S2 provider docs page, go the locale section, make sure disclosure works

## 🧢 Your Project:

<!--- Company/project for pull request -->
