### PR TITLE
fix(react-aria): prevent useId FinalizationRegistry memory leak on re-renders

### DIFF
--- a/packages/react-aria/src/utils/useId.ts
+++ b/packages/react-aria/src/utils/useId.ts
@@ -42,9 +42,15 @@ export function useId(defaultId?: string): string {
 
   let res = useSSRSafeId(value);
   let cleanupRef = useRef(null);
+  let registeredRef = useRef<string | null>(null);
+  let cleanupTokenRef = useRef<any>(undefined);
 
   if (registry) {
-    registry.register(cleanupRef, res);
+    if (registeredRef.current !== res) {
+      cleanupTokenRef.current = {};
+      registry.register(cleanupRef, res, cleanupTokenRef.current);
+      registeredRef.current = res;
+    }
   }
 
   if (canUseDOM) {
@@ -58,11 +64,12 @@ export function useId(defaultId?: string): string {
 
   useLayoutEffect(() => {
     let r = res;
+    let token = cleanupTokenRef.current;
     return () => {
       // In Suspense, the cleanup function may be not called
       // when it is though, also remove it from the finalization registry.
-      if (registry) {
-        registry.unregister(cleanupRef);
+      if (registry && token) {
+        registry.unregister(token);
       }
       idsUpdaterMap.delete(r);
     };

--- a/packages/react-aria/test/utils/useId.test.tsx
+++ b/packages/react-aria/test/utils/useId.test.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { render, act } from '@react-spectrum/test-utils-internal';
+
+describe('useId', () => {
+  let OriginalFinalizationRegistry = global.FinalizationRegistry;
+
+  afterEach(() => {
+    global.FinalizationRegistry = OriginalFinalizationRegistry;
+    jest.resetModules();
+  });
+
+  it('does not register with FinalizationRegistry multiple times on re-renders', () => {
+    let registerCount = 0;
+    let unregisterCount = 0;
+    
+    // Mock FinalizationRegistry
+    global.FinalizationRegistry = class {
+      constructor(cleanup) {}
+      register(target, heldValue, unregisterToken) {
+        registerCount++;
+        expect(unregisterToken).toBeDefined();
+        expect(unregisterToken).not.toBe(target);
+      }
+      unregister() {
+        unregisterCount++;
+      }
+    } as any;
+
+    const { useId, mergeIds } = require('../../src/utils/useId');
+
+    function TestComponent() {
+      let [count, setCount] = useState(0);
+      let id = useId();
+      let otherId = useId();
+      
+      return (
+        <div>
+          <button onClick={() => setCount(c => c + 1)}>Increment</button>
+          <button onClick={() => { mergeIds(id, 'new-merged-id'); setCount(c => c + 1); }}>Change ID</button>
+          <div data-testid="id">{id}</div>
+          <div data-testid="count">{count}</div>
+        </div>
+      );
+    }
+
+    let { getByRole, unmount } = render(<TestComponent />);
+    
+    // Should register twice on mount (2 useId calls)
+    expect(registerCount).toBe(2);
+    expect(unregisterCount).toBe(0);
+    
+    // Trigger a re-render
+    act(() => {
+      let button = getByRole('button', { name: 'Increment' });
+      button.click();
+    });
+    
+    // Should still only have registered twice
+    expect(registerCount).toBe(2);
+    expect(unregisterCount).toBe(0);
+
+    // Trigger ID change (mergeIds triggers state update via effect)
+    act(() => {
+      let changeIdButton = getByRole('button', { name: 'Change ID' });
+      changeIdButton.click();
+    });
+    
+    // Should register new ID (so 3 total registrations)
+    expect(registerCount).toBe(3);
+    // The old ID from the first useId should be unregistered
+    expect(unregisterCount).toBe(1);
+    
+    // Unmount
+    unmount();
+    
+    // Should unregister remaining on unmount
+    expect(unregisterCount).toBe(3);
+  });
+});


### PR DESCRIPTION
Fixes #9852.

### Description

Currently, useId unconditionally registers with FinalizationRegistry on every re-render. Since FinalizationRegistry.register() creates a new entry on each call, this results in an unbounded memory leak.

This PR fixes the leak by:
1. Only calling registry.register() when the ID actually changes.
2. Providing a unique unregisterToken object for each registration so that registry.unregister(token) removes the exact callback it corresponds to.
