### PR TITLE
feat: S2 DnD docs and followups

### DIFF
--- a/.circleci/comment.js
+++ b/.circleci/comment.js
@@ -10,7 +10,7 @@ async function run() {
   let pr;
   // If we aren't running on a PR commit, double check if this is a branch created for a fork. If so, we'll need to
   // comment the build link on the fork.
-  if (true) {
+  if (!process.env.CIRCLE_PULL_REQUEST) {
     try {
       const commit = await octokit.git.getCommit({
         owner: 'adobe',
@@ -51,7 +51,7 @@ async function run() {
             break;
           }
         }
-      } else if (true) {
+      } else if (!process.env.CIRCLE_PULL_REQUEST) {
         // If it isn't a PR commit, then we are on main. Create a comment for the test app and docs build
         await octokit.repos.createCommitComment({
           owner: 'adobe',

--- a/.circleci/comment.js
+++ b/.circleci/comment.js
@@ -10,7 +10,7 @@ async function run() {
   let pr;
   // If we aren't running on a PR commit, double check if this is a branch created for a fork. If so, we'll need to
   // comment the build link on the fork.
-  if (!process.env.CIRCLE_PULL_REQUEST) {
+  if (true) {
     try {
       const commit = await octokit.git.getCommit({
         owner: 'adobe',
@@ -51,7 +51,7 @@ async function run() {
             break;
           }
         }
-      } else if (!process.env.CIRCLE_PULL_REQUEST) {
+      } else if (true) {
         // If it isn't a PR commit, then we are on main. Create a comment for the test app and docs build
         await octokit.repos.createCommitComment({
           owner: 'adobe',

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1049,9 +1049,6 @@ workflows:
             branches:
               only: main
       - verdaccio:
-          filters:
-            branches:
-              only: main
           requires:
             - install
       - v-rsp-cra-18:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1049,6 +1049,9 @@ workflows:
             branches:
               only: main
       - verdaccio:
+          filters:
+            branches:
+              only: main
           requires:
             - install
       - v-rsp-cra-18:

--- a/examples/s2-next-macros/src/app/page.tsx
+++ b/examples/s2-next-macros/src/app/page.tsx
@@ -15,13 +15,13 @@
 import React, {useState} from 'react';
 import '@react-spectrum/s2/page.css';
 import {
-  ActionBar,
   ActionButton,
   ActionButtonGroup,
   ActionMenu,
   Button,
   ButtonGroup,
   Cell,
+  Collection,
   Column,
   Content,
   ContextualHelpPopover,
@@ -48,7 +48,10 @@ import {
   TreeView,
   TreeViewItem,
   TreeViewItemContent,
-  UnavailableMenuItemTrigger
+  UnavailableMenuItemTrigger,
+  useDragAndDrop,
+  useListData,
+  useTreeData
 } from '@react-spectrum/s2';
 import Edit from '@react-spectrum/s2/icons/Edit';
 import FileTxt from '@react-spectrum/s2/icons/FileText';
@@ -59,6 +62,165 @@ import {CardViewExample} from './components/CardViewExample';
 import {CollectionCardsExample} from './components/CollectionCardsExample';
 
 const Lazy = React.lazy(() => import('./Lazy.js'));
+
+type TreeItemData = {id: string; name: string; childItems?: TreeItemData[]};
+
+let listItems = [
+  {id: 'photoshop', name: 'Adobe Photoshop'},
+  {id: 'xd', name: 'Adobe XD'},
+  {id: 'indesign', name: 'Adobe InDesign'},
+  {id: 'premiere', name: 'Adobe Premiere'},
+  {id: 'aftereffects', name: 'Adobe After Effects'}
+];
+
+let tableItems = [
+  {id: '1', name: 'Games', type: 'File folder', modified: '6/7/2020'},
+  {id: '2', name: 'Program Files', type: 'File folder', modified: '4/7/2021'},
+  {id: '3', name: 'bootmgr', type: 'System file', modified: '11/20/2010'},
+  {id: '4', name: 'log.txt', type: 'Text document', modified: '1/2/2022'},
+  {id: '5', name: 'readme.md', type: 'Text document', modified: '3/15/2023'}
+];
+
+let treeItems: TreeItemData[] = [
+  {id: 'photos', name: 'Photos'},
+  {
+    id: 'projects',
+    name: 'Projects',
+    childItems: [
+      {
+        id: 'projects-1',
+        name: 'Projects-1',
+        childItems: [{id: 'projects-1A', name: 'Projects-1A'}]
+      },
+      {id: 'projects-2', name: 'Projects-2'},
+      {id: 'projects-3', name: 'Projects-3'}
+    ]
+  }
+];
+
+function ReorderableListView() {
+  let list = useListData({initialItems: listItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key)!;
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <ListView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      items={list.items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {(item: any) => (
+        <ListViewItem textValue={item.name}>
+          <Text>{item.name}</Text>
+        </ListViewItem>
+      )}
+    </ListView>
+  );
+}
+
+function ReorderableTableView() {
+  let list = useListData({initialItems: tableItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key)!;
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TableView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Type</Column>
+        <Column>Date Modified</Column>
+      </TableHeader>
+      <TableBody items={list.items}>
+        {(item: any) => (
+          <Row id={item.id}>
+            <Cell>{item.name}</Cell>
+            <Cell>{item.type}</Cell>
+            <Cell>{item.modified}</Cell>
+          </Row>
+        )}
+      </TableBody>
+    </TableView>
+  );
+}
+
+function TreeItem({id, name, childItems}: TreeItemData) {
+  return (
+    <TreeViewItem id={id} textValue={name}>
+      <TreeViewItemContent>
+        <Text>{name}</Text>
+        {childItems?.length ? <Folder /> : <FileTxt />}
+      </TreeViewItemContent>
+      {childItems && childItems.length > 0 && (
+        <Collection items={childItems}>{(item: TreeItemData) => <TreeItem {...item} />}</Collection>
+      )}
+    </TreeViewItem>
+  );
+}
+
+function ReorderableTreeView() {
+  let treeData = useTreeData<TreeItemData>({
+    initialItems: treeItems,
+    getKey: item => item.id,
+    getChildren: item => item.childItems ?? []
+  });
+  let processItem = (node: any): TreeItemData => ({
+    ...node.value,
+    id: node.key as string,
+    childItems: node.children ? [...node.children].map(processItem) : undefined
+  });
+  let items = treeData.items.map(processItem);
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = treeData.getItem(key)!;
+        return {'text/plain': item.value.name};
+      }),
+    getAllowedDropOperations: () => ['move'],
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        treeData.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        treeData.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TreeView
+      aria-label="Reorderable tree"
+      items={items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {(item: TreeItemData) => <TreeItem {...item} />}
+    </TreeView>
+  );
+}
 
 function App() {
   let [isLazyLoaded, setLazyLoaded] = useState(false);
@@ -190,105 +352,9 @@ function App() {
               <MenuItem>Paste</MenuItem>
             </Menu>
           </MenuTrigger>
-          <ListView
-            aria-label="Files"
-            selectionMode="multiple"
-            styles={style({width: 320, height: 320})}>
-            <ListViewItem id="adobe-photoshop" textValue="Adobe Photoshop">
-              <Text>Adobe Photoshop</Text>
-              <Text slot="description">Image editing software</Text>
-            </ListViewItem>
-            <ListViewItem id="adobe-xd" textValue="Adobe XD">
-              <Text>Adobe XD</Text>
-              <Text slot="description">UI/UX design tool</Text>
-            </ListViewItem>
-            <ListViewItem id="adobe-indesign" textValue="Adobe InDesign">
-              <Text>Adobe InDesign</Text>
-              <Text slot="description">Desktop publishing</Text>
-            </ListViewItem>
-          </ListView>
-          <TableView
-            aria-label="Files"
-            styles={style({width: 320, height: 320})}
-            selectionMode="multiple"
-            renderActionBar={selectedKeys => (
-              <ActionBar>
-                <ActionButton onPress={() => console.log('edit', selectedKeys)}>Edit</ActionButton>
-                <ActionButton onPress={() => console.log('copy', selectedKeys)}>Copy</ActionButton>
-                <ActionButton onPress={() => console.log('delete', selectedKeys)}>
-                  Delete
-                </ActionButton>
-              </ActionBar>
-            )}>
-            <TableHeader>
-              <Column isRowHeader>Name</Column>
-              <Column>Type</Column>
-              <Column>Date Modified</Column>
-              <Column>A</Column>
-              <Column>B</Column>
-            </TableHeader>
-            <TableBody>
-              <Row id="1">
-                <Cell>Games</Cell>
-                <Cell>File folder</Cell>
-                <Cell>6/7/2020</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="2">
-                <Cell>Program Files</Cell>
-                <Cell>File folder</Cell>
-                <Cell>4/7/2021</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="3">
-                <Cell>bootmgr</Cell>
-                <Cell>System file</Cell>
-                <Cell>11/20/2010</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-            </TableBody>
-          </TableView>
-          <TreeView disabledKeys={['projects-1']} aria-label="test static tree">
-            <TreeViewItem id="Photos" textValue="Photos">
-              <TreeViewItemContent>
-                <Text>Photos</Text>
-                <Folder />
-              </TreeViewItemContent>
-            </TreeViewItem>
-            <TreeViewItem id="projects" textValue="Projects">
-              <TreeViewItemContent>
-                <Text>Projects</Text>
-                <Folder />
-              </TreeViewItemContent>
-              <TreeViewItem id="projects-1" textValue="Projects-1">
-                <TreeViewItemContent>
-                  <Text>Projects-1</Text>
-                  <Folder />
-                </TreeViewItemContent>
-                <TreeViewItem id="projects-1A" textValue="Projects-1A">
-                  <TreeViewItemContent>
-                    <Text>Projects-1A</Text>
-                    <FileTxt />
-                  </TreeViewItemContent>
-                </TreeViewItem>
-              </TreeViewItem>
-              <TreeViewItem id="projects-2" textValue="Projects-2">
-                <TreeViewItemContent>
-                  <Text>Projects-2</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-              <TreeViewItem id="projects-3" textValue="Projects-3">
-                <TreeViewItemContent>
-                  <Text>Projects-3</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-            </TreeViewItem>
-          </TreeView>
+          <ReorderableListView />
+          <ReorderableTableView />
+          <ReorderableTreeView />
         </Section>
 
         {!isLazyLoaded && (

--- a/examples/s2-parcel-example/src/App.js
+++ b/examples/s2-parcel-example/src/App.js
@@ -13,13 +13,13 @@
 import React, {useState} from 'react';
 import '@react-spectrum/s2/page.css';
 import {
-  ActionBar,
   ActionButton,
   ActionButtonGroup,
   ActionMenu,
   Button,
   ButtonGroup,
   Cell,
+  Collection,
   Column,
   Content,
   ContextualHelpPopover,
@@ -46,7 +46,10 @@ import {
   TreeView,
   TreeViewItem,
   TreeViewItemContent,
-  UnavailableMenuItemTrigger
+  UnavailableMenuItemTrigger,
+  useDragAndDrop,
+  useListData,
+  useTreeData
 } from '@react-spectrum/s2';
 import Edit from '@react-spectrum/s2/icons/Edit';
 import FileTxt from '@react-spectrum/s2/icons/FileText';
@@ -57,6 +60,163 @@ import {CardViewExample} from './components/CardViewExample';
 import {CollectionCardsExample} from './components/CollectionCardsExample';
 
 const Lazy = React.lazy(() => import('./Lazy'));
+
+let listItems = [
+  {id: 'photoshop', name: 'Adobe Photoshop'},
+  {id: 'xd', name: 'Adobe XD'},
+  {id: 'indesign', name: 'Adobe InDesign'},
+  {id: 'premiere', name: 'Adobe Premiere'},
+  {id: 'aftereffects', name: 'Adobe After Effects'}
+];
+
+let tableItems = [
+  {id: '1', name: 'Games', type: 'File folder', modified: '6/7/2020'},
+  {id: '2', name: 'Program Files', type: 'File folder', modified: '4/7/2021'},
+  {id: '3', name: 'bootmgr', type: 'System file', modified: '11/20/2010'},
+  {id: '4', name: 'log.txt', type: 'Text document', modified: '1/2/2022'},
+  {id: '5', name: 'readme.md', type: 'Text document', modified: '3/15/2023'}
+];
+
+let treeItems = [
+  {id: 'photos', name: 'Photos'},
+  {
+    id: 'projects',
+    name: 'Projects',
+    childItems: [
+      {
+        id: 'projects-1',
+        name: 'Projects-1',
+        childItems: [{id: 'projects-1A', name: 'Projects-1A'}]
+      },
+      {id: 'projects-2', name: 'Projects-2'},
+      {id: 'projects-3', name: 'Projects-3'}
+    ]
+  }
+];
+
+function ReorderableListView() {
+  let list = useListData({initialItems: listItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key);
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <ListView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      items={list.items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {item => (
+        <ListViewItem textValue={item.name}>
+          <Text>{item.name}</Text>
+        </ListViewItem>
+      )}
+    </ListView>
+  );
+}
+
+function ReorderableTableView() {
+  let list = useListData({initialItems: tableItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key);
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TableView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Type</Column>
+        <Column>Date Modified</Column>
+      </TableHeader>
+      <TableBody items={list.items}>
+        {item => (
+          <Row id={item.id}>
+            <Cell>{item.name}</Cell>
+            <Cell>{item.type}</Cell>
+            <Cell>{item.modified}</Cell>
+          </Row>
+        )}
+      </TableBody>
+    </TableView>
+  );
+}
+
+function TreeItem({id, name, childItems}) {
+  return (
+    <TreeViewItem id={id} textValue={name}>
+      <TreeViewItemContent>
+        <Text>{name}</Text>
+        {childItems?.length ? <Folder /> : <FileTxt />}
+      </TreeViewItemContent>
+      {childItems && childItems.length > 0 && (
+        <Collection items={childItems}>{item => <TreeItem {...item} />}</Collection>
+      )}
+    </TreeViewItem>
+  );
+}
+
+function ReorderableTreeView() {
+  let treeData = useTreeData({
+    initialItems: treeItems,
+    getKey: item => item.id,
+    getChildren: item => item.childItems ?? []
+  });
+  let processItem = node => ({
+    ...node.value,
+    id: node.key,
+    childItems: node.children ? [...node.children].map(processItem) : undefined
+  });
+  let items = treeData.items.map(processItem);
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = treeData.getItem(key);
+        return {'text/plain': item.value.name};
+      }),
+    getAllowedDropOperations: () => ['move'],
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        treeData.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        treeData.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TreeView
+      aria-label="Reorderable tree"
+      items={items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {item => <TreeItem {...item} />}
+    </TreeView>
+  );
+}
 
 function App() {
   let [isLazyLoaded, setLazyLoaded] = useState(false);
@@ -186,105 +346,9 @@ function App() {
               <MenuItem>Paste</MenuItem>
             </Menu>
           </MenuTrigger>
-          <ListView
-            aria-label="Files"
-            selectionMode="multiple"
-            styles={style({width: 320, height: 320})}>
-            <ListViewItem id="adobe-photoshop" textValue="Adobe Photoshop">
-              <Text>Adobe Photoshop</Text>
-              <Text slot="description">Image editing software</Text>
-            </ListViewItem>
-            <ListViewItem id="adobe-xd" textValue="Adobe XD">
-              <Text>Adobe XD</Text>
-              <Text slot="description">UI/UX design tool</Text>
-            </ListViewItem>
-            <ListViewItem id="adobe-indesign" textValue="Adobe InDesign">
-              <Text>Adobe InDesign</Text>
-              <Text slot="description">Desktop publishing</Text>
-            </ListViewItem>
-          </ListView>
-          <TableView
-            aria-label="Files"
-            styles={style({width: 320, height: 320})}
-            selectionMode="multiple"
-            renderActionBar={selectedKeys => (
-              <ActionBar>
-                <ActionButton onPress={() => console.log('edit', selectedKeys)}>Edit</ActionButton>
-                <ActionButton onPress={() => console.log('copy', selectedKeys)}>Copy</ActionButton>
-                <ActionButton onPress={() => console.log('delete', selectedKeys)}>
-                  Delete
-                </ActionButton>
-              </ActionBar>
-            )}>
-            <TableHeader>
-              <Column isRowHeader>Name</Column>
-              <Column>Type</Column>
-              <Column>Date Modified</Column>
-              <Column>A</Column>
-              <Column>B</Column>
-            </TableHeader>
-            <TableBody>
-              <Row id="1">
-                <Cell>Games</Cell>
-                <Cell>File folder</Cell>
-                <Cell>6/7/2020</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="2">
-                <Cell>Program Files</Cell>
-                <Cell>File folder</Cell>
-                <Cell>4/7/2021</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="3">
-                <Cell>bootmgr</Cell>
-                <Cell>System file</Cell>
-                <Cell>11/20/2010</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-            </TableBody>
-          </TableView>
-          <TreeView disabledKeys={['projects-1']} aria-label="test static tree">
-            <TreeViewItem id="Photos" textValue="Photos">
-              <TreeViewItemContent>
-                <Text>Photos</Text>
-                <Folder />
-              </TreeViewItemContent>
-            </TreeViewItem>
-            <TreeViewItem id="projects" textValue="Projects">
-              <TreeViewItemContent>
-                <Text>Projects</Text>
-                <Folder />
-              </TreeViewItemContent>
-              <TreeViewItem id="projects-1" textValue="Projects-1">
-                <TreeViewItemContent>
-                  <Text>Projects-1</Text>
-                  <Folder />
-                </TreeViewItemContent>
-                <TreeViewItem id="projects-1A" textValue="Projects-1A">
-                  <TreeViewItemContent>
-                    <Text>Projects-1A</Text>
-                    <FileTxt />
-                  </TreeViewItemContent>
-                </TreeViewItem>
-              </TreeViewItem>
-              <TreeViewItem id="projects-2" textValue="Projects-2">
-                <TreeViewItemContent>
-                  <Text>Projects-2</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-              <TreeViewItem id="projects-3" textValue="Projects-3">
-                <TreeViewItemContent>
-                  <Text>Projects-3</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-            </TreeViewItem>
-          </TreeView>
+          <ReorderableListView />
+          <ReorderableTableView />
+          <ReorderableTreeView />
         </Section>
 
         {!isLazyLoaded && (

--- a/examples/s2-vite-project/src/App.tsx
+++ b/examples/s2-vite-project/src/App.tsx
@@ -13,17 +13,19 @@
 import React, {useState} from 'react';
 import '@react-spectrum/s2/page.css';
 import {
-  ActionBar,
   ActionButton,
   ActionButtonGroup,
   ActionMenu,
   Button,
   ButtonGroup,
   Cell,
+  Collection,
   Column,
   Divider,
   Heading,
   LinkButton,
+  ListView,
+  ListViewItem,
   Menu,
   MenuItem,
   MenuTrigger,
@@ -41,7 +43,10 @@ import {
   ToggleButtonGroup,
   TreeView,
   TreeViewItem,
-  TreeViewItemContent
+  TreeViewItemContent,
+  useDragAndDrop,
+  useListData,
+  useTreeData
 } from '@react-spectrum/s2';
 import Edit from '@react-spectrum/s2/icons/Edit';
 import FileTxt from '@react-spectrum/s2/icons/FileText';
@@ -52,6 +57,165 @@ import {CardViewExample} from './components/CardViewExample';
 import {CollectionCardsExample} from './components/CollectionCardsExample';
 
 const Lazy = React.lazy(() => import('./Lazy'));
+
+type TreeItemData = {id: string; name: string; childItems?: TreeItemData[]};
+
+let listItems = [
+  {id: 'photoshop', name: 'Adobe Photoshop'},
+  {id: 'xd', name: 'Adobe XD'},
+  {id: 'indesign', name: 'Adobe InDesign'},
+  {id: 'premiere', name: 'Adobe Premiere'},
+  {id: 'aftereffects', name: 'Adobe After Effects'}
+];
+
+let tableItems = [
+  {id: '1', name: 'Games', type: 'File folder', modified: '6/7/2020'},
+  {id: '2', name: 'Program Files', type: 'File folder', modified: '4/7/2021'},
+  {id: '3', name: 'bootmgr', type: 'System file', modified: '11/20/2010'},
+  {id: '4', name: 'log.txt', type: 'Text document', modified: '1/2/2022'},
+  {id: '5', name: 'readme.md', type: 'Text document', modified: '3/15/2023'}
+];
+
+let treeItems: TreeItemData[] = [
+  {id: 'photos', name: 'Photos'},
+  {
+    id: 'projects',
+    name: 'Projects',
+    childItems: [
+      {
+        id: 'projects-1',
+        name: 'Projects-1',
+        childItems: [{id: 'projects-1A', name: 'Projects-1A'}]
+      },
+      {id: 'projects-2', name: 'Projects-2'},
+      {id: 'projects-3', name: 'Projects-3'}
+    ]
+  }
+];
+
+function ReorderableListView() {
+  let list = useListData({initialItems: listItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key)!;
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <ListView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      items={list.items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {(item: any) => (
+        <ListViewItem textValue={item.name}>
+          <Text>{item.name}</Text>
+        </ListViewItem>
+      )}
+    </ListView>
+  );
+}
+
+function ReorderableTableView() {
+  let list = useListData({initialItems: tableItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key)!;
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TableView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Type</Column>
+        <Column>Date Modified</Column>
+      </TableHeader>
+      <TableBody items={list.items}>
+        {(item: any) => (
+          <Row id={item.id}>
+            <Cell>{item.name}</Cell>
+            <Cell>{item.type}</Cell>
+            <Cell>{item.modified}</Cell>
+          </Row>
+        )}
+      </TableBody>
+    </TableView>
+  );
+}
+
+function TreeItem({id, name, childItems}: TreeItemData) {
+  return (
+    <TreeViewItem id={id} textValue={name}>
+      <TreeViewItemContent>
+        <Text>{name}</Text>
+        {childItems?.length ? <Folder /> : <FileTxt />}
+      </TreeViewItemContent>
+      {childItems && childItems.length > 0 && (
+        <Collection items={childItems}>{(item: TreeItemData) => <TreeItem {...item} />}</Collection>
+      )}
+    </TreeViewItem>
+  );
+}
+
+function ReorderableTreeView() {
+  let treeData = useTreeData<TreeItemData>({
+    initialItems: treeItems,
+    getKey: item => item.id,
+    getChildren: item => item.childItems ?? []
+  });
+  let processItem = (node: any): TreeItemData => ({
+    ...node.value,
+    id: node.key as string,
+    childItems: node.children ? [...node.children].map(processItem) : undefined
+  });
+  let items = treeData.items.map(processItem);
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = treeData.getItem(key)!;
+        return {'text/plain': item.value.name};
+      }),
+    getAllowedDropOperations: () => ['move'],
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        treeData.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        treeData.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TreeView
+      aria-label="Reorderable tree"
+      items={items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {(item: TreeItemData) => <TreeItem {...item} />}
+    </TreeView>
+  );
+}
 
 function App() {
   let [isLazyLoaded, setLazyLoaded] = useState(false);
@@ -177,88 +341,9 @@ function App() {
               <MenuItem>Paste</MenuItem>
             </Menu>
           </MenuTrigger>
-          <TableView
-            aria-label="Files"
-            styles={style({width: 320, height: 320})}
-            selectionMode="multiple"
-            renderActionBar={selectedKeys => (
-              <ActionBar>
-                <ActionButton onPress={() => console.log('edit', selectedKeys)}>Edit</ActionButton>
-                <ActionButton onPress={() => console.log('copy', selectedKeys)}>Copy</ActionButton>
-                <ActionButton onPress={() => console.log('delete', selectedKeys)}>
-                  Delete
-                </ActionButton>
-              </ActionBar>
-            )}>
-            <TableHeader>
-              <Column isRowHeader>Name</Column>
-              <Column>Type</Column>
-              <Column>Date Modified</Column>
-              <Column>A</Column>
-              <Column>B</Column>
-            </TableHeader>
-            <TableBody>
-              <Row id="1">
-                <Cell>Games</Cell>
-                <Cell>File folder</Cell>
-                <Cell>6/7/2020</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="2">
-                <Cell>Program Files</Cell>
-                <Cell>File folder</Cell>
-                <Cell>4/7/2021</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="3">
-                <Cell>bootmgr</Cell>
-                <Cell>System file</Cell>
-                <Cell>11/20/2010</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-            </TableBody>
-          </TableView>
-          <TreeView disabledKeys={['projects-1']} aria-label="test static tree">
-            <TreeViewItem id="Photos" textValue="Photos">
-              <TreeViewItemContent>
-                <Text>Photos</Text>
-                <Folder />
-              </TreeViewItemContent>
-            </TreeViewItem>
-            <TreeViewItem id="projects" textValue="Projects">
-              <TreeViewItemContent>
-                <Text>Projects</Text>
-                <Folder />
-              </TreeViewItemContent>
-              <TreeViewItem id="projects-1" textValue="Projects-1">
-                <TreeViewItemContent>
-                  <Text>Projects-1</Text>
-                  <Folder />
-                </TreeViewItemContent>
-                <TreeViewItem id="projects-1A" textValue="Projects-1A">
-                  <TreeViewItemContent>
-                    <Text>Projects-1A</Text>
-                    <FileTxt />
-                  </TreeViewItemContent>
-                </TreeViewItem>
-              </TreeViewItem>
-              <TreeViewItem id="projects-2" textValue="Projects-2">
-                <TreeViewItemContent>
-                  <Text>Projects-2</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-              <TreeViewItem id="projects-3" textValue="Projects-3">
-                <TreeViewItemContent>
-                  <Text>Projects-3</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-            </TreeViewItem>
-          </TreeView>
+          <ReorderableListView />
+          <ReorderableTableView />
+          <ReorderableTreeView />
         </Section>
 
         {!isLazyLoaded && (

--- a/examples/s2-webpack-5-example/src/App.js
+++ b/examples/s2-webpack-5-example/src/App.js
@@ -13,13 +13,13 @@
 import React, {useState} from 'react';
 import '@react-spectrum/s2/page.css';
 import {
-  ActionBar,
   ActionButton,
   ActionButtonGroup,
   ActionMenu,
   Button,
   ButtonGroup,
   Cell,
+  Collection,
   Column,
   Content,
   ContextualHelpPopover,
@@ -46,7 +46,10 @@ import {
   TreeView,
   TreeViewItem,
   TreeViewItemContent,
-  UnavailableMenuItemTrigger
+  UnavailableMenuItemTrigger,
+  useDragAndDrop,
+  useListData,
+  useTreeData
 } from '@react-spectrum/s2';
 import Edit from '@react-spectrum/s2/icons/Edit';
 import FileTxt from '@react-spectrum/s2/icons/FileText';
@@ -57,6 +60,163 @@ import {CardViewExample} from './components/CardViewExample';
 import {CollectionCardsExample} from './components/CollectionCardsExample';
 
 const Lazy = React.lazy(() => import('./Lazy'));
+
+let listItems = [
+  {id: 'photoshop', name: 'Adobe Photoshop'},
+  {id: 'xd', name: 'Adobe XD'},
+  {id: 'indesign', name: 'Adobe InDesign'},
+  {id: 'premiere', name: 'Adobe Premiere'},
+  {id: 'aftereffects', name: 'Adobe After Effects'}
+];
+
+let tableItems = [
+  {id: '1', name: 'Games', type: 'File folder', modified: '6/7/2020'},
+  {id: '2', name: 'Program Files', type: 'File folder', modified: '4/7/2021'},
+  {id: '3', name: 'bootmgr', type: 'System file', modified: '11/20/2010'},
+  {id: '4', name: 'log.txt', type: 'Text document', modified: '1/2/2022'},
+  {id: '5', name: 'readme.md', type: 'Text document', modified: '3/15/2023'}
+];
+
+let treeItems = [
+  {id: 'photos', name: 'Photos'},
+  {
+    id: 'projects',
+    name: 'Projects',
+    childItems: [
+      {
+        id: 'projects-1',
+        name: 'Projects-1',
+        childItems: [{id: 'projects-1A', name: 'Projects-1A'}]
+      },
+      {id: 'projects-2', name: 'Projects-2'},
+      {id: 'projects-3', name: 'Projects-3'}
+    ]
+  }
+];
+
+function ReorderableListView() {
+  let list = useListData({initialItems: listItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key);
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <ListView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      items={list.items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {item => (
+        <ListViewItem textValue={item.name}>
+          <Text>{item.name}</Text>
+        </ListViewItem>
+      )}
+    </ListView>
+  );
+}
+
+function ReorderableTableView() {
+  let list = useListData({initialItems: tableItems});
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = list.getItem(key);
+        return {'text/plain': item.name};
+      }),
+    onReorder(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TableView
+      aria-label="Reorderable files"
+      selectionMode="multiple"
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Type</Column>
+        <Column>Date Modified</Column>
+      </TableHeader>
+      <TableBody items={list.items}>
+        {item => (
+          <Row id={item.id}>
+            <Cell>{item.name}</Cell>
+            <Cell>{item.type}</Cell>
+            <Cell>{item.modified}</Cell>
+          </Row>
+        )}
+      </TableBody>
+    </TableView>
+  );
+}
+
+function TreeItem({id, name, childItems}) {
+  return (
+    <TreeViewItem id={id} textValue={name}>
+      <TreeViewItemContent>
+        <Text>{name}</Text>
+        {childItems?.length ? <Folder /> : <FileTxt />}
+      </TreeViewItemContent>
+      {childItems && childItems.length > 0 && (
+        <Collection items={childItems}>{item => <TreeItem {...item} />}</Collection>
+      )}
+    </TreeViewItem>
+  );
+}
+
+function ReorderableTreeView() {
+  let treeData = useTreeData({
+    initialItems: treeItems,
+    getKey: item => item.id,
+    getChildren: item => item.childItems ?? []
+  });
+  let processItem = node => ({
+    ...node.value,
+    id: node.key,
+    childItems: node.children ? [...node.children].map(processItem) : undefined
+  });
+  let items = treeData.items.map(processItem);
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys =>
+      [...keys].map(key => {
+        let item = treeData.getItem(key);
+        return {'text/plain': item.value.name};
+      }),
+    getAllowedDropOperations: () => ['move'],
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        treeData.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        treeData.moveAfter(e.target.key, e.keys);
+      }
+    }
+  });
+  return (
+    <TreeView
+      aria-label="Reorderable tree"
+      items={items}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 320, height: 320})}>
+      {item => <TreeItem {...item} />}
+    </TreeView>
+  );
+}
 
 function App() {
   let [isLazyLoaded, setLazyLoaded] = useState(false);
@@ -186,105 +346,9 @@ function App() {
               <MenuItem>Paste</MenuItem>
             </Menu>
           </MenuTrigger>
-          <ListView
-            aria-label="Files"
-            selectionMode="multiple"
-            styles={style({width: 320, height: 320})}>
-            <ListViewItem id="adobe-photoshop" textValue="Adobe Photoshop">
-              <Text>Adobe Photoshop</Text>
-              <Text slot="description">Image editing software</Text>
-            </ListViewItem>
-            <ListViewItem id="adobe-xd" textValue="Adobe XD">
-              <Text>Adobe XD</Text>
-              <Text slot="description">UI/UX design tool</Text>
-            </ListViewItem>
-            <ListViewItem id="adobe-indesign" textValue="Adobe InDesign">
-              <Text>Adobe InDesign</Text>
-              <Text slot="description">Desktop publishing</Text>
-            </ListViewItem>
-          </ListView>
-          <TableView
-            aria-label="Files"
-            styles={style({width: 320, height: 320})}
-            selectionMode="multiple"
-            renderActionBar={selectedKeys => (
-              <ActionBar>
-                <ActionButton onPress={() => console.log('edit', selectedKeys)}>Edit</ActionButton>
-                <ActionButton onPress={() => console.log('copy', selectedKeys)}>Copy</ActionButton>
-                <ActionButton onPress={() => console.log('delete', selectedKeys)}>
-                  Delete
-                </ActionButton>
-              </ActionBar>
-            )}>
-            <TableHeader>
-              <Column isRowHeader>Name</Column>
-              <Column>Type</Column>
-              <Column>Date Modified</Column>
-              <Column>A</Column>
-              <Column>B</Column>
-            </TableHeader>
-            <TableBody>
-              <Row id="1">
-                <Cell>Games</Cell>
-                <Cell>File folder</Cell>
-                <Cell>6/7/2020</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="2">
-                <Cell>Program Files</Cell>
-                <Cell>File folder</Cell>
-                <Cell>4/7/2021</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-              <Row id="3">
-                <Cell>bootmgr</Cell>
-                <Cell>System file</Cell>
-                <Cell>11/20/2010</Cell>
-                <Cell>Dummy content</Cell>
-                <Cell>Long long long long long long long cell</Cell>
-              </Row>
-            </TableBody>
-          </TableView>
-          <TreeView disabledKeys={['projects-1']} aria-label="test static tree">
-            <TreeViewItem id="Photos" textValue="Photos">
-              <TreeViewItemContent>
-                <Text>Photos</Text>
-                <Folder />
-              </TreeViewItemContent>
-            </TreeViewItem>
-            <TreeViewItem id="projects" textValue="Projects">
-              <TreeViewItemContent>
-                <Text>Projects</Text>
-                <Folder />
-              </TreeViewItemContent>
-              <TreeViewItem id="projects-1" textValue="Projects-1">
-                <TreeViewItemContent>
-                  <Text>Projects-1</Text>
-                  <Folder />
-                </TreeViewItemContent>
-                <TreeViewItem id="projects-1A" textValue="Projects-1A">
-                  <TreeViewItemContent>
-                    <Text>Projects-1A</Text>
-                    <FileTxt />
-                  </TreeViewItemContent>
-                </TreeViewItem>
-              </TreeViewItem>
-              <TreeViewItem id="projects-2" textValue="Projects-2">
-                <TreeViewItemContent>
-                  <Text>Projects-2</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-              <TreeViewItem id="projects-3" textValue="Projects-3">
-                <TreeViewItemContent>
-                  <Text>Projects-3</Text>
-                  <FileTxt />
-                </TreeViewItemContent>
-              </TreeViewItem>
-            </TreeViewItem>
-          </TreeView>
+          <ReorderableListView />
+          <ReorderableTableView />
+          <ReorderableTreeView />
         </Section>
 
         {!isLazyLoaded && (

--- a/packages/@react-spectrum/s2/src/DragPreview.tsx
+++ b/packages/@react-spectrum/s2/src/DragPreview.tsx
@@ -139,7 +139,7 @@ export interface DragPreviewProps {
   /** The overflow mode to be applied on the drag preview. */
   overflowMode?: 'wrap' | 'truncate';
   /**
-   * The contents of the drag preview. Supports the "label", "description", and "icon" slots.
+   * The contents of the drag preview. Supports the `label`, `description`, and `icon` slots.
    * If no children are provided, defaults to the first drag item's plain text content.
    */
   children?: ReactNode;

--- a/packages/@react-spectrum/s2/src/InsertionIndicator.tsx
+++ b/packages/@react-spectrum/s2/src/InsertionIndicator.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {DragAndDropContext, DropIndicator} from 'react-aria-components/useDragAndDrop';
+import {ItemDropTarget} from '@react-types/shared';
+import React, {useContext} from 'react';
+import {style} from '../style' with {type: 'macro'};
+
+let insertionIndicatorWrapper = style<{isDropTarget?: boolean; isRoot?: boolean}>({
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  marginStart: {
+    default: 'calc((var(--drop-level, 1) - 1) * var(--indent) + var(--indicator-level-padding))',
+    isRoot: 0
+  },
+  color: {
+    default: 'transparent',
+    isDropTarget: 'blue-800',
+    forcedColors: {
+      isDropTarget: 'Highlight'
+    }
+  },
+  '--indicator-circle-bg': {
+    type: 'backgroundColor',
+    value: {
+      default: 'transparent',
+      isDropTarget: 'gray-25',
+      forcedColors: {
+        isDropTarget: 'Background'
+      }
+    }
+  },
+  forcedColorAdjust: 'none'
+});
+
+export function InsertionIndicator({target}: {target: ItemDropTarget}) {
+  let {dropState} = useContext(DragAndDropContext) ?? {};
+  let level = 0;
+  if (target.type === 'item' && dropState?.collection) {
+    level = dropState.collection.getItem(target.key)?.level ?? 0;
+  }
+  return (
+    <DropIndicator className="" target={target}>
+      {({isDropTarget}) => (
+        <div
+          className={insertionIndicatorWrapper({isDropTarget, isRoot: level === 0})}
+          style={level > 0 ? ({'--drop-level': level} as React.CSSProperties) : undefined}>
+          <svg aria-hidden width="100%" height="12">
+            <line x1="0" y1="6" x2="100%" y2="6" strokeWidth="2" stroke="currentColor" />
+            <circle
+              cx="6"
+              cy="6"
+              r="5"
+              strokeWidth="2"
+              stroke="currentColor"
+              style={{fill: 'var(--indicator-circle-bg)'}}
+            />
+            <circle
+              cx="100%"
+              cy="6"
+              r="5"
+              strokeWidth="2"
+              stroke="currentColor"
+              style={{fill: 'var(--indicator-circle-bg)'}}
+              transform="translate(-6, 0)"
+            />
+          </svg>
+        </div>
+      )}
+    </DropIndicator>
+  );
+}

--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -57,7 +57,6 @@ import {
   LoadingState
 } from '@react-types/shared';
 import DragHandle from '../ui-icons/DragHandle';
-import {DropIndicator} from 'react-aria-components/useDragAndDrop';
 import {
   GridList,
   GridListItem,
@@ -69,6 +68,7 @@ import {
 } from 'react-aria-components/GridList';
 import {IconContext} from './Icon';
 import {ImageContext} from './Image';
+import {InsertionIndicator} from './InsertionIndicator';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
@@ -857,62 +857,6 @@ export let dragButton = style({
   }
 });
 
-let insertionIndicatorWrapper = style({
-  position: 'absolute',
-  inset: 0,
-  display: 'flex',
-  alignItems: 'center'
-});
-
-export let insertionIndicatorBar = style<{isDropTarget?: boolean}>({
-  flexGrow: 1,
-  height: 2,
-  backgroundColor: {
-    default: 'transparent',
-    isDropTarget: 'blue-800',
-    forcedColors: {
-      isDropTarget: 'Highlight'
-    }
-  },
-  borderBottomWidth: {
-    default: 0,
-    isDropTarget: 2
-  },
-  borderColor: {
-    isDropTarget: 'blue-800',
-    forcedColors: {
-      isDropTarget: 'Highlight'
-    }
-  },
-  forcedColorAdjust: 'none'
-});
-
-export let insertionIndicatorCircle = style<{isDropTarget: boolean}>({
-  width: 8,
-  height: 8,
-  borderRadius: 'full',
-  borderWidth: {
-    isDropTarget: 2
-  },
-  borderStyle: {
-    isDropTarget: 'solid'
-  },
-  borderColor: {
-    isDropTarget: 'blue-800',
-    forcedColors: {
-      isDropTarget: 'Highlight'
-    }
-  },
-  backgroundColor: {
-    isDropTarget: 'gray-25',
-    forcedColors: {
-      default: 'transparent',
-      isDropTarget: 'Background'
-    }
-  },
-  forcedColorAdjust: 'none'
-});
-
 const centeredWrapper = style({
   display: 'flex',
   alignItems: 'center',
@@ -934,20 +878,6 @@ const emptyStateWrapper = style({
   boxSizing: 'border-box',
   padding: 16
 });
-
-export function InsertionIndicator({target}: {target: ItemDropTarget}) {
-  return (
-    <DropIndicator className="" target={target}>
-      {({isDropTarget}) => (
-        <div className={insertionIndicatorWrapper}>
-          <div className={insertionIndicatorCircle({isDropTarget})} />
-          <div className={insertionIndicatorBar({isDropTarget})} />
-          <div className={insertionIndicatorCircle({isDropTarget})} />
-        </div>
-      )}
-    </DropIndicator>
-  );
-}
 
 function ListSelectionCheckbox({isDisabled}: {isDisabled: boolean}) {
   let selectionContext = useSlottedContext(CheckboxContext, 'selection');

--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -828,7 +828,7 @@ let dragButtonContainer = style({
   width: 10
 });
 
-let dragButton = style<{isFocusVisible?: boolean}>({
+export let dragButton = style({
   color: 'inherit',
   display: 'flex',
   alignItems: 'center',

--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -21,7 +21,6 @@ import {
   space,
   style
 } from '../style' with {type: 'macro'};
-import {Button} from 'react-aria-components/Button';
 import {centerBaseline} from './CenterBaseline';
 import {Checkbox} from './Checkbox';
 import {CheckboxContext} from 'react-aria-components/Checkbox';
@@ -56,7 +55,7 @@ import {
   ItemDropTarget,
   LoadingState
 } from '@react-types/shared';
-import DragHandle from '../ui-icons/DragHandle';
+import {DragHandleButton, InsertionIndicator} from './dnd-utils';
 import {
   GridList,
   GridListItem,
@@ -68,7 +67,6 @@ import {
 } from 'react-aria-components/GridList';
 import {IconContext} from './Icon';
 import {ImageContext} from './Image';
-import {InsertionIndicator} from './InsertionIndicator';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
@@ -80,12 +78,10 @@ import {ProgressCircle} from './ProgressCircle';
 import {Text, TextContext} from './Content';
 import {useActionBarContainer} from './ActionBar';
 import {useDOMRef} from './useDOMRef';
-import {useFocusRing} from 'react-aria/useFocusRing';
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useScale} from './utils';
 import {useSpectrumContextProps} from './useSpectrumContextProps';
-import {useVisuallyHidden} from 'react-aria/VisuallyHidden';
 
 export interface ListViewProps<T>
   extends
@@ -828,35 +824,6 @@ let dragButtonContainer = style({
   width: 10
 });
 
-export let dragButton = style({
-  color: 'inherit',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  // TODO: arbitrary, basically taken from v3
-  height: 22,
-  width: 10,
-  padding: 0,
-  margin: 0,
-  backgroundColor: 'transparent',
-  borderStyle: 'none',
-  borderRadius: 'sm',
-  // TODO: this mimicks v3 too, do we want halo focus ring?
-  outlineStyle: {
-    default: 'none',
-    isFocusVisible: 'solid'
-  },
-  outlineColor: {
-    default: 'focus-ring',
-    forcedColors: 'Highlight'
-  },
-  outlineWidth: 2,
-  '--iconPrimary': {
-    type: 'fill',
-    value: 'currentColor'
-  }
-});
-
 const centeredWrapper = style({
   display: 'flex',
   alignItems: 'center',
@@ -905,10 +872,6 @@ export function ListViewItem(props: ListViewItemProps): ReactNode {
     props.textValue || (typeof props.children === 'string' ? props.children : undefined);
   let {direction} = useLocale();
   let hasTrailingIcon = hasChildItems || (isLinkOut && !hideLinkOutIcon);
-  let {visuallyHiddenProps} = useVisuallyHidden();
-  let {isFocusVisible: isFocusVisibleWithin, focusProps: focusWithinProps} = useFocusRing({
-    within: true
-  });
 
   return (
     <GridListItem
@@ -939,7 +902,7 @@ export function ListViewItem(props: ListViewItemProps): ReactNode {
           id,
           state,
           allowsDragging,
-          isFocusVisible
+          isFocusVisibleWithin
         } = renderProps;
         return (
           <Provider
@@ -984,7 +947,7 @@ export function ListViewItem(props: ListViewItemProps): ReactNode {
                 }
               ]
             ]}>
-            <div className={rowWrapper} {...focusWithinProps}>
+            <div className={rowWrapper}>
               <div
                 className={listRowBackground({
                   ...renderProps,
@@ -1016,18 +979,7 @@ export function ListViewItem(props: ListViewItemProps): ReactNode {
               )}
               {allowsDragging && (
                 <div className={dragButtonContainer}>
-                  {!isDisabled && (
-                    <Button
-                      slot="drag"
-                      style={
-                        !isFocusVisibleWithin && !isFocusVisible
-                          ? {...visuallyHiddenProps.style}
-                          : {}
-                      }
-                      className={dragButton}>
-                      <DragHandle size="M" />
-                    </Button>
-                  )}
+                  {!isDisabled && <DragHandleButton isFocusVisibleWithin={isFocusVisibleWithin} />}
                 </div>
               )}
               {selectionMode !== 'none' && selectionBehavior === 'toggle' && (

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -81,7 +81,7 @@ import {
   LoadingState,
   Node
 } from '@react-types/shared';
-import DragHandle from '../ui-icons/DragHandle';
+import {DragHandleButton} from './dnd-utils';
 import {DragPreview} from './DragPreview';
 import {Form} from 'react-aria-components/Form';
 import {
@@ -92,7 +92,7 @@ import {
 import {getOwnerDocument} from 'react-aria/private/utils/domHelpers';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {IconContext} from './Icon';
-import {InsertionIndicator} from './InsertionIndicator';
+import {InsertionIndicator} from './dnd-utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
@@ -1305,61 +1305,10 @@ const dragCellStyle = style({
   ...stickyCell,
   paddingStart: 4,
   paddingEnd: 4,
-  display: 'flex',
   alignContent: 'center',
-  alignItems: 'center',
   height: 'calc(100% - 1px)',
   borderBottomWidth: 0,
   backgroundColor: '--rowBackgroundColor'
-});
-
-const dragButton = style({
-  color: 'inherit',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: 0,
-  backgroundColor: 'transparent',
-  borderStyle: 'none',
-  borderRadius: 'sm',
-  outlineStyle: {
-    default: 'none',
-    isFocusVisible: 'solid'
-  },
-  outlineColor: {
-    default: 'focus-ring',
-    forcedColors: 'Highlight'
-  },
-  outlineWidth: 2,
-  '--iconPrimary': {
-    type: 'fill',
-    value: 'currentColor'
-  },
-  // note that this doesn't have clip or clipPath, but this seems to be sufficient
-  height: {
-    default: 1,
-    ':is([role="row"][data-focus-visible-within] *)': 22
-  },
-  width: {
-    default: 1,
-    ':is([role="row"][data-focus-visible-within] *)': 10
-  },
-  margin: {
-    default: '[-1]',
-    ':is([role="row"][data-focus-visible-within] *)': 0
-  },
-  overflow: {
-    default: 'hidden',
-    ':is([role="row"][data-focus-visible-within] *)': 'visible'
-  },
-  position: {
-    default: 'absolute',
-    ':is([role="row"][data-focus-visible-within] *)': 'relative'
-  },
-  whiteSpace: {
-    default: 'nowrap',
-    ':is([role="row"][data-focus-visible-within] *)': 'normal'
-  }
 });
 
 const cellContent = style({
@@ -2233,14 +2182,16 @@ export const Row = /*#__PURE__*/ (forwardRef as forwardRefType)(function Row<T>(
       }
       {...otherProps}>
       {allowsDragging && (
-        // @ts-ignore
-        <Cell isSticky className={dragCellStyle}>
-          {!(otherProps.isDisabled && tableVisualOptions.disabledBehavior === 'all') && (
-            <Button slot="drag" className={dragButton}>
-              <DragHandle size="M" />
-            </Button>
-          )}
-        </Cell>
+        <RACCell
+          // @ts-ignore
+          isSticky
+          className={dragCellStyle}>
+          {({isFocusVisibleWithinRow}) =>
+            !(otherProps.isDisabled && tableVisualOptions.disabledBehavior === 'all') && (
+              <DragHandleButton isFocusVisibleWithin={isFocusVisibleWithinRow} />
+            )
+          }
+        </RACCell>
       )}
       {selectionMode !== 'none' &&
         selectionBehavior === 'toggle' &&

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1305,7 +1305,9 @@ const dragCellStyle = style({
   ...stickyCell,
   paddingStart: 4,
   paddingEnd: 4,
+  display: 'flex',
   alignContent: 'center',
+  alignItems: 'center',
   height: 'calc(100% - 1px)',
   borderBottomWidth: 0,
   backgroundColor: '--rowBackgroundColor'

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -92,7 +92,7 @@ import {
 import {getOwnerDocument} from 'react-aria/private/utils/domHelpers';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {IconContext} from './Icon';
-import {InsertionIndicator} from './ListView';
+import {InsertionIndicator} from './InsertionIndicator';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
@@ -299,7 +299,19 @@ const table = style<
       isCheckboxSelection: 56
     }
   },
-  forcedColorAdjust: 'none'
+  forcedColorAdjust: 'none',
+  '--indicator-level-padding': {
+    type: 'width',
+    value: {
+      // 16 (drag cell width) + 14 (chevron start padding + half of chevron (5) - radius of drop indicator circle (6) - 1 (fudge factor)) + 40 (checkbox cell width)
+      default: 30,
+      isCheckboxSelection: 71
+    }
+  },
+  '--indent': {
+    type: 'width',
+    value: 16
+  }
 });
 
 // component-height-100
@@ -503,7 +515,6 @@ export const TableView = forwardRef(function TableView(
   let scrollRef = useRef<HTMLElement | null>(null);
   let isCheckboxSelection = selectionMode === 'multiple' || selectionMode === 'single';
   let isDragAndDrop = !!dragAndDropHooks?.useDraggableCollectionState;
-
   let {selectedKeys, onSelectionChange, actionBar, actionBarHeight} = useActionBarContainer({
     ...props,
     scrollRef
@@ -1227,10 +1238,6 @@ const commonCellStyles = {
 } as const;
 
 const treeColumnStyles = {
-  '--indent': {
-    type: 'width',
-    value: 16
-  },
   '--treeColumnPadding': {
     type: 'width',
     value: {

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1286,23 +1286,6 @@ const stickyCell = {
   backgroundColor: 'gray-25'
 } as const;
 
-// The sticky checkbox cell covers/maskes the rest of the row's content when it is scrolled under it
-// because of that it is full height but thus covers the "on" drop styling applied on the row
-// to address this we apply the same kind of box shadow to the cells
-const rowDropTargetStickyOutline = {
-  boxShadow: {
-    default: 'none',
-    ':is([role="row"][data-drop-target] *)': {
-      default: `[inset 0 2px 0 0 ${color('blue-800')}, inset 0 -2px 0 0 ${color('blue-800')}]`,
-      forcedColors: '[inset 0 2px 0 0 Highlight, inset 0 -2px 0 0 Highlight]'
-    },
-    ':is([role="row"][data-focus-visible] *)': {
-      forcedColors: '[inset 0 2px 0 0 Highlight, inset 0 -2px 0 0 Highlight]'
-    }
-  }
-} as const;
-
-
 const checkboxCellStyle = style({
   ...commonCellStyles,
   ...stickyCell,

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -81,7 +81,7 @@ import {
   LoadingState,
   Node
 } from '@react-types/shared';
-import {DragHandleButton} from './dnd-utils';
+import {DragHandleButton, InsertionIndicator} from './dnd-utils';
 import {DragPreview} from './DragPreview';
 import {Form} from 'react-aria-components/Form';
 import {
@@ -92,7 +92,6 @@ import {
 import {getOwnerDocument} from 'react-aria/private/utils/domHelpers';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {IconContext} from './Icon';
-import {InsertionIndicator} from './dnd-utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1279,6 +1279,23 @@ const stickyCell = {
   backgroundColor: 'gray-25'
 } as const;
 
+// The sticky checkbox cell covers/maskes the rest of the row's content when it is scrolled under it
+// because of that it is full height but thus covers the "on" drop styling applied on the row
+// to address this we apply the same kind of box shadow to the cells
+const rowDropTargetStickyOutline = {
+  boxShadow: {
+    default: 'none',
+    ':is([role="row"][data-drop-target] *)': {
+      default: `[inset 0 2px 0 0 ${color('blue-800')}, inset 0 -2px 0 0 ${color('blue-800')}]`,
+      forcedColors: '[inset 0 2px 0 0 Highlight, inset 0 -2px 0 0 Highlight]'
+    },
+    ':is([role="row"][data-focus-visible] *)': {
+      forcedColors: '[inset 0 2px 0 0 Highlight, inset 0 -2px 0 0 Highlight]'
+    }
+  }
+} as const;
+
+
 const checkboxCellStyle = style({
   ...commonCellStyles,
   ...stickyCell,

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -33,15 +33,7 @@ import {
   Key,
   LoadingState
 } from '@react-types/shared';
-import {DragAndDropContext, DropIndicator} from 'react-aria-components/useDragAndDrop';
-import {
-  dragButton,
-  insertionIndicatorBar,
-  insertionIndicatorCircle,
-  isFirstItem,
-  isPrevSelected,
-  S2ListLayout
-} from './ListView';
+import {dragButton, isFirstItem, isPrevSelected, S2ListLayout} from './ListView';
 import DragHandle from '../ui-icons/DragHandle';
 import {DragPreview} from './DragPreview';
 import {
@@ -50,6 +42,7 @@ import {
   UnsafeStyles
 } from './style-utils' with {type: 'macro'};
 import {IconContext} from './Icon';
+import {InsertionIndicator} from './InsertionIndicator';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ProgressCircle} from './ProgressCircle';
@@ -237,38 +230,6 @@ const tree = style<TreeRenderProps>({
 
 let InternalTreeViewContext = createContext<{selectionStyle?: 'highlight' | 'checkbox'}>({});
 
-const insertionIndicatorWrapper = style({
-  position: 'absolute',
-  inset: 0,
-  display: 'flex',
-  alignItems: 'center',
-  marginStart: {
-    default:
-      'calc((var(--tree-item-level, 1) - 1) * var(--indent) + var(--indicator-level-padding, 0px))',
-    isRoot: 0
-  }
-});
-
-function TreeInsertionIndicator({target}: {target: ItemDropTarget}) {
-  let {dropState} = useContext(DragAndDropContext) ?? {};
-  let level = 0;
-  if (target.type === 'item' && dropState?.collection) {
-    level = dropState.collection.getItem(target.key)?.level ?? 0;
-  }
-
-  return (
-    <DropIndicator className="" target={target}>
-      {({isDropTarget}) => (
-        <div className={insertionIndicatorWrapper({isRoot: level === 0})}>
-          <div className={insertionIndicatorCircle({isDropTarget})} />
-          <div className={insertionIndicatorBar({isDropTarget})} />
-          <div className={insertionIndicatorCircle({isDropTarget})} />
-        </div>
-      )}
-    </DropIndicator>
-  );
-}
-
 /**
  * A tree view provides users with a way to navigate nested hierarchical information.
  */
@@ -293,7 +254,7 @@ export const TreeView = /*#__PURE__*/ (forwardRef as forwardRefType)(function Tr
 
   if (dragAndDropHooks) {
     dragAndDropHooks.renderDropIndicator = target => (
-      <TreeInsertionIndicator target={target as ItemDropTarget} />
+      <InsertionIndicator target={target as ItemDropTarget} />
     );
   }
   let renderer;

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -33,8 +33,7 @@ import {
   Key,
   LoadingState
 } from '@react-types/shared';
-import {dragButton, S2ListLayout} from './ListView';
-import DragHandle from '../ui-icons/DragHandle';
+import {DragHandleButton} from './dnd-utils';
 import {DragPreview} from './DragPreview';
 import {
   getAllowedOverrides,
@@ -42,7 +41,7 @@ import {
   UnsafeStyles
 } from './style-utils' with {type: 'macro'};
 import {IconContext} from './Icon';
-import {InsertionIndicator} from './InsertionIndicator';
+import {InsertionIndicator} from './dnd-utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ProgressCircle} from './ProgressCircle';
@@ -68,6 +67,7 @@ import React, {
   useContext,
   useRef
 } from 'react';
+import {S2ListLayout} from './ListView';
 import {Text, TextContext} from './Content';
 import {TreeState} from 'react-stately/useTreeState';
 import {useActionBarContainer} from './ActionBar';
@@ -75,7 +75,6 @@ import {useDOMRef} from './useDOMRef';
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useScale} from './utils';
-import {useVisuallyHidden} from 'react-aria/VisuallyHidden';
 import {Virtualizer} from 'react-aria-components/Virtualizer';
 
 interface S2TreeProps {
@@ -620,7 +619,6 @@ export const TreeViewItemContent = (props: TreeViewItemContentProps): ReactNode 
   let scale = useScale();
 
   let {selectionStyle} = useContext(InternalTreeViewContext);
-  let {visuallyHiddenProps} = useVisuallyHidden();
 
   return (
     <TreeItemContent>
@@ -671,16 +669,7 @@ export const TreeViewItemContent = (props: TreeViewItemContentProps): ReactNode 
             )}
             {allowsDragging && (
               <div className={treeDragButtonContainer}>
-                {!isDisabled && (
-                  <Button
-                    slot="drag"
-                    style={
-                      !isFocusVisibleWithin && !isFocusVisible ? {...visuallyHiddenProps.style} : {}
-                    }
-                    className={dragButton}>
-                    <DragHandle size="M" />
-                  </Button>
-                )}
+                {!isDisabled && <DragHandleButton isFocusVisibleWithin={isFocusVisibleWithin} />}
               </div>
             )}
             {selectionMode !== 'none' &&

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -34,6 +34,14 @@ import {
   LoadingState
 } from '@react-types/shared';
 import {DragAndDropContext, DropIndicator} from 'react-aria-components/useDragAndDrop';
+import {
+  dragButton,
+  insertionIndicatorBar,
+  insertionIndicatorCircle,
+  isFirstItem,
+  isPrevSelected,
+  S2ListLayout
+} from './ListView';
 import DragHandle from '../ui-icons/DragHandle';
 import {DragPreview} from './DragPreview';
 import {
@@ -42,7 +50,6 @@ import {
   UnsafeStyles
 } from './style-utils' with {type: 'macro'};
 import {IconContext} from './Icon';
-import {insertionIndicatorBar, insertionIndicatorCircle, S2ListLayout} from './ListView';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ProgressCircle} from './ProgressCircle';
@@ -582,33 +589,6 @@ const treeDragButtonContainer = style({
   width: 10
 });
 
-const treeDragButton = style({
-  color: 'inherit',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  height: 22,
-  width: 10,
-  padding: 0,
-  margin: 0,
-  backgroundColor: 'transparent',
-  borderStyle: 'none',
-  borderRadius: 'sm',
-  outlineStyle: {
-    default: 'none',
-    isFocusVisible: 'solid'
-  },
-  outlineColor: {
-    default: 'focus-ring',
-    forcedColors: 'Highlight'
-  },
-  outlineWidth: 2,
-  '--iconPrimary': {
-    type: 'fill',
-    value: 'currentColor'
-  }
-});
-
 let treeRowFocusRing = style({
   ...focusRing(),
   outlineOffset: {
@@ -736,7 +716,7 @@ export const TreeViewItemContent = (props: TreeViewItemContentProps): ReactNode 
                     style={
                       !isFocusVisibleWithin && !isFocusVisible ? {...visuallyHiddenProps.style} : {}
                     }
-                    className={treeDragButton}>
+                    className={dragButton}>
                     <DragHandle size="M" />
                   </Button>
                 )}

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -155,7 +155,7 @@ const treeViewWrapper = style(
     },
     '--root-drop-radius': {
       type: 'borderTopStartRadius',
-      value: 'default'
+      value: 'sm'
     }
   },
   getAllowedOverrides({height: true})
@@ -444,8 +444,6 @@ const treeRowBackground = style({
   backgroundColor: {
     default: '--rowBackgroundColor',
     forcedColors: 'Background',
-    ':is([role="treegrid"][data-drop-target] *)': rootRowDropStyles,
-    isDropTarget: rowDropStyles,
     selectionStyle: {
       highlight: {
         default: '--rowBackgroundColor',
@@ -457,7 +455,9 @@ const treeRowBackground = style({
           forcedColors: 'Highlight'
         }
       }
-    }
+    },
+    ':is([role="treegrid"][data-drop-target] *)': rootRowDropStyles,
+    isDropTarget: rowDropStyles
   },
   borderTopStartRadius: {
     default: '--borderRadiusTreeItem',

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -33,7 +33,7 @@ import {
   Key,
   LoadingState
 } from '@react-types/shared';
-import {DragHandleButton} from './dnd-utils';
+import {DragHandleButton, InsertionIndicator} from './dnd-utils';
 import {DragPreview} from './DragPreview';
 import {
   getAllowedOverrides,
@@ -41,7 +41,6 @@ import {
   UnsafeStyles
 } from './style-utils' with {type: 'macro'};
 import {IconContext} from './Icon';
-import {InsertionIndicator} from './dnd-utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ProgressCircle} from './ProgressCircle';

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -33,7 +33,7 @@ import {
   Key,
   LoadingState
 } from '@react-types/shared';
-import {dragButton, isFirstItem, isPrevSelected, S2ListLayout} from './ListView';
+import {dragButton, S2ListLayout} from './ListView';
 import DragHandle from '../ui-icons/DragHandle';
 import {DragPreview} from './DragPreview';
 import {

--- a/packages/@react-spectrum/s2/src/dnd-utils.tsx
+++ b/packages/@react-spectrum/s2/src/dnd-utils.tsx
@@ -10,10 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+import {Button} from 'react-aria-components/Button';
 import {DragAndDropContext, DropIndicator} from 'react-aria-components/useDragAndDrop';
+import DragHandle from '../ui-icons/DragHandle';
 import {ItemDropTarget} from '@react-types/shared';
 import React, {useContext} from 'react';
 import {style} from '../style' with {type: 'macro'};
+import {useVisuallyHidden} from 'react-aria/VisuallyHidden';
 
 let insertionIndicatorWrapper = style<{isDropTarget?: boolean; isRoot?: boolean}>({
   position: 'absolute',
@@ -79,5 +82,46 @@ export function InsertionIndicator({target}: {target: ItemDropTarget}) {
         </div>
       )}
     </DropIndicator>
+  );
+}
+
+let dragButton = style({
+  color: 'inherit',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  // TODO: arbitrary, basically taken from v3
+  height: 22,
+  width: 10,
+  padding: 0,
+  margin: 0,
+  backgroundColor: 'transparent',
+  borderStyle: 'none',
+  borderRadius: 'sm',
+  // TODO: this mimicks v3 too, do we want halo focus ring?
+  outlineStyle: {
+    default: 'none',
+    isFocusVisible: 'solid'
+  },
+  outlineColor: {
+    default: 'focus-ring',
+    forcedColors: 'Highlight'
+  },
+  outlineWidth: 2,
+  '--iconPrimary': {
+    type: 'fill',
+    value: 'currentColor'
+  }
+});
+
+export function DragHandleButton({isFocusVisibleWithin}: {isFocusVisibleWithin: boolean}) {
+  let {visuallyHiddenProps} = useVisuallyHidden();
+  return (
+    <Button
+      slot="drag"
+      style={!isFocusVisibleWithin ? visuallyHiddenProps.style : {}}
+      className={dragButton}>
+      <DragHandle size="M" />
+    </Button>
   );
 }

--- a/packages/@react-spectrum/s2/stories/ListView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/ListView.stories.tsx
@@ -46,7 +46,8 @@ const meta: Meta<typeof ListView> = {
   tags: ['autodocs'],
   argTypes: {
     ...categorizeArgTypes('Events', ['onSelectionChange']),
-    children: {table: {disable: true}}
+    children: {table: {disable: true}},
+    dragAndDropHooks: {table: {disable: true}}
   },
   title: 'ListView',
   args: {

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -68,6 +68,7 @@ const meta: Meta<typeof TableView> = {
   argTypes: {
     ...categorizeArgTypes('Events', ['onAction', 'onLoadMore', ...events]),
     children: {table: {disable: true}},
+    dragAndDropHooks: {table: {disable: true}},
     onAction: {
       options: Object.keys(onActionOptions), // An array of serializable values
       mapping: onActionOptions, // Maps serializable option values to complex arg values

--- a/packages/@react-spectrum/s2/stories/TableView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TableView.stories.tsx
@@ -2391,6 +2391,105 @@ export const DragAndDropReorder: StoryObj<typeof TableView> = {
   name: 'Drag and drop reorder'
 };
 
+function ReorderableTableWithNested(props) {
+  let tree = useTreeData({
+    initialItems: [
+      {
+        id: '1',
+        title: 'Documents',
+        type: 'Directory',
+        date: '10/20/2025',
+        children: [
+          {
+            id: '2',
+            title: 'Project',
+            type: 'Directory',
+            date: '8/2/2025',
+            children: [
+              {id: '3', title: 'Weekly Report', type: 'File', date: '7/10/2025', children: []},
+              {id: '4', title: 'Budget', type: 'File', date: '8/20/2025', children: []}
+            ]
+          }
+        ]
+      },
+      {
+        id: '5',
+        title: 'Photos',
+        type: 'Directory',
+        date: '2/3/2026',
+        children: [
+          {id: '6', title: 'Image 1', type: 'File', date: '1/23/2026', children: []},
+          {id: '7', title: 'Image 2', type: 'File', date: '2/3/2026', children: []}
+        ]
+      }
+    ]
+  });
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: (keys, items: typeof tree.items) =>
+      items.map(item => ({'text/plain': item.value.title, type: item.value.type})),
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        tree.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        tree.moveAfter(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'on') {
+        let targetNode = tree.getItem(e.target.key);
+        if (targetNode) {
+          let targetIndex = targetNode.children ? targetNode.children.length : 0;
+          let keyArray = Array.from(e.keys);
+          for (let i = 0; i < keyArray.length; i++) {
+            tree.move(keyArray[i], e.target.key, targetIndex + i);
+          }
+        }
+      }
+    },
+    renderDragPreview: items => (
+      <DragPreview items={items}>
+        {items[0].type === 'Directory' ? <Folder /> : <FileText />}
+        <Text>{items[0]['text/plain']}</Text>
+        <Text slot="description">{items[0].type}</Text>
+      </DragPreview>
+    )
+  });
+
+  return (
+    <TableView
+      aria-label="Files"
+      selectionMode="multiple"
+      treeColumn="name"
+      defaultExpandedKeys={['5']}
+      dragAndDropHooks={dragAndDropHooks}
+      styles={style({width: 400})}
+      {...props}>
+      <TableHeader>
+        <Column id="name" isRowHeader>
+          Name
+        </Column>
+        <Column id="type">Type</Column>
+        <Column id="date">Date Modified</Column>
+      </TableHeader>
+      <TableBody items={tree.items}>
+        {function renderItem(item) {
+          return (
+            <Row id={item.key}>
+              <Cell>{item.value.title}</Cell>
+              <Cell>{item.value.type}</Cell>
+              <Cell>{item.value.date}</Cell>
+              <Collection items={item.children ?? []}>{renderItem}</Collection>
+            </Row>
+          );
+        }}
+      </TableBody>
+    </TableView>
+  );
+}
+
+export const ReorderableNestedRows: StoryObj<typeof TableView> = {
+  render: args => <ReorderableTableWithNested {...args} />,
+  name: 'Reorderable, nested rows'
+};
+
 let itemProcessor = async (items, acceptedDragTypes) => {
   let processedItems: any[] = [];
   let text = '';

--- a/packages/@react-spectrum/s2/stories/TreeView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/TreeView.stories.tsx
@@ -60,6 +60,7 @@ const meta: Meta<typeof TreeView> = {
   argTypes: {
     ...categorizeArgTypes('Events', ['onAction', ...events]),
     children: {table: {disable: true}},
+    dragAndDropHooks: {table: {disable: true}},
     onAction: {
       options: Object.keys(onActionOptions), // An array of serializable values
       mapping: onActionOptions, // Maps serializable option values to complex arg values

--- a/packages/dev/s2-docs/pages/s2/DraggableListView.tsx
+++ b/packages/dev/s2-docs/pages/s2/DraggableListView.tsx
@@ -1,0 +1,17 @@
+'use client';
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonListView, type Pokemon} from './PokemonListView';
+
+export function DraggableListView() {
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    getItems(keys, items) {
+      return items.map(item => ({
+        'text/plain': `${item.name} – ${item.type}`,
+        'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+        pokemon: JSON.stringify(item)
+      }));
+    }
+  });
+
+  return <PokemonListView dragAndDropHooks={dragAndDropHooks} />;
+}

--- a/packages/dev/s2-docs/pages/s2/DraggableTableView.tsx
+++ b/packages/dev/s2-docs/pages/s2/DraggableTableView.tsx
@@ -1,0 +1,17 @@
+'use client';
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonTableView, type Pokemon} from './PokemonTableView';
+
+export function DraggableTableView() {
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    getItems(keys, items) {
+      return items.map(item => ({
+        'text/plain': `${item.name} – ${item.type}`,
+        'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+        pokemon: JSON.stringify(item)
+      }));
+    }
+  });
+
+  return <PokemonTableView dragAndDropHooks={dragAndDropHooks} />;
+}

--- a/packages/dev/s2-docs/pages/s2/DraggableTreeView.tsx
+++ b/packages/dev/s2-docs/pages/s2/DraggableTreeView.tsx
@@ -1,0 +1,17 @@
+'use client';
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonTreeView, type Pokemon} from './PokemonTreeView';
+
+export function DraggableTreeView() {
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    getItems(keys, items) {
+      return items.map(item => ({
+        'text/plain': `${item.name} – ${item.type}`,
+        'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+        pokemon: JSON.stringify(item)
+      }));
+    }
+  });
+
+  return <PokemonTreeView dragAndDropHooks={dragAndDropHooks} />;
+}

--- a/packages/dev/s2-docs/pages/s2/DroppableListView.tsx
+++ b/packages/dev/s2-docs/pages/s2/DroppableListView.tsx
@@ -1,0 +1,20 @@
+'use client';
+import {useState} from 'react';
+import {isTextDropItem, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonListView, type Pokemon} from './PokemonListView';
+
+export function DroppableListView() {
+  let [items, setItems] = useState<Pokemon[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    acceptedDragTypes: ['pokemon'],
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items.filter(isTextDropItem).map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      setItems(items);
+    }
+  });
+
+  return <PokemonListView items={items} dragAndDropHooks={dragAndDropHooks} />;
+}

--- a/packages/dev/s2-docs/pages/s2/DroppableTableView.tsx
+++ b/packages/dev/s2-docs/pages/s2/DroppableTableView.tsx
@@ -1,0 +1,20 @@
+'use client';
+import {useState} from 'react';
+import {isTextDropItem, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonTableView, type Pokemon} from './PokemonTableView';
+
+export function DroppableTableView() {
+  let [items, setItems] = useState<Pokemon[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    acceptedDragTypes: ['pokemon'],
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items.filter(isTextDropItem).map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      setItems(items);
+    }
+  });
+
+  return <PokemonTableView items={items} dragAndDropHooks={dragAndDropHooks} />;
+}

--- a/packages/dev/s2-docs/pages/s2/DroppableTreeView.tsx
+++ b/packages/dev/s2-docs/pages/s2/DroppableTreeView.tsx
@@ -1,0 +1,20 @@
+'use client';
+import {useState} from 'react';
+import {isTextDropItem, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonTreeView, type Pokemon} from './PokemonTreeView';
+
+export function DroppableTreeView() {
+  let [items, setItems] = useState<Pokemon[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    acceptedDragTypes: ['pokemon'],
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items.filter(isTextDropItem).map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      setItems(items);
+    }
+  });
+
+  return <PokemonTreeView items={items} dragAndDropHooks={dragAndDropHooks} />;
+}

--- a/packages/dev/s2-docs/pages/s2/ListView.mdx
+++ b/packages/dev/s2-docs/pages/s2/ListView.mdx
@@ -382,7 +382,7 @@ function NavigationExample() {
 
 ## Drag and drop
 
-ListView supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the list as a whole, on individual items, insert new items between existing ones, or reorder items. See the [drag and drop guide](../react-aria/dnd?component=GridList) to learn more.
+ListView supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the list as a whole, on individual items, insert new items between existing ones, or reorder items. See the [drag and drop guide](dnd?component=ListView) to learn more.
 
 You can customize the drag preview by passing <TypeLink links={docs.links} type={docs.exports.DragPreview} /> or your own custom drag preview element to `useDragAndDrop`'s `renderDragPreview`. `DragPreview` supports leading icons and `Text` with `label` and `description` slots.
 

--- a/packages/dev/s2-docs/pages/s2/PokemonListView.tsx
+++ b/packages/dev/s2-docs/pages/s2/PokemonListView.tsx
@@ -1,0 +1,60 @@
+'use client';
+import {ListView, ListViewItem} from '@react-spectrum/s2/ListView';
+import {Text} from '@react-spectrum/s2';
+import {DragAndDropHooks} from '@react-spectrum/s2/useDragAndDrop';
+import {ReactElement} from 'react';
+import {IllustratedMessage, Heading, Content} from '@react-spectrum/s2/IllustratedMessage';
+import FolderOpen from '@react-spectrum/s2/illustrations/linear/FolderOpen';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+
+export interface Pokemon {
+  id: number;
+  name: string;
+  type: string;
+  level?: number;
+}
+
+interface PokemonListViewProps {
+  items?: Pokemon[];
+  dragAndDropHooks?: DragAndDropHooks<Pokemon>;
+}
+
+///- begin collapse -///
+export let defaultItems: Pokemon[] = [
+  {id: 1, name: 'Charizard', type: 'Fire, Flying', level: 67},
+  {id: 2, name: 'Blastoise', type: 'Water', level: 56},
+  {id: 3, name: 'Venusaur', type: 'Grass, Poison', level: 83},
+  {id: 4, name: 'Pikachu', type: 'Electric', level: 100}
+];
+///- end collapse -///
+
+function renderEmptyState(): ReactElement {
+  return (
+    <IllustratedMessage>
+      <FolderOpen />
+      <Heading>No results.</Heading>
+      <Content>Drop items here.</Content>
+    </IllustratedMessage>
+  );
+}
+
+export function PokemonListView(props: PokemonListViewProps) {
+  let {items = defaultItems, dragAndDropHooks} = props;
+
+  return (
+    <ListView
+      styles={style({height: 250, width: 250})}
+      aria-label="Pokemon list"
+      selectionMode="multiple"
+      items={items}
+      renderEmptyState={renderEmptyState}
+      dragAndDropHooks={dragAndDropHooks}>
+      {item => (
+        <ListViewItem textValue={item.name}>
+          <Text slot="label">{item.name}</Text>
+          <Text slot="description">{item.type}</Text>
+        </ListViewItem>
+      )}
+    </ListView>
+  );
+}

--- a/packages/dev/s2-docs/pages/s2/PokemonTableView.tsx
+++ b/packages/dev/s2-docs/pages/s2/PokemonTableView.tsx
@@ -1,0 +1,64 @@
+'use client';
+import {TableView, TableHeader, Column, TableBody, Row, Cell} from '@react-spectrum/s2/TableView';
+import {DragAndDropHooks} from '@react-spectrum/s2/useDragAndDrop';
+import {ReactElement} from 'react';
+import {IllustratedMessage, Heading, Content} from '@react-spectrum/s2/IllustratedMessage';
+import FolderOpen from '@react-spectrum/s2/illustrations/linear/FolderOpen';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+export interface Pokemon {
+  id: number;
+  name: string;
+  type: string;
+  level?: number;
+}
+
+interface PokemonTableViewProps {
+  items?: Pokemon[];
+  dragAndDropHooks?: DragAndDropHooks<Pokemon>;
+}
+
+///- begin collapse -///
+export let defaultItems: Pokemon[] = [
+  {id: 1, name: 'Charizard', type: 'Fire, Flying', level: 67},
+  {id: 2, name: 'Blastoise', type: 'Water', level: 56},
+  {id: 3, name: 'Venusaur', type: 'Grass, Poison', level: 83},
+  {id: 4, name: 'Pikachu', type: 'Electric', level: 100}
+];
+///- end collapse -///
+
+function renderEmptyState(): ReactElement {
+  return (
+    <IllustratedMessage>
+      <FolderOpen />
+      <Heading>No results.</Heading>
+      <Content>Drop items here.</Content>
+    </IllustratedMessage>
+  );
+}
+
+export function PokemonTableView(props: PokemonTableViewProps) {
+  let {items = defaultItems, dragAndDropHooks} = props;
+
+  return (
+    <TableView
+      styles={style({height: 250, width: 250})}
+      aria-label="Pokemon table"
+      selectionMode="multiple"
+      dragAndDropHooks={dragAndDropHooks}>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Type</Column>
+        <Column>Level</Column>
+      </TableHeader>
+      <TableBody items={items} renderEmptyState={renderEmptyState}>
+        {item => (
+          <Row>
+            <Cell>{item.name}</Cell>
+            <Cell>{item.type}</Cell>
+            <Cell>{item.level}</Cell>
+          </Row>
+        )}
+      </TableBody>
+    </TableView>
+  );
+}

--- a/packages/dev/s2-docs/pages/s2/PokemonTreeView.tsx
+++ b/packages/dev/s2-docs/pages/s2/PokemonTreeView.tsx
@@ -1,0 +1,128 @@
+'use client';
+import {
+  TreeView,
+  TreeViewItem,
+  TreeViewItemContent,
+  Collection,
+  Text
+} from '@react-spectrum/s2/TreeView';
+import {DragAndDropHooks} from '@react-spectrum/s2/useDragAndDrop';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {ReactElement} from 'react';
+import {IllustratedMessage, Heading, Content} from '@react-spectrum/s2/IllustratedMessage';
+import FolderOpen from '@react-spectrum/s2/illustrations/linear/FolderOpen';
+
+export interface Pokemon {
+  id: number;
+  name: string;
+  type: string;
+  level?: number;
+  children?: Pokemon[];
+}
+
+interface PokemonTreeViewProps {
+  items?: Pokemon[];
+  dragAndDropHooks?: DragAndDropHooks<Pokemon>;
+}
+
+///- begin collapse -///
+export let defaultItems: Pokemon[] = [
+  {
+    id: 1,
+    name: 'Bulbasaur',
+    type: 'Grass',
+    level: 14,
+    children: [
+      {
+        id: 2,
+        name: 'Ivysaur',
+        type: 'Grass',
+        level: 30,
+        children: [{id: 3, name: 'Venusaur', type: 'Grass', level: 83}]
+      }
+    ]
+  },
+  {
+    id: 4,
+    name: 'Charmander',
+    type: 'Fire',
+    level: 16,
+    children: [
+      {
+        id: 5,
+        name: 'Charmeleon',
+        type: 'Fire',
+        level: 32,
+        children: [{id: 6, name: 'Charizard', type: 'Fire, Flying', level: 67}]
+      }
+    ]
+  },
+  {
+    id: 7,
+    name: 'Squirtle',
+    type: 'Water',
+    level: 8,
+    children: [
+      {
+        id: 8,
+        name: 'Wartortle',
+        type: 'Water',
+        level: 34,
+        children: [{id: 9, name: 'Blastoise', type: 'Water', level: 56}]
+      }
+    ]
+  },
+  {
+    id: 10,
+    name: 'Pichu',
+    type: 'Electric',
+    level: 45,
+    children: [
+      {
+        id: 11,
+        name: 'Pikachu',
+        type: 'Electric',
+        level: 85,
+        children: [{id: 12, name: 'Raichu', type: 'Electric', level: 100}]
+      }
+    ]
+  }
+];
+///- end collapse -///
+
+function renderEmptyState(): ReactElement {
+  return (
+    <IllustratedMessage>
+      <FolderOpen />
+      <Heading>No results.</Heading>
+      <Content>Drop items here.</Content>
+    </IllustratedMessage>
+  );
+}
+
+export function PokemonTreeView(props: PokemonTreeViewProps) {
+  let {items = defaultItems, dragAndDropHooks} = props;
+
+  return (
+    <TreeView
+      styles={style({height: 250, width: 250})}
+      aria-label="Pokemon tree"
+      selectionMode="multiple"
+      items={items}
+      renderEmptyState={renderEmptyState}
+      dragAndDropHooks={dragAndDropHooks}>
+      {function renderItem(item: Pokemon) {
+        return (
+          <TreeViewItem textValue={item.name}>
+            <TreeViewItemContent>
+              <Text>
+                {item.name} – {item.type}
+              </Text>
+            </TreeViewItemContent>
+            <Collection items={item.children}>{renderItem}</Collection>
+          </TreeViewItem>
+        );
+      }}
+    </TreeView>
+  );
+}

--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -949,7 +949,7 @@ function subscribe(fn) {
 
 ## Drag and drop
 
-Table supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the table as a whole, on individual rows, insert new rows between existing ones, or reorder rows. See the [drag and drop guide](../react-aria/dnd?component=Table) to learn more.
+Table supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the table as a whole, on individual rows, insert new rows between existing ones, or reorder rows. See the [drag and drop guide](dnd?component=TableView) to learn more.
 
 You can customize the drag preview by passing <TypeLink links={docs.links} type={docs.exports.DragPreview} /> or your own custom drag preview element to `useDragAndDrop`'s `renderDragPreview`. `DragPreview` supports leading icons and `Text` with `label` and `description` slots.
 

--- a/packages/dev/s2-docs/pages/s2/TreeView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TreeView.mdx
@@ -388,7 +388,7 @@ function Example(props) {
 
 ## Drag and drop
 
-TreeView supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the tree as a whole, on individual items, insert new items between existing ones, or reorder items. React Spectrum supports drag and drop via mouse, touch, keyboard, and screen reader interactions. See the [drag and drop guide](../react-aria/dnd?component=Tree) to learn more.
+TreeView supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the tree as a whole, on individual items, insert new items between existing ones, or reorder items. React Spectrum supports drag and drop via mouse, touch, keyboard, and screen reader interactions. See the [drag and drop guide](dnd?component=TreeView) to learn more.
 
 You can customize the drag preview by passing <TypeLink links={docs.links} type={docs.exports.DragPreview} /> or your own custom drag preview element to `useDragAndDrop`'s `renderDragPreview`. `DragPreview` supports leading icons and `Text` with `label` and `description` slots.
 

--- a/packages/dev/s2-docs/pages/s2/TreeView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TreeView.mdx
@@ -388,7 +388,7 @@ function Example(props) {
 
 ## Drag and drop
 
-TreeView supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the tree as a whole, on individual items, insert new items between existing ones, or reorder items. The insertion indicator is level-aware, so drop positions reflect the target item's nesting depth. React Aria supports drag and drop via mouse, touch, keyboard, and screen reader interactions. See the [drag and drop guide](../react-aria/dnd?component=Tree) to learn more.
+TreeView supports drag and drop interactions when the `dragAndDropHooks` prop is provided using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. Users can drop data on the tree as a whole, on individual items, insert new items between existing ones, or reorder items. React Spectrum supports drag and drop via mouse, touch, keyboard, and screen reader interactions. See the [drag and drop guide](../react-aria/dnd?component=Tree) to learn more.
 
 You can customize the drag preview by passing <TypeLink links={docs.links} type={docs.exports.DragPreview} /> or your own custom drag preview element to `useDragAndDrop`'s `renderDragPreview`. `DragPreview` supports leading icons and `Text` with `label` and `description` slots.
 

--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -166,7 +166,7 @@ A <TypeLink links={docs.links} type={docs.links[docs.exports.FileDropItem.id]} /
 "use client";
 import {ListView, ListViewItem} from '@react-spectrum/s2/ListView';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {Text} from '@react-spectrum/s2';
+import {Image, Text} from '@react-spectrum/s2';
 import {useDragAndDrop, isFileDropItem} from '@react-spectrum/s2/useDragAndDrop';
 import {useState} from 'react';
 
@@ -204,7 +204,7 @@ function DroppableListView() {
       styles={style({height: 250})}>
       {item => (
         <ListViewItem textValue={item.name}>
-          <img src={item.url} style={{width: 24, height: 24, objectFit: 'cover'}} alt={item.name} />
+          {item.url ? <Image src={item.url} alt={item.title} /> : null}
           <Text slot="label">{item.name}</Text>
         </ListViewItem>
       )}

--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -204,7 +204,7 @@ function DroppableListView() {
       styles={style({height: 250})}>
       {item => (
         <ListViewItem textValue={item.name}>
-          {item.url ? <Image src={item.url} alt={item.title} /> : null}
+          {item.url ? <Image src={item.url} alt={item.name} /> : null}
           <Text slot="label">{item.name}</Text>
         </ListViewItem>
       )}

--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -1,0 +1,931 @@
+import {Layout} from '../../src/Layout';
+export default Layout;
+
+import docs from 'docs:@react-spectrum/s2';
+import DropOperation from '/packages/react-aria/docs/dnd/DropOperation.svg';
+import BetweenDropPosition from '/packages/react-aria/docs/dnd/BetweenDropPosition.svg';
+import OnDropPosition from '/packages/react-aria/docs/dnd/OnDropPosition.svg';
+import RootDropPosition from '/packages/react-aria/docs/dnd/RootDropPosition.svg';
+import Anatomy from '/packages/react-aria/docs/dnd/Anatomy.svg';
+import DragAffordance from '/packages/react-aria/docs/dnd/DragAffordance.svg';
+import {GroupedPropTable, PropTable} from '../../src/PropTable';
+
+export const section = 'Guides';
+export const description = 'How to implement drag and drop.';
+
+# Drag and Drop
+
+<PageDescription>React Spectrum collection components support drag and drop with mouse and touch interactions, and full keyboard and screen reader accessibility. Learn how to provide drag data and handle drop events to move, insert, or reorder items.</PageDescription>
+
+## Introduction
+
+Drag and drop allows a user to move data between two locations. The initial location is referred to as a **drag source**, and the final location is referred to as a **drop target**. The dragged data consists of one or more **drag items**, each of which contains data such as text, files, or application-specific objects. These are shown in a **drag preview** under the user's cursor.
+
+<Anatomy role="img" aria-label="Drag and drop anatomy diagram, showing drag source, drag preview, and drop target." />
+
+Drag and drop is implemented using the <TypeLink links={docs.links} type={docs.exports.useDragAndDrop} /> hook. The result of this function is passed into components that support drag and drop, such as [ListView](ListView), [TreeView](TreeView), and [TableView](TableView).
+
+## Drag source
+
+A drag source provides one or more **drag items**. Each item includes one or more data formats, e.g. JSON, HTML, or plain text. Drag types can be standard [mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) or application-specific strings. Providing multiple data formats allows the user to drop in external applications such as email clients or text editors.
+
+This example provides items as plain text, HTML, and a custom app-specific data format. Dropping within this page will use the custom data format. If you drop in an external application supporting rich text, the HTML representation will be used. Dropping in a text editor will use the plain text format.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DroppableCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonCOMPONENT, Pokemon} from './PokemonCOMPONENT';
+import {DroppableCOMPONENT} from './DroppableCOMPONENT';
+
+function DraggableCOMPONENT() {
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    ///- begin highlight -///
+    getItems(keys, values) {
+      return values.map(item => {
+        return {
+          'text/plain': `${item.name} – ${item.type}`,
+          'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+          'pokemon': JSON.stringify(item)
+        };
+      });
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT dragAndDropHooks={dragAndDropHooks} />;
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+## Drag preview
+
+While dragging, a **drag preview** is displayed under the user's mouse or finger to represent the items being dragged. React Spectrum provides a <TypeLink links={docs.links} type={docs.exports.DragPreview} /> component that renders a styled drag preview matching the design system. Pass it to `renderDragPreview` to customize the preview's contents using an icon and `Text` slots for the label and description. When multiple items are dragged, a badge is automatically shown.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {DragPreview} from '@react-spectrum/s2/COMPONENT';
+import {Text} from '@react-spectrum/s2';
+import File from '@react-spectrum/s2/icons/File';
+import {PokemonCOMPONENT, Pokemon} from './PokemonCOMPONENT';
+
+function DraggableCOMPONENT() {
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    ///- begin collapse -///
+    getItems(keys, items: Pokemon[]) {
+      return items.map(item => ({
+        'text/plain': item.name
+      }));
+    },
+    ///- end collapse -///
+    ///- begin highlight -///
+    renderDragPreview(items) {
+      return (
+        <DragPreview items={items}>
+          <File />
+          <Text>{items[0]['text/plain']}</Text>
+        </DragPreview>
+      );
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT dragAndDropHooks={dragAndDropHooks} />;
+}
+```
+
+</ExampleSwitcher>
+
+## Drop items
+
+Users can drop one or more **drop items**, each of which contains data to be transferred from the drag source to drop target. There are three kinds of drag items:
+
+* `text` – represents data inline as a string in one or more formats
+* `file` – references a file on the user's device
+* `directory` – references the contents of a directory
+
+### Text
+
+A **TextDropItem** represents textual data in one or more different formats. These may be either standard [mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) or custom app-specific formats.
+
+This example uses the `acceptedDragTypes` prop to accept items that include an app-specific type, which is retrieved using the item's `getText` method. When `acceptedDragTypes` is specified, the dropped items are filtered to include only items that include the accepted types.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DraggableCOMPONENT.tsx']}
+"use client";
+import {isTextDropItem, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useState} from 'react';
+import {PokemonCOMPONENT, Pokemon} from './PokemonCOMPONENT';
+import {DraggableCOMPONENT} from './DraggableCOMPONENT';
+
+function DroppableCOMPONENT() {
+  let [items, setItems] = useState<Pokemon[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    ///- begin highlight -///
+    acceptedDragTypes: ['pokemon'],
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items
+          .filter(isTextDropItem)
+          .map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      setItems(items);
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT items={items} dragAndDropHooks={dragAndDropHooks} />;
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### Files
+
+A **FileDropItem** references a file on the user's device. It includes the name and mime type of the file, and methods to read the contents as plain text, or retrieve a [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object for uploading. This example accepts JPEG and PNG image files, and renders them by creating a local [object URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).
+
+```tsx render type="s2"
+"use client";
+import {ListView, ListViewItem} from '@react-spectrum/s2/ListView';
+import {Text} from '@react-spectrum/s2';
+import {useDragAndDrop, isFileDropItem} from '@react-spectrum/s2/useDragAndDrop';
+import {useState} from 'react';
+
+interface ImageItem {
+  id: number,
+  url: string,
+  name: string
+}
+
+function DroppableListView() {
+  let [items, setItems] = useState<ImageItem[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    ///- begin highlight -///
+    acceptedDragTypes: ['image/jpeg', 'image/png'],
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items.filter(isFileDropItem).map(async item => ({
+          id: Math.random(),
+          url: URL.createObjectURL(await item.getFile()),
+          name: item.name
+        }))
+      );
+      setItems(items);
+    }
+    ///- end highlight -///
+  });
+
+  return (
+    <ListView
+      aria-label="Droppable list"
+      items={items}
+      dragAndDropHooks={dragAndDropHooks}
+      renderEmptyState={() => "Drop images here"}
+      style={{height: 250}}>
+      {item => (
+        <ListViewItem textValue={item.name}>
+          <img src={item.url} style={{width: 24, height: 24, objectFit: 'cover'}} alt={item.name} />
+          <Text slot="label">{item.name}</Text>
+        </ListViewItem>
+      )}
+    </ListView>
+  );
+}
+```
+
+### Directories
+
+A **DirectoryDropItem** references the contents of a directory on the user's device. It includes the name of the directory, as well as a method to iterate through the files and folders within the directory. Include the special `DIRECTORY_DRAG_TYPE` type in `acceptedDragTypes` to limit drops to directories.
+
+```tsx render type="s2"
+"use client";
+import {TreeView, TreeViewItem, TreeViewItemContent, Collection, Text} from '@react-spectrum/s2/TreeView';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {useDragAndDrop, DIRECTORY_DRAG_TYPE, type DirectoryDropItem, isDirectoryDropItem} from '@react-spectrum/s2/useDragAndDrop';
+import {useState} from 'react';
+import File from '@react-spectrum/s2/icons/File';
+import Folder from '@react-spectrum/s2/icons/Folder';
+import {IllustratedMessage, Heading, Content} from '@react-spectrum/s2/IllustratedMessage';
+import FolderOpen from '@react-spectrum/s2/illustrations/linear/FolderOpen';
+
+interface DirItem {
+  id: number,
+  name: string,
+  kind: string,
+  children: DirItem[]
+}
+
+function renderEmptyState(): ReactElement {
+  return (
+    <IllustratedMessage>
+      <FolderOpen />
+      <Heading>No results.</Heading>
+      <Content>Drop items here.</Content>
+    </IllustratedMessage>
+  );
+}
+
+function DroppableTreeView() {
+  let [files, setFiles] = useState<DirItem[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    ///- begin highlight -///
+    acceptedDragTypes: [DIRECTORY_DRAG_TYPE],
+    async onRootDrop(e) {
+      // Read entries in directory and update state with relevant info.
+      let getFiles = async (dir: DirectoryDropItem): Promise<DirItem[]> => {
+        let files: DirItem[] = [];
+        for await (let entry of dir.getEntries()) {
+          files.push({
+            id: Math.random(),
+            name: entry.name,
+            kind: entry.kind,
+            children: entry.kind === 'directory' ? await getFiles(entry) : []
+          });
+        }
+        return files;
+      };
+
+      let dir = e.items.find(isDirectoryDropItem)!;
+      setFiles(await getFiles(dir));
+    }
+    ///- end highlight -///
+  });
+
+  return (
+    <TreeView
+      aria-label="Droppable tree"
+      items={files}
+      dragAndDropHooks={dragAndDropHooks}
+      renderEmptyState={renderEmptyState}
+      styles={style({height: 250, width: 400})}>
+      {function renderItem(item: DirItem) {
+        return (
+          <TreeViewItem textValue={item.name}>
+            <TreeViewItemContent>
+              {item.kind === 'directory' ? <Folder /> : <File />}
+              <Text>{item.name}</Text>
+            </TreeViewItemContent>
+            <Collection items={item.children}>
+              {renderItem}
+            </Collection>
+          </TreeViewItem>
+        );
+      }}
+    </TreeView>
+  );
+}
+```
+
+## Drop positions
+
+Collection components such as [ListView](ListView), [TreeView](TreeView), and [TableView](TableView) support multiple **drop positions**.
+
+* The `"root"` drop position allows dropping on the collection as a whole.
+* The `"on"` drop position allows dropping on individual collection items, such as a folder within a tree.
+* The `"before"` and `"after"` drop positions allow the user to insert or move items between other items. This is displayed by rendering a **drop indicator** between items.
+
+<Figure>
+  <div style={{display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 50, marginBottom: 4, background: 'var(--anatomy-gray-100)', padding: 32, width: 'calc(100% - 64px)', borderRadius: 'var(--anatomy-radius)'}}>
+    <RootDropPosition role="img" aria-label="Root drop position" />
+    <OnDropPosition role="img" aria-label="On drop position" />
+    <BetweenDropPosition role="img" aria-label="Between drop position" />
+  </div>
+  <Caption style={{fontStyle: 'italic'}}>The "root", "on", and "between" drop positions.</Caption>
+</Figure>
+
+### Dropping on the collection
+
+Use the `onRootDrop` event to enable dropping on the entire collection. When a valid drag hovers over the collection, it receives the `data-drop-target` state.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DraggableCOMPONENT.tsx']}
+"use client";
+import {isTextDropItem, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useState} from 'react';
+import {PokemonCOMPONENT, Pokemon} from './PokemonCOMPONENT';
+import {DraggableCOMPONENT} from './DraggableCOMPONENT';
+
+function DroppableCOMPONENT() {
+  let [items, setItems] = useState<Pokemon[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    acceptedDragTypes: ['pokemon'],
+    ///- begin highlight -///
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items
+          .filter(isTextDropItem)
+          .map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      setItems(items);
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT items={items} dragAndDropHooks={dragAndDropHooks} />;
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### Dropping on items
+
+Use the `onItemDrop` event to enable dropping on items. When a valid drag hovers over an item, it receives the `data-drop-target` state.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DraggableCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {PokemonCOMPONENT} from './PokemonCOMPONENT';
+import {DraggableCOMPONENT} from './DraggableCOMPONENT';
+
+function DroppableCOMPONENT() {
+  let {dragAndDropHooks} = useDragAndDrop({
+    ///- begin highlight -///
+    onItemDrop(e) {
+      alert(`Dropped on ${e.target.key}`);
+    }
+    ///- end highlight -///
+  });
+
+  return (
+    <PokemonCOMPONENT
+      dragAndDropHooks={dragAndDropHooks}
+      items={[
+        {id: 1, name: 'Beedrill', type: 'Bug, Poison', level: 25},
+        {id: 2, name: 'Pidgeot', type: 'Flying', level: 40},
+        {id: 3, name: 'Fearow', type: 'Flying', level: 32},
+        {id: 4, name: 'Jigglypuff', type: 'Fairy', level: 56}
+      ]} />
+  );
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### Dropping between items
+
+Use the `onInsert` event to enable dropping between items. React Spectrum renders a drop indicator between items to indicate the insertion position.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DraggableCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop, isTextDropItem} from '@react-spectrum/s2/useDragAndDrop';
+import {useListData} from '@react-spectrum/s2/useListData';
+import {PokemonCOMPONENT} from './PokemonCOMPONENT';
+import {DraggableCOMPONENT} from './DraggableCOMPONENT';
+
+function DroppableCOMPONENT() {
+  let list = useListData({
+    initialItems: [
+      {id: 1, name: 'Beedrill', type: 'Bug, Poison', level: 25},
+      {id: 2, name: 'Pidgeot', type: 'Flying', level: 40},
+      {id: 3, name: 'Fearow', type: 'Flying', level: 32},
+      {id: 4, name: 'Jigglypuff', type: 'Fairy', level: 56}
+    ]
+  });
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    ///- begin highlight -///
+    async onInsert(e) {
+      let items = await Promise.all(
+        e.items
+          .filter(isTextDropItem)
+          .map(async item => {
+            let pokemon = JSON.parse(await item.getText('pokemon'));
+            let processItem = item => ({
+              ...item,
+              id: Math.random(),
+              children: item.children?.map(processItem)
+            });
+            return processItem(pokemon);
+          })
+      );
+
+      if (e.target.dropPosition === 'before') {
+        list.insertBefore(e.target.key, ...items);
+      } else if (e.target.dropPosition === 'after') {
+        list.insertAfter(e.target.key, ...items);
+      }
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT items={list.items} dragAndDropHooks={dragAndDropHooks} />;
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### Reordering items
+
+Use the `onMove` event to enable reordering items within a collection.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useListData} from '@react-spectrum/s2/useListData';
+import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';
+
+function ReorderableCOMPONENT() {
+  let list = useListData({
+    initialItems: defaultItems
+  });
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    ///- begin collapse -///
+    getItems(keys, items: Pokemon[]) {
+      return items.map(item => {
+        return {
+          'text/plain': `${item.name} – ${item.type}`,
+          'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+          'pokemon': JSON.stringify(item)
+        };
+      });
+    },
+    ///- end collapse -///
+    ///- begin highlight -///
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT items={list.items} dragAndDropHooks={dragAndDropHooks} />
+}
+```
+
+</ExampleSwitcher>
+
+### Moving items
+
+Use the `onMove` event to enable moving items within a collection. For components with hierarchy like [TreeView](TreeView) and [TableView](TableView), this allows moving items between levels by dropping on an item with the `"on"` position.
+
+<ExampleSwitcher type="component" examples={['TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useTreeData} from '@react-spectrum/s2/useTreeData';
+import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';
+
+function ReorderableCOMPONENT() {
+  let tree = useTreeData({
+    initialItems: [
+      {id: 1, name: 'Bulbasaur', type: 'Grass', level: 14, children: [
+        {id: 2, name: 'Ivysaur', type: 'Grass', level: 30, children: [
+          {id: 3, name: 'Venusaur', type: 'Grass', level: 83, children: []}
+        ]}
+      ]},
+      {id: 4, name: 'Charmander', type: 'Fire', level: 16, children: [
+        {id: 5, name: 'Charmeleon', type: 'Fire', level: 32, children: [
+          {id: 6, name: 'Charizard', type: 'Fire, Flying', level: 67, children: []}
+        ]}
+      ]},
+      {id: 7, name: 'Squirtle', type: 'Water', level: 8, children: [
+        {id: 8, name: 'Wartortle', type: 'Water', level: 34, children: [
+          {id: 9, name: 'Blastoise', type: 'Water', level: 56, children: []}
+        ]}
+      ]},
+      {id: 10, name: 'Pichu', type: 'Electric', level: 45, children: [
+        {id: 11, name: 'Pikachu', type: 'Electric', level: 85, children: [
+          {id: 12, name: 'Raichu', type: 'Electric', level: 100, children: []}
+        ]}
+      ]}
+    ]
+  });
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    ///- begin collapse -///
+    getItems(keys, items: Pokemon[]) {
+      return items.map(item => {
+        return {
+          'text/plain': `${item.name} – ${item.type}`,
+          'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+          'pokemon': JSON.stringify(item)
+        };
+      });
+    },
+    ///- end collapse -///
+    ///- begin highlight -///
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        tree.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        tree.moveAfter(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'on') {
+        // Move items to become children of the target
+        let targetNode = tree.getItem(e.target.key);
+        if (targetNode) {
+          let targetIndex = targetNode.children
+            ? targetNode.children.length
+            : 0;
+          let keyArray = Array.from(e.keys);
+          for (let i = 0; i < keyArray.length; i++) {
+            tree.move(keyArray[i], e.target.key, targetIndex + i);
+          }
+        }
+      }
+    }
+    ///- end highlight -///
+  });
+
+  // Map tree items to Pokemon objects
+  let processItem = item => {
+    return {...item.value, children: item.children.map(processItem)}
+  };
+
+  let items = tree.items.map(processItem);
+  return <PokemonCOMPONENT items={items} dragAndDropHooks={dragAndDropHooks} />
+}
+```
+
+</ExampleSwitcher>
+
+### Multiple positions
+
+This example puts together many of the examples described above, allowing users to drag items between lists bidirectionally. It also supports reordering items within the same list. When a list is empty, it accepts drops on the whole collection.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2"
+"use client";
+import {useDragAndDrop, isTextDropItem} from '@react-spectrum/s2/useDragAndDrop';
+import {useListData} from '@react-spectrum/s2/useListData';
+import {DragPreview} from '@react-spectrum/s2/COMPONENT';
+import {Text} from '@react-spectrum/s2';
+import File from '@react-spectrum/s2/icons/File';
+import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';
+
+interface DndCOMPONENTProps {
+  initialItems: Pokemon[],
+  'aria-label': string
+}
+
+function DndCOMPONENT(props: DndCOMPONENTProps) {
+  let list = useListData({
+    initialItems: props.initialItems
+  });
+
+  let {dragAndDropHooks} = useDragAndDrop({
+    renderDragPreview(items) {
+      return (
+        <DragPreview items={items}>
+          <File />
+          <Text>{items[0]['text/plain']}</Text>
+        </DragPreview>
+      );
+    },
+    // Provide drag data in a custom format as well as plain text.
+    getItems(keys, items: Pokemon[]) {
+      return items.map(item => ({
+        'pokemon': JSON.stringify(item),
+        'text/plain': item.name
+      }));
+    },
+
+    // Accept drops with the custom format.
+    acceptedDragTypes: ['pokemon'],
+
+    // Ensure items are always moved rather than copied.
+    getDropOperation: () => 'move',
+
+    ///- begin focus -///
+    // Handle drops between items from other lists.
+    async onInsert(e) {
+      let processedItems = await Promise.all(
+        e.items
+          .filter(isTextDropItem)
+          .map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      if (e.target.dropPosition === 'before') {
+        list.insertBefore(e.target.key, ...processedItems);
+      } else if (e.target.dropPosition === 'after') {
+        list.insertAfter(e.target.key, ...processedItems);
+      }
+    },
+
+    // Handle drops on the collection when empty.
+    async onRootDrop(e) {
+      let processedItems = await Promise.all(
+        e.items
+          .filter(isTextDropItem)
+          .map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      list.append(...processedItems);
+    },
+
+    // Handle reordering items within the same list.
+    onMove(e) {
+      if (e.target.dropPosition === 'before') {
+        list.moveBefore(e.target.key, e.keys);
+      } else if (e.target.dropPosition === 'after') {
+        list.moveAfter(e.target.key, e.keys);
+      }
+    },
+
+    // Remove the items from the source list on drop
+    // if they were moved to a different list.
+    onDragEnd(e) {
+      if (e.dropOperation === 'move' && !e.isInternal) {
+        list.remove(...e.keys);
+      }
+    }
+  });
+  ///- end focus -///
+
+  return <PokemonCOMPONENT items={list.items} dragAndDropHooks={dragAndDropHooks} aria-label={props['aria-label']} />
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DndCOMPONENT
+    initialItems={defaultItems}
+    aria-label="Drag and drop COMPONENT" />
+  <DndCOMPONENT
+    initialItems={[]}
+    aria-label="Drag and drop COMPONENT" />
+</div>
+```
+
+</ExampleSwitcher>
+
+## Drop operations
+
+A **drop operation** is an indication of what will happen when dragged data is dropped on a particular drop target. These are:
+
+* `move` – the dragged data will be moved from its source location to the target location.
+* `copy` – the dragged data will be copied to the target destination.
+* `link` – a relationship will be established between the source and target locations.
+* `cancel` – the drag and drop operation will be canceled, resulting in no changes made to the source or target.
+
+Many operating systems display these in the form of a cursor change, e.g. a plus sign to indicate a copy operation. The user may also be able to use a modifier key to choose which drop operation to perform, such as <Keyboard>Option</Keyboard> or <Keyboard>Alt</Keyboard> to switch from move to copy.
+
+<Figure>
+  <DropOperation role="img" aria-labelledby="drop-operation-caption" />
+  <Caption id="drop-operation-caption" style={{fontStyle: 'italic'}}>Visual feedback for a copy drop operation.</Caption>
+</Figure>
+
+
+### getDropOperation
+
+Use `getDropOperation` option to provide feedback to the user when a drag hovers over the drop target. This function receives the drop target, set of types contained in the drag, and a list of allowed drop operations. It should return the operation that will be performed on drop, or `'cancel'` to reject the drop. If the returned operation is not in `allowedOperations`, the drop will be canceled.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DraggableCOMPONENT.tsx']}
+"use client";
+import {isTextDropItem, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useState} from 'react';
+import {PokemonCOMPONENT, Pokemon} from './PokemonCOMPONENT';
+import {DraggableCOMPONENT} from './DraggableCOMPONENT';
+
+function DroppableCOMPONENT() {
+  let [items, setItems] = useState<Pokemon[]>([]);
+
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    acceptedDragTypes: ['pokemon'],
+    ///- begin highlight -///
+    getDropOperation: (target, types, allowedOperations) => 'copy',
+    ///- end highlight -///
+    async onRootDrop(e) {
+      let items = await Promise.all(
+        e.items
+          .filter(isTextDropItem)
+          .map(async item => JSON.parse(await item.getText('pokemon')))
+      );
+      setItems(items);
+    }
+  });
+
+  return <PokemonCOMPONENT items={items} dragAndDropHooks={dragAndDropHooks} />;
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### getAllowedDropOperations
+
+The drag source can also control which drop operations are allowed. In the example below, the cursor shows the copy cursor by default, and pressing a modifier key cancels the drop.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DroppableCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useListData} from '@react-spectrum/s2/useListData';
+import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';
+import {DroppableCOMPONENT} from './DroppableCOMPONENT';
+
+function DraggableCOMPONENT() {
+  ///- begin collapse -///
+  let list = useListData({
+    initialItems: defaultItems
+  });
+  ///- end collapse -///
+
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    ///- begin collapse -///
+    getItems(keys, items: Pokemon[]) {
+      return items.map(item => {
+        return {
+          'text/plain': `${item.name} – ${item.type}`,
+          'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+          'pokemon': JSON.stringify(item)
+        };
+      });
+    },
+    ///- end collapse -///
+    ///- begin highlight -///
+    getAllowedDropOperations: () => ['copy']
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT items={list.items} dragAndDropHooks={dragAndDropHooks} />
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### onDragEnd
+
+The `onDragEnd` event allows the drag source to respond when a drag that it initiated ends, either because it was dropped or because it was canceled by the user. The `dropOperation` property of the event object indicates the operation that was performed. For example, when data is moved, the UI could be updated to reflect this change by removing the original dragged items.
+
+This example removes the dragged items from the UI when a move operation is completed. Try holding the <Keyboard>Option</Keyboard> or <Keyboard>Alt</Keyboard> keys to change the operation to copy, and see how the behavior changes.
+
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
+
+```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx', 'packages/dev/s2-docs/pages/s2/DroppableCOMPONENT.tsx']}
+"use client";
+import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {useListData} from '@react-spectrum/s2/useListData';
+import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';
+import {DroppableCOMPONENT} from './DroppableCOMPONENT';
+
+function DraggableCOMPONENT() {
+  ///- begin collapse -///
+  let list = useListData({
+    initialItems: defaultItems
+  });
+  ///- end collapse -///
+
+  let {dragAndDropHooks} = useDragAndDrop<Pokemon>({
+    ///- begin collapse -///
+    getItems(keys, items: Pokemon[]) {
+      return items.map(item => {
+        return {
+          'text/plain': `${item.name} – ${item.type}`,
+          'text/html': `<strong>${item.name}</strong> – <em>${item.type}</em>`,
+          'pokemon': JSON.stringify(item)
+        };
+      });
+    },
+    ///- end collapse -///
+    ///- begin highlight -///
+    onDragEnd(e) {
+      if (e.dropOperation === 'move') {
+        list.remove(...e.keys);
+      }
+    }
+    ///- end highlight -///
+  });
+
+  return <PokemonCOMPONENT items={list.items} dragAndDropHooks={dragAndDropHooks} />
+}
+
+<div style={{display: 'flex', gap: 12, flexWrap: 'wrap', width: '100%', justifyContent: 'center'}}>
+  <DraggableCOMPONENT />
+  <DroppableCOMPONENT />
+</div>
+```
+
+</ExampleSwitcher>
+
+### Drop events
+
+Drop events such as `onInsert`, `onItemDrop`, etc. also include the `dropOperation`. This can be used to perform different actions accordingly, for example, when communicating with a backend API.
+
+```tsx
+let onItemDrop = async (e) => {
+  let data = JSON.parse(await e.items[0].getText('my-app-file'));
+  switch (e.dropOperation) {
+    case 'move':
+      MyAppFileService.move(data.filePath, props.filePath);
+      break;
+    case 'copy':
+      MyAppFileService.copy(data.filePath, props.filePath);
+      break;
+    case 'link':
+      MyAppFileService.link(data.filePath, props.filePath);
+      break;
+  }
+};
+```
+
+## Accessibility
+
+While drag and drop has historically been mostly limited to mouse and touchscreen users, keyboard and screen reader friendly alternatives are important for users who cannot use these interaction methods. React Spectrum implements keyboard and screen reader interactions for drag and drop that provide full parity with the mouse and touch experiences.
+
+Users can press <Keyboard>Enter</Keyboard> on a draggable element to enter drag and drop mode. Then, they can press <Keyboard>Tab</Keyboard> to cycle between the drop targets that accept the dragged data, and <Keyboard>Enter</Keyboard> to drop. <Keyboard>Escape</Keyboard> cancels a drag. Touch screen reader users can also drag by double tapping to activate drag and drop mode, swiping between drop targets, and double tapping again to drop. Screen reader announcements are included to help guide the user through this process.
+
+Collection components such as [ListView](ListView), [TreeView](TreeView), and [TableView](TableView) are treated as a single drop target, so that users can easily tab past them to get to the next drop target. Within a droppable collection, keys such as <Keyboard>ArrowDown</Keyboard> and <Keyboard>ArrowUp</Keyboard> can be used to select a **drop position**, such as on an item, or between items.
+
+Draggable elements can sometimes have conflicting keyboard interactions, such as selection. These are handled by adding an explicit **drag affordance**. Keyboard and screen reader users can focus this element, and use it to initiate drag and drop for the parent item. In addition, this has the added benefit of making drag and drop more discoverable.
+
+<Figure>
+  <DragAffordance role="img" aria-labelledby="drag-affordance-caption" />
+  <Caption id="drag-affordance-caption" style={{fontStyle: 'italic'}}>A focusable drag affordance to initiate keyboard and screen reader drag and drop.</Caption>
+</Figure>
+
+Note that because mouse and touch drag and drop interactions utilize the native browser APIs, they work both within the browser window and with external applications on the user's device. Keyboard and screen reader drag and drop is implemented from scratch, and therefore can only be supported within the browser window. Alternative interactions for operations involving external applications, such as file uploading or copy and paste, should be implemented in addition to drag and drop.
+
+## API
+
+### useDragAndDrop
+
+<GroupedPropTable
+  properties={docs.exports.DragAndDropOptions?.properties}
+  links={docs.links}
+  propGroups={{
+    'Drag source': [
+      'getItems',
+      'renderDragPreview',
+      'getAllowedDropOperations',
+      'onDragStart',
+      'onDragMove',
+      'onDragEnd'
+    ],
+    'Drop target': [
+      'onRootDrop',
+      'onItemDrop',
+      'onInsert',
+      'onReorder',
+      'onMove',
+      'onDropEnter',
+      'onDropExit',
+      'onDropActivate',
+      'onDrop',
+      'renderDropIndicator',
+      'acceptedDragTypes',
+      'shouldAcceptItemDrop',
+      'getDropOperation',
+      'dropTargetDelegate'
+    ]
+  }}
+  defaultExpanded={new Set(['Drag source', 'Drop target'])} />
+
+### DragPreview
+
+<PropTable component={docs.exports.DragPreview} links={docs.links} />

--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -12,6 +12,7 @@ import {GroupedPropTable, PropTable} from '../../src/PropTable';
 
 export const section = 'Guides';
 export const description = 'How to implement drag and drop.';
+export const tags = ['dnd'];
 
 # Drag and Drop
 
@@ -116,7 +117,7 @@ Users can drop one or more **drop items**, each of which contains data to be tra
 
 ### Text
 
-A **TextDropItem** represents textual data in one or more different formats. These may be either standard [mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) or custom app-specific formats.
+A <TypeLink links={docs.links} type={docs.links[docs.exports.TextDropItem.id]} /> represents textual data in one or more different formats. These may be either standard [mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) or custom app-specific formats.
 
 This example uses the `acceptedDragTypes` prop to accept items that include an app-specific type, which is retrieved using the item's `getText` method. When `acceptedDragTypes` is specified, the dropped items are filtered to include only items that include the accepted types.
 
@@ -159,7 +160,7 @@ function DroppableCOMPONENT() {
 
 ### Files
 
-A **FileDropItem** references a file on the user's device. It includes the name and mime type of the file, and methods to read the contents as plain text, or retrieve a [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object for uploading. This example accepts JPEG and PNG image files, and renders them by creating a local [object URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).
+A <TypeLink links={docs.links} type={docs.links[docs.exports.FileDropItem.id]} /> references a file on the user's device. It includes the name and mime type of the file, and methods to read the contents as plain text, or retrieve a [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object for uploading. This example accepts JPEG and PNG image files, and renders them by creating a local [object URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).
 
 ```tsx render type="s2"
 "use client";
@@ -213,7 +214,7 @@ function DroppableListView() {
 
 ### Directories
 
-A **DirectoryDropItem** references the contents of a directory on the user's device. It includes the name of the directory, as well as a method to iterate through the files and folders within the directory. Include the special `DIRECTORY_DRAG_TYPE` type in `acceptedDragTypes` to limit drops to directories.
+A <TypeLink links={docs.links} type={docs.links[docs.exports.DirectoryDropItem.id]} /> references the contents of a directory on the user's device. It includes the name of the directory, as well as a method to iterate through the files and folders within the directory. Include the special `DIRECTORY_DRAG_TYPE` type in `acceptedDragTypes` to limit drops to directories.
 
 ```tsx render type="s2"
 "use client";
@@ -456,7 +457,7 @@ function DroppableCOMPONENT() {
 
 ### Reordering items
 
-Use the `onMove` event to enable reordering items within a collection.
+Use the `onReorder` event to enable reordering items. For components with hierarchy like [TreeView](TreeView), this only allows reordering within the same level. Use `onMove` to allow moving items between levels.
 
 <ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
 
@@ -484,7 +485,7 @@ function ReorderableCOMPONENT() {
     },
     ///- end collapse -///
     ///- begin highlight -///
-    onMove(e) {
+    onReorder(e) {
       if (e.target.dropPosition === 'before') {
         list.moveBefore(e.target.key, e.keys);
       } else if (e.target.dropPosition === 'after') {
@@ -502,9 +503,9 @@ function ReorderableCOMPONENT() {
 
 ### Moving items
 
-Use the `onMove` event to enable moving items within a collection. For components with hierarchy like [TreeView](TreeView) and [TableView](TableView), this allows moving items between levels by dropping on an item with the `"on"` position.
+Use the `onMove` event to enable moving items within a collection. This allows reordering items within a level and moving items between levels. It supports dropping both on and between items.
 
-<ExampleSwitcher type="component" examples={['TreeView', 'TableView']}>
+<ExampleSwitcher type="component" examples={['ListView', 'TreeView', 'TableView']}>
 
 ```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx']}
 "use client";
@@ -514,28 +515,7 @@ import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';
 
 function ReorderableCOMPONENT() {
   let tree = useTreeData({
-    initialItems: [
-      {id: 1, name: 'Bulbasaur', type: 'Grass', level: 14, children: [
-        {id: 2, name: 'Ivysaur', type: 'Grass', level: 30, children: [
-          {id: 3, name: 'Venusaur', type: 'Grass', level: 83, children: []}
-        ]}
-      ]},
-      {id: 4, name: 'Charmander', type: 'Fire', level: 16, children: [
-        {id: 5, name: 'Charmeleon', type: 'Fire', level: 32, children: [
-          {id: 6, name: 'Charizard', type: 'Fire, Flying', level: 67, children: []}
-        ]}
-      ]},
-      {id: 7, name: 'Squirtle', type: 'Water', level: 8, children: [
-        {id: 8, name: 'Wartortle', type: 'Water', level: 34, children: [
-          {id: 9, name: 'Blastoise', type: 'Water', level: 56, children: []}
-        ]}
-      ]},
-      {id: 10, name: 'Pichu', type: 'Electric', level: 45, children: [
-        {id: 11, name: 'Pikachu', type: 'Electric', level: 85, children: [
-          {id: 12, name: 'Raichu', type: 'Electric', level: 100, children: []}
-        ]}
-      ]}
-    ]
+    initialItems: defaultItems
   });
 
   let {dragAndDropHooks} = useDragAndDrop({
@@ -659,7 +639,7 @@ function DndCOMPONENT(props: DndCOMPONENTProps) {
     },
 
     // Handle reordering items within the same list.
-    onMove(e) {
+    onReorder(e) {
       if (e.target.dropPosition === 'before') {
         list.moveBefore(e.target.key, e.keys);
       } else if (e.target.dropPosition === 'after') {
@@ -694,7 +674,7 @@ function DndCOMPONENT(props: DndCOMPONENTProps) {
 
 ## Drop operations
 
-A **drop operation** is an indication of what will happen when dragged data is dropped on a particular drop target. These are:
+A <TypeLink links={docs.links} type={docs.links[docs.exports.DropOperation.id]} /> is an indication of what will happen when dragged data is dropped on a particular drop target. These are:
 
 * `move` – the dragged data will be moved from its source location to the target location.
 * `copy` – the dragged data will be copied to the target destination.

--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -165,6 +165,7 @@ A <TypeLink links={docs.links} type={docs.links[docs.exports.FileDropItem.id]} /
 ```tsx render type="s2"
 "use client";
 import {ListView, ListViewItem} from '@react-spectrum/s2/ListView';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Text} from '@react-spectrum/s2';
 import {useDragAndDrop, isFileDropItem} from '@react-spectrum/s2/useDragAndDrop';
 import {useState} from 'react';
@@ -200,7 +201,7 @@ function DroppableListView() {
       items={items}
       dragAndDropHooks={dragAndDropHooks}
       renderEmptyState={() => "Drop images here"}
-      style={{height: 250}}>
+      styles={style({height: 250})}>
       {item => (
         <ListViewItem textValue={item.name}>
           <img src={item.url} style={{width: 24, height: 24, objectFit: 'cover'}} alt={item.name} />
@@ -221,7 +222,7 @@ A <TypeLink links={docs.links} type={docs.links[docs.exports.DirectoryDropItem.i
 import {TreeView, TreeViewItem, TreeViewItemContent, Collection, Text} from '@react-spectrum/s2/TreeView';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {useDragAndDrop, DIRECTORY_DRAG_TYPE, type DirectoryDropItem, isDirectoryDropItem} from '@react-spectrum/s2/useDragAndDrop';
-import {useState} from 'react';
+import {ReactElement, useState} from 'react';
 import File from '@react-spectrum/s2/icons/File';
 import Folder from '@react-spectrum/s2/icons/Folder';
 import {IllustratedMessage, Heading, Content} from '@react-spectrum/s2/IllustratedMessage';

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -449,6 +449,12 @@ export interface GridListItemRenderProps extends ItemRenderProps {
   /** The unique id of the item. */
   id?: Key;
   /**
+   * Whether the item's children have keyboard focus.
+   *
+   * @selector [data-focus-visible-within]
+   */
+  isFocusVisibleWithin: boolean;
+  /**
    * State of the grid list.
    */
   state: ListState<unknown>;
@@ -509,6 +515,8 @@ export const GridListItem = /*#__PURE__*/ createLeafComponent(ItemNode, function
   );
 
   let {hoverProps, isHovered} = useHover({
+    // because of https://bugs.webkit.org/show_bug.cgi?id=214609, supporting hover styles when a item is ONLY isDraggable
+    // results in hover styles sticking around after a reorder/drop operation...
     isDisabled: !states.allowsSelection && !states.hasAction && !isDraggable,
     onHoverStart: item.props.onHoverStart,
     onHoverChange: item.props.onHoverChange,
@@ -516,6 +524,9 @@ export const GridListItem = /*#__PURE__*/ createLeafComponent(ItemNode, function
   });
 
   let {isFocusVisible, focusProps} = useFocusRing();
+  let {isFocusVisible: isFocusVisibleWithin, focusProps: focusWithinProps} = useFocusRing({
+    within: true
+  });
   let {checkboxProps} = useGridListSelectionCheckbox({key: item.key}, state);
 
   let buttonProps =
@@ -554,6 +565,7 @@ export const GridListItem = /*#__PURE__*/ createLeafComponent(ItemNode, function
       ...states,
       isHovered,
       isFocusVisible,
+      isFocusVisibleWithin,
       selectionMode: state.selectionManager.selectionMode,
       selectionBehavior: state.selectionManager.selectionBehavior,
       allowsDragging: !!dragState,
@@ -606,6 +618,7 @@ export const GridListItem = /*#__PURE__*/ createLeafComponent(ItemNode, function
           renderProps,
           rowProps,
           focusProps,
+          focusWithinProps,
           hoverProps,
           draggableItem?.dragProps
         )}
@@ -615,6 +628,7 @@ export const GridListItem = /*#__PURE__*/ createLeafComponent(ItemNode, function
         data-hovered={isHovered || undefined}
         data-focused={states.isFocused || undefined}
         data-focus-visible={isFocusVisible || undefined}
+        data-focus-visible-within={isFocusVisibleWithin || undefined}
         data-pressed={states.isPressed || undefined}
         data-allows-dragging={!!dragState || undefined}
         data-dragging={isDragging || undefined}

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -1675,6 +1675,14 @@ export interface RowRenderProps extends ItemRenderProps {
   state: TableState<unknown>;
 }
 
+export interface RowFocusContextValue {
+  isFocusVisibleWithinRow: boolean;
+}
+
+export const RowFocusContext = createContext<RowFocusContextValue>({
+  isFocusVisibleWithinRow: false
+});
+
 export interface RowProps<T>
   extends
     StyleRenderProps<RowRenderProps, 'tr' | 'div'>,
@@ -1779,6 +1787,8 @@ export const Row = /*#__PURE__*/ createBranchComponent(
       within: true
     });
     let {hoverProps, isHovered} = useHover({
+      // because of https://bugs.webkit.org/show_bug.cgi?id=214609, supporting hover styles when a item is ONLY isDraggable
+      // results in hover styles sticking around after a reorder/drop operation...
       isDisabled: !states.allowsSelection && !states.hasAction && !isDraggable,
       onHoverStart: props.onHoverStart,
       onHoverChange: props.onHoverChange,
@@ -1935,7 +1945,8 @@ export const Row = /*#__PURE__*/ createBranchComponent(
                   }
                 }
               ],
-              [SelectionIndicatorContext, {isSelected: states.isSelected}]
+              [SelectionIndicatorContext, {isSelected: states.isSelected}],
+              [RowFocusContext, {isFocusVisibleWithinRow: isFocusVisibleWithin}]
             ]}>
             <CollectionBranch collection={state.collection} parent={item} />
           </Provider>
@@ -1997,6 +2008,12 @@ export interface CellRenderProps {
    * @selector [data-disabled]
    */
   isDisabled: boolean;
+  /**
+   * Whether keyboard focus is visible anywhere within the parent row.
+   *
+   * @selector [data-focus-visible-within-row]
+   */
+  isFocusVisibleWithinRow: boolean;
   /**
    * The unique id of the cell.
    */
@@ -2091,6 +2108,7 @@ export const Cell = /*#__PURE__*/ createLeafComponent(
     );
     let {isFocused, isFocusVisible, focusProps} = useFocusRing();
     let {hoverProps, isHovered} = useHover({});
+    let {isFocusVisibleWithinRow} = useContext(RowFocusContext);
     let isSelected =
       cell.parentKey != null ? state.selectionManager.isSelected(cell.parentKey) : false;
     // colIndex is null, when there is so span, falling back to using the index
@@ -2108,6 +2126,7 @@ export const Cell = /*#__PURE__*/ createLeafComponent(
       values: {
         isFocused,
         isFocusVisible,
+        isFocusVisibleWithinRow,
         isPressed,
         isHovered,
         isSelected,
@@ -2130,6 +2149,7 @@ export const Cell = /*#__PURE__*/ createLeafComponent(
         ref={ref as any}
         data-focused={isFocused || undefined}
         data-focus-visible={isFocusVisible || undefined}
+        data-focus-visible-within-row={isFocusVisibleWithinRow || undefined}
         data-pressed={isPressed || undefined}
         data-selected={isSelected || undefined}
         data-column-index={columnIndex}

--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -794,6 +794,8 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent(
     let level = rowProps['aria-level'] || 1;
 
     let {hoverProps, isHovered} = useHover({
+      // because of https://bugs.webkit.org/show_bug.cgi?id=214609, supporting hover styles when a item is ONLY isDraggable
+      // results in hover styles sticking around after a reorder/drop operation...
       isDisabled: !states.allowsSelection && !states.hasAction && !isDraggable,
       onHoverStart: props.onHoverStart,
       onHoverChange: props.onHoverChange,

--- a/packages/react-stately/src/layout/ListLayout.ts
+++ b/packages/react-stately/src/layout/ListLayout.ts
@@ -803,14 +803,14 @@ export class ListLayout<T, O extends ListLayoutOptions = ListLayoutOptions>
       rect =
         this.orientation === 'horizontal'
           ? new Rect(
-              layoutInfo.rect.x - this.dropIndicatorThickness / 2,
+              Math.max(0, layoutInfo.rect.x - this.dropIndicatorThickness / 2),
               layoutInfo.rect.y,
               this.dropIndicatorThickness,
               layoutInfo.rect.height
             )
           : new Rect(
               layoutInfo.rect.x,
-              layoutInfo.rect.y - this.dropIndicatorThickness / 2,
+              Math.max(0, layoutInfo.rect.y - this.dropIndicatorThickness / 2),
               layoutInfo.rect.width,
               this.dropIndicatorThickness
             );
@@ -831,7 +831,6 @@ export class ListLayout<T, O extends ListLayoutOptions = ListLayoutOptions>
           currentKey = this.collection.getKeyAfter(currentKey);
         }
       }
-
       rect =
         this.orientation === 'horizontal'
           ? new Rect(

--- a/starters/docs/src/GridList.css
+++ b/starters/docs/src/GridList.css
@@ -20,7 +20,7 @@
     scroll-padding: 50px;
   }
 
-  &[data-layout='grid']:not(:has(.react-aria-GridListSection)) {
+  &[data-layout='grid']:not(:has(.react-aria-GridListSection)):not([data-empty]) {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(100px, var(--grid-item-size)));
     grid-auto-rows: min-content;
@@ -54,7 +54,7 @@
     }
   }
 
-  &[data-layout='stack'] {
+  &[data-layout='stack']:not([data-empty]) {
     display: grid;
     grid-template-columns: auto;
     align-items: center;


### PR DESCRIPTION
Follow ups from testing and PR review:
- Adds S2 DnD docs, basically same content as RAC DnD docs minus insertion indicator styling/ListBox/etc
- Unifies InsertionIndicator and DragHandle implementations (uses SVG for InsertionIndicator, DragHandle needed the addition of `isFocusVisibleWithinRow` to `TableCell` `renderProps` and `isFocusVisibleWithin` for `GridRow`)
- Adds DnD components to test apps
- various small fixes (miscentered drag handle in iOS safari, row fill color in TableView highlight selection when dropping on row, etc)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go through the S2 DnD docs and verify things look fine. Smoke test DnD insertion indicators styling/appearance/positioning and that drag handles are properly visually hidden still and other mentioned bugs in description. Test DnD component in test apps (see https://github.com/adobe/react-spectrum/commit/fece8b92d1d1fc8d6095074fc730415474420725#comments for links)

See chromatic: https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=1198

## 🧢 Your Project:

RSP
