### PR TITLE
fix: pass selection mode generic to ComboBox validate type

### DIFF
--- a/packages/@react-types/combobox/src/index.d.ts
+++ b/packages/@react-types/combobox/src/index.d.ts
@@ -51,7 +51,7 @@ export interface ComboBoxValidationValue<M extends SelectionMode = 'single'> {
   inputValue: string
 }
 
-export interface ComboBoxProps<T, M extends SelectionMode = 'single'> extends CollectionBase<T>, InputBase, ValueBase<ValueType<M>, ChangeValueType<M>>, TextInputBase, Validation<ComboBoxValidationValue>, FocusableProps<HTMLInputElement>, LabelableProps, HelpTextProps {
+export interface ComboBoxProps<T, M extends SelectionMode = 'single'> extends CollectionBase<T>, InputBase, ValueBase<ValueType<M>, ChangeValueType<M>>, TextInputBase, Validation<ComboBoxValidationValue<M>>, FocusableProps<HTMLInputElement>, LabelableProps, HelpTextProps {
   /** The list of ComboBox items (uncontrolled). */
   defaultItems?: Iterable<T>,
   /** The list of ComboBox items (controlled). */


### PR DESCRIPTION
## Summary
- `ComboBoxProps` was using `Validation<ComboBoxValidationValue>` without passing the `M` (selection mode) generic through. Fixed by changing to `Validation<ComboBoxValidationValue<M>>` so multi-select mode gets the correct `Key[]` type for `value` in the validate callback.

## Test plan
- [x] `yarn check-types` passes with no new errors
- [ ] Verify that `ComboBox` with `selectionMode="multiple"` has correctly typed `value` field (`Key[]`) in the validate callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)