### PR TITLE
docs: Fix copying markdown in Safari

### DIFF
--- a/packages/dev/s2-docs/src/MarkdownMenu.tsx
+++ b/packages/dev/s2-docs/src/MarkdownMenu.tsx
@@ -15,6 +15,7 @@ interface MarkdownMenuProps {
 export function MarkdownMenu({url}: MarkdownMenuProps) {
   let mdUrl = (url ?? '').replace(/\.html?$/i, '') + '.md';
   let [isCopied, setIsCopied] = useState(false);
+  let [isPending, setPending] = useState(false);
   let timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   
   let pageUrl = typeof window !== 'undefined' && url ? new URL(url, window.location.origin).href : url ?? '';
@@ -38,6 +39,7 @@ export function MarkdownMenu({url}: MarkdownMenuProps) {
     }
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
       try {
+        setPending(true);
         await navigator.clipboard.write([
           new ClipboardItem({
             ['text/plain']: fetch(mdUrl).then(res => res.text())
@@ -47,13 +49,15 @@ export function MarkdownMenu({url}: MarkdownMenuProps) {
         timeout.current = setTimeout(() => setIsCopied(false), 2000);
       } catch {
         ToastQueue.negative('Failed to copy markdown.');
+      } finally {
+        setPending(false);
       }
     }
   }, [mdUrl]);
 
   return (
     <div className={style({display: 'flex', justifyContent: 'space-between', paddingX: 4, paddingBottom: 16})}>
-      <ActionButton isQuiet size="M" onPress={handleCopy}>
+      <ActionButton isQuiet size="M" onPress={handleCopy} isPending={isPending}>
         {isCopied ? <CheckmarkCircle /> : <Copy />}
         <Text>Copy for LLM</Text>
       </ActionButton>


### PR DESCRIPTION
Writing to the clipboard must be done within an event handler, and the fetch is asynchronous so this doesn't work in Safari. Instead, we can trigger the write synchronously but pass a promise to the `ClipboardItem` constructor.