### PR TITLE
chore: fix docs build race condition

### DIFF
--- a/packages/dev/parcel-packager-docs/DocsPackager.js
+++ b/packages/dev/parcel-packager-docs/DocsPackager.js
@@ -13,25 +13,23 @@
 const {Packager} = require('@parcel/plugin');
 const v8 = require('v8');
 
-let cache = new Map();
-let nodes = {};
-
 module.exports = new Packager({
-  async loadBundleConfig() {
-    cache = new Map();
-    nodes = {};
-  },
   async package({bundle, bundleGraph, options}) {
+    let cache = new Map();
+    let nodes = {};
+
     let promises = [];
     bundle.traverseAssets(asset => {
       promises.push(parse(asset));
     });
 
     let code = new Map(await Promise.all(promises));
+    let entryAsset = bundle.getEntryAssets()[0];
+    let result;
     try {
-      var result = processAsset(bundle.getEntryAssets()[0]);
+      result = processAsset(entryAsset);
     } catch (err) {
-      console.log(err.stack);
+      throw new Error(`Failed to process docs for ${entryAsset?.filePath || 'unknown asset'}: ${err.message}\n${err.stack}`);
     }
 
     function processAsset(asset) {


### PR DESCRIPTION
Attempt to fix the intermittent build error:

```
🚨 Build failed.

@parcel/packager-react-static: An error occurred in the Server Components 
render. The specific message is omitted in production builds to avoid leaking 
sensitive details. A digest property is included on this error instance which 
may provide additional details about the nature of the error.

  Error: An error occurred in the Server Components render. The specific message
   is omitted in production builds to avoid leaking sensitive details. A digest 
  property is included on this error instance which may provide additional 
  details about the nature of the error.

make[1]: *** [Makefile:165: build-s2-docs] Error 1
make[1]: Leaving directory '/home/circleci/react-spectrum'
make: *** [Makefile:152: s2-docs] Error 2

Exited with code exit status 2
```

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
