### PR TITLE
fix: skip focused item on new typeahead search

### DIFF
--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -503,6 +503,47 @@ describe('Select', () => {
       expect(trigger).toHaveTextContent('Northern Territory');
       expect(trigger).not.toHaveAttribute('data-pressed');
     });
+
+    it('should handle typeahead transitions correctly with and without debounce', async () => {
+      let {getByTestId} = render(
+        <Select data-testid="select">
+          <Label>Test</Label>
+          <Button>
+            <SelectValue />
+          </Button>
+          <Popover>
+            <ListBox>
+              <ListBoxItem id="a">a</ListBoxItem>
+              <ListBoxItem id="aa">aa</ListBoxItem>
+              <ListBoxItem id="ab">ab</ListBoxItem>
+            </ListBox>
+          </Popover>
+        </Select>
+      );
+
+      let wrapper = getByTestId('select');
+      let selectTester = testUtilUser.createTester('Select', {root: wrapper});
+      let trigger = selectTester.trigger;
+
+      await user.tab();
+
+      await user.keyboard('a');
+      expect(trigger).toHaveTextContent('a');
+
+      // continuing search narrows — 'aa' matches 'aa'
+      await user.keyboard('a');
+      expect(trigger).toHaveTextContent('aa');
+
+      // no match on 'aaa' — selection unchanged
+      await user.keyboard('a');
+      expect(trigger).toHaveTextContent('aa');
+
+      act(() => { jest.runAllTimers(); });
+
+      // new search after debounce skips focused item and cycles to next match
+      await user.keyboard('a');
+      expect(trigger).toHaveTextContent('ab');
+    });
   });
 
   it('should support autoFocus', () => {

--- a/packages/react-aria/src/selection/useTypeSelect.ts
+++ b/packages/react-aria/src/selection/useTypeSelect.ts
@@ -72,10 +72,15 @@ export function useTypeSelect(options: AriaTypeSelectOptions): TypeSelectAria {
     state.search += character;
 
     if (keyboardDelegate.getKeyForSearch != null) {
-      // Use the delegate to find a key to focus.
-      // Prioritize items after the currently focused item, falling back to searching the whole list.
-      let key = keyboardDelegate.getKeyForSearch(state.search, selectionManager.focusedKey);
+      // On a new search, skip the focused item; when continuing a search, include it.
+      // Falls back to searching the whole list if no match is found.
+      let fromKey = selectionManager.focusedKey;
+      const isNewSearch = state.search === character;
+      if (isNewSearch && fromKey != null && keyboardDelegate.getKeyBelow) {
+        fromKey = keyboardDelegate.getKeyBelow(fromKey);
+      }
 
+      let key = keyboardDelegate.getKeyForSearch(state.search, fromKey);
       // If no key found, search from the top.
       if (key == null) {
         key = keyboardDelegate.getKeyForSearch(state.search);


### PR DESCRIPTION
Closes #8919

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
