### PR TITLE
fix: add DEFAULT_SLOT to TreeItem CheckboxContext so unslotted Checkboxes render

### DIFF
--- a/packages/react-aria-components/src/Tree.tsx
+++ b/packages/react-aria-components/src/Tree.tsx
@@ -1004,6 +1004,7 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent(
                   CheckboxContext,
                   {
                     slots: {
+                      [DEFAULT_SLOT]: {},
                       selection: checkboxProps
                     }
                   }
@@ -1012,6 +1013,7 @@ export const TreeItem = /*#__PURE__*/ createBranchComponent(
                   CheckboxFieldContext,
                   {
                     slots: {
+                      [DEFAULT_SLOT]: {},
                       selection: checkboxProps
                     }
                   }

--- a/packages/react-aria-components/test/Tree.test.tsx
+++ b/packages/react-aria-components/test/Tree.test.tsx
@@ -664,6 +664,21 @@ describe('Tree', () => {
     }
   );
 
+  it('should allow unslotted checkboxes in item content', () => {
+    let {getByRole} = render(
+      <Tree aria-label="test tree">
+        <TreeItem id="item" textValue="Item">
+          <TreeItemContent>
+            <Text>Item</Text>
+            <Checkbox>Flag item</Checkbox>
+          </TreeItemContent>
+        </TreeItem>
+      </Tree>
+    );
+
+    expect(getByRole('checkbox', {name: 'Flag item'})).toBeInTheDocument();
+  });
+
   it('should not render checkboxes for selection with selectionBehavior=replace ', async () => {
     let {getByRole, getAllByRole} = render(
       <StaticTree treeProps={{selectionMode: 'multiple', selectionBehavior: 'replace'}} />


### PR DESCRIPTION
Closes #10204

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10204).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component). No documentation changes are needed for this internal slot fix.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

`TreeItem` provided a `CheckboxContext`/`CheckboxFieldContext` whose `slots` only contained `selection`, unlike `TableRow` and `GridListItem` which also include `[DEFAULT_SLOT]: {}`. As a result, any `Checkbox` or `CheckboxField` without `slot="selection"` rendered as a React descendant of a `TreeItem` threw `A slot prop is required. Valid slot names are "selection".`

This adds `[DEFAULT_SLOT]: {}` to both slot maps in `TreeItem`, mirroring `Table.tsx`, so an unslotted checkbox renders normally while the existing `slot="selection"` behavior is unchanged.

To verify:

1. Render a `Tree` with a `TreeItem` containing an unslotted `<Checkbox>` in its content. It now renders without throwing.
2. A `Checkbox slot="selection"` inside a `TreeItem` still drives selection (no regression).

Tests:

```
yarn jest packages/react-aria-components/test/Tree.test.tsx
```

Result: 109 passed, 1 skipped. Added a new case asserting an unslotted `Checkbox` under a `TreeItem` renders without error.

## 🧢 Your Project:

Community contribution.
