### PR TITLE
fix(Combobox): use stable selectedKeys to prevent infinite loop in useValueId

### DIFF
--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -208,7 +208,7 @@ export function useComboBox<T, M extends SelectionMode = 'single'>(props: AriaCo
     state.setFocused(true);
   };
 
-  let valueId = useValueId([state.selectedItems, state.selectionManager.selectionMode]);
+  let valueId = useValueId([state.selectionManager.selectedKeys, state.selectionManager.selectionMode]);
   let {isInvalid, validationErrors, validationDetails} = state.displayValidation;
   let {labelProps, inputProps, descriptionProps, errorMessageProps} = useTextField({
     ...props,

--- a/packages/@react-aria/combobox/test/useComboBox.test.js
+++ b/packages/@react-aria/combobox/test/useComboBox.test.js
@@ -52,6 +52,22 @@ describe('useComboBox', function () {
     jest.clearAllMocks();
   });
 
+  it('should not infinite loop when children is an inline function', function () {
+    let {result} = renderHook(() => {
+      let inlineProps = {
+        items: [{id: 'a', name: 'Option A'}, {id: 'b', name: 'Option B'}],
+        children: (item) => <Item key={item.id} textValue={item.name}>{item.name}</Item>,
+        placeholder: 'Select...',
+        allowsCustomValue: true,
+        menuTrigger: 'focus'
+      };
+      let state = useComboBoxState(inlineProps);
+      return useComboBox({...inlineProps, ...props}, state);
+    });
+    expect(result.current.inputProps).toBeDefined();
+    expect(result.current.inputProps.role).toBe('combobox');
+  });
+
   it('should return default props for all the button group elements', function () {
     let {result} = renderHook(() => useComboBox(props, useComboBoxState(defaultProps)));
     let {buttonProps, inputProps, listBoxProps, labelProps} = result.current;


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9776

When `children` is passed to `useComboBox` as an inline function (`(item) => <Item>...</Item>`), a new function reference is created on every render. This creates a new collection every render. Since `selectedItems` is derived from `collection.getItem(key)`, it is a new array every render.

Since `useValueId` uses `setState` during render when deps change and `selectedItems` changes every render, there is an infinite loop.

We can instead use `selectedKeys` to avoid the loop.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Verify test, smoke test Combobox.

## 🧢 Your Project:

<!--- Company/project for pull request -->
