### PR TITLE
chore: update @parcel/core patch to remove extra Buffer.from()

### DIFF
--- a/patches/@parcel+core+2.16.3.patch
+++ b/patches/@parcel+core+2.16.3.patch
@@ -8,9 +8,9 @@ index 1234567..abcdefg 100644
        }
 -      boundaryStr = replaced.subarray(replacedLength - BOUNDARY_LENGTH, replacedLength);
 -      let strUpToBoundary = replaced.subarray(0, replacedLength - BOUNDARY_LENGTH);
-+      // Copy buffers to avoid reuse issues - subarray returns a view that can be
++      // Copy buffer to avoid reuse issues - subarray returns a view that can be
 +      // corrupted if the underlying buffer is modified before the data is written
-+      boundaryStr = Buffer.from(replaced.subarray(replacedLength - BOUNDARY_LENGTH, replacedLength));
++      boundaryStr = replaced.subarray(replacedLength - BOUNDARY_LENGTH, replacedLength);
 +      let strUpToBoundary = Buffer.from(replaced.subarray(0, replacedLength - BOUNDARY_LENGTH));
        cb(null, strUpToBoundary);
      },


### PR DESCRIPTION
As @devongovett mentioned in https://github.com/adobe/react-spectrum/pull/9489, we can remove the extra `Buffer.from()` in this patch. 

Test locally and verified 15/15 successful builds.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
