### PR TITLE
fix: filter DOM props on TabPanels

### DIFF
--- a/packages/react-aria-components/src/Tabs.tsx
+++ b/packages/react-aria-components/src/Tabs.tsx
@@ -394,9 +394,12 @@ export const TabPanels = /*#__PURE__*/ createHideableComponent(function TabPanel
     prevSize.current = ref.current.getBoundingClientRect();
   }
 
+  let DOMProps = filterDOMProps(props, {global: true});
+  delete DOMProps.id;
+
   return (
     <div 
-      {...props}
+      {...DOMProps}
       ref={ref}
       className={props.className || 'react-aria-TabPanels'}>
       <Collection {...props} />


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9419

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to RAC Tab docs, go to first example under the Content section, open dev tools, inspect the TabPanel element, you should not see `<div items="[object Object],[object Object],[object Object]" class="react-aria-TabPanels">`

## 🧢 Your Project:

<!--- Company/project for pull request -->
