### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/beta-docs.yaml
+++ b/.github/workflows/beta-docs.yaml
@@ -4,6 +4,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trigger-circleci:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,9 @@
 name: Manual nightly deploy
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   trigger-circleci:
     runs-on: ubuntu-latest

--- a/.github/workflows/prod-docs.yaml
+++ b/.github/workflows/prod-docs.yaml
@@ -4,6 +4,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trigger-circleci:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-chromatic.yml
+++ b/.github/workflows/weekly-chromatic.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 17 * * 1' # Monday 9am PST / 10am PDT (GH Actions cron is UTC)
   workflow_dispatch: # manual trigger for testing
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `weekly-api-diff.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.