### PR TITLE
fix(mcp): store page keys with library prefix

### DIFF
--- a/packages/dev/mcp/shared/src/page-manager.ts
+++ b/packages/dev/mcp/shared/src/page-manager.ts
@@ -29,9 +29,10 @@ export async function buildPageIndex(library: Library): Promise<PageInfo[]> {
     const href = (m[2] || '').trim();
     const description = (m[3] || '').trim() || undefined;
     if (!href || !/\.md$/i.test(href)) {continue;}
-    const key = href.replace(/\.md$/i, '').replace(/\\/g, '/');
-    const name = display || path.basename(key);
-    const filePath = `${baseUrl}/${key}.md`;
+    const hrefWithoutExt = href.replace(/\.md$/i, '').replace(/\\/g, '/');
+    const key = `${library}/${hrefWithoutExt}`;
+    const name = display || path.basename(hrefWithoutExt);
+    const filePath = `${baseUrl}/${hrefWithoutExt}.md`;
     const info: PageInfo = {key, name, description, filePath, sections: []};
     pages.push(info);
     pageCache.set(info.key, info);


### PR DESCRIPTION
We were storing page keys without the library prefix (e.g., `"Accordion"`, `"Button"`). When the cached pages were returned, we filtered by `p.key.startsWith(\${library}/\)`, which caused the list_pages tools to return an empty array.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Build the servers locally: `yarn build:mcp`.

Then run the servers locally (Cursor -> Settings -> Cursor Settings -> Tools & MCP):

```json
{
  "mcpServers": {
    "React Aria": {
      "command": "node",
      "args": ["/Users/{your_path}/react-spectrum/packages/dev/mcp/react-aria/dist/react-aria/src/index.js"]
    },
    "React Spectrum (S2)": {
      "command": "node",
      "args": ["/Users/{your_path}/react-spectrum/packages/dev/mcp/s2/dist/s2/src/index.js"]
    }
  }
}
```

Ask your agent to test out all the tools for React Aria and React Spectrum. Specifically, after this fix, the list_pages tools should return all the pages instead of an empty array.

## 🧢 Your Project:

<!--- Company/project for pull request -->
