### PR TITLE
docs: add api section with slots to DragPreview

### DIFF
--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -909,4 +909,12 @@ Note that because mouse and touch drag and drop interactions utilize the native 
 
 ### DragPreview
 
+```tsx links={{Button: '#button', Icon: 'icons', Text: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span'}}
+<DragPreview>
+  <Icon />
+  <Text slot="label" />
+  <Text slot="description" />
+</DragPreview>
+```
+
 <PropTable component={docs.exports.DragPreview} links={docs.links} />


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to S2 Dnd docs and scroll to bottom under the API section to DragPreview 

## 🧢 Your Project:

<!--- Company/project for pull request -->
