### PR TITLE
fix: MenuItem render function should not receive an href when not a link

### DIFF
--- a/packages/react-aria-components/test/Menu.test.tsx
+++ b/packages/react-aria-components/test/Menu.test.tsx
@@ -137,7 +137,10 @@ describe('Menu', () => {
   it('should support custom render function', () => {
     let {getAllByRole, getByRole} = renderMenu(
       {render: props => <div {...props} data-custom="true" />},
-      {render: props => <div {...props} data-custom="true" />}
+      {render: props => {
+        expect('href' in props).toBe(false);
+        return <div {...props} data-custom="true" />;
+      }}
     );
     let menu = getByRole('menu');
     expect(menu).toHaveAttribute('data-custom', 'true');
@@ -150,8 +153,11 @@ describe('Menu', () => {
   it('should support custom render function as a link', () => {
     let {getAllByRole, getByRole} = renderMenu(
       {render: props => <div {...props} data-custom="true" />},
-      // eslint-disable-next-line jsx-a11y/anchor-has-content
-      {href: '#foo', render: props => <a {...props} data-custom="true" />}
+      {href: '#foo', render: props => {
+        expect(props.href).toBe('#foo');
+        // eslint-disable-next-line jsx-a11y/anchor-has-content
+        return <a {...props} data-custom="true" />;
+      }}
     );
     let menu = getByRole('menu');
     expect(menu).toHaveAttribute('data-custom', 'true');

--- a/packages/react-aria/src/utils/openLink.tsx
+++ b/packages/react-aria/src/utils/openLink.tsx
@@ -174,14 +174,15 @@ export function getSyntheticLinkProps(props: LinkDOMProps): DOMAttributes<HTMLEl
 export function useLinkProps(props?: LinkDOMProps): LinkDOMProps {
   let router = useRouter();
   const href = router.useHref(props?.href ?? '');
-  return {
-    href: props?.href ? href : undefined,
-    target: props?.target,
-    rel: props?.rel,
-    download: props?.download,
-    ping: props?.ping,
-    referrerPolicy: props?.referrerPolicy
-  };
+  let linkProps: LinkDOMProps = {};
+  if (props) {
+    for (let key of ['href', 'target', 'rel', 'download', 'ping', 'referrerPolicy']) {
+      if (key in props) {
+        linkProps[key] = key === 'href' ? href : props[key];
+      }
+    }
+  }
+  return linkProps;
 }
 
 export function handleLinkClick(e: ReactMouseEvent, router: Router, href: Href | undefined, routerOptions: RouterOptions | undefined): void {


### PR DESCRIPTION
Closes #9988

[Our docs](https://react-aria.adobe.com/Menu#links) say that you should check if `'href' in domProps` to conditionally render a link element, but this is currently always true (href is undefined). TypeScript is not smart enough to narrow the type when checking both conditions, so this PR removes the property entirely when it is not set on the input props.