### PR TITLE
fix(s2): prevent infinite render loop in Tabs inside DropZone

### DIFF
--- a/packages/@react-spectrum/s2/src/Tabs.tsx
+++ b/packages/@react-spectrum/s2/src/Tabs.tsx
@@ -139,6 +139,7 @@ const InternalTabsContext = createContext<
   Partial<TabsProps> & {
     tablistRef?: RefObject<HTMLDivElement | null>;
     selectedKey?: Key | null;
+    baseId?: string;
   }
 >({});
 
@@ -200,6 +201,8 @@ export const Tabs = forwardRef(function Tabs(props: TabsProps, ref: DOMRef<HTMLD
   }
 
   let tablistRef = useRef<HTMLDivElement | null>(null);
+  // Shared base id so child Tab/TabPanel components can derive stable ids.
+  let baseId = useId();
 
   return (
     <Provider
@@ -215,6 +218,7 @@ export const Tabs = forwardRef(function Tabs(props: TabsProps, ref: DOMRef<HTMLD
             tablistRef,
             onSelectionChange: setValue,
             labelBehavior,
+            baseId,
             'aria-label': props['aria-label'],
             'aria-labelledby': props['aria-labelledby']
           }
@@ -460,9 +464,12 @@ const icon = style({
 });
 
 export function Tab(props: TabProps): ReactNode {
-  let {density, orientation, labelBehavior} = useContext(InternalTabsContext) ?? {};
+  let {density, orientation, labelBehavior, baseId} = useContext(InternalTabsContext) ?? {};
 
-  let contentId = useId();
+  // Derive a stable content id from the shared baseId on InternalTabsContext.
+  // Prevents infinite loop when rendering across multiple CollectionBuilder portals.
+  let fallbackId = useId();
+  let contentId = `${baseId ?? fallbackId}-content-${props.id ?? fallbackId}`;
   let ariaLabelledBy = props['aria-labelledby'] || '';
 
   return (

--- a/packages/@react-spectrum/s2/test/Tabs.test.tsx
+++ b/packages/@react-spectrum/s2/test/Tabs.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {act, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {Button} from '../src/Button';
+import {DropZone as RACDropZone} from 'react-aria-components/DropZone';
+import React, {useState} from 'react';
+import {Skeleton} from '../src/Skeleton';
+import {Tab, TabList, TabPanel, Tabs} from '../src/Tabs';
+import {Text} from '../src/Content';
+import userEvent from '@testing-library/user-event';
+
+describe('Tabs', () => {
+  let user;
+  beforeAll(() => {
+    jest.useFakeTimers();
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    act(() => jest.runAllTimers());
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should not infinite-loop when inside DropZone with a controlled Tabs + Skeleton + Text', async () => {
+    function Repro() {
+      const [tab, setTab] = useState<string>('a');
+      return (
+        <RACDropZone data-testid="dropzone" aria-label="DropZone">
+          <Button onPress={() => {}}>Sign in</Button>
+          <Tabs aria-label="x" selectedKey={tab} onSelectionChange={k => setTab(k as string)}>
+            <TabList>
+              <Tab id="a">A</Tab>
+            </TabList>
+            <TabPanel id="a">
+              <Skeleton isLoading>
+                <Text>x</Text>
+              </Skeleton>
+            </TabPanel>
+          </Tabs>
+        </RACDropZone>
+      );
+    }
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const {getByTestId} = render(<Repro />);
+
+    await act(async () => {
+      await user.hover(getByTestId('dropzone'));
+    });
+
+    const updateDepthError = errorSpy.mock.calls.find(call =>
+      call.some(arg => String(arg).includes('Maximum update depth'))
+    );
+    expect(updateDepthError).toBeUndefined();
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/@react-spectrum/s2/test/Tabs.test.tsx
+++ b/packages/@react-spectrum/s2/test/Tabs.test.tsx
@@ -24,6 +24,7 @@ describe('Tabs', () => {
   beforeAll(() => {
     jest.useFakeTimers();
     user = userEvent.setup({delay: null, pointerMap});
+    Element.prototype.getAnimations = jest.fn().mockImplementation(() => []);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10057

Updates S2 Tab to derive contentId from a baseId shared on InternalTabsContext plus the tab's id, so independent CollectionBuilder portals produce the same value and mergeIds doesn't infinitely oscillate between values.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Unit test should cover. Just smoke test S2 Tabs.

## 🧢 Your Project:

<!--- Company/project for pull request -->
