### PR TITLE
fix: numberfield spinning indefinitely

### DIFF
--- a/packages/@react-aria/spinbutton/src/useSpinButton.ts
+++ b/packages/@react-aria/spinbutton/src/useSpinButton.ts
@@ -57,15 +57,17 @@ export function useSpinButton(
   } = props;
   const stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-aria/spinbutton');
 
-  let prevTouchPosition = useRef<{x: number, y: number} | null>(null);
   let isSpinning = useRef(false);
-  const clearAsync = () => {
+  const clearAsync = useCallback(() => {
     clearTimeout(_async.current);
     isSpinning.current = false;
-  };
+  }, []);
+  const clearAsyncEvent = useEffectEvent(() => {
+    clearAsync();
+  });
 
   useEffect(() => {
-    return () => clearAsync();
+    return () => clearAsyncEvent();
   }, []);
 
   let onKeyDown = (e) => {
@@ -140,21 +142,13 @@ export function useSpinButton(
   }, [ariaTextValue]);
 
   // For touch users, if they move their finger like they're scrolling, we don't want to trigger a spin.
-  let onTouchMove = useCallback((e) => {
-    if (!prevTouchPosition.current) {
-      prevTouchPosition.current = {x: e.touches[0].clientX, y: e.touches[0].clientY};
-    }
-    let touchPosition = {x: e.touches[0].clientX, y: e.touches[0].clientY};
-    // Arbitrary distance that worked in testing, even with slight movements or a slow-ish start to scrolling.
-    if (Math.abs(touchPosition.x - prevTouchPosition.current.x) > 1 || Math.abs(touchPosition.y - prevTouchPosition.current.y) > 1) {
-      clearAsync();
-    }
-    prevTouchPosition.current = touchPosition;
-  }, []);
+  let onPointerCancel = useCallback(() => {
+    clearAsync();
+  }, [clearAsync]);
 
   const onIncrementPressStart = useEffectEvent(
     (initialStepDelay: number) => {
-      clearAsync();
+      clearAsyncEvent();
       isSpinning.current = true;
       onIncrement?.();
       // Start spinning after initial delay
@@ -171,7 +165,7 @@ export function useSpinButton(
 
   const onDecrementPressStart = useEffectEvent(
     (initialStepDelay: number) => {
-      clearAsync();
+      clearAsyncEvent();
       isSpinning.current = true;
       onDecrement?.();
       // Start spinning after initial delay
@@ -239,7 +233,7 @@ export function useSpinButton(
             clearAsync();
           }
 
-          addGlobalListener(window, 'touchmove', onTouchMove, {capture: true});
+          addGlobalListener(window, 'pointercancel', onPointerCancel, {capture: true});
           isUp.current = false;
           // For touch users, don't trigger a decrement on press start, we'll wait for the press end to trigger it if
           // the control isn't spinning.
@@ -253,7 +247,6 @@ export function useSpinButton(
         if (e.pointerType === 'touch') {
           isUp.current = true;
         }
-        prevTouchPosition.current = null;
         clearAsync();
         removeAllGlobalListeners();
         setIsIncrementPressed(null);
@@ -263,6 +256,8 @@ export function useSpinButton(
           if (!isSpinning.current && isUp.current) {
             onIncrement?.();
           }
+        } else {
+          clearAsync();
         }
         isUp.current = false;
         setIsIncrementPressed(null);
@@ -279,7 +274,7 @@ export function useSpinButton(
             clearAsync();
           }
 
-          addGlobalListener(window, 'touchmove', onTouchMove, {capture: true});
+          addGlobalListener(window, 'pointercancel', onPointerCancel, {capture: true});
           isUp.current = false;
           // For touch users, don't trigger a decrement on press start, we'll wait for the press end to trigger it if
           // the control isn't spinning.
@@ -292,7 +287,6 @@ export function useSpinButton(
         if (e.pointerType === 'touch') {
           isUp.current = true;
         }
-        prevTouchPosition.current = null;
         clearAsync();
         removeAllGlobalListeners();
         setIsDecrementPressed(null);
@@ -302,6 +296,8 @@ export function useSpinButton(
           if (!isSpinning.current && isUp.current) {
             onDecrement?.();
           }
+        } else {
+          clearAsync();
         }
         isUp.current = false;
         setIsDecrementPressed(null);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Go to s2-docs for NumberField, press and hold on the increment or decrement button. While holding and spinning has started, mouse off. This spinning should stop. You can also mouse back on to continue the spinning afterwards.

This also simplifies the touch scrolling behaviour. On a mobile device, go to the same docs and try scrolling the page by starting on the increment/decrement button.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
