### PR TITLE
fix: repeated yarn installs

### DIFF
--- a/patches/@mdx-js+react+2.0.0-rc.2.patch
+++ b/patches/@mdx-js+react+2.0.0-rc.2.patch
@@ -4,6 +4,7 @@ index be47704..c7ca78e 100644
 +++ b/node_modules/@mdx-js/react/lib/index.d.ts
 @@ -1,3 +1,4 @@
 +import type {JSX} from 'react';
- /**
+-/**
++/**
   * @param {import('react').ComponentType<any>} Component
   * @deprecated


### PR DESCRIPTION
Closes <!-- Github issue # here -->

fixes the issue where if you do
```
yarn
yarn
yarn check-types
```

you get errors
```
[0] node_modules/@mdx-js/react/lib/index.d.ts(1,14): error TS2300: Duplicate identifier 'JSX'.
```

you can test by running a
```
make clean_all
```
then running the steps listed above.
If you want to verify that it was happening, then just do those 4 commands once before checking out the PR and again after.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
