### PR TITLE
fix: CoachMarkContext and SlottedContextValue types for autocomplete

### DIFF
--- a/packages/@react-spectrum/s2/src/CoachMark.tsx
+++ b/packages/@react-spectrum/s2/src/CoachMark.tsx
@@ -320,7 +320,7 @@ const actionButtonSize = {
   XL: 'L'
 } as const;
 
-export const CoachMarkContext = createContext<ContextValue<CoachMarkProps, HTMLElement>>({});
+export const CoachMarkContext = createContext<ContextValue<Partial<CoachMarkProps>, HTMLElement>>({});
 
 export const CoachMark = forwardRef((props: CoachMarkProps, ref: ForwardedRef<HTMLElement>) => {
   let colorScheme = useContext(ColorSchemeContext);

--- a/packages/react-aria-components/src/utils.tsx
+++ b/packages/react-aria-components/src/utils.tsx
@@ -20,7 +20,7 @@ interface SlottedValue<T> {
   slots?: Record<string | symbol, T>
 }
 
-export type SlottedContextValue<T> = SlottedValue<T> | T | null | undefined;
+export type SlottedContextValue<T> = (SlottedValue<T> & T) | null | undefined;
 export type ContextValue<T, E> = SlottedContextValue<WithRef<T, E>>;
 
 type ProviderValue<T> = [Context<T>, T];


### PR DESCRIPTION
Closes #9422 

Note that this PR fix the type which is technically breaking, as it makes the type validation function properly.

The change to `CoachMark.tsx` shows the breakage:

```ts
- export const CoachMarkContext = createContext<ContextValue<CoachMarkProps, HTMLElement>>({});
+ export const CoachMarkContext = createContext<ContextValue<Partial<CoachMarkProps>, HTMLElement>>({});
```

Although the breakage can be "avoided" by:

```ts
- export type SlottedContextValue<T> = SlottedValue<T> & T | null | undefined;
+ export type SlottedContextValue<T> = SlottedValue<T> & Partial<T> | null | undefined;
```

Keeping the `Partial<T>` in user land is more flexible and more correct, e.g. if the user want to NOT doing `Partial<T>` for their specific use case.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run `yarn check-types`
 