### PR TITLE
fix(TableView): updated disabled behavior to match ListView/TreeView

### DIFF
--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -947,21 +947,13 @@ const commonCellStyles = {
   borderXWidth: 0,
   borderStyle: 'solid',
   position: 'relative',
-  color: {
-    default: 'gray-800',
-    forcedColors: 'ButtonText'
-  },
+  color: '--rowTextColor',
   outlineStyle: 'none',
   paddingX: 16 // table-edge-to-content
 } as const;
 
 const cell = style<CellRenderProps & S2TableProps & {isDivider: boolean}>({
   ...commonCellStyles,
-  color: {
-    default: baseColor('neutral-subdued'),
-    isSelected: baseColor('neutral'),
-    forcedColors: 'ButtonText'
-  },
   paddingY: centerPadding(),
   minHeight: {
     default: 40,
@@ -1398,6 +1390,16 @@ const rowBackgroundColor = {
   }
 } as const;
 
+const rowTextColor = {
+  default: baseColor('neutral-subdued'),
+  isSelected: baseColor('neutral'),
+  isDisabled: {
+    default: 'disabled',
+    forcedColors: 'GrayText'
+  },
+  forcedColors: 'ButtonText'
+} as const;
+
 const row = style<RowRenderProps & S2TableProps>({
   height: 'full',
   position: 'relative',
@@ -1406,6 +1408,10 @@ const row = style<RowRenderProps & S2TableProps>({
   '--rowBackgroundColor': {
     type: 'backgroundColor',
     value: rowBackgroundColor
+  },
+  '--rowTextColor': {
+    type: 'color',
+    value: rowTextColor
   },
   '--rowFocusIndicatorColor': {
     type: 'outlineColor',


### PR DESCRIPTION
- Hides the selection checkbox in TableView if the row is disabled (regardless of disabledBehavior). 
- Renders text content as disabled for disabledBehavior="all"

Matches behavior found in ListView and TreeView.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check [TableView -> "Disabled Rows"](https://reactspectrum.blob.core.windows.net/reactspectrum/09cdebacac45e66af680f06e2f8b3f8672c64675/storybook-s2/index.html?path=/story/tableview--disabled-rows) story and chromatic diff.

## 🧢 Your Project:

<!--- Company/project for pull request -->
