### PR TITLE
fix(S2): adjust Menu/Picker/ComboBox item transition to prevent background color transition

### DIFF
--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -268,7 +268,7 @@ export let listboxItem = style({
     default: 'default',
     isLink: 'pointer'
   },
-  transition: 'default'
+  transition: 'transform'
 }, getAllowedOverrides());
 
 export let listboxHeader = style<{size?: 'S' | 'M' | 'L' | 'XL'}>({

--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -200,7 +200,7 @@ export let menuitem = style<Omit<MenuItemRenderProps, 'hasSubmenu' | 'isOpen'> &
     default: 'default',
     isLink: 'pointer'
   },
-  transition: 'default',
+  transition: 'transform',
   forcedColorAdjust: 'none'
 }, getAllowedOverrides());
 
@@ -296,8 +296,7 @@ export let description = style<{size: 'S' | 'M' | 'L' | 'XL', isFocused: boolean
     forcedColors: {
       default: 'inherit'
     }
-  },
-  transition: 'default'
+  }
 });
 
 let value = style({


### PR DESCRIPTION
Adjusts the S2 Menu, Picker, and ComboBox item styles to where the default transition (containing 150ms duration) does not apply to the background color, but still applies to `transform` (for press scaling).

From a UX perspective, this was making these components feel laggy/unresponsive when moving the cursor between items quickly. Open to feedback for this, just wanted to get up a PR for people to try out.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/00b30a10-14b0-4dda-84ae-f92d77d99267" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/d340984a-7c2b-43eb-9708-3d0b6f6cd701" controls width="100%"></video> |


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

On an S2 [Menu](https://d1pzu54gtk2aed.cloudfront.net/pr/7fe90f58f1c76d0cfe68c896812c048a56d569bd/Menu), [Picker](https://d1pzu54gtk2aed.cloudfront.net/pr/7fe90f58f1c76d0cfe68c896812c048a56d569bd/Picker), or [ComboBox](https://d1pzu54gtk2aed.cloudfront.net/pr/7fe90f58f1c76d0cfe68c896812c048a56d569bd/ComboBox) and move your cursor quickly between items. Observe the behavior difference between production (it should feel snappier now). 


## 🧢 Your Project:

<!--- Company/project for pull request -->
