### PR TITLE
fix: docs use client usage in examples

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Slider.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Slider.mdx
@@ -71,6 +71,7 @@ function Example() {
 Set the `value` or `defaultValue` to an array of numbers to render multiple thumbs. Each thumb should have an `aria-label` to describe it for assistive technologies (provided via `thumbLabels` here).
 
 ```tsx render
+"use client";
 import {Slider} from 'vanilla-starter/Slider';
 
 <Slider

--- a/packages/dev/s2-docs/pages/react-aria/blog/how-we-internationalized-our-numberfield.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/blog/how-we-internationalized-our-numberfield.mdx
@@ -51,6 +51,7 @@ Number fields can be used to represent many different types of numeric values, e
 We use the [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) API built into browsers to handle all of these formatting requirements across all locales. Our number field component supports most of the formatting options that the Intl API supports, which ensures that it is international friendly and supports many common formatting options out of the box. The browser currently only provides formatting support, however, not parsing support, so we built a custom number parser using information from the formatter. We'll discuss how this works in detail later in the post.
 
 ```tsx render
+"use client";
 import {NumberField} from '@react-spectrum/s2';
 
 <NumberField
@@ -70,6 +71,7 @@ Many number fields also support incrementing and decrementing their value using 
 One area of complexity here is dealing with floating point rounding errors. All JavaScript numbers are double precision floating point, which means when you add or subtract two numbers, you can get rounding errors. For example, `0.1 + 0.2 === 0.30000000000000004`. This isn't really what users expect, however, so to fix this, we determine how many decimal places there are, multiply to convert the two numbers to integers, perform the addition or subtraction, and then divide again to get a decimal. A similar fix is necessary to perform step snapping on blur.
 
 ```tsx render
+"use client";
 import {NumberField} from '@react-spectrum/s2';
 
 <NumberField

--- a/packages/dev/s2-docs/pages/react-aria/selection.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/selection.mdx
@@ -868,6 +868,7 @@ import {TagGroup, Tag} from 'vanilla-starter/TagGroup';
 ```
 
 ```tsx render wide docs={docs.exports.Table} links={docs.links} props={['disabledBehavior']}
+"use client";
 import {Table, TableHeader, Column, Row, TableBody, Cell} from 'vanilla-starter/Table';
 
 <Table

--- a/packages/dev/s2-docs/pages/s2/AvatarGroup.mdx
+++ b/packages/dev/s2-docs/pages/s2/AvatarGroup.mdx
@@ -11,6 +11,7 @@ export const description = 'A grouping of avatars that are related to each other
 <PageDescription>{docs.exports.AvatarGroup.description}</PageDescription>
 
 ```tsx render docs={docs.exports.AvatarGroup} links={docs.links} props={['label', 'size']} initialProps={{'aria-label': 'Collaborators', label: '123 members'}} controlOptions={{size: {control: 'picker'}}} type="s2"
+"use client";
 import {AvatarGroup, Avatar} from '@react-spectrum/s2';
 
 <AvatarGroup/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/Breadcrumbs.mdx
+++ b/packages/dev/s2-docs/pages/s2/Breadcrumbs.mdx
@@ -12,6 +12,7 @@ export const description = 'Display a hierarchy of links to the current page or 
 <PageDescription>{docs.exports.Breadcrumbs.description}</PageDescription>
 
 ```tsx render docs={docs.exports.Breadcrumbs} links={docs.links} props={['size', 'isDisabled']} initialProps={{}} type="s2"
+"use client";
 import {Breadcrumbs, Breadcrumb} from '@react-spectrum/s2';
 
 <Breadcrumbs/* PROPS */>
@@ -74,7 +75,7 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
     padding: 16,
     boxSizing: 'border-box',
     borderWidth: 1,
-    borderStyle: 'solid', 
+    borderStyle: 'solid',
     borderColor: 'gray-300',
     borderRadius: 'default',
     resize: 'horizontal',

--- a/packages/dev/s2-docs/pages/s2/ButtonGroup.mdx
+++ b/packages/dev/s2-docs/pages/s2/ButtonGroup.mdx
@@ -12,6 +12,7 @@ export const description = 'A grouping of buttons whose actions are related to e
 <PageDescription>{docs.exports.ButtonGroup.description}</PageDescription>
 
 ```tsx render docs={docs.exports.ButtonGroup} links={docs.links} props={['orientation', 'align', 'size', 'isDisabled']} type="s2"
+"use client";
 import {ButtonGroup, Button} from '@react-spectrum/s2';
 
 <ButtonGroup/* PROPS */>
@@ -37,7 +38,7 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
     padding: 16,
     boxSizing: 'border-box',
     borderWidth: 1,
-    borderStyle: 'solid', 
+    borderStyle: 'solid',
     borderColor: 'gray-300',
     borderRadius: 'default',
     resize: 'horizontal',

--- a/packages/dev/s2-docs/pages/s2/Card.mdx
+++ b/packages/dev/s2-docs/pages/s2/Card.mdx
@@ -236,6 +236,7 @@ import Select from '@react-spectrum/s2/icons/Select';
 Wrap a card in a [Skeleton](Skeleton) to display a loading state. Placeholder text content and images are displayed in a skeleton style.
 
 ```tsx render docs={docs.exports.Skeleton} links={docs.links} props={['isLoading']} initialProps={{isLoading: true}} type="s2" wide
+"use client";
 import {Skeleton, Card, CardPreview, Image, Content, Text} from '@react-spectrum/s2';
 
 <Skeleton isLoading>

--- a/packages/dev/s2-docs/pages/s2/CheckboxGroup.mdx
+++ b/packages/dev/s2-docs/pages/s2/CheckboxGroup.mdx
@@ -15,6 +15,7 @@ export const description = 'Allows a user to select one or more items in a list 
 <PageDescription>{docs.exports.CheckboxGroup.description}</PageDescription>
 
 ```tsx render docs={docs.exports.CheckboxGroup} links={docs.links} props={['label', 'size', 'orientation', 'labelPosition', 'description', 'contextualHelp', 'isEmphasized', 'isDisabled']} initialProps={{label: 'Favorite sports'}} type="s2"
+"use client";
 import {CheckboxGroup, Checkbox} from '@react-spectrum/s2';
 
 <CheckboxGroup/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/ComboBox.mdx
+++ b/packages/dev/s2-docs/pages/s2/ComboBox.mdx
@@ -15,6 +15,7 @@ export const description = 'Combines a text input with a listbox, and allows a u
 <PageDescription>{docs.exports.ComboBox.description}</PageDescription>
 
 ```tsx render docs={docs.exports.ComboBox} links={docs.links} props={['label', 'placeholder', 'size', 'labelPosition', 'description', 'contextualHelp', 'isDisabled']} initialProps={{label: 'Ice cream flavor', placeholder: 'Select a flavor'}} type="s2"
+"use client";
 import {ComboBox, ComboBoxItem} from '@react-spectrum/s2';
 
 <ComboBox/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/ContextualHelp.mdx
+++ b/packages/dev/s2-docs/pages/s2/ContextualHelp.mdx
@@ -12,6 +12,7 @@ export const description = 'Shows extra information about an adjacent component.
 <PageDescription>{docs.exports.ContextualHelp.description}</PageDescription>
 
 ```tsx render docs={docs.exports.ContextualHelp} links={docs.links} props={['variant', 'size', 'placement']} initialProps={{variant: 'help'}} type="s2"
+"use client";
 import {ContextualHelp, Heading, Content, Footer, Link} from '@react-spectrum/s2';
 
 <ContextualHelp/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/Form.mdx
+++ b/packages/dev/s2-docs/pages/s2/Form.mdx
@@ -13,6 +13,7 @@ export const description = 'Provides layout and alignment for a grouping of fiel
 
 
 ```tsx render docs={docs.exports.Form} links={docs.links} props={['size', 'labelPosition', 'labelAlign', 'necessityIndicator', 'isRequired', 'isDisabled', 'isEmphasized']} type="s2"
+"use client";
 import {Form, TextField, Checkbox, ButtonGroup, Button} from '@react-spectrum/s2';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 

--- a/packages/dev/s2-docs/pages/s2/Picker.mdx
+++ b/packages/dev/s2-docs/pages/s2/Picker.mdx
@@ -15,6 +15,7 @@ export const description = 'Displays a collapsible list of options, and allows a
 <PageDescription>{docs.exports.Picker.description}</PageDescription>
 
 ```tsx render docs={docs.exports.Picker} links={docs.links} props={['label', 'selectionMode', 'size', 'labelPosition', 'description', 'contextualHelp', 'isQuiet', 'isDisabled']} initialProps={{label: 'Ice cream flavor'}} type="s2"
+"use client";
 import {Picker, PickerItem} from '@react-spectrum/s2';
 
 <Picker/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/RadioGroup.mdx
+++ b/packages/dev/s2-docs/pages/s2/RadioGroup.mdx
@@ -15,6 +15,7 @@ export const description = 'Allows a user to select a single item from a list of
 <PageDescription>{docs.exports.RadioGroup.description}</PageDescription>
 
 ```tsx render docs={docs.exports.RadioGroup} links={docs.links} props={['label', 'size', 'orientation', 'labelPosition', 'description', 'contextualHelp', 'isEmphasized', 'isDisabled']} initialProps={{label: 'Favorite pet'}} type="s2"
+"use client";
 import {RadioGroup, Radio} from '@react-spectrum/s2';
 
 <RadioGroup/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/SegmentedControl.mdx
+++ b/packages/dev/s2-docs/pages/s2/SegmentedControl.mdx
@@ -12,6 +12,7 @@ export const description = 'A mutually exclusive group of buttons used for view 
 <PageDescription>{docs.exports.SegmentedControl.description}</PageDescription>
 
 ```tsx render docs={docs.exports.SegmentedControl} links={docs.links} props={['isJustified', 'isDisabled']} initialProps={{'aria-label': 'Time granularity'}} type="s2" wide
+"use client";
 import {SegmentedControl, SegmentedControlItem} from '@react-spectrum/s2';
 
 <SegmentedControl/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -15,6 +15,7 @@ export const description = 'Displays data in rows and columns, with row selectio
 <PageDescription>{docs.exports.TableView.description}</PageDescription>
 
 ```tsx render docs={docs.exports.TableView} links={docs.links} props={['selectionMode', 'overflowMode', 'density', 'isQuiet']} initialProps={{'aria-label': 'Files', selectionMode: 'multiple'}} type="s2"
+"use client";
 import {TableView, TableHeader, Column, TableBody, Row, Cell} from '@react-spectrum/s2';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 

--- a/packages/dev/s2-docs/pages/s2/TagGroup.mdx
+++ b/packages/dev/s2-docs/pages/s2/TagGroup.mdx
@@ -11,6 +11,7 @@ export const description = 'Displays a list of items, with support for keyboard 
 <PageDescription>{docs.exports.TagGroup.description}</PageDescription>
 
 ```tsx render docs={docs.exports.TagGroup} links={docs.links} props={['label', 'selectionMode', 'size', 'labelPosition', 'maxRows', 'description', 'contextualHelp', 'isEmphasized']} initialProps={{label: 'Ice cream flavors', selectionMode: 'multiple', maxRows: 2}} controlOptions={{maxRows: {minValue: 1}}} type="s2"
+"use client";
 import {TagGroup, Tag} from '@react-spectrum/s2';
 
 <TagGroup/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/TreeView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TreeView.mdx
@@ -15,6 +15,7 @@ export const description = 'Displays hierarchical data with selection and collap
 <PageDescription>{docs.exports.TreeView.description}</PageDescription>
 
 ```tsx render docs={docs.exports.TreeView} links={docs.links} props={['selectionMode']} initialProps={{selectionMode: 'multiple'}} type="s2" wide
+"use client";
 import {TreeView, TreeViewItem, TreeViewItemContent} from '@react-spectrum/s2';
 
 <TreeView

--- a/packages/dev/s2-docs/pages/s2/forms.mdx
+++ b/packages/dev/s2-docs/pages/s2/forms.mdx
@@ -17,6 +17,7 @@ export const description = 'How to build accessible forms with validation.';
 Accessible forms start with clear, descriptive labels for each field. Use the `label` prop to add a visible label to any field. Additional help text can also be added via the `description` prop. The label and help text are announced by screen readers when the field is focused.
 
 ```tsx render
+"use client";
 import {TextField} from '@react-spectrum/s2';
 
 <TextField

--- a/packages/dev/s2-docs/pages/s2/selection.mdx
+++ b/packages/dev/s2-docs/pages/s2/selection.mdx
@@ -1186,6 +1186,7 @@ import AlertNotice from '@react-spectrum/s2/illustrations/linear/AlertNotice';
 ```
 
 ```tsx render wide type="s2"
+"use client";
 import {TableView, TableHeader, Column, Row, TableBody, Cell} from '@react-spectrum/s2';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 

--- a/packages/react-aria-components/docs/Tree.mdx
+++ b/packages/react-aria-components/docs/Tree.mdx
@@ -282,6 +282,7 @@ A Tree consists of a container element, with items containing data inside. The i
 If the tree supports item selection, each item can optionally include a selection checkbox.
 
 ```tsx render=false
+"use client";
 import {Tree, TreeItem, TreeItemContent, Button, Checkbox, SelectionIndicator} from 'react-aria-components';
 
 <Tree>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

fixes our usage of use client in the docs which was causing intermittent build issues

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
