### PR TITLE
fix(numberfield): preserve validation errors on blur when value unchanged

### DIFF
--- a/packages/@react-stately/numberfield/src/useNumberFieldState.ts
+++ b/packages/@react-stately/numberfield/src/useNumberFieldState.ts
@@ -175,11 +175,14 @@ export function useNumberFieldState(
     }
 
     clampedValue = numberParser.parse(format(clampedValue));
+    let shouldValidate = clampedValue !== numberValue;
     setNumberValue(clampedValue);
 
     // in a controlled state, the numberValue won't change, so we won't go back to our old input without help
     setInputValue(format(value === undefined ? clampedValue : numberValue));
-    validation.commitValidation();
+    if (shouldValidate) {
+      validation.commitValidation();
+    }
   };
 
   let safeNextStep = (operation: '+' | '-', minMax: number = 0) => {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/9444

Replaces https://github.com/adobe/react-spectrum/pull/9629 because it didn't have a signed CLA

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
