### PR TITLE
fix(table): make TableHeaderProps.columns accept readonly arrays

### DIFF
--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -82,7 +82,7 @@ export interface SpectrumTableProps<T> extends TableProps<T>, SpectrumSelectionP
 
 export interface TableHeaderProps<T> {
   /** A list of table columns. */
-  columns?: T[],
+  columns?: readonly T[],
   /** A list of `Column(s)` or a function. If the latter, a list of columns must be provided using the `columns` prop. */
   children: ColumnElement<T> | ColumnElement<T>[] | ColumnRenderer<T>
 }


### PR DESCRIPTION
Closes #5625  

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

- Type change only. No runtime impact.  

## 🧢 Your Project:

- Personal contribution 
