### PR TITLE
fix: should include maxValue year in CalendarYearPicker range

### DIFF
--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -776,4 +776,74 @@ describe('Calendar', () => {
         .map(o => o.textContent)
     ).toEqual(['Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec', 'Jan']);
   });
+
+  it('supports minValue and maxValue', async () => {
+    function YearPickerExample({calendarProps, yearPickerProps}) {
+      return (
+        <Calendar {...calendarProps} aria-label="Appointment date">
+          <header>
+            <Button slot="previous">◀</Button>
+            <CalendarYearPicker {...yearPickerProps}>
+              {({items, value, onChange, 'aria-label': ariaLabel}) => (
+                <select
+                  aria-label={ariaLabel}
+                  value={value}
+                  onChange={e => onChange(e.target.value)}>
+                  {items.map(item => (
+                    <option key={item.id} value={item.id}>
+                      {item.formatted}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </CalendarYearPicker>
+            <Button slot="next">▶</Button>
+          </header>
+          <CalendarGrid>{date => <CalendarCell date={date} />}</CalendarGrid>
+        </Calendar>
+      );
+    }
+
+    let tree = render(
+      <YearPickerExample calendarProps={{maxValue: new CalendarDate(2026, 6, 30)}} />
+    );
+    expect(
+      within(tree.getByLabelText('year'))
+        .getAllByRole('option')
+        .map(o => o.textContent)
+    ).toEqual(Array.from({length: 20}, (_, i) => String(2026 - i)).reverse());
+
+    tree.rerender(<YearPickerExample calendarProps={{minValue: new CalendarDate(2020, 6, 30)}} />);
+    expect(
+      within(tree.getByLabelText('year'))
+        .getAllByRole('option')
+        .map(o => o.textContent)
+    ).toEqual(Array.from({length: 20}, (_, i) => String(i + 2020)));
+
+    tree.rerender(
+      <YearPickerExample
+        calendarProps={{
+          minValue: new CalendarDate(2020, 6, 30),
+          maxValue: new CalendarDate(2026, 6, 30)
+        }}
+      />
+    );
+    expect(
+      within(tree.getByLabelText('year'))
+        .getAllByRole('option')
+        .map(o => o.textContent)
+    ).toEqual(Array.from({length: 7}, (_, i) => String(i + 2020)));
+
+    tree.rerender(
+      <YearPickerExample
+        calendarProps={{defaultFocusedValue: new CalendarDate(2026, 6, 30)}}
+        yearPickerProps={{visibleYears: 1}}
+      />
+    );
+    expect(
+      within(tree.getByLabelText('year'))
+        .getAllByRole('option')
+        .map(o => o.textContent)
+    ).toEqual(['2026']);
+  });
 });

--- a/packages/react-aria/src/calendar/useCalendarYearPicker.ts
+++ b/packages/react-aria/src/calendar/useCalendarYearPicker.ts
@@ -68,15 +68,15 @@ export function useCalendarYearPicker(
   // However, this can be constrained by the calendar's minimum and maximum date.
   let visibleYears = props.visibleYears || 20;
   let minDate = state.focusedDate.subtract({years: Math.floor(visibleYears / 2)});
-  let maxDate = state.focusedDate.add({years: Math.ceil(visibleYears / 2)});
+  let maxDate = state.focusedDate.add({years: Math.ceil(visibleYears / 2) - 1});
   if (state.maxValue && maxDate.compare(state.maxValue) > 0) {
     maxDate = toCalendarDate(state.maxValue);
-    minDate = maxDate.subtract({years: visibleYears});
+    minDate = maxDate.subtract({years: visibleYears - 1});
   }
 
   if (state.minValue && minDate.compare(state.minValue) < 0) {
     minDate = toCalendarDate(state.minValue);
-    maxDate = minDate.add({years: visibleYears});
+    maxDate = minDate.add({years: visibleYears - 1});
     if (state.maxValue && maxDate.compare(state.maxValue) > 0) {
       maxDate = toCalendarDate(state.maxValue);
     }
@@ -85,7 +85,7 @@ export function useCalendarYearPicker(
   let years: CalendarYearPickerItem[] = [];
   let date = minDate;
   let value = 0;
-  while (date.compare(maxDate) < 0) {
+  while (date.compare(maxDate) <= 0) {
     if (isSameYear(date, state.focusedDate)) {
       value = years.length;
     }


### PR DESCRIPTION
Closes #10140

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
