### PR TITLE
export Virtualizer from react-aria

### DIFF
--- a/packages/react-aria/exports/Virtualizer.ts
+++ b/packages/react-aria/exports/Virtualizer.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export {Virtualizer} from '../src/virtualizer/Virtualizer';
+export type {VirtualizerProps} from '../src/virtualizer/Virtualizer';

--- a/packages/react-aria/exports/index.ts
+++ b/packages/react-aria/exports/index.ts
@@ -140,6 +140,7 @@ export {mergeRefs} from '../src/utils/mergeRefs';
 export {useId} from '../src/utils/useId';
 export {useObjectRef} from '../src/utils/useObjectRef';
 export {RouterProvider} from '../src/utils/openLink';
+export {Virtualizer} from '../src/virtualizer/Virtualizer';
 export {VisuallyHidden, useVisuallyHidden} from '../src/visually-hidden/VisuallyHidden';
 
 export type {AriaAutocompleteProps, AriaAutocompleteOptions, AutocompleteAria, CollectionOptions, InputProps} from '../src/autocomplete/useAutocomplete';
@@ -268,5 +269,6 @@ export type {TooltipTriggerAria} from '../src/tooltip/useTooltipTrigger';
 export type {TooltipTriggerProps} from 'react-stately/useTooltipTriggerState';
 export type {AriaTreeProps, TreeProps, TreeAria, AriaTreeOptions} from '../src/tree/useTree';
 export type {AriaTreeItemOptions, TreeItemAria} from '../src/tree/useTreeItem';
+export type {VirtualizerProps} from '../src/virtualizer/Virtualizer';
 export type {VisuallyHiddenAria, VisuallyHiddenProps} from '../src/visually-hidden/VisuallyHidden';
 export type {Key, Orientation, RangeValue} from '@react-types/shared';

--- a/packages/react-aria/src/virtualizer/Virtualizer.tsx
+++ b/packages/react-aria/src/virtualizer/Virtualizer.tsx
@@ -26,7 +26,7 @@ type RenderWrapper<T extends object, V> = (
   renderChildren: (views: ReusableView<T, V>[]) => ReactElement[]
 ) => ReactElement | null;
 
-interface VirtualizerProps<T extends object, V, O> extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'onScroll'> {
+export interface VirtualizerProps<T extends object, V, O> extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'onScroll'> {
   children: (type: string, content: T) => V,
   renderWrapper?: RenderWrapper<T, V>,
   layout: Layout<T, O>,


### PR DESCRIPTION
Closes #10000 

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [X] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [X] Updated documentation (if it already exists for this component).
- [X] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

- Install `react-aria` in a new project
- Verify that you can import `Virtualizer` directly from `react-aria`