### PR TITLE
docs: add missing Portuguese language support

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/quality.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/quality.mdx
@@ -112,6 +112,7 @@ function App() {
   <li>Lithuanian (Lithuania) (`lt-LT`)</li>
   <li>Norwegian (Norway) (`nb-NO`)</li>
   <li>Polish (Poland) (`pl-PL`)</li>
+  <li>Portuguese (Portugal) (`pt-PT`)</li>
   <li>Portuguese (Brazil) (`pt-BR`)</li>
   <li>Romanian (Romania) (`ro-RO`)</li>
   <li>Russian (Russia) (`ru-RU`)</li>


### PR DESCRIPTION
[The `pt-PT` locale](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/dnd/intl/pt-PT.json) exists but not in the documentation


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
