### PR TITLE
fix(autocomplete): apply virtual focus to first item on IME composition input

### DIFF
--- a/packages/react-aria/src/autocomplete/useAutocomplete.ts
+++ b/packages/react-aria/src/autocomplete/useAutocomplete.ts
@@ -287,7 +287,14 @@ export function useAutocomplete<T>(
   let onChange = (value: string) => {
     // Tell wrapped collection to focus the first element in the list when typing forward and to clear focused key when modifying the text via
     // copy paste/backspacing/undo/redo for screen reader announcements
-    if (lastInputType.current === 'insertText' && !disableAutoFocusFirst) {
+    if (
+      (lastInputType.current === 'insertText' ||
+        // IME composition (e.g. CJK input) reports 'insertCompositionText'/'insertFromComposition'
+        // instead of 'insertText'. Treat these as forward typing so the first item gets virtual focus.
+        lastInputType.current === 'insertCompositionText' ||
+        lastInputType.current === 'insertFromComposition') &&
+      !disableAutoFocusFirst
+    ) {
       focusFirstItem();
     } else if (
       lastInputType.current &&


### PR DESCRIPTION
Closes #10126

When typing into an Autocomplete with an IME (CJK languages such as Korean / Japanese / Chinese), the first matching item was not getting virtual focus, so pressing **Enter** would not select it.

The root cause is in `useAutocomplete`'s `onChange`: it only calls `focusFirstItem()` when `lastInputType.current === 'insertText'`. IME composition does not emit `insertText` — it emits `insertCompositionText` (while composing) and `insertFromComposition` (on commit). Those input types fell through to the `else if` branch and triggered `clearVirtualFocus(true)`, removing focus entirely.

This PR extends the forward-typing condition to also recognize the IME composition input types so virtual focus on the first item behaves the same as Latin text input.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10126).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open an Autocomplete / ComboBox story (e.g. Autocomplete with a filterable ListBox).
2. Switch your OS input to a CJK IME (Korean 2-set, Japanese, or Pinyin).
3. Type a query that matches an item.
4. **Before:** no item is virtually focused; pressing Enter selects nothing.
   **After:** the first matching item receives virtual focus and pressing Enter selects it — matching the existing Latin-input behavior.

## 🧢 Your Project:

Discovered while building an internal web app on top of `react-aria` Autocomplete (Korean IME).
