### PR TITLE
docs: fix llms.txt links to open in new tab to avoid client side routing failure

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/ai.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ai.mdx
@@ -103,4 +103,4 @@ Add the `.md` extension to the URL to get the markdown version of a page. Additi
 
 ## llms.txt
 
-The [llms.txt](https://react-aria.adobe.com/llms.txt) file contains a list of all the markdown pages available in the React Aria documentation.
+The <Link href="llms.txt" target="_blank">llms.txt</Link> file contains a list of all the markdown pages available in the React Aria documentation.

--- a/packages/dev/s2-docs/pages/s2/ai.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai.mdx
@@ -103,4 +103,4 @@ Add the `.md` extension to the URL to get the markdown version of a page. Additi
 
 ## llms.txt
 
-The [llms.txt](https://react-spectrum.adobe.com/llms.txt) file contains a list of all the markdown pages available in the React Spectrum documentation.
+The <Link href="llms.txt" target="_blank">llms.txt</Link> file contains a list of all the markdown pages available in the React Spectrum documentation.


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check that both llms.txt links open in a new tab:

https://d5iwopk28bdhl.cloudfront.net/pr/9e873fc9bd40c66b5e93455d121230f619e67b03/ai#llmstxt
https://d1pzu54gtk2aed.cloudfront.net/pr/9e873fc9bd40c66b5e93455d121230f619e67b03/ai#llmstxt


## 🧢 Your Project:

<!--- Company/project for pull request -->
