### PR TITLE
fix: allow passing function as formAction button prop

### DIFF
--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, FocusableDOMProps, FocusableProps, Key, PressEvents, StyleProps} from '@react-types/shared';
-import {ElementType, JSXElementConstructor, ReactNode} from 'react';
+import {ButtonHTMLAttributes, ElementType, JSXElementConstructor, ReactNode} from 'react';
 
 interface ButtonProps extends PressEvents, FocusableProps {
   /** Whether the button is disabled. */
@@ -81,7 +81,7 @@ interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
    * The URL that processes the information submitted by the button.
    * Overrides the action attribute of the button's form owner.
    */
-  formAction?: string,
+  formAction?: ButtonHTMLAttributes<HTMLButtonElement>['formAction'],
   /** Indicates how to encode the form data that is submitted. */
   formEncType?: string,
   /** Indicates the HTTP method used to submit the form. */


### PR DESCRIPTION
Closes #9500

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
