### PR TITLE
fix: revert erroneous translation change for picker in sr-SP

### DIFF
--- a/packages/@react-spectrum/s2/intl/sr-SP.json
+++ b/packages/@react-spectrum/s2/intl/sr-SP.json
@@ -26,7 +26,7 @@
   "notificationbadge.indicatorOnly": "Nova aktivnost",
   "notificationbadge.plus": "{notifications}+",
   "picker.placeholder": "Izaberite...",
-  "picker.selectedCount": "{count, plural, =0 {No items selected} one {# item selected} other {# items selected}}",
+  "picker.selectedCount": "{count, plural, =0 {Nije izabrana nijedna stavka} one {Izabrana je # stavka} other {Izabrano je # stavki}}",
   "slider.maximum": "Najviše",
   "slider.minimum": "Najmanje",
   "table.cancel": "Otkaži",


### PR DESCRIPTION
In case we don't get a update by release

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
