### PR TITLE
fix: eslint warnings that came back

### DIFF
--- a/packages/@adobe/react-spectrum/src/card/CardBase.tsx
+++ b/packages/@adobe/react-spectrum/src/card/CardBase.tsx
@@ -124,7 +124,7 @@ export const CardBase = React.forwardRef(function CardBase<T extends object>(
       heading: {UNSAFE_className: classNames(styles, 'spectrum-Card-heading'), ...titleProps},
       content: {UNSAFE_className: classNames(styles, 'spectrum-Card-content'), ...contentProps},
       detail: {UNSAFE_className: classNames(styles, 'spectrum-Card-detail')}
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     }),
     [titleProps, contentProps, height, isQuiet, orientation]
   );

--- a/packages/@adobe/react-spectrum/src/card/CardBase.tsx
+++ b/packages/@adobe/react-spectrum/src/card/CardBase.tsx
@@ -124,8 +124,8 @@ export const CardBase = React.forwardRef(function CardBase<T extends object>(
       heading: {UNSAFE_className: classNames(styles, 'spectrum-Card-heading'), ...titleProps},
       content: {UNSAFE_className: classNames(styles, 'spectrum-Card-content'), ...contentProps},
       detail: {UNSAFE_className: classNames(styles, 'spectrum-Card-detail')}
-       
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [titleProps, contentProps, height, isQuiet, orientation]
   );
 

--- a/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
@@ -104,8 +104,8 @@ export const Dialog = React.forwardRef(function Dialog(props: SpectrumDialogProp
         }),
         align: 'end'
       }
-       
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [hasFooter, hasHeader, titleProps]
   );
 

--- a/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
@@ -104,7 +104,7 @@ export const Dialog = React.forwardRef(function Dialog(props: SpectrumDialogProp
         }),
         align: 'end'
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     }),
     [hasFooter, hasHeader, titleProps]
   );

