### PR TITLE
fix: use-monopackages codemod should not rewrite S2 imports to v3

### DIFF
--- a/packages/dev/codemods/src/use-monopackages/src/codemod.test.ts
+++ b/packages/dev/codemods/src/use-monopackages/src/codemod.test.ts
@@ -1,0 +1,47 @@
+// @ts-ignore
+import {defineInlineTest} from 'jscodeshift/dist/testUtils';
+import transform from './codemod';
+
+function test(name: string, input: string, output: string) {
+  defineInlineTest(transform, {}, input, output, name);
+}
+
+test(
+  'rewrites individual react-aria imports',
+  `
+import {useButton} from '@react-aria/button';
+`,
+  `
+import { useButton } from "react-aria";
+`
+);
+
+test(
+  'rewrites individual react-stately imports',
+  `
+import {useComboBoxState} from '@react-stately/combobox';
+`,
+  `
+import { useComboBoxState } from "react-stately";
+`
+);
+
+test(
+  'rewrites individual react-spectrum imports',
+  `
+import {Button} from '@react-spectrum/button';
+`,
+  `
+import { Button } from "@adobe/react-spectrum";
+`
+);
+
+test(
+  'does not re-write S2 imports',
+  `
+import {Button} from '@react-spectrum/s2';
+`,
+  `
+import {Button} from '@react-spectrum/s2';
+`
+);

--- a/packages/dev/codemods/src/use-monopackages/src/codemod.ts
+++ b/packages/dev/codemods/src/use-monopackages/src/codemod.ts
@@ -111,7 +111,7 @@ const transformer: Transformer = function transformer(file: FileInfo, api: API, 
     const individualPackageImports = root
       .find(j.ImportDeclaration)
       .filter((path) => {
-        return (path.node.source.value as string)?.startsWith(
+        return path.node.source.value !== '@react-spectrum/s2' && (path.node.source.value as string)?.startsWith(
           packages[pkg].individualPrefix
         );
       });


### PR DESCRIPTION
`import {Button} from '@react-spectrum/s2'` was becoming `import {Button} from '@adobe/react-spectrum'`

Also added a few tests.