### PR TITLE
fix: bump unplugin to v2 to make plugin work under Node 26

### DIFF
--- a/packages/dev/optimize-locales-plugin/package.json
+++ b/packages/dev/optimize-locales-plugin/package.json
@@ -7,6 +7,6 @@
     "access": "public"
   },
   "dependencies": {
-    "unplugin": "^1.4.0"
+    "unplugin": "^2.3.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6958,7 +6958,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-aria/optimize-locales-plugin@workspace:packages/dev/optimize-locales-plugin"
   dependencies:
-    unplugin: "npm:^1.4.0"
+    unplugin: "npm:^2.3.11"
   languageName: unknown
   linkType: soft
 
@@ -12092,7 +12092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.12.1, acorn@npm:^8.4.1":
+"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.4.1":
   version: 8.12.1
   resolution: "acorn@npm:8.12.1"
   bin:
@@ -13955,7 +13955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.0, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.4.0, chokidar@npm:^3.5.3":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -30845,18 +30845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unplugin@npm:^1.4.0":
-  version: 1.12.0
-  resolution: "unplugin@npm:1.12.0"
-  dependencies:
-    acorn: "npm:^8.12.1"
-    chokidar: "npm:^3.6.0"
-    webpack-sources: "npm:^3.2.3"
-    webpack-virtual-modules: "npm:^0.6.2"
-  checksum: 10c0/d4ca9508adbc3724fbafe0eec50e346b3772d3bca7881f20b29d403c576fae5ac2f1224cc84481913396e9c52cba5e934d2815d1b2a206c439fdc52ec39889b8
-  languageName: node
-  linkType: hard
-
 "unplugin@npm:^1.9.0":
   version: 1.16.1
   resolution: "unplugin@npm:1.16.1"
@@ -30867,7 +30855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unplugin@npm:^2.3.5":
+"unplugin@npm:^2.3.11, unplugin@npm:^2.3.5":
   version: 2.3.11
   resolution: "unplugin@npm:2.3.11"
   dependencies:
@@ -31724,13 +31712,6 @@ __metadata:
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
   checksum: 10c0/228d8cb6d270c23b0720cb2d95c579202db3aaf8f633b4e9dd94ec2000a04e7e6e43b76a94509cdb30479bd00ae253ab2371a2da9f81446cc313f89a4213a2c4
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "webpack-sources@npm:3.2.3"
-  checksum: 10c0/2ef63d77c4fad39de4a6db17323d75eb92897b32674e97d76f0a1e87c003882fc038571266ad0ef581ac734cbe20952912aaa26155f1905e96ce251adbb1eb4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

`unplugin@^1.4.0` uses `rmdirSync` method which is deprecated in Node 24 (emits a warning when called) and removed in Node 26.
That was fixed in `unplugin@^2`.

In this PR I bumped to `unplugin^2.3.11`. The latest version - `unplugin@3.0.0`, dropped CJS support, so migrating to it may mean more changes. In any case this PR does not hurt, migrating to `unplugin@3.0.0` can be done separately.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
pipeline should pass

## 🧢 Your Project:

<!--- Company/project for pull request -->
Adobe Workfront