### PR TITLE
fix: resolve locales with explicit script to language-script strings

### DIFF
--- a/packages/@internationalized/string/src/LocalizedStringDictionary.ts
+++ b/packages/@internationalized/string/src/LocalizedStringDictionary.ts
@@ -114,6 +114,15 @@ function getStringsForLocale<K extends string, T extends LocalizedString>(
   // This could be replaced with Intl.LocaleMatcher once it is supported.
   // https://github.com/tc39/proposal-intl-localematcher
   let language = getLanguage(locale);
+
+  // If the locale has an explicit script (e.g. sr-Latn-RS), prefer a
+  // language-script match (sr-Latn) over a language-only match (sr), since
+  // those may represent entirely different scripts.
+  let script = getScript(locale);
+  if (script && strings[`${language}-${script}`]) {
+    return strings[`${language}-${script}`];
+  }
+
   if (strings[language]) {
     return strings[language];
   }
@@ -136,4 +145,14 @@ function getLanguage(locale: string) {
   }
 
   return locale.split('-')[0];
+}
+
+function getScript(locale: string) {
+  // @ts-ignore
+  if (Intl.Locale) {
+    // @ts-ignore
+    return new Intl.Locale(locale).script;
+  }
+
+  return undefined;
 }

--- a/packages/@internationalized/string/test/LocalizedStringDictionary.test.js
+++ b/packages/@internationalized/string/test/LocalizedStringDictionary.test.js
@@ -27,6 +27,14 @@ describe('LocalizedStringDictionary', function () {
       'it-IT': {
         hello: 'Ciao',
         goodbye: 'Arrivederci'
+      },
+      sr: {
+        hello: 'Здраво',
+        goodbye: 'Збогом'
+      },
+      'sr-Latn': {
+        hello: 'Zdravo',
+        goodbye: 'Zbogom'
       }
     });
 
@@ -50,6 +58,14 @@ describe('LocalizedStringDictionary', function () {
     it('uses default locale when specified locale key exists, but the value is falsy', function () {
       const localizedStringDictionary = new LocalizedStringDictionary(messages, 'es-ES');
       expect(localizedStringDictionary.getStringForLocale('hello', 'ja-JP')).toBe('Hola');
+    });
+
+    it('prefers a language-script match if available over a language-only match', function () {
+      const localizedStringDictionary = new LocalizedStringDictionary(messages);
+      expect(localizedStringDictionary.getStringForLocale('hello', 'sr-Latn-RS')).toBe('Zdravo');
+      expect(localizedStringDictionary.getStringForLocale('hello', 'sr-Latn')).toBe('Zdravo');
+      expect(localizedStringDictionary.getStringForLocale('hello', 'sr')).toBe('Здраво');
+      expect(localizedStringDictionary.getStringForLocale('hello', 'sr-Cyrl-RS')).toBe('Здраво');
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10255

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10255).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

`LocalizedStringDictionary.getStringsForLocale` matched a language-only entry before checking for a language-script entry. For Latin-script Serbian (`sr-Latn-RS`) it resolved to the Cyrillic `sr` strings instead of the Latin `sr-Latn` strings, so DateField/DatePicker placeholders rendered in the wrong script.

This change adds a language-script lookup using `Intl.Locale#script`: when a locale has an explicit script subtag and a matching `language-script` entry exists, it is preferred over the language-only fallback. Locales without an explicit script, or without a matching entry, behave exactly as before — so only `placeholders.ts` (the one dictionary with `sr-Latn`) is affected; all language/region-keyed translation dictionaries are unchanged.

To verify:

```js
const dict = new LocalizedStringDictionary({
  sr: {year: 'гггг'},        // Cyrillic
  'sr-Latn': {year: 'gggg'}  // Latin
});

dict.getStringForLocale('year', 'sr-Latn-RS'); // 'gggg'  (was 'гггг')
dict.getStringForLocale('year', 'sr-Cyrl-RS'); // 'гггг'  (no sr-Cyrl entry → falls back to sr)

Run the unit tests:

yarn jest packages/@internationalized/string/test/LocalizedStringDictionary.test.js