### PR TITLE
docs: add RAC docs to S2 skill, and clean up 

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/ai.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/ai.mdx
@@ -12,6 +12,14 @@ export const tags = ['ai', 'mcp', 'agent', 'skills', 'llms.txt', 'markdown'];
 
 <PageDescription>Learn how to use the React Aria MCP Server, Agent Skills, and more to help you build with AI.</PageDescription>
 
+## Agent Skills
+
+[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that your AI coding tool can load when relevant to help with specific tasks.
+
+To install the React Aria skill, run:
+
+<Command command="npx skills add https://react-aria.adobe.com" />
+
 ## MCP Server
 
 [Node.js](https://nodejs.org/) must be installed on your system to run the MCP server.
@@ -111,14 +119,6 @@ export const tags = ['ai', 'mcp', 'agent', 'skills', 'llms.txt', 'markdown'];
     ```
   </TabPanel>
 </Tabs>
-
-## Agent Skills
-
-[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that your AI coding tool can load when relevant to help with specific tasks.
-
-To install the React Aria skill, run:
-
-<Command command="npx skills add https://react-aria.adobe.com" />
 
 ## Markdown docs
 

--- a/packages/dev/s2-docs/pages/s2/ai.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai.mdx
@@ -12,6 +12,14 @@ export const tags = ['ai', 'mcp', 'agent', 'skills', 'llms.txt', 'markdown'];
 
 <PageDescription>Learn how to use the React Spectrum MCP Server, Agent Skills, and more to help you build with AI.</PageDescription>
 
+## Agent Skills
+
+[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that your AI coding tool can load when relevant to help with specific tasks.
+
+To install the React Spectrum skill, run:
+
+<Command command="npx skills add https://react-spectrum.adobe.com" />
+
 ## MCP Server
 
 [Node.js](https://nodejs.org/) must be installed on your system to run the MCP server.
@@ -111,14 +119,6 @@ export const tags = ['ai', 'mcp', 'agent', 'skills', 'llms.txt', 'markdown'];
     ```
   </TabPanel>
 </Tabs>
-
-## Agent Skills
-
-[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that your AI coding tool can load when relevant to help with specific tasks.
-
-To install the React Spectrum skill, run:
-
-<Command command="npx skills add https://react-spectrum.adobe.com" />
 
 ## Markdown docs
 

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -36,9 +36,18 @@ const SKILLS = {
   'react-spectrum-s2': {
     name: 'react-spectrum-s2',
     description:
-      'Build accessible UI components with React Spectrum S2 (Spectrum 2). Use when developers mention React Spectrum, Spectrum 2, S2, @react-spectrum/s2, or Adobe design system components. Provides documentation for buttons, forms, dialogs, tables, date/time pickers, color pickers, and other accessible components.',
+      'Build accessible UI components with React Spectrum S2 (Spectrum 2). Use when developers mention React Spectrum, Spectrum 2, S2, @react-spectrum/s2, or Adobe design system components. Provides documentation for buttons, forms, dialogs, tables, date/time pickers, color pickers, and other accessible components. Includes React Aria Components documentation as a fallback reference for custom components that must use unstyled primitives.',
     license: 'Apache-2.0',
     sourceDir: 's2',
+    additionalReferenceLibraries: [
+      {
+        skillName: 'react-aria',
+        referenceSubdir: 'react-aria',
+        title: 'React Aria Components',
+        description:
+          'Fallback documentation for unstyled accessible primitives. Use only when no React Spectrum S2 component fits the required interaction or layout.'
+      }
+    ],
     compatibility: 'Requires a React project with @react-spectrum/s2 installed.',
     metadata: {
       author: 'Adobe',
@@ -75,8 +84,24 @@ const SKILLS = {
 
 const CUSTOM_SKILL_CONTENT = {
   'react-spectrum-s2': {
-    skillNotesMarkdown:
-      'If the requirements do not clearly specify which React Spectrum component to use, consult the [Component Decision Tree](references/guides/component-decision-tree.md) before choosing a component.\n\nIf the request involves a Figma design, frame, or URL — or if the Figma MCP (`get_design_context`, `get_screenshot`, `get_variable_defs`, `search_design_system`) is available — consult [Implementing Figma designs with React Spectrum S2](references/guides/figma-to-s2.md) before generating code. The Figma MCP returns React + Tailwind reference output that must be translated to S2 components and the `style` macro.',
+    skillNotesMarkdown: [
+      'If the requirements do not clearly specify which React Spectrum component to use, consult the [Component Decision Tree](references/guides/component-decision-tree.md) before choosing a component.',
+      'If the request involves a Figma design, frame, or URL — or if the Figma MCP (`get_design_context`, `get_screenshot`, `get_variable_defs`, `search_design_system`) is available — consult [Implementing Figma designs with React Spectrum S2](references/guides/figma-to-s2.md) before generating code. The Figma MCP returns React + Tailwind reference output that must be translated to S2 components and the `style` macro.',
+      `## React Spectrum S2 vs React Aria Components
+
+React Spectrum S2 is built on top of React Aria Components. The S2 components add Spectrum 2 styling, behavior, and slot structure on top of the unstyled React Aria primitives. Always prefer S2 components for React Spectrum work because they are pre-styled, design-system compliant, and cover most common UI patterns.
+
+Only reach for React Aria Components directly when:
+- Building a custom component because no S2 component matches the required interaction or layout. Follow [Creating Custom Components](references/guides/creating-custom-components.md) and pair the React Aria primitive with the S2 \`style\` macro for Spectrum styling.
+- Composing a primitive that S2 does not expose at all, such as \`FocusScope\`, \`VisuallyHidden\`, \`useFocusRing\`, \`mergeProps\`, or \`Toolbar\`.
+
+When using both libraries in the same file:
+- Import S2 components from \`@react-spectrum/s2/<ComponentName>\` and React Aria primitives from \`react-aria-components\` or \`react-aria-components/<ComponentName>\`.
+- Do not mix \`Item\` or \`Section\` from \`react-aria-components\` into S2 collections. Use the typed item exports from the S2 collection itself, such as \`MenuItem\`, \`PickerItem\`, or \`ListViewItem\`.
+- Do not re-import shared types such as \`Key\`, \`Selection\`, \`SortDescriptor\`, or \`PressEvent\` from \`react-aria-components\` when they are re-exported from \`@react-spectrum/s2\`.
+
+The React Aria Components documentation is bundled under \`references/react-aria/\`. Start with [React Aria llms.txt](references/react-aria/llms.txt) only after confirming that no S2 component fits.`
+    ].join('\n\n'),
     embeddedMarkdownPaths: [
       path.join(
         REPO_ROOT,
@@ -181,6 +206,25 @@ function getCustomGuideEntries(skillName) {
 
 function getCustomSkillNotesMarkdown(skillName) {
   return getCustomSkillContent(skillName)?.skillNotesMarkdown ?? '';
+}
+
+function getAdditionalReferenceLibraries(skillConfig) {
+  return (skillConfig.additionalReferenceLibraries ?? []).flatMap(library => {
+    const referencedSkillConfig = SKILLS[library.skillName];
+    if (!referencedSkillConfig) {
+      console.warn(
+        `Additional reference skill "${library.skillName}" not found for ${skillConfig.name}`
+      );
+      return [];
+    }
+
+    return [
+      {
+        ...library,
+        skillConfig: referencedSkillConfig
+      }
+    ];
+  });
 }
 
 /**
@@ -399,6 +443,7 @@ metadata:
 function generateDocsSkillMd(skillConfig, categories, isS2) {
   const customGuideEntries = getCustomGuideEntries(skillConfig.name);
   const customSkillNotesMarkdown = getCustomSkillNotesMarkdown(skillConfig.name);
+  const additionalReferenceLibraries = getAdditionalReferenceLibraries(skillConfig);
   const embeddedCustomMarkdown = readCustomEmbeddedMarkdown(skillConfig.name, {
     '{{guidesBase}}': 'references/guides/',
     '{{componentsBase}}': 'references/components/',
@@ -492,6 +537,15 @@ The \`references/\` directory contains detailed documentation organized as follo
 `;
     for (const entry of categories.testing) {
       content += `- [${entry.title}](references/testing/${entry.path})\n`;
+    }
+    content += '\n';
+  }
+
+  if (additionalReferenceLibraries.length > 0) {
+    content += `### Additional References
+`;
+    for (const library of additionalReferenceLibraries) {
+      content += `- [${library.title}](references/${library.referenceSubdir}/llms.txt)${library.description ? `: ${library.description}` : ''}\n`;
     }
     content += '\n';
   }
@@ -619,8 +673,8 @@ Use these when you need more component-by-component or API-level detail:
 /**
  * Copy documentation files to the skill's references directory.
  */
-function copyDocsDocumentation(skillConfig, categories, skillDir) {
-  const refsDir = path.join(skillDir, 'references');
+function copyDocsDocumentation(skillConfig, categories, skillDir, options = {}) {
+  const refsDir = path.join(skillDir, 'references', options.referenceSubdir ?? '');
   const sourceDir = path.join(MARKDOWN_DOCS_DIST, skillConfig.sourceDir);
   const customGuideEntries = getCustomGuideEntries(skillConfig.name);
 
@@ -711,6 +765,25 @@ function copyDocsDocumentation(skillConfig, categories, skillDir) {
   const llmsTxtSource = path.join(sourceDir, 'llms.txt');
   if (fs.existsSync(llmsTxtSource)) {
     fs.copyFileSync(llmsTxtSource, path.join(refsDir, 'llms.txt'));
+  }
+}
+
+function copyAdditionalReferenceLibraries(skillConfig, skillDir) {
+  for (const library of getAdditionalReferenceLibraries(skillConfig)) {
+    const llmsTxtPath = path.join(MARKDOWN_DOCS_DIST, library.skillConfig.sourceDir, 'llms.txt');
+    if (!fs.existsSync(llmsTxtPath)) {
+      console.warn(`Warning: expected additional reference docs not found: ${llmsTxtPath}`);
+      continue;
+    }
+
+    const entries = parseLlmsTxt(llmsTxtPath);
+    const categories = categorizeEntries(entries, library.skillConfig.sourceDir);
+    copyDocsDocumentation(library.skillConfig, categories, skillDir, {
+      referenceSubdir: library.referenceSubdir
+    });
+    console.log(
+      `Copied ${library.title} documentation to ${path.relative(REPO_ROOT, path.join(skillDir, 'references', library.referenceSubdir))}`
+    );
   }
 }
 
@@ -871,6 +944,7 @@ function generateSkill(skillConfig, wellKnownRoot) {
   console.log(
     `Copied documentation to ${path.relative(REPO_ROOT, path.join(skillDir, 'references'))}`
   );
+  copyAdditionalReferenceLibraries(skillConfig, skillDir);
 
   return skillDir;
 }

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -36,7 +36,7 @@ const SKILLS = {
   'react-spectrum-s2': {
     name: 'react-spectrum-s2',
     description:
-      "Build UIs with React Spectrum S2 (Spectrum 2), Adobe's component library for React. Use when developers are using `@react-spectrum/s2` or need Adobe design system components. Provides comprehensive documentation, guides, and guidelines for all components. Also includes React Aria Components documentation as a reference for the cases where a custom component must be built on top of the unstyled React Aria primitives.",
+      "Build UIs with React Spectrum S2 (Spectrum 2), Adobe's component library for React. Use when developers are using `@react-spectrum/s2` or need Adobe design system components. Includes React Aria Components docs as a reference for building custom components on top of unstyled primitives.",
     license: 'Apache-2.0',
     sourceDir: 's2',
     additionalReferenceLibraries: [
@@ -461,15 +461,9 @@ function generateDocsSkillMd(skillConfig, categories, isS2) {
   let content = generateFrontmatter(skillConfig);
 
   if (isS2) {
-    content += `# React Spectrum S2 (Spectrum 2)
-
-React Spectrum S2 is Adobe's implementation of the Spectrum 2 design system in React. It provides a collection of accessible, adaptive, and high-quality UI components.
-`;
+    content += '# React Spectrum S2 (Spectrum 2)\n';
   } else {
-    content += `# React Aria Components
-
-React Aria Components is a library of unstyled, accessible UI components that you can style with any CSS solution. Built on top of React Aria hooks, it provides the accessibility and behavior without prescribing any visual design.
-`;
+    content += '# React Aria Components\n';
   }
 
   if (customSkillNotesMarkdown) {
@@ -494,7 +488,7 @@ The \`references/\` directory contains detailed documentation organized as follo
       content += `- [${entry.title}](references/guides/${entry.path})${entry.description ? `: ${entry.description}` : ''}\n`;
     }
     for (const entry of categories.guides) {
-      content += `- [${entry.title}](references/guides/${entry.path})${entry.description ? `: ${entry.description}` : ''}\n`;
+      content += `- [${entry.title}](references/guides/${entry.path})\n`;
     }
     content += '\n';
   }

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -497,12 +497,14 @@ The \`references/\` directory contains detailed documentation organized as follo
   }
 
   if (categories.components.length > 0) {
+    const componentNames = categories.components.map(entry => entry.title).join(', ');
     content += `### Components
+
+Component documentation is in \`references/components/\` — one Markdown file per component (e.g. \`references/components/Button.md\`). Read the file for a component when you need its API, props, examples, or accessibility notes.
+
+Available components: ${componentNames}.
+
 `;
-    for (const entry of categories.components) {
-      content += `- [${entry.title}](references/components/${entry.path})${entry.description ? `: ${entry.description}` : ''}\n`;
-    }
-    content += '\n';
   }
 
   if (categories.interactions.length > 0) {

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -247,6 +247,9 @@ function parseLlmsTxt(llmsTxtPath) {
     if (node.type === 'text') {
       return node.value;
     }
+    if (node.type === 'inlineCode') {
+      return '`' + node.value + '`';
+    }
     if (Array.isArray(node.children)) {
       return node.children.map(toText).join('');
     }

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -36,7 +36,7 @@ const SKILLS = {
   'react-spectrum-s2': {
     name: 'react-spectrum-s2',
     description:
-      'Build accessible UI components with React Spectrum S2 (Spectrum 2). Use when developers mention React Spectrum, Spectrum 2, S2, @react-spectrum/s2, or Adobe design system components. Provides documentation for buttons, forms, dialogs, tables, date/time pickers, color pickers, and other accessible components. Includes React Aria Components documentation as a fallback reference for custom components that must use unstyled primitives.',
+      "Build UIs with React Spectrum S2 (Spectrum 2), Adobe's component library for React. Use when developers are using `@react-spectrum/s2` or need Adobe design system components. Provides comprehensive documentation, guides, and guidelines for all components. Also includes React Aria Components documentation as a reference for the cases where a custom component must be built on top of the unstyled React Aria primitives.",
     license: 'Apache-2.0',
     sourceDir: 's2',
     additionalReferenceLibraries: [
@@ -45,7 +45,7 @@ const SKILLS = {
         referenceSubdir: 'react-aria',
         title: 'React Aria Components',
         description:
-          'Fallback documentation for unstyled accessible primitives. Use only when no React Spectrum S2 component fits the required interaction or layout.'
+          'Documentation for unstyled accessible primitives. Use only when no React Spectrum S2 component fits the requirements.'
       }
     ],
     compatibility: 'Requires a React project with @react-spectrum/s2 installed.',
@@ -86,28 +86,23 @@ const CUSTOM_SKILL_CONTENT = {
   'react-spectrum-s2': {
     skillNotesMarkdown: [
       'If the requirements do not clearly specify which React Spectrum component to use, consult the [Component Decision Tree](references/guides/component-decision-tree.md) before choosing a component.',
-      'If the request involves a Figma design, frame, or URL — or if the Figma MCP (`get_design_context`, `get_screenshot`, `get_variable_defs`, `search_design_system`) is available — consult [Implementing Figma designs with React Spectrum S2](references/guides/figma-to-s2.md) before generating code. The Figma MCP returns React + Tailwind reference output that must be translated to S2 components and the `style` macro.',
+      'If the request involves a Figma design, frame, or URL — or if the Figma MCP (`get_design_context`,`search_design_system`, etc.) is available — consult [Implementing Figma designs with React Spectrum S2](references/guides/figma-to-s2.md) before generating code.',
+      'When writing tests that exercise S2 components, consult [Testing with React Spectrum S2](references/guides/test-utils-guidance.md) and prefer the ARIA pattern testers from `@react-spectrum/test-utils` over hand-rolled role/selector queries.',
       `## React Spectrum S2 vs React Aria Components
 
 React Spectrum S2 is built on top of React Aria Components. The S2 components add Spectrum 2 styling, behavior, and slot structure on top of the unstyled React Aria primitives. Always prefer S2 components for React Spectrum work because they are pre-styled, design-system compliant, and cover most common UI patterns.
 
 Only reach for React Aria Components directly when:
-- Building a custom component because no S2 component matches the required interaction or layout. Follow [Creating Custom Components](references/guides/creating-custom-components.md) and pair the React Aria primitive with the S2 \`style\` macro for Spectrum styling.
-- Composing a primitive that S2 does not expose at all, such as \`FocusScope\`, \`VisuallyHidden\`, \`useFocusRing\`, \`mergeProps\`, or \`Toolbar\`.
+- Building a custom component because no S2 component matches the requirements. Follow [Creating Custom Components](references/guides/creating-custom-components.md) and pair the React Aria primitive with the S2 \`style\` macro for Spectrum styling.
+- You need a utility such as \`FocusScope\`, \`VisuallyHidden\`, \`useFocusRing\`, \`mergeProps\`, etc.
 
-When using both libraries in the same file:
-- Import S2 components from \`@react-spectrum/s2/<ComponentName>\` and React Aria primitives from \`react-aria-components\` or \`react-aria-components/<ComponentName>\`.
-- Do not mix \`Item\` or \`Section\` from \`react-aria-components\` into S2 collections. Use the typed item exports from the S2 collection itself, such as \`MenuItem\`, \`PickerItem\`, or \`ListViewItem\`.
-- Do not re-import shared types such as \`Key\`, \`Selection\`, \`SortDescriptor\`, or \`PressEvent\` from \`react-aria-components\` when they are re-exported from \`@react-spectrum/s2\`.
-
-The React Aria Components documentation is bundled under \`references/react-aria/\`. Start with [React Aria llms.txt](references/react-aria/llms.txt) only after confirming that no S2 component fits.`
+The React Aria Components documentation is bundled under \`references/react-aria/\`. Many unstyled React Aria Components share the same name as S2 components, so ensure that you're searching and accessing the correct docs where needed.`
     ].join('\n\n'),
     embeddedMarkdownPaths: [
       path.join(
         REPO_ROOT,
         'packages/dev/s2-docs/skills/react-spectrum-s2/implementation-guidance.md'
-      ),
-      path.join(REPO_ROOT, 'packages/dev/s2-docs/skills/react-spectrum-s2/test-utils-guidance.md')
+      )
     ],
     guideEntries: [
       {
@@ -139,6 +134,16 @@ The React Aria Components documentation is bundled under \`references/react-aria
         ),
         description:
           'How to build custom Spectrum 2 components using React Aria Components and the `style` macro.'
+      },
+      {
+        title: 'Testing with React Spectrum S2',
+        path: 'test-utils-guidance.md',
+        sourcePath: path.join(
+          REPO_ROOT,
+          'packages/dev/s2-docs/skills/react-spectrum-s2/test-utils-guidance.md'
+        ),
+        description:
+          'How to write tests for S2 components using ARIA pattern testers from `@react-spectrum/test-utils`.'
       }
     ]
   },
@@ -532,15 +537,6 @@ The \`references/\` directory contains detailed documentation organized as follo
     content += '\n';
   }
 
-  if (categories.testing.length > 0) {
-    content += `### Testing
-`;
-    for (const entry of categories.testing) {
-      content += `- [${entry.title}](references/testing/${entry.path})\n`;
-    }
-    content += '\n';
-  }
-
   if (additionalReferenceLibraries.length > 0) {
     content += `### Additional References
 `;
@@ -727,7 +723,8 @@ function copyDocsDocumentation(skillConfig, categories, skillDir, options = {}) 
       targetPath,
       renderCustomMarkdown(sourcePath, {
         '{{guidesBase}}': '',
-        '{{componentsBase}}': '../components/'
+        '{{componentsBase}}': '../components/',
+        '{{testingBase}}': '../testing/'
       }) + '\n'
     );
   }

--- a/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
+++ b/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
@@ -3834,10 +3834,11 @@ async function main() {
       heading = headingMatch[1].trim();
     }
 
-    // Extract the description (first paragraph after heading)
+    // Extract the description (first paragraph after heading). Skip if the
+    // first block after the heading is another heading rather than prose.
     let description = null;
     const descriptionMatch = markdown.match(/^#\s+.+$\n\n(.+?)(?:\n\n|$)/m);
-    if (descriptionMatch) {
+    if (descriptionMatch && !descriptionMatch[1].trim().startsWith('#')) {
       description = descriptionMatch[1].trim();
     }
 

--- a/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
+++ b/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
@@ -109,12 +109,14 @@ function getTsFileIndex() {
     path.posix.join(REPO_ROOT, 'packages/**/*.{ts,tsx,d.ts}')
   ];
 
-  const files = glob.sync(patterns, {
-    absolute: true,
-    suppressErrors: true,
-    deep: 5,
-    ignore: ['**/node_modules/**', '**/*.test.*', '**/*.stories.*', '**/dist/**']
-  });
+  const files = glob
+    .sync(patterns, {
+      absolute: true,
+      suppressErrors: true,
+      deep: 5,
+      ignore: ['**/node_modules/**', '**/*.test.*', '**/*.stories.*', '**/dist/**']
+    })
+    .sort((a, b) => a.localeCompare(b));
 
   // Build index: for each file, extract exported names for quick lookup
   tsFileIndex = new Map();
@@ -152,6 +154,9 @@ function getTsFileIndex() {
   }
 
   console.log(`Built index with ${tsFileIndex.size} symbols in ${Date.now() - startTime}ms`);
+  for (const candidates of tsFileIndex.values()) {
+    candidates.sort((a, b) => a.localeCompare(b));
+  }
   return tsFileIndex;
 }
 
@@ -163,7 +168,255 @@ function cleanTypeText(t) {
   let cleaned = t.replace(/import\(["'][^)]*["']\)\./g, '');
   // Remove duplicate type parameters.
   cleaned = cleaned.replace(/<\s*([A-Za-z0-9_$.]+)\s*,\s*\1\s*>/g, '<$1>');
-  return cleaned;
+  return normalizeTypeText(cleaned);
+}
+
+// TypeScript can emit union members in different orders across fresh projects.
+// Canonicalize unions while avoiding parameter lists and object type bodies.
+function findTopLevelArrow(text) {
+  let depth = 0;
+  let quote = null;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === '\\') {
+        i++;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '(' || ch === '[' || ch === '{' || ch === '<') {
+      depth++;
+    } else if (ch === ')' || ch === ']' || ch === '}' || ch === '>') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === '=' && text[i + 1] === '>' && depth === 0) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function findMatchingDelimiter(text, start) {
+  const pairs = {
+    '(': ')',
+    '[': ']',
+    '{': '}',
+    '<': '>'
+  };
+  const open = text[start];
+  const close = pairs[open];
+  if (!close) {
+    return -1;
+  }
+
+  let depth = 0;
+  let quote = null;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === '\\') {
+        i++;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === open) {
+      depth++;
+    } else if (ch === close) {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function normalizeNestedTypeText(text) {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const start = i;
+      i++;
+      while (i < text.length) {
+        if (text[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (text[i] === ch) {
+          break;
+        }
+        i++;
+      }
+      out += text.slice(start, Math.min(i + 1, text.length));
+      continue;
+    }
+
+    if (ch === '(' || ch === '[' || ch === '{' || ch === '<') {
+      const end = findMatchingDelimiter(text, i);
+      if (end !== -1) {
+        const nextText = text.slice(end + 1);
+        const isFunctionParams = ch === '(' && /^\s*=>/.test(nextText);
+        const inner = text.slice(i + 1, end);
+        const normalizedInner =
+          ch === '{' || isFunctionParams
+            ? normalizeNestedTypeText(inner)
+            : normalizeTypeText(inner);
+        out += ch + normalizedInner + text[end];
+        i = end;
+        continue;
+      }
+    }
+
+    out += ch;
+  }
+
+  return out;
+}
+
+function splitTopLevelUnion(text) {
+  const parts = [];
+  let depth = 0;
+  let quote = null;
+  let start = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === '\\') {
+        i++;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '(' || ch === '[' || ch === '{' || ch === '<') {
+      depth++;
+    } else if (ch === ')' || ch === ']' || ch === '}' || ch === '>') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === '|' && depth === 0) {
+      parts.push(text.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  if (parts.length > 0) {
+    parts.push(text.slice(start).trim());
+  }
+
+  return parts;
+}
+
+function stringLiteralValue(text) {
+  const match = text.match(/^(['"])(.*)\1$/);
+  return match ? match[2] : null;
+}
+
+function unionSortKey(part) {
+  const text = part.trim();
+  const primitiveOrder = new Map([
+    ['any', 0],
+    ['unknown', 1],
+    ['never', 2],
+    ['void', 3],
+    ['boolean', 4],
+    ['number', 5],
+    ['string', 6],
+    ['symbol', 7],
+    ['bigint', 8]
+  ]);
+
+  if (primitiveOrder.has(text)) {
+    return [0, primitiveOrder.get(text), ''];
+  }
+
+  if (/^-?\d+(?:\.\d+)?$/.test(text)) {
+    return [1, Number(text), ''];
+  }
+
+  const literal = stringLiteralValue(text);
+  if (literal != null) {
+    const booleanLiteralOrder = new Map([
+      ['true', 0],
+      ['false', 1]
+    ]);
+    if (booleanLiteralOrder.has(literal)) {
+      return [2, booleanLiteralOrder.get(literal), literal];
+    }
+    return [2, 2, literal.toLowerCase()];
+  }
+
+  if (text === 'null') {
+    return [8, 0, ''];
+  }
+
+  if (text === 'undefined') {
+    return [9, 0, ''];
+  }
+
+  return [3, 0, text.toLowerCase()];
+}
+
+function compareUnionParts(a, b) {
+  const aKey = unionSortKey(a);
+  const bKey = unionSortKey(b);
+  for (let i = 0; i < Math.max(aKey.length, bKey.length); i++) {
+    if (aKey[i] < bKey[i]) {
+      return -1;
+    }
+    if (aKey[i] > bKey[i]) {
+      return 1;
+    }
+  }
+  return a.localeCompare(b);
+}
+
+function sortUnionMembers(text) {
+  const parts = splitTopLevelUnion(text);
+  if (parts.length <= 1) {
+    return text;
+  }
+
+  return parts.sort(compareUnionParts).join(' | ');
+}
+
+function normalizeTypeText(t) {
+  const text = t.trim();
+  if (!text) {
+    return text;
+  }
+
+  const normalized = normalizeNestedTypeText(text);
+  const arrowIndex = findTopLevelArrow(normalized);
+  if (arrowIndex >= 0) {
+    const before = normalized.slice(0, arrowIndex + 2);
+    const after = normalized.slice(arrowIndex + 2).trim();
+    return `${before} ${normalizeTypeText(after)}`;
+  }
+
+  return sortUnionMembers(normalized);
 }
 
 /**
@@ -1602,7 +1855,7 @@ function generateInterfaceTable(interfaceName, file) {
     // Check if we need a Default column
     const hasDefaults = properties.some(p => !!p.defVal);
 
-    // Sort properties so required ones are shown first
+    // Sort properties so required ones are shown first, then alphabetically.
     const sortedProps = properties.sort((a, b) => {
       if (!a.optional && b.optional) {
         return -1;
@@ -1610,7 +1863,7 @@ function generateInterfaceTable(interfaceName, file) {
       if (a.optional && !b.optional) {
         return 1;
       }
-      return 0;
+      return a.name.localeCompare(b.name);
     });
 
     if (hasDefaults) {
@@ -1640,12 +1893,14 @@ function generateInterfaceTable(interfaceName, file) {
       sections.push('### Methods\n');
     }
 
-    methods.forEach(m => {
-      sections.push(`#### \`${m.signature}\`\n`);
-      if (m.description) {
-        sections.push(`${m.description}\n`);
-      }
-    });
+    methods
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach(m => {
+        sections.push(`#### \`${m.signature}\`\n`);
+        if (m.description) {
+          sections.push(`${m.description}\n`);
+        }
+      });
   }
 
   const result = sections.join('\n');
@@ -3505,10 +3760,12 @@ function generateLibraryLlmsTxt(lib, files) {
  * with plain markdown equivalents so that the resulting *.md files can be consumed by LLMs.
  */
 async function main() {
-  const mdxFiles = await glob('*/**/*.mdx', {
-    cwd: S2_DOCS_PAGES_ROOT,
-    absolute: true
-  });
+  const mdxFiles = (
+    await glob('*/**/*.mdx', {
+      cwd: S2_DOCS_PAGES_ROOT,
+      absolute: true
+    })
+  ).sort((a, b) => a.localeCompare(b));
 
   // Collect generated markdown filenames and headings for each library so we can build llms.txt files.
   const docsByLibrary = {

--- a/packages/dev/s2-docs/skills/react-spectrum-s2/implementation-guidance.md
+++ b/packages/dev/s2-docs/skills/react-spectrum-s2/implementation-guidance.md
@@ -10,7 +10,7 @@ import Folder from '@react-spectrum/s2/icons/Folder';
 import CloudUpload from '@react-spectrum/s2/illustrations/gradient/generic2/CloudUpload';
 ```
 
-Common types and list-data hooks are re-exported from `@react-spectrum/s2` — don't pull them from `react-aria-components`, `react-stately`, or `@react-types/*`:
+Common types and list-data hooks are re-exported from `@react-spectrum/s2` — prefer importing from there instead of `react-aria-components`, `react-stately`, or `@react-types/*`:
 
 ```tsx
 import type {Key, Selection, SortDescriptor, PressEvent, RangeValue, DateValue, DateRange, TimeValue, RouterConfig} from '@react-spectrum/s2';
@@ -19,7 +19,7 @@ import {useListData, useTreeData, useAsyncList} from '@react-spectrum/s2';
 
 ### Use the typed Item for each collection
 
-Each S2 collection component has its own item export — don't import a generic `Item` from `react-aria-components`. `Menu` → `MenuItem`/`MenuSection`; `Picker` → `PickerItem`/`PickerSection`; `ComboBox` → `ComboBoxItem`/`ComboBoxSection`; `ListView` → `ListViewItem`; `TreeView` → `TreeViewItem` (with `TreeViewItemContent`); `TableView` → `Row`/`Column`/`Cell`/`TableHeader`/`TableBody`; `SegmentedControl` → `SegmentedControlItem`; `TagGroup` → `Tag`; `Breadcrumbs` → `Breadcrumb`; `Accordion` → `AccordionItem` (with `AccordionItemHeader`/`AccordionItemTitle`/`AccordionItemPanel`).
+Each S2 collection component has its own item export — there is no generic `Item` component. `Menu` → `MenuItem`/`MenuSection`; `Picker` → `PickerItem`/`PickerSection`; `ComboBox` → `ComboBoxItem`/`ComboBoxSection`; `ListView` → `ListViewItem`; `TreeView` → `TreeViewItem` (with `TreeViewItemContent`); `TableView` → `Row`/`Column`/`Cell`/`TableHeader`/`TableBody`; `SegmentedControl` → `SegmentedControlItem`; `TagGroup` → `Tag`; `Breadcrumbs` → `Breadcrumb`; `Accordion` → `AccordionItem` (with `AccordionItemHeader`/`AccordionItemTitle`/`AccordionItemPanel`).
 
 ## Styling
 
@@ -122,30 +122,6 @@ Prefer **semantic** color tokens when the color carries meaning: `'accent'`, `'n
 ### Don't restate default prop values
 
 `variant="primary"` on `Button`, `size="M"` on most components, `density="regular"` on collections — setting a prop to its default is noise. Omit it.
-
-### Built-in macro utilities
-
-`@react-spectrum/s2/style` exports helpers — use them instead of rebuilding by hand:
-
-- `focusRing()` — Spectrum focus outline (color, width, offset, `isFocusVisible`, forced colors). Spread into a `style({...})` call; the call must receive `isFocusVisible` at runtime. RAC components pass this as a render prop to className, or you can use the `useFocusRing` hook.
-
-  ```tsx
-  import {focusRing, style} from '@react-spectrum/s2/style' with {type: 'macro'};
-  import {Button} from 'react-aria-components';
-
-  const tile = style({
-    ...focusRing(),
-    borderRadius: 'lg',
-    padding: 8
-  });
-  <Button className={tile}>…</Button>
-  ```
-- `lightDark(light, dark)` — a value that adapts to the current color scheme. Use this for one-off light/dark differences.
-- `baseColor(token)` / `color(token)` — produce a color value for custom CSS variables.
-- `space(px)` / `fontRelative(px)` — escape hatches for non-grid pixel values (rare).
-- `pressScale(scale)` — press-state scale transforms on custom interactive elements.
-
-See [Styling]({{guidesBase}}styling.md) and [Style Macro]({{guidesBase}}style-macro.md) for the full reference. When building a custom component on top of React Aria Components with the `style` macro, see [Creating Custom Components]({{guidesBase}}creating-custom-components.md) for best practices. If you hit a `style` macro import error, see the 'Framework setup' section of [Getting started]({{guidesBase}}getting-started.md).
 
 ## Responsive design
 
@@ -268,7 +244,7 @@ Every collection (`ListView`, `TableView`, `CardView`, `TreeView`, `Menu`, `List
 ### Empty and loading states are built in
 
 - Empty state: pass `renderEmptyState` returning an `IllustratedMessage`. Don't conditionally swap the whole collection for a custom empty `div`.
-- Async data: use `useAsyncList` (or the user's preferred data fetching library) plus the collection's `loadingState`/`onLoadMore` props. Don't render a separate spinner above the collection.
+- Async data: use `useAsyncList` (or the user's preferred data fetching library) plus the collection's `loadingState`/`onLoadMore` props. Don't render a separate spinner.
 
 ### Bulk actions with ActionBar
 
@@ -374,4 +350,3 @@ Before reporting the task as complete, exercise the project's own toolchain. The
 - **Typecheck.** Run the project's typecheck (`tsc --noEmit`, `tsc -b`, etc.). Fix everything — wrong `size` values, missing required props, raw CSS in the macro all surface here.
 - **Build or dev server.** Run at least once. The macro's "cannot statically evaluate" error means a value inside `style({...})` depends on something non-literal; refactor to use runtime conditions or the runtime style function.
 - **Runtime warnings.** If you can render the page, check the console for missing `aria-label`/`textValue`, deprecated props, etc. Treat these as failures.
-

--- a/packages/dev/s2-docs/skills/react-spectrum-s2/implementation-guidance.md
+++ b/packages/dev/s2-docs/skills/react-spectrum-s2/implementation-guidance.md
@@ -94,14 +94,6 @@ const card = style({
 <div className={card({isActive})} />
 ```
 
-```tsx
-// ❌ Inline style alongside the macro.
-<div className={style({display: 'grid', gap: 12})} style={{gridTemplateColumns: '1fr 2fr'}} />
-
-// ✅ Everything in one macro call.
-<div className={style({display: 'grid', gap: 12, gridTemplateColumns: '1fr 2fr'})} />
-```
-
 If a value seems impossible to express in the macro, check the [Style Macro]({{guidesBase}}style-macro.md) reference before falling back to inline styles — most CSS properties (grid placement, overflow, position, sizing, display) are supported.
 
 ### Style macro values are tokens, not raw CSS
@@ -156,23 +148,15 @@ S2 components define their own internal DOM and slot structure. Don't inject wra
 
 ### Buttons with text and icon
 
-`Button`/`ActionButton`/`LinkButton` with **both** an icon and a text label require the label to be wrapped in `<Text>` — plain string children next to an icon render incorrectly. Icon-only or text-only children are fine as-is (icon-only needs `aria-label`).
-
-`Text` is re-exported from each button's own subpath — import it alongside the button component:
+`Button`/`ActionButton`/`LinkButton` with **both** an icon and a text label require the label to be wrapped in `<Text>` — plain string children next to an icon render incorrectly. (Icon-only children render fine but require `aria-label`.) `Text` is re-exported from each button's own subpath:
 
 ```tsx
 import {ActionButton, Text} from '@react-spectrum/s2/ActionButton';
 import Download from '@react-spectrum/s2/icons/Download';
 
-// ✅ Icon + text — label in <Text>, no slot attribute.
 <ActionButton>
   <Download />
   <Text>Download</Text>
-</ActionButton>
-
-// ✅ Icon only — aria-label required.
-<ActionButton aria-label="Download">
-  <Download />
 </ActionButton>
 ```
 
@@ -212,18 +196,15 @@ Collection components (`Menu`, `Picker`, `ComboBox`, `ListView`, `TreeView`, `Ta
 Items use `id` for selection, `onAction(key)`, sort, expansion, and React reconciliation. Static items get a literal `id`; dynamic items get `id={item.something}` inside the render function. When using `.map`, set **both** `id` and React's `key`:
 
 ```tsx
-// ✅ Dynamic collection with render function — id only.
-<ListView aria-label="Files" items={files}>
-  {item => <ListViewItem id={item.id}>{item.name}</ListViewItem>}
-</ListView>
-
-// ✅ Dynamic collection using array.map — id AND key.
+// ✅ With array.map — set BOTH `id` (for the collection) and `key` (for React).
 <ListView aria-label="Files">
   {files.map(item => (
     <ListViewItem key={item.id} id={item.id}>{item.name}</ListViewItem>
   ))}
 </ListView>
 ```
+
+When passing data via the `items` prop and using a render function, only `id` is needed.
 
 ### `textValue` when item children aren't plain text
 
@@ -288,7 +269,7 @@ If your app uses `ToastQueue`, place a single `<ToastContainer />` as a sibling 
 
 ```tsx
 import {Provider} from '@react-spectrum/s2/Provider';
-import {ToastContainer, ToastQueue} from '@react-spectrum/s2/Toast';
+import {ToastContainer} from '@react-spectrum/s2/Toast';
 
 function App() {
   return (
@@ -298,14 +279,11 @@ function App() {
     </Provider>
   );
 }
-
-// Anywhere in the tree:
-ToastQueue.positive('Saved!', {timeout: 5000});
 ```
 
 ## Form fields
 
-S2 form fields (`TextField`, `TextArea`, `NumberField`, `SearchField`, `Picker`, `ComboBox`, `Checkbox`, `CheckboxGroup`, `RadioGroup`, `Switch`, `Slider`, `RangeSlider`, `ColorField`, `DateField`, `DatePicker`, `TimeField`, `DateRangePicker`, etc.) render their own label, description, error message, and required indicator. Pass those as props on the field — don't wrap the field in a `<label>`/`<p>`/`<div>` to attach them.
+S2 form fields render their own label, description, error message, and required indicator. Pass those as props on the field — don't wrap the field in a `<label>`/`<p>`/`<div>` to attach them.
 
 - `label="..."` — visible label.
 - `description="..."` — help text.


### PR DESCRIPTION

- Bundle RAC docs inside the S2 skill under `references/react-aria/` and mention when to use them in `SKILL.md`
- Shrink the `SKILL.md` size by removing info that was redundant or not alway useful. We'd like to keep it around ~5k tokens or less. Skills use progressive disclosure, so only important details should be included here since it is loaded into context first.
- Make the TS prop tables deterministic to avoid false positives in the skill differ that were just related to type member ordering
- Moves the "Agent Skills" section to be above the "MCP Server" section in the docs

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
