### PR TITLE
chore: update NumberParser's cldr data

### DIFF
--- a/packages/@internationalized/number/src/NumberParser.ts
+++ b/packages/@internationalized/number/src/NumberParser.ts
@@ -274,9 +274,9 @@ class NumberParserImpl {
 
 const nonLiteralParts = new Set(['decimal', 'fraction', 'integer', 'minusSign', 'plusSign', 'group']);
 
-// This list is derived from https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html#comparison and includes
+// This list is derived from https://www.unicode.org/cldr/charts/49/supplemental/language_plural_rules.html#comparison and includes
 // all unique numbers which we need to check in order to determine all the plural forms for a given locale.
-// See: https://github.com/adobe/react-spectrum/pull/5134/files#r1337037855 for used script
+// Run scripts/generateAllPlurals.mjs to generate this list.
 const pluralNumbers = [
   0, 4, 2, 1, 11, 20, 3, 7, 100, 21, 0.1, 1.1
 ];

--- a/scripts/generateAllPlurals.mjs
+++ b/scripts/generateAllPlurals.mjs
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-/* Scrapes data on CLDR https://www.unicode.org/cldr/charts/44/supplemental/language_plural_rules.html#comparison
+/* Scrapes data on CLDR https://www.unicode.org/cldr/charts/49/supplemental/language_plural_rules.html#comparison
  * and generates a list of all possible values needed between all locales for plural rules.
  * It is used by our NumberParser to generate all literal strings, ex units 1 foot, 2 feet, but other locales have more than 2 forms.
  */
@@ -150,7 +150,7 @@ function extractTable(dom, integerTable, fractionTable) {
   return Array.from(values);
 }
 
-fetch('https://www.unicode.org/cldr/charts/44/supplemental/language_plural_rules.html#comparison')
+fetch('https://www.unicode.org/cldr/charts/49/supplemental/language_plural_rules.html#comparison')
   .then(async (response) => {
     let data = await response.text();
     const dom = new JSDOM(data);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Just doing some maintenance. Note, 49 is currently not actually released, but they have the correct page and section and the script generates the same values for 48.2 and 49 (and 44), so i figured it was ok to set it to 49 ahead of time, it should be released pretty soon based on their usual cadence.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
