### PR TITLE
docs: Add inline completions example to Autocomplete docs

### DIFF
--- a/packages/dev/s2-docs/package.json
+++ b/packages/dev/s2-docs/package.json
@@ -44,6 +44,7 @@
     "remark-stringify": "^11.0.0",
     "satori": "^0.16.1",
     "sharp": "^0.33.5",
+    "textarea-caret": "^3.1.0",
     "tree-sitter-highlight": "^1.0.1",
     "ts-morph": "^26.0.0",
     "unified": "^11.0.5",

--- a/packages/dev/s2-docs/pages/react-aria/Autocomplete.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Autocomplete.mdx
@@ -1103,6 +1103,137 @@ function AsyncLoadingExample() {
 }
 ```
 
+## Inline completions
+
+Set the Autocomplete `inputValue` to a substring of the full input value to enable inline completions such as @mentions. Completions can be displayed in a popover by controlling its `isOpen` state. For inline suggestions, use the `getTargetRect` prop to position the popover relative to the anchor character.
+
+```tsx render
+"use client";
+import {Autocomplete, useFilter} from 'react-aria-components/Autocomplete';
+import {TextArea} from 'vanilla-starter/TextField';
+import {Popover} from 'vanilla-starter/Popover';
+import {Menu, MenuItem} from 'vanilla-starter/Menu';
+import {useState, useRef} from 'react';
+import {flushSync} from 'react-dom';
+import getCaretRect from 'textarea-caret';
+
+/*- begin collapse -*/
+const usernames = [
+  'alexmiller',
+  'sarahjones',
+  'davidkim',
+  'emmawatson',
+  'oliverliu',
+  'ellagreen',
+  'lucasbrown',
+  'amandarivera',
+  'masonlee',
+  'nataliasmith',
+  'benjamintaylor',
+  'zoewilson',
+  'henrywalker',
+  'madelineyoung',
+  'noahscott',
+  'lucygonzalez',
+  'jacobmartin',
+  'averymoore',
+  'loganmurphy',
+  'miahernandez',
+  'danieladair',
+  'sofiacox',
+  'jackharris',
+  'chloebaker',
+  'liamrodriguez'
+];
+/*- end collapse -*/
+
+function Example() {
+  let {startsWith} = useFilter({sensitivity: 'base'});
+  let [inputValue, setInputValue] = useState('');
+  let [anchorIndex, setAnchorIndex] = useState(-1);
+  let [filterValue, setFilterValue] = useState('');
+  let inputRef = useRef<HTMLTextAreaElement>(null);
+
+  let updateFilter = () => {
+    let {selectionStart, selectionEnd, value} = inputRef.current!;
+    if (selectionStart === selectionEnd && document.activeElement === inputRef.current!) {
+      // The current filter value is the substring between 
+      // the anchor character '@' and the caret position.
+      let index = value.lastIndexOf('@', selectionStart);
+      if (index >= 0) {
+        let slice = value.slice(index + 1, selectionStart);
+        // Spaces are not allowed in the filter value.
+        if (!slice.includes(' ')) { 
+          setAnchorIndex(index);
+          setFilterValue(slice);
+          return;
+        }
+      }
+    }
+
+    // Reset the anchor index, but not the filter value so 
+    // that the menu does not flicker during the close animation.
+    setAnchorIndex(-1);
+  };
+  
+  return (
+    /*- begin highlight -*/
+    // Pass the filter substring to Autocomplete.
+    <Autocomplete inputValue={filterValue} filter={startsWith}>
+    {/*- end highlight -*/}
+      <TextArea
+        label="Comment"
+        placeholder="Type @ for autocomplete"
+        style={{width: '100%'}}
+        /*- begin highlight -*/
+        // Pass the full input value to the TextArea.
+        value={inputValue}
+        /*- end highlight -*/
+        onChange={value => {
+          setInputValue(value);
+          updateFilter();
+        }}
+        onSelect={updateFilter}
+        onBlur={updateFilter}
+        inputRef={inputRef} />
+      <Popover
+        triggerRef={inputRef}
+        /*- begin highlight -*/
+        // Open the popover when there is an active anchor character.
+        isOpen={anchorIndex >= 0}
+        /*- end highlight -*/
+        isNonModal
+        placement="bottom start"
+        trigger="MenuTrigger"
+        /*- begin highlight -*/
+        // Calculate the position of the popover relative to the anchor character.
+        getTargetRect={target => {
+          let {top, left} = getCaretRect(inputRef.current!, anchorIndex!);
+          let {top: targetTop, left: targetLeft} = target.getBoundingClientRect();
+          return new DOMRect(targetLeft + left, targetTop + top, 1, 16);
+        }}>
+        {/*- end highlight -*/}
+        <Menu
+          items={usernames}
+          renderEmptyState={() => 'No results found.'}
+          onAction={value => {
+            /*- begin highlight -*/
+            // Insert the completion at the anchor index and update the caret position.
+            let prefix = inputValue.slice(0, anchorIndex!) + '@' + value + ' ';
+            let suffix = inputValue.slice(inputRef.current!.selectionEnd!);
+            flushSync(() => setInputValue(prefix + suffix));
+            inputRef.current!.setSelectionRange(prefix.length, prefix.length);
+            updateFilter();
+            /*- end highlight -*/
+          }}>
+          {(item) => <MenuItem id={item}>{item}</MenuItem>}
+        </Menu>
+      </Popover>
+    </Autocomplete>
+  );
+}
+```
+
 ## Examples
 
 <ExampleList tag="autocomplete" pages={props.pages} />

--- a/starters/docs/src/TextField.tsx
+++ b/starters/docs/src/TextField.tsx
@@ -2,17 +2,20 @@
 import {
   Input,
   TextField as AriaTextField,
+  TextArea as AriaTextArea,
   type TextFieldProps as AriaTextFieldProps,
   type ValidationResult
 } from 'react-aria-components/TextField';
 import {Label, FieldError, Description} from './Form';
 import './TextField.css';
+import type React from 'react';
 
-export interface TextFieldProps extends AriaTextFieldProps {
+export interface TextFieldProps<T = HTMLInputElement> extends AriaTextFieldProps {
   label?: string;
   description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
   placeholder?: string;
+  inputRef?: React.Ref<T>;
 }
 
 export function TextField({
@@ -20,12 +23,35 @@ export function TextField({
   description,
   errorMessage,
   placeholder,
+  inputRef,
   ...props
 }: TextFieldProps) {
   return (
     <AriaTextField {...props}>
       <Label>{label}</Label>
-      <Input className="react-aria-Input inset" placeholder={placeholder} />
+      <Input ref={inputRef} className="react-aria-Input inset" placeholder={placeholder} />
+      {description && <Description>{description}</Description>}
+      <FieldError>{errorMessage}</FieldError>
+    </AriaTextField>
+  );
+}
+
+export function TextArea({
+  label,
+  description,
+  errorMessage,
+  placeholder,
+  inputRef,
+  ...props
+}: TextFieldProps<HTMLTextAreaElement>) {
+  return (
+    <AriaTextField {...props}>
+      <Label>{label}</Label>
+      <AriaTextArea
+        ref={inputRef}
+        className="react-aria-TextArea inset"
+        placeholder={placeholder}
+      />
       {description && <Description>{description}</Description>}
       <FieldError>{errorMessage}</FieldError>
     </AriaTextField>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8066,6 +8066,7 @@ __metadata:
     remark-stringify: "npm:^11.0.0"
     satori: "npm:^0.16.1"
     sharp: "npm:^0.33.5"
+    textarea-caret: "npm:^3.1.0"
     tree-sitter-highlight: "npm:^1.0.1"
     ts-morph: "npm:^26.0.0"
     unified: "npm:^11.0.5"
@@ -29644,6 +29645,13 @@ __metadata:
   version: 2.0.0
   resolution: "text-extensions@npm:2.0.0"
   checksum: 10c0/d20fb458c6c2c77319b8e1a39fae1d61d89d590abebc78a28cdda71855b4c9b209bfcb27e10165d2402afbce7f9c2e336bc781001c366f982db90e01f91a6820
+  languageName: node
+  linkType: hard
+
+"textarea-caret@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "textarea-caret@npm:3.1.0"
+  checksum: 10c0/ae6a9d31eb337d0e5925642718484a56664cd94d88adeb7e68498a0149a0d3359bba8a21790f286f95843407ba9622dad10c092a429165587427270792071709
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds an example to the Autocomplete docs of a text area with inline autocomplete for mentions, using the new `getTargetRect` Popover API and improvements to Autocomplete.