### PR TITLE
Fix/numberfield format options input reset (reopened PR)

### DIFF
--- a/packages/react-stately/src/numberfield/useNumberFieldState.ts
+++ b/packages/react-stately/src/numberfield/useNumberFieldState.ts
@@ -15,7 +15,7 @@ import {clamp, snapValueToStep} from '../utils/number';
 import {FocusableProps, HelpTextProps, InputBase, LabelableProps, RangeInputBase, TextInputBase, Validation, ValueBase} from '@react-types/shared';
 import {FormValidationState, useFormValidationState} from '../form/useFormValidationState';
 import {NumberFormatter, NumberParser} from '@internationalized/number';
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import {useControlledState} from '../utils/useControlledState';
 
 export interface NumberFieldProps extends InputBase, Validation<number>, FocusableProps, TextInputBase, ValueBase<number>, RangeInputBase<number>, LabelableProps, HelpTextProps {
@@ -110,6 +110,14 @@ export function useNumberFieldState(
     isReadOnly,
     commitBehavior = 'snap'
   } = props;
+
+  // Stabilize formatOptions reference to avoid unnecessary re-renders
+  // when consumers pass inline object literals with the same content.
+  let formatOptionsRef = useRef(formatOptions);
+  if (!isEqualFormatOptions(formatOptions, formatOptionsRef.current)) {
+    formatOptionsRef.current = formatOptions;
+  }
+  formatOptions = formatOptionsRef.current;
 
   if (value === null) {
     value = NaN;
@@ -302,6 +310,26 @@ export function useNumberFieldState(
     inputValue,
     commit
   };
+}
+
+function isEqualFormatOptions(a: Intl.NumberFormatOptions | undefined, b: Intl.NumberFormatOptions | undefined) {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  let aKeys = Object.keys(a);
+  let bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (let key of aKeys) {
+    if (b[key] !== a[key]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function handleDecimalOperation(operator: '-' | '+', value1: number, value2: number): number {

--- a/packages/react-stately/src/numberfield/useNumberFieldState.ts
+++ b/packages/react-stately/src/numberfield/useNumberFieldState.ts
@@ -15,7 +15,7 @@ import {clamp, snapValueToStep} from '../utils/number';
 import {FocusableProps, HelpTextProps, InputBase, LabelableProps, RangeInputBase, TextInputBase, Validation, ValueBase} from '@react-types/shared';
 import {FormValidationState, useFormValidationState} from '../form/useFormValidationState';
 import {NumberFormatter, NumberParser} from '@internationalized/number';
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {useControlledState} from '../utils/useControlledState';
 
 export interface NumberFieldProps extends InputBase, Validation<number>, FocusableProps, TextInputBase, ValueBase<number>, RangeInputBase<number>, LabelableProps, HelpTextProps {
@@ -111,14 +111,6 @@ export function useNumberFieldState(
     commitBehavior = 'snap'
   } = props;
 
-  // Stabilize formatOptions reference to avoid unnecessary re-renders
-  // when consumers pass inline object literals with the same content.
-  let formatOptionsRef = useRef(formatOptions);
-  if (!isEqualFormatOptions(formatOptions, formatOptionsRef.current)) {
-    formatOptionsRef.current = formatOptions;
-  }
-  formatOptions = formatOptionsRef.current;
-
   if (value === null) {
     value = NaN;
   }
@@ -163,7 +155,7 @@ export function useNumberFieldState(
   let [prevValue, setPrevValue] = useState(numberValue);
   let [prevLocale, setPrevLocale] = useState(locale);
   let [prevFormatOptions, setPrevFormatOptions] = useState(formatOptions);
-  if (!Object.is(numberValue, prevValue) || locale !== prevLocale || formatOptions !== prevFormatOptions) {
+  if (!Object.is(numberValue, prevValue) || locale !== prevLocale || !isEqualFormatOptions(formatOptions, prevFormatOptions)) {
     setInputValue(format(numberValue));
     setPrevValue(numberValue);
     setPrevLocale(locale);
@@ -312,6 +304,7 @@ export function useNumberFieldState(
   };
 }
 
+// Shallow equality is sufficient here because all values in Intl.NumberFormatOptions are primitives.
 function isEqualFormatOptions(a: Intl.NumberFormatOptions | undefined, b: Intl.NumberFormatOptions | undefined) {
   if (a === b) {
     return true;

--- a/packages/react-stately/test/numberfield/useNumberFieldState.test.ts
+++ b/packages/react-stately/test/numberfield/useNumberFieldState.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {actHook as act, renderHook} from '@react-spectrum/test-utils-internal';
+import {useNumberFieldState} from '../../src/numberfield/useNumberFieldState';
+
+describe('useNumberFieldState', () => {
+  describe('formatOptions stability', () => {
+    it('does not reset inputValue when re-rendered with same formatOptions content', () => {
+      let initialFormatOptions = {unit: 'millisecond', useGrouping: false};
+      let {result, rerender} = renderHook(
+        ({formatOptions}) => useNumberFieldState({defaultValue: 1, formatOptions, locale: 'en-US'}),
+        {initialProps: {formatOptions: initialFormatOptions}}
+      );
+
+      // Simulate user typing '2' (without committing)
+      act(() => {
+        result.current.setInputValue('2');
+      });
+      expect(result.current.inputValue).toBe('2');
+
+      // Re-render with new-reference but same-content formatOptions (simulates inline object literal)
+      rerender({formatOptions: {unit: 'millisecond', useGrouping: false}});
+
+      // inputValue should NOT be reset to '1' (the formatted defaultValue)
+      expect(result.current.inputValue).toBe('2');
+    });
+
+    it('resets inputValue when formatOptions content actually changes', () => {
+      let {result, rerender} = renderHook(
+        ({formatOptions}) => useNumberFieldState({defaultValue: 1024, formatOptions, locale: 'en-US'}),
+        {initialProps: {formatOptions: {style: 'currency', currency: 'EUR'} as Intl.NumberFormatOptions}}
+      );
+
+      expect(result.current.inputValue).toBe('€1,024.00');
+
+      rerender({formatOptions: {style: 'currency', currency: 'USD'}});
+
+      expect(result.current.inputValue).toBe('$1,024.00');
+    });
+
+    it('does not reset inputValue when re-rendered with undefined formatOptions', () => {
+      let {result, rerender} = renderHook(
+        ({formatOptions}) => useNumberFieldState({defaultValue: 1, formatOptions, locale: 'en-US'}),
+        {initialProps: {formatOptions: undefined as Intl.NumberFormatOptions | undefined}}
+      );
+
+      act(() => {
+        result.current.setInputValue('2');
+      });
+      expect(result.current.inputValue).toBe('2');
+
+      rerender({formatOptions: undefined});
+
+      expect(result.current.inputValue).toBe('2');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1893
Related to #9899 & #9905 

 ## Summary

  When formatOptions is passed as an inline object literal (e.g. formatOptions={{ style: 'currency',
  currency: 'USD' }}), every parent re-render creates a new object reference. This caused
  useNumberFieldState to detect a "change" in formatOptions and overwrite the current inputValue with
  the last committed number value — resetting whatever the user was typing mid-input.

  This fix stabilizes the formatOptions reference inside useNumberFieldState using a useRef and a
  shallow equality check. If the new formatOptions has the same key-value pairs as the previous one,
  the old reference is reused, preventing a spurious inputValue reset. I though this approach is appropriate
  because all values in Intl.NumberFormatOptions are primitives (strings, numbers, booleans), so
  shallow equality is equivalent to deep equality.


## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Run the existing NumberField test suites to verify nothing is broken:
  yarn jest packages/react-aria-components/test/NumberField.test.js
  yarn jest packages/@adobe/react-spectrum/test/numberfield/NumberField.test.js
  2. The two new regression tests specifically cover this fix:
    - "does not reset input value when parent re-renders with same formatOptions content" — a parent
  component with its own state re-renders while formatOptions is an inline object literal; the typed
  value must be preserved.
    - "does not reset input during typing when re-rendered with same formatOptions content" — same
  scenario via the rerender helper.
  3. To manually verify: render a NumberField with formatOptions={{ style: 'currency', currency: 'USD'
   }} as an inline literal inside a component that re-renders on some other state change. Type a value
   without committing (no blur/Enter) and trigger the parent re-render — the typed value should no
  longer be reset.

## 🧢 Your Project:
