### PR TITLE
chore: remove orphaned intl ts-ignore comments

### DIFF
--- a/packages/@adobe/react-spectrum/src/actionbar/ActionBar.tsx
+++ b/packages/@adobe/react-spectrum/src/actionbar/ActionBar.tsx
@@ -11,7 +11,6 @@
  */
 
 import {ActionButton} from '../button/ActionButton';
-
 import {ActionGroup} from '../actiongroup/ActionGroup';
 import {announce} from 'react-aria/private/live-announcer/LiveAnnouncer';
 import {classNames} from '../utils/classNames';
@@ -19,9 +18,9 @@ import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DOMProps, DOMRef, ItemElement, ItemRenderer, Key, StyleProps} from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusScope} from 'react-aria/FocusScope';
+// @ts-ignore
 import intlMessages from '../../intl/actionbar/*.json';
 import {OpenTransition} from '../overlays/OpenTransition';
-// @ts-ignore
 import React, {ReactElement, Ref, useEffect, useRef, useState} from 'react';
 import styles from './actionbar.css';
 import {Text} from '../text/Text';

--- a/packages/@adobe/react-spectrum/src/actionbar/ActionBar.tsx
+++ b/packages/@adobe/react-spectrum/src/actionbar/ActionBar.tsx
@@ -18,7 +18,6 @@ import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DOMProps, DOMRef, ItemElement, ItemRenderer, Key, StyleProps} from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusScope} from 'react-aria/FocusScope';
-// @ts-ignore
 import intlMessages from '../../intl/actionbar/*.json';
 import {OpenTransition} from '../overlays/OpenTransition';
 import React, {ReactElement, Ref, useEffect, useRef, useState} from 'react';

--- a/packages/@adobe/react-spectrum/src/actiongroup/ActionGroup.tsx
+++ b/packages/@adobe/react-spectrum/src/actiongroup/ActionGroup.tsx
@@ -11,7 +11,6 @@
  */
 
 import {ActionButton} from '../button/ActionButton';
-
 import {AriaActionGroupProps, useActionGroup} from 'react-aria/private/actiongroup/useActionGroup';
 import {AriaLabelingProps, DOMProps, DOMRef, Key, Node, StyleProps} from '@react-types/shared';
 import buttonStyles from '@adobe/spectrum-css-temp/components/button/vars.css';
@@ -20,6 +19,7 @@ import {classNames} from '../utils/classNames';
 import {ClearSlots, SlotProvider, useSlotProps} from '../utils/Slots';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusScope} from 'react-aria/FocusScope';
+// @ts-ignore
 import intlMessages from '../../intl/actiongroup/*.json';
 import {Item} from 'react-stately/Item';
 import {ListState, useListState} from 'react-stately/useListState';
@@ -28,7 +28,6 @@ import {MenuTrigger} from '../menu/MenuTrigger';
 import {mergeProps} from 'react-aria/mergeProps';
 import More from '@spectrum-icons/workflow/More';
 import {PressResponder} from 'react-aria/private/interactions/PressResponder';
-// @ts-ignore
 import {Provider, useProviderProps} from '../provider/Provider';
 import React, {
   forwardRef,

--- a/packages/@adobe/react-spectrum/src/actiongroup/ActionGroup.tsx
+++ b/packages/@adobe/react-spectrum/src/actiongroup/ActionGroup.tsx
@@ -19,7 +19,6 @@ import {classNames} from '../utils/classNames';
 import {ClearSlots, SlotProvider, useSlotProps} from '../utils/Slots';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusScope} from 'react-aria/FocusScope';
-// @ts-ignore
 import intlMessages from '../../intl/actiongroup/*.json';
 import {Item} from 'react-stately/Item';
 import {ListState, useListState} from 'react-stately/useListState';

--- a/packages/@adobe/react-spectrum/src/autocomplete/MobileSearchAutocomplete.tsx
+++ b/packages/@adobe/react-spectrum/src/autocomplete/MobileSearchAutocomplete.tsx
@@ -22,7 +22,6 @@ import {FocusableRef, ValidationState} from '@react-types/shared';
 import {focusSafely} from 'react-aria/private/interactions/focusSafely';
 import {FocusScope} from 'react-aria/FocusScope';
 import {getActiveElement} from 'react-aria/private/utils/shadowdom/DOMFunctions';
-// @ts-ignore
 import intlMessages from '../../intl/autocomplete/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import Magnifier from '@spectrum-icons/ui/Magnifier';

--- a/packages/@adobe/react-spectrum/src/autocomplete/MobileSearchAutocomplete.tsx
+++ b/packages/@adobe/react-spectrum/src/autocomplete/MobileSearchAutocomplete.tsx
@@ -22,6 +22,7 @@ import {FocusableRef, ValidationState} from '@react-types/shared';
 import {focusSafely} from 'react-aria/private/interactions/focusSafely';
 import {FocusScope} from 'react-aria/FocusScope';
 import {getActiveElement} from 'react-aria/private/utils/shadowdom/DOMFunctions';
+// @ts-ignore
 import intlMessages from '../../intl/autocomplete/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import Magnifier from '@spectrum-icons/ui/Magnifier';
@@ -39,7 +40,6 @@ import React, {
 } from 'react';
 import searchAutocompleteStyles from './searchautocomplete.css';
 import searchStyles from '@adobe/spectrum-css-temp/components/search/vars.css';
-// @ts-ignore
 import {setInteractionModality} from 'react-aria/private/interactions/useFocusVisible';
 import {SpectrumSearchAutocompleteProps} from './SearchAutocomplete';
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';

--- a/packages/@adobe/react-spectrum/src/autocomplete/SearchAutocomplete.tsx
+++ b/packages/@adobe/react-spectrum/src/autocomplete/SearchAutocomplete.tsx
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 import {AriaButtonProps} from 'react-aria/useButton';
-
 import {
   AriaSearchAutocompleteProps,
   useSearchAutocomplete
@@ -32,11 +31,11 @@ import {dimensionValue} from '../utils/styleProps';
 import {Field} from '../label/Field';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusRing} from 'react-aria/FocusRing';
+// @ts-ignore
 import intlMessages from '../../intl/autocomplete/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import Magnifier from '@spectrum-icons/ui/Magnifier';
 import {MenuTriggerAction, useComboBoxState} from 'react-stately/useComboBoxState';
-// @ts-ignore
 import {MobileSearchAutocomplete} from './MobileSearchAutocomplete';
 import {Popover} from '../overlays/Popover';
 import {ProgressCircle} from '../progress/ProgressCircle';

--- a/packages/@adobe/react-spectrum/src/autocomplete/SearchAutocomplete.tsx
+++ b/packages/@adobe/react-spectrum/src/autocomplete/SearchAutocomplete.tsx
@@ -31,7 +31,6 @@ import {dimensionValue} from '../utils/styleProps';
 import {Field} from '../label/Field';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusRing} from 'react-aria/FocusRing';
-// @ts-ignore
 import intlMessages from '../../intl/autocomplete/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import Magnifier from '@spectrum-icons/ui/Magnifier';

--- a/packages/@adobe/react-spectrum/src/button/Button.tsx
+++ b/packages/@adobe/react-spectrum/src/button/Button.tsx
@@ -11,15 +11,14 @@
  */
 
 import {AriaButtonProps, useButton} from 'react-aria/useButton';
-
 import {classNames} from '../utils/classNames';
 import {FocusableRef, StyleProps} from '@react-types/shared';
 import {FocusRing} from 'react-aria/FocusRing';
+// @ts-ignore
 import intlMessages from '../../intl/button/*.json';
 import {isAppleDevice, isFirefox} from 'react-aria/private/utils/platform';
 import {mergeProps} from 'react-aria/mergeProps';
 import {ProgressCircle} from '../progress/ProgressCircle';
-// @ts-ignore
 import React, {ElementType, ReactElement, useEffect, useState} from 'react';
 import {SlotProvider, useSlotProps} from '../utils/Slots';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';

--- a/packages/@adobe/react-spectrum/src/button/Button.tsx
+++ b/packages/@adobe/react-spectrum/src/button/Button.tsx
@@ -14,7 +14,6 @@ import {AriaButtonProps, useButton} from 'react-aria/useButton';
 import {classNames} from '../utils/classNames';
 import {FocusableRef, StyleProps} from '@react-types/shared';
 import {FocusRing} from 'react-aria/FocusRing';
-// @ts-ignore
 import intlMessages from '../../intl/button/*.json';
 import {isAppleDevice, isFirefox} from 'react-aria/private/utils/platform';
 import {mergeProps} from 'react-aria/mergeProps';

--- a/packages/@adobe/react-spectrum/src/calendar/CalendarBase.tsx
+++ b/packages/@adobe/react-spectrum/src/calendar/CalendarBase.tsx
@@ -11,7 +11,6 @@
  */
 
 import {ActionButton} from '../button/ActionButton';
-
 import {AriaButtonProps} from 'react-aria/useButton';
 import {CalendarDate} from '@internationalized/date';
 import {CalendarMonth} from './CalendarMonth';
@@ -21,9 +20,9 @@ import ChevronRight from '@spectrum-icons/ui/ChevronRightLarge';
 import {classNames} from '../utils/classNames';
 import {DOMProps, RefObject, StyleProps} from '@react-types/shared';
 import {HelpText} from '../label/HelpText';
+// @ts-ignore
 import intlMessages from '../../intl/calendar/*.json';
 import {RangeCalendarState} from 'react-stately/useRangeCalendarState';
-// @ts-ignore
 import React, {HTMLAttributes, JSX} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/calendar/vars.css';
 import {useDateFormatter} from 'react-aria/useDateFormatter';

--- a/packages/@adobe/react-spectrum/src/calendar/CalendarBase.tsx
+++ b/packages/@adobe/react-spectrum/src/calendar/CalendarBase.tsx
@@ -20,7 +20,6 @@ import ChevronRight from '@spectrum-icons/ui/ChevronRightLarge';
 import {classNames} from '../utils/classNames';
 import {DOMProps, RefObject, StyleProps} from '@react-types/shared';
 import {HelpText} from '../label/HelpText';
-// @ts-ignore
 import intlMessages from '../../intl/calendar/*.json';
 import {RangeCalendarState} from 'react-stately/useRangeCalendarState';
 import React, {HTMLAttributes, JSX} from 'react';

--- a/packages/@adobe/react-spectrum/src/card/CardView.tsx
+++ b/packages/@adobe/react-spectrum/src/card/CardView.tsx
@@ -16,7 +16,6 @@ import {CardViewContext, useCardViewContext} from './CardViewContext';
 import {classNames} from '../utils/classNames';
 import {DOMRef, DOMRefValue, Node} from '@react-types/shared';
 import {GridCollection} from 'react-stately/private/grid/GridCollection';
-// @ts-ignore
 import intlMessages from '../../intl/card/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {ProgressCircle} from '../progress/ProgressCircle';

--- a/packages/@adobe/react-spectrum/src/card/CardView.tsx
+++ b/packages/@adobe/react-spectrum/src/card/CardView.tsx
@@ -16,10 +16,10 @@ import {CardViewContext, useCardViewContext} from './CardViewContext';
 import {classNames} from '../utils/classNames';
 import {DOMRef, DOMRefValue, Node} from '@react-types/shared';
 import {GridCollection} from 'react-stately/private/grid/GridCollection';
+// @ts-ignore
 import intlMessages from '../../intl/card/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {ProgressCircle} from '../progress/ProgressCircle';
-// @ts-ignore
 import React, {ReactElement, ReactNode, useCallback, useMemo, useRef} from 'react';
 import {ReusableView} from 'react-stately/useVirtualizerState';
 import {SpectrumCardViewProps} from './types';

--- a/packages/@adobe/react-spectrum/src/color/ColorEditor.tsx
+++ b/packages/@adobe/react-spectrum/src/color/ColorEditor.tsx
@@ -3,7 +3,6 @@ import {ColorField} from './ColorField';
 import {ColorSlider} from './ColorSlider';
 import {ColorSpace, getColorChannels} from 'react-stately/Color';
 import {DOMRef} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/color/*.json';
 import {Item} from 'react-stately/Item';
 import {Picker} from '../picker/Picker';

--- a/packages/@adobe/react-spectrum/src/combobox/ComboBox.tsx
+++ b/packages/@adobe/react-spectrum/src/combobox/ComboBox.tsx
@@ -11,7 +11,6 @@
  */
 
 import {AriaButtonProps} from 'react-aria/useButton';
-
 import {AriaComboBoxProps, useComboBox} from 'react-aria/useComboBox';
 import {
   AsyncLoadable,
@@ -38,10 +37,10 @@ import {dimensionValue} from '../utils/styleProps';
 import {Field} from '../label/Field';
 import {FieldButton} from '../button/FieldButton';
 import {FocusRing} from 'react-aria/FocusRing';
+// @ts-ignore
 import intlMessages from '../../intl/combobox/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import {MobileComboBox} from './MobileComboBox';
-// @ts-ignore
 import {Popover} from '../overlays/Popover';
 import {PressResponder} from 'react-aria/private/interactions/PressResponder';
 import {ProgressCircle} from '../progress/ProgressCircle';

--- a/packages/@adobe/react-spectrum/src/combobox/ComboBox.tsx
+++ b/packages/@adobe/react-spectrum/src/combobox/ComboBox.tsx
@@ -37,7 +37,6 @@ import {dimensionValue} from '../utils/styleProps';
 import {Field} from '../label/Field';
 import {FieldButton} from '../button/FieldButton';
 import {FocusRing} from 'react-aria/FocusRing';
-// @ts-ignore
 import intlMessages from '../../intl/combobox/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import {MobileComboBox} from './MobileComboBox';

--- a/packages/@adobe/react-spectrum/src/combobox/MobileComboBox.tsx
+++ b/packages/@adobe/react-spectrum/src/combobox/MobileComboBox.tsx
@@ -26,6 +26,7 @@ import {FocusRing} from 'react-aria/FocusRing';
 import {focusSafely} from 'react-aria/private/interactions/focusSafely';
 import {FocusScope} from 'react-aria/FocusScope';
 import {getActiveElement} from 'react-aria/private/utils/shadowdom/DOMFunctions';
+// @ts-ignore
 import intlMessages from '../../intl/combobox/*.json';
 import labelStyles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
@@ -44,7 +45,6 @@ import React, {
 } from 'react';
 import searchStyles from '@adobe/spectrum-css-temp/components/search/vars.css';
 import {setInteractionModality} from 'react-aria/private/interactions/useFocusVisible';
-// @ts-ignore
 import {SpectrumComboBoxProps} from './ComboBox';
 import styles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
 import {TextFieldBase} from '../textfield/TextFieldBase';

--- a/packages/@adobe/react-spectrum/src/combobox/MobileComboBox.tsx
+++ b/packages/@adobe/react-spectrum/src/combobox/MobileComboBox.tsx
@@ -26,7 +26,6 @@ import {FocusRing} from 'react-aria/FocusRing';
 import {focusSafely} from 'react-aria/private/interactions/focusSafely';
 import {FocusScope} from 'react-aria/FocusScope';
 import {getActiveElement} from 'react-aria/private/utils/shadowdom/DOMFunctions';
-// @ts-ignore
 import intlMessages from '../../intl/combobox/*.json';
 import labelStyles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';

--- a/packages/@adobe/react-spectrum/src/contextualhelp/ContextualHelp.tsx
+++ b/packages/@adobe/react-spectrum/src/contextualhelp/ContextualHelp.tsx
@@ -20,7 +20,6 @@ import {DialogTrigger} from '../dialog/DialogTrigger';
 import HelpOutline from '@spectrum-icons/workflow/HelpOutline';
 import helpStyles from '@adobe/spectrum-css-temp/components/contextualhelp/vars.css';
 import InfoOutline from '@spectrum-icons/workflow/InfoOutline';
-// @ts-ignore
 import intlMessages from '../../intl/contextualhelp/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {OverlayTriggerProps} from 'react-stately/useOverlayTriggerState';

--- a/packages/@adobe/react-spectrum/src/datepicker/DatePicker.tsx
+++ b/packages/@adobe/react-spectrum/src/datepicker/DatePicker.tsx
@@ -11,7 +11,6 @@
  */
 
 import {AriaDatePickerProps, DateValue, useDatePicker} from 'react-aria/useDatePicker';
-
 import {Calendar} from '../calendar/Calendar';
 import CalendarIcon from '@spectrum-icons/workflow/Calendar';
 import {CalendarIdentifier, Calendar as ICalendar} from '@internationalized/date';
@@ -25,8 +24,8 @@ import {Field} from '../label/Field';
 import {FieldButton} from '../button/FieldButton';
 import {FocusableRef, SpectrumLabelableProps, StyleProps} from '@react-types/shared';
 import {Input} from './Input';
-import intlMessages from '../../intl/datepicker/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import React, {ReactElement, useRef} from 'react';
 import {SpectrumDateFieldBase} from './DateField';

--- a/packages/@adobe/react-spectrum/src/datepicker/DatePicker.tsx
+++ b/packages/@adobe/react-spectrum/src/datepicker/DatePicker.tsx
@@ -24,7 +24,6 @@ import {Field} from '../label/Field';
 import {FieldButton} from '../button/FieldButton';
 import {FocusableRef, SpectrumLabelableProps, StyleProps} from '@react-types/shared';
 import {Input} from './Input';
-// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import React, {ReactElement, useRef} from 'react';

--- a/packages/@adobe/react-spectrum/src/datepicker/DateRangePicker.tsx
+++ b/packages/@adobe/react-spectrum/src/datepicker/DateRangePicker.tsx
@@ -27,8 +27,8 @@ import {FieldButton} from '../button/FieldButton';
 import {Flex} from '../layout/Flex';
 import {FocusableRef} from '@react-types/shared';
 import {Input} from './Input';
-import intlMessages from '../../intl/datepicker/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {RangeCalendar} from '../calendar/RangeCalendar';
 import React, {ReactElement, useRef} from 'react';

--- a/packages/@adobe/react-spectrum/src/datepicker/DateRangePicker.tsx
+++ b/packages/@adobe/react-spectrum/src/datepicker/DateRangePicker.tsx
@@ -27,7 +27,6 @@ import {FieldButton} from '../button/FieldButton';
 import {Flex} from '../layout/Flex';
 import {FocusableRef} from '@react-types/shared';
 import {Input} from './Input';
-// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {RangeCalendar} from '../calendar/RangeCalendar';

--- a/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
@@ -22,8 +22,8 @@ import {Divider} from '../divider/Divider';
 import {DOMProps, DOMRef, StyleProps} from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {Heading} from '../text/Heading';
-import intlMessages from '../../intl/dialog/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/dialog/*.json';
 import React, {forwardRef, ReactNode, useContext} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';

--- a/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
@@ -22,7 +22,6 @@ import {Divider} from '../divider/Divider';
 import {DOMProps, DOMRef, StyleProps} from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {Heading} from '../text/Heading';
-// @ts-ignore
 import intlMessages from '../../intl/dialog/*.json';
 import React, {forwardRef, ReactNode, useContext} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';

--- a/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
@@ -11,18 +11,17 @@
  */
 
 import {ActionButton} from '../button/ActionButton';
-
 import {AriaDialogProps, useDialog} from 'react-aria/useDialog';
 import {classNames} from '../utils/classNames';
 import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DialogContext, DialogContextValue} from './context';
 import {DOMRef, StyleProps} from '@react-types/shared';
 import {Grid} from '../layout/Grid';
+// @ts-ignore
 import intlMessages from '../../intl/dialog/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import React, {ReactNode, useContext, useMemo, useRef} from 'react';
 import {SlotProvider, useSlotProps} from '../utils/Slots';
-// @ts-ignore
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
 import {unwrapDOMRef, useDOMRef} from '../utils/useDOMRef';
 import {useHasChild} from '../utils/useHasChild';

--- a/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
@@ -17,7 +17,6 @@ import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DialogContext, DialogContextValue} from './context';
 import {DOMRef, StyleProps} from '@react-types/shared';
 import {Grid} from '../layout/Grid';
-// @ts-ignore
 import intlMessages from '../../intl/dialog/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import React, {ReactNode, useContext, useMemo, useRef} from 'react';

--- a/packages/@adobe/react-spectrum/src/dropzone/DropZone.tsx
+++ b/packages/@adobe/react-spectrum/src/dropzone/DropZone.tsx
@@ -14,11 +14,11 @@ import {AriaLabelingProps, DOMProps, DOMRef, StyleProps} from '@react-types/shar
 import {classNames} from '../utils/classNames';
 import {DropZoneProps, DropZone as RACDropZone} from 'react-aria-components/DropZone';
 import {HeadingContext} from 'react-aria-components/Heading';
+// @ts-ignore
 import intlMessages from '../../intl/dropzone/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {Provider} from 'react-aria-components/slots';
 import React, {ReactNode} from 'react';
-// @ts-ignore
 import {SlotProvider} from '../utils/Slots';
 import styles from '@adobe/spectrum-css-temp/components/dropzone/vars.css';
 import {useDOMRef} from '../utils/useDOMRef';

--- a/packages/@adobe/react-spectrum/src/dropzone/DropZone.tsx
+++ b/packages/@adobe/react-spectrum/src/dropzone/DropZone.tsx
@@ -14,7 +14,6 @@ import {AriaLabelingProps, DOMProps, DOMRef, StyleProps} from '@react-types/shar
 import {classNames} from '../utils/classNames';
 import {DropZoneProps, DropZone as RACDropZone} from 'react-aria-components/DropZone';
 import {HeadingContext} from 'react-aria-components/Heading';
-// @ts-ignore
 import intlMessages from '../../intl/dropzone/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {Provider} from 'react-aria-components/slots';

--- a/packages/@adobe/react-spectrum/src/inlinealert/InlineAlert.tsx
+++ b/packages/@adobe/react-spectrum/src/inlinealert/InlineAlert.tsx
@@ -17,7 +17,6 @@ import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusRing} from 'react-aria/FocusRing';
 import {Grid} from '../layout/Grid';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
-// @ts-ignore
 import intlMessages from '../../intl/inlinealert/*.json';
 import React, {ReactNode, useEffect, useRef} from 'react';
 import {SlotProvider} from '../utils/Slots';

--- a/packages/@adobe/react-spectrum/src/inlinealert/InlineAlert.tsx
+++ b/packages/@adobe/react-spectrum/src/inlinealert/InlineAlert.tsx
@@ -17,10 +17,10 @@ import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusRing} from 'react-aria/FocusRing';
 import {Grid} from '../layout/Grid';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
+// @ts-ignore
 import intlMessages from '../../intl/inlinealert/*.json';
 import React, {ReactNode, useEffect, useRef} from 'react';
 import {SlotProvider} from '../utils/Slots';
-// @ts-ignore
 import styles from '@adobe/spectrum-css-temp/components/inlinealert/vars.css';
 import SuccessMedium from '@spectrum-icons/ui/SuccessMedium';
 import {useDOMRef} from '../utils/useDOMRef';

--- a/packages/@adobe/react-spectrum/src/label/Label.tsx
+++ b/packages/@adobe/react-spectrum/src/label/Label.tsx
@@ -21,7 +21,6 @@ import {
 import Asterisk from '@spectrum-icons/ui/Asterisk';
 import {classNames} from '../utils/classNames';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
-// @ts-ignore
 import intlMessages from '../../intl/label/*.json';
 import React, {ElementType, HTMLAttributes, ReactNode} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';

--- a/packages/@adobe/react-spectrum/src/label/Label.tsx
+++ b/packages/@adobe/react-spectrum/src/label/Label.tsx
@@ -21,9 +21,9 @@ import {
 import Asterisk from '@spectrum-icons/ui/Asterisk';
 import {classNames} from '../utils/classNames';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
+// @ts-ignore
 import intlMessages from '../../intl/label/*.json';
 import React, {ElementType, HTMLAttributes, ReactNode} from 'react';
-// @ts-ignore
 import styles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
 import {useDOMRef} from '../utils/useDOMRef';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';

--- a/packages/@adobe/react-spectrum/src/list/ListView.tsx
+++ b/packages/@adobe/react-spectrum/src/list/ListView.tsx
@@ -29,7 +29,6 @@ import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusRing} from 'react-aria/FocusRing';
 import {FocusScope} from 'react-aria/FocusScope';
 import InsertionIndicator from './InsertionIndicator';
-// @ts-ignore
 import intlMessages from '../../intl/list/*.json';
 import {ListKeyboardDelegate} from 'react-aria/ListKeyboardDelegate';
 import {ListState, useListState} from 'react-stately/useListState';

--- a/packages/@adobe/react-spectrum/src/list/ListView.tsx
+++ b/packages/@adobe/react-spectrum/src/list/ListView.tsx
@@ -11,7 +11,6 @@
  */
 
 import {AriaGridListProps, useGridList} from 'react-aria/useGridList';
-
 import {
   AsyncLoadable,
   DOMRef,
@@ -30,11 +29,11 @@ import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusRing} from 'react-aria/FocusRing';
 import {FocusScope} from 'react-aria/FocusScope';
 import InsertionIndicator from './InsertionIndicator';
+// @ts-ignore
 import intlMessages from '../../intl/list/*.json';
 import {ListKeyboardDelegate} from 'react-aria/ListKeyboardDelegate';
 import {ListState, useListState} from 'react-stately/useListState';
 import listStyles from './styles.css';
-// @ts-ignore
 import {ListViewItem} from './ListViewItem';
 import {ListViewLayout} from './ListViewLayout';
 import {mergeProps} from 'react-aria/mergeProps';

--- a/packages/@adobe/react-spectrum/src/listbox/ListBoxBase.tsx
+++ b/packages/@adobe/react-spectrum/src/listbox/ListBoxBase.tsx
@@ -22,7 +22,6 @@ import {
 import {AriaListBoxOptions, AriaListBoxPropsBase, useListBox} from 'react-aria/useListBox';
 import {classNames} from '../utils/classNames';
 import {FocusScope} from 'react-aria/FocusScope';
-// @ts-ignore
 import intlMessages from '../../intl/listbox/*.json';
 import {ListBoxContext} from './ListBoxContext';
 import {ListBoxLayout} from './ListBoxLayout';

--- a/packages/@adobe/react-spectrum/src/listbox/ListBoxBase.tsx
+++ b/packages/@adobe/react-spectrum/src/listbox/ListBoxBase.tsx
@@ -22,8 +22,8 @@ import {
 import {AriaListBoxOptions, AriaListBoxPropsBase, useListBox} from 'react-aria/useListBox';
 import {classNames} from '../utils/classNames';
 import {FocusScope} from 'react-aria/FocusScope';
-import intlMessages from '../../intl/listbox/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/listbox/*.json';
 import {ListBoxContext} from './ListBoxContext';
 import {ListBoxLayout} from './ListBoxLayout';
 import {ListBoxOption} from './ListBoxOption';

--- a/packages/@adobe/react-spectrum/src/menu/ActionMenu.tsx
+++ b/packages/@adobe/react-spectrum/src/menu/ActionMenu.tsx
@@ -20,7 +20,6 @@ import {
   StyleProps
 } from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
-// @ts-ignore
 import intlMessages from '../../intl/menu/*.json';
 import {Menu} from './Menu';
 import {MenuTrigger, SpectrumMenuTriggerProps} from './MenuTrigger';

--- a/packages/@adobe/react-spectrum/src/menu/Menu.tsx
+++ b/packages/@adobe/react-spectrum/src/menu/Menu.tsx
@@ -11,16 +11,15 @@
  */
 
 import {ActionButton} from '../button/ActionButton';
-
 import {AriaMenuProps, useMenu} from 'react-aria/useMenu';
 import ArrowDownSmall from '@spectrum-icons/ui/ArrowDownSmall';
 import {classNames} from '../utils/classNames';
 import {DOMRef, StyleProps} from '@react-types/shared';
 import {FocusScope} from 'react-aria/FocusScope';
+// @ts-ignore
 import intlMessages from '../../intl/menu/*.json';
 import {MenuContext, MenuStateContext, useMenuStateContext} from './context';
 import {MenuItem} from './MenuItem';
-// @ts-ignore
 import {MenuSection} from './MenuSection';
 import {mergeProps} from 'react-aria/mergeProps';
 import React, {

--- a/packages/@adobe/react-spectrum/src/menu/Menu.tsx
+++ b/packages/@adobe/react-spectrum/src/menu/Menu.tsx
@@ -16,7 +16,6 @@ import ArrowDownSmall from '@spectrum-icons/ui/ArrowDownSmall';
 import {classNames} from '../utils/classNames';
 import {DOMRef, StyleProps} from '@react-types/shared';
 import {FocusScope} from 'react-aria/FocusScope';
-// @ts-ignore
 import intlMessages from '../../intl/menu/*.json';
 import {MenuContext, MenuStateContext, useMenuStateContext} from './context';
 import {MenuItem} from './MenuItem';

--- a/packages/@adobe/react-spectrum/src/menu/MenuItem.tsx
+++ b/packages/@adobe/react-spectrum/src/menu/MenuItem.tsx
@@ -19,7 +19,6 @@ import {DOMAttributes, Node} from '@react-types/shared';
 import {FocusRing} from 'react-aria/FocusRing';
 import {Grid} from '../layout/Grid';
 import InfoOutline from '@spectrum-icons/workflow/InfoOutline';
-// @ts-ignore
 import intlMessages from '../../intl/menu/*.json';
 import {mergeRefs} from 'react-aria/mergeRefs';
 import React, {JSX, useMemo, useRef} from 'react';

--- a/packages/@adobe/react-spectrum/src/picker/Picker.tsx
+++ b/packages/@adobe/react-spectrum/src/picker/Picker.tsx
@@ -29,10 +29,10 @@ import {classNames} from '../utils/classNames';
 import {dimensionValue} from '../utils/styleProps';
 import {Field} from '../label/Field';
 import {FieldButton} from '../button/FieldButton';
+// @ts-ignore
 import intlMessages from '../../intl/picker/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import {mergeProps} from 'react-aria/mergeProps';
-// @ts-ignore
 import {Popover} from '../overlays/Popover';
 import {PressResponder} from 'react-aria/private/interactions/PressResponder';
 import {ProgressCircle} from '../progress/ProgressCircle';

--- a/packages/@adobe/react-spectrum/src/picker/Picker.tsx
+++ b/packages/@adobe/react-spectrum/src/picker/Picker.tsx
@@ -29,7 +29,6 @@ import {classNames} from '../utils/classNames';
 import {dimensionValue} from '../utils/styleProps';
 import {Field} from '../label/Field';
 import {FieldButton} from '../button/FieldButton';
-// @ts-ignore
 import intlMessages from '../../intl/picker/*.json';
 import {ListBoxBase, useListBoxLayout} from '../listbox/ListBoxBase';
 import {mergeProps} from 'react-aria/mergeProps';

--- a/packages/@adobe/react-spectrum/src/slider/RangeSlider.tsx
+++ b/packages/@adobe/react-spectrum/src/slider/RangeSlider.tsx
@@ -13,7 +13,6 @@
 import {classNames} from '../utils/classNames';
 
 import {FocusableRef, RangeValue} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/slider/*.json';
 import React from 'react';
 import {

--- a/packages/@adobe/react-spectrum/src/steplist/StepListItem.tsx
+++ b/packages/@adobe/react-spectrum/src/steplist/StepListItem.tsx
@@ -12,7 +12,6 @@
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import {classNames} from '../utils/classNames';
 import {FocusRing} from 'react-aria/FocusRing';
-// @ts-ignore
 import intlMessages from '../../intl/steplist/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {Node} from '@react-types/shared';

--- a/packages/@adobe/react-spectrum/src/table/Resizer.tsx
+++ b/packages/@adobe/react-spectrum/src/table/Resizer.tsx
@@ -4,8 +4,8 @@ import eCursor from 'bundle-text:./cursors/Cur_MoveToRight_9_9.svg';
 import ewCursor from 'bundle-text:./cursors/Cur_MoveHorizontal_9_9.svg';
 import {FocusRing} from 'react-aria/FocusRing';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
-import intlMessages from '../../intl/table/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/table/*.json';
 import {isWebKit} from 'react-aria/private/utils/platform';
 import {Key, RefObject} from '@react-types/shared';
 import {mergeProps} from 'react-aria/mergeProps';

--- a/packages/@adobe/react-spectrum/src/table/Resizer.tsx
+++ b/packages/@adobe/react-spectrum/src/table/Resizer.tsx
@@ -4,7 +4,6 @@ import eCursor from 'bundle-text:./cursors/Cur_MoveToRight_9_9.svg';
 import ewCursor from 'bundle-text:./cursors/Cur_MoveHorizontal_9_9.svg';
 import {FocusRing} from 'react-aria/FocusRing';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {isWebKit} from 'react-aria/private/utils/platform';
 import {Key, RefObject} from '@react-types/shared';

--- a/packages/@adobe/react-spectrum/src/table/TableViewBase.tsx
+++ b/packages/@adobe/react-spectrum/src/table/TableViewBase.tsx
@@ -40,6 +40,7 @@ import {
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {HoverProps, useHover} from 'react-aria/useHover';
 import {InsertionIndicator} from './InsertionIndicator';
+// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {isAndroid} from 'react-aria/private/utils/platform';
 import {Item} from 'react-stately/Item';
@@ -51,7 +52,6 @@ import {Menu} from '../menu/Menu';
 import {MenuTrigger} from '../menu/MenuTrigger';
 import {mergeProps} from 'react-aria/mergeProps';
 import {Nubbin} from './Nubbin';
-// @ts-ignore
 import {ProgressCircle} from '../progress/ProgressCircle';
 import React, {
   DOMAttributes,

--- a/packages/@adobe/react-spectrum/src/table/TableViewBase.tsx
+++ b/packages/@adobe/react-spectrum/src/table/TableViewBase.tsx
@@ -40,7 +40,6 @@ import {
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {HoverProps, useHover} from 'react-aria/useHover';
 import {InsertionIndicator} from './InsertionIndicator';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {isAndroid} from 'react-aria/private/utils/platform';
 import {Item} from 'react-stately/Item';

--- a/packages/@adobe/react-spectrum/src/tag/TagGroup.tsx
+++ b/packages/@adobe/react-spectrum/src/tag/TagGroup.tsx
@@ -11,7 +11,6 @@
  */
 
 import {ActionButton} from '../button/ActionButton';
-
 import {AriaTagGroupProps, useTagGroup} from 'react-aria/useTagGroup';
 import {classNames} from '../utils/classNames';
 import {
@@ -25,8 +24,8 @@ import {
 import {Field} from '../label/Field';
 import {FocusRing} from 'react-aria/FocusRing';
 import {FocusScope} from 'react-aria/FocusScope';
-import intlMessages from '../../intl/tag/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/tag/*.json';
 import {ListCollection} from 'react-stately/private/list/ListCollection';
 import {ListKeyboardDelegate} from 'react-aria/ListKeyboardDelegate';
 import {Provider, useProvider, useProviderProps} from '../provider/Provider';

--- a/packages/@adobe/react-spectrum/src/tag/TagGroup.tsx
+++ b/packages/@adobe/react-spectrum/src/tag/TagGroup.tsx
@@ -24,7 +24,6 @@ import {
 import {Field} from '../label/Field';
 import {FocusRing} from 'react-aria/FocusRing';
 import {FocusScope} from 'react-aria/FocusScope';
-// @ts-ignore
 import intlMessages from '../../intl/tag/*.json';
 import {ListCollection} from 'react-stately/private/list/ListCollection';
 import {ListKeyboardDelegate} from 'react-aria/ListKeyboardDelegate';

--- a/packages/@adobe/react-spectrum/src/textfield/TextFieldBase.tsx
+++ b/packages/@adobe/react-spectrum/src/textfield/TextFieldBase.tsx
@@ -15,7 +15,6 @@ import CheckmarkMedium from '@spectrum-icons/ui/CheckmarkMedium';
 import {classNames} from '../utils/classNames';
 import {createFocusableRef} from '../utils/useDOMRef';
 import {Field} from '../label/Field';
-// @ts-ignore
 import intlMessages from '../../intl/textfield/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {PressEvents, RefObject, ValidationResult} from '@react-types/shared';

--- a/packages/@adobe/react-spectrum/src/toast/Toast.tsx
+++ b/packages/@adobe/react-spectrum/src/toast/Toast.tsx
@@ -18,7 +18,6 @@ import CrossMedium from '@spectrum-icons/ui/CrossMedium';
 import {DOMProps, DOMRef} from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
-// @ts-ignore
 import intlMessages from '../../intl/toast/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {QueuedToast, ToastState} from 'react-stately/useToastState';

--- a/packages/@adobe/react-spectrum/src/toast/Toast.tsx
+++ b/packages/@adobe/react-spectrum/src/toast/Toast.tsx
@@ -18,10 +18,10 @@ import CrossMedium from '@spectrum-icons/ui/CrossMedium';
 import {DOMProps, DOMRef} from '@react-types/shared';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
+// @ts-ignore
 import intlMessages from '../../intl/toast/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {QueuedToast, ToastState} from 'react-stately/useToastState';
-// @ts-ignore
 import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/toast/vars.css';
 import SuccessMedium from '@spectrum-icons/ui/SuccessMedium';

--- a/packages/@react-spectrum/s2/src/ActionBar.tsx
+++ b/packages/@react-spectrum/s2/src/ActionBar.tsx
@@ -29,8 +29,8 @@ import {
 } from 'react';
 import {DOMProps, DOMRef, DOMRefValue, Key} from '@react-types/shared';
 import {FocusScope} from 'react-aria/FocusScope';
-import intlMessages from '../intl/*.json';
 // @ts-ignore
+import intlMessages from '../intl/*.json';
 import {lightDark, style} from '../style' with {type: 'macro'};
 import {StyleProps} from './style-utils' with {type: 'macro'};
 import {useControlledState} from 'react-stately/useControlledState';

--- a/packages/@react-spectrum/s2/src/ActionBar.tsx
+++ b/packages/@react-spectrum/s2/src/ActionBar.tsx
@@ -29,7 +29,6 @@ import {
 } from 'react';
 import {DOMProps, DOMRef, DOMRefValue, Key} from '@react-types/shared';
 import {FocusScope} from 'react-aria/FocusScope';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {lightDark, style} from '../style' with {type: 'macro'};
 import {StyleProps} from './style-utils' with {type: 'macro'};

--- a/packages/@react-spectrum/s2/src/ActionButton.tsx
+++ b/packages/@react-spectrum/s2/src/ActionButton.tsx
@@ -34,7 +34,6 @@ import {createContext, forwardRef, ReactNode, useContext} from 'react';
 import {FocusableRef, FocusableRefValue, GlobalDOMAttributes} from '@react-types/shared';
 import {IconContext} from './Icon';
 import {ImageContext} from './Image';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {NotificationBadgeContext} from './NotificationBadge';
 import {OverlayTriggerStateContext} from 'react-aria-components/Dialog';

--- a/packages/@react-spectrum/s2/src/ActionMenu.tsx
+++ b/packages/@react-spectrum/s2/src/ActionMenu.tsx
@@ -16,7 +16,6 @@ import {ContextValue} from 'react-aria-components/slots';
 import {createContext, forwardRef} from 'react';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {forwardRefType} from './types';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Menu, MenuProps, MenuTrigger, MenuTriggerProps} from './Menu';
 import MoreIcon from '../s2wf-icons/S2_Icon_More_20_N.svg';

--- a/packages/@react-spectrum/s2/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/s2/src/AlertDialog.tsx
@@ -20,7 +20,6 @@ import {Dialog} from './Dialog';
 import {DOMProps, DOMRef} from '@react-types/shared';
 import {forwardRef, ReactNode} from 'react';
 import {IconContext} from './Icon';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import NoticeSquare from '../s2wf-icons/S2_Icon_AlertDiamond_20_N.svg';
 import {Provider} from 'react-aria-components/slots';

--- a/packages/@react-spectrum/s2/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/s2/src/Breadcrumbs.tsx
@@ -11,14 +11,12 @@
  */
 
 import {ActionButton} from './ActionButton';
-
 import {
   Breadcrumb as AriaBreadcrumb,
   BreadcrumbProps as AriaBreadcrumbItemProps,
   BreadcrumbsProps as AriaBreadcrumbsProps,
   Breadcrumbs as RACBreadcrumbs
 } from 'react-aria-components/Breadcrumbs';
-
 import {baseColor, focusRing, size, style} from '../style' with {type: 'macro'};
 import ChevronIcon from '../ui-icons/Chevron';
 import {
@@ -56,13 +54,12 @@ import {
 } from 'react';
 import FolderIcon from '../s2wf-icons/S2_Icon_FolderBreadcrumb_20_N.svg';
 import {forwardRefType} from './types';
-// @ts-ignore
 import {HeadingContext} from 'react-aria-components/Heading';
 import {inertValue} from 'react-aria/private/utils/inertValue';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Link, LinkRenderProps} from 'react-aria-components/Link';
 import {Menu, MenuItem, MenuTrigger} from './Menu';
-// @ts-ignore
 import {Text} from './Content';
 import {useDOMRef} from './useDOMRef';
 import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';

--- a/packages/@react-spectrum/s2/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/s2/src/Breadcrumbs.tsx
@@ -56,7 +56,6 @@ import FolderIcon from '../s2wf-icons/S2_Icon_FolderBreadcrumb_20_N.svg';
 import {forwardRefType} from './types';
 import {HeadingContext} from 'react-aria-components/Heading';
 import {inertValue} from 'react-aria/private/utils/inertValue';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Link, LinkRenderProps} from 'react-aria-components/Link';
 import {Menu, MenuItem, MenuTrigger} from './Menu';

--- a/packages/@react-spectrum/s2/src/Button.tsx
+++ b/packages/@react-spectrum/s2/src/Button.tsx
@@ -27,9 +27,9 @@ import {
 import {createContext, forwardRef, ReactNode, useContext, useEffect, useState} from 'react';
 import {FocusableRef, FocusableRefValue, GlobalDOMAttributes} from '@react-types/shared';
 import {IconContext} from './Icon';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {linearGradient} from '../style/spectrum-theme' with {type: 'macro'};
-// @ts-ignore
 import {Link, LinkProps} from 'react-aria-components/Link';
 import {OverlayTriggerStateContext} from 'react-aria-components/Dialog';
 import {pressScale} from './pressScale';

--- a/packages/@react-spectrum/s2/src/Button.tsx
+++ b/packages/@react-spectrum/s2/src/Button.tsx
@@ -27,7 +27,6 @@ import {
 import {createContext, forwardRef, ReactNode, useContext, useEffect, useState} from 'react';
 import {FocusableRef, FocusableRefValue, GlobalDOMAttributes} from '@react-types/shared';
 import {IconContext} from './Icon';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {linearGradient} from '../style/spectrum-theme' with {type: 'macro'};
 import {Link, LinkProps} from 'react-aria-components/Link';

--- a/packages/@react-spectrum/s2/src/Calendar.tsx
+++ b/packages/@react-spectrum/s2/src/Calendar.tsx
@@ -40,7 +40,6 @@ import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
 import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {Header, HeaderContext, HeadingContext} from './Content';
 import {helpTextStyles} from './Field';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {pressScale} from './pressScale';
 import {RangeCalendarContext, RangeCalendarStateContext} from 'react-aria-components/RangeCalendar';

--- a/packages/@react-spectrum/s2/src/CloseButton.tsx
+++ b/packages/@react-spectrum/s2/src/CloseButton.tsx
@@ -22,7 +22,6 @@ import {
 import {createContext, forwardRef} from 'react';
 import CrossIcon from '../ui-icons/Cross';
 import {FocusableRef, FocusableRefValue} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {pressScale} from './pressScale';
 import {useFocusableRef} from './useDOMRef';

--- a/packages/@react-spectrum/s2/src/ComboBox.tsx
+++ b/packages/@react-spectrum/s2/src/ComboBox.tsx
@@ -77,7 +77,6 @@ import {forwardRefType} from './types';
 import {HeaderContext, HeadingContext, Text, TextContext} from './Content';
 import {IconContext} from './Icon';
 import {InputContext, InputProps} from 'react-aria-components/Input';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ListLayout} from 'react-stately/useVirtualizerState';
 import {mergeRefs} from 'react-aria/mergeRefs';

--- a/packages/@react-spectrum/s2/src/ContextualHelp.tsx
+++ b/packages/@react-spectrum/s2/src/ContextualHelp.tsx
@@ -13,7 +13,6 @@ import {DialogTrigger, DialogTriggerProps} from './DialogTrigger';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import HelpIcon from '../s2wf-icons/S2_Icon_HelpCircle_20_N.svg';
 import InfoIcon from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {mergeStyles} from '../style/runtime';

--- a/packages/@react-spectrum/s2/src/ContextualHelp.tsx
+++ b/packages/@react-spectrum/s2/src/ContextualHelp.tsx
@@ -13,11 +13,11 @@ import {DialogTrigger, DialogTriggerProps} from './DialogTrigger';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import HelpIcon from '../s2wf-icons/S2_Icon_HelpCircle_20_N.svg';
 import InfoIcon from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {mergeProps} from 'react-aria/mergeProps';
 import {mergeStyles} from '../style/runtime';
 import {Placement} from 'react-aria-components/Popover';
-// @ts-ignore
 import {Popover, PopoverDialogProps} from './Popover';
 import {space, style} from '../style' with {type: 'macro'};
 import {StyleProps} from './style-utils' with {type: 'macro'};

--- a/packages/@react-spectrum/s2/src/DatePicker.tsx
+++ b/packages/@react-spectrum/s2/src/DatePicker.tsx
@@ -48,7 +48,6 @@ import {
   SpectrumLabelableProps
 } from '@react-types/shared';
 import {IconContext} from './Icon';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Popover} from './Popover';
 import {PopoverProps} from 'react-aria-components/Popover';

--- a/packages/@react-spectrum/s2/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/s2/src/DateRangePicker.tsx
@@ -33,7 +33,6 @@ import {
   HelpTextProps,
   SpectrumLabelableProps
 } from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {PopoverProps} from 'react-aria-components/Popover';
 import {RangeCalendar, RangeCalendarProps} from './RangeCalendar';

--- a/packages/@react-spectrum/s2/src/DropZone.tsx
+++ b/packages/@react-spectrum/s2/src/DropZone.tsx
@@ -26,7 +26,6 @@ import {
   UnsafeStyles
 } from './style-utils' with {type: 'macro'};
 import {IllustratedMessageContext} from './IllustratedMessage';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {style} from '../style' with {type: 'macro'};
 import {useDOMRef} from './useDOMRef';

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -35,11 +35,11 @@ import {
   Input as RACInput,
   InputProps as RACInputProps
 } from 'react-aria-components/Input';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Label, LabelProps} from 'react-aria-components/Label';
 import {mergeStyles} from '../style/runtime';
 import {Provider} from 'react-aria-components/slots';
-// @ts-ignore
 import {StyleString} from '../style/types';
 import {Text} from 'react-aria-components/Text';
 import {useDOMRef} from './useDOMRef';

--- a/packages/@react-spectrum/s2/src/Field.tsx
+++ b/packages/@react-spectrum/s2/src/Field.tsx
@@ -35,7 +35,6 @@ import {
   Input as RACInput,
   InputProps as RACInputProps
 } from 'react-aria-components/Input';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Label, LabelProps} from 'react-aria-components/Label';
 import {mergeStyles} from '../style/runtime';

--- a/packages/@react-spectrum/s2/src/InlineAlert.tsx
+++ b/packages/@react-spectrum/s2/src/InlineAlert.tsx
@@ -21,7 +21,6 @@ import {focusRing, style} from '../style' with {type: 'macro'};
 import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {IconContext} from './Icon';
 import InfoCircle from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import NoticeSquare from '../s2wf-icons/S2_Icon_AlertDiamond_20_N.svg';
 import {useDOMRef} from './useDOMRef';

--- a/packages/@react-spectrum/s2/src/ListView.tsx
+++ b/packages/@react-spectrum/s2/src/ListView.tsx
@@ -67,7 +67,6 @@ import {
 } from 'react-aria-components/GridList';
 import {IconContext} from './Icon';
 import {ImageContext} from './Image';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
 import {LayoutInfo, Virtualizer} from 'react-aria-components/Virtualizer';

--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -64,7 +64,6 @@ import {IconContext} from './Icon';
 import {ImageContext} from './Image';
 import InfoCircleIcon from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg'; // chevron right removed??
 import {InPopoverContext, Popover, PopoverContext} from './Popover';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import LinkOutIcon from '../ui-icons/LinkOut';
 import {mergeStyles} from '../style/runtime';

--- a/packages/@react-spectrum/s2/src/NotificationBadge.tsx
+++ b/packages/@react-spectrum/s2/src/NotificationBadge.tsx
@@ -15,7 +15,6 @@ import {ContextValue, SlotProps} from 'react-aria-components/slots';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {fontRelative, style} from '../style' with {type: 'macro'};
 import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {NumberFormatter} from '@internationalized/number';
 import React, {createContext, forwardRef} from 'react';

--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -76,13 +76,13 @@ import {forwardRefType} from './types';
 import {getOwnerDocument} from 'react-aria/private/utils/domHelpers';
 import {HeaderContext, HeadingContext, Text, TextContext} from './Content';
 import {IconContext} from './Icon';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isFocusable} from 'react-aria/private/utils/isFocusable';
 import {ListLayout} from 'react-stately/useVirtualizerState';
 import {mergeStyles} from '../style/runtime';
 import {Placement} from 'react-aria-components/Popover';
 import {Popover} from './Popover';
-// @ts-ignore
 import {PressResponder} from 'react-aria/private/interactions/PressResponder';
 import {pressScale} from './pressScale';
 import {ProgressCircle} from './ProgressCircle';

--- a/packages/@react-spectrum/s2/src/Picker.tsx
+++ b/packages/@react-spectrum/s2/src/Picker.tsx
@@ -76,7 +76,6 @@ import {forwardRefType} from './types';
 import {getOwnerDocument} from 'react-aria/private/utils/domHelpers';
 import {HeaderContext, HeadingContext, Text, TextContext} from './Content';
 import {IconContext} from './Icon';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isFocusable} from 'react-aria/private/utils/isFocusable';
 import {ListLayout} from 'react-stately/useVirtualizerState';

--- a/packages/@react-spectrum/s2/src/RangeCalendar.tsx
+++ b/packages/@react-spectrum/s2/src/RangeCalendar.tsx
@@ -22,7 +22,6 @@ import {forwardRefType, GlobalDOMAttributes} from '@react-types/shared';
 import {getAllowedOverrides, StyleProps} from './style-utils' with {type: 'macro'};
 import {HeaderContext, HeadingContext} from './Content';
 import {helpTextStyles} from './Field';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {style} from '../style' with {type: 'macro'};
 import {Text} from 'react-aria-components/Text';

--- a/packages/@react-spectrum/s2/src/RangeSlider.tsx
+++ b/packages/@react-spectrum/s2/src/RangeSlider.tsx
@@ -24,7 +24,6 @@ import {
 } from './Slider';
 import {FocusableRef, FocusableRefValue, RangeValue} from '@react-types/shared';
 import {FormContext, useFormProps} from './Form';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {pressScale} from './pressScale';
 import {SliderFill, SliderThumb, SliderTrack} from 'react-aria-components/Slider';

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -92,7 +92,6 @@ import {
 import {getOwnerDocument} from 'react-aria/private/utils/domHelpers';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {IconContext} from './Icon';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {Key} from '@react-types/shared';
 import {LayoutInfo, Rect, TableLayout, Virtualizer} from 'react-aria-components/Virtualizer';

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -101,7 +101,6 @@ import {Menu, MenuItem, MenuSection, MenuTrigger} from './Menu';
 import Nubbin from '../ui-icons/S2_MoveHorizontalTableWidget.svg';
 import {OverlayTriggerStateContext} from 'react-aria-components/Dialog';
 import {ProgressCircle} from './ProgressCircle';
-// @ts-ignore
 import {CheckboxContext as RACCheckboxContext} from 'react-aria-components/Checkbox';
 import {Popover as RACPopover} from 'react-aria-components/Popover';
 import React, {

--- a/packages/@react-spectrum/s2/src/TagGroup.tsx
+++ b/packages/@react-spectrum/s2/src/TagGroup.tsx
@@ -56,6 +56,7 @@ import {forwardRefType} from './types';
 import {IconContext} from './Icon';
 import {ImageContext} from './Image';
 import {inertValue} from 'react-aria/private/utils/inertValue';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {pressScale} from './pressScale';
 import {ButtonContext as RACButtonContext} from 'react-aria-components/Button';
@@ -63,7 +64,6 @@ import {TextContext as RACTextContext} from 'react-aria-components/Text';
 import {Text, TextContext} from './Content';
 import {useDOMRef} from './useDOMRef';
 import {useEffectEvent} from 'react-aria/private/utils/useEffectEvent';
-// @ts-ignore
 import {useId} from 'react-aria/useId';
 import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
 import {useLocale} from 'react-aria/I18nProvider';

--- a/packages/@react-spectrum/s2/src/TagGroup.tsx
+++ b/packages/@react-spectrum/s2/src/TagGroup.tsx
@@ -56,7 +56,6 @@ import {forwardRefType} from './types';
 import {IconContext} from './Icon';
 import {ImageContext} from './Image';
 import {inertValue} from 'react-aria/private/utils/inertValue';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {pressScale} from './pressScale';
 import {ButtonContext as RACButtonContext} from 'react-aria-components/Button';

--- a/packages/@react-spectrum/s2/src/Toast.tsx
+++ b/packages/@react-spectrum/s2/src/Toast.tsx
@@ -25,10 +25,10 @@ import {focusRing, style} from '../style' with {type: 'macro'};
 import {FocusScope} from 'react-aria/FocusScope';
 import {getEventTarget} from 'react-aria/private/utils/shadowdom/DOMFunctions';
 import InfoIcon from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isWebKit} from 'react-aria/private/utils/platform';
 import {ToastOptions as RACToastOptions, ToastQueue} from 'react-stately/useToastState';
-// @ts-ignore
 import {Text} from './Content';
 import {
   UNSTABLE_Toast as Toast,
@@ -39,9 +39,7 @@ import {
   ToastRegionProps,
   UNSTABLE_ToastStateContext as ToastStateContext
 } from 'react-aria-components/Toast';
-
 import toastCss from './Toast.module.css';
-
 import {useEvent} from 'react-aria/private/utils/useEvent';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useMediaQuery} from './useMediaQuery';

--- a/packages/@react-spectrum/s2/src/Toast.tsx
+++ b/packages/@react-spectrum/s2/src/Toast.tsx
@@ -25,7 +25,6 @@ import {focusRing, style} from '../style' with {type: 'macro'};
 import {FocusScope} from 'react-aria/FocusScope';
 import {getEventTarget} from 'react-aria/private/utils/shadowdom/DOMFunctions';
 import InfoIcon from '../s2wf-icons/S2_Icon_InfoCircle_20_N.svg';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isWebKit} from 'react-aria/private/utils/platform';
 import {ToastOptions as RACToastOptions, ToastQueue} from 'react-stately/useToastState';

--- a/packages/@react-spectrum/s2/src/TreeView.tsx
+++ b/packages/@react-spectrum/s2/src/TreeView.tsx
@@ -41,7 +41,6 @@ import {
   UnsafeStyles
 } from './style-utils' with {type: 'macro'};
 import {IconContext} from './Icon';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ProgressCircle} from './ProgressCircle';
 import {Provider, useContextProps} from 'react-aria-components/slots';

--- a/packages/dev/s2-docs/pages/react-aria/blog/ColorEditorExample.tsx
+++ b/packages/dev/s2-docs/pages/react-aria/blog/ColorEditorExample.tsx
@@ -24,7 +24,6 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {getColorChannels} from '@react-stately/color';
 import {useState} from 'react';
 import type {ColorSpace} from 'react-aria-components';
-// @ts-ignore
 import intlMessages from './intl/*.json';
 import {useLocalizedStringFormatter} from '@react-aria/i18n';
 

--- a/packages/react-aria-components/src/ColorSwatchPicker.tsx
+++ b/packages/react-aria-components/src/ColorSwatchPicker.tsx
@@ -16,7 +16,6 @@ import {
 import {Color} from 'react-stately/Color';
 import {ColorSwatchContext} from './ColorSwatch';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ListBox, ListBoxItem, ListBoxItemRenderProps, ListBoxRenderProps} from './ListBox';
 import {parseColor} from 'react-stately/Color';

--- a/packages/react-aria-components/src/ColorSwatchPicker.tsx
+++ b/packages/react-aria-components/src/ColorSwatchPicker.tsx
@@ -16,9 +16,9 @@ import {
 import {Color} from 'react-stately/Color';
 import {ColorSwatchContext} from './ColorSwatch';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ListBox, ListBoxItem, ListBoxItemRenderProps, ListBoxRenderProps} from './ListBox';
-// @ts-ignore
 import {parseColor} from 'react-stately/Color';
 import React, {
   createContext,

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -24,6 +24,7 @@ import {
 import {DropOptions, useDrop} from 'react-aria/useDrop';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {getEventTarget, nodeContains} from 'react-aria/private/utils/shadowdom/DOMFunctions';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isFocusable} from 'react-aria/private/utils/isFocusable';
 import {mergeProps} from 'react-aria/mergeProps';
@@ -35,7 +36,6 @@ import {useFocusRing} from 'react-aria/useFocusRing';
 import {useHover} from 'react-aria/useHover';
 import {useLabels} from 'react-aria/private/utils/useLabels';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
-// @ts-ignore
 import {useObjectRef} from 'react-aria/useObjectRef';
 import {useSlotId} from 'react-aria/private/utils/useId';
 import {VisuallyHidden} from 'react-aria/VisuallyHidden';

--- a/packages/react-aria-components/src/DropZone.tsx
+++ b/packages/react-aria-components/src/DropZone.tsx
@@ -24,7 +24,6 @@ import {
 import {DropOptions, useDrop} from 'react-aria/useDrop';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {getEventTarget, nodeContains} from 'react-aria/private/utils/shadowdom/DOMFunctions';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isFocusable} from 'react-aria/private/utils/isFocusable';
 import {mergeProps} from 'react-aria/mergeProps';

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -34,7 +34,6 @@ import {FieldErrorContext} from './FieldError';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FormContext} from './Form';
 import {GlobalDOMAttributes} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {ItemRenderProps} from './Collection';
 import {LabelContext} from './Label';

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -73,7 +73,6 @@ import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusScope} from 'react-aria/FocusScope';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {inertValue} from 'react-aria/private/utils/inertValue';
-// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isScrollable} from 'react-aria/private/utils/isScrollable';
 import {ITableCollection} from 'react-stately/private/table/TableCollection';

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -73,6 +73,7 @@ import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {FocusScope} from 'react-aria/FocusScope';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
 import {inertValue} from 'react-aria/private/utils/inertValue';
