### PR TITLE
docs: fix scroll position restoration when navigating back/forward

### DIFF
--- a/packages/dev/s2-docs/src/client.tsx
+++ b/packages/dev/s2-docs/src/client.tsx
@@ -7,6 +7,11 @@ import {type ReactElement} from 'react';
 import {setNavigationPromise} from './Router';
 import {ToastQueue} from '@react-spectrum/s2';
 
+if ('scrollRestoration' in history) {
+  // Disable browser's automatic scroll restoration since we handle it manually
+  history.scrollRestoration = 'manual';
+}
+
 // Hydrate initial RSC payload embedded in the HTML.
 let updateRoot = hydrate({
   // Intercept HMR window reloads, and do it with RSC instead.


### PR DESCRIPTION
We need to handle this manually since we're using the scrollable container instead of the window.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Verify that scroll position is restored when navigating back/forward in the browser. Also verify that scroll positions are still accurate for hash links. Also test on mobile.

## 🧢 Your Project:

<!--- Company/project for pull request -->
