### PR TITLE
chore(docs): remove deprecated/private props from markdown output

### DIFF
--- a/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
+++ b/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
@@ -1059,12 +1059,16 @@ function getJsDocData(node) {
       .find(Boolean) || '',
     defaultValue: tags.find(tag => tag.getTagName() === 'default')?.getCommentText() || '',
     selector: tags.find(tag => tag.getTagName() === 'selector')?.getCommentText() || '',
-    deprecated: tags.some(tag => tag.getTagName() === 'deprecated')
+    deprecated: tags.some(tag => tag.getTagName() === 'deprecated'),
+    private: tags.some(tag => tag.getTagName() === 'private')
   };
 }
 
-function isDeprecatedSymbol(sym) {
-  return (sym.getDeclarations?.() || []).some(decl => getJsDocData(decl).deprecated);
+function shouldOmitSymbol(sym) {
+  return (sym.getDeclarations?.() || []).some(decl => {
+    const docData = getJsDocData(decl);
+    return docData.deprecated || docData.private;
+  });
 }
 
 /**
@@ -1105,7 +1109,7 @@ function generatePropTable(componentName, file) {
   const propSymbols = iface.getType().getProperties();
 
   const rows = propSymbols.flatMap((sym) => {
-    if (isDeprecatedSymbol(sym)) {
+    if (shouldOmitSymbol(sym)) {
       return [];
     }
 
@@ -1174,7 +1178,7 @@ function generateInterfaceTable(interfaceName, file) {
   const methods = [];
 
   for (const sym of propSymbols) {
-    if (isDeprecatedSymbol(sym)) {
+    if (shouldOmitSymbol(sym)) {
       continue;
     }
 
@@ -2626,7 +2630,8 @@ function generateClassAPITable(className, file) {
   // Generate properties documentation
   const properties = classDecl.getProperties().filter(p => {
     const scope = p.getScope();
-    return (scope === undefined || scope === 1) && !getJsDocData(p).deprecated; // public, non-deprecated properties only
+    const docData = getJsDocData(p);
+    return (scope === undefined || scope === 1) && !docData.deprecated && !docData.private; // public, non-deprecated, non-private properties only
   });
 
   if (properties.length > 0) {
@@ -2687,7 +2692,7 @@ function generateStateTable(renderPropsName, {showOptional = false, hideSelector
 
   // Build rows
   const rows = propSymbols.map(sym => {
-    if (isDeprecatedSymbol(sym)) {
+    if (shouldOmitSymbol(sym)) {
       return null;
     }
 


### PR DESCRIPTION
Updated the markdown generation script to omit deprecated/private from from the props table output.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Verify that Select/Picker/Combobox no longer have `selectedKey`, `defaultSelectedKey`, or `onSelectionChange` (deprecated).

Verify that Modal/Popover/Tooltip no longer have `UNSTABLE_portalContainer` (private).

Verify that S2 TableView no longer has `isSticky` on Cell (private).


| Before | After |
|---|---|
| [RAC ComboBox](https://react-aria.adobe.com/ComboBox.md) | [RAC ComboBox](https://d5iwopk28bdhl.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/ComboBox.md) |
| [RAC Modal](https://react-aria.adobe.com/Modal.md) | [RAC Modal](https://d5iwopk28bdhl.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/Modal.md) |
| [RAC Popover](https://react-aria.adobe.com/Popover.md) | [RAC Popover](https://d5iwopk28bdhl.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/Popover.md) |
| [RAC Select](https://react-aria.adobe.com/Select.md) | [RACSelect](https://d5iwopk28bdhl.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/Select.md) |
| [RAC Tooltip](https://react-aria.adobe.com/Tooltip.md) | [RAC Tooltip](https://d5iwopk28bdhl.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/Tooltip.md) |
| [S2 Popover](https://react-spectrum.adobe.com/Popover.md) | [S2 Popover](https://d1pzu54gtk2aed.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/Popover.md) |
| [S2 TableView](https://react-spectrum.adobe.com/TableView.md) | [S2 TableView](https://d1pzu54gtk2aed.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/TableView.md) |
| [S2 Tooltip](https://react-spectrum.adobe.com/Tooltip.md) | [S2 Tooltip](https://d1pzu54gtk2aed.cloudfront.net/pr/ab93932c11b772bcaadc9b9b7de3a0d074e70835/Tooltip.md) |



## 🧢 Your Project:

<!--- Company/project for pull request -->