+// @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isScrollable} from 'react-aria/private/utils/isScrollable';
 import {ITableCollection} from 'react-stately/private/table/TableCollection';
@@ -115,7 +116,6 @@ import {useControlledState} from 'react-stately/useControlledState';
 import {useFocusRing} from 'react-aria/useFocusRing';
 import {useHover} from 'react-aria/useHover';
 import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
-// @ts-ignore
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useMultipleSelectionState} from 'react-stately/useMultipleSelectionState';

--- a/packages/react-aria/src/autocomplete/useAutocomplete.ts
+++ b/packages/react-aria/src/autocomplete/useAutocomplete.ts
@@ -36,7 +36,6 @@ import {
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getInteractionModality, getPointerType} from '../interactions/useFocusVisible';
 import {getOwnerDocument} from '../utils/domHelpers';
-// @ts-ignore
 import intlMessages from '../../intl/autocomplete/*.json';
 import {isAndroid, isIOS} from '../utils/platform';
 import {isCtrlKeyPressed} from '../utils/keyboard';

--- a/packages/react-aria/src/autocomplete/useAutocomplete.ts
+++ b/packages/react-aria/src/autocomplete/useAutocomplete.ts
@@ -36,6 +36,7 @@ import {
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getInteractionModality, getPointerType} from '../interactions/useFocusVisible';
 import {getOwnerDocument} from '../utils/domHelpers';