--- a/packages/@adobe/react-spectrum/stories/combobox/ComboBox.stories.tsx
+++ b/packages/@adobe/react-spectrum/stories/combobox/ComboBox.stories.tsx
@@ -747,9 +747,10 @@ let customFilterItems = [
 let CustomFilterComboBox = props => {
   let {startsWith} = useFilter({sensitivity: 'base'});
   let [filterValue, setFilterValue] = React.useState('');
-   
+
   let filteredItems = React.useMemo(
     () => customFilterItems.filter(item => startsWith(item.name, filterValue)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.items, filterValue, startsWith]
   );
 

--- a/packages/@adobe/react-spectrum/stories/combobox/ComboBox.stories.tsx
+++ b/packages/@adobe/react-spectrum/stories/combobox/ComboBox.stories.tsx
@@ -747,7 +747,7 @@ let customFilterItems = [
 let CustomFilterComboBox = props => {
   let {startsWith} = useFilter({sensitivity: 'base'});
   let [filterValue, setFilterValue] = React.useState('');
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   let filteredItems = React.useMemo(
     () => customFilterItems.filter(item => startsWith(item.name, filterValue)),
     [props.items, filterValue, startsWith]

--- a/packages/dev/eslint-plugin-rsp-rules/rules/no-getByRole-toThrow.js
+++ b/packages/dev/eslint-plugin-rsp-rules/rules/no-getByRole-toThrow.js
@@ -19,7 +19,6 @@ const plugin = {
     /**
      * expect(() => tree.getByRole('separator')).toThrow();
      */
-     
     [`CallExpression[callee.property.name='getByRole'][parent.parent.callee.name='expect'][parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {
@@ -38,7 +37,6 @@ const plugin = {
     /**
      * expect(() => getByRole('separator')).toThrow();
      */
-     
     [`CallExpression[callee.name='getByRole'][parent.parent.callee.name='expect'][parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {
@@ -53,7 +51,6 @@ const plugin = {
     /**
      * expect(() => {tree.getByRole('separator')}).toThrow();
      */
-     
     [`CallExpression[callee.property.name='getByRole'][parent.parent.parent.parent.callee.name='expect'][parent.parent.parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {
@@ -73,7 +70,6 @@ const plugin = {
     /**
      * expect(() => {getByRole('separator')}).toThrow();
      */
-     
     [`CallExpression[callee.name='getByRole'][parent.parent.parent.parent.callee.name='expect'][parent.parent.parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {

--- a/packages/dev/eslint-plugin-rsp-rules/rules/no-getByRole-toThrow.js
+++ b/packages/dev/eslint-plugin-rsp-rules/rules/no-getByRole-toThrow.js
@@ -19,7 +19,7 @@ const plugin = {
     /**
      * expect(() => tree.getByRole('separator')).toThrow();
      */
-    // eslint-disable-next-line quotes
+     
     [`CallExpression[callee.property.name='getByRole'][parent.parent.callee.name='expect'][parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {
@@ -38,7 +38,7 @@ const plugin = {
     /**
      * expect(() => getByRole('separator')).toThrow();
      */
-    // eslint-disable-next-line quotes
+     
     [`CallExpression[callee.name='getByRole'][parent.parent.callee.name='expect'][parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {
@@ -53,7 +53,7 @@ const plugin = {
     /**
      * expect(() => {tree.getByRole('separator')}).toThrow();
      */
-    // eslint-disable-next-line quotes
+     
     [`CallExpression[callee.property.name='getByRole'][parent.parent.parent.parent.callee.name='expect'][parent.parent.parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {
@@ -73,7 +73,7 @@ const plugin = {
     /**
      * expect(() => {getByRole('separator')}).toThrow();
      */
-    // eslint-disable-next-line quotes
+     
     [`CallExpression[callee.name='getByRole'][parent.parent.parent.parent.callee.name='expect'][parent.parent.parent.parent.parent.property.name=/toThrow/]`](
       node
     ) {

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -86,9 +86,9 @@ export function useRenderDropIndicator(
           <DropIndicator target={target} />
         );
       }
-      // We invalidate whenever the target changes.
-       
     },
+    // We invalidate whenever the target changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [dropState?.target, isVirtualDragging, renderDropIndicator]
   );
   return dragAndDropHooks?.useDropIndicator ? fn : undefined;

--- a/packages/react-aria-components/src/DragAndDrop.tsx
+++ b/packages/react-aria-components/src/DragAndDrop.tsx
@@ -87,7 +87,7 @@ export function useRenderDropIndicator(
         );
       }
       // We invalidate whenever the target changes.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     },
     [dropState?.target, isVirtualDragging, renderDropIndicator]
   );

--- a/packages/react-aria/src/collections/CollectionBuilder.tsx
+++ b/packages/react-aria/src/collections/CollectionBuilder.tsx
@@ -291,8 +291,8 @@ export function Collection<T extends object>(props: CollectionProps<T>): JSX.Ele
     () => ({
       dependencies,
       idScope
-       
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [idScope, ...dependencies]
   );
 

--- a/packages/react-aria/src/collections/CollectionBuilder.tsx
+++ b/packages/react-aria/src/collections/CollectionBuilder.tsx
@@ -291,7 +291,7 @@ export function Collection<T extends object>(props: CollectionProps<T>): JSX.Ele
     () => ({
       dependencies,
       idScope
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     }),
     [idScope, ...dependencies]
   );

--- a/packages/react-stately/src/table/useTableState.ts
+++ b/packages/react-stately/src/table/useTableState.ts
@@ -114,7 +114,7 @@ export function useTableState<T extends object>(props: TableStateProps<T>): Tabl
       showDragButtons: showDragButtons,
       selectionMode,
       columns: []
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     }),
     [props.children, showSelectionCheckboxes, selectionMode, showDragButtons]
   );

--- a/packages/react-stately/src/table/useTableState.ts
+++ b/packages/react-stately/src/table/useTableState.ts
@@ -114,8 +114,8 @@ export function useTableState<T extends object>(props: TableStateProps<T>): Tabl
       showDragButtons: showDragButtons,
       selectionMode,
       columns: []
-       
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.children, showSelectionCheckboxes, selectionMode, showDragButtons]
   );
 

--- a/packages/react-stately/src/table/useTreeGridState.ts
+++ b/packages/react-stately/src/table/useTreeGridState.ts
@@ -72,8 +72,8 @@ export function UNSTABLE_useTreeGridState<T extends object>(
       showDragButtons: showDragButtons,
       selectionMode,
       columns: []
-       
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [children, showSelectionCheckboxes, selectionMode, showDragButtons]
   );
 

--- a/packages/react-stately/src/table/useTreeGridState.ts
+++ b/packages/react-stately/src/table/useTreeGridState.ts
@@ -72,7 +72,7 @@ export function UNSTABLE_useTreeGridState<T extends object>(
       showDragButtons: showDragButtons,
       selectionMode,
       columns: []
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     }),
     [children, showSelectionCheckboxes, selectionMode, showDragButtons]
   );


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Noticed a bunch of our warnings had come back. The formatter moved lines but didn't move eslint disabled next line with the line in question

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
