### PR TITLE
chore: re-export mergeRefs from react-aria index

### DIFF
--- a/packages/react-aria/exports/index.ts
+++ b/packages/react-aria/exports/index.ts
@@ -133,6 +133,7 @@ export {useTree} from '../src/tree/useTree';
 export {useTreeItem} from '../src/tree/useTreeItem';
 export {chain} from '../src/utils/chain';
 export {mergeProps} from '../src/utils/mergeProps';
+export {mergeRefs} from '../src/utils/mergeRefs';
 export {useId} from '../src/utils/useId';
 export {useObjectRef} from '../src/utils/useObjectRef';
 export {RouterProvider} from '../src/utils/openLink';


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

The `react-aria` package already ships a `mergeRefs` subpath file (`packages/react-aria/exports/mergeRefs.ts`) that re-exports `mergeRefs` from `../src/utils/mergeRefs`, so `import {mergeRefs} from 'react-aria/mergeRefs'` works today. However, the main `index.ts` did not re-export it, so `import {mergeRefs} from 'react-aria'` fails. This change adds the missing re-export so both import paths resolve, matching the pattern used for sibling utilities like `mergeProps`, `chain`, `useId`, and `useObjectRef`.

To verify:
- `import {mergeRefs} from 'react-aria'` resolves and the function works as expected.
- `import {mergeRefs} from 'react-aria/mergeRefs'` continues to resolve (unchanged).

## 🧢 Your Project:

React Spectrum