### PR TITLE
fix: Update locale plugin doc import to match plugin referenced in the bundler config object

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/frameworks.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/frameworks.mdx
@@ -263,7 +263,7 @@ export const description = 'How to integrate with your framework.';
         ```ts
         // vite.config.ts
         import {defineConfig} from 'vite';
-        import localesPlugin from '@react-aria/optimize-locales-plugin';
+        import optimizeLocales from '@react-aria/optimize-locales-plugin';
 
         export default defineConfig({
           plugins: [

--- a/packages/dev/s2-docs/pages/s2/getting-started.mdx
+++ b/packages/dev/s2-docs/pages/s2/getting-started.mdx
@@ -233,7 +233,7 @@ Install React Spectrum with your preferred package manager.
         ```ts
         // vite.config.ts
         import {defineConfig} from 'vite';
-        import localesPlugin from '@react-aria/optimize-locales-plugin';
+        import optimizeLocales from '@react-aria/optimize-locales-plugin';
 
         export default defineConfig({
           plugins: [
@@ -451,7 +451,7 @@ Install React Spectrum with your preferred package manager.
         ```ts
         // vite.config.ts
         import {defineConfig} from 'vite';
-        import localesPlugin from '@react-aria/optimize-locales-plugin';
+        import optimizeLocales from '@react-aria/optimize-locales-plugin';
 
         export default defineConfig({
           plugins: [


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Happy to make a GH issue if desired but this was a quick doc update.

I'm playing with Tanstack Start and RSP2 and found this mismatch in import and usage down below while configuring the locale plugin.

Thanks!

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

N/A - doc update

## 🧢 Your Project:

<!--- Company/project for pull request -->

Adobe Stock (hi :wave:) but just poking around for funsies as we are not on spectrum 2 yet
