### PR TITLE
fix: Menu, Select, and ComboBox inside Tabs

### DIFF
--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -33,14 +33,14 @@ import {createHideableComponent} from 'react-aria/private/collections/Hidden';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FormContext} from './Form';
-import {forwardRefType, GlobalDOMAttributes, Key, RefObject} from '@react-types/shared';
+import {GlobalDOMAttributes, Key, RefObject} from '@react-types/shared';
 import {GroupContext} from './Group';
 import {InputContext} from './Input';
 import {LabelContext} from './Label';
 import {ListBoxContext, ListStateContext} from './ListBox';
 import {OverlayTriggerStateContext} from './Dialog';
 import {PopoverContext} from './Popover';
-import React, {createContext, ForwardedRef, forwardRef, HTMLAttributes, ReactElement, ReactNode, useCallback, useContext, useMemo, useRef, useState} from 'react';
+import React, {createContext, ForwardedRef, HTMLAttributes, ReactElement, ReactNode, useCallback, useContext, useMemo, useRef, useState} from 'react';
 import {TextContext} from './Text';
 import {useFilter} from 'react-aria/useFilter';
 import {useListFormatter} from 'react-aria/useListFormatter';
@@ -100,7 +100,7 @@ export const ComboBoxStateContext = createContext<ComboBoxState<any, SelectionMo
 /**
  * A combo box combines a text input with a listbox, allowing users to filter a list of options to items matching a query.
  */
