### PR TITLE
fix: ensure Tableview and ListView render their dividers and borders with the proper colors in HCM

### DIFF
--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -223,7 +223,10 @@ const listView = style<GridListRenderProps & {isQuiet?: boolean; isDropTarget?: 
     default: 'default',
     isQuiet: 'none'
   },
-  borderColor: 'gray-300',
+  borderColor: {
+    default: 'gray-300',
+    forcedColors: 'ButtonBorder'
+  },
   borderWidth: {
     default: 1,
     isQuiet: 0
@@ -504,8 +507,7 @@ const listitem = style<
   borderColor: {
     default: '--borderColor',
     isNextSelected: 'transparent',
-    isSelected: 'transparent',
-    forcedColors: 'ButtonBorder'
+    isSelected: 'transparent'
   },
   '--radius': {
     type: 'borderTopStartRadius',
@@ -590,7 +592,14 @@ const listRowBackground = style<
         }
       }
     },
-    forcedColors: 'transparent',
+    forcedColors: {
+      default: 'transparent',
+      selectionStyle: {
+        highlight: {
+          isSelected: 'Highlight'
+        }
+      }
+    },
     ':is([role="grid"][data-drop-target] *)': rootRowDropStyles,
     isDropTarget: rowDropStyles
   },

--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -507,7 +507,8 @@ const listitem = style<
   borderColor: {
     default: '--borderColor',
     isNextSelected: 'transparent',
-    isSelected: 'transparent'
+    isSelected: 'transparent',
+    forcedColors: 'ButtonBorder'
   },
   '--radius': {
     type: 'borderTopStartRadius',

--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -438,6 +438,11 @@ const listitem = style<
     isDisabled: 'disabled',
     forcedColors: {
       default: 'ButtonText',
+      isSelected: {
+        selectionStyle: {
+          highlight: 'HighlightText'
+        }
+      },
       isDisabled: 'GrayText'
     }
   },

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -270,6 +270,7 @@ const table = style<
     default: 'gray-300',
     isDropTarget: 'blue-800',
     forcedColors: {
+      default: 'ButtonBorder',
       isDropTarget: 'Highlight'
     }
   },
@@ -1102,7 +1103,10 @@ function ResizerIndicator({isFocusVisible, isResizing}) {
 const tableHeader = style({
   height: 'full',
   width: 'full',
-  backgroundColor: 'gray-75',
+  backgroundColor: {
+    default: 'gray-75',
+    forcedColors: 'transparent'
+  },
   // Attempt to prevent 1px area where you can see scrolled cell content between the table outline and the table header
   marginTop: '[-1px]',
   '--resizerDisplay': {
@@ -1145,7 +1149,10 @@ const selectAllCheckboxColumn = style({
   },
   borderBottomWidth: 1,
   borderStyle: 'solid',
-  backgroundColor: 'gray-75'
+  backgroundColor: {
+    default: 'gray-75',
+    forcedColors: 'transparent'
+  }
 });
 
 export interface TableHeaderProps<T> extends Omit<
@@ -1870,6 +1877,9 @@ const rowBackgroundColor = {
     default: 'gray-25',
     isQuiet: '--s2-container-bg'
   },
+  forcedColors: {
+    default: 'Background'
+  },
   isHovered: colorMix('gray-25', 'gray-900', 7), // table-row-hover-color
   isPressed: colorMix('gray-25', 'gray-900', 10), // table-row-hover-color
   isSelected: {
@@ -1893,9 +1903,6 @@ const rowBackgroundColor = {
     }
   },
   isInFooter: 'gray-200',
-  forcedColors: {
-    default: 'Background'
-  },
   ':is([role="grid"][data-drop-target] *)': rootRowDropStyles,
   isDropTarget: rowDropStyles
 } as const;
@@ -2030,7 +2037,10 @@ const row = style<
   borderColor: {
     selectionStyle: {
       highlight: 'transparent',
-      checkbox: 'gray-300'
+      checkbox: {
+        default: 'gray-300',
+        forcedColors: 'ButtonBorder'
+      }
     }
   },
   '--borderColorGray': {

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -1910,7 +1910,14 @@ const rowBackgroundColor = {
 const rowTextColor = {
   default: baseColor('neutral-subdued'),
   isSelected: baseColor('neutral'),
-  forcedColors: 'ButtonText',
+  forcedColors: {
+    default: 'ButtonText',
+    isSelected: {
+      selectionStyle: {
+        highlight: 'HighlightText'
+      }
+    }
+  },
   isDisabled: {
     default: 'disabled',
     forcedColors: 'GrayText'


### PR DESCRIPTION
Found via chromatic. I've restored the ListView's selected row background `Highlight` color in highlight selection to help with visual clarity

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test S2 ListView and TableView in high contrast mode, particularly in highlight selection mode. Make sure the borders/dividers render with ButtonBorder

Also see https://www.chromatic.com/build?appId=651b502f6b74abaae4ee734c&number=102
https://www.chromatic.com/build?appId=651b502f6b74abaae4ee734c&number=103
https://www.chromatic.com/build?appId=651b502f6b74abaae4ee734c&number=104

ignore any non ListView and TableView changes, those are from main

## 🧢 Your Project:

RSP
