### PR TITLE
chore: remove unsupported calendar locale from DateField chromatic

### DIFF
--- a/packages/@react-spectrum/datepicker/chromatic/DateField.stories.tsx
+++ b/packages/@react-spectrum/datepicker/chromatic/DateField.stories.tsx
@@ -116,7 +116,7 @@ export const ContextualHelpSideLabel: DateFieldStory = (args) => <DateField labe
 export const ArabicAlgeriaPreferences: DateFieldStory = (args) => <Provider><DateField label="Date" value={dateTime} {...args} /></Provider>;
 ArabicAlgeriaPreferences.parameters = {
   chromaticProvider: {
-    locales: ['ar-DZ-u-ca-gregory', 'ar-DZ-u-ca-islamic', 'ar-DZ-u-ca-islamic-civil', 'ar-DZ-u-ca-islamic-tbla'],
+    locales: ['ar-DZ-u-ca-gregory', 'ar-DZ-u-ca-islamic-civil', 'ar-DZ-u-ca-islamic-tbla'],
     scales: ['medium'],
     colorSchemes: ['light'],
     express: false
@@ -126,7 +126,7 @@ ArabicAlgeriaPreferences.parameters = {
 export const ArabicUAEPreferences: DateFieldStory = (args) => <Provider><DateField label="Date" value={dateTime} {...args} /></Provider>;
 ArabicUAEPreferences.parameters = {
   chromaticProvider: {
-    locales: ['ar-AE-u-ca-gregory', 'ar-AE-u-ca-islamic-umalqura', 'ar-AE-u-ca-islamic', 'ar-AE-u-ca-islamic-civil', 'ar-AE-u-ca-islamic-tbla'],
+    locales: ['ar-AE-u-ca-gregory', 'ar-AE-u-ca-islamic-umalqura', 'ar-AE-u-ca-islamic-civil', 'ar-AE-u-ca-islamic-tbla'],
     scales: ['medium'],
     colorSchemes: ['light'],
     express: false
@@ -136,7 +136,7 @@ ArabicUAEPreferences.parameters = {
 export const ArabicEgyptPreferences: DateFieldStory = (args) => <Provider><DateField label="Date" value={dateTime} {...args} /></Provider>;
 ArabicEgyptPreferences.parameters = {
   chromaticProvider: {
-    locales: ['ar-EG-u-ca-gregory', 'ar-EG-u-ca-coptic', 'ar-EG-u-ca-islamic', 'ar-EG-u-ca-islamic-civil', 'ar-EG-u-ca-islamic-tbla'],
+    locales: ['ar-EG-u-ca-gregory', 'ar-EG-u-ca-coptic', 'ar-EG-u-ca-islamic-civil', 'ar-EG-u-ca-islamic-tbla'],
     scales: ['medium'],
     colorSchemes: ['light'],
     express: false
@@ -146,7 +146,7 @@ ArabicEgyptPreferences.parameters = {
 export const ArabicSaudiPreferences: DateFieldStory = (args) => <Provider><DateField label="Date" value={dateTime} {...args} /></Provider>;
 ArabicSaudiPreferences.parameters = {
   chromaticProvider: {
-    locales: ['ar-SA-u-ca-islamic-umalqura', 'ar-SA-u-ca-gregory', 'ar-SA-u-ca-islamic', 'ar-SA-u-ca-islamic-rgsa'],
+    locales: ['ar-SA-u-ca-gregory', 'ar-SA-u-ca-islamic-umalqura'],
     scales: ['medium'],
     colorSchemes: ['light'],
     express: false


### PR DESCRIPTION
I'll be honest, I don't know why I added `ca-islamic` as part of the preferences. It's not supported (at least not anymore according to mdn) and were wrong to begin with so I'm removing it from chromatic so we don't get caught up in it again

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_calendar_types

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
