### PR TITLE
fix: add date picker placeholder for Icelandic

### DIFF
--- a/packages/@react-stately/datepicker/src/placeholders.ts
+++ b/packages/@react-stately/datepicker/src/placeholders.ts
@@ -56,6 +56,7 @@ const placeholders = new LocalizedStringDictionary({
   hu: {year: 'éééé', month: 'hh', day: 'nn'},
   ia: {year: 'aaaa', month: 'mm', day: 'dd'},
   id: {year: 'tttt', month: 'bb', day: 'hh'},
+  is: {year: 'áááá', month: 'mm', day: 'dd'},
   it: {year: 'aaaa', month: 'mm', day: 'gg'},
   ja: {year: '年', month: '月', day: '日'},
   ka: {year: 'წწწწ', month: 'თთ', day: 'რრ'},


### PR DESCRIPTION
Closes #9599

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Testing a date picker with the locale set to "is-IS" should produce the placeholder `dd.mm.áááá`

## 🧢 Your Project:

<!--- Company/project for pull request -->
