### PR TITLE
fix: roving tabindex in useSelectableCollection for virtualized collections

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -580,7 +580,7 @@ export function useSelectableCollection(options: AriaSelectableCollectionOptions
   // This will be marshalled to either the first or last item depending on where focus came from.
   let tabIndex: number | undefined = undefined;
   if (!shouldUseVirtualFocus) {
-    tabIndex = manager.isFocused ? -1 : 0;
+    tabIndex = manager.focusedKey == null ? 0 : -1;
   }
 
   let collectionId = useCollectionId(manager.collection);


### PR DESCRIPTION
https://github.com/adobe/react-spectrum/pull/8767

This did a couple too many things, reverting the change that removed our roving tab index. We believe this change is unneeded as the PR suggests with the other two points done.

There are still some issues around focus restore and moving focus that we're considering here https://github.com/adobe/react-spectrum/pull/9545

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
