### PR TITLE
docs: Fix TableView empty state example dropping TableBody tag

### DIFF
--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -363,7 +363,6 @@ import FolderOpen from '@react-spectrum/s2/illustrations/linear/FolderOpen';
   </TableHeader>
   {/*- begin highlight -*/}
   <TableBody
-    /*- begin highlight -*/
     renderEmptyState={() => (
       <IllustratedMessage>
         <FolderOpen />


### PR DESCRIPTION
## Closes #10231

### Problem
On https://react-spectrum.adobe.com/TableView#empty-state the rendered example code is missing its `<TableBody>` opening tag, and "Open in StackBlitz" produces code that does not compile (an orphaned `renderEmptyState` prop with no element).

### Root cause
The example wrapped a single highlighted block with **two** `- begin highlight -` markers but only **one** `- end highlight -`:

```tsx
{/*- begin highlight -*/}
<TableBody
  /*- begin highlight -*/   // <- redundant second begin
  renderEmptyState={() => (
    ...
  )}>
  {/*- end highlight -*/}
```

The docs code highlighter (`packages/dev/s2-docs/src/Code.tsx`, function `lines()`) starts a new highlight grouping on every `begin` marker and resets the current line, with no guard for a grouping that is already open. The second `begin` therefore replaced the in-progress grouping and discarded the already-accumulated `<TableBody` line. Because the StackBlitz / copy / download export (`getExampleCode` in `CodePlatter.tsx`) reads the *same* rendered code from the DOM, both the displayed snippet and the exported file lost the tag.

### Fix
Remove the redundant inner `/*- begin highlight -*/` marker, leaving the canonical single begin/end pair already used elsewhere in this file (e.g. the `treeColumn` example just above). The full `<TableBody ... renderEmptyState>` tag now renders and the example compiles in StackBlitz.

### Verification
Ran the actual `tree-sitter-highlight` highlighter through a faithful port of `Code.tsx`'s `lines()` grouping logic on the on-disk example:

- Before: rendered output jumps from `</TableHeader>` straight to `renderEmptyState={() => (` — `<TableBody` absent.
- After: `<TableBody ... renderEmptyState>` present, valid JSX, all highlight markers stripped.

This is a docs-only change in a private package, so no changeset is included (consistent with recent docs-example fixes such as #10214).