### PR TITLE
fix: fix optimize-locales-plugin not "tree shaking" react-aria package

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.js
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.js
@@ -18,7 +18,7 @@ module.exports = createUnplugin(({locales}) => {
     name: 'locales-plugin',
     resolveId(specifier, sourcePath, options) {
       if (
-        !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria-components)[/\\]/.test(
+        !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria|react-aria-components)[/\\]/.test(
           sourcePath
         ) ||
         options?.ssr

--- a/packages/dev/parcel-resolver-optimize-locales/LocalesResolver.js
+++ b/packages/dev/parcel-resolver-optimize-locales/LocalesResolver.js
@@ -23,7 +23,7 @@ module.exports = new Resolver({
   resolve({specifier, dependency, config}) {
     if (
       !Array.isArray(config) ||
-      !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria-components)[/\\]/.test(
+      !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria|react-aria-components)[/\\]/.test(
         dependency.sourcePath
       )
     ) {


### PR DESCRIPTION
Closes #10022

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Monkey patch any project using optimize-locales-plugin with the same patch. Observe:

Before:
```
wojciech.maj@MacBook-Pro proj % yarn build
vite v8.0.5 building client environment for production...
✓ 3047 modules transformed.
computing gzip size...
dist/index.html                  0.91 kB │ gzip:   0.45 kB
dist/assets/index-DmZq51SN.js  477.35 kB │ gzip: 154.79 kB

✓ built in 317ms
```

After:
```
wojciech.maj@MacBook-Pro proj % yarn build
vite v8.0.5 building client environment for production...
✓ 2503 modules transformed.
computing gzip size...
dist/index.html                  0.91 kB │ gzip:   0.45 kB
dist/assets/index-D_7D3FJe.js  472.42 kB │ gzip: 151.82 kB

✓ built in 233ms
```

4.93 KB savings just like that!

## 🧢 Your Project:

<!--- Company/project for pull request -->
