### PR TITLE
fix: S2 ListView polish styles

### DIFF
--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -419,7 +419,8 @@ const listRowBackground = style<GridListItemRenderProps & {
           highlight: 'default'
         }
       },
-      isQuiet: 'default'
+      isQuiet: 'default',
+      isFocusVisible: 'default'
     }
   },
   borderTopEndRadius: {
@@ -430,7 +431,8 @@ const listRowBackground = style<GridListItemRenderProps & {
           highlight: 'default'
         }
       },
-      isQuiet: 'default'
+      isQuiet: 'default',
+      isFocusVisible: 'default'
     }
   },
   borderBottomStartRadius: {
@@ -441,7 +443,8 @@ const listRowBackground = style<GridListItemRenderProps & {
           highlight: 'default'
         }
       },
-      isQuiet: 'default'
+      isQuiet: 'default',
+      isFocusVisible: 'default'
     }
   },
   borderBottomEndRadius: {
@@ -452,7 +455,8 @@ const listRowBackground = style<GridListItemRenderProps & {
           highlight: 'default'
         }
       },
-      isQuiet: 'default'
+      isQuiet: 'default',
+      isFocusVisible: 'default'
     }
   },
   borderTopWidth: {


### PR DESCRIPTION
Found while testing fixes some of these https://github.com/orgs/adobe/projects/19/views/32?pane=issue&itemId=160905769

The first one appears intentional from design, but I'm double checking with them.

To test, turn scrollbars always on, then visit Example and Dynamic and set the various combinations of selectionStyle and isQuiet

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
