### PR TITLE
docs(react-aria-components): document overriding Popover z-index via the style prop

### DIFF
--- a/packages/react-aria-components/docs/Popover.mdx
+++ b/packages/react-aria-components/docs/Popover.mdx
@@ -344,6 +344,16 @@ The example below will maintain at least 50px between the popover and the edge o
 </DialogTrigger>
 ```
 
+### Z-index
+
+By default, popovers render with a `z-index` of 100000 so they appear above other content on the page. To position a popover relative to other layers — for example, beneath a modal — set a `zIndex` via the `style` prop. The `style` prop is applied after the default positioning styles, so it takes precedence.
+
+```jsx
+<Popover style={{zIndex: 30}}>
+  {/* ... */}
+</Popover>
+```
+
 ## Controlled open state
 
 The above examples have shown `Popover` used within a `<DialogTrigger>`, which handles opening the popover when a button is clicked, and positioning relative to the trigger. This is convenient, but there are cases where you want to show a popover programmatically rather than as a result of a user action, or render the `<Popover>` in a different part of the JSX tree.


### PR DESCRIPTION
Closes <!-- docs-only clarification; no existing issue -->

The `style` prop on `Popover` is applied after the computed positioning styles, so it overrides them — including the default `z-index: 100000`. That's the simplest way to place a popover relative to other layers (e.g. beneath a modal), but it isn't documented, so it's easy to miss and reach for `UNSAFE_PortalProvider` or a global z-index bump instead. This adds a short note + example under Positioning.

```jsx
<Popover style={{zIndex: 30}}>
  {/* ... */}
</Popover>
```

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding React Spectrum GitHub Issue. <!-- docs clarification, no issue -->
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests). <!-- docs-only; behaviour is already covered by the existing test, see below -->
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature. <!-- docs-only, no behaviour change -->

## 📝 Test Instructions:

No behaviour change. The documented behaviour is already covered by the existing `supports overriding styles` test in `packages/react-aria-components/test/Popover.test.js` (`<Popover style={{zIndex: 5}}>` → asserts `z-index: 5`). The doc change can be verified by building the docs and viewing the Popover page — the new "Z-index" note appears under Positioning.

## 🧢 Your Project:

Lokalise
