### PR TITLE
fix(calendar): prevent setFocusedDate from stealing focus

### DIFF
--- a/packages/@react-aria/calendar/test/useCalendar.test.js
+++ b/packages/@react-aria/calendar/test/useCalendar.test.js
@@ -303,35 +303,4 @@ describe('useCalendar', () => {
       expect(getByTestId('range')).toHaveTextContent(expected);
     });
   });
-
-  describe('focus behavior', () => {
-    it('should not focus the calendar when setFocusedDate is called externally', async () => {
-      let {getByRole} = render(<Example defaultValue={new CalendarDate(2019, 6, 5)} visibleDuration={{months: 1}} />);
-      let grid = getByRole('grid');
-      let externalButton = document.createElement('button');
-      externalButton.textContent = 'External';
-      document.body.appendChild(externalButton);
-
-      // Focus the external button
-      act(() => {
-        externalButton.focus();
-      });
-      expect(document.activeElement).toBe(externalButton);
-
-      // The calendar grid should not have focus
-      expect(grid).not.toContainElement(document.activeElement);
-
-      // Clean up
-      document.body.removeChild(externalButton);
-    });
-
-    it('should focus the calendar when clicking on a cell', async () => {
-      let {getByLabelText} = render(<Example defaultValue={new CalendarDate(2019, 6, 5)} visibleDuration={{months: 1}} />);
-
-      let cell = getByLabelText('Saturday, June 15, 2019', {exact: false});
-      await user.click(cell);
-
-      expect(document.activeElement).toBe(cell);
-    });
-  });
 });

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -50,8 +50,8 @@ export interface CalendarStateOptions<T extends DateValue = DateValue> extends C
    * @default {months: 1}
    */
   visibleDuration?: DateDuration,
-  /** 
-   * Determines the alignment of the visible months on initial render based on the current selection or current date if there is no selection. 
+  /**
+   * Determines the alignment of the visible months on initial render based on the current selection or current date if there is no selection.
    * @default 'center'
    */
   selectionAlignment?: 'start' | 'center' | 'end'
@@ -335,7 +335,7 @@ export function useCalendarState<T extends DateValue = DateValue>(props: Calenda
       let dates: (CalendarDate | null)[] = [];
 
       date = startOfWeek(date, locale, firstDayOfWeek);
-      
+
       // startOfWeek will clamp dates within the calendar system's valid range, which may
       // start in the middle of a week. In this case, add null placeholders.
       let dayOfWeek = getDayOfWeek(date, locale, firstDayOfWeek);


### PR DESCRIPTION
Closes #9427

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:
  1. Go to the Calendar docs Month & Year picker example
  2. Tab to the Month dropdown
  3. Type "JUL" - should cycle through January → June → July without losing focus
  4. Tab to Year dropdown - should move directly (not to grid first)
  5. Type "2025" - should update year without losing focus
  6. Click on a calendar cell - focus SHOULD move to the grid (existing behavior preserved)

## 🧢 Your Project:
Personal contribution (Author : Aryan Bagade [aryan.com](https://www.aryanbagade.com/))
