### PR TITLE
feat: use CloseWatcher API for overlay dismiss in supported browsers

### DIFF
--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -140,8 +140,11 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
     lastVisibleOverlay.current = undefined;
   };
 
-  // Handle the escape key
-  let onKeyDown = (e) => {
+  // Handle the escape key — only used as a fallback when CloseWatcher is not supported.
+  // When CloseWatcher handles dismiss, the keydown handler is skipped entirely to avoid
+  // double-dismiss in nested overlays (e.g. submenus where Escape would close both the
+  // submenu via CloseWatcher and the parent menu via the bubbling keydown event).
+  let onKeyDown = supportsCloseWatcher() ? undefined : (e) => {
     if (e.key === 'Escape' && !isKeyboardDismissDisabled && !e.nativeEvent.isComposing) {
       e.stopPropagation();
       e.preventDefault();

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -14,6 +14,7 @@ import {DOMAttributes, RefObject} from '@react-types/shared';
 import {getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {isElementInChildOfActiveScope} from '../focus/FocusScope';
 import {useEffect, useRef} from 'react';
+import {useEffectEvent} from '../utils/useEffectEvent';
 import {useFocusWithin} from '../interactions/useFocusWithin';
 import {useInteractOutside} from '../interactions/useInteractOutside';
 
@@ -57,6 +58,10 @@ export interface OverlayAria {
 
 const visibleOverlays: RefObject<Element | null>[] = [];
 
+function supportsCloseWatcher(): boolean {
+  return typeof globalThis.CloseWatcher !== 'undefined';
+}
+
 /**
  * Provides the behavior for overlays such as dialogs, popovers, and menus.
  * Hides the overlay when the user interacts outside it, when the Escape key is pressed,
@@ -74,25 +79,44 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
 
   let lastVisibleOverlay = useRef<RefObject<Element | null>>(undefined);
 
-  // Add the overlay ref to the stack of visible overlays on mount, and remove on unmount.
-  useEffect(() => {
-    if (isOpen && !visibleOverlays.includes(ref)) {
-      visibleOverlays.push(ref);
-      return () => {
-        let index = visibleOverlays.indexOf(ref);
-        if (index >= 0) {
-          visibleOverlays.splice(index, 1);
-        }
-      };
-    }
-  }, [isOpen, ref]);
-
   // Only hide the overlay when it is the topmost visible overlay in the stack
   let onHide = () => {
     if (visibleOverlays[visibleOverlays.length - 1] === ref && onClose) {
       onClose();
     }
   };
+
+  // Stable callback for CloseWatcher that always calls the latest onHide.
+  // useEffectEvent returns a stable reference, so the watcher doesn't need
+  // to be recreated when onClose changes.
+  let onHideEvent = useEffectEvent(onHide);
+
+  // Add the overlay ref to the stack of visible overlays on mount, and remove on unmount.
+  // When CloseWatcher is supported, each overlay gets its own instance. The browser
+  // internally stacks watchers so Escape dismisses the most recently created one first,
+  // which also handles the Android back button. The onKeyDown handler below is kept as
+  // a fallback and is a no-op if the CloseWatcher already dismissed the overlay.
+  useEffect(() => {
+    if (isOpen && !visibleOverlays.includes(ref)) {
+      visibleOverlays.push(ref);
+
+      let watcher: {onclose: (() => void) | null, destroy: () => void} | null = null;
+      if (!isKeyboardDismissDisabled && supportsCloseWatcher()) {
+        watcher = new (globalThis as any).CloseWatcher();
+        watcher!.onclose = () => {
+          onHideEvent();
+        };
+      }
+
+      return () => {
+        let index = visibleOverlays.indexOf(ref);
+        if (index >= 0) {
+          visibleOverlays.splice(index, 1);
+        }
+        watcher?.destroy();
+      };
+    }
+  }, [isOpen, isKeyboardDismissDisabled, ref]);
 
   let onInteractOutsideStart = (e: PointerEvent) => {
     const topMostOverlay = visibleOverlays[visibleOverlays.length - 1];

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -64,8 +64,12 @@ interface VisibleOverlayData {
   isKeyboardDismissDisabled: boolean;
 }
 
-const visibleOverlays: RefObject<Element | null>[] = [];
-const visibleOverlayData = new Map<RefObject<Element | null>, VisibleOverlayData>();
+interface VisibleOverlay {
+  ref: RefObject<Element | null>;
+  data: VisibleOverlayData;
+}
+
+const visibleOverlays: VisibleOverlay[] = [];
 
 interface CloseWatcher {
   oncancel: ((event: Event) => void) | null;
@@ -77,8 +81,43 @@ function supportsCloseWatcher(): boolean {
   return typeof globalThis.CloseWatcher !== 'undefined';
 }
 
-function getTopMostOverlay(): RefObject<Element | null> | undefined {
-  return visibleOverlays[visibleOverlays.length - 1];
+function getTopMostOverlay(): VisibleOverlay | undefined {
+  let topMostOverlay: VisibleOverlay | undefined;
+  for (let overlay of visibleOverlays) {
+    let element = overlay.ref.current;
+    if (!element) {
+      continue;
+    }
+
+    if (!topMostOverlay?.ref.current) {
+      topMostOverlay = overlay;
+      continue;
+    }
+
+    let topMostElement = topMostOverlay.ref.current;
+    if (topMostElement === element) {
+      topMostOverlay = overlay;
+      continue;
+    }
+
+    let ownerNode = element.ownerDocument.defaultView?.Node;
+    let position = topMostElement.compareDocumentPosition(element);
+    if (
+      ownerNode &&
+      !(position & ownerNode.DOCUMENT_POSITION_DISCONNECTED) &&
+      position & ownerNode.DOCUMENT_POSITION_FOLLOWING
+    ) {
+      topMostOverlay = overlay;
+    }
+  }
+
+  return topMostOverlay ?? visibleOverlays[visibleOverlays.length - 1];
+}
+
+function isOnlyVisibleOverlayForRef(overlay: VisibleOverlay): boolean {
+  return !visibleOverlays.some(
+    visibleOverlay => visibleOverlay !== overlay && visibleOverlay.ref === overlay.ref
+  );
 }
 
 /**
@@ -96,7 +135,8 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
     shouldCloseOnInteractOutside
   } = props;
 
-  let lastVisibleOverlay = useRef<RefObject<Element | null> | undefined>(undefined);
+  let lastVisibleOverlay = useRef<VisibleOverlay | undefined>(undefined);
+  let visibleOverlay = useRef<VisibleOverlay | null>(null);
 
   let onHide = () => {
     onClose?.();
@@ -106,7 +146,7 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
 
   // Only hide the overlay when it is the topmost visible overlay in the stack.
   let onHideTopmost = () => {
-    if (getTopMostOverlay() === ref && onClose) {
+    if (getTopMostOverlay() === visibleOverlay.current && onClose) {
       onHide();
     }
   };
@@ -120,18 +160,22 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   // When CloseWatcher is supported, each overlay gets its own instance so the browser's
   // native close watcher stack handles nested overlay ordering for Escape and Android back.
   useEffect(() => {
-    if (isOpen && !visibleOverlays.includes(ref)) {
-      visibleOverlays.push(ref);
-      visibleOverlayData.set(ref, {
-        onClose: () => onHideEvent(),
-        isKeyboardDismissDisabled
-      });
+    if (isOpen && !visibleOverlay.current) {
+      let overlay: VisibleOverlay = {
+        ref,
+        data: {
+          onClose: () => onHideEvent(),
+          isKeyboardDismissDisabled
+        }
+      };
+      visibleOverlay.current = overlay;
+      visibleOverlays.push(overlay);
 
       let watcher: CloseWatcher | null = null;
       if (!isKeyboardDismissDisabled && supportsCloseWatcher()) {
         let closeWatcher: CloseWatcher = new (globalThis as any).CloseWatcher();
         closeWatcher.oncancel = event => {
-          if (getTopMostOverlay() !== ref) {
+          if (getTopMostOverlay() !== overlay) {
             event.preventDefault();
           }
         };
@@ -142,11 +186,11 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
       }
 
       return () => {
-        let index = visibleOverlays.indexOf(ref);
+        let index = visibleOverlays.indexOf(overlay);
         if (index >= 0) {
           visibleOverlays.splice(index, 1);
         }
-        visibleOverlayData.delete(ref);
+        visibleOverlay.current = null;
         watcher?.destroy();
       };
     }
@@ -159,7 +203,11 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
       !shouldCloseOnInteractOutside ||
       shouldCloseOnInteractOutside(getEventTarget(e) as Element)
     ) {
-      if (topMostOverlay === ref) {
+      if (
+        topMostOverlay &&
+        topMostOverlay === visibleOverlay.current &&
+        isOnlyVisibleOverlayForRef(topMostOverlay)
+      ) {
         e.stopPropagation();
       }
     }
@@ -170,11 +218,19 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
       !shouldCloseOnInteractOutside ||
       shouldCloseOnInteractOutside(getEventTarget(e) as Element)
     ) {
-      if (getTopMostOverlay() === ref) {
+      let topMostOverlay = getTopMostOverlay();
+      if (
+        topMostOverlay &&
+        topMostOverlay === visibleOverlay.current &&
+        isOnlyVisibleOverlayForRef(topMostOverlay)
+      ) {
         e.stopPropagation();
       }
-      if (lastVisibleOverlay.current === ref) {
-        onHideTopmost();
+      if (
+        lastVisibleOverlay.current === visibleOverlay.current ||
+        lastVisibleOverlay.current?.ref === ref
+      ) {
+        onHide();
       }
     }
     lastVisibleOverlay.current = undefined;
@@ -183,25 +239,33 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   // Handle the escape key.
   let {keyboardProps} = useKeyboard({
     shortcuts: {
-      Escape: () => {
+      Escape: e => {
+        if (e.nativeEvent.cancelBubble) {
+          return false;
+        }
+
+        if (supportsCloseWatcher()) {
+          return false;
+        }
+
         let topMostOverlay = getTopMostOverlay();
         if (!topMostOverlay) {
           return false;
         }
 
-        let topMostOverlayData = visibleOverlayData.get(topMostOverlay);
-        if (!topMostOverlayData) {
+        let overlay = topMostOverlay.ref === ref ? visibleOverlay.current : topMostOverlay;
+        if (!overlay) {
           return false;
         }
 
-        if (topMostOverlayData.isKeyboardDismissDisabled) {
-          if (topMostOverlay !== ref) {
+        if (overlay.data.isKeyboardDismissDisabled) {
+          if (overlay !== visibleOverlay.current) {
             return;
           }
           return false;
         }
 
-        topMostOverlayData.onClose();
+        overlay.data.onClose();
         return;
       }
     }

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -59,15 +59,26 @@ export interface OverlayAria {
   underlayProps: DOMAttributes;
 }
 
+interface VisibleOverlayData {
+  onClose: () => void;
+  isKeyboardDismissDisabled: boolean;
+}
+
 const visibleOverlays: RefObject<Element | null>[] = [];
+const visibleOverlayData = new Map<RefObject<Element | null>, VisibleOverlayData>();
 
 interface CloseWatcher {
-  onclose: (() => void) | null,
-  destroy: () => void
+  oncancel: ((event: Event) => void) | null;
+  onclose: (() => void) | null;
+  destroy: () => void;
 }
 
 function supportsCloseWatcher(): boolean {
   return typeof globalThis.CloseWatcher !== 'undefined';
+}
+
+function getTopMostOverlay(): RefObject<Element | null> | undefined {
+  return visibleOverlays[visibleOverlays.length - 1];
 }
 
 /**
@@ -85,15 +96,17 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
     shouldCloseOnInteractOutside
   } = props;
 
-  let lastVisibleOverlay = useRef<RefObject<Element | null>>(undefined);
+  let lastVisibleOverlay = useRef<RefObject<Element | null> | undefined>(undefined);
 
   let onHide = () => {
     onClose?.();
   };
 
+  let onHideEvent = useEffectEvent(onHide);
+
   // Only hide the overlay when it is the topmost visible overlay in the stack.
   let onHideTopmost = () => {
-    if (visibleOverlays[visibleOverlays.length - 1] === ref && onClose) {
+    if (getTopMostOverlay() === ref && onClose) {
       onHide();
     }
   };
@@ -109,10 +122,19 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
   useEffect(() => {
     if (isOpen && !visibleOverlays.includes(ref)) {
       visibleOverlays.push(ref);
+      visibleOverlayData.set(ref, {
+        onClose: () => onHideEvent(),
+        isKeyboardDismissDisabled
+      });
 
       let watcher: CloseWatcher | null = null;
       if (!isKeyboardDismissDisabled && supportsCloseWatcher()) {
         let closeWatcher: CloseWatcher = new (globalThis as any).CloseWatcher();
+        closeWatcher.oncancel = event => {
+          if (getTopMostOverlay() !== ref) {
+            event.preventDefault();
+          }
+        };
         closeWatcher.onclose = () => {
           onHideTopmostEvent();
         };
@@ -124,13 +146,14 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
         if (index >= 0) {
           visibleOverlays.splice(index, 1);
         }
+        visibleOverlayData.delete(ref);
         watcher?.destroy();
       };
     }
   }, [isOpen, isKeyboardDismissDisabled, ref]);
 
   let onInteractOutsideStart = (e: PointerEvent) => {
-    const topMostOverlay = visibleOverlays[visibleOverlays.length - 1];
+    const topMostOverlay = getTopMostOverlay();
     lastVisibleOverlay.current = topMostOverlay;
     if (
       !shouldCloseOnInteractOutside ||
@@ -147,7 +170,7 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
       !shouldCloseOnInteractOutside ||
       shouldCloseOnInteractOutside(getEventTarget(e) as Element)
     ) {
-      if (visibleOverlays[visibleOverlays.length - 1] === ref) {
+      if (getTopMostOverlay() === ref) {
         e.stopPropagation();
       }
       if (lastVisibleOverlay.current === ref) {
@@ -157,18 +180,29 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
     lastVisibleOverlay.current = undefined;
   };
 
-  // Handle the escape key. This only dismisses as a fallback when CloseWatcher is
-  // not supported. When CloseWatcher handles dismiss, this shortcut is a no-op so the
-  // native per-overlay close watcher owns nested Escape ordering (closing the innermost
-  // overlay first) and we avoid double-dismissing the parent overlay.
+  // Handle the escape key.
   let {keyboardProps} = useKeyboard({
     shortcuts: {
       Escape: () => {
-        if (!supportsCloseWatcher() && !isKeyboardDismissDisabled) {
-          onHideTopmost();
-          return;
+        let topMostOverlay = getTopMostOverlay();
+        if (!topMostOverlay) {
+          return false;
         }
-        return false;
+
+        let topMostOverlayData = visibleOverlayData.get(topMostOverlay);
+        if (!topMostOverlayData) {
+          return false;
+        }
+
+        if (topMostOverlayData.isKeyboardDismissDisabled) {
+          if (topMostOverlay !== ref) {
+            return;
+          }
+          return false;
+        }
+
+        topMostOverlayData.onClose();
+        return;
       }
     }
   });

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -14,6 +14,7 @@ import {DOMAttributes, RefObject} from '@react-types/shared';
 import {getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {isElementInChildOfActiveScope} from '../focus/FocusScope';
 import {useEffect, useRef} from 'react';
+import {useEffectEvent} from '../utils/useEffectEvent';
 import {useFocusWithin} from '../interactions/useFocusWithin';
 import {useInteractOutside} from '../interactions/useInteractOutside';
 import {useKeyboard} from '../interactions/useKeyboard';
@@ -60,6 +61,15 @@ export interface OverlayAria {
 
 const visibleOverlays: RefObject<Element | null>[] = [];
 
+interface CloseWatcher {
+  onclose: (() => void) | null,
+  destroy: () => void
+}
+
+function supportsCloseWatcher(): boolean {
+  return typeof globalThis.CloseWatcher !== 'undefined';
+}
+
 /**
  * Provides the behavior for overlays such as dialogs, popovers, and menus.
  * Hides the overlay when the user interacts outside it, when the Escape key is pressed,
@@ -77,25 +87,47 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
 
   let lastVisibleOverlay = useRef<RefObject<Element | null>>(undefined);
 
+  let onHide = () => {
+    onClose?.();
+  };
+
+  // Only hide the overlay when it is the topmost visible overlay in the stack.
+  let onHideTopmost = () => {
+    if (visibleOverlays[visibleOverlays.length - 1] === ref && onClose) {
+      onHide();
+    }
+  };
+
+  // Stable callback for CloseWatcher that always calls the latest onHideTopmost.
+  // useEffectEvent returns a stable reference, so the watcher doesn't need
+  // to be recreated when onClose changes.
+  let onHideTopmostEvent = useEffectEvent(onHideTopmost);
+
   // Add the overlay ref to the stack of visible overlays on mount, and remove on unmount.
+  // When CloseWatcher is supported, each overlay gets its own instance so the browser's
+  // native close watcher stack handles nested overlay ordering for Escape and Android back.
   useEffect(() => {
     if (isOpen && !visibleOverlays.includes(ref)) {
       visibleOverlays.push(ref);
+
+      let watcher: CloseWatcher | null = null;
+      if (!isKeyboardDismissDisabled && supportsCloseWatcher()) {
+        let closeWatcher: CloseWatcher = new (globalThis as any).CloseWatcher();
+        closeWatcher.onclose = () => {
+          onHideTopmostEvent();
+        };
+        watcher = closeWatcher;
+      }
+
       return () => {
         let index = visibleOverlays.indexOf(ref);
         if (index >= 0) {
           visibleOverlays.splice(index, 1);
         }
+        watcher?.destroy();
       };
     }
-  }, [isOpen, ref]);
-
-  // Only hide the overlay when it is the topmost visible overlay in the stack
-  let onHide = () => {
-    if (visibleOverlays[visibleOverlays.length - 1] === ref && onClose) {
-      onClose();
-    }
-  };
+  }, [isOpen, isKeyboardDismissDisabled, ref]);
 
   let onInteractOutsideStart = (e: PointerEvent) => {
     const topMostOverlay = visibleOverlays[visibleOverlays.length - 1];
@@ -119,18 +151,21 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
         e.stopPropagation();
       }
       if (lastVisibleOverlay.current === ref) {
-        onHide();
+        onHideTopmost();
       }
     }
     lastVisibleOverlay.current = undefined;
   };
 
-  // Handle the escape key
+  // Handle the escape key. This only dismisses as a fallback when CloseWatcher is
+  // not supported. When CloseWatcher handles dismiss, this shortcut is a no-op so the
+  // native per-overlay close watcher owns nested Escape ordering (closing the innermost
+  // overlay first) and we avoid double-dismissing the parent overlay.
   let {keyboardProps} = useKeyboard({
     shortcuts: {
       Escape: () => {
-        if (!isKeyboardDismissDisabled) {
-          onHide();
+        if (!supportsCloseWatcher() && !isKeyboardDismissDisabled) {
+          onHideTopmost();
           return;
         }
         return false;

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -220,13 +220,9 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
 
   // Handle the escape key.
   let {keyboardProps} = useKeyboard({
-    shortcuts: {
+    shortcuts: supportsCloseWatcher() ? undefined : {
       Escape: e => {
         if (e.nativeEvent.cancelBubble) {
-          return false;
-        }
-
-        if (supportsCloseWatcher()) {
           return false;
         }
 

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -72,7 +72,6 @@ interface VisibleOverlay {
 const visibleOverlays: VisibleOverlay[] = [];
 
 interface CloseWatcher {
-  oncancel: ((event: Event) => void) | null;
   onclose: (() => void) | null;
   destroy: () => void;
 }
@@ -144,18 +143,6 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
 
   let onHideEvent = useEffectEvent(onHide);
 
-  // Only hide the overlay when it is the topmost visible overlay in the stack.
-  let onHideTopmost = () => {
-    if (getTopMostOverlay() === visibleOverlay.current && onClose) {
-      onHide();
-    }
-  };
-
-  // Stable callback for CloseWatcher that always calls the latest onHideTopmost.
-  // useEffectEvent returns a stable reference, so the watcher doesn't need
-  // to be recreated when onClose changes.
-  let onHideTopmostEvent = useEffectEvent(onHideTopmost);
-
   // Add the overlay ref to the stack of visible overlays on mount, and remove on unmount.
   // When CloseWatcher is supported, each overlay gets its own instance so the browser's
   // native close watcher stack handles nested overlay ordering for Escape and Android back.
@@ -174,13 +161,8 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
       let watcher: CloseWatcher | null = null;
       if (!isKeyboardDismissDisabled && supportsCloseWatcher()) {
         let closeWatcher: CloseWatcher = new (globalThis as any).CloseWatcher();
-        closeWatcher.oncancel = event => {
-          if (getTopMostOverlay() !== overlay) {
-            event.preventDefault();
-          }
-        };
         closeWatcher.onclose = () => {
-          onHideTopmostEvent();
+          onHideEvent();
         };
         watcher = closeWatcher;
       }

--- a/packages/react-aria/src/overlays/useOverlay.ts
+++ b/packages/react-aria/src/overlays/useOverlay.ts
@@ -220,33 +220,35 @@ export function useOverlay(props: AriaOverlayProps, ref: RefObject<Element | nul
 
   // Handle the escape key.
   let {keyboardProps} = useKeyboard({
-    shortcuts: supportsCloseWatcher() ? undefined : {
-      Escape: e => {
-        if (e.nativeEvent.cancelBubble) {
-          return false;
-        }
+    shortcuts: supportsCloseWatcher()
+      ? undefined
+      : {
+          Escape: e => {
+            if (e.nativeEvent.cancelBubble) {
+              return false;
+            }
 
-        let topMostOverlay = getTopMostOverlay();
-        if (!topMostOverlay) {
-          return false;
-        }
+            let topMostOverlay = getTopMostOverlay();
+            if (!topMostOverlay) {
+              return false;
+            }
 
-        let overlay = topMostOverlay.ref === ref ? visibleOverlay.current : topMostOverlay;
-        if (!overlay) {
-          return false;
-        }
+            let overlay = topMostOverlay.ref === ref ? visibleOverlay.current : topMostOverlay;
+            if (!overlay) {
+              return false;
+            }
 
-        if (overlay.data.isKeyboardDismissDisabled) {
-          if (overlay !== visibleOverlay.current) {
+            if (overlay.data.isKeyboardDismissDisabled) {
+              if (overlay !== visibleOverlay.current) {
+                return;
+              }
+              return false;
+            }
+
+            overlay.data.onClose();
             return;
           }
-          return false;
         }
-
-        overlay.data.onClose();
-        return;
-      }
-    }
   });
 
   // Handle clicking outside the overlay to close it

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -197,6 +197,40 @@ describe('useOverlay', function () {
       expect(onCloseOuter).not.toHaveBeenCalled();
     });
 
+    it('should not attach onKeyDown when CloseWatcher is supported', function () {
+      let onClose = jest.fn();
+      let res = render(<Example isOpen onClose={onClose} />);
+      let el = res.getByTestId('test');
+
+      // With CloseWatcher active, Escape keydown should not trigger onClose
+      // (the browser's CloseWatcher handles it instead)
+      fireEvent.keyDown(el, {key: 'Escape'});
+      expect(onClose).not.toHaveBeenCalled();
+
+      // But CloseWatcher still works
+      closeWatcherInstances[0].onclose();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not double-dismiss nested overlays on Escape when CloseWatcher is active', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      let outer = render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      let outerEl = outer.getByTestId('outer');
+
+      // Simulate browser behavior: CloseWatcher fires for inner overlay
+      closeWatcherInstances[1].onclose();
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+
+      // The Escape keydown event that triggered CloseWatcher also bubbles to the
+      // outer overlay's DOM. With the fix, onKeyDown is undefined so the outer
+      // overlay is NOT dismissed.
+      fireEvent.keyDown(outerEl, {key: 'Escape'});
+      expect(onCloseOuter).not.toHaveBeenCalled();
+    });
+
     it('should dismiss inner then outer with per-overlay watchers', function () {
       let onCloseOuter = jest.fn();
       let onCloseInner = jest.fn();

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -128,4 +128,94 @@ describe('useOverlay', function () {
     fireEvent.keyDown(el, {key: 'Escape'});
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  describe('CloseWatcher', function () {
+    let closeWatcherInstances;
+    let MockCloseWatcher;
+
+    beforeEach(function () {
+      closeWatcherInstances = [];
+      MockCloseWatcher = class {
+        constructor() {
+          this.onclose = null;
+          closeWatcherInstances.push(this);
+        }
+        destroy() {
+          let index = closeWatcherInstances.indexOf(this);
+          if (index >= 0) {
+            closeWatcherInstances.splice(index, 1);
+          }
+        }
+      };
+      globalThis.CloseWatcher = MockCloseWatcher;
+    });
+
+    afterEach(function () {
+      delete globalThis.CloseWatcher;
+    });
+
+    it('should use CloseWatcher to dismiss overlay when available', function () {
+      let onClose = jest.fn();
+      render(<Example isOpen onClose={onClose} />);
+      expect(closeWatcherInstances.length).toBe(1);
+      closeWatcherInstances[0].onclose();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not create CloseWatcher when isKeyboardDismissDisabled is true', function () {
+      let onClose = jest.fn();
+      render(<Example isOpen onClose={onClose} isKeyboardDismissDisabled />);
+      expect(closeWatcherInstances.length).toBe(0);
+    });
+
+    it('should not create CloseWatcher when overlay is not open', function () {
+      let onClose = jest.fn();
+      render(<Example isOpen={false} onClose={onClose} />);
+      expect(closeWatcherInstances.length).toBe(0);
+    });
+
+    it('should destroy CloseWatcher when overlay unmounts', function () {
+      let onClose = jest.fn();
+      let res = render(<Example isOpen onClose={onClose} />);
+      expect(closeWatcherInstances.length).toBe(1);
+      res.unmount();
+      expect(closeWatcherInstances.length).toBe(0);
+    });
+
+    it('should dismiss only the top-most overlay with nested overlays', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      // Each overlay gets its own CloseWatcher
+      expect(closeWatcherInstances.length).toBe(2);
+
+      // Browser fires close on the most recently created watcher (inner overlay)
+      closeWatcherInstances[1].onclose();
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+      expect(onCloseOuter).not.toHaveBeenCalled();
+    });
+
+    it('should dismiss inner then outer with per-overlay watchers', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      let inner = render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      expect(closeWatcherInstances.length).toBe(2);
+
+      // Dismiss inner overlay via its watcher
+      closeWatcherInstances[1].onclose();
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+
+      // Unmount inner - its watcher is destroyed
+      inner.unmount();
+      expect(closeWatcherInstances.length).toBe(1);
+
+      // Dismiss outer via its watcher
+      closeWatcherInstances[0].onclose();
+      expect(onCloseOuter).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -11,6 +11,7 @@
  */
 
 import {
+  act,
   fireEvent,
   installMouseEvent,
   installPointerEvent,
@@ -137,5 +138,155 @@ describe('useOverlay', function () {
     let el = res.getByTestId('test');
     fireEvent.keyDown(el, {key: 'Escape'});
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('CloseWatcher', function () {
+    let closeWatcherInstances;
+    let MockCloseWatcher;
+
+    beforeEach(function () {
+      closeWatcherInstances = [];
+      MockCloseWatcher = class {
+        constructor() {
+          this.onclose = null;
+          closeWatcherInstances.push(this);
+        }
+        destroy() {
+          let index = closeWatcherInstances.indexOf(this);
+          if (index >= 0) {
+            closeWatcherInstances.splice(index, 1);
+          }
+        }
+      };
+      globalThis.CloseWatcher = MockCloseWatcher;
+    });
+
+    afterEach(function () {
+      delete globalThis.CloseWatcher;
+    });
+
+    it('should use CloseWatcher to dismiss overlay when available', function () {
+      let onClose = jest.fn();
+      render(<Example isOpen onClose={onClose} />);
+      expect(closeWatcherInstances.length).toBe(1);
+      closeWatcherInstances[0].onclose();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not create CloseWatcher when isKeyboardDismissDisabled is true', function () {
+      let onClose = jest.fn();
+      render(<Example isOpen onClose={onClose} isKeyboardDismissDisabled />);
+      expect(closeWatcherInstances.length).toBe(0);
+    });
+
+    it('should not create CloseWatcher when overlay is not open', function () {
+      let onClose = jest.fn();
+      render(<Example isOpen={false} onClose={onClose} />);
+      expect(closeWatcherInstances.length).toBe(0);
+    });
+
+    it('should destroy CloseWatcher when overlay unmounts', function () {
+      let onClose = jest.fn();
+      let res = render(<Example isOpen onClose={onClose} />);
+      expect(closeWatcherInstances.length).toBe(1);
+      res.unmount();
+      expect(closeWatcherInstances.length).toBe(0);
+    });
+
+    it('should dismiss only the top-most overlay with nested overlays', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      expect(closeWatcherInstances.length).toBe(2);
+
+      // The browser's native CloseWatcher stack closes the most recently created watcher first.
+      closeWatcherInstances[1].onclose();
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+      expect(onCloseOuter).not.toHaveBeenCalled();
+    });
+
+    it('should dismiss the most recently opened overlay even when focus is in an older overlay', function () {
+      let onCloseFirst = jest.fn();
+      let onCloseSecond = jest.fn();
+      let first = render(
+        <Example isOpen onClose={onCloseFirst} data-testid="first">
+          <input data-testid="first-input" />
+        </Example>
+      );
+      render(
+        <Example isOpen onClose={onCloseSecond} data-testid="second">
+          <input data-testid="second-input" />
+        </Example>
+      );
+
+      expect(closeWatcherInstances.length).toBe(2);
+      let firstInput = first.getByTestId('first-input');
+      act(() => {
+        firstInput.focus();
+      });
+      expect(document.activeElement).toBe(firstInput);
+
+      closeWatcherInstances[1].onclose();
+      expect(onCloseSecond).toHaveBeenCalledTimes(1);
+      expect(onCloseFirst).not.toHaveBeenCalled();
+    });
+
+    it('should not attach onKeyDown when CloseWatcher is supported', function () {
+      let onClose = jest.fn();
+      let res = render(<Example isOpen onClose={onClose} />);
+      let el = res.getByTestId('test');
+
+      // With CloseWatcher active, Escape keydown should not trigger onClose
+      // (the browser's CloseWatcher handles it instead)
+      fireEvent.keyDown(el, {key: 'Escape'});
+      expect(onClose).not.toHaveBeenCalled();
+
+      // But CloseWatcher still works
+      closeWatcherInstances[0].onclose();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not double-dismiss nested overlays on Escape when CloseWatcher is active', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      let outer = render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      let outerEl = outer.getByTestId('outer');
+
+      // Simulate browser behavior: CloseWatcher fires for inner overlay
+      closeWatcherInstances[1].onclose();
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+
+      // The Escape keydown event that triggered CloseWatcher also bubbles to the
+      // outer overlay's DOM. With the fix, onKeyDown is undefined so the outer
+      // overlay is NOT dismissed.
+      fireEvent.keyDown(outerEl, {key: 'Escape'});
+      expect(onCloseOuter).not.toHaveBeenCalled();
+    });
+
+    it('should dismiss inner then outer with native watcher stack', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      let inner = render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      expect(closeWatcherInstances.length).toBe(2);
+
+      // Dismiss inner overlay via its watcher
+      closeWatcherInstances[1].onclose();
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+      expect(closeWatcherInstances.length).toBe(2);
+
+      // Unmount inner - the outer watcher remains.
+      inner.unmount();
+      expect(closeWatcherInstances.length).toBe(1);
+
+      // Dismiss outer via its watcher
+      closeWatcherInstances[0].onclose();
+      expect(onCloseOuter).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -18,7 +18,7 @@ import {
   render
 } from '@react-spectrum/test-utils-internal';
 import {mergeProps} from '../../src/utils/mergeProps';
-import React, {useRef} from 'react';
+import React, {useRef, useState} from 'react';
 import {useOverlay} from '../../src/overlays/useOverlay';
 
 function Example(props) {
@@ -33,6 +33,19 @@ function Example(props) {
         {props.children}
       </div>
     </div>
+  );
+}
+
+function StatefulExample({defaultIsOpen, onClose, ...props}) {
+  let [isOpen, setIsOpen] = useState(defaultIsOpen);
+  return (
+    <Example
+      {...props}
+      isOpen={isOpen}
+      onClose={() => {
+        setIsOpen(false);
+        onClose?.();
+      }} />
   );
 }
 
@@ -213,6 +226,9 @@ describe('useOverlay', function () {
             closeWatcherInstances.splice(index, 1);
           }
         }
+        static closeTopMost() {
+          closeWatcherInstances[closeWatcherInstances.length - 1]?.onclose();
+        }
       };
       globalThis.CloseWatcher = MockCloseWatcher;
     });
@@ -340,51 +356,47 @@ describe('useOverlay', function () {
     it('should only dismiss the top-most nested overlay on Escape when CloseWatcher is active', function () {
       let onCloseOuter = jest.fn();
       let onCloseInner = jest.fn();
-      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
-      let inner = render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+      let res = render(
+        <>
+          <StatefulExample defaultIsOpen onClose={onCloseOuter} data-testid="outer" />
+          <StatefulExample defaultIsOpen onClose={onCloseInner} data-testid="inner" />
+        </>
+      );
 
-      let innerEl = inner.getByTestId('inner');
+      let innerEl = res.getByTestId('inner');
 
       fireEvent.keyDown(innerEl, {key: 'Escape'});
       expect(onCloseInner).not.toHaveBeenCalled();
       expect(onCloseOuter).not.toHaveBeenCalled();
 
-      closeWatcherInstances[1].onclose();
+      act(() => MockCloseWatcher.closeTopMost());
       expect(onCloseInner).toHaveBeenCalledTimes(1);
       expect(onCloseOuter).not.toHaveBeenCalled();
-    });
-
-    it('should let the browser determine which CloseWatcher closes', function () {
-      let onCloseOuter = jest.fn();
-      let onCloseInner = jest.fn();
-      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
-      render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
-
-      closeWatcherInstances[0].onclose();
-      expect(onCloseOuter).toHaveBeenCalledTimes(1);
-      expect(onCloseInner).not.toHaveBeenCalled();
+      expect(res.queryByTestId('inner')).toBeNull();
+      expect(closeWatcherInstances).toHaveLength(1);
     });
 
     it('should dismiss inner then outer with native watcher stack', function () {
       let onCloseOuter = jest.fn();
       let onCloseInner = jest.fn();
-      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
-      let inner = render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+      let res = render(
+        <>
+          <StatefulExample defaultIsOpen onClose={onCloseOuter} data-testid="outer" />
+          <StatefulExample defaultIsOpen onClose={onCloseInner} data-testid="inner" />
+        </>
+      );
 
       expect(closeWatcherInstances.length).toBe(2);
 
-      // Dismiss inner overlay via its watcher
-      closeWatcherInstances[1].onclose();
+      act(() => MockCloseWatcher.closeTopMost());
       expect(onCloseInner).toHaveBeenCalledTimes(1);
-      expect(closeWatcherInstances.length).toBe(2);
-
-      // Unmount inner - the outer watcher remains.
-      inner.unmount();
+      expect(res.queryByTestId('inner')).toBeNull();
       expect(closeWatcherInstances.length).toBe(1);
 
-      // Dismiss outer via its watcher
-      closeWatcherInstances[0].onclose();
+      act(() => MockCloseWatcher.closeTopMost());
       expect(onCloseOuter).toHaveBeenCalledTimes(1);
+      expect(res.queryByTestId('outer')).toBeNull();
+      expect(closeWatcherInstances.length).toBe(0);
     });
   });
 });

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -148,6 +148,7 @@ describe('useOverlay', function () {
       closeWatcherInstances = [];
       MockCloseWatcher = class {
         constructor() {
+          this.oncancel = null;
           this.onclose = null;
           closeWatcherInstances.push(this);
         }
@@ -233,38 +234,67 @@ describe('useOverlay', function () {
       expect(onCloseFirst).not.toHaveBeenCalled();
     });
 
-    it('should not attach onKeyDown when CloseWatcher is supported', function () {
+    it('should dismiss on Escape when CloseWatcher is supported', function () {
       let onClose = jest.fn();
       let res = render(<Example isOpen onClose={onClose} />);
       let el = res.getByTestId('test');
 
-      // With CloseWatcher active, Escape keydown should not trigger onClose
-      // (the browser's CloseWatcher handles it instead)
       fireEvent.keyDown(el, {key: 'Escape'});
-      expect(onClose).not.toHaveBeenCalled();
-
-      // But CloseWatcher still works
-      closeWatcherInstances[0].onclose();
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('should not double-dismiss nested overlays on Escape when CloseWatcher is active', function () {
+    it('should dismiss the most recently opened overlay on Escape when focus is in an older overlay', function () {
+      let onCloseFirst = jest.fn();
+      let onCloseSecond = jest.fn();
+      let first = render(
+        <Example isOpen onClose={onCloseFirst} data-testid="first">
+          <input data-testid="first-input" />
+        </Example>
+      );
+      render(
+        <Example isOpen onClose={onCloseSecond} data-testid="second">
+          <input data-testid="second-input" />
+        </Example>
+      );
+
+      expect(closeWatcherInstances.length).toBe(2);
+      let firstInput = first.getByTestId('first-input');
+      act(() => {
+        firstInput.focus();
+      });
+      expect(document.activeElement).toBe(firstInput);
+
+      fireEvent.keyDown(firstInput, {key: 'Escape'});
+      expect(onCloseSecond).toHaveBeenCalledTimes(1);
+      expect(onCloseFirst).not.toHaveBeenCalled();
+    });
+
+    it('should only dismiss the top-most nested overlay on Escape when CloseWatcher is active', function () {
       let onCloseOuter = jest.fn();
       let onCloseInner = jest.fn();
-      let outer = render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
+      let inner = render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
+
+      let innerEl = inner.getByTestId('inner');
+
+      fireEvent.keyDown(innerEl, {key: 'Escape'});
+      expect(onCloseInner).toHaveBeenCalledTimes(1);
+      expect(onCloseOuter).not.toHaveBeenCalled();
+    });
+
+    it('should cancel non-topmost CloseWatcher close requests when possible', function () {
+      let onCloseOuter = jest.fn();
+      let onCloseInner = jest.fn();
+      render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
       render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
 
-      let outerEl = outer.getByTestId('outer');
+      let outerCancelEvent = new Event('cancel', {cancelable: true});
+      closeWatcherInstances[0].oncancel(outerCancelEvent);
+      expect(outerCancelEvent.defaultPrevented).toBe(true);
 
-      // Simulate browser behavior: CloseWatcher fires for inner overlay
-      closeWatcherInstances[1].onclose();
-      expect(onCloseInner).toHaveBeenCalledTimes(1);
-
-      // The Escape keydown event that triggered CloseWatcher also bubbles to the
-      // outer overlay's DOM. With the fix, onKeyDown is undefined so the outer
-      // overlay is NOT dismissed.
-      fireEvent.keyDown(outerEl, {key: 'Escape'});
-      expect(onCloseOuter).not.toHaveBeenCalled();
+      let innerCancelEvent = new Event('cancel', {cancelable: true});
+      closeWatcherInstances[1].oncancel(innerCancelEvent);
+      expect(innerCancelEvent.defaultPrevented).toBe(false);
     });
 
     it('should dismiss inner then outer with native watcher stack', function () {

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -204,7 +204,6 @@ describe('useOverlay', function () {
       closeWatcherInstances = [];
       MockCloseWatcher = class {
         constructor() {
-          this.oncancel = null;
           this.onclose = null;
           closeWatcherInstances.push(this);
         }
@@ -355,19 +354,15 @@ describe('useOverlay', function () {
       expect(onCloseOuter).not.toHaveBeenCalled();
     });
 
-    it('should cancel non-topmost CloseWatcher close requests when possible', function () {
+    it('should let the browser determine which CloseWatcher closes', function () {
       let onCloseOuter = jest.fn();
       let onCloseInner = jest.fn();
       render(<Example isOpen onClose={onCloseOuter} data-testid="outer" />);
       render(<Example isOpen onClose={onCloseInner} data-testid="inner" />);
 
-      let outerCancelEvent = new Event('cancel', {cancelable: true});
-      closeWatcherInstances[0].oncancel(outerCancelEvent);
-      expect(outerCancelEvent.defaultPrevented).toBe(true);
-
-      let innerCancelEvent = new Event('cancel', {cancelable: true});
-      closeWatcherInstances[1].oncancel(innerCancelEvent);
-      expect(innerCancelEvent.defaultPrevented).toBe(false);
+      closeWatcherInstances[0].onclose();
+      expect(onCloseOuter).toHaveBeenCalledTimes(1);
+      expect(onCloseInner).not.toHaveBeenCalled();
     });
 
     it('should dismiss inner then outer with native watcher stack', function () {

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -26,9 +26,23 @@ function Example(props) {
   let {overlayProps, underlayProps} = useOverlay(props, ref);
   return (
     <div {...mergeProps(underlayProps, props.underlayProps || {})}>
-      <div ref={ref} {...overlayProps} data-testid={props['data-testid'] || 'test'}>
+      <div
+        ref={ref}
+        {...mergeProps(props.overlayProps || {}, overlayProps)}
+        data-testid={props['data-testid'] || 'test'}>
         {props.children}
       </div>
+    </div>
+  );
+}
+
+function SharedRefExample(props) {
+  let ref = useRef();
+  let first = useOverlay({isOpen: true, onClose: props.onCloseFirst}, ref);
+  let second = useOverlay({isOpen: true, onClose: props.onCloseSecond}, ref);
+  return (
+    <div ref={ref} {...first.overlayProps} data-testid="group">
+      <div {...second.overlayProps} data-testid="test" />
     </div>
   );
 }
@@ -140,6 +154,48 @@ describe('useOverlay', function () {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should not hide the overlay when an earlier Escape handler stops propagation', function () {
+    let onClose = jest.fn();
+    let res = render(
+      <Example
+        isOpen
+        onClose={onClose}
+        overlayProps={{
+          onKeyDown: e => e.stopPropagation()
+        }}
+      />
+    );
+    let el = res.getByTestId('test');
+    fireEvent.keyDown(el, {key: 'Escape'});
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should hide the innermost overlay when nested overlays mount together', function () {
+    let onCloseOuter = jest.fn();
+    let onCloseInner = jest.fn();
+    let res = render(
+      <Example isOpen onClose={onCloseOuter} data-testid="outer">
+        <Example isOpen onClose={onCloseInner} data-testid="inner" />
+      </Example>
+    );
+
+    fireEvent.keyDown(res.getByTestId('inner'), {key: 'Escape'});
+    expect(onCloseInner).toHaveBeenCalledTimes(1);
+    expect(onCloseOuter).not.toHaveBeenCalled();
+  });
+
+  it('should keep separate close handlers for overlays using the same ref', function () {
+    let onCloseFirst = jest.fn();
+    let onCloseSecond = jest.fn();
+    let res = render(
+      <SharedRefExample onCloseFirst={onCloseFirst} onCloseSecond={onCloseSecond} />
+    );
+
+    fireEvent.keyDown(res.getByTestId('test'), {key: 'Escape'});
+    expect(onCloseSecond).toHaveBeenCalledTimes(1);
+    expect(onCloseFirst).not.toHaveBeenCalled();
+  });
+
   describe('CloseWatcher', function () {
     let closeWatcherInstances;
     let MockCloseWatcher;
@@ -234,16 +290,25 @@ describe('useOverlay', function () {
       expect(onCloseFirst).not.toHaveBeenCalled();
     });
 
-    it('should dismiss on Escape when CloseWatcher is supported', function () {
+    it('should let CloseWatcher handle Escape when supported', function () {
       let onClose = jest.fn();
-      let res = render(<Example isOpen onClose={onClose} />);
+      let onKeyDown = jest.fn();
+      let res = render(
+        <div role="presentation" onKeyDown={onKeyDown}>
+          <Example isOpen onClose={onClose} />
+        </div>
+      );
       let el = res.getByTestId('test');
 
       fireEvent.keyDown(el, {key: 'Escape'});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(onClose).not.toHaveBeenCalled();
+
+      closeWatcherInstances[0].onclose();
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('should dismiss the most recently opened overlay on Escape when focus is in an older overlay', function () {
+    it('should let native CloseWatcher dismiss the most recently opened overlay', function () {
       let onCloseFirst = jest.fn();
       let onCloseSecond = jest.fn();
       let first = render(
@@ -265,6 +330,10 @@ describe('useOverlay', function () {
       expect(document.activeElement).toBe(firstInput);
 
       fireEvent.keyDown(firstInput, {key: 'Escape'});
+      expect(onCloseSecond).not.toHaveBeenCalled();
+      expect(onCloseFirst).not.toHaveBeenCalled();
+
+      closeWatcherInstances[1].onclose();
       expect(onCloseSecond).toHaveBeenCalledTimes(1);
       expect(onCloseFirst).not.toHaveBeenCalled();
     });
@@ -278,6 +347,10 @@ describe('useOverlay', function () {
       let innerEl = inner.getByTestId('inner');
 
       fireEvent.keyDown(innerEl, {key: 'Escape'});
+      expect(onCloseInner).not.toHaveBeenCalled();
+      expect(onCloseOuter).not.toHaveBeenCalled();
+
+      closeWatcherInstances[1].onclose();
       expect(onCloseInner).toHaveBeenCalledTimes(1);
       expect(onCloseOuter).not.toHaveBeenCalled();
     });

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -38,6 +38,13 @@ function Example(props) {
 
 function StatefulExample({defaultIsOpen, onClose, ...props}) {
   let [isOpen, setIsOpen] = useState(defaultIsOpen);
+  // Unmount on close the way a real consumer does. Example renders its node
+  // unconditionally, so leaving it mounted would keep both the element and the
+  // overlay's CloseWatcher alive and make the nested-dismiss assertions
+  // unobservable.
+  if (!isOpen) {
+    return null;
+  }
   return (
     <Example
       {...props}

--- a/packages/react-aria/test/overlays/useOverlay.test.js
+++ b/packages/react-aria/test/overlays/useOverlay.test.js
@@ -45,7 +45,8 @@ function StatefulExample({defaultIsOpen, onClose, ...props}) {
       onClose={() => {
         setIsOpen(false);
         onClose?.();
-      }} />
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- Uses the [CloseWatcher API](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) when available to dismiss overlays, integrating with the browser's native dismiss signal (including Android back button, Escape key)
- Feature-detects `CloseWatcher` at runtime and falls back to the existing Escape key handler in unsupported browsers
- Respects `isKeyboardDismissDisabled` prop and only-top-overlay stack behavior

Closes #5531

## Approach

In `useOverlay`, a new `useEffect` creates a `CloseWatcher` instance when:
1. The overlay `isOpen` is true
2. `isKeyboardDismissDisabled` is false
3. `CloseWatcher` is available in the browser

When active, the existing `onKeyDown` Escape handler is short-circuited to avoid double-firing. The watcher is destroyed on unmount or when `isOpen`/`isKeyboardDismissDisabled` changes.

This aligns with the platform direction where native `<dialog>` and popovers already use CloseWatcher behavior internally.

## Test plan

- [x] New tests: CloseWatcher dismisses overlay when available
- [x] New tests: CloseWatcher not created when `isKeyboardDismissDisabled` is true
- [x] New tests: CloseWatcher not created when overlay is closed
- [x] New tests: CloseWatcher destroyed on unmount
- [x] New tests: Escape keyDown handler skipped when CloseWatcher is active
- [x] Existing tests: Escape key fallback still works (all original tests pass)
- [x] `yarn jest packages/react-aria/test/overlays/useOverlay.test.js` - 25/25 passing

This contribution was developed with AI assistance (Claude Code).