### PR TITLE
chore: add a hook for agents to run the formatter after file edits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; [[ -n \"$f\" ]] && oxfmt --no-error-on-unmatched-pattern \"$f\"; } 2>/dev/null || true",
+            "statusMessage": "oxfmt"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a [hook](https://code.claude.com/docs/en/hooks#posttooluse) that runs our formatter after any file edits.

The hook essentially:

1. Reads the file path from the tool's output
2. Runs `oxfmt` on matching files

or more specifically:

1. `jq -r '.tool_input.file_path // empty'`  reads the JSON payload that the agent sends to the hook on stdin, extracts the file path, and prints it. The `// empty` means if there's no file path, print nothing rather than `null`.

2. `| { read -r f; ... }` pipes that output into a block, reading it into the variable `$f`.

3. `[[ -n "$f" ]]` guards against an empty `$f`. Without this, `oxfmt` with no argument would format the entire project.

4. `oxfmt --no-error-on-unmatched-pattern "$f"` formats the file in place. The flag tells `oxfmt` to silently skip files it doesn't handle (e.g. `.json`, `.md`) instead of exiting with an error.

5. `2>/dev/null || true` suppresses stderr so the hook always exits 0, which makes a formatter failure non-blocking.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Ask your agent to test it by making some unformatted edits, then check the file content afterwards to ensure they were automatically formatted.

## 🧢 Your Project:

<!--- Company/project for pull request -->
