### PR TITLE
fix: guard inert feature detection against undefined HTMLElement.prototype

### DIFF
--- a/packages/react-aria/src/overlays/ariaHideOutside.ts
+++ b/packages/react-aria/src/overlays/ariaHideOutside.ts
@@ -16,7 +16,10 @@ import {getOwnerDocument, getOwnerWindow} from '../utils/domHelpers';
 import {nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {shadowDOM} from 'react-stately/private/flags/flags';
 
-const supportsInert = typeof HTMLElement !== 'undefined' && 'inert' in HTMLElement.prototype;
+const supportsInert =
+  typeof HTMLElement !== 'undefined' &&
+  HTMLElement.prototype != null &&
+  'inert' in HTMLElement.prototype;
 
 function isAlwaysVisibleNode(node: HTMLElement | SVGElement): boolean {
   return node.dataset.liveAnnouncer === 'true' || node.dataset.reactAriaTopLayer !== undefined;

--- a/packages/react-aria/test/overlays/ariaHideOutside.test.js
+++ b/packages/react-aria/test/overlays/ariaHideOutside.test.js
@@ -914,3 +914,29 @@ describe('ariaHideOutside with shadow DOM', function () {
     });
   });
 });
+
+describe('ariaHideOutside inert feature detection', function () {
+  let originalHTMLElement = global.HTMLElement;
+
+  afterEach(function () {
+    global.HTMLElement = originalHTMLElement;
+    jest.resetModules();
+  });
+
+  it('does not throw at import time when HTMLElement.prototype is undefined', function () {
+    // Simulate bundler/SSR environments where HTMLElement is defined but its prototype is not.
+    let FakeHTMLElement = function () {};
+    FakeHTMLElement.prototype = undefined;
+    global.HTMLElement = FakeHTMLElement;
+
+    jest.resetModules();
+    expect(() => require('../../src/overlays/ariaHideOutside')).not.toThrow();
+  });
+
+  it('does not throw at import time when HTMLElement is undefined (non-DOM SSR)', function () {
+    global.HTMLElement = undefined;
+
+    jest.resetModules();
+    expect(() => require('../../src/overlays/ariaHideOutside')).not.toThrow();
+  });
+});


### PR DESCRIPTION

Closes #10219

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component). No user-facing docs exist for this internal feature-detection guard.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

The module-level `supportsInert` detection in `packages/react-aria/src/overlays/ariaHideOutside.ts` evaluated `'inert' in HTMLElement.prototype` after only checking that `HTMLElement` was defined. In some bundler/SSR setups (reported with Next.js/Turbopack reloads) `HTMLElement` exists but `HTMLElement.prototype` is `undefined`, so the `in` operator threw `TypeError: Cannot use 'in' operator to search for 'inert' in undefined` at import time.

This adds a `HTMLElement.prototype != null` guard before the `in` check. When the prototype is missing, `supportsInert` now resolves to `false`, the same path used in environments without inert support, and the code falls back to `aria-hidden`. Behavior in a normal DOM is unchanged.

To verify:

- `yarn jest packages/react-aria/test/overlays/ariaHideOutside.test.js` passes, including two new cases under `ariaHideOutside inert feature detection` that import the module with `HTMLElement.prototype` undefined and with `HTMLElement` undefined and assert no throw.
- In a normal DOM the existing tests still confirm elements are hidden via the `inert` path.

## 🧢 Your Project:

Personal open source contribution.