+// @ts-ignore
 import intlMessages from '../../intl/autocomplete/*.json';
 import {isAndroid, isIOS} from '../utils/platform';
 import {isCtrlKeyPressed} from '../utils/keyboard';
@@ -53,11 +54,8 @@ import {
 } from 'react';
 import {useEffectEvent} from '../utils/useEffectEvent';
 import {useEvent} from '../utils/useEvent';
-
 import {useId} from '../utils/useId';
-
 import {useLabels} from '../utils/useLabels';
-// @ts-ignore
 import {useLayoutEffect} from '../utils/useLayoutEffect';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';
 import {useObjectRef} from '../utils/useObjectRef';

--- a/packages/react-aria/src/breadcrumbs/useBreadcrumbs.ts
+++ b/packages/react-aria/src/breadcrumbs/useBreadcrumbs.ts
@@ -12,7 +12,6 @@
 
 import {AriaLabelingProps, DOMAttributes, DOMProps} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
-// @ts-ignore
 import intlMessages from '../../intl/breadcrumbs/*.json';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';
 

--- a/packages/react-aria/src/calendar/useCalendarBase.ts
+++ b/packages/react-aria/src/calendar/useCalendarBase.ts
@@ -20,7 +20,6 @@ import {
 } from 'react-stately/useCalendarState';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {hookData, useSelectedDateDescription, useVisibleRangeDescription} from './utils';
