### PR TITLE
feat: Add codemod to migrate to subpaths

### DIFF
--- a/packages/dev/codemods/src/index.ts
+++ b/packages/dev/codemods/src/index.ts
@@ -2,6 +2,7 @@
 const {parseArgs} = require('node:util');
 import {s1_to_s2} from './s1-to-s2/src';
 import {use_monopackages} from './use-monopackages/src';
+import {use_subpaths} from './use-subpaths/src';
 
 interface JSCodeshiftOptions {
   /**
@@ -52,9 +53,12 @@ export interface UseMonopackagesCodemodOptions extends JSCodeshiftOptions {
   packages?: string
 }
 
-const codemods: Record<string, (options: S1ToS2CodemodOptions | UseMonopackagesCodemodOptions) => void> = {
+export interface UseSubpathsCodemodOptions extends JSCodeshiftOptions {}
+
+const codemods: Record<string, (options: S1ToS2CodemodOptions | UseMonopackagesCodemodOptions | UseSubpathsCodemodOptions) => void> = {
   's1-to-s2': s1_to_s2,
-  'use-monopackages': use_monopackages
+  'use-monopackages': use_monopackages,
+  'use-subpaths': use_subpaths
 };
 
 // https://github.com/facebook/jscodeshift?tab=readme-ov-file#usage-cli
@@ -103,6 +107,7 @@ async function main() {
     parser: 'tsx',
     ignorePattern: '**/node_modules/**',
     path: '.',
+    extensions: 'js,jsx,mjs,cjs,ts,tsx',
     ...values
   }));
 }

--- a/packages/dev/codemods/src/use-monopackages/src/codemod.ts
+++ b/packages/dev/codemods/src/use-monopackages/src/codemod.ts
@@ -1,6 +1,8 @@
 import {API, FileInfo, ImportSpecifier, Options} from 'jscodeshift';
 const fs = require('fs');
 const path = require('path');
+const Module = require('module');
+const url = require('url');
 
 function areSpecifiersAlphabetized(specifiers: ImportSpecifier[]) {
   const specifierNames = specifiers.map(
@@ -54,10 +56,16 @@ const transformer: Transformer = function transformer(file: FileInfo, api: API, 
   const monopackageExports: Record<string, string[]> = {};
 
   selectedPackages.forEach((pkg) => {
-    const indexPath = path.join(
-      process.cwd(),
-      `node_modules/${packages[pkg].monopackage}/dist/types.d.ts`
-    );
+    let indexPath: string;
+    try {
+      let pkgPath = path.dirname(Module.findPackageJSON(packages[pkg].monopackage, url.pathToFileURL(file.path || `${process.cwd()}/index`))!);
+      indexPath = `${pkgPath}/dist/types/exports/index.d.ts`;
+      if (!fs.existsSync(indexPath)) {
+        indexPath = `${pkgPath}/exports/index.ts`;
+      }
+    } catch {
+      return;
+    }
 
     if (fs.existsSync(indexPath)) {
       anyIndexFound = true;

--- a/packages/dev/codemods/src/use-subpaths/README.md
+++ b/packages/dev/codemods/src/use-subpaths/README.md
@@ -1,0 +1,19 @@
+# Codemod to use subpath exports
+
+Replaces monopackage imports with subpaths.
+
+```diff
+- import {Button} from 'react-aria-components';
++ import {Button} from 'react-aria-components/Button';
+```
+
+## Usage
+
+Run `npx @react-spectrum/codemods use-subpaths` from the directory you want to update imports in.
+
+### Options
+
+- `--parser` - The [parser](https://github.com/facebook/jscodeshift?tab=readme-ov-file#parser) to use for parsing the source files. Defaults to `tsx`.
+- `--ignore-pattern` - A [glob pattern](https://github.com/facebook/jscodeshift?tab=readme-ov-file#ignoring-files-and-directories) of files to ignore. Defaults to `**/node_modules/**`.
+- `--dry` - Run the codemod without making changes to the files.
+- `--path` - The path to the directory to run the codemod in. Defaults to the current directory.

--- a/packages/dev/codemods/src/use-subpaths/src/codemod.test.ts
+++ b/packages/dev/codemods/src/use-subpaths/src/codemod.test.ts
@@ -1,0 +1,128 @@
+// @ts-ignore
+import {defineInlineTest} from 'jscodeshift/dist/testUtils';
+import transform from './codemod';
+
+function test(name: string, input: string, output: string) {
+  defineInlineTest(transform, {}, input, output, name);
+}
+
+test(
+  'rewrites a uniquely mapped specifier',
+  `
+import {Accordion} from '@adobe/react-spectrum';
+`,
+  `
+import { Accordion } from '@adobe/react-spectrum/Accordion';
+`
+);
+
+test(
+  'splits mixed uniquely mapped specifiers across subpaths',
+  `
+import {Accordion, Button} from '@adobe/react-spectrum';
+`,
+  `
+import { Accordion } from '@adobe/react-spectrum/Accordion';
+import { Button } from '@adobe/react-spectrum/Button';
+`
+);
+
+test(
+  'groups multi-mapped specifiers with a uniquely mapped import from the same declaration',
+  `
+import {ListView, Item} from '@adobe/react-spectrum';
+`,
+  `
+import { ListView, Item } from '@adobe/react-spectrum/ListView';
+`
+);
+
+test(
+  'handles when Item is available in multiple existing imports',
+  `
+import {ListView, ActionGroup, Item} from '@adobe/react-spectrum';
+`,
+  `
+import { ListView, Item } from '@adobe/react-spectrum/ListView';
+import { ActionGroup } from '@adobe/react-spectrum/ActionGroup';
+`
+);
+
+test(
+  'handles multiple monopackage imports',
+  `
+import {ListView} from '@adobe/react-spectrum';
+import {ActionGroup, Item} from '@adobe/react-spectrum';
+`,
+  `
+import { ListView, Item } from '@adobe/react-spectrum/ListView';
+import { ActionGroup } from '@adobe/react-spectrum/ActionGroup';
+`
+);
+
+test(
+  'reuses an existing matching subpath import elsewhere in the file',
+  `
+import {Item} from '@adobe/react-spectrum';
+import {ListView} from '@adobe/react-spectrum/ListView';
+`,
+  `
+import { ListView, Item } from '@adobe/react-spectrum/ListView';
+`
+);
+
+test(
+  'preserves aliases when moving specifiers',
+  `
+import {ListView as RSListView, Item as RSItem} from '@adobe/react-spectrum';
+`,
+  `
+import { ListView as RSListView, Item as RSItem } from '@adobe/react-spectrum/ListView';
+`
+);
+
+test(
+  'keeps unsupported, default, and namespace imports untouched',
+  `
+import ReactSpectrum, {Accordion, fakeThing} from '@adobe/react-spectrum';
+import * as RAC from 'react-aria-components';
+`,
+  `
+import ReactSpectrum, { fakeThing } from '@adobe/react-spectrum';
+import { Accordion } from '@adobe/react-spectrum/Accordion';
+import * as RAC from 'react-aria-components';
+`
+);
+
+test(
+  'merges into an existing destination import',
+  `
+import {Disclosure} from '@adobe/react-spectrum';
+import {Accordion} from '@adobe/react-spectrum/Accordion';
+`,
+  `
+import { Accordion, Disclosure } from '@adobe/react-spectrum/Accordion';
+`
+);
+
+test(
+  'leaves already subpathed imports unchanged',
+  `
+import {Accordion} from '@adobe/react-spectrum/Accordion';
+`,
+  `
+import {Accordion} from '@adobe/react-spectrum/Accordion';
+`
+);
+
+test(
+  'groups by import kind',
+  `
+import {Button, ButtonContext} from 'react-aria-components';
+import type {ButtonProps} from 'react-aria-components';
+`,
+  `
+import { Button, ButtonContext } from 'react-aria-components/Button';
+import type { ButtonProps } from 'react-aria-components/Button';
+`
+);

--- a/packages/dev/codemods/src/use-subpaths/src/codemod.ts
+++ b/packages/dev/codemods/src/use-subpaths/src/codemod.ts
@@ -1,0 +1,204 @@
+/* eslint-disable max-depth */
+import {API, FileInfo} from 'jscodeshift';
+import {getSpecifiersByPackage} from './specifiers';
+import {parse} from '@babel/parser';
+import {parse as recastParse} from 'recast';
+import * as t from '@babel/types';
+
+function getImportedName(specifier: t.ImportSpecifier): string {
+  return specifier.imported.type === 'Identifier' ? specifier.imported.name : specifier.imported.value;
+}
+
+function getImportKey(specifier: t.ImportSpecifier): string {
+  const importedName = getImportedName(specifier);
+  const localName = specifier.local?.name ?? importedName;
+  const importKind = specifier.importKind ?? 'value';
+  return `${importKind}:${importedName}:${localName}`;
+}
+
+function getImportDeclarationKey(node: t.ImportDeclaration): string {
+  return (node.importKind ?? 'value') + ':' + node.source.value;
+}
+
+function getNamedSpecifierKeys(importDeclaration: t.ImportDeclaration): Set<string> {
+  let keys = new Set<string>();
+  for (let specifier of importDeclaration.specifiers ?? []) {
+    if (specifier.type === 'ImportSpecifier') {
+      keys.add(getImportKey(specifier));
+    }
+  }
+
+  return keys;
+}
+
+function createImportDeclaration(
+  source: string,
+  importKind: t.ImportSpecifier['importKind'],
+  specifiers: t.ImportSpecifier[]
+): t.ImportDeclaration {
+  let declaration = t.importDeclaration(specifiers, t.stringLiteral(source));
+  declaration.importKind = importKind ?? 'value';
+  return declaration;
+}
+
+function resolveTargetSource(
+  candidates: string[],
+  uniqueSources: Set<string>,
+  existingImports: Map<string, any>
+): string {
+  // Group with the first unique source that contained a candidate.
+  // For example if you imported ListBox, ActionGroup, and Item, Item would be grouped with ListBox.
+  for (let source of uniqueSources) {
+    if (candidates.includes(source)) {
+      return source;
+    }
+  }
+
+  // Group with an already existing import.
+  for (let source of existingImports.keys()) {
+    if (candidates.includes(source)) {
+      return source;
+    }
+  }
+
+  return candidates[0];
+}
+
+export default function transformer(file: FileInfo, api: API): string {
+  let specifiersByPackage = getSpecifiersByPackage(file.path);
+  let j = api.jscodeshift.withParser({
+    parse(source: string) {
+      return recastParse(source, {
+        parser: {
+          parse(innerSource: string) {
+            return parse(innerSource, {
+              sourceType: 'module',
+              plugins: [
+                'jsx',
+                'typescript',
+                'importAssertions',
+                'dynamicImport',
+                'decorators-legacy',
+                'classProperties',
+                'classPrivateProperties',
+                'classPrivateMethods',
+                'exportDefaultFrom',
+                'exportNamespaceFrom',
+                'objectRestSpread',
+                'optionalChaining',
+                'nullishCoalescingOperator',
+                'topLevelAwait'
+              ],
+              tokens: true,
+              errorRecovery: true
+            });
+          }
+        }
+      });
+    }
+  });
+
+  let root = j(file.source);
+  let program = root.get().node.program as t.Program;
+  let uniqueSources = new Set<string>();
+  let existingImports = new Map<string, t.ImportDeclaration>();
+
+  for (let node of program.body) {
+    if (node.type === 'ImportDeclaration') {
+      let source = node.source.value;
+      if (typeof source !== 'string') {
+        continue;
+      }
+
+      existingImports.set(getImportDeclarationKey(node), node);
+      
+      if (source in specifiersByPackage) {
+        let sourceMap = specifiersByPackage[source];
+        for (let specifier of node.specifiers ?? []) {
+          if (specifier.type !== 'ImportSpecifier') {
+            continue;
+          }
+
+          let importedName = getImportedName(specifier);
+          let candidates = sourceMap[importedName];
+          if (candidates && candidates.length === 1) {
+            let importKind = node.importKind || 'value';
+            uniqueSources.add(importKind + ':' + candidates[0]);
+          }
+        }
+      }
+    }
+  }
+
+  let didChange = false;
+  
+  program.body = program.body.flatMap(node => {
+    if (node.type !== 'ImportDeclaration') {
+      return [node];
+    }
+    
+    let source = node.source.value;
+    if (typeof source !== 'string' || !(source in specifiersByPackage)) {
+      return [node];
+    }
+    
+    let importDeclaration = node;
+    let sourceMap = specifiersByPackage[node.source.value];
+    let movedSpecifiersBySource = new Map<string, any[]>();
+
+    importDeclaration.specifiers = importDeclaration.specifiers.filter(specifier => {
+      if (specifier.type !== 'ImportSpecifier') {
+        return true;
+      }
+
+      let importedName = getImportedName(specifier);
+      let candidates = sourceMap[importedName];
+      if (!candidates || candidates.length === 0) {
+        return true;
+      }
+
+      let importKind = node.importKind || 'value';
+      let targetSource = candidates.length === 1
+        ? importKind + ':' + candidates[0]
+        : resolveTargetSource(candidates.map(c => importKind + ':' + c), uniqueSources, existingImports);
+
+      let movedSpecifiers = movedSpecifiersBySource.get(targetSource) ?? [];
+      movedSpecifiers.push(t.cloneNode(specifier, true));
+      movedSpecifiersBySource.set(targetSource, movedSpecifiers);
+      didChange = true;
+      return false;
+    });
+
+    if (movedSpecifiersBySource.size === 0) {
+      return [node];
+    }
+
+    let newDeclarations: t.Statement[] = [];
+    if (importDeclaration.specifiers.length > 0) {
+      newDeclarations.push(node);
+    }
+
+    for (let [targetSource, movedSpecifiers] of movedSpecifiersBySource) {
+      let destinationImport = existingImports.get(targetSource);
+
+      if (!destinationImport) {
+        destinationImport = createImportDeclaration(targetSource.slice(targetSource.indexOf(':') + 1), importDeclaration.importKind, []);
+        newDeclarations.push(destinationImport);
+        existingImports.set(targetSource, destinationImport);
+      }
+
+      let existingSpecifierKeys = getNamedSpecifierKeys(destinationImport);
+      for (let movedSpecifier of movedSpecifiers) {
+        let key = getImportKey(movedSpecifier);
+        if (!existingSpecifierKeys.has(key)) {
+          destinationImport.specifiers.push(movedSpecifier);
+          existingSpecifierKeys.add(key);
+        }
+      }
+    }
+
+    return newDeclarations;
+  });
+
+  return didChange ? root.toSource({quote: 'single'}) : file.source;
+};

--- a/packages/dev/codemods/src/use-subpaths/src/index.ts
+++ b/packages/dev/codemods/src/use-subpaths/src/index.ts
@@ -1,0 +1,14 @@
+import {run as jscodeshift} from 'jscodeshift/src/Runner.js';
+import path from 'path';
+import {UseSubpathsCodemodOptions} from '../..';
+
+const transformPath = path.join(__dirname, 'codemod.js');
+
+export async function use_subpaths(options: UseSubpathsCodemodOptions): Promise<ReturnType<typeof jscodeshift>> {
+  let {
+    path: filePath = '.',
+    ...rest
+  } = options;
+
+  return await jscodeshift(transformPath, [filePath], rest);
+}

--- a/packages/dev/codemods/src/use-subpaths/src/specifiers.ts
+++ b/packages/dev/codemods/src/use-subpaths/src/specifiers.ts
@@ -1,0 +1,72 @@
+/* eslint-disable max-depth */
+import fs from 'fs';
+import Module from 'module';
+import {parse} from '@babel/parser';
+import path from 'path';
+import url from 'url';
+
+const PACKAGES = [
+  '@adobe/react-spectrum',
+  '@react-spectrum/s2',
+  'react-aria-components',
+  'react-aria',
+  'react-stately'
+];
+
+const specifiersByPackage: Record<string, Record<string, string[]>> = {};
+
+/** Builds a mapping of monopackage -> export -> subpaths that contain the export. */
+export function getSpecifiersByPackage(from: string) {    
+  for (let pkg of PACKAGES) {
+    if (specifiersByPackage[pkg]) {
+      continue;
+    }
+
+    let dir: string;
+    try {
+      let pkgPath = path.dirname(Module.findPackageJSON(pkg, url.pathToFileURL(from || `${process.cwd()}/index`))!);
+      dir = `${pkgPath}/dist/types/exports`;
+      if (!fs.existsSync(dir)) {
+        dir = `${pkgPath}/exports`;
+      }
+      
+      if (!fs.existsSync(dir)) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    let exports: Record<string, string[]> = {};
+    for (let entry of fs.readdirSync(dir, {withFileTypes: true})) {
+      if (entry.name === 'index.ts' || entry.name === 'index.d.ts' || !entry.isFile()) {
+        continue;
+      }
+
+      let contents = fs.readFileSync(`${dir}/${entry.name}`, 'utf8');
+      let ast = parse(contents, {
+        sourceType: 'module',
+        plugins: ['typescript']
+      });
+
+      let importSpecifier = `${pkg}/${entry.name.replace(/(\.d)?\.ts$/, '')}`;
+      for (let node of ast.program.body) {
+        if (node.type === 'ExportNamedDeclaration') {
+          for (let specifier of node.specifiers) {
+            if (specifier.type !== 'ExportSpecifier') {
+              continue;
+            }
+
+            let exported = specifier.exported.type === 'Identifier' ? specifier.exported.name : specifier.exported.value;
+            exports[exported] ??= [];
+            exports[exported].push(importSpecifier);
+          }
+        }
+      }
+
+      specifiersByPackage[pkg] = exports;
+    }
+  }
+
+  return specifiersByPackage;
+}


### PR DESCRIPTION
Adds a new codemod to migrate from monopackage imports to subpaths.

```diff
- import {Button} from 'react-aria-components';
+ import {Button} from 'react-aria-components/Button';
```

Tries to group related imports together. For example, even though `Item` is available via many different subpaths, it will be imported from the one that is being used elsewhere in the file.

If you want to migrate from individual packages (e.g. `@react-aria/button`) to subpaths, run the `use-monopackages` codemod first before running `use-subpaths`.