### PR TITLE
fix: prevent Modal from closing when dismissing DateRangePicker via outside click

### DIFF
--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -93,7 +93,8 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   };
 
   let onInteractOutsideStart = (e: PointerEvent) => {
-    const topMostOverlay = (lastVisibleOverlay.current = visibleOverlays[visibleOverlays.length - 1]);
+    const topMostOverlay = visibleOverlays[visibleOverlays.length - 1];
+    lastVisibleOverlay.current = topMostOverlay;
     if (!shouldCloseOnInteractOutside || shouldCloseOnInteractOutside(e.target as Element)) {
       if (topMostOverlay === ref) {
         e.stopPropagation();

--- a/packages/react-aria-components/stories/DatePicker.stories.tsx
+++ b/packages/react-aria-components/stories/DatePicker.stories.tsx
@@ -125,7 +125,7 @@ export const DatePickerTriggerWidthExample: DatePickerStory = (args) => (
   </DatePicker>
 );
 
-export const DateRangePickerExample = (args) => (
+export const DateRangePickerExample: DateRangePickerStory = (args) => (
   <DateRangePicker data-testid="date-range-picker-example" {...args}>
     <Label style={{display: 'block'}}>Date</Label>
     <Group style={{display: 'inline-flex'}}>

--- a/packages/react-aria-components/stories/Modal.stories.tsx
+++ b/packages/react-aria-components/stories/Modal.stories.tsx
@@ -176,6 +176,7 @@ function DateRangePickerInsideModal() {
             padding: 30
           }}>
           <Dialog>
+            {/* @ts-ignore */}
             <DateRangePickerExample />
           </Dialog>
         </Modal>

--- a/packages/react-aria-components/test/Dialog.test.js
+++ b/packages/react-aria-components/test/Dialog.test.js
@@ -27,10 +27,14 @@ import {
   Popover,
   TextField
 } from '../';
+import {composeStories} from '@storybook/react';
 import React, {useRef} from 'react';
+import * as stories from '../stories/Modal.stories';
 import {UNSAFE_PortalProvider} from '@react-aria/overlays';
 import {User} from '@react-aria/test-utils';
 import userEvent from '@testing-library/user-event';
+
+let {DateRangePickerInsideModalStory: DateRangePickerInsideModal} = composeStories(stories);
 
 describe('Dialog', () => {
   let user;
@@ -460,5 +464,27 @@ describe('Dialog', () => {
 
     const input = getByTestId('email');
     expect(document.activeElement).toBe(input);
+  });
+
+  it('should not close Modal when DateRangePicker is dismissed by outside click', async () => {
+    let {getAllByRole, getByRole} = render(<DateRangePickerInsideModal />);
+    await user.click(getByRole('button'));
+
+    let modal = getByRole('dialog').closest('.react-aria-ModalOverlay');
+    expect(modal).toBeInTheDocument();
+
+    let button = getByRole('group').querySelector('.react-aria-Button');
+    expect(button).toHaveAttribute('aria-label', 'Calendar');
+    await user.click(button);
+
+    let popover = getByRole('dialog').closest('.react-aria-Popover');
+    expect(popover).toBeInTheDocument();
+    expect(popover).toHaveAttribute('data-trigger', 'DateRangePicker');
+
+    let cells = getAllByRole('gridcell');
+    await user.click(cells[5].children[0]);
+    await user.click(document.body);
+    expect(popover).not.toBeInTheDocument();
+    expect(modal).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #9469

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to DateRangePickerInsideModal story

Open the Modal, then open the DateRangePicker and select a start date. Clicking outside the Modal should close the picker but keep the Modal open.

## 🧢 Your Project:

<!--- Company/project for pull request -->
