### PR TITLE
feat(RAC): expose `--page-scroll-left` from Modal

### DIFF
--- a/packages/react-aria-components/src/Modal.tsx
+++ b/packages/react-aria-components/src/Modal.tsx
@@ -185,17 +185,20 @@ function ModalOverlayInner({UNSTABLE_portalContainer, ...props}: ModalOverlayInn
 
   let viewport = useViewportSize();
   let pageHeight: number | undefined = undefined;
+  let pageScrollLeft: number | undefined = undefined;
   if (typeof document !== 'undefined') {
     let scrollingElement = isScrollable(document.body) ? document.body : document.scrollingElement || document.documentElement;
     // Prevent Firefox from adding scrollbars when the page has a fractional height.
     let fractionalHeightDifference = scrollingElement.getBoundingClientRect().height % 1;
     pageHeight = scrollingElement.scrollHeight - fractionalHeightDifference;
+    pageScrollLeft = scrollingElement.scrollLeft;
   }
 
   let style = {
     ...renderProps.style,
     '--visual-viewport-height': viewport.height + 'px',
-    '--page-height': pageHeight !== undefined ? pageHeight + 'px' : undefined
+    '--page-height': pageHeight !== undefined ? pageHeight + 'px' : undefined,
+    '--page-scroll-left': pageScrollLeft !== undefined ? pageScrollLeft + 'px' : undefined
   };
 
   return (


### PR DESCRIPTION
May supersede #9318 

This allows us to properly place a dialog in a horizontally scrolled page (`document.scrollingElement.scrollLeft !== 0`).

```tsx
<ModalOverlay className="absolute top-0 left-(--page-scroll-left) h-(--page-height) w-full">
  <Modal className="grid place-items-center sticky top-0 h-(--visual-viewport-height) w-full">
    <Dialog />
  </Modal>
</ModalOverlay>
```

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
