### PR TITLE
docs: Fix DialogTrigger -> TooltipTrigger typo in custom trigger section

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Tooltip.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Tooltip.mdx
@@ -108,7 +108,7 @@ function Example(props) {
 
 ## Custom trigger
 
-`DialogTrigger` works with any focusable React Aria component (e.g. [Button](Button), [Link](Link), etc.). Use the `<Focusable>` component to wrap a custom trigger element such as a third party component or DOM element.
+`TooltipTrigger` works with any focusable React Aria component (e.g. [Button](Button), [Link](Link), etc.). Use the `<Focusable>` component to wrap a custom trigger element such as a third party component or DOM element.
 
 ```tsx render
 "use client"


### PR DESCRIPTION
https://react-aria.adobe.com/Tooltip#custom-trigger

Fixed a typo in the Tooltip documentation where `DialogTrigger` was incorrectly used instead of `TooltipTrigger` in the custom trigger section.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check docs that typo has been fixed

## 🧢 Your Project:

<!--- Company/project for pull request -->
