### PR TITLE
chore: Only export DragPreview from useDragAndDrop subpath

### DIFF
--- a/packages/@react-spectrum/s2/exports/ListView.ts
+++ b/packages/@react-spectrum/s2/exports/ListView.ts
@@ -1,8 +1,6 @@
 export {ListView, ListViewContext, ListViewItem} from '../src/ListView';
-export {DragPreview} from '../src/DragPreview';
 export {Collection} from 'react-aria/Collection';
 export type {ListViewProps, ListViewItemProps} from '../src/ListView';
-export type {DragPreviewProps} from '../src/DragPreview';
 export type {Selection, Key, SelectionMode} from '@react-types/shared';
 
 export {Text} from '../src/Content';

--- a/packages/@react-spectrum/s2/exports/TableView.ts
+++ b/packages/@react-spectrum/s2/exports/TableView.ts
@@ -9,7 +9,6 @@ export {
   EditableCell,
   TableFooter
 } from '../src/TableView';
-export {DragPreview} from '../src/DragPreview';
 export {Collection} from 'react-aria/Collection';
 export type {
   TableViewProps,
@@ -20,7 +19,6 @@ export type {
   ColumnProps,
   TableFooterProps
 } from '../src/TableView';
-export type {DragPreviewProps} from '../src/DragPreview';
 export type {
   Selection,
   Key,

--- a/packages/@react-spectrum/s2/exports/TreeView.ts
+++ b/packages/@react-spectrum/s2/exports/TreeView.ts
@@ -1,5 +1,4 @@
 export {TreeView, TreeViewItem, TreeViewItemContent, TreeViewLoadMoreItem} from '../src/TreeView';
-export {DragPreview} from '../src/DragPreview';
 export {Collection} from 'react-aria/Collection';
 export type {
   TreeViewProps,
@@ -7,7 +6,6 @@ export type {
   TreeViewItemContentProps,
   TreeViewLoadMoreItemProps
 } from '../src/TreeView';
-export type {DragPreviewProps} from '../src/DragPreview';
 export type {Selection, Key, SelectionMode} from '@react-types/shared';
 
 export {Text} from '../src/Content';

--- a/packages/@react-spectrum/s2/exports/useDragAndDrop.ts
+++ b/packages/@react-spectrum/s2/exports/useDragAndDrop.ts
@@ -5,6 +5,7 @@ export {
   isFileDropItem,
   isTextDropItem
 } from 'react-aria/useDrop';
+export {DragPreview} from '../src/DragPreview';
 export type {DragAndDropHooks} from 'react-aria-components/useDragAndDrop';
 export type {
   DirectoryDropItem,
@@ -32,3 +33,4 @@ export type {
 } from '@react-types/shared';
 export type {DragAndDropOptions} from '../src/useDragAndDrop';
 export type {DragAndDrop} from 'react-aria-components/useDragAndDrop';
+export type {DragPreviewProps} from '../src/DragPreview';

--- a/packages/dev/s2-docs/pages/react-aria/dnd.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/dnd.mdx
@@ -314,7 +314,7 @@ function DroppableTree() {
 
 Collection components such as [ListBox](ListBox), [Table](Table), [Tree](Tree), and [GridList](GridList) support multiple **drop positions**.
 
-* The `"root"` drop position allows dropping on the collection as a whole. 
+* The `"root"` drop position allows dropping on the collection as a whole.
 * The `"on"` drop position allows dropping on individual collection items, such as a folder within a list.
 * The `"before"` and `"after"` drop positions allow the user to insert or move items between other items. This is displayed by rendering a **drop indicator** between items.
 

--- a/packages/dev/s2-docs/pages/s2/ListView.mdx
+++ b/packages/dev/s2-docs/pages/s2/ListView.mdx
@@ -388,10 +388,10 @@ You can customize the drag preview by passing <TypeLink links={docs.links} type=
 
 ```tsx render type="s2"
 "use client";
-import {ListView, ListViewItem, DragPreview} from '@react-spectrum/s2/ListView';
+import {ListView, ListViewItem} from '@react-spectrum/s2/ListView';
 import {Text} from '@react-spectrum/s2';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {DragPreview, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
 import {useListData} from '@react-spectrum/s2/useListData';
 import File from '@react-spectrum/s2/icons/File';
 

--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -955,10 +955,10 @@ You can customize the drag preview by passing <TypeLink links={docs.links} type=
 
 ```tsx render type="s2"
 "use client";
-import {TableView, TableHeader, TableBody, Column, Row, Cell, Collection, DragPreview} from '@react-spectrum/s2/TableView';
+import {TableView, TableHeader, TableBody, Column, Row, Cell, Collection} from '@react-spectrum/s2/TableView';
 import {Text} from '@react-spectrum/s2';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {DragPreview, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
 import {useTreeData} from '@react-spectrum/s2/useTreeData';
 import File from '@react-spectrum/s2/icons/File';
 import Folder from '@react-spectrum/s2/icons/Folder';

--- a/packages/dev/s2-docs/pages/s2/TreeView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TreeView.mdx
@@ -395,9 +395,9 @@ You can customize the drag preview by passing <TypeLink links={docs.links} type=
 ```tsx render type="s2"
 "use client";
 import {Text} from '@react-spectrum/s2';
-import {TreeView, TreeViewItem, TreeViewItemContent, DragPreview} from '@react-spectrum/s2/TreeView';
+import {TreeView, TreeViewItem, TreeViewItemContent} from '@react-spectrum/s2/TreeView';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
+import {DragPreview, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
 import {useTreeData} from '@react-spectrum/s2/useTreeData';
 import {Collection} from '@react-spectrum/s2';
 import Folder from '@react-spectrum/s2/icons/Folder';

--- a/packages/dev/s2-docs/pages/s2/dnd.mdx
+++ b/packages/dev/s2-docs/pages/s2/dnd.mdx
@@ -74,8 +74,7 @@ While dragging, a **drag preview** is displayed under the user's mouse or finger
 
 ```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/PokemonCOMPONENT.tsx']}
 "use client";
-import {useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
-import {DragPreview} from '@react-spectrum/s2/COMPONENT';
+import {DragPreview, useDragAndDrop} from '@react-spectrum/s2/useDragAndDrop';
 import {Text} from '@react-spectrum/s2';
 import File from '@react-spectrum/s2/icons/File';
 import {PokemonCOMPONENT, Pokemon} from './PokemonCOMPONENT';
@@ -574,9 +573,8 @@ This example puts together many of the examples described above, allowing users 
 
 ```tsx render type="s2"
 "use client";
-import {useDragAndDrop, isTextDropItem} from '@react-spectrum/s2/useDragAndDrop';
+import {DragPreview, useDragAndDrop, isTextDropItem} from '@react-spectrum/s2/useDragAndDrop';
 import {useListData} from '@react-spectrum/s2/useListData';
-import {DragPreview} from '@react-spectrum/s2/COMPONENT';
 import {Text} from '@react-spectrum/s2';
 import File from '@react-spectrum/s2/icons/File';
 import {PokemonCOMPONENT, Pokemon, defaultItems} from './PokemonCOMPONENT';

--- a/packages/dev/s2-docs/skills/react-aria/test-utils-guidance.md
+++ b/packages/dev/s2-docs/skills/react-aria/test-utils-guidance.md
@@ -10,10 +10,7 @@ npm install @react-aria/test-utils --save-dev
 
 ### Core pattern
 
-External consumers should import from `@react-aria/test-utils`. Tests inside the `packages/` monorepo should import everything from `@react-spectrum/test-utils-internal`, which re-exports `User` and all other test utilities:
-```ts
-import {act, render, User} from '@react-spectrum/test-utils-internal';
-```
+External consumers should import from `@react-aria/test-utils`.
 
 Initialize a `User` once per test file. Call `createTester` to get a tester for a specific ARIA pattern, then call tester methods to simulate interactions.
 
@@ -73,7 +70,7 @@ Skip the testers and write manual interactions for the following cases:
 Components with draggable handles (Slider, ColorArea, ColorSlider, ColorWheel) need `getBoundingClientRect` mocked so move calculations work:
 
 ```ts
-import {installMouseEvent} from '@react-spectrum/test-utils';
+import {installMouseEvent} from '@react-aria/test-utils';
 installMouseEvent();
 
 beforeAll(() => {

--- a/packages/dev/s2-docs/skills/react-spectrum-s2/test-utils-guidance.md
+++ b/packages/dev/s2-docs/skills/react-spectrum-s2/test-utils-guidance.md
@@ -10,10 +10,7 @@ npm install @react-spectrum/test-utils --save-dev
 
 ### Core pattern
 
-External consumers import from `@react-spectrum/test-utils`. Tests inside the `packages/` monorepo should import everything from `@react-spectrum/test-utils-internal`, which re-exports `User` and all other test utilities:
- ```ts
-import {act, render, User} from '@react-spectrum/test-utils-internal';
-```
+External consumers import from `@react-spectrum/test-utils`.
 
 Initialize a `User` once per test file. Call `createTester` to get a tester for a specific ARIA pattern, then call tester methods to simulate interactions.
 


### PR DESCRIPTION
from audit

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Smoke test that the drag preview examples still work in S2

## 🧢 Your Project:

RSP
