### PR TITLE
fix: textfield prefix design feedback

### DIFF
--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -304,7 +304,6 @@ export const FieldGroup = forwardRef(function FieldGroup(
           <CenterBaseline
             id={prefixId}
             styles={style({
-              minWidth: 20,
               color: 'gray-600',
               flexShrink: 0,
               marginEnd: 'text-to-visual'


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Design feedback that space between small prefix, such as the first example in the textfield docs, was too large. It was leftover from when I thought the prefix was only going to be wf icons or text.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Go to docs, there shouldn't be a large amount of space between the '#' and the placeholder in the first example of Textfield's prefix example.

## 🧢 Your Project:

<!--- Company/project for pull request -->
