### PR TITLE
fix: update labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,6 +11,6 @@ RAC:
   - any-glob-to-any-file: ['**/react-aria-components/**', '**/@react-aria/**']
 
 V3:
-  - changed-files:
-    - any-glob-to-any-file: '**/@react-spectrum/**'
-    - all-globs-to-all-files: '!**/@react-spectrum/s2/**'
+- changed-files:
+  - any-glob-to-any-file: '**/@react-spectrum/**'
+  - all-globs-to-all-files: '!**/@react-spectrum/s2/**'


### PR DESCRIPTION
The labeler was marking s2 changes as v3 because I forgot that s2 is also under the @react-spectrum directory. Hopefully this fixes that


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
