### PR TITLE
Add sr-Latn placeholder to datepicker for Serbian Latin locale

### DIFF
--- a/packages/react-stately/src/datepicker/placeholders.ts
+++ b/packages/react-stately/src/datepicker/placeholders.ts
@@ -86,6 +86,7 @@ const placeholders = new LocalizedStringDictionary(
     sk: {year: 'rrrr', month: 'mm', day: 'dd'},
     sl: {year: 'llll', month: 'mm', day: 'dd'},
     sr: {year: 'гггг', month: 'мм', day: 'дд'},
+    'sr-Latn': {year: 'gggg', month: 'mm', day: 'dd'},
     sv: {year: 'åååå', month: 'mm', day: 'dd'},
     szl: {year: 'rrrr', month: 'mm', day: 'dd'},
     tg: {year: 'сссс', month: 'мм', day: 'рр'},


### PR DESCRIPTION
## Summary

Adds `sr-Latn` to the hardcoded placeholder dictionary in `@react-stately/datepicker` so that users with a Serbian Latin locale (`sr-Latn` / `sr-Latn-RS`) see Latin segment placeholders instead of Cyrillic ones.

## Problem

The `LocalizedStringDictionary` in `placeholders.ts` has an entry for `sr` (Cyrillic: `гггг`, `мм`, `дд`) but no entry for `sr-Latn`. Because the dictionary falls back from `sr-Latn-RS` → `sr-Latn` → `sr`, users in a Serbian Latin locale see Cyrillic placeholders (`гггг`, `мм`, `дд`) in date fields instead of the Latin equivalents (`gggg`, `mm`, `dd`).

## Fix

Add `'sr-Latn': {year: 'gggg', month: 'mm', day: 'dd'}` to the dictionary, consistent with the placeholders used by Chrome and Firefox for `<input type="date">` in that locale.

## Related issue

Fixes #10033