### PR TITLE
fix: make sure trackpad taps properly fire press events consistently

### DIFF
--- a/packages/@adobe/react-spectrum/test/list/ListView.test.js
+++ b/packages/@adobe/react-spectrum/test/list/ListView.test.js
@@ -1225,6 +1225,11 @@ describe('ListView', function () {
       });
 
       it("should support single tap to perform row selection with screen reader if onAction isn't provided", async function () {
+        // oxlint-disable-next-line no-unused-vars
+        using uaMock = jest
+          .spyOn(navigator, 'userAgent', 'get')
+          .mockImplementation(() => 'Android');
+
         let tree = renderSelectionList({
           onSelectionChange,
           selectionMode: 'multiple',
@@ -1281,6 +1286,11 @@ describe('ListView', function () {
       });
 
       it('should support single tap to perform onAction with screen reader', async function () {
+        // oxlint-disable-next-line no-unused-vars
+        using uaMock = jest
+          .spyOn(navigator, 'userAgent', 'get')
+          .mockImplementation(() => 'Android');
+
         let tree = renderSelectionList({
           onSelectionChange,
           selectionMode: 'multiple',

--- a/packages/@adobe/react-spectrum/test/table/TableTests.js
+++ b/packages/@adobe/react-spectrum/test/table/TableTests.js
@@ -3414,6 +3414,11 @@ export let tableTests = () => {
       describe('needs pointerEvents', function () {
         installPointerEvent();
         it("should support single tap to perform row selection with screen reader if onAction isn't provided", function () {
+          // oxlint-disable-next-line no-unused-vars
+          using uaMock = jest
+            .spyOn(navigator, 'userAgent', 'get')
+            .mockImplementation(() => 'Android');
+
           let onSelectionChange = jest.fn();
           let tree = renderTable({onSelectionChange, selectionStyle: 'highlight'});
 
@@ -3482,6 +3487,11 @@ export let tableTests = () => {
         });
 
         it('should support single tap to perform onAction with screen reader', function () {
+          // oxlint-disable-next-line no-unused-vars
+          using uaMock = jest
+            .spyOn(navigator, 'userAgent', 'get')
+            .mockImplementation(() => 'Android');
+
           let onSelectionChange = jest.fn();
           let onAction = jest.fn();
           let tree = renderTable({onSelectionChange, selectionStyle: 'highlight', onAction});

--- a/packages/react-aria/src/utils/isVirtualEvent.ts
+++ b/packages/react-aria/src/utils/isVirtualEvent.ts
@@ -48,7 +48,8 @@ export function isVirtualPointerEvent(event: PointerEvent): boolean {
   // Talkback double tap from Windows Firefox touch screen press
   return (
     (!isAndroid() && event.width === 0 && event.height === 0) ||
-    (event.width === 1 &&
+    (isAndroid() &&
+      event.width === 1 &&
       event.height === 1 &&
       event.pressure === 0 &&
       event.detail === 0 &&

--- a/packages/react-aria/test/dnd/dnd.test.js
+++ b/packages/react-aria/test/dnd/dnd.test.js
@@ -2882,6 +2882,9 @@ describe('useDrag and useDrop', function () {
     });
 
     it('should support clicking the original drag target to cancel drag (virtual pointer event)', async () => {
+      // oxlint-disable-next-line no-unused-vars
+      using uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
+
       let tree = render(
         <>
           <Draggable />
@@ -2942,6 +2945,9 @@ describe('useDrag and useDrop', function () {
     });
 
     it('should support double tapping the drop target to complete drag (virtual pointer event)', async () => {
+      // oxlint-disable-next-line no-unused-vars
+      using uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
+
       let onDrop = jest.fn();
       let tree = render(
         <>

--- a/packages/react-aria/test/interactions/usePress.test.js
+++ b/packages/react-aria/test/interactions/usePress.test.js
@@ -1218,6 +1218,9 @@ describe('usePress', function () {
     });
 
     it('should detect Android TalkBack double tap', function () {
+      // oxlint-disable-next-line no-unused-vars
+      using uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
+
       let events = [];
       let addEvent = e => events.push(e);
       let res = render(
@@ -1309,6 +1312,45 @@ describe('usePress', function () {
           target: el
         }
       ]);
+    });
+
+    it('should fire if pressure is 0 but is not android', function () {
+      let events = [];
+      let addEvent = e => events.push(e);
+      let res = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPress={addEvent}
+          onPressUp={addEvent}
+          onClick={e => addEvent({type: e.type, target: e.target})}
+        />
+      );
+
+      let el = res.getByText('test');
+      fireEvent(
+        el,
+        pointerEvent('pointerdown', {
+          pointerId: 1,
+          width: 1,
+          height: 1,
+          pressure: 0,
+          detail: 0,
+          pointerType: 'mouse'
+        })
+      );
+      fireEvent(
+        el,
+        pointerEvent('pointerup', {
+          pointerId: 1,
+          width: 1,
+          height: 1,
+          pressure: 0,
+          detail: 0,
+          pointerType: 'mouse'
+        })
+      );
+      expect(events).not.toEqual([]);
     });
 
     it('should not fire press/click events for disabled elements', function () {
@@ -5038,6 +5080,9 @@ describe('usePress', function () {
     });
 
     it('should detect Android TalkBack double tap', function () {
+      // oxlint-disable-next-line no-unused-vars
+      using uaMock = jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => 'Android');
+
       const shadowRoot = setupShadowDOMTest({onPressChange: null});
 
       const el = shadowRoot.getElementById('testElement');
@@ -5109,6 +5154,46 @@ describe('usePress', function () {
           altKey: false
         })
       ]);
+    });
+
+    it('should fire if pressure is 0 but is not android', function () {
+      let events = [];
+      let addEvent = e => events.push(e);
+      let res = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPress={addEvent}
+          onPressUp={addEvent}
+          onClick={e => addEvent({type: e.type, target: e.target})}
+        />
+      );
+
+      let el = res.getByText('test');
+      fireEvent(
+        el,
+        pointerEvent('pointerdown', {
+          pointerId: 1,
+          width: 1,
+          height: 1,
+          pressure: 0,
+          detail: 0,
+          pointerType: 'mouse'
+        })
+      );
+      fireEvent(
+        el,
+        pointerEvent('pointerup', {
+          pointerId: 1,
+          width: 1,
+          height: 1,
+          pressure: 0,
+          detail: 0,
+          pointerType: 'mouse'
+        })
+      );
+
+      expect(events).not.toEqual([]);
     });
 
     it('should not fire press/click events for disabled elements', function () {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10184

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Make sure you have tap to click enabled for your track pad. Attempt to tap on checkboxes in FireFox and verify it always toggles the checkbox on tap. Test other browser/device/screenreader combinations. 

## 🧢 Your Project:

RSP
