### PR TITLE
docs(S2): fix stale results in Icons search

### DIFF
--- a/packages/dev/s2-docs/src/MobileSearchMenu.tsx
+++ b/packages/dev/s2-docs/src/MobileSearchMenu.tsx
@@ -315,13 +315,13 @@ function MobileNav({initialTag}: {initialTag?: string}) {
               <MobileTabPanel key={library.id} id={library.id}>
                 <Autocomplete
                   key={isTypographySelected ? 'typography' : 'default'}
+                  inputValue={searchValue}
+                  onInputChange={handleSearchChange}
                   filter={showIcons ? iconFilter : undefined}
                   disableVirtualFocus={isTypographySelected}>
                   <div className={stickySearchContainer}>
                     <SearchField
                       aria-label="Search"
-                      value={searchValue}
-                      onChange={handleSearchChange}
                       onFocus={handleSearchFocus}
                       onBlur={handleSearchBlur}
                       placeholder={placeholderText}
@@ -403,4 +403,3 @@ function MobileNav({initialTag}: {initialTag?: string}) {
     </div>
   );
 }
-

--- a/packages/dev/s2-docs/src/SearchMenu.tsx
+++ b/packages/dev/s2-docs/src/SearchMenu.tsx
@@ -163,13 +163,13 @@ export function SearchMenu(props: SearchMenuProps) {
             <TabPanel key={tab.id} id={tab.id}>
               <Autocomplete
                 key={selectedTagId === 'typography' ? 'typography' : 'default'}
+                inputValue={searchValue}
+                onInputChange={setSearchValue}
                 filter={isIconsSelected ? iconFilter : undefined}
                 disableVirtualFocus={selectedTagId === 'typography'}>
                 <div className={style({display: 'flex', flexDirection: 'column', height: 'full'})}>
                   <div className={style({flexShrink: 0, marginStart: 16, marginEnd: 64})}>
                     <SearchField
-                      value={searchValue}
-                      onChange={setSearchValue}
                       ref={searchRef}
                       size="L"
                       aria-label={`Search ${tab.label}`}


### PR DESCRIPTION
Previously the results in the icons search could be using a stale value if the search menu was closed and re-opened. 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open the search menu
2. Type 'button'
3. Close the search menu
4. Re-open the search menu
5. Open the "Icons" tab

On main, this would still be showing the 'button' results in the icons search, even though the input is now empty.

After this PR, it should show all the icons, because the field is now empty.

## 🧢 Your Project:

<!--- Company/project for pull request -->
