### PR TITLE
docs(AI): move MCP clients into Tabs

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/ai.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ai.mdx
@@ -1,7 +1,7 @@
 import {Layout} from '../../src/Layout';
 import {StaticTable} from '../../src/StaticTable';
 import {Command} from '../../src/Command';
-import {Link} from '@react-spectrum/s2';
+import {Link, Tabs, TabList, Tab, TabPanel} from '@react-spectrum/s2';
 export default Layout;
 
 export const section = 'Guides';
@@ -14,78 +14,96 @@ export const tags = ['ai', 'mcp', 'agent', 'skills', 'llms.txt', 'markdown'];
 
 ## MCP Server
 
-### Pre-requisites
-
 [Node.js](https://nodejs.org/) must be installed on your system to run the MCP server.
 
-### Using with an MCP client
+<Tabs aria-label="MCP Clients" density="compact">
+  <TabList><Tab id="cursor">Cursor</Tab><Tab id="vscode">VS Code</Tab><Tab id="claude-code">Claude Code</Tab><Tab id="codex">Codex</Tab><Tab id="gemini-cli">Gemini CLI</Tab><Tab id="other">Other</Tab></TabList>
+  <TabPanel id="cursor">
+    Click the button to install:
 
-Add the server to your MCP client configuration (the exact file and schema may depend on your client).
+    <Link href="cursor://anysphere.cursor-deeplink/mcp/install?name=React%20Aria&config=eyJjb21tYW5kIjoibnB4IEByZWFjdC1hcmlhL21jcEBsYXRlc3QifQ%3D%3D" aria-label="Add to Cursor">
+      <picture>
+        <source srcSet="https://cursor.com/deeplink/mcp-install-dark.svg" media="(prefers-color-scheme: light)" />
+        <source srcSet="https://cursor.com/deeplink/mcp-install-light.svg"  media="(prefers-color-scheme: dark)" />
+        <img src="https://cursor.com/deeplink/mcp-install-light.svg" alt="Add to Cursor" />
+      </picture>
+    </Link>
 
-```js
-{
-  "mcpServers": {
-    "React Aria": {
-      "command": "npx",
-      "args": ["@react-aria/mcp@latest"]
+    Or follow Cursor's MCP install [guide](https://cursor.com/docs/context/mcp#installing-mcp-servers) and use the following config:
+
+    ```js
+    {
+      "mcpServers": {
+        "React Aria": {
+          "command": "npx",
+          "args": ["@react-aria/mcp@latest"]
+        }
+      }
     }
-  }
-}
-```
+    ```
+  </TabPanel>
+  <TabPanel id="vscode">
+    Click the button to install:
 
-### Cursor
+    <Link href="vscode:mcp/install?%7B%22name%22%3A%22React%20Aria%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40react-aria%2Fmcp%40latest%22%5D%7D" aria-label="Add to Visual Studio Code">
+      <img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in Visual Studio Code" />
+    </Link>
 
-<Link href="cursor://anysphere.cursor-deeplink/mcp/install?name=React%20Aria&config=eyJjb21tYW5kIjoibnB4IEByZWFjdC1hcmlhL21jcEBsYXRlc3QifQ%3D%3D" aria-label="Add to Cursor">
-  <picture>
-    <source srcSet="https://cursor.com/deeplink/mcp-install-dark.svg" media="(prefers-color-scheme: light)" />
-    <source srcSet="https://cursor.com/deeplink/mcp-install-light.svg"  media="(prefers-color-scheme: dark)" />
-    <img src="https://cursor.com/deeplink/mcp-install-light.svg" alt="Add to Cursor" />
-  </picture>
-</Link>
+    Or follow VS Code's MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server) and use the following config. You can also add the server using the VS Code CLI:
 
-Or follow Cursor's MCP install [guide](https://cursor.com/docs/context/mcp#installing-mcp-servers) and use the standard config above.
+    <Command command='code --add-mcp &#39;{"name":"React Aria","command":"npx","args":["@react-aria/mcp@latest"]}&#39;' />
 
