### PR TITLE
fix: getEventTarget returned the wrong target

### DIFF
--- a/packages/@react-aria/utils/src/shadowdom/DOMFunctions.ts
+++ b/packages/@react-aria/utils/src/shadowdom/DOMFunctions.ts
@@ -1,5 +1,5 @@
 // Source: https://github.com/microsoft/tabster/blob/a89fc5d7e332d48f68d03b1ca6e344489d1c3898/src/Shadowdomize/DOMFunctions.ts#L16
-/* eslint-disable rsp-rules/no-non-shadow-contains */
+/* eslint-disable rsp-rules/no-non-shadow-contains, rsp-rules/safe-event-target */
 
 import {getOwnerWindow, isShadowRoot} from '../domHelpers';
 import {shadowDOM} from '@react-stately/flags';


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Noticed while testing in https://github.com/adobe/react-spectrum/pull/9632 that useHover was broken in Menus. I'm not sure how none of our tests caught this, other than hover is hard to do in jest and in chromatic.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
