### PR TITLE
chore: textfield prefix design feedback docs examples

### DIFF
--- a/packages/dev/s2-docs/pages/s2/NumberField.mdx
+++ b/packages/dev/s2-docs/pages/s2/NumberField.mdx
@@ -117,16 +117,35 @@ Use the `prefix` prop to display an additional element before the input in the n
 ```tsx render
 "use client";
 import {NumberField} from '@react-spectrum/s2/NumberField';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 function Example() {
   return (
-    <NumberField
-      label="Price"
-      /*- begin highlight -*/
-      prefix="USD"
-      /*- end highlight -*/
-      formatOptions={{style: 'currency', currency: 'USD', currencyDisplay: 'narrowSymbol'}}
-      placeholder="0.00" />
+    <div className={style({display: 'flex', flexDirection: 'column', gap: 8})}>
+      <div style={{font: 'title'}}>Dimensions</div>
+      <div className={style({display: 'flex', flexDirection: 'row', gap: 8})}>
+        <NumberField
+          aria-label="Width"
+          /*- begin highlight -*/
+          prefix="W"
+          /*- end highlight -*/
+          formatOptions={{style: 'unit', unit: 'inch'}}
+          defaultValue={10}
+          placeholder="0"
+          styles={style({width: 100})}
+          hideStepper />
+        <NumberField
+          aria-label="Height"
+          /*- begin highlight -*/
+          prefix="H"
+          /*- end highlight -*/
+          formatOptions={{style: 'unit', unit: 'inch'}}
+          defaultValue={10}
+          placeholder="0"
+          styles={style({width: 100})}
+          hideStepper />
+      </div>
+    </div>
   );
 }
 ```

--- a/packages/dev/s2-docs/pages/s2/TextField.mdx
+++ b/packages/dev/s2-docs/pages/s2/TextField.mdx
@@ -64,7 +64,6 @@ import {Avatar} from '@react-spectrum/s2/Avatar';
 function Example() {
   return (
     <div className={style({display: 'flex', flexDirection: 'column', gap: 8})}>
-      <TextField label="Phone Number" prefix="#" placeholder="(000) 000-0000" type="tel" />
       <TextField label="URL" prefix="https://" placeholder="example.com" />
       <TextField label="Mention" prefix={<MentionIcon />} placeholder="username" />
       <TextField label="User Email" prefix={<Avatar size={20} src="https://i.imgur.com/xIe7Wlb.png" />} placeholder="contact@example.com" />


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Design had feedback on the prefix examples for TextField and NumberField that they weren't realistic enough. This makes them more like how they envisioned it being used.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Docs examples weren't realistic enough and looked funny as a result. Go to TextField and NumberField and check that these looks reasonable.

## 🧢 Your Project:

<!--- Company/project for pull request -->
