### PR TITLE
fix: parsing for numbers from other locales or common accidental form…

### DIFF
--- a/packages/@internationalized/number/src/NumberParser.ts
+++ b/packages/@internationalized/number/src/NumberParser.ts
@@ -205,8 +205,24 @@ class NumberParserImpl {
     if (this.symbols.noNumeralUnits.length > 0 && this.symbols.noNumeralUnits.find(obj => obj.unit === value)) {
       return this.symbols.noNumeralUnits.find(obj => obj.unit === value)!.value.toString();
     }
+    // Do our best to preserve the number and its possible group and decimal symbols, this includes the sign as well
+    let preservedInsideNumber = value.match(new RegExp(`([${this.symbols.numerals.join('')}].*[${this.symbols.numerals.join('')}])`));
+    if (preservedInsideNumber) {
+      // If we found a number, replace literals everywhere except inside the number
+      let beforeNumber = value.substring(0, preservedInsideNumber.index!);
+      let afterNumber = value.substring(preservedInsideNumber.index! + preservedInsideNumber[0].length);
+      let insideNumber = preservedInsideNumber[0];
 
-    value = value.replace(this.symbols.literals, '');
+      // Replace literals in the parts outside the number
+      beforeNumber = beforeNumber.replace(this.symbols.literals, '');
+      afterNumber = afterNumber.replace(this.symbols.literals, '');
+
+      // Reconstruct the value with literals removed from outside the number
+      value = beforeNumber + insideNumber + afterNumber;
+    } else {
+      // If no number found, replace literals everywhere
+      value = value.replace(this.symbols.literals, '');
+    }
 
     // Replace the ASCII minus sign with the minus sign used in the current locale
     // so that both are allowed in case the user's keyboard doesn't have the locale's minus sign.
@@ -237,6 +253,66 @@ class NumberParserImpl {
     if (this.options.locale === 'fr-FR' && this.symbols.group && isGroupSymbolAllowed) {
       value = replaceAll(value, ' ', this.symbols.group);
       value = replaceAll(value, /\u00A0/g, this.symbols.group);
+    }
+
+    // If there are multiple decimal separators and only one group separator, swap them
+    if (this.symbols.decimal
+      && (this.symbols.group && isGroupSymbolAllowed)
+      && [...value.matchAll(new RegExp(escapeRegex(this.symbols.decimal), 'g'))].length > 1
+      && [...value.matchAll(new RegExp(escapeRegex(this.symbols.group), 'g'))].length <= 1) {
+      value = swapCharacters(value, this.symbols.decimal, this.symbols.group);
+    }
+
+    // If the decimal separator is before the group separator, swap them
+    let decimalIndex = value.indexOf(this.symbols.decimal!);
+    let groupIndex = value.indexOf(this.symbols.group!);
+    if (this.symbols.decimal && (this.symbols.group && isGroupSymbolAllowed) && decimalIndex > -1 && groupIndex > -1 && decimalIndex < groupIndex) {
+      value = swapCharacters(value, this.symbols.decimal, this.symbols.group);
+    }
+
+    // in the value, for any non-digits and not the plus/minus sign,
+    // if there is only one of that character and its index in the string is 0 or it's only preceeded by this numbering system's "0" character,
+    // then we could try to guess that it's a decimal character and replace it, but it's too ambiguous, a user may be deleting 1,024 -> ,024 and
+    // we don't want to change 24 into .024
+    let temp = value;
+    if (this.symbols.minusSign) {
+      temp = replaceAll(temp, this.symbols.minusSign, '');
+      temp = replaceAll(temp, '\u2212', '');
+    }
+    if (this.symbols.plusSign) {
+      temp = replaceAll(temp, this.symbols.plusSign, '');
+    }
+    temp = replaceAll(temp, new RegExp(`^${escapeRegex(this.symbols.numerals[0])}+`, 'g'), '');
+    let nonDigits = new Set(replaceAll(temp, this.symbols.numeral, '').split(''));
+
+    // This is to fuzzy match group and decimal symbols from a different formatting, we can only do it if there are 2 non-digits, otherwise it's too ambiguous
+    let areOnlyGroupAndDecimalSymbols = [...nonDigits].every(char => allPossibleGroupAndDecimalSymbols.has(char));
+    let oneSymbolNotMatching = (
+      nonDigits.size === 2
+      && (this.symbols.group && isGroupSymbolAllowed)
+      && this.symbols.decimal
+      && (!nonDigits.has(this.symbols.group!) || !nonDigits.has(this.symbols.decimal!))
+    );
+    let bothSymbolsNotMatching = (
+      nonDigits.size === 2
+      && (this.symbols.group && isGroupSymbolAllowed)
+      && this.symbols.decimal
+      && !nonDigits.has(this.symbols.group!) && !nonDigits.has(this.symbols.decimal!)
+    );
+    if (areOnlyGroupAndDecimalSymbols && (oneSymbolNotMatching || bothSymbolsNotMatching)) {
+      // Try to determine which of the nonDigits is the group and which is the decimal
+      // Whichever of the nonDigits is first in the string is the group.
+      // If there are more than one of a nonDigit, then that one is the group.
+      let [firstChar, secondChar] = [...nonDigits];
+      if (value.indexOf(firstChar) < value.indexOf(secondChar)) {
+        value = replaceAll(value, firstChar, '__GROUP__');
+        value = replaceAll(value, secondChar, this.symbols.decimal!);
+        value = replaceAll(value, '__GROUP__', this.symbols.group!);
+      } else {
+        value = replaceAll(value, secondChar, '__GROUP__');
+        value = replaceAll(value, firstChar, this.symbols.decimal!);
+        value = replaceAll(value, '__GROUP__', this.symbols.group!);
+      }
     }
 
     return value;
@@ -273,6 +349,9 @@ class NumberParserImpl {
 }
 
 const nonLiteralParts = new Set(['decimal', 'fraction', 'integer', 'minusSign', 'plusSign', 'group']);
+
+// This list is a best guess at the moment
+const allPossibleGroupAndDecimalSymbols = new Set(['.', ',', ' ', String.fromCharCode(1548), '\u00A0', "'"]);
 
 // This list is derived from https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html#comparison and includes
 // all unique numbers which we need to check in order to determine all the plural forms for a given locale.
@@ -339,6 +418,14 @@ function getSymbols(locale: string, formatter: Intl.NumberFormat, intlOptions: I
   let index = d => String(indexes.get(d));
 
   return {minusSign, plusSign, decimal, group, literals, numeral, numerals, index, noNumeralUnits};
+}
+
+function swapCharacters(str: string, char1: string, char2: string) {
+  const tempChar = '_TEMP_';
+  let result = str.replaceAll(char1, tempChar);
+  result = result.replaceAll(char2, char1);
+  result = result.replaceAll(tempChar, char2);
+  return result;
 }
 
 function replaceAll(str: string, find: string | RegExp, replace: string) {

--- a/packages/@internationalized/number/test/NumberParser.test.js
+++ b/packages/@internationalized/number/test/NumberParser.test.js
@@ -38,6 +38,11 @@ describe('NumberParser', function () {
       expect(new NumberParser('en-US', {style: 'decimal'}).parse('-1,000,000')).toBe(-1000000);
     });
 
+    it('should support accidentally using a group character as a decimal character', function () {
+      expect(new NumberParser('en-US', {style: 'decimal'}).parse('1.000,00')).toBe(1000);
+      expect(new NumberParser('en-US', {style: 'decimal'}).parse('1.000.000,00')).toBe(1000000);
+    });
+
     it('should support signDisplay', function () {
       expect(new NumberParser('en-US', {style: 'decimal'}).parse('+10')).toBe(10);
       expect(new NumberParser('en-US', {style: 'decimal', signDisplay: 'always'}).parse('+10')).toBe(10);

--- a/packages/react-aria-components/test/NumberField.test.js
+++ b/packages/react-aria-components/test/NumberField.test.js
@@ -207,14 +207,14 @@ describe('NumberField', () => {
     });
     await user.paste('3.000.000,25');
     await user.keyboard('{Enter}');
-    expect(input).toHaveValue('1,024');
+    expect(input).toHaveValue('3,000,000.25');
 
     act(() => {
       input.setSelectionRange(0, input.value.length);
     });
     await user.paste('3 000 000,25');
     await user.keyboard('{Enter}');
-    expect(input).toHaveValue('300,000,025');
+    expect(input).toHaveValue('3,000,000.25');
 
     rerender(<TestNumberField formatOptions={{style: 'currency', currency: 'USD'}} />);
 
@@ -223,7 +223,7 @@ describe('NumberField', () => {
     });
     await user.paste('3 000 000,256789');
     await user.keyboard('{Enter}');
-    expect(input).toHaveValue('$3,000,000,256,789.00');
+    expect(input).toHaveValue('$3,000,000.26');
 
     act(() => {
       input.setSelectionRange(0, input.value.length);


### PR DESCRIPTION
Closes <!-- Github issue # here -->
Follow up to https://github.com/adobe/react-spectrum/pull/8592, specifically https://github.com/adobe/react-spectrum/pull/8592#issuecomment-3863366857

This allows users to more reliably copy a number from a non-localized source such as a PDF or excel or another application, and paste it in our components. See some of the tests for examples of how this behaves.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Try pasting numbers with group/decimal characters that are opposite of what the current formatting expects. Note, this is an improvement, there are some cases we can reasonably handle, then there are those which are still ambiguous.

For example, if there are two symbols in use, one is before the other, it's reasonable to assume that the first one is group and the second is decimal.
Or if there are multiple of one symbol, but only one of the other, then it's reasonable to assume that the symbol with multiple instances is the group, and the symbol with only one instance is the decimal.

On the other side, ambiguous cases are if there is only one symbol in use, we cannot reasonably know if it's a partial number with a group separator vs a decimal symbol. At least, I have determined a good way to figure this one out.

One other note, this does not extend to units/currency symbols. Those are literal and should not be fuzzy matched/removed. For example, pasting €10 into a currency formatted numberfield should not become $10 just because the formatting is for USD. They are not equivalent.

While this PR closes 9086, it just matches other locales to the current behaviour of en-US.

## 🧢 Your Project:

<!--- Company/project for pull request -->
