### PR TITLE
fix: DnD for moving child before parent with single root item

### DIFF
--- a/packages/react-aria-components/src/TreeDropTargetDelegate.ts
+++ b/packages/react-aria-components/src/TreeDropTargetDelegate.ts
@@ -194,7 +194,7 @@ export class TreeDropTargetDelegate<T> {
     if (potentialTargets.length === 1) {
       let nextKey = collection.getKeyAfter(target.key);
       let nextNode = nextKey ? collection.getItem(nextKey) : null;
-      if (nextKey != null && nextNode && currentItem && nextNode.level != null && currentItem.level != null && nextNode.level > currentItem.level) {
+      if (nextKey != null && nextNode && currentItem && nextNode.type === 'item' && nextNode.level != null && currentItem.level != null && nextNode.level > currentItem.level) {
         let beforeTarget = {
           type: 'item',
           key: nextKey,

--- a/packages/react-aria-components/test/Tree.test.tsx
+++ b/packages/react-aria-components/test/Tree.test.tsx
@@ -2045,6 +2045,65 @@ describe('Tree', () => {
       expect(getItems).toHaveBeenCalledTimes(1);
       expect(getItems).toHaveBeenCalledWith(new Set(['projects', 'reports']));
     });
+
+    it('should allow dropping a child before its parent when parent is the only root node', () => {
+      let onMove = jest.fn();
+      let items = [
+        {id: 'projects', name: 'Projects', childItems: [
+          {id: 'project-1', name: 'Project 1'}
+        ]}
+      ];
+
+      let realGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect;
+      let rectSpy = jest.spyOn(window.HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement): DOMRect {
+        let rect = realGetBoundingClientRect.call(this);
+
+        if (this.getAttribute('role') === 'treegrid') {
+          return {...rect, top: 0, left: 0, width: 100, height: 100, bottom: 100, right: 100};
+        }
+
+        if (this.getAttribute('data-key') === 'projects') {
+          return {...rect, top: 10, left: 0, width: 100, height: 20, bottom: 30, right: 100};
+        }
+
+        if (this.getAttribute('data-key') === 'project-1') {
+          return {...rect, top: 30, left: 0, width: 100, height: 20, bottom: 50, right: 100};
+        }
+
+        return rect;
+      });
+
+      function SingleRootDraggableTree() {
+        let {dragAndDropHooks} = useDragAndDrop({
+          getItems: (keys) => [...keys].map((key) => ({'text/plain': key.toString()})),
+          onMove
+        });
+
+        return <DynamicTree treeProps={{dragAndDropHooks, items}} />;
+      }
+
+      let {getByRole} = render(<SingleRootDraggableTree />);
+
+      let tree = getByRole('treegrid');
+      let project1Row = getByRole('row', {name: 'Project 1'});
+      let dataTransfer = new DataTransfer();
+
+      fireEvent(project1Row, new DragEvent('dragstart', {dataTransfer, clientX: 50, clientY: 35}));
+      act(() => jest.runAllTimers());
+
+      fireEvent(tree, new DragEvent('dragenter', {dataTransfer, clientX: 50, clientY: 0}));
+      fireEvent(tree, new DragEvent('dragover', {dataTransfer, clientX: 50, clientY: 0}));
+
+      fireEvent(tree, new DragEvent('drop', {dataTransfer, clientX: 50, clientY: 0}));
+      fireEvent(project1Row, new DragEvent('dragend', {dataTransfer, clientX: 50, clientY: 0}));
+      act(() => jest.runAllTimers());
+
+      expect(onMove).toHaveBeenCalledTimes(1);
+      expect(onMove.mock.calls[0][0].keys).toEqual(new Set(['project-1']));
+      expect(onMove.mock.calls[0][0].target).toEqual({type: 'item', key: 'projects', dropPosition: 'before'});
+
+      rectSpy.mockRestore();
+    });
   });
 
   describe('press events', () => {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

See discussion #9796

If a tree contains a single root item with a child, the child can't be moved before the parent element via drag & drop, the drag indicator doesn't appear and dropping it calls `onMove` with an invalid id.

I made a fix by checking the node type (as suggested by snowystinger in the discussion), because the bug was caused by a `content` node which resulted in the invalid id. While checking the type likely makes sense (it's also done further up in the code for other cases), I'm not really confident with the change. I'm not sure what use case the whole *Handle converting "after" to "before next"* block handles and if the change breaks anything else. The if statement also doesn't check whether the target actually has `after` as drop position, so maybe this would be another way to fix it.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

1. Start Storybook
2. Open the *Tree With Drag And Drop* Story from React Aria Components
3. Adjust the Story to only have a single root item (with children)
4. Move a child before its parent item via drag & drop

## 🧢 Your Project:

<!--- Company/project for pull request -->
