### PR TITLE
chore: make ai stories not appear in v3 storybook

### DIFF
--- a/.storybook/main.mjs
+++ b/.storybook/main.mjs
@@ -5,7 +5,7 @@ const localAddon = rel => fileURLToPath(import.meta.resolve(rel));
 export default {
   stories: [
     '../packages/@{react-aria,react-stately,spectrum-icons}/*/stories/*.stories.{js,jsx,ts,tsx}',
-    '../packages/@react-spectrum/!(s2)/stories/*.stories.{js,jsx,ts,tsx}',
+    '../packages/@react-spectrum/!(s2|ai)/stories/*.stories.{js,jsx,ts,tsx}',
     '../packages/@adobe/react-spectrum/stories/*/*.stories.{js,jsx,ts,tsx}',
     '../packages/react-aria/stories/*/*.stories.{js,jsx,ts,tsx}',
     '../packages/react-stately/stories/*/*.stories.{js,jsx,ts,tsx}',


### PR DESCRIPTION
makes the AI component stories not appear in the v3/rac storybook

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
