### PR TITLE
fix: prevent calling focus on elements within template elements

### DIFF
--- a/packages/@react-aria/interactions/src/focusSafely.ts
+++ b/packages/@react-aria/interactions/src/focusSafely.ts
@@ -24,9 +24,7 @@ import {getInteractionModality} from './useFocusVisible';
  * as page scrolling and screen reader issues with CSS transitions.
  */
 export function focusSafely(element: FocusableElement): void {
-  // don't try to focus in template element's document fragment, but let this work for shadow dom
-  let root = element.getRootNode();
-  if (root instanceof DocumentFragment && !('host' in root)) {
+  if (!element.isConnected) {
     return;
   }
 

--- a/packages/@react-spectrum/s2/src/ContextualHelp.tsx
+++ b/packages/@react-spectrum/s2/src/ContextualHelp.tsx
@@ -1,11 +1,11 @@
 import {ActionButton} from './ActionButton';
 import {AriaLabelingProps, DOMProps, FocusableRef, FocusableRefValue} from '@react-types/shared';
 import {ContentContext, FooterContext, HeadingContext, TextContext as SpectrumTextContext} from './Content';
-import {ContextValue, DEFAULT_SLOT, Provider, Dialog as RACDialog, TextContext} from 'react-aria-components';
+import {ContextValue, DEFAULT_SLOT, Provider, TextContext} from 'react-aria-components';
 import {createContext, forwardRef, ReactNode} from 'react';
 import {dialogInner} from './Dialog';
 import {DialogTrigger, DialogTriggerProps} from './DialogTrigger';
-import {filterDOMProps, mergeProps, useLabels, useSlotId} from '@react-aria/utils';
+import {filterDOMProps, mergeProps, useId, useLabels} from '@react-aria/utils';
 import HelpIcon from '../s2wf-icons/S2_Icon_HelpCircle_20_N.svg';
 import InfoIcon from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg';
 // @ts-ignore
@@ -44,16 +44,18 @@ const headingStyles = style({
  */
 export function ContextualHelpPopover(props: ContextualHelpPopoverProps) {
   let {children, ...popoverProps} = props;
-  let titleId = useSlotId();
+  let titleId = useId();
+
   return (
     <Popover
       padding="none"
       hideArrow
+      aria-labelledby={titleId}
       {...popoverProps}>
       <div
         className={wrappingDiv}>
-        <RACDialog
-          aria-labelledby={titleId}
+        <div
+
           className={mergeStyles(dialogInner, style({borderRadius: 'none', margin: 'calc(self(paddingTop) * -1)', padding: 24}))}>
           <Provider
             values={[
@@ -71,7 +73,7 @@ export function ContextualHelpPopover(props: ContextualHelpPopoverProps) {
                   // ContextualHelp (they get the aria-labelled by from the button)
                   // otherwise, use the heading if available aka unavaiable menu item
                   [DEFAULT_SLOT]: {styles: headingStyles},
-                  title: {id: titleId, styles: headingStyles}
+                  title: {id: titleId, styles: headingStyles, level: 2}
                 }
               }],
               [ContentContext, {styles: style({
@@ -84,7 +86,7 @@ export function ContextualHelpPopover(props: ContextualHelpPopoverProps) {
             ]}>
             {children}
           </Provider>
-        </RACDialog>
+        </div>
       </div>
     </Popover>
   );


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Navigate to the S2 Picker storybook docs story. Check your console and you shouldn't see "Error: Could not determine window of node. Node was [object HTMLElement]"

Go to S2 Picker docs. Type any description in the first example's description control, it should apply without crashing. Also try going to another page and coming back to the Picker page and adding a description.

## 🧢 Your Project:

RSP
