### PR TITLE
fix: export types for page.css

### DIFF
--- a/packages/@react-spectrum/s2/package.json
+++ b/packages/@react-spectrum/s2/package.json
@@ -24,6 +24,7 @@
     },
     "./page.css": {
       "source": "./src/page.ts",
+      "types": "./dist/types/src/page.d.ts",
       "default": "./page.css"
     },
     "./style": {


### PR DESCRIPTION
We missed a declaration for the types for page.css in package exports, leading to typescript error when trying to import it.