### PR TITLE
fix: update expand hover behaviors

### DIFF
--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1121,13 +1121,15 @@ interface ExpandableRowChevronProps {
   isExpanded?: boolean,
   isDisabled?: boolean,
   isRTL?: boolean,
-  isHidden?: boolean
+  isHidden?: boolean,
+  isHovered?: boolean
 }
 
 const expandButton = style<ExpandableRowChevronProps>({
   gridArea: 'expand-button',
   color: {
     default: 'inherit',
+    isHovered: baseColor('neutral-subdued').isHovered,
     isDisabled: {
       default: 'disabled',
       forcedColors: 'GrayText'

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -521,13 +521,15 @@ interface ExpandableRowChevronProps {
   isDisabled?: boolean,
   isRTL?: boolean,
   scale: 'medium' | 'large',
-  isHidden?: boolean
+  isHidden?: boolean,
+  isHovered?: boolean
 }
 
 const expandButton = style<ExpandableRowChevronProps>({
   gridArea: 'expand-button',
   color: {
     default: 'inherit',
+    isHovered: baseColor('neutral-subdued').isHovered,
     isDisabled: {
       default: 'disabled',
       forcedColors: 'GrayText'

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -1783,7 +1783,7 @@ export const TableWithNestedRows: StoryObj<typeof TableView> = {
             <Cell>5/22/1980</Cell>
           </Row>
         </Row>
-        <Row id="apps" isDisabled>
+        <Row id="apps">
           <Cell>Applications</Cell>
           <Cell>Folder</Cell>
           <Cell>4/7/2025</Cell>

--- a/packages/@react-spectrum/s2/stories/TreeView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TreeView.stories.tsx
@@ -81,7 +81,7 @@ const TreeExampleStatic = (args: TreeViewProps<any>): ReactElement => (
   <div style={{width: '300px', resize: 'both', height: '320px', overflow: 'auto'}}>
     <TreeView
       {...args}
-      disabledKeys={['projects']}
+      disabledKeys={['projects-1']}
       aria-label="test static tree"
       onExpandedChange={action('onExpandedChange')}
       onSelectionChange={action('onSelectionChange')}>

--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -21,7 +21,7 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 <TableView
   /* PROPS */
-  disabledKeys={['pacman', 'apps']}
+  disabledKeys={['pacman']}
   styles={style({width: 'full'})}>
   <TableHeader>
     <Column id="name" isRowHeader>Name</Column>

--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -14,14 +14,13 @@ export const description = 'Displays data in rows and columns, with row selectio
 
 <PageDescription>{docs.exports.TableView.description}</PageDescription>
 
-```tsx render docs={docs.exports.TableView} links={docs.links} props={['selectionMode', 'overflowMode', 'density', 'isQuiet', 'disabledBehavior']} initialProps={{'aria-label': 'Files', selectionMode: 'multiple', 'treeColumn': 'name', disabledBehavior: 'selection'}} type="s2"
+```tsx render docs={docs.exports.TableView} links={docs.links} props={['selectionMode', 'overflowMode', 'density', 'isQuiet']} initialProps={{'aria-label': 'Files', selectionMode: 'multiple', 'treeColumn': 'name'}} type="s2"
 "use client";
 import {TableView, TableHeader, Column, TableBody, Row, Cell} from '@react-spectrum/s2/TableView';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 <TableView
   /* PROPS */
-  disabledKeys={['pacman']}
   styles={style({width: 'full'})}>
   <TableHeader>
     <Column id="name" isRowHeader>Name</Column>
@@ -644,7 +643,7 @@ export default function EditableTable(props) {
 
 Use `selectionMode` to enable single or multiple selection, and `selectedKeys` (matching each row's `id`) to control the selected rows. Return an [ActionBar](ActionBar) from `renderActionBar` to handle bulk actions, and use `onAction` for row navigation. Disable rows with `isDisabled`. See the [selection guide](selection) for details.
 
-```tsx render docs={docs.exports.TableView} links={docs.links} props={['selectionMode', 'disallowEmptySelection']} initialProps={{selectionMode: 'multiple'}} wide type="s2"
+```tsx render docs={docs.exports.TableView} links={docs.links} props={['selectionMode', 'disallowEmptySelection', 'disabledBehavior']} initialProps={{selectionMode: 'multiple', disabledBehavior: 'selection'}} wide type="s2"
 "use client";
 import {TableView, TableHeader, Column, TableBody, Row, Cell, type Selection} from '@react-spectrum/s2/TableView';
 import {ActionBar, ActionButton} from '@react-spectrum/s2/ActionBar';

--- a/packages/react-aria-components/test/Tree.test.tsx
+++ b/packages/react-aria-components/test/Tree.test.tsx
@@ -751,36 +751,6 @@ describe('Tree', () => {
       expect(onSelectionChange).toHaveBeenCalledTimes(0);
     });
 
-    it('multi select should expand the row if anywhere on the row is clicked and there is no onAction provided', async () => {
-      let {getAllByRole} = render(<StaticTree treeProps={{defaultExpandedKeys: new Set([]), selectionMode: 'multiple', disabledBehavior: 'selection', disabledKeys: ['projects']}} />);
-      let row = getAllByRole('row')[1];
-      await user.hover(row);
-      expect(row).toHaveAttribute('data-hovered', 'true');
-
-      await user.click(row);
-      expect(row).toHaveAttribute('aria-expanded', 'true');
-    });
-
-    it('single select should expand the row if anywhere on the row is clicked and there is no onAction provided', async () => {
-      let {getAllByRole} = render(<StaticTree treeProps={{defaultExpandedKeys: new Set([]), selectionMode: 'single', disabledBehavior: 'selection', disabledKeys: ['projects']}} />);
-      let row = getAllByRole('row')[1];
-      await user.hover(row);
-      expect(row).toHaveAttribute('data-hovered', 'true');
-
-      await user.click(row);
-      expect(row).toHaveAttribute('aria-expanded', 'true');
-    });
-
-    it('no selection should expand the row if anywhere on the row is clicked and there is no onAction provided', async () => {
-      let {getAllByRole} = render(<StaticTree treeProps={{defaultExpandedKeys: new Set([]), selectionMode: 'none', disabledBehavior: 'selection', disabledKeys: ['projects']}} />);
-      let row = getAllByRole('row')[1];
-      await user.hover(row);
-      expect(row).toHaveAttribute('data-hovered', 'true');
-
-      await user.click(row);
-      expect(row).toHaveAttribute('aria-expanded', 'true');
-    });
-
     it('should prevent Esc from clearing selection if escapeKeyBehavior is "none"', async () => {
       let {getAllByRole} = render(<StaticTree treeProps={{selectionMode: 'multiple', escapeKeyBehavior: 'none'}}  />);
 

--- a/packages/react-aria-components/test/Treeble.test.tsx
+++ b/packages/react-aria-components/test/Treeble.test.tsx
@@ -536,39 +536,6 @@ describe('Treeble', () => {
     expect(onSelectionChange).toHaveBeenLastCalledWith(new Set(['games', 'mario', 'tetris']));
   });
 
-  it('supports expansion on disabled items with no action in disabledBehavior="selection" multiple selection', async () => {
-    let tree = render(<Example disabledKeys={['apps']} selectionMode="multiple" disabledBehavior="selection" />);
-    let tester = utils.createTester('Table', {root: tree.getByTestId('treeble')});
-
-    await user.hover(tester.rows[1]);
-    expect(tester.rows[1]).toHaveAttribute('data-hovered', 'true');
-
-    await user.click(tester.rows[1]);
-    expect(tester.rows[1]).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  it('supports expansion on disabled items with no action in disabledBehavior="selection" single selection', async () => {
-    let tree = render(<Example disabledKeys={['apps']} selectionMode="single" disabledBehavior="selection" />);
-    let tester = utils.createTester('Table', {root: tree.getByTestId('treeble')});
-
-    await user.hover(tester.rows[1]);
-    expect(tester.rows[1]).toHaveAttribute('data-hovered', 'true');
-
-    await user.click(tester.rows[1]);
-    expect(tester.rows[1]).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  it('supports expansion on disabled items with no action in disabledBehavior="selection" no selection', async () => {
-    let tree = render(<Example disabledKeys={['apps']} selectionMode="none" disabledBehavior="selection" />);
-    let tester = utils.createTester('Table', {root: tree.getByTestId('treeble')});
-
-    await user.hover(tester.rows[1]);
-    expect(tester.rows[1]).toHaveAttribute('data-hovered', 'true');
-
-    await user.click(tester.rows[1]);
-    expect(tester.rows[1]).toHaveAttribute('aria-expanded', 'true');
-  });
-
   it('should support drag and drop', async () => {
     let tree = render(<ReorderableTreeble />);
     let tester = utils.createTester('Table', {root: tree.getByRole('treegrid')});

--- a/packages/react-aria/src/grid/useGridRow.ts
+++ b/packages/react-aria/src/grid/useGridRow.ts
@@ -77,8 +77,7 @@ export function useGridRow<T, C extends GridCollection<T>, S extends GridState<T
     if (
       !hasLink &&
       hasChildRows &&
-      ((state.disabledKeys.has(node.key) || node.props?.isDisabled) || 
-        state.selectionManager.selectionMode === 'none')) {
+      state.selectionManager.selectionMode === 'none') {
       onRowAction = () => tableState.toggleKey(node.key);
     }
   }

--- a/packages/react-aria/src/gridlist/useGridListItem.ts
+++ b/packages/react-aria/src/gridlist/useGridListItem.ts
@@ -102,12 +102,7 @@ export function useGridListItem<T>(props: AriaGridListItemOptions, state: ListSt
     let children = state.collection.getChildren?.(node.key);
     hasChildRows = hasChildRows || [...(children ?? [])].length > 1;
 
-    if (
-      onAction == null &&
-      !hasLink && 
-      hasChildRows &&
-      ((state.disabledKeys.has(node.key) || node.props?.isDisabled) ||
-        state.selectionManager.selectionMode === 'none')) {
+    if (onAction == null && !hasLink && state.selectionManager.selectionMode === 'none' && hasChildRows) {
       onAction = () => state.toggleKey(node.key);
     }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Discussed in slack, this gets rid of the full row hover behavior when disabledBehavior is selection and there is no onAction. Instead it adds a hover style to the expand button directly

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
