### PR TITLE
docs: Fix plant images

### DIFF
--- a/packages/dev/s2-docs/.parcelrc-s2-docs
+++ b/packages/dev/s2-docs/.parcelrc-s2-docs
@@ -21,5 +21,6 @@
   },
   "packagers": {
     "*.json": "parcel-packager-docs"
-  }
+  },
+  "namers": ["./S2DocsNamer.js", "..."]
 }

--- a/packages/dev/s2-docs/S2DocsNamer.js
+++ b/packages/dev/s2-docs/S2DocsNamer.js
@@ -1,0 +1,12 @@
+const {Namer} = require('@parcel/plugin');
+const path = require('path');
+
+module.exports = new Namer({
+  name({bundle}) {
+    // Content hashing plant images messes up RSC parsing, and we don't expect these to ever change.
+    let asset = bundle.getMainEntry();
+    if (asset && asset.filePath.startsWith(path.join(__dirname, 'pages/react-aria/examples/plants/plants'))) {
+      return 'assets/plants/' + path.basename(asset.filePath);
+    }
+  }
+});

--- a/packages/dev/s2-docs/pages/react-aria/examples/plants/App.tsx
+++ b/packages/dev/s2-docs/pages/react-aria/examples/plants/App.tsx
@@ -121,7 +121,7 @@ export default function App(): React.ReactNode {
   };
 
   return (
-    <div className="h-full flex flex-col gap-4 p-4 max-w-[600px] mx-auto">
+    <div className="flex flex-col gap-4 p-4 max-w-[600px] mx-auto">
       <div className="grid grid-cols-[1fr_auto_auto] sm:grid-cols-[1.1fr_auto_auto_1fr_auto] gap-2 items-end">
         <SearchField
           aria-label="Search"

--- a/packages/dev/s2-docs/src/CodeBlock.tsx
+++ b/packages/dev/s2-docs/src/CodeBlock.tsx
@@ -1,5 +1,5 @@
 // @ts-ignore
-import assets from 'url:../pages/**/*.{png,jpg,svg}';
+import assets from 'url:../pages/**/*.{png,jpg,svg}' with {env: 'react-client'};
 import {cache, ReactNode} from 'react';
 import {Code, ICodeProps} from './Code';
 import {CodePlatter, FileProvider, Pre} from './CodePlatter';


### PR DESCRIPTION
Fixes Filterable CRUD Table example in production builds. This was broken in #9135 due to `plants.ts` being included in the downloadable ZIP. Parcel content hashes URLs by default, but this changes the length of the string which messes up the RSC payload. This changes those plant images to be non-content hashed, which should be fine since they should never change.