### PR TITLE
chore: disable tsdiff on mergequeue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -940,20 +940,26 @@ workflows:
             - install
           filters:
             branches:
-              ignore: main
+              ignore: 
+                - /main$/
+                - /gh-readonly-queue\/.*$/
       - ts-build-branch:
           requires:
             - install
           filters:
             branches:
-              ignore: main
+              ignore: 
+                - /main$/
+                - /gh-readonly-queue\/.*$/
       - ts-diff:
           requires:
             - ts-build-fork-point
             - ts-build-branch
           filters:
             branches:
-              ignore: main
+              ignore: 
+                - /main$/
+                - /gh-readonly-queue\/.*$/
       - typecheck-docs:
           requires:
             - install


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Mergequeue frequently fails due to forkpoint job, in addition to that, it just isn't needed. We already know the tsdiff from the PR and we'll see it again on main when we do audits and the comment doesn't end up anywhere easily reviewable. Finally, it's slow, so if we can skip it, that should speed up the merge queue.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
