### PR TITLE
fix(README): update broken architecture.html links to getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ React Spectrum includes several libraries, which you can choose depending on you
 * [React Aria](https://react-spectrum.adobe.com/react-aria/getting-started.html) is a collection of unstyled React components and hooks that helps you build accessible, high quality UI components for your own application or design system. If you're building a component library for the web from scratch with your own styling, start here.
 * [React Stately](https://react-spectrum.adobe.com/react-stately/getting-started.html) is a library of state management hooks for use in your component library. If you're using React Aria, you'll likely also use React Stately, but it can also be used independently (e.g. on other platforms like React Native).
 
-[Read more about our architecture](https://react-spectrum.adobe.com/architecture.html).
+[Read more about our architecture](https://react-spectrum.adobe.com/react-spectrum/getting-started.html).
 
 ## Contributing
 
 One of the goals of the React Spectrum project is to make building design systems and component libraries as easy as possible, while maintaining high quality interactions and accessibility support. We aim to raise the bar for web applications. The best way to achieve that goal is **together**. We would love contributions from the community no matter how big or small. 😍
 
-Read our [contributing guide](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md) to learn about how to propose bugfixes and improvements, and how the development process works. For detailed information about our architecture, and how all of the pieces fit together, read our [architecture docs](https://react-spectrum.adobe.com/architecture.html).
+Read our [contributing guide](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md) to learn about how to propose bugfixes and improvements, and how the development process works. For detailed information about our architecture, and how all of the pieces fit together, read our [architecture docs](https://react-spectrum.adobe.com/react-spectrum/getting-started.html).


### PR DESCRIPTION
Fixes #10103

Why
The `architecture.html` link in README.md (appearing in two places) redirects to the top page because the page no longer exists at that URL.

Changes
Updated both occurrences of `https://react-spectrum.adobe.com/architecture.html` to `https://react-spectrum.adobe.com/react-spectrum/getting-started.html`.

Updated component: `README.md`

Surface area
- Documentation
- Bug fix