### PR TITLE
fix: ts-fork-point github ssh error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,6 @@ jobs:
           name: build fork-point apis
           command: |
             mkdir -p ~/.ssh
-            ssh-keygen -R github.com
             curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
             yarn build:api-branch --githash="origin/main" --output="base-api" && yarn build:api-branch && yarn compare:apis
 


### PR DESCRIPTION
Not exactly sure what changed, but GitHub seems to have updated their SSH keys. This will remove the old one from the known hosts and add the latest ones.

From https://stackoverflow.com/questions/47707922/error-the-authenticity-of-host-github-com-cant-be-established-rsa-key-finge