### PR TITLE
chore: add codemod for S2 Picker selection props

### DIFF
--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
@@ -161,6 +161,10 @@ let selectedKey = 'cat';
     <PickerItem id="dog">Dog</PickerItem>
     <PickerItem id="cat">Cat</PickerItem>
   </Picker>
+  <Picker label="Pets" defaultValue="cat">
+    <PickerItem id="dog">Dog</PickerItem>
+    <PickerItem id="cat">Cat</PickerItem>
+  </Picker>
 </div>"
 `;
 

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/__snapshots__/picker.test.ts.snap
@@ -149,6 +149,21 @@ exports[`handles sections 1`] = `
 </Picker>"
 `;
 
+exports[`renames deprecated selection props 1`] = `
+"import { PickerItem, Picker } from "@react-spectrum/s2";
+let selectedKey = 'cat';
+<div>
+  <Picker label="Pets" onChange={console.log} value="dog">
+    <PickerItem id="dog">Dog</PickerItem>
+    <PickerItem id="cat">Cat</PickerItem>
+  </Picker>
+  <Picker label="Pets" onChange={(key) => console.log(key)} value={selectedKey}>
+    <PickerItem id="dog">Dog</PickerItem>
+    <PickerItem id="cat">Cat</PickerItem>
+  </Picker>
+</div>"
+`;
+
 exports[`replaces isLoading with loadingState and keeps onLoadMore 1`] = `
 "import { PickerItem, Picker } from "@react-spectrum/s2";
     <>

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
@@ -175,5 +175,9 @@ let selectedKey = 'cat';
     <Item key="dog">Dog</Item>
     <Item key="cat">Cat</Item>
   </Picker>
+  <Picker label="Pets" defaultSelectedKey="cat">
+    <Item key="dog">Dog</Item>
+    <Item key="cat">Cat</Item>
+  </Picker>
 </div>
 `);

--- a/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
+++ b/packages/dev/codemods/src/s1-to-s2/__tests__/picker.test.ts
@@ -162,3 +162,18 @@ test('replaces isLoading with loadingState and keeps onLoadMore', `
       </Picker>
     </>
 `);
+
+test('renames deprecated selection props', `
+import {Picker, Item} from '@adobe/react-spectrum';
+let selectedKey = 'cat';
+<div>
+  <Picker label="Pets" onSelectionChange={console.log} selectedKey="dog">
+    <Item key="dog">Dog</Item>
+    <Item key="cat">Cat</Item>
+  </Picker>
+  <Picker label="Pets" onSelectionChange={(key) => console.log(key)} selectedKey={selectedKey}>
+    <Item key="dog">Dog</Item>
+    <Item key="cat">Cat</Item>
+  </Picker>
+</div>
+`);

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Picker/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Picker/transform.ts
@@ -16,6 +16,7 @@ import * as t from '@babel/types';
  * - Replace isLoading with loadingState.
  * - Rename onSelectionChange to onChange.
  * - Rename selectedKey to value.
+ * - Rename defaultSelectedKey to defaultValue.
  */
 export default function transformPicker(path: NodePath<t.JSXElement>): void {
   // Change menuWidth value from a DimensionValue to a pixel value
@@ -52,5 +53,11 @@ export default function transformPicker(path: NodePath<t.JSXElement>): void {
   updatePropName(path, {
     oldPropName: 'selectedKey',
     newPropName: 'value'
+  });
+
+  // Rename defaultSelectedKey to defaultValue
+  updatePropName(path, {
+    oldPropName: 'defaultSelectedKey',
+    newPropName: 'defaultValue'
   });
 }

--- a/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Picker/transform.ts
+++ b/packages/dev/codemods/src/s1-to-s2/src/codemods/components/Picker/transform.ts
@@ -14,6 +14,8 @@ import * as t from '@babel/types';
  * - Change validationState="invalid" to isInvalid.
  * - Remove validationState="valid" (it is no longer supported in Spectrum 2).
  * - Replace isLoading with loadingState.
+ * - Rename onSelectionChange to onChange.
+ * - Rename selectedKey to value.
  */
 export default function transformPicker(path: NodePath<t.JSXElement>): void {
   // Change menuWidth value from a DimensionValue to a pixel value
@@ -38,5 +40,17 @@ export default function transformPicker(path: NodePath<t.JSXElement>): void {
     oldPropName: 'isLoading',
     newPropName: 'loadingState',
     comment: 'Replace boolean passed to isLoading with appropriate loadingState.'
+  });
+
+  // Rename onSelectionChange to onChange
+  updatePropName(path, {
+    oldPropName: 'onSelectionChange',
+    newPropName: 'onChange'
+  });
+
+  // Rename selectedKey to value
+  updatePropName(path, {
+    oldPropName: 'selectedKey',
+    newPropName: 'value'
   });
 }


### PR DESCRIPTION
In S2 Picker, `selectedKey`, `defaultSelectedKey`, and `onSelectionChange` were deprecated in favor of `value`, `defaultValue`, and `onChange` (in order to support multi-select) (https://github.com/adobe/react-spectrum/pull/8734), so this updates the codemod to make that change.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check snapshot test.

## 🧢 Your Project:

<!--- Company/project for pull request -->
