### PR TITLE
fix: allow null value in ComboBox validate for single selection

### DIFF
--- a/packages/@react-types/combobox/src/index.d.ts
+++ b/packages/@react-types/combobox/src/index.d.ts
@@ -37,7 +37,7 @@ export type MenuTriggerAction = 'focus' | 'input' | 'manual';
 export type SelectionMode = 'single' | 'multiple';
 export type ValueType<M extends SelectionMode> = M extends 'single' ? Key | null : readonly Key[];
 export type ChangeValueType<M extends SelectionMode> = M extends 'single' ? Key | null : Key[];
-type ValidationType<M extends SelectionMode> = M extends 'single' ? Key : Key[];
+type ValidationType<M extends SelectionMode> = M extends 'single' ? Key | null : Key[];
 
 export interface ComboBoxValidationValue<M extends SelectionMode = 'single'> {
   /**


### PR DESCRIPTION
## Summary
- `ValidationType<'single'>` resolved to `Key` but the validate function can be called with `null` when no item is selected (e.g. with `allowsCustomValue`). Updated to `Key | null` to match the runtime behavior.

Depends on #9795.

## Test plan
- [x] `yarn check-types` passes with no new errors
- [ ] Verify that single-select `ComboBox` validate callback correctly types `value` as `Key | null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)