### PR TITLE
chore: fix so that TSDiff doesnt return non-existant layout changes

### DIFF
--- a/packages/dev/parcel-transformer-docs/DocsTransformer.js
+++ b/packages/dev/parcel-transformer-docs/DocsTransformer.js
@@ -548,7 +548,11 @@ module.exports = new Transformer({
         );
       }
 
-      if (path.isTSExpressionWithTypeArguments()) {
+      // due to oxlint formatting, WaterfallLayout/other classes now are multiline declarations
+      // the "extends Layout<Node<T>, 0>" part then ends up becoming isTSInstantiationExpressions superclass rather than just Identifier.
+      // as a result, should be handled similar to isTSExpressionWithTypeArguments (aka Blah<T>)
+      // see https://astexplorer.net/#/gist/451958d4b4a31868f0896664e2291a92/15ffdc9fe4097cfdb9f997f12d550fdff4761205 for verification
+      if (path.isTSExpressionWithTypeArguments() || path.isTSInstantiationExpression()) {
         if (path.node.typeParameters) {
           return Object.assign(node, {
             type: 'application',


### PR DESCRIPTION
TSDiffer was claiming that the layouts lost `getVisibleLayoutInfos`/`virtualizer`/etc from their API but it turned out to be that DocsTransformer wasn't processing the [Layout extends](https://github.com/adobe/react-spectrum/blob/88ff2432cb87b738c9607012c26d873005100252/packages/react-stately/src/layout/WaterfallLayout.ts#L93) properly anymore via DocsTransformer since it became multiline from the oxlint formatting changes

See https://astexplorer.net/#/gist/451958d4b4a31868f0896664e2291a92/15ffdc9fe4097cfdb9f997f12d550fdff4761205 for a validation of what Layout's ast returns (click on `Layout` for the multiline `ListLayout` definition vs the single line `ListLayout` defintion)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check the TSDiff reported and verify that the changes look correct 

## 🧢 Your Project:

RSP
