### PR TITLE
chore(date): add package support metadata

### DIFF
--- a/packages/@internationalized/date/package.json
+++ b/packages/@internationalized/date/package.json
@@ -2,6 +2,10 @@
   "name": "@internationalized/date",
   "version": "3.12.2",
   "description": "Internationalized calendar, date, and time manipulation utilities",
+  "homepage": "https://github.com/adobe/react-spectrum/tree/main/packages/@internationalized/date#readme",
+  "bugs": {
+    "url": "https://github.com/adobe/react-spectrum/issues"
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- add `homepage` metadata for the package README
- add `bugs.url` metadata for the React Spectrum issue tracker
- leave runtime code, exports, dependencies, and package contents unchanged

## Validation

- `node -e "const p=require('./packages/@internationalized/date/package.json'); if (p.name !== '@internationalized/date' || p.bugs?.url !== 'https://github.com/adobe/react-spectrum/issues' || p.homepage !== 'https://github.com/adobe/react-spectrum/tree/main/packages/@internationalized/date#readme') throw new Error(JSON.stringify({name:p.name, bugs:p.bugs, homepage:p.homepage})); console.log(JSON.stringify({name:p.name, version:p.version, repository:p.repository, bugs:p.bugs, homepage:p.homepage}))"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `packages/@internationalized/date`

The dry-run package includes `README.md`, `package.json`, and existing source files.
