### PR TITLE
docs: add S2 style macro MCP tool

### DIFF
--- a/packages/dev/mcp/s2/scripts/build-data.mjs
+++ b/packages/dev/mcp/s2/scripts/build-data.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
+import {createRequire} from 'module';
 import fg from 'fast-glob';
 import {fileURLToPath, pathToFileURL} from 'url';
 import fs from 'fs';
 import path from 'path';
+// eslint-disable-next-line rulesdir/imports
+import * as ts from 'typescript';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,6 +16,7 @@ const ICONS_DIR = path.resolve(REPO_ROOT, 'packages/@react-spectrum/s2/s2wf-icon
 const ILLUSTRATIONS_DIR = path.resolve(REPO_ROOT, 'packages/@react-spectrum/s2/spectrum-illustrations/linear');
 const ICON_ALIASES_JS = path.resolve(REPO_ROOT, 'packages/dev/s2-docs/src/iconAliases.js');
 const ILLUSTRATION_ALIASES_JS = path.resolve(REPO_ROOT, 'packages/dev/s2-docs/src/illustrationAliases.js');
+const STYLE_PROPERTIES_TS = path.resolve(REPO_ROOT, 'packages/dev/s2-docs/src/styleProperties.ts');
 
 function ensureDir(p) {
   fs.mkdirSync(p, {recursive: true});
@@ -22,6 +26,23 @@ function writeJson(file, data) {
   ensureDir(path.dirname(file));
   fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n', 'utf8');
   console.log('Wrote', path.relative(REPO_ROOT, file));
+}
+
+async function importTsModule(tsFilePath) {
+  if (!fs.existsSync(tsFilePath)) {
+    throw new Error(`TS module not found: ${tsFilePath}`);
+  }
+  const sourceText = fs.readFileSync(tsFilePath, 'utf8');
+  const result = ts.transpileModule(sourceText, {
+    fileName: tsFilePath,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      esModuleInterop: true
+    }
+  });
+  const url = `data:text/javascript;base64,${Buffer.from(result.outputText, 'utf8').toString('base64')}`;
+  return import(url);
 }
 
 function buildIconNames() {
@@ -61,6 +82,107 @@ async function loadAliases(modPath, exportName) {
   return mod[exportName] ?? {};
 }
 
+function buildBaseColorKeysFromSpectrumTokens(tokens) {
+  const keys = new Set();
+
+  // Matches spectrum-theme.ts
+  keys.add('transparent');
+  keys.add('black');
+  keys.add('white');
+
+  const addScale = (scale) => {
+    const re = new RegExp(`^${scale}-\\d+$`);
+    for (const tokenName of Object.keys(tokens)) {
+      if (re.test(tokenName)) {
+        // Match @react-spectrum/s2/style/tokens.ts behavior: strip "-color" in the middle.
+        keys.add(tokenName.replace('-color', ''));
+      }
+    }
+  };
+
+  // Global color scales
+  for (const scale of [
+    'gray', 'blue', 'red', 'orange', 'yellow', 'chartreuse', 'celery', 'green',
+    'seafoam', 'cyan', 'indigo', 'purple', 'fuchsia', 'magenta', 'pink',
+    'turquoise', 'brown', 'silver', 'cinnamon'
+  ]) {
+    addScale(scale);
+  }
+
+  // Semantic color scales
+  for (const scale of ['accent-color', 'informative-color', 'negative-color', 'notice-color', 'positive-color']) {
+    addScale(scale);
+  }
+
+  // Simple transparent scales (names remain unchanged)
+  for (const scale of ['transparent-white', 'transparent-black']) {
+    const re = new RegExp(`^${scale}-\\d+$`);
+    for (const tokenName of Object.keys(tokens)) {
+      if (re.test(tokenName)) {
+        keys.add(tokenName);
+      }
+    }
+  }
+
+  // Overlay scale keys (derived in tokens.ts, we only need the names here)
+  for (const n of [25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]) {
+    keys.add(`transparent-overlay-${n}`);
+  }
+
+  // High contrast keywords (matches spectrum-theme.ts)
+  for (const k of ['Background', 'ButtonBorder', 'ButtonFace', 'ButtonText', 'Field', 'Highlight', 'HighlightText', 'GrayText', 'Mark', 'LinkText']) {
+    keys.add(k);
+  }
+
+  return Array.from(keys).sort((a, b) => a.localeCompare(b));
+}
+
+function buildExpandedStyleMacroPropertyValues(styleProperties, spacingTypeValues, baseColorKeys) {
+  const out = {};
+
+  for (const [propertyName, def] of Object.entries(styleProperties)) {
+    const values = [];
+    const seen = new Set();
+
+    const pushUnique = (items) => {
+      for (const v of items) {
+        const s = String(v);
+        if (!seen.has(s)) {
+          seen.add(s);
+          values.push(s);
+        }
+      }
+    };
+
+    // Expand 'baseColors' placeholder into actual color token names.
+    const expandedBase = [];
+    for (const v of def.values ?? []) {
+      if (v === 'baseColors') {
+        expandedBase.push(...baseColorKeys);
+      } else {
+        expandedBase.push(v);
+      }
+    }
+    pushUnique(expandedBase);
+
+    // Expand spacing type placeholders into the actual numeric values shown in docs.
+    const additionalTypes = Array.isArray(def.additionalTypes) ? def.additionalTypes : [];
+    if (additionalTypes.includes('baseSpacing')) {
+      pushUnique(spacingTypeValues?.baseSpacing ?? []);
+    }
+    if (additionalTypes.includes('negativeSpacing')) {
+      pushUnique(spacingTypeValues?.negativeSpacing ?? []);
+    }
+
+    out[propertyName] = {
+      values,
+      additionalTypes
+    };
+  }
+
+  return out;
+}
+
 async function main() {
   const icons = buildIconNames();
   const illustrations = buildIllustrationNames();
@@ -71,6 +193,22 @@ async function main() {
   writeJson(path.join(OUT_DIR, 'illustrations.json'), illustrations);
   writeJson(path.join(OUT_DIR, 'iconAliases.json'), iconAliases);
   writeJson(path.join(OUT_DIR, 'illustrationAliases.json'), illustrationAliases);
+
+  // Style macro property definitions
+  const stylePropsMod = await importTsModule(STYLE_PROPERTIES_TS);
+  const propertyCategories = ['color', 'dimensions', 'text', 'effects', 'layout', 'misc', 'conditions'];
+  const styleProperties = {};
+  for (const category of propertyCategories) {
+    Object.assign(styleProperties, stylePropsMod.getPropertyDefinitions(category));
+  }
+  Object.assign(styleProperties, stylePropsMod.getShorthandDefinitions());
+  writeJson(path.join(OUT_DIR, 'styleProperties.json'), styleProperties);
+
+  const require = createRequire(import.meta.url);
+  const spectrumTokens = require('@adobe/spectrum-tokens/dist/json/variables.json');
+  const baseColorKeys = buildBaseColorKeysFromSpectrumTokens(spectrumTokens);
+  const expanded = buildExpandedStyleMacroPropertyValues(styleProperties, stylePropsMod.spacingTypeValues, baseColorKeys);
+  writeJson(path.join(OUT_DIR, 'styleMacroPropertyValues.json'), expanded);
 }
 
 main().catch((err) => {

--- a/packages/dev/mcp/s2/src/s2-data.ts
+++ b/packages/dev/mcp/s2/src/s2-data.ts
@@ -9,6 +9,7 @@ let iconIdCache: string[] | null = null;
 let illustrationIdCache: string[] | null = null;
 let iconAliasesCache: Record<string, string[]> | null = null;
 let illustrationAliasesCache: Record<string, string[]> | null = null;
+let styleMacroPropertyValuesCache: Record<string, {values: string[], additionalTypes?: string[]}> | null = null;
 
 function readBundledJson(filename: string): any | null {
   try {
@@ -44,4 +45,13 @@ export async function loadIllustrationAliases(): Promise<Record<string, string[]
   if (illustrationAliasesCache) {return illustrationAliasesCache;}
   const bundled = readBundledJson('illustrationAliases.json');
   return (illustrationAliasesCache = (bundled && typeof bundled === 'object') ? bundled : {});
+}
+
+export function loadStyleMacroPropertyValues(): Record<string, {values: string[], additionalTypes?: string[]}> {
+  if (styleMacroPropertyValuesCache) {return styleMacroPropertyValuesCache;}
+  const bundled = readBundledJson('styleMacroPropertyValues.json');
+  if (!bundled || typeof bundled !== 'object' || Array.isArray(bundled)) {
+    return (styleMacroPropertyValuesCache = {});
+  }
+  return (styleMacroPropertyValuesCache = bundled as any);
 }


### PR DESCRIPTION
Adds a new `get_style_macro_property_values` tool to the S2 MCP server.

Example tool call:

```
get_style_macro_property_values(propertyName: 'backgroundColor')
```

<details>
<summary>Response</summary>

```json
{
   "values":[
      "accent",
      "accent-subtle",
      "neutral",
      "neutral-subdued",
      "neutral-subtle",
      "negative",
      "negative-subtle",
      "informative",
      "informative-subtle",
      "positive",
      "positive-subtle",
      "notice",
      "notice-subtle",
      "gray",
      "gray-subtle",
      "red",
      "red-subtle",
      "orange",
      "orange-subtle",
      "yellow",
      "yellow-subtle",
      "chartreuse",
      "chartreuse-subtle",
      "celery",
      "celery-subtle",
      "green",
      "green-subtle",
      "seafoam",
      "seafoam-subtle",
      "cyan",
      "cyan-subtle",
      "blue",
      "blue-subtle",
      "indigo",
      "indigo-subtle",
      "purple",
      "purple-subtle",
      "fuchsia",
      "fuchsia-subtle",
      "magenta",
      "magenta-subtle",
      "pink",
      "pink-subtle",
      "turquoise",
      "turquoise-subtle",
      "cinnamon",
      "cinnamon-subtle",
      "brown",
      "brown-subtle",
      "silver",
      "silver-subtle",
      "disabled",
      "base",
      "layer-1",
      "layer-2",
      "pasteboard",
      "elevated",
      "accent-100",
      "accent-1000",
      "accent-1100",
      "accent-1200",
      "accent-1300",
      "accent-1400",
      "accent-1500",
      "accent-1600",
      "accent-200",
      "accent-300",
      "accent-400",
      "accent-500",
      "accent-600",
      "accent-700",
      "accent-800",
      "accent-900",
      "Background",
      "black",
      "blue-100",
      "blue-1000",
      "blue-1100",
      "blue-1200",
      "blue-1300",
      "blue-1400",
      "blue-1500",
      "blue-1600",
      "blue-200",
      "blue-300",
      "blue-400",
      "blue-500",
      "blue-600",
      "blue-700",
      "blue-800",
      "blue-900",
      "brown-100",
      "brown-1000",
      "brown-1100",
      "brown-1200",
      "brown-1300",
      "brown-1400",
      "brown-1500",
      "brown-1600",
      "brown-200",
      "brown-300",
      "brown-400",
      "brown-500",
      "brown-600",
      "brown-700",
      "brown-800",
      "brown-900",
      "ButtonBorder",
      "ButtonFace",
      "ButtonText",
      "celery-100",
      "celery-1000",
      "celery-1100",
      "celery-1200",
      "celery-1300",
      "celery-1400",
      "celery-1500",
      "celery-1600",
      "celery-200",
      "celery-300",
      "celery-400",
      "celery-500",
      "celery-600",
      "celery-700",
      "celery-800",
      "celery-900",
      "chartreuse-100",
      "chartreuse-1000",
      "chartreuse-1100",
      "chartreuse-1200",
      "chartreuse-1300",
      "chartreuse-1400",
      "chartreuse-1500",
      "chartreuse-1600",
      "chartreuse-200",
      "chartreuse-300",
      "chartreuse-400",
      "chartreuse-500",
      "chartreuse-600",
      "chartreuse-700",
      "chartreuse-800",
      "chartreuse-900",
      "cinnamon-100",
      "cinnamon-1000",
      "cinnamon-1100",
      "cinnamon-1200",
      "cinnamon-1300",
      "cinnamon-1400",
      "cinnamon-1500",
      "cinnamon-1600",
      "cinnamon-200",
      "cinnamon-300",
      "cinnamon-400",
      "cinnamon-500",
      "cinnamon-600",
      "cinnamon-700",
      "cinnamon-800",
      "cinnamon-900",
      "cyan-100",
      "cyan-1000",
      "cyan-1100",
      "cyan-1200",
      "cyan-1300",
      "cyan-1400",
      "cyan-1500",
      "cyan-1600",
      "cyan-200",
      "cyan-300",
      "cyan-400",
      "cyan-500",
      "cyan-600",
      "cyan-700",
      "cyan-800",
      "cyan-900",
      "Field",
      "fuchsia-100",
      "fuchsia-1000",
      "fuchsia-1100",
      "fuchsia-1200",
      "fuchsia-1300",
      "fuchsia-1400",
      "fuchsia-1500",
      "fuchsia-1600",
      "fuchsia-200",
      "fuchsia-300",
      "fuchsia-400",
      "fuchsia-500",
      "fuchsia-600",
      "fuchsia-700",
      "fuchsia-800",
      "fuchsia-900",
      "gray-100",
      "gray-1000",
      "gray-200",
      "gray-25",
      "gray-300",
      "gray-400",
      "gray-50",
      "gray-500",
      "gray-600",
      "gray-700",
      "gray-75",
      "gray-800",
      "gray-900",
      "GrayText",
      "green-100",
      "green-1000",
      "green-1100",
      "green-1200",
      "green-1300",
      "green-1400",
      "green-1500",
      "green-1600",
      "green-200",
      "green-300",
      "green-400",
      "green-500",
      "green-600",
      "green-700",
      "green-800",
      "green-900",
      "Highlight",
      "HighlightText",
      "indigo-100",
      "indigo-1000",
      "indigo-1100",
      "indigo-1200",
      "indigo-1300",
      "indigo-1400",
      "indigo-1500",
      "indigo-1600",
      "indigo-200",
      "indigo-300",
      "indigo-400",
      "indigo-500",
      "indigo-600",
      "indigo-700",
      "indigo-800",
      "indigo-900",
      "informative-100",
      "informative-1000",
      "informative-1100",
      "informative-1200",
      "informative-1300",
      "informative-1400",
      "informative-1500",
      "informative-1600",
      "informative-200",
      "informative-300",
      "informative-400",
      "informative-500",
      "informative-600",
      "informative-700",
      "informative-800",
      "informative-900",
      "LinkText",
      "magenta-100",
      "magenta-1000",
      "magenta-1100",
      "magenta-1200",
      "magenta-1300",
      "magenta-1400",
      "magenta-1500",
      "magenta-1600",
      "magenta-200",
      "magenta-300",
      "magenta-400",
      "magenta-500",
      "magenta-600",
      "magenta-700",
      "magenta-800",
      "magenta-900",
      "Mark",
      "negative-100",
      "negative-1000",
      "negative-1100",
      "negative-1200",
      "negative-1300",
      "negative-1400",
      "negative-1500",
      "negative-1600",
      "negative-200",
      "negative-300",
      "negative-400",
      "negative-500",
      "negative-600",
      "negative-700",
      "negative-800",
      "negative-900",
      "notice-100",
      "notice-1000",
      "notice-1100",
      "notice-1200",
      "notice-1300",
      "notice-1400",
      "notice-1500",
      "notice-1600",
      "notice-200",
      "notice-300",
      "notice-400",
      "notice-500",
      "notice-600",
      "notice-700",
      "notice-800",
      "notice-900",
      "orange-100",
      "orange-1000",
      "orange-1100",
      "orange-1200",
      "orange-1300",
      "orange-1400",
      "orange-1500",
      "orange-1600",
      "orange-200",
      "orange-300",
      "orange-400",
      "orange-500",
      "orange-600",
      "orange-700",
      "orange-800",
      "orange-900",
      "pink-100",
      "pink-1000",
      "pink-1100",
      "pink-1200",
      "pink-1300",
      "pink-1400",
      "pink-1500",
      "pink-1600",
      "pink-200",
      "pink-300",
      "pink-400",
      "pink-500",
      "pink-600",
      "pink-700",
      "pink-800",
      "pink-900",
      "positive-100",
      "positive-1000",
      "positive-1100",
      "positive-1200",
      "positive-1300",
      "positive-1400",
      "positive-1500",
      "positive-1600",
      "positive-200",
      "positive-300",
      "positive-400",
      "positive-500",
      "positive-600",
      "positive-700",
      "positive-800",
      "positive-900",
      "purple-100",
      "purple-1000",
      "purple-1100",
      "purple-1200",
      "purple-1300",
      "purple-1400",
      "purple-1500",
      "purple-1600",
      "purple-200",
      "purple-300",
      "purple-400",
      "purple-500",
      "purple-600",
      "purple-700",
      "purple-800",
      "purple-900",
      "red-100",
      "red-1000",
      "red-1100",
      "red-1200",
      "red-1300",
      "red-1400",
      "red-1500",
      "red-1600",
      "red-200",
      "red-300",
      "red-400",
      "red-500",
      "red-600",
      "red-700",
      "red-800",
      "red-900",
      "seafoam-100",
      "seafoam-1000",
      "seafoam-1100",
      "seafoam-1200",
      "seafoam-1300",
      "seafoam-1400",
      "seafoam-1500",
      "seafoam-1600",
      "seafoam-200",
      "seafoam-300",
      "seafoam-400",
      "seafoam-500",
      "seafoam-600",
      "seafoam-700",
      "seafoam-800",
      "seafoam-900",
      "silver-100",
      "silver-1000",
      "silver-1100",
      "silver-1200",
      "silver-1300",
      "silver-1400",
      "silver-1500",
      "silver-1600",
      "silver-200",
      "silver-300",
      "silver-400",
      "silver-500",
      "silver-600",
      "silver-700",
      "silver-800",
      "silver-900",
      "transparent",
      "transparent-black-100",
      "transparent-black-1000",
      "transparent-black-200",
      "transparent-black-25",
      "transparent-black-300",
      "transparent-black-400",
      "transparent-black-50",
      "transparent-black-500",
      "transparent-black-600",
      "transparent-black-700",
      "transparent-black-75",
      "transparent-black-800",
      "transparent-black-900",
      "transparent-overlay-100",
      "transparent-overlay-1000",
      "transparent-overlay-200",
      "transparent-overlay-25",
      "transparent-overlay-300",
      "transparent-overlay-400",
      "transparent-overlay-50",
      "transparent-overlay-500",
      "transparent-overlay-600",
      "transparent-overlay-700",
      "transparent-overlay-75",
      "transparent-overlay-800",
      "transparent-overlay-900",
      "transparent-white-100",
      "transparent-white-1000",
      "transparent-white-200",
      "transparent-white-25",
      "transparent-white-300",
      "transparent-white-400",
      "transparent-white-50",
      "transparent-white-500",
      "transparent-white-600",
      "transparent-white-700",
      "transparent-white-75",
      "transparent-white-800",
      "transparent-white-900",
      "turquoise-100",
      "turquoise-1000",
      "turquoise-1100",
      "turquoise-1200",
      "turquoise-1300",
      "turquoise-1400",
      "turquoise-1500",
      "turquoise-1600",
      "turquoise-200",
      "turquoise-300",
      "turquoise-400",
      "turquoise-500",
      "turquoise-600",
      "turquoise-700",
      "turquoise-800",
      "turquoise-900",
      "white",
      "yellow-100",
      "yellow-1000",
      "yellow-1100",
      "yellow-1200",
      "yellow-1300",
      "yellow-1400",
      "yellow-1500",
      "yellow-1600",
      "yellow-200",
      "yellow-300",
      "yellow-400",
      "yellow-500",
      "yellow-600",
      "yellow-700",
      "yellow-800",
      "yellow-900"
   ],
   "additionalTypes":[
      
   ]
}
```
</details>

Example tool call:

```
get_style_macro_property_values(propertyName: 'padding')
```

<details>
<summary>Response</summary>

```json
{
   "values":[
      "text-to-control",
      "text-to-visual",
      "edge-to-text",
      "pill",
      "0",
      "2",
      "4",
      "8",
      "12",
      "16",
      "20",
      "24",
      "28",
      "32",
      "36",
      "40",
      "44",
      "48",
      "56",
      "64",
      "80",
      "96"
   ],
   "additionalTypes":[
      "baseSpacing",
      "LengthPercentage"
   ]
}
```
</details>


In the future, we may want to add a "compact" mode, since some of these can be pretty verbose. We could use `red-{100...900}` etc. instead of listing every value. That would take some more planning, so I think what we have here is better than nothing.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Build locally:
```
yarn build:mcp
```

Then start the local server:

```json
{
  "mcpServers": {
    "React Spectrum (S2)": {
      "command": "node",
      "args": [
        "{your path}/react-spectrum/packages/dev/mcp/s2/dist/s2/src/index.js"
      ]
    },
  }
}
```

## 🧢 Your Project:

<!--- Company/project for pull request -->
