### PR TITLE
fix(RAC): clear pressed state on DialogTrigger when dialog opens

### DIFF
--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -106,7 +106,7 @@ export function DialogTrigger(props: DialogTriggerProps): JSX.Element {
           }
         ]
       ]}>
-      <PressResponder {...triggerProps} ref={buttonRef} isPressed={state.isOpen}>
+      <PressResponder {...triggerProps} ref={buttonRef} isPressed={false}>
         {props.children}
       </PressResponder>
     </Provider>

--- a/packages/react-aria-components/test/Dialog.test.js
+++ b/packages/react-aria-components/test/Dialog.test.js
@@ -172,7 +172,7 @@ describe('Dialog', () => {
 
     let dialogTester = testUtilUser.createTester('Dialog', {root: button, overlayType: 'popover'});
     await dialogTester.open();
-    expect(button).toHaveAttribute('data-pressed');
+    expect(button).not.toHaveAttribute('data-pressed');
 
     let dialog = dialogTester.getDialog();
     let heading = getByRole('heading');


### PR DESCRIPTION
## Summary

Fixes #8339

When a modal dialog is opened via \DialogTrigger\, the trigger button remains visually stuck in a 'pressed' state because \isPressed\ was bound to \state.isOpen\. This causes the press animation to never complete, giving the button the appearance of a frozen press state after the dialog opens.

## Root cause

In \packages/react-aria-components/src/Dialog.tsx\, the \PressResponder\ wrapping the trigger child had:

\\\	sx
<PressResponder {...triggerProps} ref={buttonRef} isPressed={state.isOpen}>
\\\

This means once the dialog opens (\state.isOpen === true\), the trigger button's press state is locked to \	rue\, regardless of whether the user has actually released the pointer.

## Fix

Set \isPressed={false}\ unconditionally in \DialogTrigger\:

\\\	sx
<PressResponder {...triggerProps} ref={buttonRef} isPressed={false}>
\\\

This matches the behavior already implemented in **Spectrum 2's \DialogTrigger\**, which wraps \AriaDialogTrigger\ with a \PressResponder isPressed={false}\ override specifically to address this issue:

https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/s2/src/DialogTrigger.tsx#L29-L37

For modal dialogs, the trigger button should return to its normal unpressed state once the dialog is open — the dialog itself provides the visual context that an action was taken.