### PR TITLE
remove Node dependency (`typeof global`) from `domHelpers`

### DIFF
--- a/packages/@react-aria/utils/src/domHelpers.ts
+++ b/packages/@react-aria/utils/src/domHelpers.ts
@@ -3,8 +3,8 @@ export const getOwnerDocument = (el: Element | null | undefined): Document => {
 };
 
 export const getOwnerWindow = (
-  el: (Window & typeof global) | Element | null | undefined
-): Window & typeof global => {
+  el: Window | Element | null | undefined
+): Window => {
   if (el && 'window' in el && el.window === el) {
     return el;
   }


### PR DESCRIPTION
Closes #9250
