### PR TITLE
fix: Custom 454 Calendar month

### DIFF
--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -34,7 +34,11 @@ import {
   startOfWeek,
   today
 } from '@internationalized/date';
+import {Custom454Calendar} from '@internationalized/date/tests/customCalendarImpl';
+import {ListBox, ListBoxItem} from '../src/ListBox';
+import {Popover} from '../src/Popover';
 import React, {useContext, useState} from 'react';
+import {Select, SelectValue} from '../src/Select';
 import userEvent from '@testing-library/user-event';
 
 let TestCalendar = ({calendarProps, gridProps, cellProps}) => (
@@ -716,5 +720,60 @@ describe('Calendar', () => {
       />
     );
     expect(heading).toHaveTextContent('April 2026');
+  });
+
+  it('should use getFormattableMonth for CalendarHeading with a custom calendar', () => {
+    let tree = render(
+      <TestCalendar
+        calendarProps={{
+          defaultFocusedValue: new CalendarDate(2022, 2, 3),
+          createCalendar: () => new Custom454Calendar()
+        }}
+      />
+    );
+    let heading = tree.container.querySelector('.react-aria-CalendarHeading');
+    expect(heading).toHaveTextContent('February 2022');
+  });
+
+  it('should use getFormattableMonth for CalendarMonthPicker with a custom calendar', async () => {
+    // Jan 30, 2022 (Gregorian) is the first day of fiscal year 2022 in Custom454,
+    // so the focused date is month 1, day 1
+    let tree = render(
+      <Calendar
+        aria-label="Appointment date"
+        defaultFocusedValue={new CalendarDate(2022, 1, 30)}
+        createCalendar={() => new Custom454Calendar()}>
+        <header>
+          <Button slot="previous">◀</Button>
+          <CalendarMonthPicker>
+            {({items, value, onChange, 'aria-label': ariaLabel}) => (
+              <Select aria-label={ariaLabel} selectedKey={value} onSelectionChange={onChange}>
+                <Button>
+                  <SelectValue />
+                </Button>
+                <Popover>
+                  <ListBox items={items}>
+                    {item => <ListBoxItem id={item.id}>{item.formatted}</ListBoxItem>}
+                  </ListBox>
+                </Popover>
+              </Select>
+            )}
+          </CalendarMonthPicker>
+          <Button slot="next">▶</Button>
+        </header>
+        <CalendarGrid>{date => <CalendarCell date={date} />}</CalendarGrid>
+      </Calendar>
+    );
+
+    let monthPicker = tree.getByLabelText('month');
+    expect(monthPicker).toHaveTextContent('Feb');
+    await user.click(monthPicker);
+    // The Custom454Calendar's fiscal year starts in February, so month 1 should
+    // display as "Feb" (Gregorian February), not "Jan".
+    expect(
+      within(tree.getByRole('listbox'))
+        .getAllByRole('option')
+        .map(o => o.textContent)
+    ).toEqual(['Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec', 'Jan']);
   });
 });

--- a/packages/react-aria/src/calendar/useCalendarHeading.ts
+++ b/packages/react-aria/src/calendar/useCalendarHeading.ts
@@ -70,6 +70,11 @@ export function useCalendarHeading(
       );
     }
 
-    return formatter.format(startDate.toDate(state.timeZone));
+    // Custom calendars like the 4-5-4 fiscal calendar use getFormattableMonth to map
+    // their internal month back to the Gregorian month that should be displayed.
+    let displayDate = startDate.calendar.getFormattableMonth
+      ? startDate.calendar.getFormattableMonth(startDate)
+      : startDate;
+    return formatter.format(displayDate.toDate(state.timeZone));
   }, [formatter, isDays, startDate, state.timeZone, state.visibleRange.end]);
 }

--- a/packages/react-aria/src/calendar/useCalendarMonthPicker.ts
+++ b/packages/react-aria/src/calendar/useCalendarMonthPicker.ts
@@ -56,10 +56,15 @@ export function useCalendarMonthPicker(
   let numMonths = state.focusedDate.calendar.getMonthsInYear(state.focusedDate);
   for (let i = 1; i <= numMonths; i++) {
     let date = state.focusedDate.set({month: i});
+    // Calendars like the 4-5-4 fiscal calendar use getFormattableMonth to map
+    // their internal month back to the Gregorian month that should be displayed.
+    let displayDate = date.calendar.getFormattableMonth
+      ? date.calendar.getFormattableMonth(date)
+      : date;
     months.push({
       id: i,
       date,
-      formatted: formatter.format(date.toDate(state.timeZone))
+      formatted: formatter.format(displayDate.toDate(state.timeZone))
     });
   }
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Looks like the new hooks forgot to include the old logic. `useVisibleRangeDescription` path called `startDate.calendar.getFormattableMonth(startDate)` first, which is how `Custom454Calendar` remaps its internal "month 1" back to the Gregorian month that should be displayed (February).

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Covered by Chromatic and now a unit test as well

## 🧢 Your Project:

<!--- Company/project for pull request -->
