### PR TITLE
fix: prevent double focus rings in table when clicking on expand buttons

### DIFF
--- a/packages/react-aria/src/interactions/utils.ts
+++ b/packages/react-aria/src/interactions/utils.ts
@@ -109,7 +109,7 @@ export let ignoreFocusEvent = false;
  */
 export function preventFocus(target: FocusableElement | null): (() => void) | undefined {
   // The browser will focus the nearest focusable ancestor of our target.
-  while (target && !isFocusable(target)) {
+  while (target && !isFocusable(target, {skipVisibilityCheck: true})) {
     target = target.parentElement;
   }
 

--- a/packages/react-aria/src/utils/isFocusable.ts
+++ b/packages/react-aria/src/utils/isFocusable.ts
@@ -34,8 +34,8 @@ const FOCUSABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]),') + '
 focusableElements.push('[tabindex]:not([tabindex="-1"]):not([disabled])');
 const TABBABLE_ELEMENT_SELECTOR = focusableElements.join(':not([hidden]):not([tabindex="-1"]),');
 
-export function isFocusable(element: Element): boolean {
-  return element.matches(FOCUSABLE_ELEMENT_SELECTOR) && isElementVisible(element) && !isInert(element);
+export function isFocusable(element: Element, options?: {skipVisibilityCheck?: boolean}): boolean {
+  return element.matches(FOCUSABLE_ELEMENT_SELECTOR) && !isInert(element) && (options?.skipVisibilityCheck || isElementVisible(element));
 }
 
 export function isTabbable(element: Element): boolean {


### PR DESCRIPTION
## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to docs or storybook for S2 TableView with expandable rows. Click to expand any row, the click to expand a different row, and then hit arrow right/left. There should only be one focus ring

## 🧢 Your Project:

RSP
