### PR TITLE
fix: add UNSAFE_className and UNSAFE_style to ActionBar

### DIFF
--- a/packages/@react-spectrum/s2/src/ActionBar.tsx
+++ b/packages/@react-spectrum/s2/src/ActionBar.tsx
@@ -161,8 +161,8 @@ const ActionBarInner = forwardRef(function ActionBarInner(props: ActionBarProps 
         ref={objectRef}
         {...otherProps}
         {...keyboardProps}
-        className={actionBarStyles({isEmphasized, isInContainer: !!scrollRef, isEntering, isExiting})}
-        style={{insetInlineEnd: `calc(var(--insetEnd) + ${scrollbarWidth}px)`}}>
+        className={(props.UNSAFE_className || '') + actionBarStyles({isEmphasized, isInContainer: !!scrollRef, isEntering, isExiting})}
+        style={{insetInlineEnd: `calc(var(--insetEnd) + ${scrollbarWidth}px)`, ...props.UNSAFE_style}}>
         <div className={style({order: 1, marginStart: 'auto'})}>
           <ActionButtonGroup
             staticColor={isEmphasized ? 'auto' : undefined}


### PR DESCRIPTION
i'm not sure why these weren't added in the first place, im guessing we just forgot since they exist in the types. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
