### PR TITLE
fix: rename turbosnap reporter

### DIFF
--- a/packages/dev/parcel-reporter-turbosnap-stats/package.json
+++ b/packages/dev/parcel-reporter-turbosnap-stats/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@parcel/reporter-turbosnap-stats",
+  "name": "parcel-reporter-turbosnap-stats",
   "version": "0.0.0",
   "private": true,
   "source": "StatsReporter.ts",

--- a/packages/dev/storybook-builder-parcel/package.json
+++ b/packages/dev/storybook-builder-parcel/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "@parcel/core": "^2.16.3",
     "@parcel/reporter-cli": "^2.16.3",
-    "@parcel/reporter-turbosnap-stats": "0.0.0",
     "@parcel/utils": "^2.16.3",
     "http-proxy-middleware": "^2.0.6",
+    "parcel-reporter-turbosnap-stats": "0.0.0",
     "storybook": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/dev/storybook-builder-parcel/preset.mjs
+++ b/packages/dev/storybook-builder-parcel/preset.mjs
@@ -128,7 +128,7 @@ async function createParcel(options, isDev = false) {
       ...(options.statsJson
         ? [
             {
-              packageName: '@parcel/reporter-turbosnap-stats',
+              packageName: 'parcel-reporter-turbosnap-stats',
               resolveFrom: __filename
             }
           ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,15 +5715,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/reporter-turbosnap-stats@npm:0.0.0, @parcel/reporter-turbosnap-stats@workspace:packages/dev/parcel-reporter-turbosnap-stats":
-  version: 0.0.0-use.local
-  resolution: "@parcel/reporter-turbosnap-stats@workspace:packages/dev/parcel-reporter-turbosnap-stats"
-  dependencies:
-    "@parcel/plugin": "npm:^2.16.3"
-    "@parcel/types": "npm:^2.16.3"
-  languageName: unknown
-  linkType: soft
-
 "@parcel/resolver-default@npm:2.16.3, @parcel/resolver-default@npm:^2.16.3":
   version: 2.16.3
   resolution: "@parcel/resolver-default@npm:2.16.3"
@@ -25207,6 +25198,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"parcel-reporter-turbosnap-stats@npm:0.0.0, parcel-reporter-turbosnap-stats@workspace:packages/dev/parcel-reporter-turbosnap-stats":
+  version: 0.0.0-use.local
+  resolution: "parcel-reporter-turbosnap-stats@workspace:packages/dev/parcel-reporter-turbosnap-stats"
+  dependencies:
+    "@parcel/plugin": "npm:^2.16.3"
+    "@parcel/types": "npm:^2.16.3"
+  languageName: unknown
+  linkType: soft
+
 "parcel-resolver-build@workspace:packages/dev/parcel-resolver-build":
   version: 0.0.0-use.local
   resolution: "parcel-resolver-build@workspace:packages/dev/parcel-resolver-build"
@@ -28887,9 +28887,9 @@ __metadata:
   dependencies:
     "@parcel/core": "npm:^2.16.3"
     "@parcel/reporter-cli": "npm:^2.16.3"
-    "@parcel/reporter-turbosnap-stats": "npm:0.0.0"
     "@parcel/utils": "npm:^2.16.3"
     http-proxy-middleware: "npm:^2.0.6"
+    parcel-reporter-turbosnap-stats: "npm:0.0.0"
     react: "npm:*"
     storybook: "npm:^10.0.0"
   peerDependencies:


### PR DESCRIPTION
The `@parcel/*` scope is reserved for official parcel packages.