### PR TITLE
fix(docs): preserve trailing content after code comments in code output

### DIFF
--- a/packages/dev/s2-docs/src/Code.tsx
+++ b/packages/dev/s2-docs/src/Code.tsx
@@ -228,7 +228,7 @@ function renderHast(node: HastNode | HastTextNode, key: string, links?: Links, i
 
     // CodeProps includes the indent and newlines in case there are no props to show.
     if (node.tagName === 'div' && typeof childArray[0] === 'string' && /^\s+$/.test(childArray[0]) && React.isValidElement(childArray[1]) && childArray[1].type === CodeProps) {
-      children = childArray[1];
+      children = childArray.slice(1);
     }
 
     let tagName: any = node.tagName;


### PR DESCRIPTION
Previously we were discarding everything after the `/* PROPS */` comment, which resulted invalid JSX in code outputs. Outputs such as the following should now be fixed:  

```diff
<Disclosure
  styles={style({width: 250})}
+>
  <DisclosureTitle>System Requirements</DisclosureTitle>
  <DisclosurePanel>Details about system requirements here.</DisclosurePanel>
</Disclosure>
```

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Verify various code outputs are rendering correctly.

[Before](https://reactspectrum.blob.core.windows.net/reactspectrum/cf7c1541e5d46110bde75a2c7035461d5187fd1b/s2-docs/s2/Disclosure.html) -> [After](https://reactspectrum.blob.core.windows.net/reactspectrum/ec3889083b248f81455c1913aaa8c12074922e85/s2-docs/s2/Disclosure.html)

## 🧢 Your Project:

<!--- Company/project for pull request -->
