### PR TITLE
docs: fix content-type for *.md and *.txt files in docs deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,25 @@ commands:
               --cache-control "public,max-age=31536000,immutable" \
               --exclude "*.html" --exclude "*.rsc" --exclude "*.txt" --exclude "*.json" --exclude "*.md" --exclude "*.xml"
       - run:
-          name: Copy HTML and text files to S3
+          name: Copy HTML and data files to S3
           command: |
             aws s3 cp /tmp/dist/s2-docs/<< parameters.dir >> << parameters.bucket >> --recursive \
               --cache-control "public,max-age=300,stale-while-revalidate=300" \
-              --exclude "*" --include "*.html" --include "*.txt" --include "*.json" --include "*.md" --include "*.xml"
+              --exclude "*" --include "*.html" --include "*.json" --include "*.xml"
+      - run:
+          name: Copy Markdown files to S3
+          command: |
+            aws s3 cp /tmp/dist/s2-docs/<< parameters.dir >> << parameters.bucket >> --recursive \
+              --cache-control "public,max-age=300,stale-while-revalidate=300" \
+              --content-type "text/markdown;charset=utf-8" \
+              --exclude "*" --include "*.md"
+      - run:
+          name: Copy text files to S3
+          command: |
+            aws s3 cp /tmp/dist/s2-docs/<< parameters.dir >> << parameters.bucket >> --recursive \
+              --cache-control "public,max-age=300,stale-while-revalidate=300" \
+              --content-type "text/plain;charset=utf-8" \
+              --exclude "*" --include "*.txt"
       - run:
           name: Copy RSC files to S3
           command: |


### PR DESCRIPTION
Some unicode characters weren't getting rendered correctly (e.g. as `â€`) in *.md and *.txt files in the docs build. We need to be more explicit about the content-type here.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Before: https://react-aria.adobe.com/Calendar.md
Before: https://react-aria.adobe.com/llms.txt

After: https://d5iwopk28bdhl.cloudfront.net/pr/b11acecd045b658f4247ce3dfc019d7453350e84/Calendar.md
After: https://d5iwopk28bdhl.cloudfront.net/pr/b11acecd045b658f4247ce3dfc019d7453350e84/llms.txt

Cmd+F search to confirm that `â€` isn't in the new output.

## 🧢 Your Project:

<!--- Company/project for pull request -->
