### PR TITLE
fix: prevent onPress from being called when RadioGroup is read only

### DIFF
--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -86,7 +86,7 @@ export function useRadio(props: AriaRadioProps, state: RadioGroupState, ref: Ref
     onPressChange,
     onPressUp,
     onClick,
-    isDisabled,
+    isDisabled: isDisabled || state.isReadOnly,
     onPress(e) {
       onPress?.(e);
       state.setSelectedValue(value);

--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -276,6 +276,28 @@ describe('RadioGroup', () => {
     expect(label).toHaveClass('readonly');
   });
 
+  it('should not trigger onPress when read only', async () => {
+    let onPress = jest.fn();
+    let className = ({isReadOnly}) => isReadOnly ? 'readonly' : '';
+    let {getByRole, getAllByRole} = renderGroup({isReadOnly: true, className}, {className, onPress});
+
+    let group = getByRole('radiogroup');
+    let label = getAllByRole('radio')[0].closest('label');
+
+    expect(group).toHaveAttribute('aria-readonly');
+    expect(group).toHaveClass('readonly');
+
+    expect(label).toHaveAttribute('data-readonly');
+    expect(label).toHaveClass('readonly');
+
+    let radios = getAllByRole('radio');
+    let radioA = radios[0];
+    let labelA = radioA.closest('label');
+
+    await user.click(labelA);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
   it('should support invalid state', () => {
     let className = ({isInvalid}) => isInvalid ? 'invalid' : null;
     let {getByRole, getAllByRole} = renderGroup({isInvalid: true, className}, {className});


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9425

We do this in useToggle for Checkbox/CheckboxGroup https://github.com/adobe/react-spectrum/blob/5670b2accb4d40be8eb1b2c916a563a861de8ba3/packages/%40react-aria/toggle/src/useToggle.ts#L96 so the logic is similar

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
