### PR TITLE
docs(starters): fix storybook autodocs config

### DIFF
--- a/starters/docs/.storybook/main.js
+++ b/starters/docs/.storybook/main.js
@@ -12,6 +12,7 @@ function getAbsolutePath(value) {
 const config = {
   stories: ["../stories/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
+    getAbsolutePath("@storybook/addon-docs"),
     getAbsolutePath("@storybook/addon-webpack5-compiler-babel"),
   ],
   framework: {

--- a/starters/docs/package.json
+++ b/starters/docs/package.json
@@ -14,9 +14,11 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.27.1",
+    "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-webpack5-compiler-babel": "^3.0.6",
     "@storybook/react": "^9.0.18",
     "@storybook/react-webpack5": "^9.0.18",
+    "@vueless/storybook-dark-mode": "^9.0.6",
     "clsx": "^2.1.1",
     "lightningcss-loader": "^2.1.0",
     "lucide-react": "^0.517.0",
@@ -24,7 +26,6 @@
     "react-aria-components": "^1.14.0",
     "react-dom": "^19.2.0",
     "storybook": "^9.0.18",
-    "@vueless/storybook-dark-mode": "^9.0.6",
     "typescript": "^5.8.2"
   },
   "resolutions": {

--- a/starters/tailwind/.storybook/main.js
+++ b/starters/tailwind/.storybook/main.js
@@ -4,7 +4,7 @@ const config = {
     "../stories/**/*.mdx",
     "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
-  addons: [],
+  addons: ["@storybook/addon-docs"],
   framework: {
     name: "@storybook/react-vite",
     options: {},

--- a/starters/tailwind/package.json
+++ b/starters/tailwind/package.json
@@ -5,6 +5,7 @@
   "packageManager": "yarn@4.2.2",
   "devDependencies": {
     "@babel/preset-react": "^7.24.1",
+    "@storybook/addon-docs": "^9.0.18",
     "@storybook/react": "^9.0.18",
     "@storybook/react-vite": "^9.0.18",
     "@tailwindcss/postcss": "^4.0.0",


### PR DESCRIPTION
The storybook docs for the RAC starters are currently broken (although individual stories work):
- https://react-aria.adobe.com/react-aria-starter/?path=/docs/breadcrumbs--docs
- https://react-aria.adobe.com/react-aria-tailwind-starter/?path=/docs/alertdialog--docs

This fixes the autodocs addon so that these pages now render.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test the starter storybooks locally and confirm the docs load.

## 🧢 Your Project:

<!--- Company/project for pull request -->
