### PR TITLE
fix: prevent the selectedKey be set to null in Tabs

### DIFF
--- a/packages/@react-types/tabs/src/index.d.ts
+++ b/packages/@react-types/tabs/src/index.d.ts
@@ -30,12 +30,14 @@ export interface AriaTabProps extends AriaLabelingProps {
   shouldSelectOnPressUp?: boolean
 }
 
-export interface TabListProps<T> extends CollectionBase<T>, Omit<SingleSelection, 'disallowEmptySelection' | 'onSelectionChange'> {
+export interface TabListProps<T> extends CollectionBase<T>, Omit<SingleSelection, 'disallowEmptySelection' | 'selectedKey' | 'onSelectionChange'> {
   /**
    * Whether the TabList is disabled.
    * Shows that a selection exists, but is not available in that circumstance.
    */
   isDisabled?: boolean,
+  /** The currently selected key in the collection (controlled). */
+  selectedKey?: Key,
   /** Handler that is called when the selection changes. */
   onSelectionChange?: (key: Key) => void
 }
@@ -60,7 +62,7 @@ export interface AriaTabPanelProps extends Omit<DOMProps, 'id'>, AriaLabelingPro
   id?: Key
 }
 
-export interface SpectrumTabsProps<T> extends AriaTabListBase, Omit<SingleSelection, 'onSelectionChange' | 'disallowEmptySelection'>, DOMProps, StyleProps {
+export interface SpectrumTabsProps<T> extends AriaTabListBase, Omit<SingleSelection, 'disallowEmptySelection' | 'selectedKey' | 'onSelectionChange'>, DOMProps, StyleProps {
   /** The children of the `<Tabs>` element. Should include `<TabList>` and `<TabPanels>` elements. */
   children: ReactNode,
   /** The item objects for each tab, for dynamic collections. */
@@ -75,6 +77,8 @@ export interface SpectrumTabsProps<T> extends AriaTabListBase, Omit<SingleSelect
   isEmphasized?: boolean,
   /** The amount of space between the tabs. */
   density?: 'compact' | 'regular',
+  /** The currently selected key in the collection (controlled). */
+  selectedKey?: Key,
   /** Handler that is called when the selection changes. */
   onSelectionChange?: (key: Key) => void
 }


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9584

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Type check should pass. Attempting to set `selectedKey` to null should result in a type error
