### PR TITLE
fix: Allow cursor to move when pressing arrow keys in inline Autocomplete

### DIFF
--- a/packages/react-aria/src/autocomplete/useAutocomplete.ts
+++ b/packages/react-aria/src/autocomplete/useAutocomplete.ts
@@ -381,7 +381,7 @@ export function useAutocomplete<T>(
         // to the wrapped collection if there is a focused node so that a user can continue moving the
         // virtual focus. However, if the user doesn't have a focus in the collection, just move the text
         // cursor instead. They can move focus down into the collection via down/up arrow if need be
-        if ((e.key === 'ArrowRight' || e.key === 'ArrowLeft') && state.inputValue.length > 0) {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
           if (focusedNodeId == null) {
             if (!e.isPropagationStopped()) {
               e.stopPropagation();


### PR DESCRIPTION
Fixes an issue in the inline completions Autocomplete example where when the cursor was just after the @ character, arrow left and arrow right did not move the cursor. This is a tradeoff with another behavior related to controlling grids, i.e. our docs search. Now pressing the left and right arrow keys when the search field is empty does not move into the collection. Now it always behaves the same: if you are already in the collection, arrow keys move the focused item, if you are in the input, arrow keys move the cursor.