### PR TITLE
chore: fix labeler from tagging everything as v3

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,7 +10,8 @@ RAC:
 - changed-files:
   - any-glob-to-any-file: ['**/react-aria-components/**', '**/@react-aria/**']
 
-V3:
-- changed-files:
-  - any-glob-to-any-file: '**/@react-spectrum/**'
-  - all-globs-to-all-files: '!**/@react-spectrum/s2/**'
+v3:
+- all:
+  - changed-files:
+    - any-glob-to-any-file: '**/@react-spectrum/**'
+    - all-globs-to-all-files: '!**/@react-spectrum/s2/**'


### PR DESCRIPTION
it feels like the labeler is tagging everything as v3...so i think i was missing an `- all` to the conditions. i also had it label V3 instead of v3...


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
