### PR TITLE
fix: scrollIntoView scrollbar width & rtl layout support

### DIFF
--- a/packages/@react-aria/utils/src/scrollIntoView.ts
+++ b/packages/@react-aria/utils/src/scrollIntoView.ts
@@ -70,10 +70,10 @@ export function scrollIntoView(scrollView: HTMLElement, element: HTMLElement, op
   let scrollAreaLeft = target.left - scrollMarginLeft;
   let scrollAreaRight = target.right + scrollMarginRight;
 
-  let borderWidth = scrollView === root ? 0 : borderLeftWidth + borderRightWidth;
-  let borderHeight = scrollView === root ? 0 : borderTopWidth + borderBottomWidth;
-  let scrollBarWidth = scrollView.offsetWidth - scrollView.clientWidth - borderWidth;
-  let scrollBarHeight = scrollView.offsetHeight - scrollView.clientHeight - borderHeight;
+  let scrollBarOffsetX = scrollView === root ? 0 : borderLeftWidth + borderRightWidth;
+  let scrollBarOffsetY = scrollView === root ? 0 : borderTopWidth + borderBottomWidth;
+  let scrollBarWidth = scrollView.offsetWidth - scrollView.clientWidth - scrollBarOffsetX;
+  let scrollBarHeight = scrollView.offsetHeight - scrollView.clientHeight - scrollBarOffsetY;
 
   let scrollPortTop = viewTop + borderTopWidth + scrollPaddingTop;
   let scrollPortBottom = viewBottom - borderBottomWidth - scrollPaddingBottom - scrollBarHeight;


### PR DESCRIPTION
Follow up to #9146 

The fix pushed last minute doubled the border width and didn't account for RTL layouts.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
