### PR TITLE
fix: nightly packing too many files

### DIFF
--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -34,15 +34,15 @@
   "source": "exports/index.ts",
   "files": [
     "*",
-    "!chromatic",
-    "!chromatic-fc",
-    "!docs",
-    "!exports",
-    "!intl",
-    "!scripts",
-    "!src",
-    "!stories",
-    "!test"
+    "!chromatic/**",
+    "!chromatic-fc/**",
+    "!docs/**",
+    "!exports/**",
+    "!intl/**",
+    "!scripts/**",
+    "!src/**",
+    "!stories/**",
+    "!test/**"
   ],
   "sideEffects": [
     "*.css"

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -35,13 +35,13 @@
   },
   "files": [
     "*",
-    "!docs",
-    "!example",
-    "!exports",
-    "!intl",
-    "!src",
-    "!stories",
-    "!test"
+    "!docs/**",
+    "!example/**",
+    "!exports/**",
+    "!intl/**",
+    "!src/**",
+    "!stories/**",
+    "!test/**"
   ],
   "sideEffects": [
     "*.css"

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -34,12 +34,12 @@
   "source": "exports/index.ts",
   "files": [
     "*",
-    "!docs",
-    "!exports",
-    "!intl",
-    "!src",
-    "!stories",
-    "!test"
+    "!docs/**",
+    "!exports/**",
+    "!intl/**",
+    "!src/**",
+    "!stories/**",
+    "!test/**"
   ],
   "sideEffects": false,
   "repository": {

--- a/packages/react-stately/package.json
+++ b/packages/react-stately/package.json
@@ -24,12 +24,12 @@
   "source": "exports/index.ts",
   "files": [
     "*",
-    "!docs",
-    "!exports",
-    "!intl",
-    "!src",
-    "!stories",
-    "!test"
+    "!docs/**",
+    "!exports/**",
+    "!intl/**",
+    "!src/**",
+    "!stories/**",
+    "!test/**"
   ],
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

I found that yarn uses micromatch, https://github.com/yarnpkg/berry/blob/master/packages/plugin-pack/sources/packUtils.ts which will treat a pattern like `!stories` as literally just exclude the `stories` file, it doesn't match as a directory like `npm` or `gitignore` will.
We can test it here https://codesandbox.io/p/devbox/6wzks8

npm will however still work with the glob syntax, so doing it more explicitly as in this PR should work for both tools.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
