### PR TITLE
feat(s2): add missing StatusLight color variants for Badge parity

### DIFF
--- a/packages/@react-spectrum/s2/src/StatusLight.tsx
+++ b/packages/@react-spectrum/s2/src/StatusLight.tsx
@@ -30,24 +30,30 @@ interface StatusLightStyleProps {
    * @default 'neutral'
    */
   variant?:
+    | 'accent'
     | 'informative'
     | 'neutral'
     | 'positive'
     | 'notice'
     | 'negative'
-    | 'celery'
-    | 'chartreuse'
-    | 'cyan'
-    | 'fuchsia'
-    | 'purple'
-    | 'magenta'
-    | 'indigo'
-    | 'seafoam'
+    | 'gray'
+    | 'red'
+    | 'orange'
     | 'yellow'
+    | 'chartreuse'
+    | 'celery'
+    | 'green'
+    | 'seafoam'
+    | 'cyan'
+    | 'blue'
+    | 'indigo'
+    | 'purple'
+    | 'fuchsia'
+    | 'magenta'
     | 'pink'
     | 'turquoise'
-    | 'cinnamon'
     | 'brown'
+    | 'cinnamon'
     | 'silver';
   /**
    * The size of the StatusLight.
@@ -103,24 +109,30 @@ const light = style<StatusLightStyleProps & {isSkeleton: boolean}>({
   },
   fill: {
     variant: {
+      accent: 'accent',
       informative: 'informative',
       neutral: 'neutral',
       positive: 'positive',
       notice: 'notice',
       negative: 'negative',
-      celery: 'celery',
-      chartreuse: 'chartreuse',
-      cyan: 'cyan',
-      fuchsia: 'fuchsia',
-      purple: 'purple',
-      magenta: 'magenta',
-      indigo: 'indigo',
-      seafoam: 'seafoam',
+      gray: 'gray',
+      red: 'red',
+      orange: 'orange',
       yellow: 'yellow',
+      chartreuse: 'chartreuse',
+      celery: 'celery',
+      green: 'green',
+      seafoam: 'seafoam',
+      cyan: 'cyan',
+      blue: 'blue',
+      indigo: 'indigo',
+      purple: 'purple',
+      fuchsia: 'fuchsia',
+      magenta: 'magenta',
       pink: 'pink',
       turquoise: 'turquoise',
-      cinnamon: 'cinnamon',
       brown: 'brown',
+      cinnamon: 'cinnamon',
       silver: 'silver'
     },
     isSkeleton: 'gray-200'

--- a/packages/@react-spectrum/s2/stories/StatusLight.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/StatusLight.stories.tsx
@@ -46,3 +46,43 @@ export const LongLabel: Story = {
     variant: 'positive'
   }
 };
+
+const variants = [
+  'accent',
+  'informative',
+  'neutral',
+  'positive',
+  'notice',
+  'negative',
+  'gray',
+  'red',
+  'orange',
+  'yellow',
+  'chartreuse',
+  'celery',
+  'green',
+  'seafoam',
+  'cyan',
+  'blue',
+  'indigo',
+  'purple',
+  'fuchsia',
+  'magenta',
+  'pink',
+  'turquoise',
+  'brown',
+  'cinnamon',
+  'silver'
+] as const;
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className={style({display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'start'})}>
+      {variants.map(variant => (
+        <StatusLight key={variant} variant={variant}>
+          {variant}
+        </StatusLight>
+      ))}
+    </div>
+  )
+};


### PR DESCRIPTION
Add accent, gray, red, orange, green, and blue variants using existing visual-color fill tokens, plus an AllVariants Storybook story.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
