### PR TITLE
fix: change `live-announcer`'s only `dependency` to a `devDependency`

### DIFF
--- a/packages/@react-aria/live-announcer/package.json
+++ b/packages/@react-aria/live-announcer/package.json
@@ -25,7 +25,7 @@
     "type": "git",
     "url": "https://github.com/adobe/react-spectrum"
   },
-  "dependencies": {
+  "devDependencies": {
     "@swc/helpers": "^0.5.0"
   },
   "publishConfig": {


### PR DESCRIPTION
I don't see where this file is used in run-time (is it necessary even as a devDependency?) 

Its showing up as another dependency for us to load for this package which seems unnecessary if its not used in the run time.


Closes [9511](https://github.com/adobe/react-spectrum/issues/9511)

## ✅ Pull Request Checklist:

- [ x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ x] Filled out test instructions.
- [ x] Updated documentation (if it already exists for this component).
- [ x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Nothing to test