-// @ts-ignore
 import intlMessages from '../../intl/calendar/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {RangeCalendarState} from 'react-stately/useRangeCalendarState';

--- a/packages/react-aria/src/calendar/useCalendarCell.ts
+++ b/packages/react-aria/src/calendar/useCalendarCell.ts
@@ -18,7 +18,6 @@ import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions'
 import {getEraFormat, hookData} from './utils';
 import {getInteractionModality} from '../interactions/useFocusVisible';
 import {getScrollParent} from '../utils/getScrollParent';
-// @ts-ignore
 import intlMessages from '../../intl/calendar/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {RangeCalendarState} from 'react-stately/useRangeCalendarState';

--- a/packages/react-aria/src/calendar/utils.ts
+++ b/packages/react-aria/src/calendar/utils.ts
@@ -18,7 +18,6 @@ import {
   startOfMonth
 } from '@internationalized/date';
 import {CalendarSelectionMode, CalendarState} from 'react-stately/useCalendarState';
-// @ts-ignore
 import intlMessages from '../../intl/calendar/*.json';
 import type {LocalizedStringFormatter} from '@internationalized/string';
 import {RangeCalendarState} from 'react-stately/useRangeCalendarState';

--- a/packages/react-aria/src/color/useColorArea.ts
+++ b/packages/react-aria/src/color/useColorArea.ts
@@ -14,12 +14,12 @@ import {AriaLabelingProps, DOMAttributes, DOMProps, RefObject} from '@react-type
 import {ColorAreaProps, ColorAreaState} from 'react-stately/useColorAreaState';
 import {ColorChannel} from 'react-stately/Color';
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
+// @ts-ignore
 import intlMessages from '../../intl/color/*.json';
 import {isAndroid, isIOS} from '../utils/platform';
 import {mergeProps} from '../utils/mergeProps';
 import React, {ChangeEvent, InputHTMLAttributes, useCallback, useRef, useState} from 'react';
 import {useColorAreaGradient} from './useColorAreaGradient';
-// @ts-ignore
 import {useFocus} from '../interactions/useFocus';
 import {useFocusWithin} from '../interactions/useFocusWithin';
 import {useFormReset} from '../utils/useFormReset';

--- a/packages/react-aria/src/color/useColorArea.ts
+++ b/packages/react-aria/src/color/useColorArea.ts
@@ -14,7 +14,6 @@ import {AriaLabelingProps, DOMAttributes, DOMProps, RefObject} from '@react-type
 import {ColorAreaProps, ColorAreaState} from 'react-stately/useColorAreaState';
 import {ColorChannel} from 'react-stately/Color';
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
-// @ts-ignore
 import intlMessages from '../../intl/color/*.json';
 import {isAndroid, isIOS} from '../utils/platform';
 import {mergeProps} from '../utils/mergeProps';

--- a/packages/react-aria/src/color/useColorSwatch.ts
+++ b/packages/react-aria/src/color/useColorSwatch.ts
@@ -14,9 +14,9 @@ import {AriaLabelingProps, DOMProps} from '@react-types/shared';
 import {Color} from 'react-stately/Color';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {HTMLAttributes, useMemo} from 'react';
+// @ts-ignore
 import intlMessages from '../../intl/color/*.json';
 import {parseColor} from 'react-stately/Color';
-// @ts-ignore
 import {useId} from '../utils/useId';
 import {useLocale} from '../i18n/I18nProvider';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';

--- a/packages/react-aria/src/color/useColorSwatch.ts
+++ b/packages/react-aria/src/color/useColorSwatch.ts
@@ -14,7 +14,6 @@ import {AriaLabelingProps, DOMProps} from '@react-types/shared';
 import {Color} from 'react-stately/Color';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {HTMLAttributes, useMemo} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/color/*.json';
 import {parseColor} from 'react-stately/Color';
 import {useId} from '../utils/useId';

--- a/packages/react-aria/src/combobox/useComboBox.ts
+++ b/packages/react-aria/src/combobox/useComboBox.ts
@@ -11,7 +11,6 @@
  */
 
 import {announce} from '../live-announcer/LiveAnnouncer';
