### PR TITLE
fix: Export DayOfWeek type from @internationalized/date

### DIFF
--- a/packages/@internationalized/date/src/index.ts
+++ b/packages/@internationalized/date/src/index.ts
@@ -28,6 +28,7 @@ export type {
   CycleTimeOptions
 } from './types';
 export type {DateValue} from './CalendarDate';
+export type {DayOfWeek} from './queries';
 
 export {CalendarDate, CalendarDateTime, Time, ZonedDateTime} from './CalendarDate';
 export {GregorianCalendar} from './calendars/GregorianCalendar';

--- a/packages/@internationalized/date/src/queries.ts
+++ b/packages/@internationalized/date/src/queries.ts
@@ -79,7 +79,7 @@ const DAY_MAP = {
   sat: 6
 };
 
-type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+export type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
 
 /**
  * Returns the day of week for the given date and locale. Days are numbered from zero to six,


### PR DESCRIPTION
## Closes #9971

### Problem
`DayOfWeek` (`'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'`) appears in the public signatures of the exported `getDayOfWeek`, `startOfWeek`, `endOfWeek`, and `getWeeksInMonth` functions as the optional `firstDayOfWeek` parameter, but the type itself is not exported:

```ts
import { type DayOfWeek } from '@internationalized/date';
// TS error: '"@internationalized/date"' has no exported member named 'DayOfWeek'.
```

Consumers who accept `firstDayOfWeek` as a prop and forward it to these functions have no canonical type to use; they must duplicate the string union.

### Root cause
`DayOfWeek` was declared without `export` in `src/queries.ts` and never re-exported from `src/index.ts`. Previously TypeScript would let tooling import it from the `.d.ts` anyway, but after the package moved to the `exports` field in `package.json` the declaration file it lived in is no longer reachable, so it became unimportable.

As discussed in the issue, a maintainer was open to exporting it formally ("we can consider exporting it formally").

### Fix
- Add `export` to the `DayOfWeek` type declaration in `queries.ts`.
- Re-export it from `index.ts` next to the other public type exports.

Purely additive — no existing export of `DayOfWeek` exists elsewhere in the repo, so nothing is shadowed or duplicated.

### Verification
- `git grep` confirms `DayOfWeek` had no other export and no downstream package references it (no conflict).
- Type-checked with `tsc` that `export type {DayOfWeek} from './queries'` resolves to a real exported member (no `TS2305 "no exported member"` error).