-### VS Code
+    ```js
+    {
+      "mcpServers": {
+        "React Aria": {
+          "command": "npx",
+          "args": ["@react-aria/mcp@latest"]
+        }
+      }
+    }
+    ```
+  </TabPanel>
+  <TabPanel id="claude-code">
+    Use the Claude Code CLI to add the server:
 
-<Link href="vscode:mcp/install?%7B%22name%22%3A%22React%20Aria%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40react-aria%2Fmcp%40latest%22%5D%7D" aria-label="Add to Visual Studio Code">
-  <img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in Visual Studio Code" />
-</Link>
+    <Command command="claude mcp add react-aria npx @react-aria/mcp@latest" />
 
-Or follow VS Code's MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server) and use the standard config above. You can also add the server using the VS Code CLI:
+    For more information, see the [Claude Code MCP documentation](https://docs.claude.com/en/docs/claude-code/mcp).
+  </TabPanel>
+  <TabPanel id="codex">
+    Create or edit the configuration file `~/.codex/config.toml` and add:
 
-<Command command='code --add-mcp &#39;{"name":"React Aria","command":"npx","args":["@react-aria/mcp@latest"]}&#39;' />
+    ```
+    [mcp_servers.react-aria]
+    command = "npx"
+    args = ["@react-aria/mcp@latest"]
+    ```
 
-### Claude Code
+    For more information, see the [Codex MCP documentation](https://github.com/openai/codex/blob/main/docs/config.md#mcp_servers).
+  </TabPanel>
+  <TabPanel id="gemini-cli">
+    Use the Gemini CLI to add the server:
 
-Use the Claude Code CLI to add the server:
+    <Command command="gemini mcp add react-aria npx @react-aria/mcp@latest" />
 
-<Command command="claude mcp add react-aria npx @react-aria/mcp@latest" />
+    For more information, see the [Gemini CLI MCP documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#how-to-set-up-your-mcp-server).
+  </TabPanel>
+  <TabPanel id="other">
+    Add the server to your MCP client configuration (the exact file and schema may depend on your client).
 
-For more information, see the [Claude Code MCP documentation](https://docs.claude.com/en/docs/claude-code/mcp).
-
-### Codex
-
-Create or edit the configuration file `~/.codex/config.toml` and add:
-
-```
-[mcp_servers.react-aria]
-command = "npx"
-args = ["@react-aria/mcp@latest"]
-```
-
-For more information, see the [Codex MCP documentation](https://github.com/openai/codex/blob/main/docs/config.md#mcp_servers).
-
-### Gemini CLI
-
-Use the Gemini CLI to add the server:
-
-<Command command="gemini mcp add react-aria npx @react-aria/mcp@latest" />
-
-For more information, see the [Gemini CLI MCP documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#how-to-set-up-your-mcp-server).
-
-### Windsurf
-
-Follow the Windsurf MCP [documentation](https://docs.windsurf.com/windsurf/cascade/mcp) and use the standard config above.
+    ```js
+    {
+      "mcpServers": {
+        "React Aria": {
+          "command": "npx",
+          "args": ["@react-aria/mcp@latest"]
+        }
+      }
+    }
+    ```
+  </TabPanel>
+</Tabs>
 
 ## Agent Skills
 

--- a/packages/dev/s2-docs/pages/s2/ai.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai.mdx
@@ -1,7 +1,7 @@
 import {Layout} from '../../src/Layout';
 import {StaticTable} from '../../src/StaticTable';
 import {Command} from '../../src/Command';
-import {Link} from '@react-spectrum/s2';
+import {Link, Tabs, TabList, Tab, TabPanel} from '@react-spectrum/s2';
 export default Layout;
 
 export const section = 'Guides';
@@ -14,78 +14,96 @@ export const tags = ['ai', 'mcp', 'agent', 'skills', 'llms.txt', 'markdown'];
 
 ## MCP Server
 
-### Pre-requisites
-
 [Node.js](https://nodejs.org/) must be installed on your system to run the MCP server.
 
-### Using with an MCP client
+<Tabs aria-label="MCP Clients" density="compact">
+  <TabList><Tab id="cursor">Cursor</Tab><Tab id="vscode">VS Code</Tab><Tab id="claude-code">Claude Code</Tab><Tab id="codex">Codex</Tab><Tab id="gemini-cli">Gemini CLI</Tab><Tab id="other">Other</Tab></TabList>
+  <TabPanel id="cursor">
+    Click the button to install:
+  
+    <Link href="cursor://anysphere.cursor-deeplink/mcp/install?name=React%20Spectrum%20(S2)&config=eyJjb21tYW5kIjoibnB4IEByZWFjdC1zcGVjdHJ1bS9tY3BAbGF0ZXN0In0%3D" aria-label="Add to Cursor">
+      <picture>
+        <source srcSet="https://cursor.com/deeplink/mcp-install-dark.svg" media="(prefers-color-scheme: light)" />
+        <source srcSet="https://cursor.com/deeplink/mcp-install-light.svg"  media="(prefers-color-scheme: dark)" />
+        <img src="https://cursor.com/deeplink/mcp-install-light.svg" alt="Add to Cursor" />
+      </picture>
+    </Link>
 
-Add the server to your MCP client configuration (the exact file and schema may depend on your client).
+    Or follow Cursor's MCP install [guide](https://cursor.com/docs/context/mcp#installing-mcp-servers) and use the following config:
 
-```js
-{
-  "mcpServers": {
-    "React Spectrum (S2)": {
-      "command": "npx",
-      "args": ["@react-spectrum/mcp@latest"]
+    ```js
+    {
+      "mcpServers": {
+        "React Spectrum (S2)": {
+          "command": "npx",
+          "args": ["@react-spectrum/mcp@latest"]
+        }
+      }
     }
-  }
-}
-```
+    ```
+  </TabPanel>
+  <TabPanel id="vscode">
+    Click the button to install:
 
-### Cursor
+    <Link href="vscode:mcp/install?%7B%22name%22%3A%22React%20Spectrum%20(S2)%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40react-spectrum%2Fmcp%40latest%22%5D%7D" aria-label="Add to Visual Studio Code">
+      <img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in Visual Studio Code" />
+    </Link>
 
-<Link href="cursor://anysphere.cursor-deeplink/mcp/install?name=React%20Spectrum%20(S2)&config=eyJjb21tYW5kIjoibnB4IEByZWFjdC1zcGVjdHJ1bS9tY3BAbGF0ZXN0In0%3D" aria-label="Add to Cursor">
-  <picture>
-    <source srcSet="https://cursor.com/deeplink/mcp-install-dark.svg" media="(prefers-color-scheme: light)" />
-    <source srcSet="https://cursor.com/deeplink/mcp-install-light.svg"  media="(prefers-color-scheme: dark)" />
-    <img src="https://cursor.com/deeplink/mcp-install-light.svg" alt="Add to Cursor" />
-  </picture>
-</Link>
+    Or follow VS Code's MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server) and use the following config. You can also add the server using the VS Code CLI:
 
-Or follow Cursor's MCP install [guide](https://cursor.com/docs/context/mcp#installing-mcp-servers) and use the standard config above.
+    <Command command='code --add-mcp &#39;{"name":"React Spectrum (S2)","command":"npx","args":["@react-spectrum/mcp@latest"]}&#39;' />
 
-### VS Code
+    ```js
+    {
+      "mcpServers": {
+        "React Spectrum (S2)": {
+          "command": "npx",
+          "args": ["@react-spectrum/mcp@latest"]
+        }
+      }
+    }
+    ```
+  </TabPanel>
+  <TabPanel id="claude-code">
+    Use the Claude Code CLI to add the server:
 
-<Link href="vscode:mcp/install?%7B%22name%22%3A%22React%20Spectrum%20(S2)%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40react-spectrum%2Fmcp%40latest%22%5D%7D" aria-label="Add to Visual Studio Code">
-  <img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in Visual Studio Code" />
-</Link>
+    <Command command="claude mcp add react-spectrum-s2 npx @react-spectrum/mcp@latest" />
 
-Or follow VS Code's MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server) and use the standard config above. You can also add the server using the VS Code CLI:
+    For more information, see the [Claude Code MCP documentation](https://docs.claude.com/en/docs/claude-code/mcp).
+  </TabPanel>
+  <TabPanel id="codex">
+    Create or edit the configuration file `~/.codex/config.toml` and add:
 
-<Command command='code --add-mcp &#39;{"name":"React Spectrum (S2)","command":"npx","args":["@react-spectrum/mcp@latest"]}&#39;' />
+    ```
+    [mcp_servers.react-spectrum-s2]
+    command = "npx"
+    args = ["@react-spectrum/mcp@latest"]
+    ```
 
-### Claude Code
+    For more information, see the [Codex MCP documentation](https://github.com/openai/codex/blob/main/docs/config.md#mcp_servers).
+  </TabPanel>
+  <TabPanel id="gemini-cli">
+    Use the Gemini CLI to add the server:
 
-Use the Claude Code CLI to add the server:
+    <Command command="gemini mcp add react-spectrum-s2 npx @react-spectrum/mcp@latest" />
 
-<Command command="claude mcp add react-spectrum-s2 npx @react-spectrum/mcp@latest" />
+    For more information, see the [Gemini CLI MCP documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#how-to-set-up-your-mcp-server).
+  </TabPanel>
+  <TabPanel id="other">
+    Add the server to your MCP client configuration (the exact file and schema may depend on your client).
 
-For more information, see the [Claude Code MCP documentation](https://docs.claude.com/en/docs/claude-code/mcp).
-
-### Codex
-
-Create or edit the configuration file `~/.codex/config.toml` and add:
-
-```
-[mcp_servers.react-spectrum-s2]
-command = "npx"
-args = ["@react-spectrum/mcp@latest"]
-```
-
-For more information, see the [Codex MCP documentation](https://github.com/openai/codex/blob/main/docs/config.md#mcp_servers).
-
-### Gemini CLI
-
-Use the Gemini CLI to add the server:
-
-<Command command="gemini mcp add react-spectrum-s2 npx @react-spectrum/mcp@latest" />
-
-For more information, see the [Gemini CLI MCP documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#how-to-set-up-your-mcp-server).
-
-### Windsurf
-
-Follow the Windsurf MCP [documentation](https://docs.windsurf.com/windsurf/cascade/mcp) and use the standard config above.
+    ```js
+    {
+      "mcpServers": {
+        "React Spectrum (S2)": {
+          "command": "npx",
+          "args": ["@react-spectrum/mcp@latest"]
+        }
+      }
+    }
+    ```
+  </TabPanel>
+</Tabs>
 
 ## Agent Skills
 


### PR DESCRIPTION
Updates the S2 and React Aria `/ai` pages to where the individual MCP client guides are inside Tabs.

This is similar to the [Framework Setup](https://react-spectrum.adobe.com/getting-started#framework-setup) section in our getting started page.

By removing all those subsections, it is easier to discover the remaining sections on the page (Agent Skills, etc.). 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check the updated pages:
- [Working with AI | React Spectrum](https://d1pzu54gtk2aed.cloudfront.net/pr/97205110a22aae6f72c3d6ddb8747ab3a4d19ac5/ai)
- [Working with AI | React Aria](https://d5iwopk28bdhl.cloudfront.net/pr/97205110a22aae6f72c3d6ddb8747ab3a4d19ac5/ai)

## 🧢 Your Project:

<!--- Company/project for pull request -->
