### PR TITLE
docs: remove unneeded warning and calculate image widths to prevent overlapping

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Virtualizer.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Virtualizer.mdx
@@ -3,7 +3,6 @@ export default Layout;
 
 import docs from 'docs:react-aria-components';
 import {GroupedPropTable} from '../../src/PropTable';
-import {InlineAlert, Heading, Content} from '@react-spectrum/s2';
 
 export const tags = ['windowing', 'list', 'grid', 'infinite'];
 export const description = 'Renders a scrollable collection of data using customizable layouts.';


### PR DESCRIPTION
from testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test the RAC Virtualizer docs horizontal list example. Make sure it doesn't exhibit any overlapping behavior

## 🧢 Your Project:

RSP
