### PR TITLE
Fix: Wrap commit() in flushSync on Enter in NumberField

### DIFF
--- a/packages/@react-spectrum/tree/stories/TreeView.stories.tsx
+++ b/packages/@react-spectrum/tree/stories/TreeView.stories.tsx
@@ -317,6 +317,7 @@ const DynamicTreeItem = (props) => {
 };
 
 export const TreeExampleDynamic: StoryObj<typeof TreeView> = {
+  ...TreeExampleStatic,
   render: (args: SpectrumTreeViewProps<unknown>) => (
     <div style={{width: '300px', resize: 'both', height: '90vh', overflow: 'auto'}}>
       <TreeView disabledKeys={['reports-1AB']} aria-label="test dynamic tree" items={rows} onExpandedChange={action('onExpandedChange')} onSelectionChange={action('onSelectionChange')} {...args}>
@@ -331,7 +332,6 @@ export const TreeExampleDynamic: StoryObj<typeof TreeView> = {
       </TreeView>
     </div>
   ),
-  ...TreeExampleStatic,
   parameters: undefined
 };
 

--- a/packages/dev/s2-docs/pages/s2/Picker.mdx
+++ b/packages/dev/s2-docs/pages/s2/Picker.mdx
@@ -249,15 +249,16 @@ Use the `renderValue` prop to provide a custom element to display selected items
 
 ```tsx render
 "use client";
-import {Avatar, Picker, PickerItem, Text} from '@react-spectrum/s2';
-import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {Avatar, AvatarGroup, Picker, PickerItem, Text} from '@react-spectrum/s2';
 
+///- begin collapse -///
 let users = [
   {id: 'abraham-baker', avatar: 'https://www.untitledui.com/images/avatars/abraham-baker', name: 'Abraham Baker', email: 'abraham@example.com'},
   {id: 'adriana-sullivan', avatar: 'https://www.untitledui.com/images/avatars/adriana-sullivan', name: 'Adriana Sullivan', email: 'adriana@example.com'},
   {id: 'jonathan-kelly', avatar: 'https://www.untitledui.com/images/avatars/jonathan-kelly', name: 'Jonathan Kelly', email: 'jonathan@example.com'},
   {id: 'zara-bush', avatar: 'https://www.untitledui.com/images/avatars/zara-bush', name: 'Zara Bush', email: 'zara@example.com'}
 ];
+///- end collapse -///
 
 function Example() {
   return (
@@ -268,11 +269,11 @@ function Example() {
         selectionMode={"multiple"}
         ///- begin highlight -///
         renderValue={(selectedItems) => (
-          <div className={style({ display: 'flex', gap: 4, height: '80%' })}>
+          <AvatarGroup aria-label="Selected users">
             {selectedItems.map(item => (
-              <Avatar slot={null} key={item.id} src={item.avatar} alt={item.name} />
+              <Avatar key={item.id} src={item.avatar} alt={item.name} />
             ))}
-          </div>
+          </AvatarGroup>
         )}
         ///- end highlight -///
       >


### PR DESCRIPTION
Fixes the inconsistency where `commit()` is wrapped in `flushSync` on blur but not on Enter keydown in `useNumberField`.

Closes #9671

## Problem

When a user types a value in NumberField and presses Enter:
1. react-aria calls `commit()` without `flushSync`
2. The browser synthesizes a trusted click on the submit button
3. Form's `onSubmit` fires before `commit()` has flushed to React state
4. Controlled form libraries (TanStack Form, React Hook Form, Formik) read stale/default values

This works correctly with native HTML forms because they read from the hidden input after `commit()` has updated `state.numberValue`. But controlled form libraries that read React state directly are exposed to this race condition.

## Solution

Wrap `commit()` in `flushSync()` on Enter, consistent with how the blur handler already does it. This ensures the value is flushed synchronously before any consumer reads form state.

## ✅ Pull Request Checklist:
- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/9671).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

### Before the fix:
1. Create a NumberField inside a controlled form (TanStack Form, React Hook Form, etc.)
2. Set a `defaultValue` (e.g., 1)
3. Type a new value (e.g., 5)
4. Press Enter without blurring the field first
5. Observe: form submits with defaultValue (1) instead of typed value (5)

### After the fix:
1. Same setup as above
2. Type a new value and press Enter
3. Observe: form submits with the correct typed value (5)

### Existing behavior preserved:
- Blur behavior unchanged (already uses flushSync)
- Stepper buttons work correctly
- Native HTML form submission still works
- All existing tests pass

## 🧢 Your Project:
Cryptlex (SaaS license management platform)