### PR TITLE
Fix: required validation for multi-select ComboBox (#9788)

### DIFF
--- a/packages/@react-aria/combobox/src/useComboBox.ts
+++ b/packages/@react-aria/combobox/src/useComboBox.ts
@@ -216,13 +216,10 @@ export function useComboBox<T, M extends SelectionMode = 'single'>(props: AriaCo
 
   let valueId = useValueId([state.selectionManager.selectedKeys, state.selectionManager.selectionMode]);
   let {isInvalid, validationErrors, validationDetails} = state.displayValidation;
-  let textFieldProps = {...props};
-  // In multi-select mode, don't set required on the visible input - it will be on the hidden input instead
-  if (props.selectionMode === 'multiple') {
-    delete textFieldProps.isRequired;
-  }
   let {labelProps, inputProps, descriptionProps, errorMessageProps} = useTextField({
-    ...textFieldProps,
+    ...props,
+    // In multi-select mode, only set required if the selection is empty.
+    isRequired: props.selectionMode === 'multiple' ? props.isRequired && state.selectionManager.isEmpty : props.isRequired,
     onChange: state.setInputValue,
     onKeyDown: !isReadOnly ? chain(state.isOpen && collectionProps.onKeyDown, onKeyDown, props.onKeyDown) : props.onKeyDown,
     onBlur,

--- a/packages/@react-stately/combobox/src/useComboBoxState.ts
+++ b/packages/@react-stately/combobox/src/useComboBoxState.ts
@@ -414,7 +414,7 @@ export function useComboBoxState<T extends object, M extends SelectionMode = 'si
 
   let validation = useFormValidationState({
     ...props,
-    value: useMemo(() => (Array.isArray(displayValue) && displayValue.length === 0 ? null : {inputValue, value: displayValue as any, selectedKey}), [inputValue, selectedKey, displayValue])
+    value: useMemo(() => Array.isArray(displayValue) && displayValue.length === 0 ? null : ({inputValue, value: displayValue as any, selectedKey}), [inputValue, selectedKey, displayValue])
   });
 
   // Revert input value and close menu
@@ -481,10 +481,10 @@ export function useComboBoxState<T extends object, M extends SelectionMode = 'si
     }
   };
 
-  let valueOnFocus = useRef(inputValue);
+  let valueOnFocus = useRef([inputValue, displayValue]);
   let setFocused = (isFocused: boolean) => {
     if (isFocused) {
-      valueOnFocus.current = inputValue;
+      valueOnFocus.current = [inputValue, displayValue];
       if (menuTrigger === 'focus' && !props.isReadOnly) {
         open(null, 'focus');
       }
@@ -493,7 +493,8 @@ export function useComboBoxState<T extends object, M extends SelectionMode = 'si
         commitValue();
       }
 
-      if (inputValue !== valueOnFocus.current) {
+      // Commit validation if the input value or selected items changed.
+      if (inputValue !== valueOnFocus.current[0] || displayValue !== valueOnFocus.current[1]) {
         validation.commitValidation();
       }
     }

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -152,7 +152,6 @@ function ComboBoxInner<T extends object>({props, collection, comboBoxRef: ref}: 
   let [labelRef, label] = useSlot(
     !props['aria-label'] && !props['aria-labelledby']
   );
-  let comboBoxProps = removeDataAttributes(props);
   let {
     buttonProps,
     inputProps,
@@ -163,7 +162,7 @@ function ComboBoxInner<T extends object>({props, collection, comboBoxRef: ref}: 
     valueProps,
     ...validation
   } = useComboBox({
-    ...comboBoxProps,
+    ...removeDataAttributes(props),
     label,
     inputRef,
     buttonRef,
@@ -210,23 +209,13 @@ function ComboBoxInner<T extends object>({props, collection, comboBoxRef: ref}: 
   let inputs: ReactElement[] = [];
   if (name && formValue === 'key') {
     let values: (Key | null)[] = Array.isArray(state.value) ? state.value : [state.value];
-    // For multiple mode with isRequired, we need a text input with display:none because type="hidden" doesn't support required
-    if (props.selectionMode === 'multiple' && props.isRequired) {
-      // When no values selected, show a required empty input to trigger validation
-      if (values.length === 0) {
-        inputs = [<input key="empty" type="text" name={name} form={props.form} value="" required style={{display: 'none'}} />];
-      } else {
-        // When values are selected, don't show the required input
-        inputs = values.map((value, i) => (
-          <input key={i} type="hidden" name={name} form={props.form} value={value ?? ''} />
-        ));
-      }
-    } else {
-      // Single-select mode or not required - use hidden inputs
-      inputs = values.length === 0 ? [] : values.map((value, i) => (
-        <input key={i} type="hidden" name={name} form={props.form} value={value ?? ''} />
-      ));
+    if (values.length === 0) {
+      values = [null];
     }
+
+    inputs = values.map((value, i) => (
+      <input key={i} type="hidden" name={name} form={props.form} value={value ?? ''} />
+    ));
   }
 
   return (

--- a/packages/react-aria-components/test/ComboBox.test.js
+++ b/packages/react-aria-components/test/ComboBox.test.js
@@ -671,14 +671,17 @@ describe('ComboBox', () => {
     expect(listbox).toBeInTheDocument();
     expect(listbox).toBeVisible();
 
+    // Verify we can still interact with options
     let options = comboboxTester.options();
     expect(options.length).toBeGreaterThan(0);
 
+    // Click an option
     await user.click(options[0]);
     act(() => {
       jest.runAllTimers();
     });
 
+    // Verify the combobox is closed and the value is updated
     expect(tree.queryByRole('listbox')).toBeNull();
     expect(comboboxTester.combobox).toHaveValue('Apple');
   });
@@ -772,6 +775,7 @@ describe('ComboBox', () => {
   });
 
   it('should support multi-select with custom value', async () => {
+    // allowsCustomValue doesn't really make sense to use with multi-selection, but test it anyway.
     let {container} = render(<TestComboBox selectionMode="multiple" allowsCustomValue />);
     let comboboxTester = testUtilUser.createTester('ComboBox', {root: container});
 
@@ -818,42 +822,57 @@ describe('ComboBox', () => {
   it('should support isRequired with multiple selection', async () => {
     let {container, getByTestId} = render(
       <Form data-testid="form">
-        <TestComboBox name="combobox" selectionMode="multiple" isRequired />
-        <input type="reset" />
+        <ComboBox name="combobox" selectionMode="multiple" isRequired>
+          <Label>Favorite Animal</Label>
+          <Input />
+          <Button />
+          <FieldError />
+          <Popover>
+            <ListBox>
+              <ListBoxItem id="1">Cat</ListBoxItem>
+              <ListBoxItem id="2">Dog</ListBoxItem>
+              <ListBoxItem id="3">Kangaroo</ListBoxItem>
+            </ListBox>
+          </Popover>
+        </ComboBox>
       </Form>
     );
     let comboboxTester = testUtilUser.createTester('ComboBox', {root: container});
     let combobox = comboboxTester.combobox;
 
-    expect(combobox).not.toHaveAttribute('required');
+    expect(combobox).toHaveAttribute('required');
+    expect(combobox.validity.valid).toBe(false);
 
     act(() => {getByTestId('form').checkValidity();});
     expect(combobox).toHaveAttribute('aria-describedby');
     expect(container.querySelector('.react-aria-ComboBox')).toHaveAttribute('data-invalid');
-
+    
     await comboboxTester.open();
     let options = comboboxTester.options();
     await user.click(options[0]);
-
-    act(() => {getByTestId('form').checkValidity();});
-    expect(combobox).not.toHaveAttribute('aria-describedby');
+    
+    act(() => combobox.blur());
+    expect(combobox).not.toHaveAttribute('required');
+    expect(combobox.validity.valid).toBe(true);
     expect(container.querySelector('.react-aria-ComboBox')).not.toHaveAttribute('data-invalid');
 
     let hiddenInputs = container.querySelectorAll('input[type="hidden"]');
     expect(hiddenInputs).toHaveLength(1);
     expect(hiddenInputs[0]).toHaveAttribute('name', 'combobox');
     expect(hiddenInputs[0]).toHaveAttribute('value', '1');
-    expect(hiddenInputs[0]).not.toHaveAttribute('required');
 
+    await comboboxTester.open();
+    options = comboboxTester.options();
     await user.click(options[0]);
-    act(() => {getByTestId('form').checkValidity();});
+    act(() => combobox.blur());
+    expect(combobox).toHaveAttribute('required');
+    expect(combobox.validity.valid).toBe(false);
     expect(combobox).toHaveAttribute('aria-describedby');
 
     hiddenInputs = container.querySelectorAll('input[type="hidden"]');
     expect(hiddenInputs).toHaveLength(1);
     expect(hiddenInputs[0]).toHaveAttribute('name', 'combobox');
     expect(hiddenInputs[0]).toHaveAttribute('value', '');
-    expect(hiddenInputs[0]).toHaveAttribute('required');
   });
 
   it('should not close the combobox when clicking on the input', async () => {


### PR DESCRIPTION
Closes #9788

## ✅ Pull Request Checklist:

- [x] Included link to corresponding React Spectrum GitHub Issue.
- [ ] Added/updated unit tests and storybook for this change.
- [x] Filled out test instructions.
- [ ] Updated documentation (not required for this fix).
- [ ] Looked at the Accessibility Practices for this feature.

## 📝 Test Instructions:

1. Create a form containing a ComboBox with `selectionMode="multiple"` and `isRequired`.
2. Select one or more items.
3. Submit the form.

Expected result:
Form submission succeeds when items are selected.

4. Submit the form with no selections.

Expected result:
Form validation prevents submission due to required constraint.

## 🧢 Your Project:

Personal open source contribution.
