### PR TITLE
fix: rac missing internationalized/string dependency

### DIFF
--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -3,10 +3,27 @@
   "version": "1.18.0",
   "description": "A library of styleable components built using React Aria",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/react-spectrum"
+  },
+  "source": "exports/index.ts",
+  "files": [
+    "*",
+    "!docs/**",
+    "!example/**",
+    "!exports/**",
+    "!intl/**",
+    "!src/**",
+    "!stories/**",
+    "!test/**"
+  ],
+  "sideEffects": [
+    "*.css"
+  ],
   "main": "./dist/exports/index.cjs",
   "module": "./dist/exports/index.js",
   "types": "./dist/types/exports/index.d.ts",
-  "source": "exports/index.ts",
   "exports": {
     ".": {
       "source": "./exports/index.ts",
@@ -33,40 +50,24 @@
     },
     "./private/*": null
   },
-  "files": [
-    "*",
-    "!docs/**",
-    "!example/**",
-    "!exports/**",
-    "!intl/**",
-    "!src/**",
-    "!stories/**",
-    "!test/**"
-  ],
-  "sideEffects": [
-    "*.css"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/adobe/react-spectrum"
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@internationalized/date": "^3.12.2",
+    "@internationalized/string": "^3.2.9",
     "@react-types/shared": "^3.35.0",
     "@swc/helpers": "^0.5.0",
     "client-only": "^0.0.1",
     "react-aria": "3.49.0",
     "react-stately": "3.47.0"
   },
-  "peerDependencies": {
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
     "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@tailwindcss/postcss": "^4.0.0",
+  "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
     "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26402,6 +26402,7 @@ __metadata:
   resolution: "react-aria-components@workspace:packages/react-aria-components"
   dependencies:
     "@internationalized/date": "npm:^3.12.2"
+    "@internationalized/string": "npm:^3.2.9"
     "@react-types/shared": "npm:^3.35.0"
     "@swc/helpers": "npm:^0.5.0"
     "@tailwindcss/postcss": "npm:^4.0.0"


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10194

react-aria
react-stately
These packages already had this dependency, so it was only missing in RAC

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
