### PR TITLE
chore: update circleci resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ executors:
   rsp:
     docker:
       - image: cimg/node:24.14.1
+    resource_class: medium.gen2
     environment:
       CACHE_VERSION: v1
     working_directory: ~/react-spectrum
@@ -28,7 +29,7 @@ executors:
   rsp-large:
     docker:
       - image: cimg/node:24.14.1
-    resource_class: large
+    resource_class: large.gen2
     environment:
       CACHE_VERSION: v1
     working_directory: ~/react-spectrum
@@ -36,7 +37,7 @@ executors:
   rsp-xlarge:
     docker:
       - image: cimg/node:24.14.1
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     environment:
       CACHE_VERSION: v1
     working_directory: ~/react-spectrum
@@ -44,7 +45,7 @@ executors:
   rsp-2xlarge:
     docker:
       - image: cimg/node:24.14.1
-    resource_class: 2xlarge
+    resource_class: 2xlarge.gen2
     environment:
       CACHE_VERSION: v1
     working_directory: ~/react-spectrum


### PR DESCRIPTION
Closes <!-- Github issue # here -->

New CircleCI resource classes, Gen 2 https://circleci.com/docs/guides/execution-managed/using-docker/#docker-gen2-benefits came out recently. These claim a 1.4x average speedup. This PR is closer to 1.5x, the entire pipeline took as long as the s2 docs build job used to take all on its own.

One thing to weigh, they are a little more expensive upfront to use. 
But if I'm doing my maths correctly, it's still cheaper overall, even if we only hit their 1.4x speedup.

https://circleci.com/pricing/price-list/

Was:
Medium 10 credits/min
Large 20 credits/min
X-large 40 credits/min
2 X-large 80 credits/min

Now:
Medium 12 credits/min
Large 24 credits/min
X-large 48 credits/min
2 X-large 96 credits/min

But if we consider the time savings, we can compare it like this:
Assuming a task takes 1min to complete

Medium 10 credits/task vs 8.04 credits/task
Large 24 credits/min vs 16.08 credits/task
X-large 48 credits/min vs 32.16 credits/task
2 X-large 96 credits/min vs 64.32 credits/task

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
