### PR TITLE
chore: Omit calendar features from v3

### DIFF
--- a/packages/@adobe/react-spectrum/src/calendar/Calendar.tsx
+++ b/packages/@adobe/react-spectrum/src/calendar/Calendar.tsx
@@ -23,7 +23,7 @@ import {useLocale} from 'react-aria/I18nProvider';
 import {useProviderProps} from '../provider/Provider';
 
 export interface SpectrumCalendarProps<T extends DateValue>
-  extends AriaCalendarProps<T>, StyleProps {
+  extends Omit<AriaCalendarProps<T>, 'selectionMode' | 'weeksInMonth'>, StyleProps {
   /**
    * The number of months to display at once. Up to 3 months are supported.
    *
@@ -52,7 +52,7 @@ export const Calendar = React.forwardRef(function Calendar<T extends DateValue>(
   visibleMonths = Math.max(visibleMonths, 1);
   let visibleDuration = useMemo(() => ({months: visibleMonths}), [visibleMonths]);
   let {locale} = useLocale();
-  let state = useCalendarState({
+  let state = useCalendarState<T, 'single'>({
     ...props,
     locale,
     visibleDuration,

--- a/packages/@adobe/react-spectrum/src/calendar/RangeCalendar.tsx
+++ b/packages/@adobe/react-spectrum/src/calendar/RangeCalendar.tsx
@@ -23,7 +23,7 @@ import {useProviderProps} from '../provider/Provider';
 import {useRangeCalendarState} from 'react-stately/useRangeCalendarState';
 
 export interface SpectrumRangeCalendarProps<T extends DateValue>
-  extends AriaRangeCalendarProps<T>, StyleProps {
+  extends Omit<AriaRangeCalendarProps<T>, 'weeksInMonth'>, StyleProps {
   /**
    * The number of months to display at once. Up to 3 months are supported.
    *


### PR DESCRIPTION
Omits selectionMode and weeksInMonth from v3 typescript API