### PR TITLE
fix: guard isInert/isElementVisible against detached nodes with null defaultView

### DIFF
--- a/packages/react-aria/src/utils/isElementVisible.ts
+++ b/packages/react-aria/src/utils/isElementVisible.ts
@@ -29,7 +29,7 @@ function isStyleVisible(element: Element) {
   let isVisible = display !== 'none' && visibility !== 'hidden' && visibility !== 'collapse';
 
   if (isVisible) {
-    const {getComputedStyle} = element.ownerDocument.defaultView as unknown as Window;
+    const {getComputedStyle} = getOwnerWindow(element);
     let {display: computedDisplay, visibility: computedVisibility} = getComputedStyle(element);
 
     isVisible =

--- a/packages/react-aria/src/utils/isFocusable.ts
+++ b/packages/react-aria/src/utils/isFocusable.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {getOwnerWindow} from './domHelpers';
 import {isElementVisible} from './isElementVisible';
 
 const focusableElements = [
@@ -52,7 +53,7 @@ export function isTabbable(element: Element): boolean {
 function isInert(element: Element): boolean {
   let node: Element | null = element;
   while (node != null) {
-    if (node instanceof node.ownerDocument.defaultView!.HTMLElement && node.inert) {
+    if (node instanceof getOwnerWindow(node).HTMLElement && node.inert) {
       return true;
     }
 

--- a/packages/react-aria/test/utils/isFocusable.test.tsx
+++ b/packages/react-aria/test/utils/isFocusable.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {isFocusable, isTabbable} from '../../src/utils/isFocusable';
+
+describe('isFocusable', () => {
+  it('detects focusable elements in the document', () => {
+    let button = document.createElement('button');
+    document.body.appendChild(button);
+    expect(isFocusable(button)).toBe(true);
+    document.body.removeChild(button);
+  });
+
+  describe('detached nodes (ownerDocument.defaultView === null)', () => {
+    let detachedDocument: Document;
+
+    beforeEach(() => {
+      detachedDocument = document.implementation.createHTMLDocument('');
+      // Sanity check that we are reproducing the detached condition.
+      expect(detachedDocument.defaultView).toBe(null);
+    });
+
+    it('does not throw for isFocusable', () => {
+      let button = detachedDocument.createElement('button');
+      detachedDocument.body.appendChild(button);
+      // Matches how the dev-only effect in useFocusable calls isFocusable (no options).
+      expect(() => isFocusable(button)).not.toThrow();
+      expect(() => isFocusable(button, {skipVisibilityCheck: true})).not.toThrow();
+      expect(isFocusable(button, {skipVisibilityCheck: true})).toBe(true);
+    });
+
+    it('does not throw for isTabbable', () => {
+      let button = detachedDocument.createElement('button');
+      detachedDocument.body.appendChild(button);
+      expect(() => isTabbable(button)).not.toThrow();
+    });
+
+    it('does not throw when an ancestor is inert', () => {
+      let wrapper = detachedDocument.createElement('div');
+      wrapper.inert = true;
+      let button = detachedDocument.createElement('button');
+      wrapper.appendChild(button);
+      detachedDocument.body.appendChild(wrapper);
+      expect(() => isFocusable(button, {skipVisibilityCheck: true})).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10141

Updates `isFocusable` and `isElementVisible` to use `getOwnerWindow`. Prevents `TypeError: Cannot read properties of null (reading 'HTMLElement')` error thrown for nodes detached from a browsing context (i.e. a Focusable/TooltipTrigger that renders into a detached document while enumerating collection items), where `defaultView` is null.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Unit tests should cover. Smoke test focus behavior.

## 🧢 Your Project:

<!--- Company/project for pull request -->
