### PR TITLE
fix(s2-docs): auto-scroll and expand section for group selected nav link

### DIFF
--- a/packages/@react-aria/utils/src/scrollIntoView.ts
+++ b/packages/@react-aria/utils/src/scrollIntoView.ts
@@ -23,9 +23,7 @@ interface ScrollIntoViewOpts {
 
 interface ScrollIntoViewportOpts {
   /** The optional containing element of the target to be centered in the viewport. */
-  containingElement?: Element | null,
-  /** The optional alignment of the target element within the viewport. */
-  block?: ScrollIntoViewOptions['block']
+  containingElement?: Element | null
 }
 
 /**
@@ -127,12 +125,11 @@ export function scrollIntoView(scrollView: HTMLElement, element: HTMLElement, op
 
 /**
  * Scrolls the `targetElement` so it is visible in the viewport. Accepts an optional `opts.containingElement`
- * that will be centered in the viewport prior to scrolling the targetElement into view, and `opts.block`
- * to determine the alignment of the target element. If scrolling is prevented on the body (e.g. targetElement is in a popover),
- * this will only scroll the scroll parents of the targetElement up to but not including the body itself.
+ * that will be centered in the viewport prior to scrolling the targetElement into view. If scrolling is prevented on
+ * the body (e.g. targetElement is in a popover), this will only scroll the scroll parents of the targetElement up to but not including the body itself.
  */
 export function scrollIntoViewport(targetElement: Element | null, opts: ScrollIntoViewportOpts = {}): void {
-  let {containingElement, block = 'nearest'} = opts;
+  let {containingElement} = opts;
   if (targetElement && targetElement.isConnected) {
     let root = document.scrollingElement || document.documentElement;
     let isScrollPrevented = window.getComputedStyle(root).overflow === 'hidden';
@@ -143,12 +140,12 @@ export function scrollIntoViewport(targetElement: Element | null, opts: ScrollIn
 
       // use scrollIntoView({block: 'nearest'}) instead of .focus to check if the element is fully in view or not since .focus()
       // won't cause a scroll if the element is already focused and doesn't behave consistently when an element is partially out of view horizontally vs vertically
-      targetElement?.scrollIntoView?.({block});
+      targetElement?.scrollIntoView?.({block: 'nearest'});
       let {left: newLeft, top: newTop} = targetElement.getBoundingClientRect();
       // Account for sub pixel differences from rounding
       if ((Math.abs(originalLeft - newLeft) > 1) || (Math.abs(originalTop - newTop) > 1)) {
         containingElement?.scrollIntoView?.({block: 'center', inline: 'center'});
-        targetElement.scrollIntoView?.({block});
+        targetElement.scrollIntoView?.({block: 'nearest'});
       }
     } else {
       let {left: originalLeft, top: originalTop} = targetElement.getBoundingClientRect();
@@ -156,14 +153,14 @@ export function scrollIntoViewport(targetElement: Element | null, opts: ScrollIn
       // If scrolling is prevented, we don't want to scroll the body since it might move the overlay partially offscreen and the user can't scroll it back into view.
       let scrollParents = getScrollParents(targetElement, true);
       for (let scrollParent of scrollParents) {
-        scrollIntoView(scrollParent as HTMLElement, targetElement as HTMLElement, {block: opts.block || 'start'});
+        scrollIntoView(scrollParent as HTMLElement, targetElement as HTMLElement);
       }
       let {left: newLeft, top: newTop} = targetElement.getBoundingClientRect();
       // Account for sub pixel differences from rounding
       if ((Math.abs(originalLeft - newLeft) > 1) || (Math.abs(originalTop - newTop) > 1)) {
         scrollParents = containingElement ? getScrollParents(containingElement, true) : [];
         for (let scrollParent of scrollParents) {
-          scrollIntoView(scrollParent as HTMLElement, containingElement as HTMLElement, {block: opts.block || 'center', inline: 'center'});
+          scrollIntoView(scrollParent as HTMLElement, containingElement as HTMLElement, {block: 'center', inline: 'center'});
         }
       }
     }

--- a/packages/dev/s2-docs/src/Nav.tsx
+++ b/packages/dev/s2-docs/src/Nav.tsx
@@ -7,7 +7,6 @@ import {getLibraryFromPage} from './library';
 import LinkOutIcon from '../../../@react-spectrum/s2/ui-icons/LinkOut';
 import type {Page} from '@parcel/rsc';
 import React, {createContext, useContext, useEffect, useRef, useState} from 'react';
-import {scrollIntoViewport} from '@react-aria/utils';
 import {usePendingPage, useRouter} from './Router';
 
 type SectionValue = Page[] | Map<string, Page[]>;
@@ -256,16 +255,17 @@ export function SideNavItem(props) {
 }
 
 export function SideNavLink(props) {
-  let linkRef = useRef(null);
+  let linkRef = useRef<HTMLAnchorElement | null>(null);
   let selected = useContext(SideNavContext);
   let {isExternal, ...linkProps} = props;
 
   useEffect(() => {
-    if (!linkRef.current || !props.isSelected) {
+    let link = linkRef.current;
+    if (!link || !props.isSelected) {
       return;
     }
 
-    scrollIntoViewport(linkRef.current, {block: 'start'});
+    link.scrollIntoView({block: 'start', behavior: 'smooth'});
   }, [props.isSelected]);
 
   return (


### PR DESCRIPTION
Closes #9663

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Current behaviour (prod):

https://github.com/user-attachments/assets/081f72a7-f269-4978-b36f-44f19b0d1d1c

Ideal behaviour (this changeset):

https://github.com/user-attachments/assets/237d1b2b-758a-491f-ae1f-b4bf02bb8a6b

Summary of changes needed for this in `packages/dev/s2-docs/src/Nav.tsx`:
  1. Auto-expand disclosure when the current page's group, not only section, matches the nav section name                    
  2. Auto-scroll the selected SideNavLink into view on mount
  3. Add scrollMarginTop to prevent the link from being hidden behind the fixed header
  4. Add type annotation to linkRef to pass TypeScript checks

## 🧢 Your Project:

https://github.com/domhhv/habitrack
