### PR TITLE
fix: fix testing sheet workflow on github

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-max-files-changed: 101
+max-files-changed: 100
 
 needs translations:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+max-files-changed: 101
+
 needs translations:
   - changed-files:
       - any-glob-to-any-file: ['**/intl/*.json']

--- a/.github/workflows/weekly-excel-sheet.yaml
+++ b/.github/workflows/weekly-excel-sheet.yaml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
       - name: Generate and post Excel testing sheet to Slack
         run: node scripts/sendWeeklyExcelSheet.mjs
         env:

--- a/scripts/getCommitsForTesting.mjs
+++ b/scripts/getCommitsForTesting.mjs
@@ -43,10 +43,7 @@ async function writeTestingCSV() {
 }
 
 export async function generateData(startDate, endDate) {
-  let [data, openOffPRs] = await Promise.all([
-    listCommits(startDate, endDate),
-    listOpenOffPRs()
-  ]);
+  let [data, openOffPRs] = await Promise.all([listCommits(startDate, endDate), listOpenOffPRs()]);
 
   // First pass: extract PR numbers from commit messages
   let commitsWithPRs = [];
@@ -75,7 +72,7 @@ export async function generateData(startDate, endDate) {
     let component = '';
     if (matches.length > 0) {
       if (matches.includes('documentation')) {
-        component = 'Docs'
+        component = 'Docs';
       } else {
         component = matches.sort().join('/');
       }
@@ -128,11 +125,7 @@ export async function generateData(startDate, endDate) {
     row.push(info.data.html_url);
     row.push(removePRNumber(title));
 
-    if (
-      !labels.has('S2') &&
-      !labels.has('RAC') &&
-      !labels.has('v3')
-    ) {
+    if (!labels.has('S2') && !labels.has('RAC') && !labels.has('v3')) {
       otherPRs.push(row);
     } else {
       if (labels.has('S2')) {

--- a/scripts/getCommitsForTesting.mjs
+++ b/scripts/getCommitsForTesting.mjs
@@ -43,7 +43,10 @@ async function writeTestingCSV() {
 }
 
 export async function generateData(startDate, endDate) {
-  let data = await listCommits(startDate, endDate);
+  let [data, openOffPRs] = await Promise.all([
+    listCommits(startDate, endDate),
+    listOpenOffPRs()
+  ]);
 
   // First pass: extract PR numbers from commit messages
   let commitsWithPRs = [];
@@ -63,7 +66,33 @@ export async function generateData(startDate, endDate) {
   let racPRs = [];
   let v3PRs = [];
   let otherPRs = [];
-  let offPRs = [];
+
+  // Off PRs are currently open PRs with the 'test off PR' label
+  let offPRs = openOffPRs.map(pr => {
+    let labels = new Set(pr.labels.map(l => l.name));
+    let matches = [...validLabels].filter(name => labels.has(name));
+
+    let component = '';
+    if (matches.length > 0) {
+      if (matches.includes('documentation')) {
+        component = 'Docs'
+      } else {
+        component = matches.sort().join('/');
+      }
+    }
+
+    if (matches.length === 0) {
+      component = removePRNumber(pr.title);
+    }
+
+    let testInstructions = extractTestInstructions(pr.body);
+    return [
+      component,
+      testInstructions.length > 300 ? 'See PR for testing instructions' : testInstructions,
+      pr.html_url,
+      removePRNumber(pr.title)
+    ];
+  });
 
   for (let i = 0; i < commitsWithPRs.length; i++) {
     let {title, num} = commitsWithPRs[i];
@@ -102,12 +131,9 @@ export async function generateData(startDate, endDate) {
     if (
       !labels.has('S2') &&
       !labels.has('RAC') &&
-      !labels.has('v3') &&
-      !labels.has('test off PR')
+      !labels.has('v3')
     ) {
       otherPRs.push(row);
-    } else if (labels.has('test off PR')) {
-      offPRs.push(row);
     } else {
       if (labels.has('S2')) {
         s2PRs.push(row);
@@ -151,6 +177,26 @@ export async function generateCSV(startDate, endDate) {
   let csv = `V3 \n${formatRows(v3PRs)}\n\nRainbow \n${formatRows(s2PRs)}\n\nRAC \n${formatRows(racPRs)}\n\nOff PR \n${formatRows(offPRs)}\n\nOther \n${formatRows(otherPRs)}\n`;
 
   return {csv, counts};
+}
+
+async function listOpenOffPRs() {
+  let allPRs = [];
+  let page = 1;
+  let lastPageSize;
+  do {
+    let res = await octokit.issues.listForRepo({
+      owner: 'adobe',
+      repo: 'react-spectrum',
+      state: 'open',
+      labels: 'test off PR',
+      per_page: 100,
+      page
+    });
+    allPRs.push(...res.data.filter(issue => issue.pull_request));
+    lastPageSize = res.data.length;
+    page++;
+  } while (lastPageSize === 100);
+  return allPRs;
 }
 
 async function listCommits(startDate, endDate) {
@@ -300,6 +346,7 @@ let validLabels = new Set([
   'IllustratedMessage',
   'Image',
   'InlineAlert',
+  'LabeledValue',
   'Link',
   'LinkButton',
   'ListBox',

--- a/scripts/sendWeeklyExcelSheet.mjs
+++ b/scripts/sendWeeklyExcelSheet.mjs
@@ -13,7 +13,6 @@ if (!SLACK_TESTING_BOT_TOKEN || !SLACK_CHANNEL_ID) {
 function getPreviousWeekRange() {
   let today = new Date();
   let endDate = new Date(today);
-  endDate.setDate(today.getDate() - 1);
 
   let startDate = new Date(today);
   startDate.setDate(today.getDate() - 7);


### PR DESCRIPTION
i was using npm when i should have been using yarn 😅

but otherwise fixes the test off PR label (bc it needs to look at the PR's that are currently open, not the commits on main) and adds LabeledValue to the list of valid labels

also skips labeling if the number of files changed exceed 100s. this is an arbitrary number, happy to lower it if we feel like that might make more sense. see docs: https://github.com/actions/labeler#skipping-labeling-for-large-prs

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
