### PR TITLE
fix: Chromatic flaky popovers and cardview

### DIFF
--- a/.chromatic-fc/custom-addons/chromatic/disableAnimations.css
+++ b/.chromatic-fc/custom-addons/chromatic/disableAnimations.css
@@ -8,9 +8,7 @@
   render at a translate offset while [data-entering]/[data-exiting] is true,
   relying on the transition to slide back to translate: 0. With transitions
   disabled in Chromatic, the slide never happens, so a snapshot taken while
-  isEntering is still true catches the popover ~4px off. Firefox is more
-  prone to this than Chrome because getAnimations().finished resolves later,
-  giving snapshots a wider window to land in the entering state.
+  isEntering is still true catches the popover ~4px off.
 */
 .disableAnimations [data-entering],
 .disableAnimations [data-exiting] {

--- a/.chromatic-fc/custom-addons/chromatic/disableAnimations.css
+++ b/.chromatic-fc/custom-addons/chromatic/disableAnimations.css
@@ -1,3 +1,18 @@
 .disableAnimations * {
   transition: none !important;
+  animation: none !important;
+}
+
+/*
+  Overlays that use useEnterAnimation/useExitAnimation (Popover, Tooltip, Tabs)
+  render at a translate offset while [data-entering]/[data-exiting] is true,
+  relying on the transition to slide back to translate: 0. With transitions
+  disabled in Chromatic, the slide never happens, so a snapshot taken while
+  isEntering is still true catches the popover ~4px off. Firefox is more
+  prone to this than Chrome because getAnimations().finished resolves later,
+  giving snapshots a wider window to land in the entering state.
+*/
+.disableAnimations [data-entering],
+.disableAnimations [data-exiting] {
+  translate: none !important;
 }

--- a/.chromatic/custom-addons/chromatic/disableAnimations.css
+++ b/.chromatic/custom-addons/chromatic/disableAnimations.css
@@ -8,9 +8,7 @@
   render at a translate offset while [data-entering]/[data-exiting] is true,
   relying on the transition to slide back to translate: 0. With transitions
   disabled in Chromatic, the slide never happens, so a snapshot taken while
-  isEntering is still true catches the popover ~4px off. Firefox is more
-  prone to this than Chrome because getAnimations().finished resolves later,
-  giving snapshots a wider window to land in the entering state.
+  isEntering is still true catches the popover ~4px off.
 */
 .disableAnimations [data-entering],
 .disableAnimations [data-exiting] {

--- a/.chromatic/custom-addons/chromatic/disableAnimations.css
+++ b/.chromatic/custom-addons/chromatic/disableAnimations.css
@@ -1,3 +1,18 @@
 .disableAnimations * {
   transition: none !important;
+  animation: none !important;
+}
+
+/*
+  Overlays that use useEnterAnimation/useExitAnimation (Popover, Tooltip, Tabs)
+  render at a translate offset while [data-entering]/[data-exiting] is true,
+  relying on the transition to slide back to translate: 0. With transitions
+  disabled in Chromatic, the slide never happens, so a snapshot taken while
+  isEntering is still true catches the popover ~4px off. Firefox is more
+  prone to this than Chrome because getAnimations().finished resolves later,
+  giving snapshots a wider window to land in the entering state.
+*/
+.disableAnimations [data-entering],
+.disableAnimations [data-exiting] {
+  translate: none !important;
 }

--- a/packages/@react-spectrum/s2/chromatic/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/CardView.stories.tsx
@@ -24,7 +24,8 @@ const meta: Meta<typeof CardView> = {
   component: CardView,
   parameters: {
     layout: 'fullscreen',
-    chromaticProvider: {disableAnimations: true}
+    chromaticProvider: {disableAnimations: true},
+    chromatic: {prefersReducedMotion: 'reduce'}
   },
   title: 'S2 Chromatic/CardView'
 };


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Fixes animation based flaky tests. Popovers which used animation and skeleton which only didn't move if we set the prefers reduced motion.
I've scoped the prefers reduced motion to just the story that usually breaks, there may be others, but I think in general it's ok to leave alone.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
