### PR TITLE
fix: prevent docs crash by making template elements always append children into .content

### DIFF
--- a/packages/@react-aria/collections/src/Hidden.tsx
+++ b/packages/@react-aria/collections/src/Hidden.tsx
@@ -20,11 +20,6 @@ import React, {Context, createContext, forwardRef, JSX, ReactElement, ReactNode,
 // does the same for appendChild/removeChild/insertBefore as per the issue below
 // See https://github.com/facebook/react/issues/19932
 if (typeof HTMLTemplateElement !== 'undefined') {
-  const getFirstChild = Object.getOwnPropertyDescriptor(Node.prototype, 'firstChild')!.get!;
-  const originalAppendChild = Object.getOwnPropertyDescriptor(Node.prototype, 'appendChild')!.value!;
-  const originalRemoveChild = Object.getOwnPropertyDescriptor(Node.prototype, 'removeChild')!.value!;
-  const originalInsertBefore = Object.getOwnPropertyDescriptor(Node.prototype, 'insertBefore')!.value!;
-
   Object.defineProperty(HTMLTemplateElement.prototype, 'firstChild', {
     configurable: true,
     enumerable: true,


### PR DESCRIPTION
follow up to https://github.com/adobe/react-spectrum/pull/9385

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to S2 Picker docs. Type any description in the first example's description control, it should apply without crashing. Also try going to another page and coming back to the Picker page and adding a description.

## 🧢 Your Project:

RSP
