### PR TITLE
fix: export HeaderProps type from react-aria-components

### DIFF
--- a/packages/react-aria-components/src/index.ts
+++ b/packages/react-aria-components/src/index.ts
@@ -111,6 +111,7 @@ export type {FileTriggerProps} from './FileTrigger';
 export type {FormProps} from './Form';
 export type {GridListProps, GridListRenderProps, GridListItemProps, GridListItemRenderProps, GridListLoadMoreItemProps, GridListSectionProps} from './GridList';
 export type {GroupProps, GroupRenderProps} from './Group';
+export type {HeaderProps} from './Header';
 export type {HeadingProps} from './Heading';
 export type {InputProps, InputRenderProps} from './Input';
 export type {SectionProps, CollectionRenderer} from './Collection';


### PR DESCRIPTION
## Summary

- Export `HeaderProps` type from the main `index.ts` entry point

## Problem

When wrapping the `Header` component (e.g., with a styling library), TypeScript needs to infer and emit the type in declaration files. For example:

```typescript
export const DropdownMenuSectionHeader = styled(Header, { ... });
```

TypeScript tries to express something like:

```typescript
export const DropdownMenuSectionHeader: StyledComponent<HeaderProps, ...>
```

But `HeaderProps` is defined internally in react-aria-components without being exported from the package entry point:

```typescript
// In react-aria-components/dist/types.d.ts
interface HeaderProps extends HTMLAttributes<HTMLElement>, DOMRenderProps<'header', undefined> {}
export const Header: (props: HeaderProps & RefAttributes<HTMLElement>) => ReactElement | null;
```

This produces the error:

```
Exported variable 'DropdownMenuSectionHeader' has or is using name 'HeaderProps' 
from external module "react-aria-components/dist/types" but cannot be named. ts(4023)
```

### Why It Worked Before

Previously, `HeaderProps` extended only `HTMLAttributes<HTMLElement>` - a built-in type from `@types/react` that's universally available. TypeScript could inline or reference these portable types without needing to name `HeaderProps` itself.

In 1.15.0, `HeaderProps` now extends `DOMRenderProps<'header', undefined>` - a type internal to react-aria-components. TypeScript can't express the component's props without referencing `HeaderProps`, but since `HeaderProps` isn't exported, it can't be named in declaration files.

### Why It Matters for Libraries

Libraries that emit declaration files require all exported types to be nameable - TypeScript needs to be able to write valid type references that consumers can resolve. When a type depends on an unexported internal type from a dependency, TypeScript throws `TS4023`.
