### PR TITLE
fix: ListView item size and borders

### DIFF
--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -334,24 +334,7 @@ const listitem = style<GridListItemRenderProps & {
       forcedColors: 'ButtonBorder'
     }
   },
-  borderTopWidth: 0,
-  borderBottomWidth: {
-    default: 1,
-    isLastItem: {
-      default: 1,
-      isQuiet: {
-        selectionStyle: {
-          checkbox: 0,
-          highlight: {
-            default: 0,
-            isSelected: 1
-          }
-        }
-      }
-    }
-  },
-  borderStartWidth: 0,
-  borderEndWidth: 0,
+  borderWidth: 0,
   borderStyle: 'solid',
   borderColor: {
     default: '--borderColor',
@@ -405,15 +388,7 @@ const listRowBackground = style<GridListItemRenderProps & {
   top: 0,
   left: 0,
   right: 0,
-  bottom: {
-    default: 0,
-    isSelected: {
-      selectionStyle: {
-        checkbox: 0,
-        highlight: '[-1px]'
-      }
-    }
-  },
+  bottom: 0,
   backgroundColor: {
     default: '--rowBackgroundColor',
     isHovered: {
@@ -468,13 +443,17 @@ const listRowBackground = style<GridListItemRenderProps & {
     }
   },
   borderTopWidth: {
-    default: 1,
-    isPrevSelected: {
-      selectionStyle: {
-        highlight: 0,
-        checkbox: 0
+    default: 0,
+    isSelected: 1,
+    isFirstItem: {
+      default: 0,
+      isSelected: 1,
+      isQuiet: {
+        default: 0,
+        isSelected: 1
       }
-    }
+    },
+    isPrevSelected: 0
   },
   borderBottomWidth: {
     default: 1,
@@ -487,6 +466,7 @@ const listRowBackground = style<GridListItemRenderProps & {
     isLastItem: {
       default: 1,
       isQuiet: {
+        isLastItem: 0,
         selectionStyle: {
           checkbox: 0,
           highlight: {
@@ -497,11 +477,17 @@ const listRowBackground = style<GridListItemRenderProps & {
       }
     }
   },
-  borderStartWidth: 1,
-  borderEndWidth: 1,
+  borderStartWidth: {
+    default: 0,
+    isSelected: 1
+  },
+  borderEndWidth: {
+    default: 0,
+    isSelected: 1
+  },
   borderStyle: 'solid',
   borderColor: {
-    default: 'transparent',
+    default: '--borderColor',
     isSelected: {
       selectionStyle: {
         highlight: '--borderColor',


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Solves the issues we had with a gap between items and not needing a hack to absolute position the background 1 px outside the item. It also prevents any layout shifts inside an item by moving it all to the background. It also gets rid of that odd almost transitiony-look that the border had when selecting and deselecting.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
