### PR TITLE
fix: optimize-locales-plugin not tree-shaking react-aria and react-stately monopackage

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.js
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.js
@@ -18,7 +18,7 @@ module.exports = createUnplugin(({locales}) => {
     name: 'locales-plugin',
     resolveId(specifier, sourcePath, options) {
       if (
-        !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria|react-aria-components)[/\\]/.test(
+        !/[/\\](@react-stately|@react-aria|@react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/.test(
           sourcePath
         ) ||
         options?.ssr

--- a/packages/dev/parcel-resolver-optimize-locales/LocalesResolver.js
+++ b/packages/dev/parcel-resolver-optimize-locales/LocalesResolver.js
@@ -23,7 +23,7 @@ module.exports = new Resolver({
   resolve({specifier, dependency, config}) {
     if (
       !Array.isArray(config) ||
-      !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria|react-aria-components)[/\\]/.test(
+      !/[/\\](@react-stately|@react-aria|@react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/.test(
         dependency.sourcePath
       )
     ) {


### PR DESCRIPTION


Closes #10109

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

We applied the following patch to react-aria and noticed a 60kb improvement:

```

const fs = require('fs')
const path = require('path')

const pluginPath = path.join(__dirname, '..', 'node_modules', '@react-aria', 'optimize-locales-plugin', 'LocalesPlugin.js')

if (!fs.existsSync(pluginPath)) {
  console.warn('[patch] @react-aria/optimize-locales-plugin not found, skipping patch')
  process.exit(0)
}

const original = '/[/\\\\](@react-stately|@react-aria|@react-spectrum|react-aria-components)[/\\\\]/'
const patched = '/[/\\\\](@react-stately|@react-aria|@react-spectrum|react-aria-components|react-aria|react-stately)[/\\\\]/'

let content = fs.readFileSync(pluginPath, 'utf8')

if (content.includes(patched)) {
  console.log('[patch] @react-aria/optimize-locales-plugin already patched, skipping')
  process.exit(0)
}

if (!content.includes(original)) {
  console.warn('[patch] Expected pattern not found in LocalesPlugin.js — plugin may have been updated. Manual review needed.')
  process.exit(0)
}

content = content.replace(original, patched)
fs.writeFileSync(pluginPath, content, 'utf8')
console.log('[patch] @react-aria/optimize-locales-plugin patched for monopackage path support')
```

## 🧢 Your Project:


