### PR TITLE
fix: properly apply minwidth set by Tableview column menu

### DIFF
--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -409,7 +409,7 @@ export const Menu = /*#__PURE__*/ (forwardRef as forwardRefType)(function Menu<T
         hideArrow>
         <div
           style={UNSAFE_style}
-          className={(UNSAFE_className || '') + wrappingDiv}>
+          className={(UNSAFE_className || '') + mergeStyles(wrappingDiv, styles)}>
           {content}
         </div>
       </Popover>


### PR DESCRIPTION
No issue, from slack via quarry

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Inspect the wrapping div around the S2 TableView column resizing menu. It should have a min width applied to it now

## 🧢 Your Project:

RSP