### PR TITLE
fix: shadcn registry build

### DIFF
--- a/scripts/buildRegistry.mjs
+++ b/scripts/buildRegistry.mjs
@@ -153,7 +153,14 @@ function analyzeDeps(file, type) {
               : '@/registry/react-aria/ui/' + source.slice(2);
         }
       } else {
-        dependencies.add(source);
+        // Use the bare package name (e.g. `react-aria-components`) rather than the
+        // deep import path (`react-aria-components/Button`). npm treats `owner/repo`
+        // specifiers as GitHub shorthand, so passing deep paths to `shadcn add` (which
+        // runs `npm install <deps>`) would fail to resolve the dependency.
+        let pkg = source.startsWith('@')
+          ? source.split('/').slice(0, 2).join('/')
+          : source.split('/')[0];
+        dependencies.add(pkg);
       }
     }
   }


### PR DESCRIPTION
Closes <!-- Github issue # here -->
```
mkdir /tmp/regbug && cd /tmp/regbug && mkdir src && printf '' > src/index.css
echo '{"name":"regbug","private":true,"version":"0.0.0","type":"module"}' > package.json
echo '{"compilerOptions":{"baseUrl":".","paths":{"@/*":["./src/*"]}}}' > tsconfig.json
cat > components.json <<'EOF'
{ "$schema": "https://ui.shadcn.com/schema.json", "style": "default", "rsc": false, "tsx": true,
  "tailwind": { "config": "", "css": "src/index.css", "baseColor": "neutral", "cssVariables": false },
  "aliases": { "components": "@/components", "utils": "@/lib/utils", "ui": "@/components/ui", "lib": "@/lib" } }
EOF
npx shadcn@latest add https://react-aria.adobe.com/registry/css-button.json --yes
```

It will fail with

> Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue on GitHub.

> Command failed with exit code 128: npm install react-aria-components/composeRenderProps react-aria-components/ProgressBar react-aria-components/Button

I also found that the command on our React Aria Getting started page for everything is wrong. `npx shadcn@latest add @react-aria/css`

After this PR, it should collapse all the sub paths to just the root, `npm install react-aria-components`

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
