### PR TITLE
fix: ensure the focus ring for column headers renders when keyboard focused

### DIFF
--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -690,7 +690,7 @@ function CellFocusRing() {
       className={style({
         ...cellFocus,
         position: 'absolute',
-        top: 'var(--topFocusRing)',
+        top: 'var(--topFocusRing, 0)',
         bottom: 0,
         insetStart: 0,
         insetEnd: 0,


### PR DESCRIPTION
Small regression from https://github.com/adobe/react-spectrum/commit/6503fc49b6e557859d9ba47189666777b3f28d72, just needed a fallback for the TableView column headers focus ring so it actually is positioned properly and has a height.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Keyboard navigate and focus the S2 TableView column header. The focus ring should be visible.

Compare to broken version here: https://reactspectrum.blob.core.windows.net/reactspectrum/474cdccf939dd44fd21d94a7d4fd1d3c3ece8f35/storybook-s2/index.html?path=/story/tableview--example

## 🧢 Your Project:

RSP
