### PR TITLE
fix: Ensure that opening a submenu via enter/space moves focus to first item in submenu

### DIFF
--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -288,7 +288,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
           interaction.current = {pointerType: 'keyboard', key: ' '};
           (getEventTarget(e) as HTMLElement).click();
 
-          // click above sets modality to "virutal", need to set interaction modality back to 'keyboard' so focusSafely calls properly move focus
+          // click above sets modality to "virtual", need to set interaction modality back to 'keyboard' so focusSafely calls properly move focus
           // to the newly opened submenu's first item.
           setInteractionModality('keyboard');
           break;
@@ -300,7 +300,7 @@ export function useMenuItem<T>(props: AriaMenuItemProps, state: TreeState<T>, re
             (getEventTarget(e) as HTMLElement).click();
           }
 
-          // click above sets modality to "virutal", need to set interaction modality back to 'keyboard' so focusSafely calls properly move focus
+          // click above sets modality to "virtual", need to set interaction modality back to 'keyboard' so focusSafely calls properly move focus
           // to the newly opened submenu's first item.
           setInteractionModality('keyboard');
           break;


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9686

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to RAC Submenu story and make sure that Enter/Space opens the submenu and that focus lands on the first item in the submenu. Pressing Enter/Space again should trigger the submenu item

## 🧢 Your Project:

RSP
