### PR TITLE
docs(S2): fix clipping in Picker custom value AvatarGroup example

### DIFF
--- a/packages/dev/s2-docs/pages/s2/Picker.mdx
+++ b/packages/dev/s2-docs/pages/s2/Picker.mdx
@@ -250,6 +250,7 @@ Use the `renderValue` prop to provide a custom element to display selected items
 ```tsx render
 "use client";
 import {Avatar, AvatarGroup, Picker, PickerItem, Text} from '@react-spectrum/s2';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 ///- begin collapse -///
 let users = [
@@ -269,7 +270,7 @@ function Example() {
         selectionMode={"multiple"}
         ///- begin highlight -///
         renderValue={(selectedItems) => (
-          <AvatarGroup aria-label="Selected users">
+          <AvatarGroup aria-label="Selected users" styles={style({marginX: 4})}>
             {selectedItems.map(item => (
               <Avatar key={item.id} src={item.avatar} alt={item.name} />
             ))}


### PR DESCRIPTION
Fixes the AvatarGroup getting clipped when rendered as a custom value in the Picker.


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test the docs example and make sure the avatar group doesn't get clipped.

## 🧢 Your Project:

<!--- Company/project for pull request -->