-
 import {AriaButtonProps} from '../button/useButton';
 import {ariaHideOutside} from '../overlays/ariaHideOutside';
 import {
@@ -46,6 +45,7 @@ import {getChildNodes} from 'react-stately/private/collections/getChildNodes';
 import {getItemCount} from 'react-stately/private/collections/getItemCount';
 import {getItemId, listData} from '../listbox/utils';
 import {getOwnerDocument} from '../utils/domHelpers';
+// @ts-ignore
 import intlMessages from '../../intl/combobox/*.json';
 import {isAppleDevice} from '../utils/platform';
 import {ListKeyboardDelegate} from '../selection/ListKeyboardDelegate';
@@ -54,7 +54,6 @@ import {privateValidationStateProp} from 'react-stately/private/form/useFormVali
 import {useEvent} from '../utils/useEvent';
 import {useFormReset} from '../utils/useFormReset';
 import {useId} from '../utils/useId';
-// @ts-ignore
 import {useLabels} from '../utils/useLabels';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';
 import {useMenuTrigger} from '../menu/useMenuTrigger';

--- a/packages/react-aria/src/combobox/useComboBox.ts
+++ b/packages/react-aria/src/combobox/useComboBox.ts
@@ -45,7 +45,6 @@ import {getChildNodes} from 'react-stately/private/collections/getChildNodes';
 import {getItemCount} from 'react-stately/private/collections/getItemCount';
 import {getItemId, listData} from '../listbox/utils';
 import {getOwnerDocument} from '../utils/domHelpers';
-// @ts-ignore
 import intlMessages from '../../intl/combobox/*.json';
 import {isAppleDevice} from '../utils/platform';
 import {ListKeyboardDelegate} from '../selection/ListKeyboardDelegate';

--- a/packages/react-aria/src/datepicker/useDateField.ts
+++ b/packages/react-aria/src/datepicker/useDateField.ts
@@ -24,7 +24,6 @@ import {createFocusManager, FocusManager} from '../focus/FocusScope';
 import {DateFieldProps, DateFieldState, DateValue} from 'react-stately/useDateFieldState';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {InputHTMLAttributes, useEffect, useMemo, useRef} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {TimeFieldState, TimePickerProps, TimeValue} from 'react-stately/useTimeFieldState';

--- a/packages/react-aria/src/datepicker/useDateField.ts
+++ b/packages/react-aria/src/datepicker/useDateField.ts
@@ -24,11 +24,11 @@ import {createFocusManager, FocusManager} from '../focus/FocusScope';
 import {DateFieldProps, DateFieldState, DateValue} from 'react-stately/useDateFieldState';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {InputHTMLAttributes, useEffect, useMemo, useRef} from 'react';
+// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {TimeFieldState, TimePickerProps, TimeValue} from 'react-stately/useTimeFieldState';
 import {useDatePickerGroup} from './useDatePickerGroup';
-// @ts-ignore
 import {useDescription} from '../utils/useDescription';
 import {useField} from '../label/useField';
 import {useFocusWithin} from '../interactions/useFocusWithin';

--- a/packages/react-aria/src/datepicker/useDatePicker.ts
+++ b/packages/react-aria/src/datepicker/useDatePicker.ts
@@ -26,7 +26,6 @@ import {CalendarProps} from 'react-stately/useCalendarState';
 import {createFocusManager} from '../focus/FocusScope';
 import {DatePickerProps, DatePickerState, DateValue} from 'react-stately/useDatePickerState';
 import {filterDOMProps} from '../utils/filterDOMProps';
-// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {nodeContains} from '../utils/shadowdom/DOMFunctions';

--- a/packages/react-aria/src/datepicker/useDatePicker.ts
+++ b/packages/react-aria/src/datepicker/useDatePicker.ts
@@ -11,7 +11,6 @@
  */
 
 import {AriaButtonProps} from '../button/useButton';
-
 import {AriaDialogProps} from '../dialog/useDialog';
 import {
   AriaLabelingProps,
@@ -27,11 +26,11 @@ import {CalendarProps} from 'react-stately/useCalendarState';
 import {createFocusManager} from '../focus/FocusScope';
 import {DatePickerProps, DatePickerState, DateValue} from 'react-stately/useDatePickerState';
 import {filterDOMProps} from '../utils/filterDOMProps';
+// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {privateValidationStateProp} from 'react-stately/private/form/useFormValidationState';
-// @ts-ignore
 import {roleSymbol} from './useDateField';
 import {useDatePickerGroup} from './useDatePickerGroup';
 import {useDescription} from '../utils/useDescription';

--- a/packages/react-aria/src/datepicker/useDateRangePicker.ts
+++ b/packages/react-aria/src/datepicker/useDateRangePicker.ts
@@ -11,7 +11,6 @@
  */
 
 import {AriaButtonProps} from '../button/useButton';
-
 import {AriaDatePickerProps} from './useDatePicker';
 import {AriaDialogProps} from '../dialog/useDialog';
 import {
@@ -38,12 +37,12 @@ import {
 } from 'react-stately/private/form/useFormValidationState';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {focusManagerSymbol, roleSymbol} from './useDateField';
+// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {RangeCalendarProps} from 'react-stately/useRangeCalendarState';
 import {useDatePickerGroup} from './useDatePickerGroup';
-// @ts-ignore
 import {useDescription} from '../utils/useDescription';
 import {useField} from '../label/useField';
 import {useFocusWithin} from '../interactions/useFocusWithin';

--- a/packages/react-aria/src/datepicker/useDateRangePicker.ts
+++ b/packages/react-aria/src/datepicker/useDateRangePicker.ts
@@ -37,7 +37,6 @@ import {
 } from 'react-stately/private/form/useFormValidationState';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {focusManagerSymbol, roleSymbol} from './useDateField';
-// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {nodeContains} from '../utils/shadowdom/DOMFunctions';

--- a/packages/react-aria/src/datepicker/useDisplayNames.ts
+++ b/packages/react-aria/src/datepicker/useDisplayNames.ts
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-// @ts-ignore
 import intlMessages from '../../intl/datepicker/*.json';
 import {LocalizedStringDictionary} from '@internationalized/string';
 import {useLocale} from '../i18n/I18nProvider';

--- a/packages/react-aria/src/dnd/useDrag.ts
+++ b/packages/react-aria/src/dnd/useDrag.ts
@@ -39,7 +39,6 @@ import {
   useDragModality,
   writeToDataTransfer
 } from './utils';
-// @ts-ignore
 import intlMessages from '../../intl/dnd/*.json';
 import {isVirtualClick, isVirtualPointerEvent} from '../utils/isVirtualEvent';
 import {useDescription} from '../utils/useDescription';

--- a/packages/react-aria/src/dnd/useDrag.ts
+++ b/packages/react-aria/src/dnd/useDrag.ts
@@ -11,7 +11,6 @@
  */
 
 import {AriaButtonProps} from '../button/useButton';
-
 import {
   DragEndEvent,
   DragItem,
@@ -40,10 +39,10 @@ import {
   useDragModality,
   writeToDataTransfer
 } from './utils';
+// @ts-ignore
 import intlMessages from '../../intl/dnd/*.json';
 import {isVirtualClick, isVirtualPointerEvent} from '../utils/isVirtualEvent';
 import {useDescription} from '../utils/useDescription';
-// @ts-ignore
 import {useGlobalListeners} from '../utils/useGlobalListeners';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';
 

--- a/packages/react-aria/src/dnd/useDraggableItem.ts
+++ b/packages/react-aria/src/dnd/useDraggableItem.ts
@@ -19,7 +19,6 @@ import {
 } from './utils';
 import {DraggableCollectionState} from 'react-stately/useDraggableCollectionState';
 import {HTMLAttributes} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/dnd/*.json';
 import {Key} from '@react-types/shared';
 import {useDescription} from '../utils/useDescription';

--- a/packages/react-aria/src/dnd/useDropIndicator.ts
+++ b/packages/react-aria/src/dnd/useDropIndicator.ts
@@ -15,7 +15,6 @@ import {DroppableCollectionState} from 'react-stately/useDroppableCollectionStat
 import {DropTarget, FocusableElement, Key, RefObject} from '@react-types/shared';
 import {getDroppableCollectionId} from './utils';
 import {HTMLAttributes} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/dnd/*.json';
 import {useDroppableItem} from './useDroppableItem';
 import {useId} from '../utils/useId';

--- a/packages/react-aria/src/dnd/useVirtualDrop.ts
+++ b/packages/react-aria/src/dnd/useVirtualDrop.ts
@@ -13,7 +13,6 @@
 import {AriaButtonProps} from '../button/useButton';
 import {DOMAttributes} from 'react';
 import * as DragManager from './DragManager';
-// @ts-ignore
 import intlMessages from '../../intl/dnd/*.json';
 import {useDescription} from '../utils/useDescription';
 import {useDragModality} from './utils';

--- a/packages/react-aria/src/grid/useGridSelectionAnnouncement.ts
+++ b/packages/react-aria/src/grid/useGridSelectionAnnouncement.ts
@@ -12,7 +12,6 @@
 
 import {announce} from '../live-announcer/LiveAnnouncer';
 import {Collection, Key, Node, Selection} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/grid/*.json';
 import {SelectionManager} from 'react-stately/private/selection/SelectionManager';
 import {useCallback, useRef} from 'react';

--- a/packages/react-aria/src/grid/useGridSelectionCheckbox.ts
+++ b/packages/react-aria/src/grid/useGridSelectionCheckbox.ts
@@ -1,7 +1,6 @@
 import {AriaCheckboxProps} from '../checkbox/useCheckbox';
 import {IGridCollection as GridCollection} from 'react-stately/private/grid/GridCollection';
 import {GridState} from 'react-stately/private/grid/useGridState';
-// @ts-ignore
 import intlMessages from '../../intl/grid/*.json';
 import {Key} from '@react-types/shared';
 import {useId} from '../utils/useId';

--- a/packages/react-aria/src/grid/useHighlightSelectionDescription.ts
+++ b/packages/react-aria/src/grid/useHighlightSelectionDescription.ts
@@ -11,7 +11,6 @@
  */
 
 import {AriaLabelingProps} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/grid/*.json';
 import {MultipleSelectionManager} from 'react-stately/useMultipleSelectionState';
 import {useDescription} from '../utils/useDescription';

--- a/packages/react-aria/src/menu/useMenuTrigger.ts
+++ b/packages/react-aria/src/menu/useMenuTrigger.ts
@@ -14,7 +14,6 @@ import {AriaButtonProps} from '../button/useButton';
 import {AriaMenuOptions} from './useMenu';
 import {FocusableElement, RefObject} from '@react-types/shared';
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
-// @ts-ignore
 import intlMessages from '../../intl/menu/*.json';
 import {MenuTriggerState, MenuTriggerType} from 'react-stately/useMenuTriggerState';
 import {PressProps} from '../interactions/usePress';

--- a/packages/react-aria/src/menu/useMenuTrigger.ts
+++ b/packages/react-aria/src/menu/useMenuTrigger.ts
@@ -11,12 +11,11 @@
  */
 
 import {AriaButtonProps} from '../button/useButton';
-
 import {AriaMenuOptions} from './useMenu';
 import {FocusableElement, RefObject} from '@react-types/shared';
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
-import intlMessages from '../../intl/menu/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/menu/*.json';
 import {MenuTriggerState, MenuTriggerType} from 'react-stately/useMenuTriggerState';
 import {PressProps} from '../interactions/usePress';
 import {useId} from '../utils/useId';

--- a/packages/react-aria/src/numberfield/useNumberField.ts
+++ b/packages/react-aria/src/numberfield/useNumberField.ts
@@ -11,7 +11,6 @@
  */
 
 import {announce} from '../live-announcer/LiveAnnouncer';
-
 import {AriaButtonProps} from '../button/useButton';
 import {
   AriaLabelingProps,
@@ -36,12 +35,12 @@ import {
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {flushSync} from 'react-dom';
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
+// @ts-ignore
 import intlMessages from '../../intl/numberfield/*.json';
 import {isAndroid, isIOS, isIPhone} from '../utils/platform';
 import {mergeProps} from '../utils/mergeProps';
 import {NumberFieldProps, NumberFieldState} from 'react-stately/useNumberFieldState';
 import {privateValidationStateProp} from 'react-stately/private/form/useFormValidationState';
-// @ts-ignore
 import {useFocus} from '../interactions/useFocus';
 import {useFocusWithin} from '../interactions/useFocusWithin';
 import {useFormattedTextField} from '../textfield/useFormattedTextField';

--- a/packages/react-aria/src/numberfield/useNumberField.ts
+++ b/packages/react-aria/src/numberfield/useNumberField.ts
@@ -35,7 +35,6 @@ import {
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {flushSync} from 'react-dom';
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
-// @ts-ignore
 import intlMessages from '../../intl/numberfield/*.json';
 import {isAndroid, isIOS, isIPhone} from '../utils/platform';
 import {mergeProps} from '../utils/mergeProps';

--- a/packages/react-aria/src/overlays/DismissButton.tsx
+++ b/packages/react-aria/src/overlays/DismissButton.tsx
@@ -11,7 +11,6 @@
  */
 
 import {AriaLabelingProps, DOMProps} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/overlays/*.json';
 import React, {JSX} from 'react';
 import {useLabels} from '../utils/useLabels';

--- a/packages/react-aria/src/searchfield/useSearchField.ts
+++ b/packages/react-aria/src/searchfield/useSearchField.ts
@@ -15,7 +15,6 @@ import {AriaTextFieldProps, useTextField} from '../textfield/useTextField';
 import {chain} from '../utils/chain';
 import {DOMAttributes, RefObject, ValidationResult} from '@react-types/shared';
 import {InputHTMLAttributes, LabelHTMLAttributes} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/searchfield/*.json';
 import {SearchFieldProps, SearchFieldState} from 'react-stately/useSearchFieldState';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';

--- a/packages/react-aria/src/spinbutton/useSpinButton.ts
+++ b/packages/react-aria/src/spinbutton/useSpinButton.ts
@@ -14,7 +14,6 @@ import {announce, clearAnnouncer} from '../live-announcer/LiveAnnouncer';
 
 import {AriaButtonProps} from '../button/useButton';
 import {DOMAttributes, InputBase, RangeInputBase, Validation, ValueBase} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/spinbutton/*.json';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useEffectEvent} from '../utils/useEffectEvent';

--- a/packages/react-aria/src/steplist/useStepList.ts
+++ b/packages/react-aria/src/steplist/useStepList.ts
@@ -13,7 +13,6 @@
 import {AriaLabelingProps, DOMProps, RefObject} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {HTMLAttributes} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/steplist/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {StepListProps, StepListState} from 'react-stately/private/steplist/useStepListState';

--- a/packages/react-aria/src/steplist/useStepList.ts
+++ b/packages/react-aria/src/steplist/useStepList.ts
@@ -13,8 +13,8 @@
 import {AriaLabelingProps, DOMProps, RefObject} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {HTMLAttributes} from 'react';
-import intlMessages from '../../intl/steplist/*.json';
 // @ts-ignore
+import intlMessages from '../../intl/steplist/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {StepListProps, StepListState} from 'react-stately/private/steplist/useStepListState';
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';

--- a/packages/react-aria/src/table/useTable.ts
+++ b/packages/react-aria/src/table/useTable.ts
@@ -14,7 +14,6 @@ import {announce} from '../live-announcer/LiveAnnouncer';
 
 import {GridAria, GridProps, useGrid} from '../grid/useGrid';
 import {gridIds} from './utils';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {Key, LayoutDelegate, Rect, RefObject, Size} from '@react-types/shared';
 import {mergeProps} from '../utils/mergeProps';

--- a/packages/react-aria/src/table/useTableColumnHeader.ts
+++ b/packages/react-aria/src/table/useTableColumnHeader.ts
@@ -13,7 +13,6 @@
 import {DOMAttributes, FocusableElement, RefObject} from '@react-types/shared';
 import {getColumnHeaderId} from './utils';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {isAndroid} from '../utils/platform';
 import {mergeProps} from '../utils/mergeProps';

--- a/packages/react-aria/src/table/useTableColumnResize.ts
+++ b/packages/react-aria/src/table/useTableColumnResize.ts
@@ -17,7 +17,6 @@ import {focusSafely} from '../interactions/focusSafely';
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getColumnHeaderId} from './utils';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {TableColumnResizeState} from 'react-stately/useTableState';

--- a/packages/react-aria/src/table/useTableColumnResize.ts
+++ b/packages/react-aria/src/table/useTableColumnResize.ts
@@ -17,6 +17,7 @@ import {focusSafely} from '../interactions/focusSafely';
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getColumnHeaderId} from './utils';
 import {GridNode} from 'react-stately/private/grid/GridCollection';
+// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {TableColumnResizeState} from 'react-stately/useTableState';
@@ -26,7 +27,6 @@ import {useId} from '../utils/useId';
 import {useInteractionModality} from '../interactions/useFocusVisible';
 import {useKeyboard} from '../interactions/useKeyboard';
 import {useLocale} from '../i18n/I18nProvider';
-// @ts-ignore
 import {useLocalizedStringFormatter} from '../i18n/useLocalizedStringFormatter';
 import {useMove} from '../interactions/useMove';
 import {usePress} from '../interactions/usePress';

--- a/packages/react-aria/src/table/useTableRow.ts
+++ b/packages/react-aria/src/table/useTableRow.ts
@@ -16,7 +16,6 @@ import {Collection, FocusableElement, Node, RefObject} from '@react-types/shared
 import {getRowLabelledBy} from './utils';
 import {GridRowAria, GridRowProps, useGridRow} from '../grid/useGridRow';
 import {HTMLAttributes} from 'react';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {ITableCollection} from 'react-stately/private/table/TableCollection';
 import {mergeProps} from '../utils/mergeProps';

--- a/packages/react-aria/src/table/useTableSelectionCheckbox.ts
+++ b/packages/react-aria/src/table/useTableSelectionCheckbox.ts
@@ -12,7 +12,6 @@
 
 import {AriaCheckboxProps} from '../checkbox/useCheckbox';
 import {getRowLabelledBy} from './utils';
-// @ts-ignore
 import intlMessages from '../../intl/table/*.json';
 import {Key} from '@react-types/shared';
 import {TableState} from 'react-stately/useTableState';

--- a/packages/react-aria/src/tag/useTag.ts
+++ b/packages/react-aria/src/tag/useTag.ts
@@ -11,15 +11,14 @@
  */
 
 import {AriaButtonProps} from '../button/useButton';
-
 import {DOMAttributes, FocusableElement, Node, RefObject} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {hookData} from './useTagGroup';
+// @ts-ignore
 import intlMessages from '../../intl/tag/*.json';
 import {KeyboardEvent} from 'react';
 import type {ListState} from 'react-stately/useListState';
 import {mergeProps} from '../utils/mergeProps';
-// @ts-ignore
 import {SelectableItemStates} from '../selection/useSelectableItem';
 import {useDescription} from '../utils/useDescription';
 import {useFocusable} from '../interactions/useFocusable';

--- a/packages/react-aria/src/tag/useTag.ts
+++ b/packages/react-aria/src/tag/useTag.ts
@@ -14,7 +14,6 @@ import {AriaButtonProps} from '../button/useButton';
 import {DOMAttributes, FocusableElement, Node, RefObject} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {hookData} from './useTagGroup';
-// @ts-ignore
 import intlMessages from '../../intl/tag/*.json';
 import {KeyboardEvent} from 'react';
 import type {ListState} from 'react-stately/useListState';

--- a/packages/react-aria/src/toast/useToast.ts
+++ b/packages/react-aria/src/toast/useToast.ts
@@ -11,12 +11,11 @@
  */
 
 import {AriaButtonProps} from '../button/useButton';
-
 import {AriaLabelingProps, DOMAttributes, FocusableElement, RefObject} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
+// @ts-ignore
 import intlMessages from '../../intl/toast/*.json';
 import {QueuedToast, ToastState} from 'react-stately/useToastState';
-// @ts-ignore
 import {useEffect, useState} from 'react';
 import {useId, useSlotId} from '../utils/useId';
 import {useLayoutEffect} from '../utils/useLayoutEffect';

--- a/packages/react-aria/src/toast/useToast.ts
+++ b/packages/react-aria/src/toast/useToast.ts
@@ -13,7 +13,6 @@
 import {AriaButtonProps} from '../button/useButton';
 import {AriaLabelingProps, DOMAttributes, FocusableElement, RefObject} from '@react-types/shared';
 import {filterDOMProps} from '../utils/filterDOMProps';
-// @ts-ignore
 import intlMessages from '../../intl/toast/*.json';
 import {QueuedToast, ToastState} from 'react-stately/useToastState';
 import {useEffect, useState} from 'react';

--- a/packages/react-aria/src/toast/useToastRegion.ts
+++ b/packages/react-aria/src/toast/useToastRegion.ts
@@ -14,11 +14,11 @@ import {AriaLabelingProps, DOMAttributes, FocusableElement, RefObject} from '@re
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
 import {getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getInteractionModality} from '../interactions/useFocusVisible';
+// @ts-ignore
 import intlMessages from '../../intl/toast/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {ToastState} from 'react-stately/useToastState';
 import {useCallback, useEffect, useRef} from 'react';
-// @ts-ignore
 import {useFocusWithin} from '../interactions/useFocusWithin';
 import {useHover} from '../interactions/useHover';
 import {useLandmark} from '../landmark/useLandmark';

--- a/packages/react-aria/src/toast/useToastRegion.ts
+++ b/packages/react-aria/src/toast/useToastRegion.ts
@@ -14,7 +14,6 @@ import {AriaLabelingProps, DOMAttributes, FocusableElement, RefObject} from '@re
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
 import {getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getInteractionModality} from '../interactions/useFocusVisible';
-// @ts-ignore
 import intlMessages from '../../intl/toast/*.json';
 import {mergeProps} from '../utils/mergeProps';
 import {ToastState} from 'react-stately/useToastState';

--- a/packages/react-aria/src/tree/useTreeItem.ts
+++ b/packages/react-aria/src/tree/useTreeItem.ts
@@ -17,7 +17,6 @@ import {
   useGridListItem
 } from '../gridlist/useGridListItem';
 import {DOMAttributes, FocusableElement, Node, RefObject} from '@react-types/shared';
-// @ts-ignore
 import intlMessages from '../../intl/tree/*.json';
 import {TreeState} from 'react-stately/useTreeState';
 import {useLabels} from '../utils/useLabels';

--- a/packages/react-stately/src/color/Color.ts
+++ b/packages/react-stately/src/color/Color.ts
@@ -19,7 +19,6 @@ import {
   ColorSpace,
   Color as IColor
 } from './types';
-// @ts-ignore
 import intlMessages from '../../intl/color/*.json';
 import {LocalizedStringDictionary, LocalizedStringFormatter} from '@internationalized/string';
 import {NumberFormatter} from '@internationalized/number';

--- a/packages/react-stately/src/datepicker/utils.ts
+++ b/packages/react-stately/src/datepicker/utils.ts
@@ -21,7 +21,6 @@ import {
   toCalendarDateTime
 } from '@internationalized/date';
 import {DatePickerProps, DateValue, Granularity, TimeValue} from './types';
-// @ts-ignore
 import i18nMessages from '../../intl/datepicker/*.json';
 import {LocalizedStringDictionary, LocalizedStringFormatter} from '@internationalized/string';
 import {mergeValidation, VALID_VALIDITY_STATE} from '../form/useFormValidationState';


### PR DESCRIPTION
Fixes orphaned ts-ignore comments after migration to oxlint with a bit of regex magic 👍 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
