### PR TITLE
fix: static Table SSR docs examples

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Table.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Table.mdx
@@ -31,22 +31,22 @@ export const description = 'Displays data in rows and columns and enables a user
       <Column>Date Modified</Column>
     </TableHeader>
     <TableBody>
-      <Row>
+      <Row id="row-1">
         <Cell>Games</Cell>
         <Cell>File folder</Cell>
         <Cell>6/7/2020</Cell>
       </Row>
-      <Row>
+      <Row id="row-2">
         <Cell>Program Files</Cell>
         <Cell>File folder</Cell>
         <Cell>4/7/2021</Cell>
       </Row>
-      <Row>
+      <Row id="row-3">
         <Cell>bootmgr</Cell>
         <Cell>System file</Cell>
         <Cell>11/20/2010</Cell>
       </Row>
-      <Row>
+      <Row id="row-4">
         <Cell>log.txt</Cell>
         <Cell>Text Document</Cell>
         <Cell>1/18/2016</Cell>
@@ -66,22 +66,22 @@ export const description = 'Displays data in rows and columns and enables a user
       <Column>Date Modified</Column>
     </TableHeader>
     <TableBody>
-      <Row>
+      <Row id="row-1">
         <Cell>Games</Cell>
         <Cell>File folder</Cell>
         <Cell>6/7/2020</Cell>
       </Row>
-      <Row>
+      <Row id="row-2">
         <Cell>Program Files</Cell>
         <Cell>File folder</Cell>
         <Cell>4/7/2021</Cell>
       </Row>
-      <Row>
+      <Row id="row-3">
         <Cell>bootmgr</Cell>
         <Cell>System file</Cell>
         <Cell>11/20/2010</Cell>
       </Row>
-      <Row>
+      <Row id="row-4">
         <Cell>log.txt</Cell>
         <Cell>Text Document</Cell>
         <Cell>1/18/2016</Cell>
@@ -275,18 +275,18 @@ import {Table, TableHeader, Column, Row, TableBody, Cell} from 'vanilla-starter/
   </TableHeader>
   <TableBody>
     {/*- begin highlight -*/}
-    <Row href="https://adobe.com/" target="_blank">
+    <Row id="row-1" href="https://adobe.com/" target="_blank">
       {/*- end highlight -*/}
       <Cell>Adobe</Cell>
       <Cell>https://adobe.com/</Cell>
       <Cell>January 28, 2023</Cell>
     </Row>
-    <Row href="https://google.com/" target="_blank">
+    <Row id="row-2" href="https://google.com/" target="_blank">
       <Cell>Google</Cell>
       <Cell>https://google.com/</Cell>
       <Cell>April 5, 2023</Cell>
     </Row>
-    <Row href="https://nytimes.com/" target="_blank">
+    <Row id="row-3" href="https://nytimes.com/" target="_blank">
       <Cell>New York Times</Cell>
       <Cell>https://nytimes.com/</Cell>
       <Cell>July 12, 2023</Cell>
@@ -662,7 +662,7 @@ function ReorderableTable() {
       <Column />
     </TableHeader>
     <TableBody>
-      <Row>
+      <Row id="row-1">
         <Cell><Button slot="drag" /></Cell>
         <Cell>
           <Checkbox slot="selection" /> or <SelectionIndicator />


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Noted in https://github.com/adobe/react-spectrum/issues/9355 we can reproduce in our React Aria docs page on a fresh page load and hovering the first example. We have a workaround, which is to add an id manually to each row in static tables.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