-export const ComboBox = /*#__PURE__*/ (forwardRef as forwardRefType)(function ComboBox<T extends object, M extends SelectionMode = 'single'>(props: ComboBoxProps<T, M>, ref: ForwardedRef<HTMLDivElement>) {
+export const ComboBox = /*#__PURE__*/ createHideableComponent(function ComboBox<T extends object, M extends SelectionMode = 'single'>(props: ComboBoxProps<T, M>, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, ComboBoxContext);
   let {children, isDisabled = false, isInvalid = false, isRequired = false, isReadOnly = false} = props;
   let content = useMemo(() => (

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -75,6 +75,7 @@ import {SharedElementTransition} from './SharedElementTransition';
 import {TextContext} from './Text';
 import {TreeState, useTreeState} from 'react-stately/useTreeState';
 import {useHover} from 'react-aria/useHover';
+import {useIsHidden} from 'react-aria/private/collections/Hidden';
 import {useMultipleSelectionState} from 'react-stately/useMultipleSelectionState';
 import {useObjectRef} from 'react-aria/useObjectRef';
 
@@ -87,7 +88,7 @@ export interface MenuTriggerProps extends BaseMenuTriggerProps {
   children: ReactNode
 }
 
-export function MenuTrigger(props: MenuTriggerProps): JSX.Element {
+export function MenuTrigger(props: MenuTriggerProps): JSX.Element | null {
   let state = useMenuTriggerState(props);
   let ref = useRef<HTMLButtonElement>(null);
   let {menuTriggerProps, menuProps} = useMenuTrigger({
@@ -95,6 +96,13 @@ export function MenuTrigger(props: MenuTriggerProps): JSX.Element {
     type: 'menu'
   }, state, ref);
   let scrollRef = useRef(null);
+
+  // If within a collection (e.g. Tabs), render nothing.
+  // Not using createHideableComponent for this because that also creates a forwardRef.
+  let isHidden = useIsHidden();
+  if (isHidden) {
+    return null;
+  }
 
   return (
     <Provider

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -33,7 +33,7 @@ import {createHideableComponent} from 'react-aria/private/collections/Hidden';
 import {FieldErrorContext} from './FieldError';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FormContext} from './Form';
-import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
+import {GlobalDOMAttributes} from '@react-types/shared';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ItemRenderProps} from './Collection';
@@ -42,7 +42,7 @@ import {ListBoxContext, ListStateContext} from './ListBox';
 import {mergeProps} from 'react-aria/mergeProps';
 import {OverlayTriggerStateContext} from './Dialog';
 import {PopoverContext} from './Popover';
-import React, {createContext, ForwardedRef, forwardRef, Fragment, HTMLAttributes, ReactNode, useContext, useMemo, useRef} from 'react';
+import React, {createContext, ForwardedRef, Fragment, HTMLAttributes, ReactNode, useContext, useMemo, useRef} from 'react';
 import {SelectState, useSelectState} from 'react-stately/useSelectState';
 import {TextContext} from './Text';
 import {useFocusRing} from 'react-aria/useFocusRing';
@@ -103,7 +103,7 @@ export const SelectStateContext = createContext<SelectState<unknown, SelectionMo
 /**
  * A select displays a collapsible list of options and allows a user to select one of them.
  */
-export const Select = /*#__PURE__*/ (forwardRef as forwardRefType)(function Select<T extends object = {}, M extends SelectionMode = 'single'>(props: SelectProps<T, M>, ref: ForwardedRef<HTMLDivElement>) {
+export const Select = /*#__PURE__*/ createHideableComponent(function Select<T extends object = {}, M extends SelectionMode = 'single'>(props: SelectProps<T, M>, ref: ForwardedRef<HTMLDivElement>) {
   [props, ref] = useContextProps(props, ref, SelectContext);
   let {children, isDisabled = false, isInvalid = false, isRequired = false} = props;
   let content = useMemo(() => (

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -12,8 +12,15 @@
 
 import {act, fireEvent, pointerMap, render, waitFor, within} from '@react-spectrum/test-utils-internal';
 import {Button} from '../src/Button';
+import {ComboBox} from '../src/ComboBox';
+import {Input} from '../src/Input';
+import {Label} from '../src/Label';
+import {ListBox, ListBoxItem} from '../src/ListBox';
+import {Menu, MenuItem, MenuTrigger} from '../src/Menu';
+import {Popover} from '../src/Popover';
 import React, {useState} from 'react';
 import {RouterProvider} from 'react-aria/private/utils/openLink';
+import {Select, SelectValue} from '../src/Select';
 import {Tab, TabList, TabPanel, TabPanels, Tabs} from '../src/Tabs';
 import {TabsExample} from '../stories/Tabs.stories';
 import {Tooltip, TooltipTrigger} from '../src/Tooltip';
@@ -847,4 +854,120 @@ describe('Tabs', () => {
       expect(getAllByRole('tab')).toHaveLength(3);
     });
   }
+
+  it('supports Menu inside Tabs', async () => {
+    let tree = render(
+      <Tabs>
+        <div>
+          <TabList>
+            <Tab id="key1">First Tab</Tab>
+            <Tab id="key2">Second Tab</Tab>
+          </TabList>
+          <MenuTrigger>
+            <Button>Menu button</Button>
+            <Popover>
+              <Menu>
+                <MenuItem>Item 1</MenuItem>
+                <MenuItem>Item 2</MenuItem>
+              </Menu>
+            </Popover>
+          </MenuTrigger>
+        </div>
+        <TabPanel id="key1">
+          First Tab content
+        </TabPanel>
+        <TabPanel id="key2">
+          Second Tab content
+        </TabPanel>
+      </Tabs>
+    );
+
+    let tester = testUtilUser.createTester('Tabs', {root: tree.getByRole('tablist')});
+    expect(tester.tabs.length).toBe(2);
+
+    let trigger = tree.getByRole('button');
+    let menu = testUtilUser.createTester('Menu', {root: trigger});
+    await menu.open();
+    expect(menu.options()).toHaveLength(2);
+    await menu.close();
+  });
+
+  it('supports Select inside Tabs', async () => {
+    let tree = render(
+      <Tabs>
+        <div>
+          <TabList>
+            <Tab id="key1">First Tab</Tab>
+            <Tab id="key2">Second Tab</Tab>
+          </TabList>
+          <Select>
+            <Label>Favorite Animal</Label>
+            <Button>
+              <SelectValue />
+            </Button>
+            <Popover>
+              <ListBox>
+                <ListBoxItem id="cat">Cat</ListBoxItem>
+                <ListBoxItem id="dog">Dog</ListBoxItem>
+                <ListBoxItem id="kangaroo">Kangaroo</ListBoxItem>
+              </ListBox>
+            </Popover>
+          </Select>
+        </div>
+        <TabPanel id="key1">
+          First Tab content
+        </TabPanel>
+        <TabPanel id="key2">
+          Second Tab content
+        </TabPanel>
+      </Tabs>
+    );
+
+    let tester = testUtilUser.createTester('Tabs', {root: tree.getByRole('tablist')});
+    expect(tester.tabs.length).toBe(2);
+
+    let trigger = tree.getByRole('button');
+    let menu = testUtilUser.createTester('Select', {root: trigger});
+    await menu.open();
+    expect(menu.options()).toHaveLength(3);
+    await menu.close();
+  });
+
+  it('supports ComboBox inside Tabs', async () => {
+    let tree = render(
+      <Tabs>
+        <div>
+          <TabList>
+            <Tab id="key1">First Tab</Tab>
+            <Tab id="key2">Second Tab</Tab>
+          </TabList>
+          <ComboBox>
+            <Label>Favorite Animal</Label>
+            <Input />
+            <Popover>
+              <ListBox>
+                <ListBoxItem id="cat">Cat</ListBoxItem>
+                <ListBoxItem id="dog">Dog</ListBoxItem>
+                <ListBoxItem id="kangaroo">Kangaroo</ListBoxItem>
+              </ListBox>
+            </Popover>
+          </ComboBox>
+        </div>
+        <TabPanel id="key1">
+          First Tab content
+        </TabPanel>
+        <TabPanel id="key2">
+          Second Tab content
+        </TabPanel>
+      </Tabs>
+    );
+
+    let tester = testUtilUser.createTester('Tabs', {root: tree.getByRole('tablist')});
+    expect(tester.tabs.length).toBe(2);
+
+    let menu = testUtilUser.createTester('ComboBox', {interactionType: 'keyboard', root: tree.container.querySelector('.react-aria-ComboBox')});
+    await menu.open();
+    expect(menu.options()).toHaveLength(3);
+    await menu.close();
+  });
 });


### PR DESCRIPTION
Closes #9011

Collection triggers should be hideable components so that the parent collection doesn't try to inherit the items from the child collection.