### PR TITLE
fix: optimize locales not tree-shaking react-stately intl messages

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.js
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.js
@@ -18,7 +18,7 @@ module.exports = createUnplugin(({locales}) => {
     name: 'locales-plugin',
     resolveId(specifier, sourcePath, options) {
       if (
-        !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria|react-aria-components)[/\\]/.test(
+        !/[/\\](@react-stately|@react-aria|@react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/.test(
           sourcePath
         ) ||
         options?.ssr

--- a/packages/dev/parcel-resolver-optimize-locales/LocalesResolver.js
+++ b/packages/dev/parcel-resolver-optimize-locales/LocalesResolver.js
@@ -23,7 +23,7 @@ module.exports = new Resolver({
   resolve({specifier, dependency, config}) {
     if (
       !Array.isArray(config) ||
-      !/[/\\](@react-stately|@react-aria|@react-spectrum|react-aria|react-aria-components)[/\\]/.test(
+      !/[/\\](@react-stately|@react-aria|@react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/.test(
         dependency.sourcePath
       )
     ) {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10109

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
