### PR TITLE
fix: keep virtualized async ListBox focus visible

### DIFF
--- a/packages/react-aria-components/src/Collection.tsx
+++ b/packages/react-aria-components/src/Collection.tsx
@@ -192,6 +192,8 @@ export interface CollectionRenderer {
   layoutDelegate?: LayoutDelegate;
   /** A delegate object that provides drop targets for pointer coordinates within the collection. */
   dropTargetDelegate?: DropTargetDelegate;
+  /** Refreshes the virtualized collection's visible rect after programmatic scrolling. */
+  refreshVisibleRect?: () => void;
   /** A component that renders the root collection items. */
   CollectionRoot: React.ComponentType<CollectionRootProps>;
   /** A component that renders the child collection items. */

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -247,7 +247,8 @@ function GridListInner<T>({props, collection, gridListRef: ref}: GridListInnerPr
     CollectionRoot,
     isVirtualized,
     layoutDelegate,
-    dropTargetDelegate: ctxDropTargetDelegate
+    dropTargetDelegate: ctxDropTargetDelegate,
+    refreshVisibleRect
   } = useContext(CollectionRendererContext);
   let gridlistState = useListState({
     ...DOMCollectionProps,
@@ -293,6 +294,7 @@ function GridListInner<T>({props, collection, gridListRef: ref}: GridListInnerPr
       // Only tab navigation is supported in grid layout.
       keyboardNavigationBehavior: layout === 'grid' ? 'tab' : keyboardNavigationBehavior,
       isVirtualized,
+      UNSTABLE_virtualizerRefresh: refreshVisibleRect,
       shouldSelectOnPressUp: props.shouldSelectOnPressUp,
       disallowTypeAhead
     },

--- a/packages/react-aria-components/src/ListBox.tsx
+++ b/packages/react-aria-components/src/ListBox.tsx
@@ -250,6 +250,7 @@ function ListBoxInner<T>({state: inputState, props, listBoxRef}: ListBoxInnerPro
     isVirtualized,
     layoutDelegate,
     dropTargetDelegate: ctxDropTargetDelegate,
+    refreshVisibleRect,
     CollectionRoot
   } = useContext(CollectionRendererContext);
   let keyboardDelegate = useMemo(
@@ -285,7 +286,8 @@ function ListBoxInner<T>({state: inputState, props, listBoxRef}: ListBoxInnerPro
       ...props,
       shouldSelectOnPressUp: isListDraggable || props.shouldSelectOnPressUp,
       keyboardDelegate,
-      isVirtualized
+      isVirtualized,
+      UNSTABLE_virtualizerRefresh: refreshVisibleRect
     },
     state,
     listBoxRef

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -721,6 +721,7 @@ function TableInner({props, forwardedRef: ref, selectionState, collection}: Tabl
     isVirtualized,
     layoutDelegate,
     dropTargetDelegate: ctxDropTargetDelegate,
+    refreshVisibleRect,
     CollectionRoot
   } = useContext(CollectionRendererContext);
   let {dragAndDropHooks} = props;
@@ -728,7 +729,8 @@ function TableInner({props, forwardedRef: ref, selectionState, collection}: Tabl
     {
       ...DOMCollectionProps,
       layoutDelegate,
-      isVirtualized
+      isVirtualized,
+      UNSTABLE_virtualizerRefresh: refreshVisibleRect
     },
     filteredState,
     ref

--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -25,6 +25,7 @@ import {
   VirtualizerState
 } from 'react-stately/useVirtualizerState';
 import React, {createContext, JSX, ReactNode, RefObject, useContext, useMemo, useRef} from 'react';
+import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
 import {useScrollView} from 'react-aria/private/virtualizer/ScrollView';
 import {VirtualizerItem} from 'react-aria/private/virtualizer/VirtualizerItem';
 
@@ -137,9 +138,14 @@ function CollectionRoot({
     scrollRef!
   );
   let refreshVisibleRectRef = useContext(RefreshVisibleRectContext);
-  if (refreshVisibleRectRef) {
-    refreshVisibleRectRef.current = refreshVisibleRect;
-  }
+  useLayoutEffect(() => {
+    if (refreshVisibleRectRef) {
+      refreshVisibleRectRef.current = refreshVisibleRect;
+      return () => {
+        refreshVisibleRectRef.current = null;
+      };
+    }
+  }, [refreshVisibleRectRef, refreshVisibleRect]);
 
   return (
     <div {...contentProps}>

--- a/packages/react-aria-components/src/Virtualizer.tsx
+++ b/packages/react-aria-components/src/Virtualizer.tsx
@@ -24,7 +24,7 @@ import {
   useVirtualizerState,
   VirtualizerState
 } from 'react-stately/useVirtualizerState';
-import React, {createContext, JSX, ReactNode, useContext, useMemo} from 'react';
+import React, {createContext, JSX, ReactNode, RefObject, useContext, useMemo, useRef} from 'react';
 import {useScrollView} from 'react-aria/private/virtualizer/ScrollView';
 import {VirtualizerItem} from 'react-aria/private/virtualizer/VirtualizerItem';
 
@@ -57,6 +57,7 @@ interface LayoutContextValue {
 
 const VirtualizerContext = createContext<VirtualizerState<any, any> | null>(null);
 const LayoutContext = createContext<LayoutContextValue | null>(null);
+const RefreshVisibleRectContext = createContext<RefObject<(() => void) | null> | null>(null);
 
 /**
  * A Virtualizer renders a scrollable collection of data using customizable layouts.
@@ -69,6 +70,7 @@ export function Virtualizer<O>(props: VirtualizerProps<O>): JSX.Element {
     () => (typeof layoutProp === 'function' ? new layoutProp() : layoutProp),
     [layoutProp]
   );
+  let refreshVisibleRectRef = useRef<(() => void) | null>(null);
   let renderer: CollectionRenderer = useMemo(
     () => ({
       isVirtualized: true,
@@ -76,6 +78,7 @@ export function Virtualizer<O>(props: VirtualizerProps<O>): JSX.Element {
       dropTargetDelegate: layout.getDropTargetFromPoint
         ? (layout as DropTargetDelegate)
         : undefined,
+      refreshVisibleRect: () => refreshVisibleRectRef.current?.(),
       CollectionRoot,
       CollectionBranch
     }),
@@ -84,7 +87,9 @@ export function Virtualizer<O>(props: VirtualizerProps<O>): JSX.Element {
 
   return (
     <CollectionRendererContext.Provider value={renderer}>
-      <LayoutContext.Provider value={{layout, layoutOptions}}>{children}</LayoutContext.Provider>
+      <RefreshVisibleRectContext.Provider value={refreshVisibleRectRef}>
+        <LayoutContext.Provider value={{layout, layoutOptions}}>{children}</LayoutContext.Provider>
+      </RefreshVisibleRectContext.Provider>
     </CollectionRendererContext.Provider>
   );
 }
@@ -120,7 +125,7 @@ function CollectionRoot({
     }, [layoutOptions, layoutOptions2])
   });
 
-  let {contentProps} = useScrollView(
+  let {contentProps, refreshVisibleRect} = useScrollView(
     {
       onVisibleRectChange: state.setVisibleRect,
       onSizeChange: state.setSize,
@@ -131,6 +136,10 @@ function CollectionRoot({
     },
     scrollRef!
   );
+  let refreshVisibleRectRef = useContext(RefreshVisibleRectContext);
+  if (refreshVisibleRectRef) {
+    refreshVisibleRectRef.current = refreshVisibleRect;
+  }
 
   return (
     <div {...contentProps}>

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -920,6 +920,86 @@ export const AsyncListBoxVirtualized: StoryFn<typeof AsyncListBoxRender> = args 
   );
 };
 
+interface AsyncVirtualizedEndKeyItem {
+  id: number;
+  name: string;
+}
+
+export const AsyncListBoxVirtualizedEndKey: StoryFn<typeof AsyncListBoxRender> = args => {
+  let list = useAsyncList<AsyncVirtualizedEndKeyItem>({
+    async load({cursor}) {
+      let page = cursor ? Number(cursor) : 0;
+      let pageSize = 25;
+      let pageCount = 12;
+      let start = page * pageSize;
+
+      await new Promise(resolve => setTimeout(resolve, args.delay));
+
+      return {
+        items: Array.from({length: pageSize}, (_, index) => ({
+          id: start + index,
+          name: `Item ${start + index}`
+        })),
+        cursor: page < pageCount - 1 ? String(page + 1) : undefined
+      };
+    }
+  });
+
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+      <p style={{margin: 0, maxWidth: 520}}>
+        Focus the listbox, press End, wait for more items to load, and repeat. The focused item should move to the last loaded item and scroll into view after each load.
+      </p>
+      <Virtualizer
+        layout={ListLayout}
+        layoutOptions={{
+          rowHeight: 50,
+          padding: 4,
+          loaderHeight: 30
+        }}>
+        <ListBox
+          {...args}
+          style={{
+            height: 400,
+            width: 160,
+            border: '1px solid gray',
+            background: 'lightgray',
+            overflow: 'auto',
+            padding: 'unset',
+            display: 'flex'
+          }}
+          aria-label="async virtualized end key issue listbox"
+          renderEmptyState={() => renderEmptyState({isLoading: list.isLoading})}>
+          <Collection items={list.items}>
+            {item => (
+              <MyListBoxItem
+                style={{
+                  backgroundColor: 'lightgrey',
+                  border: '1px solid black',
+                  boxSizing: 'border-box',
+                  height: '100%',
+                  width: '100%'
+                }}
+                id={item.id}>
+                {item.name}
+              </MyListBoxItem>
+            )}
+          </Collection>
+          <MyListBoxLoaderIndicator
+            isLoading={list.loadingState === 'loadingMore'}
+            onLoadMore={list.loadMore}
+          />
+        </ListBox>
+      </Virtualizer>
+    </div>
+  );
+};
+
+AsyncListBoxVirtualizedEndKey.args = {
+  delay: 500,
+  orientation: 'vertical'
+};
+
 export const ListBoxScrollMargin: ListBoxStory = args => {
   let items: {id: number; name: string; description: string}[] = [];
   for (let i = 0; i < 100; i++) {

--- a/packages/react-aria-components/stories/ListBox.stories.tsx
+++ b/packages/react-aria-components/stories/ListBox.stories.tsx
@@ -948,7 +948,8 @@ export const AsyncListBoxVirtualizedEndKey: StoryFn<typeof AsyncListBoxRender> =
   return (
     <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
       <p style={{margin: 0, maxWidth: 520}}>
-        Focus the listbox, press End, wait for more items to load, and repeat. The focused item should move to the last loaded item and scroll into view after each load.
+        Focus the listbox, press End, wait for more items to load, and repeat. The focused item
+        should move to the last loaded item and scroll into view after each load.
       </p>
       <Virtualizer
         layout={ListLayout}

--- a/packages/react-aria-components/test/ListBox.browser.test.tsx
+++ b/packages/react-aria-components/test/ListBox.browser.test.tsx
@@ -14,7 +14,7 @@ import {Collection} from 'react-aria/Collection';
 import {expect, it, vi} from 'vitest';
 import {ListBox, ListBoxItem, ListBoxLoadMoreItem} from '../src/ListBox';
 import {ListLayout} from 'react-stately/useVirtualizerState';
-import React, {act} from 'react';
+import React from 'react';
 import {render} from 'vitest-browser-react';
 import {useAsyncList} from 'react-stately/useAsyncList';
 import {User} from '@react-aria/test-utils';
@@ -165,7 +165,7 @@ it('moves focus and scrolls to the last loaded item with End in a virtualized as
   await vi.waitFor(() => {
     expect(listbox.querySelector('[role=option]')?.textContent).toBe('Item 0');
   });
-  act(() => listbox.focus());
+  listbox.focus();
 
   for (let page = 1; page <= 6; page++) {
     await userEvent.keyboard('{End}');
@@ -183,7 +183,7 @@ it('keeps the focused item visible while paging through a virtualized async list
   await vi.waitFor(() => {
     expect(listbox.querySelector('[role=option]')?.textContent).toBe('Item 0');
   });
-  act(() => listbox.focus());
+  listbox.focus();
 
   for (let i = 0; i < 40; i++) {
     await userEvent.keyboard('{PageDown}');

--- a/packages/react-aria-components/test/ListBox.browser.test.tsx
+++ b/packages/react-aria-components/test/ListBox.browser.test.tsx
@@ -14,9 +14,9 @@ import {Collection} from 'react-aria/Collection';
 import {expect, it, vi} from 'vitest';
 import {ListBox, ListBoxItem, ListBoxLoadMoreItem} from '../src/ListBox';
 import {ListLayout} from 'react-stately/useVirtualizerState';
-import React from 'react';
-import {useAsyncList} from 'react-stately/useAsyncList';
+import React, {act} from 'react';
 import {render} from 'vitest-browser-react';
+import {useAsyncList} from 'react-stately/useAsyncList';
 import {User} from '@react-aria/test-utils';
 import {userEvent} from 'vitest/browser';
 import {Virtualizer} from '../src/Virtualizer';
@@ -163,7 +163,7 @@ it('moves focus and scrolls to the last loaded item with End in a virtualized as
   await vi.waitFor(() => {
     expect(listbox.querySelector('[role=option]')?.textContent).toBe('Item 0');
   });
-  listbox.focus();
+  act(() => listbox.focus());
 
   for (let page = 1; page <= 6; page++) {
     await userEvent.keyboard('{End}');
@@ -181,7 +181,7 @@ it('keeps the focused item visible while paging through a virtualized async list
   await vi.waitFor(() => {
     expect(listbox.querySelector('[role=option]')?.textContent).toBe('Item 0');
   });
-  listbox.focus();
+  act(() => listbox.focus());
 
   for (let i = 0; i < 40; i++) {
     await userEvent.keyboard('{PageDown}');

--- a/packages/react-aria-components/test/ListBox.browser.test.tsx
+++ b/packages/react-aria-components/test/ListBox.browser.test.tsx
@@ -102,7 +102,9 @@ function AsyncVirtualizedListBox() {
             </ListBoxItem>
           )}
         </Collection>
-        <ListBoxLoadMoreItem isLoading={list.loadingState === 'loadingMore'} onLoadMore={list.loadMore}>
+        <ListBoxLoadMoreItem
+          isLoading={list.loadingState === 'loadingMore'}
+          onLoadMore={list.loadMore}>
           Loading...
         </ListBoxLoadMoreItem>
       </ListBox>

--- a/packages/react-aria-components/test/ListBox.browser.test.tsx
+++ b/packages/react-aria-components/test/ListBox.browser.test.tsx
@@ -10,11 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import {expect, it} from 'vitest';
-import {ListBox, ListBoxItem} from '../src/ListBox';
+import {Collection} from 'react-aria/Collection';
+import {expect, it, vi} from 'vitest';
+import {ListBox, ListBoxItem, ListBoxLoadMoreItem} from '../src/ListBox';
+import {ListLayout} from 'react-stately/useVirtualizerState';
 import React from 'react';
+import {useAsyncList} from 'react-stately/useAsyncList';
 import {render} from 'vitest-browser-react';
 import {User} from '@react-aria/test-utils';
+import {userEvent} from 'vitest/browser';
+import {Virtualizer} from '../src/Virtualizer';
 
 function GridListBox() {
   return (
@@ -34,6 +39,89 @@ function GridListBox() {
       <ListBoxItem>2,2</ListBoxItem>
     </ListBox>
   );
+}
+
+interface AsyncVirtualizedItem {
+  id: number;
+  name: string;
+}
+
+let asyncVirtualizedItems: AsyncVirtualizedItem[] = Array.from({length: 300}, (_, index) => ({
+  id: index,
+  name: `Item ${index}`
+}));
+
+function AsyncVirtualizedListBox() {
+  let list = useAsyncList<AsyncVirtualizedItem>({
+    async load({cursor}) {
+      let page = cursor ? Number(cursor) : 0;
+      let pageSize = 25;
+      let pageCount = 12;
+      let start = page * pageSize;
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      return {
+        items: asyncVirtualizedItems.slice(start, start + pageSize),
+        cursor: page < pageCount - 1 ? String(page + 1) : undefined
+      };
+    }
+  });
+
+  return (
+    <Virtualizer
+      layout={ListLayout}
+      layoutOptions={{
+        rowHeight: 50,
+        padding: 4,
+        loaderHeight: 30
+      }}>
+      <ListBox
+        aria-label="async virtualized end key issue listbox"
+        style={{
+          height: 400,
+          width: 160,
+          border: '1px solid gray',
+          background: 'lightgray',
+          overflow: 'auto',
+          padding: 'unset',
+          display: 'flex'
+        }}>
+        <Collection items={list.items}>
+          {item => (
+            <ListBoxItem
+              id={item.id}
+              style={{
+                backgroundColor: 'lightgrey',
+                border: '1px solid black',
+                boxSizing: 'border-box',
+                height: '100%',
+                width: '100%'
+              }}>
+              {item.name}
+            </ListBoxItem>
+          )}
+        </Collection>
+        <ListBoxLoadMoreItem isLoading={list.loadingState === 'loadingMore'} onLoadMore={list.loadMore}>
+          Loading...
+        </ListBoxLoadMoreItem>
+      </ListBox>
+    </Virtualizer>
+  );
+}
+
+function expectFocusedOptionInView(listbox: HTMLElement, text?: string) {
+  let activeElement = document.activeElement as HTMLElement;
+  if (text != null) {
+    expect(activeElement.textContent).toBe(text);
+  } else {
+    expect(activeElement.textContent).toMatch(/^Item /);
+  }
+
+  let listboxRect = listbox.getBoundingClientRect();
+  let activeRect = activeElement.getBoundingClientRect();
+  expect(activeRect.top).toBeGreaterThanOrEqual(listboxRect.top);
+  expect(activeRect.bottom).toBeLessThanOrEqual(listboxRect.bottom);
 }
 
 it.each`
@@ -67,3 +155,38 @@ it.each`
     expect(document.activeElement).toBe(options[8]);
   }
 );
+
+it('moves focus and scrolls to the last loaded item with End in a virtualized async listbox', async () => {
+  let {container} = await render(<AsyncVirtualizedListBox />);
+  let listbox = container.querySelector('[role=listbox]') as HTMLElement;
+
+  await vi.waitFor(() => {
+    expect(listbox.querySelector('[role=option]')?.textContent).toBe('Item 0');
+  });
+  listbox.focus();
+
+  for (let page = 1; page <= 6; page++) {
+    await userEvent.keyboard('{End}');
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    let lastItem = `Item ${page * 25 - 1}`;
+    await vi.waitFor(() => expectFocusedOptionInView(listbox, lastItem));
+  }
+});
+
+it('keeps the focused item visible while paging through a virtualized async listbox', async () => {
+  let {container} = await render(<AsyncVirtualizedListBox />);
+  let listbox = container.querySelector('[role=listbox]') as HTMLElement;
+
+  await vi.waitFor(() => {
+    expect(listbox.querySelector('[role=option]')?.textContent).toBe('Item 0');
+  });
+  listbox.focus();
+
+  for (let i = 0; i < 40; i++) {
+    await userEvent.keyboard('{PageDown}');
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    await vi.waitFor(() => expectFocusedOptionInView(listbox));
+  }
+});

--- a/packages/react-aria/src/grid/useGrid.ts
+++ b/packages/react-aria/src/grid/useGrid.ts
@@ -37,7 +37,7 @@ import {useSelectableCollection} from '../selection/useSelectableCollection';
 export interface GridProps extends DOMProps, AriaLabelingProps {
   /** Whether the grid uses virtual scrolling. */
   isVirtualized?: boolean;
-  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  /** @private Refreshes The virtualizer visible rect after programmatic scrolling. */
   UNSTABLE_virtualizerRefresh?: () => void;
   /**
    * Whether typeahead navigation is disabled.

--- a/packages/react-aria/src/grid/useGrid.ts
+++ b/packages/react-aria/src/grid/useGrid.ts
@@ -37,6 +37,8 @@ import {useSelectableCollection} from '../selection/useSelectableCollection';
 export interface GridProps extends DOMProps, AriaLabelingProps {
   /** Whether the grid uses virtual scrolling. */
   isVirtualized?: boolean;
+  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  UNSTABLE_virtualizerRefresh?: () => void;
   /**
    * Whether typeahead navigation is disabled.
    *
@@ -105,6 +107,7 @@ export function useGrid<T>(
 ): GridAria {
   let {
     isVirtualized,
+    UNSTABLE_virtualizerRefresh,
     disallowTypeAhead,
     keyboardDelegate,
     focusMode,
@@ -155,6 +158,7 @@ export function useGrid<T>(
     selectionManager: manager,
     keyboardDelegate: delegate,
     isVirtualized,
+    UNSTABLE_virtualizerRefresh,
     scrollRef,
     disallowTypeAhead,
     escapeKeyBehavior

--- a/packages/react-aria/src/gridlist/useGridList.ts
+++ b/packages/react-aria/src/gridlist/useGridList.ts
@@ -74,7 +74,7 @@ export interface AriaGridListProps<T> extends GridListProps<T>, DOMProps, AriaLa
 export interface AriaGridListOptions<T> extends Omit<AriaGridListProps<T>, 'children'> {
   /** Whether the list uses virtual scrolling. */
   isVirtualized?: boolean;
-  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  /** @private Refreshes The virtualizer visible rect after programmatic scrolling. */
   UNSTABLE_virtualizerRefresh?: () => void;
   /**
    * Whether typeahead navigation is disabled.

--- a/packages/react-aria/src/gridlist/useGridList.ts
+++ b/packages/react-aria/src/gridlist/useGridList.ts
@@ -74,6 +74,8 @@ export interface AriaGridListProps<T> extends GridListProps<T>, DOMProps, AriaLa
 export interface AriaGridListOptions<T> extends Omit<AriaGridListProps<T>, 'children'> {
   /** Whether the list uses virtual scrolling. */
   isVirtualized?: boolean;
+  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  UNSTABLE_virtualizerRefresh?: () => void;
   /**
    * Whether typeahead navigation is disabled.
    *
@@ -129,6 +131,7 @@ export function useGridList<T>(
 ): GridListAria {
   let {
     isVirtualized,
+    UNSTABLE_virtualizerRefresh,
     keyboardDelegate,
     layoutDelegate,
     onAction,
@@ -151,6 +154,7 @@ export function useGridList<T>(
     keyboardDelegate,
     layoutDelegate,
     isVirtualized,
+    UNSTABLE_virtualizerRefresh,
     selectOnFocus: state.selectionManager.selectionBehavior === 'replace',
     shouldFocusWrap: props.shouldFocusWrap,
     linkBehavior,

--- a/packages/react-aria/src/listbox/useListBox.ts
+++ b/packages/react-aria/src/listbox/useListBox.ts
@@ -82,6 +82,8 @@ export interface ListBoxAria {
 export interface AriaListBoxOptions<T> extends Omit<AriaListBoxProps<T>, 'children'> {
   /** Whether the listbox uses virtual scrolling. */
   isVirtualized?: boolean;
+  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  UNSTABLE_virtualizerRefresh?: () => void;
 
   /**
    * An optional keyboard delegate implementation for type to select,

--- a/packages/react-aria/src/listbox/useListBox.ts
+++ b/packages/react-aria/src/listbox/useListBox.ts
@@ -82,7 +82,7 @@ export interface ListBoxAria {
 export interface AriaListBoxOptions<T> extends Omit<AriaListBoxProps<T>, 'children'> {
   /** Whether the listbox uses virtual scrolling. */
   isVirtualized?: boolean;
-  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  /** @private Refreshes The virtualizer visible rect after programmatic scrolling. */
   UNSTABLE_virtualizerRefresh?: () => void;
 
   /**

--- a/packages/react-aria/src/selection/useSelectableCollection.ts
+++ b/packages/react-aria/src/selection/useSelectableCollection.ts
@@ -112,7 +112,11 @@ export interface AriaSelectableCollectionOptions {
    * Whether the collection items are contained in a virtual scroller.
    */
   isVirtualized?: boolean;
-  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  /**
+   * Refreshes the virtualizer visible rect after programmatic scrolling.
+   *
+   * @private
+   */
   UNSTABLE_virtualizerRefresh?: () => void;
   /**
    * The ref attached to the scrollable body. Used to provide automatic scrolling on item focus for

--- a/packages/react-aria/src/selection/useSelectableCollection.ts
+++ b/packages/react-aria/src/selection/useSelectableCollection.ts
@@ -112,6 +112,8 @@ export interface AriaSelectableCollectionOptions {
    * Whether the collection items are contained in a virtual scroller.
    */
   isVirtualized?: boolean;
+  /** @private Refreshes the virtualizer visible rect after programmatic scrolling. */
+  UNSTABLE_virtualizerRefresh?: () => void;
   /**
    * The ref attached to the scrollable body. Used to provide automatic scrolling on item focus for
    * non-virtualized collections. If not provided, defaults to the collection ref.
@@ -152,6 +154,8 @@ export function useSelectableCollection(
     disallowTypeAhead = false,
     shouldUseVirtualFocus,
     allowsTabNavigation = false,
+    isVirtualized,
+    UNSTABLE_virtualizerRefresh,
     // If no scrollRef is provided, assume the collection ref is the scrollable region
     scrollRef = ref,
     linkBehavior = 'action'
@@ -581,12 +585,15 @@ export function useSelectableCollection(
 
   // Scroll the focused element into view when the focusedKey changes.
   let lastFocusedKey = useRef(manager.focusedKey);
+  let lastCollection = useRef(manager.collection);
   let raf = useRef<number | null>(null);
   useEffect(() => {
     if (
       manager.isFocused &&
       manager.focusedKey != null &&
-      (manager.focusedKey !== lastFocusedKey.current || didAutoFocusRef.current) &&
+      (manager.focusedKey !== lastFocusedKey.current ||
+        didAutoFocusRef.current ||
+        (isVirtualized && manager.collection !== lastCollection.current)) &&
       scrollRef.current &&
       ref.current
     ) {
@@ -610,6 +617,9 @@ export function useSelectableCollection(
             if (modality !== 'virtual') {
               scrollIntoViewport(element, {containingElement: ref.current});
             }
+            if (isVirtualized) {
+              UNSTABLE_virtualizerRefresh?.();
+            }
           }
         });
       }
@@ -627,6 +637,7 @@ export function useSelectableCollection(
     }
 
     lastFocusedKey.current = manager.focusedKey;
+    lastCollection.current = manager.collection;
     didAutoFocusRef.current = false;
   });
 

--- a/packages/react-aria/src/virtualizer/ScrollView.tsx
+++ b/packages/react-aria/src/virtualizer/ScrollView.tsx
@@ -65,6 +65,7 @@ interface ScrollViewAria {
   isScrolling: boolean;
   scrollViewProps: HTMLAttributes<HTMLElement>;
   contentProps: HTMLAttributes<HTMLElement>;
+  refreshVisibleRect: () => void;
 }
 
 export function useScrollView(
@@ -133,6 +134,33 @@ export function useScrollView(
     }
   }, [state, allowsWindowScrolling, onVisibleRectChange]);
 
+  let updateViewportOffset = useCallback(() => {
+    let boundingRect = ref.current!.getBoundingClientRect();
+    let x = boundingRect.x < 0 ? -boundingRect.x : 0;
+    let y = boundingRect.y < 0 ? -boundingRect.y : 0;
+    state.viewportOffset = new Point(x, y);
+  }, [ref, state]);
+
+  let updateScrollPosition = useCallback(() => {
+    state.scrollPosition = new Point(
+      Math.max(0, Math.min(getScrollLeft(ref.current!, direction), contentSize.width - state.size.width)),
+      Math.max(0, Math.min(ref.current!.scrollTop, contentSize.height - state.size.height))
+    );
+  }, [contentSize, direction, ref, state]);
+
+  let refreshVisibleRect = useCallback(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    if (allowsWindowScrolling) {
+      updateViewportOffset();
+    }
+
+    updateScrollPosition();
+    updateVisibleRect();
+  }, [allowsWindowScrolling, ref, updateScrollPosition, updateViewportOffset, updateVisibleRect]);
+
   let [isScrolling, setScrolling] = useState(false);
 
   let onScroll = useCallback(
@@ -148,23 +176,18 @@ export function useScrollView(
 
       if (target !== ref.current) {
         // An ancestor element or the window was scrolled. Update the position of the scroll view relative to the viewport.
-        let boundingRect = ref.current!.getBoundingClientRect();
-        let x = boundingRect.x < 0 ? -boundingRect.x : 0;
-        let y = boundingRect.y < 0 ? -boundingRect.y : 0;
-        if (x === state.viewportOffset.x && y === state.viewportOffset.y) {
+        let lastViewportOffset = state.viewportOffset;
+        updateViewportOffset();
+        if (
+          lastViewportOffset.x === state.viewportOffset.x &&
+          lastViewportOffset.y === state.viewportOffset.y
+        ) {
           return;
         }
-
-        state.viewportOffset = new Point(x, y);
       } else {
         // The scroll view itself was scrolled. Update the local scroll position.
         // Prevent rubber band scrolling from shaking when scrolling out of bounds
-        let scrollTop = target.scrollTop;
-        let scrollLeft = getScrollLeft(target, direction);
-        state.scrollPosition = new Point(
-          Math.max(0, Math.min(scrollLeft, contentSize.width - state.size.width)),
-          Math.max(0, Math.min(scrollTop, contentSize.height - state.size.height))
-        );
+        updateScrollPosition();
       }
 
       flushSync(() => {
@@ -208,9 +231,9 @@ export function useScrollView(
     [
       onScrollProp,
       ref,
-      direction,
       state,
-      contentSize,
+      updateScrollPosition,
+      updateViewportOffset,
       updateVisibleRect,
       onScrollStart,
       onScrollEnd
@@ -394,6 +417,7 @@ export function useScrollView(
     contentProps: {
       role: 'presentation',
       style: innerStyle
-    }
+    },
+    refreshVisibleRect
   };
 }

--- a/packages/react-aria/src/virtualizer/ScrollView.tsx
+++ b/packages/react-aria/src/virtualizer/ScrollView.tsx
@@ -143,7 +143,10 @@ export function useScrollView(
 
   let updateScrollPosition = useCallback(() => {
     state.scrollPosition = new Point(
-      Math.max(0, Math.min(getScrollLeft(ref.current!, direction), contentSize.width - state.size.width)),
+      Math.max(
+        0,
+        Math.min(getScrollLeft(ref.current!, direction), contentSize.width - state.size.width)
+      ),
       Math.max(0, Math.min(ref.current!.scrollTop, contentSize.height - state.size.height))
     );
   }, [contentSize, direction, ref, state]);

--- a/packages/react-stately/src/layout/ListLayout.ts
+++ b/packages/react-stately/src/layout/ListLayout.ts
@@ -276,11 +276,7 @@ export class ListLayout<T, O extends ListLayoutOptions = ListLayoutOptions>
     // If the layout info wasn't found, it might be outside the bounds of the area that we've
     // computed layout for so far. This can happen when accessing a random key, e.g pressing Home/End.
     // Compute the full layout and try again.
-    if (
-      !this.layoutNodes.has(key) &&
-      this.requestedRect.area < this.contentSize.area &&
-      this.lastCollection
-    ) {
+    if (!this.layoutNodes.has(key) && this.lastCollection?.getItem(key)) {
       this.requestedRect = new Rect(0, 0, Infinity, Infinity);
       this.rootNodes = this.buildCollection();
       this.requestedRect = new Rect(0, 0, this.contentSize.width, this.contentSize.height);

--- a/packages/react-stately/test/virtualizer/ListLayout.test.ts
+++ b/packages/react-stately/test/virtualizer/ListLayout.test.ts
@@ -16,22 +16,26 @@ import {Rect} from '../../src/virtualizer/Rect';
 import {Size} from '../../src/virtualizer/Size';
 
 function makeCollection(itemCount: number) {
-  let items: Node<unknown>[] = Array.from({length: itemCount}, (_, index) => ({
-    type: 'item',
-    key: index,
-    value: null,
-    level: 0,
-    hasChildNodes: false,
-    rendered: null,
-    textValue: `Item ${index}`,
-    'aria-label': undefined,
-    index,
-    parentKey: null,
-    prevKey: index > 0 ? index - 1 : null,
-    nextKey: index < itemCount - 1 ? index + 1 : null,
-    childNodes: [],
-    props: {}
-  } as unknown as Node<unknown>));
+  let items: Node<unknown>[] = Array.from(
+    {length: itemCount},
+    (_, index) =>
+      ({
+        type: 'item',
+        key: index,
+        value: null,
+        level: 0,
+        hasChildNodes: false,
+        rendered: null,
+        textValue: `Item ${index}`,
+        'aria-label': undefined,
+        index,
+        parentKey: null,
+        prevKey: index > 0 ? index - 1 : null,
+        nextKey: index < itemCount - 1 ? index + 1 : null,
+        childNodes: [],
+        props: {}
+      }) as unknown as Node<unknown>
+  );
 
   return {
     size: items.length,
@@ -86,7 +90,9 @@ describe('ListLayout', () => {
       layoutOptionsChanged: true
     });
 
-    expect(layout.getVisibleLayoutInfos(virtualizer.visibleRect).map(info => info.key)).toContain(74);
+    expect(layout.getVisibleLayoutInfos(virtualizer.visibleRect).map(info => info.key)).toContain(
+      74
+    );
 
     // Simulate a previous random access such as End, which can expand the requested rect
     // to the full content size before additional async items are appended.

--- a/packages/react-stately/test/virtualizer/ListLayout.test.ts
+++ b/packages/react-stately/test/virtualizer/ListLayout.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Key, Node} from '@react-types/shared';
+import {ListLayout, ListLayoutOptions} from '../../src/layout/ListLayout';
+import {Rect} from '../../src/virtualizer/Rect';
+import {Size} from '../../src/virtualizer/Size';
+
+function makeCollection(itemCount: number) {
+  let items: Node<unknown>[] = Array.from({length: itemCount}, (_, index) => ({
+    type: 'item',
+    key: index,
+    value: null,
+    level: 0,
+    hasChildNodes: false,
+    rendered: null,
+    textValue: `Item ${index}`,
+    'aria-label': undefined,
+    index,
+    parentKey: null,
+    prevKey: index > 0 ? index - 1 : null,
+    nextKey: index < itemCount - 1 ? index + 1 : null,
+    childNodes: [],
+    props: {}
+  } as unknown as Node<unknown>));
+
+  return {
+    size: items.length,
+    getItem(key: Key) {
+      return items.find(item => item.key === key) ?? null;
+    },
+    getFirstKey() {
+      return items[0]?.key ?? null;
+    },
+    getLastKey() {
+      return items.at(-1)?.key ?? null;
+    },
+    getKeyBefore(key: Key) {
+      let index = items.findIndex(item => item.key === key);
+      return index > 0 ? items[index - 1].key : null;
+    },
+    getKeyAfter(key: Key) {
+      let index = items.findIndex(item => item.key === key);
+      return index >= 0 && index < items.length - 1 ? items[index + 1].key : null;
+    },
+    getKeys() {
+      return items.map(item => item.key);
+    },
+    [Symbol.iterator]() {
+      return items[Symbol.iterator]();
+    }
+  };
+}
+
+describe('ListLayout', () => {
+  it('renders a persisted key that is newly added outside the current requested rect', () => {
+    let layout = new ListLayout<Node<unknown>, ListLayoutOptions>();
+    let virtualizer = {
+      collection: makeCollection(75),
+      visibleRect: new Rect(0, 3354, 160, 400),
+      size: new Size(160, 400),
+      persistedKeys: new Set<Key>([74]),
+      isPersistedKey(key: Key) {
+        return this.persistedKeys.has(key);
+      }
+    };
+
+    (layout as any).virtualizer = virtualizer;
+    layout.update({
+      layoutOptions: {
+        rowHeight: 50,
+        padding: 4,
+        loaderHeight: 30
+      },
+      sizeChanged: true,
+      offsetChanged: false,
+      layoutOptionsChanged: true
+    });
+
+    expect(layout.getVisibleLayoutInfos(virtualizer.visibleRect).map(info => info.key)).toContain(74);
+
+    // Simulate a previous random access such as End, which can expand the requested rect
+    // to the full content size before additional async items are appended.
+    (layout as any).requestedRect = new Rect(0, 0, Infinity, Infinity);
+
+    virtualizer.collection = makeCollection(100);
+    virtualizer.persistedKeys = new Set([99]);
+    (layout as any).lastCollection = virtualizer.collection;
+
+    let keys = layout.getVisibleLayoutInfos(virtualizer.visibleRect).map(info => info.key);
+    expect(keys).toContain(99);
+  });
+});


### PR DESCRIPTION
Closes #10129

## Summary

This fixes keyboard navigation for virtualized async ListBox collections when pressing End or paging after more items have loaded.

Previously, `focusedKey` could move to the newest last item, but `ListLayout` did not always compute layout info for that focused/persisted key. The old fallback only forced a full layout when `requestedRect.area < contentSize.area`. Because the virtualizer overscans on both axes, a vertical list can get extra cross-axis width in `requestedRect`, making the area comparison look large enough even though the newly loaded focused item has not been laid out. As a result, the item was not mounted and could not be scrolled into view.

The fix makes `ListLayout` key-driven for this fallback: if a persisted key is missing from `layoutNodes` but exists in the current collection, it computes the full layout so the focused item can be rendered. This avoids relying on cross-axis-sensitive area comparisons. The change also refreshes the virtualizer visible rect after programmatic focus scrolling and re-scrolls virtualized collections when the collection object changes while the focused key remains the same.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10129).
- [x] Added/updated unit tests and storybook for this change.
- [x] Filled out test instructions.
- [x] Updated documentation. Not applicable for this behavior-only bug fix.
- [x] Looked at the Accessibility Practices for this feature. This preserves the expected ListBox keyboard navigation behavior.

## 📝 Test Instructions:

- `yarn jest packages/react-stately/test/virtualizer/ListLayout.test.ts --runInBand`
- `yarn vitest --config=vitest.browser.config.ts packages/react-aria-components/test/ListBox.browser.test.tsx`

Local verification:

- Passed: `yarn jest packages/react-stately/test/virtualizer/ListLayout.test.ts --runInBand`
- Not completed locally: the browser test command requires Playwright browser binaries, and this environment reported missing Chromium/Firefox/WebKit executables. Run `yarn playwright install` before the browser test command.

## 🧢 Your Project:

Personal contribution