### PR TITLE
fix(types): allow readonly TableHeader columns

### DIFF
--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -82,7 +82,7 @@ export interface SpectrumTableProps<T> extends TableProps<T>, SpectrumSelectionP
 
 export interface TableHeaderProps<T> {
   /** A list of table columns. */
-  columns?: T[],
+  columns?: ReadonlyArray<T>,
   /** A list of `Column(s)` or a function. If the latter, a list of columns must be provided using the `columns` prop. */
   children: ColumnElement<T> | ColumnElement<T>[] | ColumnRenderer<T>
 }


### PR DESCRIPTION
Fixes #5625.

Allow `readonly` arrays (e.g. `as const`) to be passed to `TableHeaderProps.columns` by widening the type from `T[]` to `ReadonlyArray<T>`.
