### PR TITLE
fix: calendar tests

### DIFF
--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -201,8 +201,10 @@ describe('Calendar', () => {
     expect(grids).toHaveLength(2);
 
     let formatter = new Intl.DateTimeFormat('en-US', {month: 'long', year: 'numeric'});
-    expect(grids[0]).toHaveAttribute('aria-label', 'Appointment date, ' + formatter.format(new Date()));
-    expect(grids[1]).toHaveAttribute('aria-label', 'Appointment date, ' + formatter.format(today(getLocalTimeZone()).add({months: 1}).toDate(getLocalTimeZone())));
+    let firstMonth = new CalendarDate(2026, 4, 1);
+    let tz = getLocalTimeZone();
+    expect(grids[0]).toHaveAttribute('aria-label', 'Appointment date, ' + formatter.format(firstMonth.toDate(tz)));
+    expect(grids[1]).toHaveAttribute('aria-label', 'Appointment date, ' + formatter.format(firstMonth.add({months: 1}).toDate(tz)));
 
     let headings = container.querySelectorAll('.react-aria-CalendarHeading');
     expect(headings).toHaveLength(2);

--- a/packages/react-aria-components/test/RangeCalendar.test.tsx
+++ b/packages/react-aria-components/test/RangeCalendar.test.tsx
@@ -212,8 +212,10 @@ describe('RangeCalendar', () => {
     expect(grids).toHaveLength(2);
 
     let formatter = new Intl.DateTimeFormat('en-US', {month: 'long', year: 'numeric'});
-    expect(grids[0]).toHaveAttribute('aria-label', 'Trip dates, ' + formatter.format(new Date()));
-    expect(grids[1]).toHaveAttribute('aria-label', 'Trip dates, ' + formatter.format(today(getLocalTimeZone()).add({months: 1}).toDate(getLocalTimeZone())));
+    let firstMonth = new CalendarDate(2026, 4, 1);
+    let tz = getLocalTimeZone();
+    expect(grids[0]).toHaveAttribute('aria-label', 'Trip dates, ' + formatter.format(firstMonth.toDate(tz)));
+    expect(grids[1]).toHaveAttribute('aria-label', 'Trip dates, ' + formatter.format(firstMonth.add({months: 1}).toDate(tz)));
 
     let headings = container.querySelectorAll('.react-aria-CalendarHeading');
     expect(headings).toHaveLength(2);


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Two tests that were sensitive to the current date. This locks them into the same month as the default focused date

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
