### PR TITLE
feat(usePress): add `key` to `PressEvent`

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -84,7 +84,8 @@ interface EventBase {
   altKey: boolean,
   clientX?: number,
   clientY?: number,
-  targetTouches?: Array<{clientX?: number, clientY?: number}>
+  targetTouches?: Array<{clientX?: number, clientY?: number}>,
+  key?: string
 }
 
 export interface PressResult {
@@ -117,6 +118,7 @@ class PressEvent implements IPressEvent {
   altKey: boolean;
   x: number;
   y: number;
+  key: string | undefined;
   #shouldStopPropagation = true;
 
   constructor(type: IPressEvent['type'], pointerType: PointerType, originalEvent: EventBase, state?: PressState) {
@@ -146,6 +148,7 @@ class PressEvent implements IPressEvent {
     this.altKey = originalEvent.altKey;
     this.x = x;
     this.y = y;
+    this.key = originalEvent.key;
   }
 
   continuePropagation() {
@@ -983,7 +986,8 @@ function createEvent(target: FocusableElement, e: EventBase): EventBase {
     metaKey: e.metaKey,
     altKey: e.altKey,
     clientX,
-    clientY
+    clientY,
+    key: e.key
   };
 }
 

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -2276,7 +2276,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2291,7 +2292,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'pressend',
@@ -2302,7 +2304,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2317,7 +2320,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'click',
@@ -2366,7 +2370,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'presschange',
@@ -2381,7 +2386,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'pressend',
@@ -2392,7 +2398,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'presschange',
@@ -2407,7 +2414,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'click'
@@ -2450,7 +2458,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'presschange',
@@ -2465,7 +2474,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'pressend',
@@ -2476,7 +2486,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'presschange',
@@ -2491,7 +2502,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'click'
@@ -2531,7 +2543,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2546,7 +2559,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'pressend',
@@ -2557,7 +2571,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2572,7 +2587,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'click'
@@ -2607,7 +2623,8 @@ describe('usePress', function () {
           shiftKey: true,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2622,7 +2639,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'pressend',
@@ -2633,7 +2651,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2648,7 +2667,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'click',
@@ -2694,7 +2714,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'presschange',
@@ -2709,7 +2730,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'pressend',
@@ -2720,7 +2742,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'presschange',
@@ -2735,7 +2758,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: 'Enter'
         },
         {
           type: 'click',
@@ -2779,7 +2803,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2794,7 +2819,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2811,7 +2837,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2826,7 +2853,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'pressend',
@@ -2837,7 +2865,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2852,7 +2881,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'click',
@@ -2915,7 +2945,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2935,7 +2966,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2950,7 +2982,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'pressend',
@@ -2961,7 +2994,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -2976,7 +3010,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'click',
@@ -3726,7 +3761,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -3741,7 +3777,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'pressend',
@@ -3752,7 +3789,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         },
         {
           type: 'presschange',
@@ -3767,7 +3805,8 @@ describe('usePress', function () {
           shiftKey: false,
           altKey: false,
           x: 0,
-          y: 0
+          y: 0,
+          key: ' '
         }
       ]);
     });
@@ -4827,7 +4866,8 @@ describe('coordinates', () => {
         shiftKey: false,
         altKey: false,
         x: 50,
-        y: 50
+        y: 50,
+        key: ' '
       },
       {
         type: 'presschange',
@@ -4842,7 +4882,8 @@ describe('coordinates', () => {
         shiftKey: false,
         altKey: false,
         x: 50,
-        y: 50
+        y: 50,
+        key: ' '
       },
       {
         type: 'pressend',
@@ -4853,7 +4894,8 @@ describe('coordinates', () => {
         shiftKey: false,
         altKey: false,
         x: 50,
-        y: 50
+        y: 50,
+        key: ' '
       },
       {
         type: 'presschange',
@@ -4868,7 +4910,8 @@ describe('coordinates', () => {
         shiftKey: false,
         altKey: false,
         x: 50,
-        y: 50
+        y: 50,
+        key: ' '
       }
     ]);
   });

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -246,7 +246,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
     itemPressProps.onPressStart = (e) => {
       modality.current = e.pointerType;
       longPressEnabledOnPressStart.current = longPressEnabled;
-      if (e.pointerType === 'keyboard' && (!hasAction || isSelectionKey())) {
+      if (e.pointerType === 'keyboard' && (!hasAction || isSelectionKey(e.key))) {
         onSelect(e);
       }
     };
@@ -256,7 +256,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
     if (!allowsDifferentPressOrigin) {
       itemPressProps.onPress = (e) => {
         if (hasPrimaryAction || (hasSecondaryAction && e.pointerType !== 'mouse')) {
-          if (e.pointerType === 'keyboard' && !isActionKey()) {
+          if (e.pointerType === 'keyboard' && !isActionKey(e.key)) {
             return;
           }
 
@@ -290,7 +290,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
       if (
         allowsSelection && (
           (e.pointerType === 'mouse' && !hasPrimaryAction) ||
-          (e.pointerType === 'keyboard' && (!allowsActions || isSelectionKey()))
+          (e.pointerType === 'keyboard' && (!allowsActions || isSelectionKey(e.key)))
         )
       ) {
         onSelect(e);
@@ -305,7 +305,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
         e.pointerType === 'touch' ||
         e.pointerType === 'pen' ||
         e.pointerType === 'virtual' ||
-        (e.pointerType === 'keyboard' && hasAction && isActionKey()) ||
+        (e.pointerType === 'keyboard' && hasAction && isActionKey(e.key)) ||
         (e.pointerType === 'mouse' && hadPrimaryActionOnPressStart.current)
       ) {
         if (hasAction) {
@@ -407,12 +407,10 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
   };
 }
 
-function isActionKey() {
-  let event = window.event as KeyboardEvent;
-  return event?.key === 'Enter';
+function isActionKey(key: string | undefined) {
+  return key === 'Enter';
 }
 
-function isSelectionKey() {
-  let event = window.event as KeyboardEvent;
-  return event?.key === ' ' || event?.code === 'Space';
+function isSelectionKey(key: string | undefined) {
+  return key === ' ';
 }

--- a/packages/@react-types/shared/src/events.d.ts
+++ b/packages/@react-types/shared/src/events.d.ts
@@ -52,6 +52,11 @@ export interface PressEvent {
   /** Y position relative to the target. */
   y: number,
   /**
+   * The key that triggered the press event, if it was triggered by a keyboard interaction.
+   * This is useful for differentiating between Space and Enter key presses.
+   */
+  key?: string,
+  /**
    * By default, press events stop propagation to parent elements.
    * In cases where a handler decides not to handle a specific event,
    * it can call `continuePropagation()` to allow a parent to handle it.


### PR DESCRIPTION
Related discussion: https://github.com/adobe/react-spectrum/discussions/9487

Passes through the `key` property to `PressEvent`, which makes it easier to tell if the keyboard-triggered press event was from a Space or Enter key press.

Allows us to remove these hacks:

https://github.com/adobe/react-spectrum/blob/c2517d3bb75b92d547859b8776aa8ca8d9f2fa36/packages/%40react-aria/selection/src/useSelectableItem.ts#L410-L418


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Open a [Button](https://reactspectrum.blob.core.windows.net/reactspectrum/322de3975722e76cecdbe2982b9f481f1d24d42b/storybook/index.html?path=/story/react-aria-components-button--button-example&providerSwitcher-express=false) story in storybook and check the PressEvent object in the Actions panel.

## 🧢 Your Project:

<!--- Company/project for pull request -->
