### PR TITLE
add support for `unbound-method` to `OverlayTriggerState`

### DIFF
--- a/packages/@react-stately/overlays/src/useOverlayTriggerState.ts
+++ b/packages/@react-stately/overlays/src/useOverlayTriggerState.ts
@@ -18,13 +18,13 @@ export interface OverlayTriggerState {
   /** Whether the overlay is currently open. */
   readonly isOpen: boolean,
   /** Sets whether the overlay is open. */
-  setOpen(isOpen: boolean): void,
+  setOpen: (isOpen: boolean) => void,
   /** Opens the overlay. */
-  open(): void,
+  open: () => void,
   /** Closes the overlay. */
-  close(): void,
+  close: () => void,
   /** Toggles the overlay's visibility. */
-  toggle(): void
+  toggle: () => void
 }
 
 /**


### PR DESCRIPTION
_Sorry for these little pings._

This is the same issue as #9453 but for `OverlayTriggerState`.

This example fails ESLint which expects the methods `close`, `open`, etc. to be bound to the state object.

```tsx
const { close } = useOverlayTriggerState(); // ❌
<DismissButton onDismiss={close} />
```

<img width="568" height="282" alt="image" src="https://github.com/user-attachments/assets/9a7a8a28-7f3c-4d55-8fcb-651aac0359b3" />

even:

```tsx
<DismissButton onDismiss={overlayTriggerState.close} /> // ❌
```

<img width="827" height="229" alt="image" src="https://github.com/user-attachments/assets/71329ddc-eee0-4f2b-a511-24f407432713" />
