### PR TITLE
chore: Revert "feat: support modern useEffectEvent"

### DIFF
--- a/packages/@react-aria/utils/src/useEffectEvent.ts
+++ b/packages/@react-aria/utils/src/useEffectEvent.ts
@@ -17,10 +17,7 @@ import {useLayoutEffect} from './useLayoutEffect';
 // before all layout effects, but is available only in React 18 and later.
 const useEarlyEffect = React['useInsertionEffect'] ?? useLayoutEffect;
 
-// Starting with React 19.2, this hook has been internalized.
-const useModernEffectEvent = React['useEffectEvent'] ?? useLegacyEffectEvent;
-
-function useLegacyEffectEvent<T extends Function>(fn?: T): T {
+export function useEffectEvent<T extends Function>(fn?: T): T {
   const ref = useRef<T | null | undefined>(null);
   useEarlyEffect(() => {
     ref.current = fn;
@@ -30,8 +27,4 @@ function useLegacyEffectEvent<T extends Function>(fn?: T): T {
     const f = ref.current!;
     return f?.(...args);
   }, []);
-}
-
-export function useEffectEvent<T extends Function>(fn: T): T {
-  return useModernEffectEvent(fn);
 }

--- a/packages/@react-aria/utils/src/useEvent.ts
+++ b/packages/@react-aria/utils/src/useEvent.ts
@@ -11,7 +11,7 @@
  */
 
 import {RefObject} from '@react-types/shared';
-import {useCallback, useEffect} from 'react';
+import {useEffect} from 'react';
 import {useEffectEvent} from './useEffectEvent';
 
 export function useEvent<K extends keyof GlobalEventHandlersEventMap>(
@@ -20,8 +20,7 @@ export function useEvent<K extends keyof GlobalEventHandlersEventMap>(
   handler?: (this: Document, ev: GlobalEventHandlersEventMap[K]) => any,
   options?: boolean | AddEventListenerOptions
 ): void {
-  let noop = useCallback(() => {}, []);
-  let handleEvent = useEffectEvent(handler ?? noop);
+  let handleEvent = useEffectEvent(handler);
   let isDisabled = handler == null;
 
   useEffect(() => {


### PR DESCRIPTION
Reverts adobe/react-spectrum#9095

In testing, we found that the real useEffectEvent is causing issues. We are too close to release to fix it this time. Will look into it for next one.

Will see how https://github.com/adobe/react-spectrum/pull/9379 does.