### PR TITLE
fix: re-calculate the visual viewport size in the effect

### DIFF
--- a/packages/@react-aria/utils/src/useViewportSize.ts
+++ b/packages/@react-aria/utils/src/useViewportSize.ts
@@ -66,6 +66,8 @@ export function useViewportSize(): ViewportSize {
       }
     };
 
+    onResize();
+
     window.addEventListener('blur', onBlur, true);
 
     if (!visualViewport) {


### PR DESCRIPTION
This mitigate the #9391 in Modal use cases. This also fixes some edge cases that the visual viewport size may change between the render and the effect.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
