### PR TITLE
fix: stabilise our flaky CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,6 @@ jobs:
       - run:
           name: build fork-point apis
           command: |
-            mkdir -p ~/.ssh
-            curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
             yarn build:api-branch --githash="origin/main" --output="base-api" && yarn build:api-branch && yarn compare:apis
 
       - persist_to_workspace:
@@ -489,8 +487,6 @@ jobs:
       - run:
           name: build agent skills (main)
           command: |
-            mkdir -p ~/.ssh
-            curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
             BRANCH_ROOT="$(pwd)"
             BUILD_SKILLS="$BRANCH_ROOT/.circleci/build-skills.sh"
             git worktree add --detach /tmp/main-worktree origin/main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,8 @@ jobs:
       - run:
           name: build fork-point apis
           command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan -t rsa,ed25519 github.com >> ~/.ssh/known_hosts
             yarn build:api-branch --githash="origin/main" --output="base-api" && yarn build:api-branch && yarn compare:apis
 
       - persist_to_workspace:
@@ -487,6 +489,8 @@ jobs:
       - run:
           name: build agent skills (main)
           command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan -t rsa,ed25519 github.com >> ~/.ssh/known_hosts
             BRANCH_ROOT="$(pwd)"
             BUILD_SKILLS="$BRANCH_ROOT/.circleci/build-skills.sh"
             git worktree add --detach /tmp/main-worktree origin/main


### PR DESCRIPTION
Closes <!-- Github issue # here -->

We've been seeing ts-build-fork-point and skills-diff. It appears that this was due to some rate limiting on github against a specific ip address, which circle shared across many customers, so it was being blown through very quickly.
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#about-primary-rate-limits

AI suggested a different endpoint that shouldn't be rate limited and should be simpler to use.

ssh-keyscan talks to github.com:22 over ssh (22 is default port for ssh)
The hope is that since ssh-keyscan doesn't authenticate, doesn't perform a Git operation, doesn't hit any HTTP endpoint then this will be safer.

This PR passed all jobs on the first go with this configuration.

The other option is to keep GitHub's published SSH host keys in our secrets and rotate manually when github does.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
