### PR TITLE
feat: add focus visible trigger hook

### DIFF
--- a/packages/@react-aria/interactions/src/index.ts
+++ b/packages/@react-aria/interactions/src/index.ts
@@ -19,6 +19,7 @@ export {
   setInteractionModality,
   getPointerType,
   addWindowFocusTracking,
+  useFocusVisibleTrigger,
   useInteractionModality,
   useFocusVisible,
   useFocusVisibleListener

--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -18,7 +18,7 @@
 import {getActiveElement, getEventTarget, getOwnerDocument, getOwnerWindow, isMac, isVirtualClick, openLink} from '@react-aria/utils';
 import {ignoreFocusEvent} from './utils';
 import {PointerType} from '@react-types/shared';
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {useIsSSR} from '@react-aria/ssr';
 
 export type Modality = 'keyboard' | 'pointer' | 'virtual';
@@ -259,6 +259,12 @@ export function setInteractionModality(modality: Modality): void {
   triggerChangeHandlers(modality, null);
 }
 
+export function useFocusVisibleTrigger(): () => void {
+  return useCallback(() => {
+    setInteractionModality('keyboard');
+  }, []);
+}
+
 /** @private */
 export function getPointerType(): PointerType {
   return currentPointerType;
@@ -356,4 +362,3 @@ export function useFocusVisibleListener(fn: FocusVisibleHandler, deps: ReadonlyA
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 }
-

--- a/packages/@react-aria/interactions/test/useFocusVisible.test.js
+++ b/packages/@react-aria/interactions/test/useFocusVisible.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {act, fireEvent, pointerMap, render, renderHook, screen, waitFor} from '@react-spectrum/test-utils-internal';
-import {addWindowFocusTracking, useFocusVisible, useFocusVisibleListener} from '../';
+import {addWindowFocusTracking, useFocusVisible, useFocusVisibleListener, useFocusVisibleTrigger} from '../';
 import {changeHandlers, hasSetupGlobalListeners} from '../src/useFocusVisible';
 import {mergeProps} from '@react-aria/utils';
 import React from 'react';
@@ -452,5 +452,34 @@ describe('useFocusVisibleListener', function () {
       changeHandlers.add = originalAdd;
       changeHandlers.delete = originalDelete;
     });
+  });
+});
+
+describe('useFocusVisibleTrigger', function () {
+  let user;
+  beforeAll(() => {
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+
+  function Example() {
+    let {isFocusVisible} = useFocusVisible();
+    let showFocusVisible = useFocusVisibleTrigger();
+
+    return (
+      <>
+        <button onClick={showFocusVisible}>Show focus visible</button>
+        <div>{isFocusVisible ? 'focus-visible' : 'not-focus-visible'}</div>
+      </>
+    );
+  }
+
+  it('sets keyboard modality when triggered', async function () {
+    render(<Example />);
+
+    expect(screen.getByText('not-focus-visible')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Show focus visible'}));
+
+    expect(screen.getByText('focus-visible')).toBeInTheDocument();
   });
 });

--- a/packages/react-aria/src/index.ts
+++ b/packages/react-aria/src/index.ts
@@ -22,7 +22,7 @@ export {useDisclosure} from '@react-aria/disclosure';
 export {useDrag, useDrop, useDraggableCollection, useDroppableCollection, useDroppableItem, useDropIndicator, useDraggableItem, useClipboard, DragPreview, ListDropTargetDelegate, DIRECTORY_DRAG_TYPE, isDirectoryDropItem, isFileDropItem, isTextDropItem} from '@react-aria/dnd';
 export {FocusRing, FocusScope, useFocusManager, useFocusRing} from '@react-aria/focus';
 export {I18nProvider, isRTL, useCollator, useDateFormatter, useFilter, useLocale, useLocalizedStringFormatter, useMessageFormatter, useNumberFormatter, useListFormatter} from '@react-aria/i18n';
-export {useFocus, useFocusVisible, useFocusWithin, useHover, useInteractOutside, useKeyboard, useMove, usePress, useLongPress, useFocusable, Pressable, Focusable} from '@react-aria/interactions';
+export {useFocus, useFocusVisible, useFocusVisibleTrigger, useFocusWithin, useHover, useInteractOutside, useKeyboard, useMove, usePress, useLongPress, useFocusable, Pressable, Focusable} from '@react-aria/interactions';
 export {useField, useLabel} from '@react-aria/label';
 export {useGridList, useGridListItem, useGridListSection, useGridListSelectionCheckbox} from '@react-aria/gridlist';
 export {useLandmark} from '@react-aria/landmark';


### PR DESCRIPTION

Closes #6809

- Added useFocusVisibleTrigger as a public hook to support programmatic focus-visible behavior (e.g. react-hook-form invalid submit flow) without using internal setInteractionModality directly.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run the interaction tests:
- `corepack yarn jest packages/@react-aria/interactions/test/useFocusVisible.test.js --runInBand`
- `corepack yarn jest packages/@react-aria/interactions/test/focusSafely.test.js --runInBand`

## 🧢 Your Project:

Personal / OSS contribution (react-spectrum fork)
