### PR TITLE
fix(RAC): use KeyboardProps in Keyboard component and context

### DIFF
--- a/packages/react-aria-components/src/Keyboard.tsx
+++ b/packages/react-aria-components/src/Keyboard.tsx
@@ -15,9 +15,9 @@ import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes} from 're
 
 export interface KeyboardProps extends HTMLAttributes<HTMLElement>, DOMRenderProps<'kbd', undefined> {}
 
-export const KeyboardContext = createContext<ContextValue<HTMLAttributes<HTMLElement>, HTMLElement>>({});
+export const KeyboardContext = createContext<ContextValue<KeyboardProps, HTMLElement>>({});
 
-export const Keyboard = forwardRef(function Keyboard(props: HTMLAttributes<HTMLElement>, ref: ForwardedRef<HTMLElement>) {
+export const Keyboard = forwardRef(function Keyboard(props: KeyboardProps, ref: ForwardedRef<HTMLElement>) {
   [props, ref] = useContextProps(props, ref, KeyboardContext);
   return <dom.kbd dir="ltr" {...props} ref={ref} />;
 });


### PR DESCRIPTION
Closes #9666

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Use `KeyboardProps` as the prop type in the `Keyboard` component
2. Verify TypeScript correctly identifies `render` prop and other props from `DOMRenderProps<'kbd', undefined>`
3. Verify no TypeScript errors when using the `Keyboard` component with the `render` prop

## 🧢 Your Project:

React Aria Components