### PR TITLE
chore: add clean and clean:all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "packageManager": "yarn@4.2.2",
   "scripts": {
     "check-types": "tsc",
+    "clean": "make clean",
+    "clean:all": "make clean_all",
     "install-16": "node scripts/react-16-install-prep.mjs && yarn add react@^16.8.0 react-dom@^16.8.0 @testing-library/react@^12 @testing-library/react-hooks@^8 @testing-library/dom@^8 react-test-renderer@^16.9.0 && node scripts/oldReactSupport.mjs",
     "install-17": "node scripts/react-17-install-prep.mjs && yarn add react@^17 react-dom@^17 @testing-library/react@^12 @testing-library/react-hooks@^8 @testing-library/dom@^8 react-test-renderer@^16.9.0 && node scripts/oldReactSupport.mjs",
     "install-18": "node scripts/react-18-install-prep.mjs && yarn add react@^18 react-dom@^18 react-test-renderer@^18.3.1 && node scripts/oldReactSupport.mjs",


### PR DESCRIPTION
One improvements on #9426

Adding `yarn clean` and `yarn clean:all` to make the script `make clean` and `make clean_all` more easily discovered and use.

Another way is to update the `CONTRIBUTION.md` to point out or list the make commands from the `Makefile`.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run `yarn clean` and `yarn clean:all`

## 🧢 Your Project:

<!--- Company/project for pull request -->
