### PR TITLE
fix: SSR hydration mismatch from Date.now private prop keys

### DIFF
--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -55,8 +55,9 @@ export const hookData: WeakMap<DateFieldState, HookData> = new WeakMap<DateField
 
 // Private props that we pass from useDatePicker/useDateRangePicker.
 // Ideally we'd use a Symbol for this, but React doesn't support them: https://github.com/facebook/react/issues/7552
-export const roleSymbol: string = '__role_' + Date.now();
-export const focusManagerSymbol: string = '__focusManager_' + Date.now();
+// These need to be stable across server and client module evaluation for SSR hydration.
+export const roleSymbol: string = '__reactAriaDateFieldRole';
+export const focusManagerSymbol: string = '__reactAriaDateFieldFocusManager';
 
 /**
  * Provides the behavior and accessibility implementation for a date field component.

--- a/packages/@react-stately/form/src/useFormValidationState.ts
+++ b/packages/@react-stately/form/src/useFormValidationState.ts
@@ -41,7 +41,10 @@ export const DEFAULT_VALIDATION_RESULT: ValidationResult = {
 
 export const FormValidationContext: Context<ValidationErrors> = createContext<ValidationErrors>({});
 
-export const privateValidationStateProp: string = '__formValidationState' + Date.now();
+// Private props that we pass from useFormValidationState to children.
+// Ideally we'd use a Symbol for this, but React doesn't support them: https://github.com/facebook/react/issues/7552
+// This needs to be stable across server and client module evaluation for SSR hydration.
+export const privateValidationStateProp: string = '__reactAriaFormValidationState';
 
 interface FormValidationProps<T> extends Validation<T> {
   builtinValidation?: ValidationResult,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9786

Removes Date.now from private prop keys to avoid SSR hydration mismatch issues. Not really sure of a better solution than just using a static string.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Smoke test date picker and form validation.

## 🧢 Your Project:

<!--- Company/project for pull request -->
