### PR TITLE
fix: URLs in RSS feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ build-s2-docs:
 	yarn workspace @react-spectrum/s2-docs generate:og
 	LIBRARY=react-aria node scripts/buildRegistry.mjs
 	yarn build:s2-docs
-	node scripts/createFeedS2.mjs
+	LIBRARY=react-aria node scripts/createFeedS2.mjs
 	mkdir -p dist/s2-docs/react-aria/$(PUBLIC_URL)
 	mkdir -p dist/s2-docs/s2/$(PUBLIC_URL)
 	mv packages/dev/s2-docs/dist/react-aria/* dist/s2-docs/react-aria/$(PUBLIC_URL)


### PR DESCRIPTION
Same issue as shadcn registry had. Actual library does not matter, it just has to be set so `getBaseUrl` doesn't resolve to localhost.