### PR TITLE
feat: prefix for combobox

### DIFF
--- a/packages/@react-spectrum/s2/chromatic/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/TextField.stories.tsx
@@ -16,6 +16,7 @@ import {Content, Footer, Heading, Text} from '../src/Content';
 import {ContextualHelp} from '../src/ContextualHelp';
 import {Form} from '../src/Form';
 import {Link} from '../src/Link';
+import Magnifier from '../s2wf-icons/S2_Icon_Search_20_N.svg';
 import type {Meta, StoryObj} from '@storybook/react';
 import {style} from '../style/spectrum-theme' with {type: 'macro'};
 import {TextArea, TextField} from '../src/TextField';
@@ -42,6 +43,21 @@ export const Example: Story = {
   }
 };
 
+export const ExampleWithPrefixText: Story = {
+  render: (args) => <TextField {...args} prefix="#" />,
+  args: {
+    label: 'Name',
+    placeholder: 'Enter your name'
+  }
+};
+
+export const ExampleWithPrefixIcon: Story = {
+  render: (args) => <TextField {...args} prefix={<Magnifier />} />,
+  args: {
+    label: 'Name',
+    placeholder: 'Enter your name'
+  }
+};
 export const Validation: Story = {
   render: (args) => (
     <Form>
@@ -84,6 +100,22 @@ export const ContextualHelpExample: Story = {
 
 export const TextAreaExample: StoryObj<typeof TextArea> = {
   render: (args) => <TextArea {...args} />,
+  args: {
+    label: 'Comment',
+    placeholder: 'Enter your name'
+  }
+};
+
+export const TextAreaExampleWithPrefixText: StoryObj<typeof TextArea> = {
+  render: (args) => <TextArea {...args} prefix="#" />,
+  args: {
+    label: 'Comment',
+    placeholder: 'Enter your name'
+  }
+};
+
+export const TextAreaExampleWithPrefixIcon: StoryObj<typeof TextArea> = {
+  render: (args) => <TextArea {...args} prefix={<Magnifier />} />,
   args: {
     label: 'Comment',
     placeholder: 'Enter your name'

--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -29,7 +29,7 @@ import {PopoverProps as AriaPopoverProps, Placement} from 'react-aria-components
 import {AsyncLoadable, GlobalDOMAttributes, HelpTextProps, LoadingState, SingleSelection, SpectrumLabelableProps} from '@react-types/shared';
 import {AvatarContext} from './Avatar';
 import {BaseCollection, CollectionNode} from 'react-aria/private/collections/BaseCollection';
-import {baseColor, centerPadding, focusRing, space, style} from '../style' with {type: 'macro'};
+import {baseColor, centerPadding, focusRing, fontRelative, space, style} from '../style' with {type: 'macro'};
 import {Button, ButtonRenderProps} from 'react-aria-components/Button';
 import {centerBaseline} from './CenterBaseline';
 import {
@@ -43,7 +43,7 @@ import {
 import CheckmarkIcon from '../ui-icons/Checkmark';
 import ChevronIcon from '../ui-icons/Chevron';
 import {Collection} from 'react-aria/Collection';
-import {ContextValue, Provider} from 'react-aria-components/slots';
+import {ContextValue, DEFAULT_SLOT, Provider} from 'react-aria-components/slots';
 import {control, controlBorderRadius, controlFont, controlSize, field, fieldInput, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {createContext, CSSProperties, ForwardedRef, forwardRef, ReactNode, Ref, useCallback, useContext, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import {createFocusableRef} from './useDOMRef';
@@ -63,6 +63,7 @@ import {Node} from '@react-types/shared';
 import {Popover} from './Popover';
 import {pressScale} from './pressScale';
 import {ProgressCircle} from './ProgressCircle';
+import {TextContext as AriaTextContext} from 'react-aria-components/Text';
 import {TextFieldRef} from './TextField';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useResizeObserver} from 'react-aria/private/utils/useResizeObserver';
@@ -77,7 +78,11 @@ export interface ComboboxStyleProps {
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL'
+  size?: 'S' | 'M' | 'L' | 'XL',
+  /**
+   * The prefix to display in the combobox. Either a string or workflow icon.
+   */
+  prefix?: ReactNode
 }
 export interface ComboBoxProps<T extends object> extends
   Omit<AriaComboBoxProps<T>, 'children' | 'style' | 'className' | 'render' | 'defaultFilter' | 'allowsEmptyCollection' | 'selectionMode' | 'selectedKey' | 'defaultSelectedKey' | 'onSelectionChange' | 'value' | 'defaultValue' | 'onChange' | keyof GlobalDOMAttributes>,
@@ -626,6 +631,34 @@ const ComboboxInner = forwardRef(function ComboboxInner(props: ComboBoxProps<any
             // [9, 4], [12, 6], [15, 8], [18, 8]
             paddingEnd: 'calc(self(height, self(minHeight)) * 3 / 16 - self(borderEndWidth, 2px))'
           })({size})}>
+          {props.prefix ? (
+            <Provider 
+              values={[
+                [IconContext, {
+                  render: centerBaseline({}),
+                  styles: style({
+                    size: fontRelative(20),
+                    '--iconPrimary': {
+                      type: 'fill',
+                      value: 'currentColor'
+                    }
+                  })
+                }],
+                [AriaTextContext, {}],
+                [TextContext, {
+                  slots: {
+                    [DEFAULT_SLOT]: {
+                      styles: style({minWidth: 20, display: 'flex', alignItems: 'center', justifyContent: 'center'})
+                    }
+                  }
+                }]
+              ]}>
+              <div className={style({color: 'gray-600', flexShrink: 0, marginEnd: 'text-to-visual'})}>
+                {typeof props.prefix === 'string' ? <Text>{props.prefix}</Text> : props.prefix}
+              </div>
+            </Provider>
+            ) : null
+          }
           <InputContext.Consumer>
             {ctx => (
               <InputContext.Provider value={{...ctx, ref: mergeRefs((ctx as any)?.ref, inputRef)}}>

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -14,7 +14,7 @@ import {TextArea as AriaTextArea, TextAreaContext as AriaTextAreaContext} from '
 import {TextContext as AriaTextContext} from 'react-aria-components/Text';
 import {TextField as AriaTextField, TextFieldProps as AriaTextFieldProps} from 'react-aria-components/TextField';
 import {centerBaseline} from './CenterBaseline';
-import {centerPadding, style} from '../style' with {type: 'macro'};
+import {centerPadding, fontRelative, style} from '../style' with {type: 'macro'};
 import {composeRenderProps} from 'react-aria-components/composeRenderProps';
 import {ContextValue, DEFAULT_SLOT, Provider, useSlottedContext} from 'react-aria-components/slots';
 import {controlSize, field, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
@@ -150,6 +150,7 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldP
                   [IconContext, {
                     render: centerBaseline({}),
                     styles: style({
+                      size: fontRelative(20),
                       '--iconPrimary': {
                         type: 'fill',
                         value: 'currentColor'

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -43,7 +43,7 @@ export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'c
    */
   size?: 'S' | 'M' | 'L' | 'XL'
   /**
-   * The prefix to display in the text field.
+   * The prefix to display in the text field. Either a string or workflow icon.
    */
   prefix?: ReactNode;
 }

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -11,10 +11,11 @@
  */
 
 import {TextArea as AriaTextArea, TextAreaContext as AriaTextAreaContext} from 'react-aria-components/TextArea';
+import {TextContext as AriaTextContext} from 'react-aria-components/Text';
 import {TextField as AriaTextField, TextFieldProps as AriaTextFieldProps} from 'react-aria-components/TextField';
 import {centerPadding, style} from '../style' with {type: 'macro'};
 import {composeRenderProps} from 'react-aria-components/composeRenderProps';
-import {ContextValue, useSlottedContext} from 'react-aria-components/slots';
+import {ContextValue, DEFAULT_SLOT, Provider, useSlottedContext} from 'react-aria-components/slots';
 import {controlSize, field, getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {createContext, forwardRef, ReactNode, Ref, useContext, useImperativeHandle, useRef} from 'react';
 import {createFocusableRef} from './useDOMRef';
@@ -24,7 +25,10 @@ import {FormContext, useFormProps} from './Form';
 import {InputContext, InputProps} from 'react-aria-components/Input';
 import {mergeRefs} from 'react-aria/mergeRefs';
 import {StyleString} from '../style/types';
+import {Text, TextContext} from './Content';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
+import { IconContext } from './Icon';
+import { centerBaseline } from './CenterBaseline';
 
 export interface TextFieldRef<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends FocusableRefValue<T, HTMLDivElement> {
   select(): void,
@@ -38,6 +42,10 @@ export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'c
    * @default 'M'
    */
   size?: 'S' | 'M' | 'L' | 'XL'
+  /**
+   * The prefix to display in the text field.
+   */
+  prefix?: ReactNode;
 }
 
 export const TextFieldContext = createContext<ContextValue<Partial<TextFieldProps>, TextFieldRef>>(null);
@@ -135,14 +143,43 @@ export const TextFieldBase = forwardRef(function TextFieldBase(props: TextFieldP
           {label}
         </FieldLabel>
         <FieldGroup size={props.size} styles={fieldGroupCss}>
-          <InputContext.Consumer>
-            {ctx => (
-              <InputContext.Provider value={{...ctx, ref: mergeRefs((ctx as any)?.ref, inputRef)}}>
-                {children}
-              </InputContext.Provider>
-            )}
-          </InputContext.Consumer>
-          {isInvalid && <FieldErrorIcon isDisabled={isDisabled} />}
+          <Provider values={[[TextContext, {}]]}>
+            {props.prefix ? (
+              <Provider 
+                values={[
+                  [IconContext, {
+                    render: centerBaseline({}),
+                    styles: style({
+                      '--iconPrimary': {
+                        type: 'fill',
+                        value: 'currentColor'
+                      }
+                    })
+                  }],
+                  [AriaTextContext, {}],
+                  [TextContext, {
+                    slots: {
+                      [DEFAULT_SLOT]: {
+                        styles: style({minWidth: 20, display: 'flex', alignItems: 'center', justifyContent: 'center'})
+                      }
+                    }
+                  }]
+                ]}>
+                <div className={style({color: 'gray-600', flexShrink: 0, marginEnd: 'text-to-visual'})}>
+                  {typeof props.prefix === 'string' ? <Text>{props.prefix}</Text> : props.prefix}
+                </div>
+              </Provider>
+              ) : null
+            }
+            <InputContext.Consumer>
+              {ctx => (
+                <InputContext.Provider value={{...ctx, ref: mergeRefs((ctx as any)?.ref, inputRef)}}>
+                  {children}
+                </InputContext.Provider>
+              )}
+            </InputContext.Consumer>
+            {isInvalid && <FieldErrorIcon isDisabled={isDisabled} />}
+          </Provider>
         </FieldGroup>
         <HelpText
           size={props.size}

--- a/packages/@react-spectrum/s2/src/TextField.tsx
+++ b/packages/@react-spectrum/s2/src/TextField.tsx
@@ -13,6 +13,7 @@
 import {TextArea as AriaTextArea, TextAreaContext as AriaTextAreaContext} from 'react-aria-components/TextArea';
 import {TextContext as AriaTextContext} from 'react-aria-components/Text';
 import {TextField as AriaTextField, TextFieldProps as AriaTextFieldProps} from 'react-aria-components/TextField';
+import {centerBaseline} from './CenterBaseline';
 import {centerPadding, style} from '../style' with {type: 'macro'};
 import {composeRenderProps} from 'react-aria-components/composeRenderProps';
 import {ContextValue, DEFAULT_SLOT, Provider, useSlottedContext} from 'react-aria-components/slots';
@@ -22,13 +23,12 @@ import {createFocusableRef} from './useDOMRef';
 import {FieldErrorIcon, FieldGroup, FieldLabel, HelpText, Input} from './Field';
 import {FocusableRefValue, GlobalDOMAttributes, HelpTextProps, RefObject, SpectrumLabelableProps} from '@react-types/shared';
 import {FormContext, useFormProps} from './Form';
+import {IconContext} from './Icon';
 import {InputContext, InputProps} from 'react-aria-components/Input';
 import {mergeRefs} from 'react-aria/mergeRefs';
 import {StyleString} from '../style/types';
 import {Text, TextContext} from './Content';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
-import { IconContext } from './Icon';
-import { centerBaseline } from './CenterBaseline';
 
 export interface TextFieldRef<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends FocusableRefValue<T, HTMLDivElement> {
   select(): void,
@@ -41,11 +41,11 @@ export interface TextFieldProps extends Omit<AriaTextFieldProps, 'children' | 'c
    *
    * @default 'M'
    */
-  size?: 'S' | 'M' | 'L' | 'XL'
+  size?: 'S' | 'M' | 'L' | 'XL',
   /**
    * The prefix to display in the text field. Either a string or workflow icon.
    */
-  prefix?: ReactNode;
+  prefix?: ReactNode
 }
 
 export const TextFieldContext = createContext<ContextValue<Partial<TextFieldProps>, TextFieldRef>>(null);

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionButton} from '../src/ActionButton';
 import {Button} from '../src/Button';
 import {Content, Footer, Heading, Text} from '../src/Content';
 import {ContextualHelp} from '../src/ContextualHelp';

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -10,12 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+import {ActionButton} from '../src/ActionButton';
 import {Button} from '../src/Button';
-
 import {Content, Footer, Heading, Text} from '../src/Content';
 import {ContextualHelp} from '../src/ContextualHelp';
 import {Form} from '../src/Form';
 import {Link} from '../src/Link';
+import Magnifier from '../s2wf-icons/S2_Icon_Search_20_N.svg';
 import type {Meta, StoryObj} from '@storybook/react';
 import {style} from '../style' with {type: 'macro'};
 import {TextArea, TextField} from '../src/TextField';
@@ -172,5 +173,33 @@ export const FormCustomWidth: StoryTextField = {
     docs: {
       disable: true
     }
+  }
+};
+
+export const TextFieldWithAddons: StoryTextField = {
+  render: (args) => (
+    <Form>
+      <TextField {...args} prefix="#" />
+      <TextField {...args} prefix={<Magnifier />} />
+      <Button type="submit" variant="primary">Submit</Button>
+    </Form>
+  ),
+  args: {
+    ...Example.args,
+    isRequired: true
+  }
+};
+
+export const TextAreaWithAddons: StoryTextArea = {
+  render: (args) => (
+    <Form>
+      <TextArea {...args} prefix="#" />
+      <TextArea {...args} prefix={<Magnifier />} />
+      <Button type="submit" variant="primary">Submit</Button>
+    </Form>
+  ),
+  args: {
+    ...TextAreaExample.args,
+    isRequired: true
   }
 };

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -179,8 +179,9 @@ export const FormCustomWidth: StoryTextField = {
 export const TextFieldWithAddons: StoryTextField = {
   render: (args) => (
     <Form>
-      <TextField {...args} prefix="#" />
-      <TextField {...args} prefix={<Magnifier />} />
+      <TextField {...args} label="Phone Number" prefix="#" placeholder="(000) 000-0000" />
+      <TextField {...args} label="URL" prefix="https://" placeholder="example.com" />
+      <TextField {...args} label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
       <Button type="submit" variant="primary">Submit</Button>
     </Form>
   ),
@@ -193,8 +194,8 @@ export const TextFieldWithAddons: StoryTextField = {
 export const TextAreaWithAddons: StoryTextArea = {
   render: (args) => (
     <Form>
-      <TextArea {...args} prefix="#" />
-      <TextArea {...args} prefix={<Magnifier />} />
+      <TextArea {...args} label="Phone Number" prefix="#" placeholder="(000) 000-0000" />
+      <TextArea {...args} label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
       <Button type="submit" variant="primary">Submit</Button>
     </Form>
   ),

--- a/packages/@react-spectrum/s2/stories/TextField.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TextField.stories.tsx
@@ -15,7 +15,7 @@ import {Content, Footer, Heading, Text} from '../src/Content';
 import {ContextualHelp} from '../src/ContextualHelp';
 import {Form} from '../src/Form';
 import {Link} from '../src/Link';
-import Magnifier from '../s2wf-icons/S2_Icon_Search_20_N.svg';
+import MentionIcon from '../s2wf-icons/S2_Icon_Mention_20_N.svg';
 import type {Meta, StoryObj} from '@storybook/react';
 import {style} from '../style' with {type: 'macro'};
 import {TextArea, TextField} from '../src/TextField';
@@ -180,7 +180,7 @@ export const TextFieldWithAddons: StoryTextField = {
     <Form>
       <TextField {...args} label="Phone Number" prefix="#" placeholder="(000) 000-0000" />
       <TextField {...args} label="URL" prefix="https://" placeholder="example.com" />
-      <TextField {...args} label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
+      <TextField {...args} label="Mention" prefix={<MentionIcon />} placeholder="username" />
       <Button type="submit" variant="primary">Submit</Button>
     </Form>
   ),
@@ -194,7 +194,7 @@ export const TextAreaWithAddons: StoryTextArea = {
   render: (args) => (
     <Form>
       <TextArea {...args} label="Phone Number" prefix="#" placeholder="(000) 000-0000" />
-      <TextArea {...args} label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
+      <TextArea {...args} label="Mention" prefix={<MentionIcon />} placeholder="username" />
       <Button type="submit" variant="primary">Submit</Button>
     </Form>
   ),

--- a/packages/dev/s2-docs/pages/s2/ComboBox.mdx
+++ b/packages/dev/s2-docs/pages/s2/ComboBox.mdx
@@ -118,6 +118,24 @@ const users = Array.from({length: 5}, (_, i) => ({
   <Content>Interactive elements (e.g. buttons) within ComboBox items are not allowed. This will break keyboard and screen reader navigation. Only add textual or decorative graphics (e.g. icons) as children.</Content>
 </InlineAlert>
 
+### Prefix
+
+Use the `prefix` prop to display a prefix in the combobox.
+
+```tsx render
+"use client";
+import {ComboBox, ComboBoxItem} from '@react-spectrum/s2/ComboBox';
+
+<ComboBox label="Phone number" placeholder="(000) 000-0000" prefix="#">
+  <ComboBoxItem>(123) 456-7890</ComboBoxItem>
+  <ComboBoxItem>(123) 456-7891</ComboBoxItem>
+  <ComboBoxItem>(123) 456-7892</ComboBoxItem>
+  <ComboBoxItem>(123) 456-7893</ComboBoxItem>
+  <ComboBoxItem>(123) 456-7894</ComboBoxItem>
+  <ComboBoxItem>(123) 456-7895</ComboBoxItem>
+</ComboBox>
+```
+
 ### Sections
 
 Use the `<ComboBoxSection>` component to group options. A `<Header>` element, with a `<Heading>` and optional `description` slot can be included to label a section. Sections without a header must have an `aria-label`.

--- a/packages/dev/s2-docs/pages/s2/TextArea.mdx
+++ b/packages/dev/s2-docs/pages/s2/TextArea.mdx
@@ -57,14 +57,14 @@ Use the `prefix` prop to display a prefix in the text area. Either a string or w
 ```tsx render
 "use client";
 import {TextArea} from '@react-spectrum/s2/TextArea';
-import Magnifier from '@react-spectrum/s2/icons/Search';
+import MentionIcon from '@react-spectrum/s2/icons/Mention';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 function Example() {
   return (
     <div className={style({display: 'flex', flexDirection: 'column', gap: 8})}>
       <TextArea label="Irrational number" prefix="#" placeholder="3.1415926535897932384626433832795028841971" />
-      <TextArea label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
+      <TextArea label="Mention" prefix={<MentionIcon />} placeholder="username" />
     </div>
   );
 }

--- a/packages/dev/s2-docs/pages/s2/TextArea.mdx
+++ b/packages/dev/s2-docs/pages/s2/TextArea.mdx
@@ -50,6 +50,26 @@ function Example() {
 }
 ```
 
+## Prefix
+
+Use the `prefix` prop to display a prefix in the text area. Either a string or workflow icon.
+
+```tsx render
+"use client";
+import {TextArea} from '@react-spectrum/s2/TextArea';
+import Magnifier from '@react-spectrum/s2/icons/Search';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+
+function Example() {
+  return (
+    <div className={style({display: 'flex', flexDirection: 'column', gap: 8})}>
+      <TextArea label="Irrational number" prefix="#" placeholder="3.1415926535897932384626433832795028841971" />
+      <TextArea label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
+    </div>
+  );
+}
+```
+
 ## Forms
 
 Use the `name` prop to submit the text value to the server. Set the `isRequired`, `minLength`, or `maxLength` props to validate the value, or implement custom client or server-side validation. See the [Forms](forms) guide to learn more.

--- a/packages/dev/s2-docs/pages/s2/TextField.mdx
+++ b/packages/dev/s2-docs/pages/s2/TextField.mdx
@@ -57,7 +57,7 @@ Use the `prefix` prop to display a prefix in the text field. Either a string or 
 ```tsx render
 "use client";
 import {TextField} from '@react-spectrum/s2/TextField';
-import Magnifier from '@react-spectrum/s2/icons/Search';
+import MentionIcon from '@react-spectrum/s2/icons/Mention';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 function Example() {
@@ -65,7 +65,7 @@ function Example() {
     <div className={style({display: 'flex', flexDirection: 'column', gap: 8})}>
       <TextField label="Phone Number" prefix="#" placeholder="(000) 000-0000" type="tel" />
       <TextField label="URL" prefix="https://" placeholder="example.com" />
-      <TextField label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
+      <TextField label="Mention" prefix={<MentionIcon />} placeholder="username" />
     </div>
   );
 }

--- a/packages/dev/s2-docs/pages/s2/TextField.mdx
+++ b/packages/dev/s2-docs/pages/s2/TextField.mdx
@@ -50,6 +50,26 @@ function Example() {
 }
 ```
 
+## Prefix
+
+Use the `prefix` prop to display a prefix in the text field. Either a string or workflow icon.
+
+```tsx render
+"use client";
+import {TextField} from '@react-spectrum/s2/TextField';
+import Magnifier from '@react-spectrum/s2/icons/Search';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+
+function Example() {
+  return (
+    <div className={style({display: 'flex', flexDirection: 'column', gap: 8})}>
+      <TextField label="Phone Number" prefix="#" placeholder="(000) 000-0000" type="tel" />
+      <TextField label="URL" prefix="https://" placeholder="example.com" />
+      <TextField label="Search" prefix={<Magnifier />} placeholder="Search phrase" />
+    </div>
+  );
+}
+```
 ## Forms
 
 Use the `name` prop to submit the text value to the server. Set the `isRequired`, `minLength`, `maxLength`, `pattern`, or `type` props to validate the value, or implement custom client or server-side validation. See the [Forms](forms) guide to learn more.


### PR DESCRIPTION
Closes <!-- Github issue # here -->

For consideration. ComboBox Items allow an icon. Should that be auto used for the prefix? It's very hard to do since we'd need to access the `rendered` item and then hide everything except the icon or whatever else we care about in that slot position. Otherwise we could do something like this PR and allow people to set the prefix themselves. It may be independent of the item. If it should be synced with the selected value, then they can control that.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
