### PR TITLE
chore: upgrade chromatic cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "babel-plugin-react-remove-properties": "^0.3.0",
     "babel-plugin-transform-glob-import": "^1.0.1",
     "chalk": "^4.1.2",
-    "chromatic": "^13.1.3",
+    "chromatic": "^15.0.0",
     "clsx": "^2.0.0",
     "color-space": "^1.16.0",
     "concurrently": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13197,9 +13197,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^13.1.3":
-  version: 13.1.3
-  resolution: "chromatic@npm:13.1.3"
+"chromatic@npm:^15.0.0":
+  version: 15.1.0
+  resolution: "chromatic@npm:15.1.0"
   peerDependencies:
     "@chromatic-com/cypress": ^0.*.* || ^1.0.0
     "@chromatic-com/playwright": ^0.*.* || ^1.0.0
@@ -13212,7 +13212,7 @@ __metadata:
     chroma: dist/bin.js
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
-  checksum: 10c0/5fa2d381e06d1b089ecb790247844cfb510b063c4d8f8c0d2a3d0620ff94864003158e34338246bb1d07504d554e73dc8d5b639dc3e176ce3c88816fdc853285
+  checksum: 10c0/aea449b3c07e599e9b4c1cd866ffa57a5fc6b158b7c1ae4c462f74133869927d0932a077191011bdb841ab81a2dde54b0a35370736ef1986b6854453f01086de
   languageName: node
   linkType: hard
 
@@ -24902,7 +24902,7 @@ __metadata:
     babel-plugin-react-remove-properties: "npm:^0.3.0"
     babel-plugin-transform-glob-import: "npm:^1.0.1"
     chalk: "npm:^4.1.2"
-    chromatic: "npm:^13.1.3"
+    chromatic: "npm:^15.0.0"
     clsx: "npm:^2.0.0"
     color-space: "npm:^1.16.0"
     concurrently: "npm:^6.0.2"


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Looks like even though the CLI says storybook 10 now as a breaking change https://github.com/chromaui/chromatic-cli/blob/main/CHANGELOG.md, it still works with our build https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=1117

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
