### PR TITLE
fix: ButtonGroup overflow detection for labels without word break

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/buttongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/buttongroup/index.css
@@ -19,6 +19,7 @@ governing permissions and limitations under the License.
   align-items: flex-start;
   /* necessary so that offsetLeft on button children is correct */
   position: relative;
+  max-width: 100%;
 
   .spectrum-ButtonGroup-Button {
     flex-shrink: 0;

--- a/packages/@react-spectrum/s2/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/s2/src/ButtonGroup.tsx
@@ -65,6 +65,7 @@ const buttongroup = style<ButtonGroupStyleProps>(
   {
     display: 'inline-flex',
     position: 'relative',
+    maxWidth: 'full',
     gap: {
       size: {
         S: 8,

--- a/packages/@react-spectrum/s2/test/ButtonGroup.browser.test.tsx
+++ b/packages/@react-spectrum/s2/test/ButtonGroup.browser.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Button} from '../src/Button';
+import {ButtonGroup} from '../src/ButtonGroup';
+import {describe, expect, it} from 'vitest';
+import React from 'react';
+import {render} from './utils/render';
+
+describe('ButtonGroup', () => {
+  it('stacks vertically when the container shrinks below the width of buttons with no-space labels', async () => {
+    let {container} = await render(
+      <div style={{width: '500px'}} data-testid="wrapper">
+        <ButtonGroup data-testid="button-group">
+          <Button variant="primary">nospace</Button>
+          <Button variant="secondary">nospace</Button>
+          <Button variant="secondary">nospace</Button>
+        </ButtonGroup>
+      </div>
+    );
+
+    let wrapper = container.querySelector('[data-testid="wrapper"]') as HTMLElement;
+    let buttonGroup = container.querySelector('[data-testid="button-group"]') as HTMLElement;
+
+    // Initially wide — buttons should be laid out horizontally
+    expect(getComputedStyle(buttonGroup).flexDirection).toBe('row');
+
+    // Shrink the container below the combined button widths to trigger overflow detection
+    wrapper.style.width = '50px';
+
+    // Wait for ResizeObserver and React re-render to settle
+    await expect.poll(() => getComputedStyle(buttonGroup).flexDirection).toBe('column');
+
+    // Restore the container width — should return to horizontal
+    wrapper.style.width = '500px';
+    await expect.poll(() => getComputedStyle(buttonGroup).flexDirection).toBe('row');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/5679

Original issue: If the button's inside a button group all had labels with no spaces/breaks, the button group would not correctly stack when the buttons overflowed the container. 

Adds a max-width: 100% to the button group so that it is never wider than the parent. Before when the buttons had no breaks in their labels, the button group's width would always be the min-content width so `child => child.offsetLeft < 0 || child.offsetLeft + child.offsetWidth > maxX` was never true. 

chromatic: https://www.chromatic.com/build?appId=5f0dd5ad2b5fc10022a2e320&number=1241

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Adds a browser test but you can check by editing the labels of the buttons in a button group to have no breaks and then resizing the container. The button group should correctly detect the overflow and switch the orientation from vertical to horizontal. Check in both V3 and S2.

## 🧢 Your Project:

<!--- Company/project for pull request -->
