### PR TITLE
fix: minify textContent

### DIFF
--- a/packages/react-aria/src/interactions/usePress.ts
+++ b/packages/react-aria/src/interactions/usePress.ts
@@ -990,13 +990,7 @@ export function usePress(props: PressHookProps): PressResult {
     // touchAction: 'manipulation' is supposed to be equivalent, but in
     // Safari it causes onPointerCancel not to fire on scroll.
     // https://bugs.webkit.org/show_bug.cgi?id=240917
-    style.textContent = `
-@layer {
-  [${PRESSABLE_ATTRIBUTE}] {
-    touch-action: pan-x pan-y pinch-zoom;
-  }
-}
-    `.trim();
+    style.textContent=`@layer{[${PRESSABLE_ATTRIBUTE}]{touch-action:pan-x pan-y pinch-zoom}}`
     ownerDocument.head.prepend(style);
   }, [domRef]);
 

--- a/packages/react-aria/src/overlays/usePreventScroll.ts
+++ b/packages/react-aria/src/overlays/usePreventScroll.ts
@@ -143,12 +143,7 @@ function preventScrollMobileSafari() {
   if (nonce) {
     style.nonce = nonce;
   }
-  style.textContent = `
-@layer {
-  * {
-    overscroll-behavior: contain;
-  }
-}`.trim();
+  style.textContent='@layer{*{overscroll-behavior:contain}}'
   document.head.prepend(style);
 
   let onTouchMove = (e: TouchEvent) => {


### PR DESCRIPTION
Shaves off 38 bytes from every bundle. `.trim()` isn't enough to actually minify CSS, so you end up with lots of redundant whitespace even after minification.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
