### PR TITLE
docs: remove mention of ListBox in S2 migration docs

### DIFF
--- a/packages/dev/s2-docs/pages/s2/migrating.mdx
+++ b/packages/dev/s2-docs/pages/s2/migrating.mdx
@@ -241,7 +241,6 @@ No updates needed.
 - If within `Breadcrumbs`: Update `Item` to be a `Breadcrumb`
 - If within `Picker`: Update `Item` to be a `PickerItem`
 - If within `ComboBox`: Update `Item` to be a `ComboBoxItem`
-- If within `ListBox`: Update `Item` to be a `ListBoxItem`
 - If within `TabList`: Update `Item` to be a `Tab`
 - If within `TabPanels`: Update `Item` to be a `TabPanel` and remove surrounding `TabPanels`
 - Update `key` to be `id` (and keep `key` if rendered inside `array.map`)
@@ -250,10 +249,6 @@ No updates needed.
 
 - Change `variant="overBackground"` to `staticColor="white"`
 - If `a` was used inside `Link` (legacy API), remove the `a` and apply props (i.e `href`) directly to `Link`
-
-### ListBox
-
-- Update `Item` to be a `ListBoxItem`
 
 ### Menu
 


### PR DESCRIPTION
Searched through S2 and didn't see anything where a user would have to import ListBox. It seemed to have confused a user (https://github.com/adobe/react-spectrum/issues/9555) so figured we remove mentions of it until it becomes relevant in S2.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
