### PR TITLE
fix: avoid forwarding overlay props in Tailwind starter Modal

### DIFF
--- a/starters/tailwind/src/Modal.tsx
+++ b/starters/tailwind/src/Modal.tsx
@@ -27,11 +27,26 @@ const modalStyles = tv({
   }
 });
 
-export function Modal(props: ModalOverlayProps) {
+export function Modal({children, ...props}: ModalOverlayProps) {
+  let {
+    isDismissable,
+    isKeyboardDismissDisabled,
+    isOpen,
+    defaultOpen,
+    onOpenChange,
+    isEntering,
+    isExiting,
+    UNSTABLE_portalContainer,
+    shouldCloseOnInteractOutside,
+    ...modalProps
+  } = props;
+
   return (
     <ModalOverlay {...props} className={overlayStyles}>
       <div className="sticky top-0 left-0 w-full h-(--visual-viewport-height) flex items-center justify-center box-border">
-        <RACModal {...props} className={modalStyles} />
+        <RACModal {...modalProps} className={modalStyles}>
+          {children}
+        </RACModal>
       </div>
     </ModalOverlay>
   );


### PR DESCRIPTION
Closes #10026

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
  - Not applicable: this is a starter wrapper prop-forwarding fix, and the starter does not appear to have existing tests for this component.
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
  - Not applicable: this updates starter code only.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Validated locally with:

- `yarn install --immutable`
- `yarn eslint --no-warn-ignored starters/tailwind/src/Modal.tsx`
- `yarn lint`

To verify manually, use the Tailwind starter `Modal` with overlay-control props such as `isOpen`, `onOpenChange`, and `isDismissable`. These props should remain on `ModalOverlay` and should not be forwarded to the inner React Aria `Modal`.