### PR TITLE
feat: Optimize style macro for build vs dev

### DIFF
--- a/packages/@react-spectrum/s2/style/runtime.ts
+++ b/packages/@react-spectrum/s2/style/runtime.ts
@@ -49,17 +49,23 @@ export function mergeStyles(...styles: (StyleString | null | undefined)[]): Styl
   }
 
   let map = new Map<string, string>();
-  let macroClasses: string[] = [];
+  let macroClasses: string[] | undefined;
+
+  if (process.env.NODE_ENV !== 'production') {
+    macroClasses = [];
+  }
 
   for (let style of definedStyles) {
     // must call toString here for the static macro
     let str = style.toString();
 
-    // Extract and preserve macro debug classes
-    let macroMatches = str.matchAll(/-macro-(static|dynamic)-[^\s]+/g);
-    for (let match of macroMatches) {
-      if (!macroClasses.includes(match[0])) {
-        macroClasses.push(match[0]);
+    // Extract and preserve macro debug classes (dev only)
+    if (process.env.NODE_ENV !== 'production') {
+      let macroMatches = str.matchAll(/-macro-(static|dynamic)-[^\s]+/g);
+      for (let match of macroMatches) {
+        if (!macroClasses!.includes(match[0])) {
+          macroClasses!.push(match[0]);
+        }
       }
     }
 
@@ -73,8 +79,8 @@ export function mergeStyles(...styles: (StyleString | null | undefined)[]): Styl
     res += value;
   }
 
-  // Append all macro debug classes
-  if (macroClasses.length > 0) {
+  // Append all macro debug classes (dev only)
+  if (process.env.NODE_ENV !== 'production' && macroClasses && macroClasses.length > 0) {
     res += ' ' + macroClasses.join(' ');
   }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

This disables the debugging tools for the style macro when the environement is prod so we don't add overhead to people's apps

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
