### PR TITLE
fix(useSelectableCollection): focus previous tab stop on Shift+Tab instead of collection root

### DIFF
--- a/packages/@adobe/react-spectrum/test/table/TableTests.js
+++ b/packages/@adobe/react-spectrum/test/table/TableTests.js
@@ -1940,13 +1940,9 @@ export let tableTests = () => {
         await user.click(tree.getAllByRole('switch')[1]);
         expect(document.activeElement).toBe(tree.getAllByRole('switch')[1]);
 
-        // Simulate shift tabbing within the table
+        // useSelectableCollection's Tab handler moves focus to the previous tab stop outside the table.
+        // jsdom does not perform default tabbing after preventDefault (see useSelectableCollection.test.js).
         fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
-        let walker = getFocusableTreeWalker(document.body, {tabbable: true});
-        walker.currentNode = document.activeElement;
-        act(() => {
-          walker.previousNode().focus();
-        });
         fireEvent.keyUp(document.activeElement, {key: 'Tab', shiftKey: true});
 
         let before = tree.getByTestId('before');

--- a/packages/react-aria/src/selection/useSelectableCollection.ts
+++ b/packages/react-aria/src/selection/useSelectableCollection.ts
@@ -140,6 +140,61 @@ export interface SelectableCollectionAria {
   collectionProps: DOMAttributes;
 }
 
+function getPreviousTabStopOutside(
+  collectionRoot: HTMLElement,
+  from: HTMLElement
+): FocusableElement | null {
+  let walker = getFocusableTreeWalker(collectionRoot.ownerDocument.body, {tabbable: true});
+  walker.currentNode = from;
+  let prev = walker.previousNode() as FocusableElement | null;
+  while (prev && nodeContains(collectionRoot, prev)) {
+    prev = walker.previousNode() as FocusableElement | null;
+  }
+  return prev;
+}
+
+function canFocusPreviousTabStopDirectly(
+  prev: FocusableElement,
+  prevFromRoot: FocusableElement,
+  collectionRoot: HTMLElement
+): boolean {
+  if (prev !== prevFromRoot) {
+    return false;
+  }
+
+  let owner = prev.closest('[data-collection]');
+  if (owner !== null && !nodeContains(collectionRoot, owner)) {
+    return false;
+  }
+
+  // Tab stops within the same menu dialog (e.g. the mobile submenu back button) should use the
+  // default Shift+Tab behavior instead of focusing them directly.
+  let menuDialog = collectionRoot.closest('[role="dialog"]');
+  if (menuDialog && nodeContains(menuDialog, prev) && !nodeContains(collectionRoot, prev)) {
+    return false;
+  }
+
+  return true;
+}
+
+function handleShiftTabFromCollection(e: KeyboardEvent, collectionRoot: HTMLElement): void {
+  let activeElement = getActiveElement();
+  if (!(activeElement instanceof HTMLElement)) {
+    return;
+  }
+
+  let prev = getPreviousTabStopOutside(collectionRoot, activeElement);
+  let prevFromRoot = getPreviousTabStopOutside(collectionRoot, collectionRoot);
+
+  if (prev && prevFromRoot && canFocusPreviousTabStopDirectly(prev, prevFromRoot, collectionRoot)) {
+    e.preventDefault();
+    focusWithoutScrolling(prev);
+    return;
+  }
+
+  collectionRoot.focus();
+}
+
 /**
  * Handles interactions with selectable collections.
  */
@@ -369,7 +424,9 @@ export function useSelectableCollection(
           // in the collection, so that the browser default behavior will apply starting from that element
           // rather than the currently focused one.
           if (e.shiftKey) {
-            ref.current.focus();
+            if (ref.current) {
+              handleShiftTabFromCollection(e, ref.current);
+            }
           } else {
             let walker = getFocusableTreeWalker(ref.current, {tabbable: true});
             let next: FocusableElement | undefined = undefined;

--- a/packages/react-aria/test/selection/useSelectableCollection.test.js
+++ b/packages/react-aria/test/selection/useSelectableCollection.test.js
@@ -80,6 +80,38 @@ describe('useSelectableCollection', () => {
     expect(options[2]).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('shift+tabs from a collection to the previous tab stop outside via the Tab key handler', async () => {
+    let {getByRole} = render(
+      <>
+        <button>before</button>
+        <List aria-label="Test">
+          <Item key="i1">One</Item>
+          <Item key="i2">Two</Item>
+        </List>
+      </>
+    );
+    let listbox = getByRole('listbox');
+    let before = getByRole('button', {name: 'before'});
+    let options = within(listbox).getAllByRole('option');
+
+    await user.tab();
+    expect(document.activeElement).toBe(before);
+    await user.tab();
+    expect(document.activeElement).toBe(options[0]);
+
+    // userEvent tab does not route through useSelectableCollection's Tab handler
+    // (see GridList.test.js — coercing focus to the collection root).
+    fireEvent.keyDown(document.activeElement, {
+      key: 'Tab',
+      shiftKey: true,
+      code: 'Tab',
+      bubbles: true
+    });
+
+    expect(document.activeElement).toBe(before);
+    expect(document.activeElement).not.toBe(listbox);
+  });
+
   describe.each`
     type | prepare | actions
     ${'VO Events'} | ${installPointerEvent} | ${[el => fireEvent.pointerDown(el, {button: 0, pointerType: 'virtual'}), el => {


### PR DESCRIPTION
## Summary

When Shift+Tab is pressed inside a collection with `allowsTabNavigation={false}` (Table, ListBox, GridList, etc.), `useSelectableCollection` called `ref.current.focus()` on the collection root before the browser continued tabbing. That intermediate focus on the grid root is an unnecessary pivot — focus should move directly to the previous tab stop outside the collection.

For RAC Table this caused extra focus transitions and downstream React re-renders (for example Row `useFocusRing({ within: true })` when focus briefly lands on the grid root).

The fix mirrors the forward-Tab branch: on Shift+Tab, when the previous external tab stop matches the collection boundary, we `preventDefault` and `focusWithoutScrolling` that element. Otherwise we fall back to `collectionRoot.focus()` (nested collections, mobile submenu back button, etc.).

**Changed files:**
- `packages/react-aria/src/selection/useSelectableCollection.ts`
- `packages/react-aria/test/selection/useSelectableCollection.test.js`
- `packages/@adobe/react-spectrum/test/table/TableTests.js`

**Guards:**
- `prev === prevFromRoot` — direct exit only from the collection boundary as a single tab stop
- `prev` must not belong to another `[data-collection]` outside the current root
- tab stops in the same menu `[role="dialog"]` but outside the collection use the fallback path
- no `stopPropagation()` (ComboBox dev-mode)

## ✅ Pull Request Checklist:

- [x] [Connected with this issue](https://github.com/adobe/react-spectrum/issues/8617)
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component). — N/A, behavior-only fix.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/) — [Grid and Table Keyboard Interaction](https://www.w3.org/WAI/ARIA/apg/patterns/grid/): Tab / Shift+Tab should move focus into/out of the grid without trapping on the grid container.

## 📝 Test Instructions:

**Automated**

```bash
yarn jest packages/react-aria/test/selection/useSelectableCollection.test.js -t "shift+tabs"
yarn jest packages/@adobe/react-spectrum/test/table/Table.test.js -t "should move focus before the table when shift tabbing"
yarn jest packages/@adobe/react-spectrum/test/combobox/ComboBox.test.js -t "tab and shift tab"
yarn jest packages/@adobe/react-spectrum/test/menu/SubMenuTrigger.test.tsx
yarn jest packages/react-aria-components/test/Tree.test.tsx -t "should focus the dropped row when dropped on a parent that is expanded"
```

The new test uses `fireEvent.keyDown` (not `user.tab({ shift: true })`) so it exercises `useSelectableCollection`'s Tab handler — same caveat as GridList.test.js.

**Manual (Table / Storybook)**

1. Place a focusable element before a Table (e.g. a button).
2. Tab into the table, focus a cell or an internal control (switch, button).
3. Shift+Tab back to the button.
4. Confirm focus lands on the button without flashing focus on the table grid root.
5. Optional: in React DevTools Profiler, confirm fewer cell re-renders on Shift+Tab vs. before.

**Regression**

- Tab into a collection still works.
- Tab out (forward) is unchanged.
- Shift+Tab between items inside a collection still works.

## 🧢 Your Project:

dxFeed (Devexperts) — internal Table built on react-aria-components (`Table`, `div-grid`, `focusMode="cell"`).