### PR TITLE
chore: remove box-shadow divider and update focus ring in TableView

### DIFF
--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -2016,11 +2016,14 @@ const row = style<
       }
     }
   },
-  // When checkbox selection, render the gray divider between rows as a border
   borderTopWidth: 0,
   borderBottomWidth: {
     selectionStyle: {
-      highlight: 0,
+      highlight: {
+        default: 1,
+        isSelected: 0,
+        isNextSelected: 0
+      },
       checkbox: 1
     }
   },
@@ -2029,7 +2032,10 @@ const row = style<
   borderStyle: 'solid',
   borderColor: {
     selectionStyle: {
-      highlight: 'transparent',
+      highlight: {
+        default: 'gray-300',
+        isSelected: 'transparent'
+      },
       checkbox: 'gray-300'
     }
   },
@@ -2057,20 +2063,11 @@ const row = style<
       isSelected: '--borderColorBlue'
     }
   },
-  // When highlight selection, render gray dividers as box shadow
-  boxShadow: {
-    selectionStyle: {
-      highlight: {
-        default: '[inset 0 -1px 0px var(--borderColorGray)]',
-        isNextSelected: '[inset 0 0 0 var(--borderColorGray)]'
-        // TODO: Determine if we want to support gray dividers between selected grouped rows
-        // isSelected: {
-        //   isNextSelected: '[inset 0 -1px 0px var(--borderColorGray)]'
-        // }
-      }
-    },
-    forcedColors: {
-      isFocusVisible: '[inset 0 0 0 2px Highlight]'
+  '--focusRingColor': {
+    type: 'outlineColor',
+    value: {
+      default: 'focus-ring',
+      forcedColors: 'Highlight'
     }
   },
   fontWeight: {
@@ -2078,11 +2075,30 @@ const row = style<
     isInFooter: 'bold'
   },
   isolation: 'isolate',
-  forcedColorAdjust: 'none'
+  forcedColorAdjust: 'none',
+  '--topPosition': {
+    type: 'top',
+    value: {
+      default: '[-1px]',
+      isFirstItem: 0
+    }
+  },
+  '--bottomPosition': {
+    type: 'bottom',
+    value: {
+      default: '[-1px]',
+      selectionStyle: {
+        highlight: {
+          default: '[-1px]',
+          isSelected: 0
+        }
+      }
+    }
+  }
 });
 
 // Sticky cells (the drag cell, and the checkbox cell when present) get an inline z-index=2 applied by the virtualizer's layout
