### PR TITLE
feat: string-compiler ESM support

### DIFF
--- a/packages/@internationalized/string-compiler/src/stringCompiler.d.ts
+++ b/packages/@internationalized/string-compiler/src/stringCompiler.d.ts
@@ -10,8 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
+interface Options {
+  /**
+   * Output module format.
+   * @default 'cjs'
+   */
+  format?: 'cjs' | 'esm'
+}
+
 /** Compiles an object containing ICU message strings to a JavaScript module. */
-export function compileStrings(messages: Record<string, string>): string;
+export function compileStrings(messages: Record<string, string>, options?: Options): string;
 
 /** Compiles a single ICU message string to JavaScript source code. */
 export function compileString(message: string): string;

--- a/packages/@internationalized/string-compiler/src/stringCompiler.js
+++ b/packages/@internationalized/string-compiler/src/stringCompiler.js
@@ -12,8 +12,8 @@
 
 const {parse, TYPE} = require('@formatjs/icu-messageformat-parser');
 
-function compileStrings(messages) {
-  let res = 'module.exports = {';
+function compileStrings(messages, options) {
+  let res = options?.format  === 'esm' ? 'export default {' : 'module.exports = {';
   for (let key in messages) {
     res += '  ' + JSON.stringify(key) + ': ' + compileString(messages[key]) + ',\n';
   }


### PR DESCRIPTION
While adopting `@internationalized/string-compiler` in our component library to reduce dependencies, we ran into issues with the existing CJS output.
This PR adds optional ESM output support to `compileStrings` , defaulting to CommonJS for backward compatibility.