### PR TITLE
docs: fix sticky header gap in gridlist section docs

### DIFF
--- a/starters/docs/src/GridList.css
+++ b/starters/docs/src/GridList.css
@@ -266,7 +266,7 @@
 .react-aria-GridListHeader {
   position: sticky;
   z-index: 2;
-  top: calc(var(--spacing-4) * -1);
+  top: calc(var(--spacing-2) * -1);
   font-size: var(--font-size-lg);
   font-weight: 500;
   background: var(--gray-100);


### PR DESCRIPTION
On mobile there was a gap between the top and the header when you scrolled on mobile because I hard coded `top:-8px` instead of using a variable that takes into account how padding changes between desktop/mobile.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to GridList Section docs, scroll the content, the header should be flush with the top both on desktop and on mobile.

## 🧢 Your Project:

<!--- Company/project for pull request -->
