### PR TITLE
fix: prevent items from getting continually loaded in S2 async TreeView

### DIFF
--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -86,6 +86,7 @@ const TreeRendererContext = createContext<TreeRendererContextValue>({});
 
 const treeViewWrapper = style({
   minHeight: 0,
+  height: 'full',
   minWidth: 160,
   display: 'flex',
   isolation: 'isolate',


### PR DESCRIPTION
found during testing where the S2 async loading tree story continually loads new items even if you aren't scrolling to the bottom anymore which was caused by https://github.com/adobe/react-spectrum/pull/9747

the root cause is because we now always render TreeView in a wrapper. in this particular story, the wrapper has no constrained height, so it expands to fit all its content and so we continually load more items.

the other alternative solution is to just fix the story and pass a height directly onto TreeView but it feels like there might be other people relying on the parent container to constrain the TreeView height


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the S2 async loading TreeView example and make sure it doesn't continuously load new items even when you aren't scrolled to the bottom 

## 🧢 Your Project:

<!--- Company/project for pull request -->
