### PR TITLE
chore(mcp): update mcp server to use production URL

### DIFF
--- a/packages/dev/mcp/shared/src/utils.ts
+++ b/packages/dev/mcp/shared/src/utils.ts
@@ -12,8 +12,16 @@ export function errorToString(err: unknown): string {
   }
 }
 
-// CDN base for docs. Can be overridden via env variable.
-export const DEFAULT_CDN_BASE = process.env.DOCS_CDN_BASE ?? 'https://react-spectrum.adobe.com/beta';
+// Default base URLs for each library
+const DEFAULT_S2_BASE = 'https://react-spectrum.adobe.com';
+const DEFAULT_REACT_ARIA_BASE = 'https://react-aria.adobe.com';
+
+export function getLibraryBaseUrl(library: 's2' | 'react-aria'): string {
+  if (process.env.DOCS_CDN_BASE) {
+    return process.env.DOCS_CDN_BASE;
+  }
+  return library === 's2' ? DEFAULT_S2_BASE : DEFAULT_REACT_ARIA_BASE;
+}
 
 export async function fetchText(url: string, timeoutMs = 15000): Promise<string> {
   const ctrl = new AbortController();


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9462

Updates the MCP servers to use the production docs URLs.  

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Build the servers locally: `yarn build:mcp`.

Then run the servers locally:

```json
{
  "mcpServers": {
    "React Aria": {
      "command": "node",
      "args": ["/Users/{your_path}/react-spectrum/packages/dev/mcp/react-aria/dist/react-aria/src/index.js"]
    },
    "React Spectrum (S2)": {
      "command": "node",
      "args": ["/Users/{your_path}/react-spectrum/packages/dev/mcp/s2/dist/s2/src/index.js"]
    }
  }
}
```

Make sure it fetches the latest docs pages and page content.

## 🧢 Your Project:

<!--- Company/project for pull request -->
