### PR TITLE
fix: Make TSDiff not return recent formatting changes as API diffs

### DIFF
--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -209,18 +209,9 @@ jobs:
                 'Content-Type': 'application/json'
               }
             )
-            try:
-              print("Calling GitHub Models API...")
-              raw = urllib.request.urlopen(req).read()
-              summary = json.loads(raw)['choices'][0]['message']['content']
-              print("GitHub Models API: OK")
-            except urllib.error.HTTPError as e:
-              body = e.read().decode()
-              raise SystemExit(f"GitHub Models API error {e.code}: {body}")
+            summary = json.loads(urllib.request.urlopen(req).read())['choices'][0]['message']['content']
             message = f"📊 Weekly API Diff — {today}\n\n{summary}\n\nWhat's new this week: {delta_url}\nFull diff vs release: {diff_url}\n\nReact ✅ if changes look expected, or 🚨 if something looks wrong."
 
-          print(f"Posting to Slack channel: {channel}")
-          print(f"Slack token present: {bool(slack_token)}, length: {len(slack_token) if slack_token else 0}")
           req = urllib.request.Request(
             'https://slack.com/api/chat.postMessage',
             data=json.dumps({"channel": channel, "text": message}).encode(),
@@ -229,11 +220,7 @@ jobs:
               'Content-Type': 'application/json'
             }
           )
-          try:
-            resp = json.loads(urllib.request.urlopen(req).read())
-          except urllib.error.HTTPError as e:
-            body = e.read().decode()
-            raise SystemExit(f"Slack HTTP error {e.code}: {body}")
+          resp = json.loads(urllib.request.urlopen(req).read())
           print("Slack response:", resp.get('ok'), resp.get('error', ''))
           if not resp.get('ok'):
             raise SystemExit(f"Slack error: {resp.get('error')}")

--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -147,7 +147,7 @@ jobs:
             raise SystemExit(f"Missing required environment variables: {', '.join(missing)}")
 
           today = os.environ['TODAY']
-          channel = os.environ['SLACK_CHANNEL_ID']
+          channel = os.environ['TEST_SLACK_ID']
           snapshots_repo = os.environ['SNAPSHOTS_REPO']
           slack_token = os.environ['SLACK_TSDIFF_CHROMATIC_BOT_TOKEN']
           github_token = os.environ['GITHUB_TOKEN']

--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   weekly-api-diff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       SNAPSHOTS_REPO: LFDanLu/react-spectrum-api-snapshots
 

--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -148,7 +148,7 @@ jobs:
             raise SystemExit(f"Missing required environment variables: {', '.join(missing)}")
 
           today = os.environ['TODAY']
-          channel = os.environ['TEST_SLACK_ID']
+          channel = os.environ['SLACK_CHANNEL_ID']
           snapshots_repo = os.environ['SNAPSHOTS_REPO']
           slack_token = os.environ['SLACK_TSDIFF_CHROMATIC_BOT_TOKEN']
           github_token = os.environ['GITHUB_TOKEN']

--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      models: read
     env:
       SNAPSHOTS_REPO: LFDanLu/react-spectrum-api-snapshots
 

--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -208,9 +208,18 @@ jobs:
                 'Content-Type': 'application/json'
               }
             )
-            summary = json.loads(urllib.request.urlopen(req).read())['choices'][0]['message']['content']
+            try:
+              print("Calling GitHub Models API...")
+              raw = urllib.request.urlopen(req).read()
+              summary = json.loads(raw)['choices'][0]['message']['content']
+              print("GitHub Models API: OK")
+            except urllib.error.HTTPError as e:
+              body = e.read().decode()
+              raise SystemExit(f"GitHub Models API error {e.code}: {body}")
             message = f"📊 Weekly API Diff — {today}\n\n{summary}\n\nWhat's new this week: {delta_url}\nFull diff vs release: {diff_url}\n\nReact ✅ if changes look expected, or 🚨 if something looks wrong."
 
+          print(f"Posting to Slack channel: {channel}")
+          print(f"Slack token present: {bool(slack_token)}, length: {len(slack_token) if slack_token else 0}")
           req = urllib.request.Request(
             'https://slack.com/api/chat.postMessage',
             data=json.dumps({"channel": channel, "text": message}).encode(),
@@ -219,7 +228,11 @@ jobs:
               'Content-Type': 'application/json'
             }
           )
-          resp = json.loads(urllib.request.urlopen(req).read())
+          try:
+            resp = json.loads(urllib.request.urlopen(req).read())
+          except urllib.error.HTTPError as e:
+            body = e.read().decode()
+            raise SystemExit(f"Slack HTTP error {e.code}: {body}")
           print("Slack response:", resp.get('ok'), resp.get('error', ''))
           if not resp.get('ok'):
             raise SystemExit(f"Slack error: {resp.get('error')}")

--- a/scripts/compareAPIs.js
+++ b/scripts/compareAPIs.js
@@ -646,8 +646,23 @@ function rebuildInterfaces(json) {
   return exports;
 }
 
+// we need to normalize the api formatting since we added oxlint formatting that gets picked up as a diff
+// vs the past release which didn't have this formatting
+function normalizeDefault(val) {
+  let s = String(val);
+  // "foo" -> 'foo'
+  s = s.replace(/"([^"\\]*)"/g, "'$1'");
+  // {a,b} -> {a, b}
+  s = s.replace(/,(?!\s)/g, ', ');
+  // {a:1} -> {a: 1}
+  s = s.replace(/:(?!\s)/g, ': ');
+  // {a: 1} -> { a: 1 }
+  s = s.replace(/\{(\S)/g, '{ $1').replace(/(\S)\}/g, '$1 }');
+  return s;
+}
+
 function formatProp([name, prop]) {
-  return `  ${name}${prop.optional ? '?' : ''}: ${prop.value}${prop.defaultVal != null ? ` = ${prop.defaultVal}` : ''}`;
+  return `  ${name}${prop.optional ? '?' : ''}: ${prop.value}${prop.defaultVal != null ? ` = ${normalizeDefault(prop.defaultVal)}` : ''}`;
 }
 
 function formatInterfaces(interfaces, allInterfaces) {


### PR DESCRIPTION
Found when establishing a recent baseline off of https://github.com/adobe/react-spectrum/pull/10059 and the number of changes made it impossible to post to Slack. This just normalizes the TSDiff so that it follows the recent formatting changes made by oxlint, won't be necessary once we do another release

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

See https://github.com/LFDanLu/react-spectrum-api-snapshots/blob/main/deltas/2026-05-15.txt and see if that seems about right for changes since 5/4. Can also look at https://github.com/LFDanLu/react-spectrum-api-snapshots/blob/main/diffs/2026-05-15.txt for the full diff

## 🧢 Your Project:

RSP
