### PR TITLE
chore: S2 LabeledValue follow-up

### DIFF
--- a/examples/s2-next-macros/src/app/Lazy.js
+++ b/examples/s2-next-macros/src/app/Lazy.js
@@ -60,6 +60,7 @@ import {
   Image,
   InlineAlert,
   Keyboard,
+  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -162,6 +163,7 @@ export default function Lazy() {
           <TextArea placeholder="Enter a description" label="Description" />
           <TextField placeholder="Enter a email" label="Email" />
           <TextField placeholder="Enter a password" label="Password" />
+          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />

--- a/examples/s2-next-macros/src/app/Lazy.js
+++ b/examples/s2-next-macros/src/app/Lazy.js
@@ -60,7 +60,6 @@ import {
   Image,
   InlineAlert,
   Keyboard,
-  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -163,7 +162,6 @@ export default function Lazy() {
           <TextArea placeholder="Enter a description" label="Description" />
           <TextField placeholder="Enter a email" label="Email" />
           <TextField placeholder="Enter a password" label="Password" />
-          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />

--- a/examples/s2-parcel-example/src/Lazy.js
+++ b/examples/s2-parcel-example/src/Lazy.js
@@ -46,6 +46,7 @@ import {
   Image,
   InlineAlert,
   Keyboard,
+  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -148,6 +149,7 @@ export default function Lazy() {
           <TextArea placeholder="Enter a description" label="Description" />
           <TextField placeholder="Enter a email" label="Email" />
           <TextField placeholder="Enter a password" label="Password" />
+          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />

--- a/examples/s2-parcel-example/src/Lazy.js
+++ b/examples/s2-parcel-example/src/Lazy.js
@@ -46,7 +46,6 @@ import {
   Image,
   InlineAlert,
   Keyboard,
-  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -149,7 +148,6 @@ export default function Lazy() {
           <TextArea placeholder="Enter a description" label="Description" />
           <TextField placeholder="Enter a email" label="Email" />
           <TextField placeholder="Enter a password" label="Password" />
-          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />

--- a/examples/s2-vite-project/src/Lazy.tsx
+++ b/examples/s2-vite-project/src/Lazy.tsx
@@ -46,6 +46,7 @@ import {
   Image,
   InlineAlert,
   Keyboard,
+  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -148,6 +149,7 @@ export default function Lazy() {
           <TextArea label="Description" />
           <TextField label="Email" />
           <TextField label="Password" />
+          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />
@@ -202,7 +204,7 @@ export default function Lazy() {
           The missing link.
         </Link>
         <Link href="/foo">Foo</Link>
-        <SegmentedControl aria-label="Time granularity" styles={style({width: 384})}>
+        <SegmentedControl aria-label="Time granularity" styles={style({width: 384})} isJustified>
           <SegmentedControlItem id="day">Day</SegmentedControlItem>
           <SegmentedControlItem id="week">Week</SegmentedControlItem>
           <SegmentedControlItem id="month">Month</SegmentedControlItem>

--- a/examples/s2-webpack-5-example/src/Lazy.js
+++ b/examples/s2-webpack-5-example/src/Lazy.js
@@ -46,6 +46,7 @@ import {
   Image,
   InlineAlert,
   Keyboard,
+  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -148,6 +149,7 @@ export default function Lazy() {
           <TextArea placeholder="Enter a description" label="Description" />
           <TextField placeholder="Enter a email" label="Email" />
           <TextField placeholder="Enter a password" label="Password" />
+          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />

--- a/examples/s2-webpack-5-example/src/Lazy.js
+++ b/examples/s2-webpack-5-example/src/Lazy.js
@@ -46,7 +46,6 @@ import {
   Image,
   InlineAlert,
   Keyboard,
-  LabeledValue,
   Link,
   Meter,
   NumberField,
@@ -149,7 +148,6 @@ export default function Lazy() {
           <TextArea placeholder="Enter a description" label="Description" />
           <TextField placeholder="Enter a email" label="Email" />
           <TextField placeholder="Enter a password" label="Password" />
-          <LabeledValue label="Actual hours" value={0} />
           <SelectBoxGroup aria-label="Choose a cloud">
             <SelectBox id="aws" textValue="Amazon Web Services">
               <Server />

--- a/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
+++ b/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
@@ -137,7 +137,7 @@ import {Link} from '@react-spectrum/s2/Link';
 
 Use `LabeledValue` within a `Form` to display non-editable information alongside editable fields.
 
-```tsx render docs={docs.exports.Form} links={docs.links} props={['size', 'labelPosition', 'labelAlign', 'necessityIndicator', 'isRequired', 'isDisabled']} type="s2"
+```tsx render docs={docs.exports.Form} links={docs.links} props={['size', 'labelAlign', 'necessityIndicator', 'isRequired', 'isDisabled']} type="s2"
 "use client";
 import {Button} from '@react-spectrum/s2/Button';
 import {ComboBox, ComboBoxItem} from '@react-spectrum/s2/ComboBox';
@@ -171,10 +171,12 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
       placeholder="–"
       defaultValue={1} 
       styles={style({width: 120})}/>
+    {/*- begin highlight -*/}
     <LabeledValue 
       label="Actual hours"
       value={0}
       styles={style({width: 120})}/>
+    {/*- end highlight -*/}
   </div>
   <div
     role="group"

--- a/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
+++ b/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
@@ -143,7 +143,6 @@ import {Button} from '@react-spectrum/s2/Button';
 import {Form} from '@react-spectrum/s2/Form';
 import {LabeledValue} from '@react-spectrum/s2/LabeledValue';
 import {NumberField} from '@react-spectrum/s2/NumberField';
-import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 <Form/* PROPS */>
   <NumberField

--- a/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
+++ b/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
@@ -144,7 +144,6 @@ import {ComboBox, ComboBoxItem} from '@react-spectrum/s2/ComboBox';
 import {Form} from '@react-spectrum/s2/Form';
 import {LabeledValue} from '@react-spectrum/s2/LabeledValue';
 import {NumberField} from '@react-spectrum/s2/NumberField';
-import {Picker, PickerItem} from '@react-spectrum/s2/Picker';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 <Form/* PROPS */>

--- a/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
+++ b/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
@@ -137,21 +137,59 @@ import {Link} from '@react-spectrum/s2/Link';
 
 Use `LabeledValue` within a `Form` to display non-editable information alongside editable fields.
 
-```tsx render docs={docs.exports.Form} links={docs.links} props={['size', 'labelPosition', 'labelAlign', 'necessityIndicator', 'isRequired', 'isDisabled', 'isEmphasized']} type="s2"
+```tsx render docs={docs.exports.Form} links={docs.links} props={['size', 'labelPosition', 'labelAlign', 'necessityIndicator', 'isRequired', 'isDisabled']} type="s2"
 "use client";
 import {Button} from '@react-spectrum/s2/Button';
+import {ComboBox, ComboBoxItem} from '@react-spectrum/s2/ComboBox';
 import {Form} from '@react-spectrum/s2/Form';
 import {LabeledValue} from '@react-spectrum/s2/LabeledValue';
 import {NumberField} from '@react-spectrum/s2/NumberField';
+import {Picker, PickerItem} from '@react-spectrum/s2/Picker';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 <Form/* PROPS */>
-  <NumberField
-    label="Planned hours"
-    placeholder="–"
-    defaultValue={1} />
-  <LabeledValue 
-    label="Actual hours"
-    value={0} />
+  <div
+    role="group"
+    className={style({display: 'flex', alignItems: 'center', gap: 48})}>
+    <ComboBox label="Duration type" styles={style({width: 120})}>
+      <ComboBoxItem>Simple</ComboBoxItem>
+      <ComboBoxItem>Calculated assignment</ComboBoxItem>
+      <ComboBoxItem>Calculated work</ComboBoxItem>
+      <ComboBoxItem>Effort driven</ComboBoxItem>
+    </ComboBox>
+    <NumberField
+    label="Duration days"
+    placeholder="# of days"
+    defaultValue={1} 
+    styles={style({width: 120})}/>
+  </div>
+  <div
+    role="group"
+    aria-labelledby="working hours"
+    className={style({display: 'flex', alignItems: 'center', gap: 48, font: 'ui'})}>
+    <NumberField
+      label="Planned hours"
+      placeholder="–"
+      defaultValue={1} 
+      styles={style({width: 120})}/>
+    <LabeledValue 
+      label="Actual hours"
+      value={0}
+      styles={style({width: 120})}/>
+  </div>
+  <div
+    role="group"
+    aria-labelledby="working hours"
+    className={style({display: 'flex', alignItems: 'center', gap: 48, font: 'ui'})}>
+    <LabeledValue 
+      label="Project duration"
+      value={1}
+      styles={style({width: 120})}/>
+    <LabeledValue 
+      label="Actual duration"
+      value={0}
+      styles={style({width: 120})}/>
+  </div>
   <Button
     type="submit"
     variant="primary">

--- a/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
+++ b/packages/dev/s2-docs/pages/s2/LabeledValue.mdx
@@ -17,7 +17,7 @@ export const description = 'Displays a non-editable value with a label';
   component={LabeledValue}
   docs={types.exports.LabeledValueProps}
   links={types.links}
-  props={['label', 'size', 'labelPosition', 'labelAlign', 'contextualHelp']}
+  props={['label', 'size', 'labelPosition', 'contextualHelp']}
   initialProps={{
     label: 'File name',
     value: 'Budget.pdf'
@@ -131,6 +131,34 @@ import {LabeledValue} from '@react-spectrum/s2/LabeledValue';
 import {Link} from '@react-spectrum/s2/Link';
 
 <LabeledValue label="Website" value={<Link href="https://www.adobe.com/">Adobe.com</Link>} />
+```
+
+## Form
+
+Use `LabeledValue` within a `Form` to display non-editable information alongside editable fields.
+
+```tsx render docs={docs.exports.Form} links={docs.links} props={['size', 'labelPosition', 'labelAlign', 'necessityIndicator', 'isRequired', 'isDisabled', 'isEmphasized']} type="s2"
+"use client";
+import {Button} from '@react-spectrum/s2/Button';
+import {Form} from '@react-spectrum/s2/Form';
+import {LabeledValue} from '@react-spectrum/s2/LabeledValue';
+import {NumberField} from '@react-spectrum/s2/NumberField';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+
+<Form/* PROPS */>
+  <NumberField
+    label="Planned hours"
+    placeholder="–"
+    defaultValue={1} />
+  <LabeledValue 
+    label="Actual hours"
+    value={0} />
+  <Button
+    type="submit"
+    variant="primary">
+    Submit
+  </Button>
+</Form>
 ```
 
 


### PR DESCRIPTION
1. Remove `labelAlign` from the controls in the docs since it looked bad
2. Adds an example of LabeledValue used in Form
3. Adds LabeledValue to test apps
4. Fixes segmented control in vite test app

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to LabeledValue docs and check to make sure labeledAlign has been removed. Also check new section under "Form". Check test apps to make sure LabeledValue has rendered correctly. Check vite test app  to make sure segmented control looks correct.

## 🧢 Your Project:

<!--- Company/project for pull request -->