-// To ensure that the highlight selection border is painted above the stick cells, set z-index to 3
+// To ensure that the highlight selection border is painted above the sticky cells, set z-index to 3
 const highlightSelectionBorder = css(
   `&:before {
     content: "";
@@ -2110,15 +2126,15 @@ const highlightSelectionBorder = css(
 const focusIndicator = css(
   `&:after {
     content: "";
-    width: 100%;
-    height: 100%;
-    top: 0;
-    z-index: 2;
+    top: var(--topPosition);
+    bottom: var(--bottomPosition);
+    z-index: 3;
     inset-inline-start: 0;
+    inset-inline-end: 0;
     border-radius: 5px;
     position: absolute;
     outline-style: solid;
-    outline-color: var(--borderColorBlue);
+    outline-color: var(--focusRingColor);
     outline-width: 2px;
     outline-offset: -2px;
     pointer-events: none;
@@ -2174,6 +2190,7 @@ export const Row = /*#__PURE__*/ (forwardRef as forwardRefType)(function Row<T>(
           ...tableVisualOptions,
           selectionStyle,
           isInFooter,
+          isFirstItem: isFirstItem(renderProps.id, renderProps.state),
           isNextSelected: isNextSelected(renderProps.id, renderProps.state),
           isPrevSelected: isPrevSelected(renderProps.id, renderProps.state)
         }) +
@@ -2253,4 +2270,11 @@ export function isPrevSelected(id: Key | undefined, state: TableState<unknown>) 
   }
   let keyBefore = state.collection.getKeyBefore(id);
   return keyBefore != null && state.selectionManager.isSelected(keyBefore);
+}
+
+function isFirstItem(id: Key | undefined, state: TableState<unknown>) {
+  if (id == null || !state) {
+    return false;
+  }
+  return state.collection.getFirstKey() === id;
 }

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -688,7 +688,15 @@ function CellFocusRing() {
   return (
     <div
       role="presentation"
-      className={style({...cellFocus, position: 'absolute', inset: 0, pointerEvents: 'none'})({
+      className={style({
+        ...cellFocus,
+        position: 'absolute',
+        top: 'var(--topFocusRing)',
+        bottom: 0,
+        insetStart: 0,
+        insetEnd: 0,
+        pointerEvents: 'none'
+      })({
         isFocusVisible: true
       })}
     />
@@ -2022,16 +2030,7 @@ const row = style<
     }
   },
   borderTopWidth: 0,
-  borderBottomWidth: {
-    selectionStyle: {
-      highlight: {
-        default: 1,
-        isSelected: 0,
-        isNextSelected: 0
-      },
-      checkbox: 1
-    }
-  },
+  borderBottomWidth: 1,
   borderStartWidth: 0,
   borderEndWidth: 0,
   borderStyle: 'solid',
@@ -2039,7 +2038,8 @@ const row = style<
     selectionStyle: {
       highlight: {
         default: 'gray-300',
-        isSelected: 'transparent'
+        isSelected: 'transparent',
+        isNextSelected: 'transparent'
       },
       checkbox: 'gray-300'
     }
@@ -2081,22 +2081,34 @@ const row = style<
   },
   isolation: 'isolate',
   forcedColorAdjust: 'none',
-  '--topPosition': {
+  '--topFocusRing': {
     type: 'top',
     value: {
       default: '[-1px]',
       isFirstItem: 0
     }
   },
+  '--topHighlightBorder': {
+    type: 'top',
+    value: {
+      default: 0,
+      isSelected: '[-1px]',
+      // Don't overlap focus ring of row above.
+      isPrevSelected: 0,
+      isFirstItem: 0,
+      forcedColors: 0
+    }
+  },
   '--bottomPosition': {
     type: 'bottom',
     value: {
-      default: '[-1px]',
       selectionStyle: {
-        highlight: {
+        checkbox: {
           default: '[-1px]',
-          isSelected: 0
-        }
+          // Avoid the next row's selected background covering this row's focus ring.
+          isNextSelected: 0
+        },
+        highlight: '[-1px]'
       }
     }
   }
@@ -2107,12 +2119,11 @@ const row = style<
 const highlightSelectionBorder = css(
   `&:before {
     content: "";
-    width: 100%;
-    height: 100%;
+    top: var(--topHighlightBorder);
+    bottom: -1px;
+    inset-inline: 0;
     position: absolute;
-    inset: 0;
     z-index: 3;
-    box-sizing: border-box;
     border-style: solid;
     border-color: var(--borderColor);
     border-top-width: var(--borderTopWidth);
@@ -2131,7 +2142,7 @@ const highlightSelectionBorder = css(
 const focusIndicator = css(
   `&:after {
     content: "";
-    top: var(--topPosition);
+    top: var(--topFocusRing);
     bottom: var(--bottomPosition);
     z-index: 3;
     inset-inline-start: 0;

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1913,7 +1913,12 @@ const rowTextColor = {
 
 const row = style<
   RowRenderProps &
-    S2TableProps & {isInFooter?: boolean; isNextSelected?: boolean; isPrevSelected?: boolean}
+    S2TableProps & {
+      isInFooter?: boolean;
+      isNextSelected?: boolean;
+      isPrevSelected?: boolean;
+      isFirstItem?: boolean;
+    }
 >({
   height: 'full',
   position: 'relative',


### PR DESCRIPTION
Some nice-to-haves that we discussed during testing. Also follows up on one comment that Devon made on the original PR here and simplifies things by removing the use of box-shadow and replacing it with borders instead. 

So in short the changes are:
1) Remove the use of box-shadows to render the gray dividers in favor of border
2) Update the focus ring to match ListView. Instead of the focus ring rendering inside the row and flush against the gray dividers, they now render on top of them instead. 

https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=1200

Not a blocker for release, just some minor improvements

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to S2 storybook and sanity check that using borders for the gray dividers did not change anything in highlight selection (like layout changes when you select and deselect a row) 

For the focus ring, make sure to test the focus ring for the entire row but also the cell focus ring. It should closely match what ListView does where the focus ring renders on top of the gray dividers rather flush against it

## 🧢 Your Project:

<!--- Company/project for pull request -->
