### PR TITLE
docs(ActionBar): add TreeView example to ActionBar docs

### DIFF
--- a/packages/dev/s2-docs/pages/s2/ActionBar.mdx
+++ b/packages/dev/s2-docs/pages/s2/ActionBar.mdx
@@ -14,7 +14,7 @@ export const description = 'Used when a user needs to perform actions on one or 
 
 ```tsx render docs={docs.exports.ActionBar} links={docs.links} props={['isEmphasized']} type="s2" wide
 "use client";
-import {ActionBar, ActionButton, TableView, TableHeader, TableBody, Column, Row, Cell, Text} from '@react-spectrum/s2';
+import {ActionBar, ActionButton, TableView, TableHeader, TableBody, Column, Row, Cell} from '@react-spectrum/s2';
 import Edit from '@react-spectrum/s2/icons/Edit';
 import Copy from '@react-spectrum/s2/icons/Copy';
 import Delete from '@react-spectrum/s2/icons/Delete';
@@ -37,17 +37,14 @@ function Example(props) {
       renderActionBar={(selectedKeys) => (
         /*- begin focus -*/
         <ActionBar {...props}/* PROPS */>
-          <ActionButton onPress={() => alert('Edit action')}>
+          <ActionButton aria-label="Edit" onPress={() => alert('Edit action')}>
             <Edit />
-            <Text>Edit</Text>
           </ActionButton>
-          <ActionButton onPress={() => alert('Copy action')}>
+          <ActionButton aria-label="Copy" onPress={() => alert('Copy action')}>
             <Copy />
-            <Text>Copy</Text>
           </ActionButton>
-          <ActionButton onPress={() => alert('Delete action')}>
+          <ActionButton aria-label="Delete" onPress={() => alert('Delete action')}>
             <Delete />
-            <Text>Delete</Text>
           </ActionButton>
         </ActionBar>
         /*- end focus -*/
@@ -97,17 +94,14 @@ function Example(props) {
       renderActionBar={(selectedKeys) => (
         /*- begin focus -*/
         <ActionBar {...props}/* PROPS */>
-          <ActionButton onPress={() => alert('Edit action')}>
+          <ActionButton aria-label="Edit" onPress={() => alert('Edit action')}>
             <Edit />
-            <Text>Edit</Text>
           </ActionButton>
-          <ActionButton onPress={() => alert('Copy action')}>
+          <ActionButton aria-label="Copy" onPress={() => alert('Copy action')}>
             <Copy />
-            <Text>Copy</Text>
           </ActionButton>
-          <ActionButton onPress={() => alert('Delete action')}>
+          <ActionButton aria-label="Delete" onPress={() => alert('Delete action')}>
             <Delete />
-            <Text>Delete</Text>
           </ActionButton>
         </ActionBar>
         /*- end focus -*/
@@ -125,7 +119,7 @@ function Example(props) {
 
 ```tsx render docs={docs.exports.ActionBar} links={docs.links} props={['isEmphasized']} type="s2" wide
 "use client";
-import {ActionBar, ActionButton, TreeView, TreeViewItem, TreeViewItemContent, Text} from '@react-spectrum/s2';
+import {ActionBar, ActionButton, TreeView, TreeViewItem, TreeViewItemContent} from '@react-spectrum/s2';
 import Edit from '@react-spectrum/s2/icons/Edit';
 import Copy from '@react-spectrum/s2/icons/Copy';
 import Delete from '@react-spectrum/s2/icons/Delete';
@@ -142,17 +136,14 @@ function Example(props) {
       renderActionBar={(selectedKeys) => (
         /*- begin focus -*/
         <ActionBar {...props}/* PROPS */>
-          <ActionButton onPress={() => alert('Edit action')}>
+          <ActionButton aria-label="Edit" onPress={() => alert('Edit action')}>
             <Edit />
-            <Text>Edit</Text>
           </ActionButton>
-          <ActionButton onPress={() => alert('Copy action')}>
+          <ActionButton aria-label="Copy" onPress={() => alert('Copy action')}>
             <Copy />
-            <Text>Copy</Text>
           </ActionButton>
-          <ActionButton onPress={() => alert('Delete action')}>
+          <ActionButton aria-label="Delete" onPress={() => alert('Delete action')}>
             <Delete />
-            <Text>Delete</Text>
           </ActionButton>
         </ActionBar>
         /*- end focus -*/


### PR DESCRIPTION
Was waiting until ListView got merged to avoid conflicts.

Also removed text from the buttons to avoid overflowing on small screen widths.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test [docs page](https://d1pzu54gtk2aed.cloudfront.net/pr/e61d4fc8b26dffd8f9b774ffb946a4b6b33ae20b/ActionBar).

## 🧢 Your Project:

<!--- Company/project for pull request -->
