### PR TITLE
chore: update hcm focus ring in S2 TreeView highlight selection

### DIFF
--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -392,11 +392,7 @@ let treeRowFocusRing = style({
     selectionStyle: {
       highlight: {
         default: 'focus-ring',
-        forcedColors: 'Highlight',
-        isSelected: {
-          default: 'focus-ring',
-          forcedColors: 'ButtonBorder'
-        }
+        forcedColors: 'ButtonBorder'
       }
     }
   },


### PR DESCRIPTION
Updates the highlight HCM focus ring to be thicker (3px) and use ButtonBorder color (to match ListView)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test in storybook 

## 🧢 Your Project:

<!--- Company/project for pull request -->
