### PR TITLE
docs(RAC): document which slots are available for Dialog

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Modal.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Modal.mdx
@@ -187,7 +187,10 @@ const CustomTrigger = React.forwardRef((props, ref) => (
   <Button />
   <ModalOverlay>
     <Modal>
-      <Dialog />
+      <Dialog>
+        <Heading slot="title" />
+        <Button slot="close" />
+      </Dialog>
     </Modal>
   </ModalOverlay>
 </DialogTrigger>


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9496

Verified this is the only place we're missing slots from the API section.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check https://d5iwopk28bdhl.cloudfront.net/pr/72698a684ae32c84bb5eea5167bccd626dfc3abb/Modal#api

## 🧢 Your Project:

<!--- Company/project for pull request -->
