### PR TITLE
fix: Handle table elements in getContainingBlock

### DIFF
--- a/packages/react-aria/src/overlays/calculatePosition.ts
+++ b/packages/react-aria/src/overlays/calculatePosition.ts
@@ -819,7 +819,19 @@ function getContainingBlock(node: HTMLElement): Element {
     offsetParent = document.documentElement;
   }
 
-  // TODO(later): handle table elements?
+  // The offsetParent can be a <table>, <td>, or <th> even when it is statically
+  // positioned, in which case it is not actually the element's containing block.
+  // Walk up to the true offsetParent so the position resolves against the real
+  // containing block, matching the behavior of Popper and Floating UI.
+  while (
+    offsetParent &&
+    (offsetParent.tagName === 'TABLE' ||
+      offsetParent.tagName === 'TD' ||
+      offsetParent.tagName === 'TH') &&
+    window.getComputedStyle(offsetParent).position === 'static'
+  ) {
+    offsetParent = (offsetParent as HTMLElement).offsetParent;
+  }
 
   // The offsetParent can be null if the element has position: fixed, or a few other cases.
   // We have to walk up the tree manually in this case because fixed positioned elements

--- a/packages/react-aria/test/overlays/useOverlayPosition.test.tsx
+++ b/packages/react-aria/test/overlays/useOverlayPosition.test.tsx
@@ -372,3 +372,104 @@ describe('useOverlayPosition with positioned container', () => {
     `);
   });
 });
+
+describe('useOverlayPosition with a table element in the offsetParent chain', () => {
+  let stubs: jest.SpyInstance<any, any>[] = [];
+  let tableElement: HTMLElement | null = null;
+  let realGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect;
+  let realGetComputedStyle = window.getComputedStyle;
+
+  afterEach(() => {
+    stubs.forEach(stub => stub.mockReset());
+    stubs.length = 0;
+    if (tableElement) {
+      document.body.removeChild(tableElement);
+      tableElement = null;
+    }
+  });
+
+  // A statically-positioned <table>, <td>, or <th> can be reported as an element's
+  // offsetParent even though it is not the element's containing block. It must be
+  // skipped so the overlay resolves against the real (positioned) containing block.
+  it.each(['table', 'td', 'th'])(
+    'walks up through a statically-positioned <%s> to the true containing block',
+    tagName => {
+      tableElement = document.createElement(tagName);
+      document.body.appendChild(tableElement);
+
+      window.visualViewport = {
+        offsetTop: 0,
+        height: 768,
+        offsetLeft: 0,
+        scale: 1,
+        width: 500,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+        onresize: () => {},
+        onscroll: () => {},
+        pageLeft: 0,
+        pageTop: 0
+      } as VisualViewport;
+      document.body.style.margin = '0';
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+        configurable: true,
+        value: 768
+      });
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', {configurable: true, value: 500});
+
+      stubs.push(
+        jest
+          .spyOn(window.HTMLElement.prototype, 'offsetParent', 'get')
+          .mockImplementation(function (this: HTMLElement) {
+            // The overlay's offsetParent is the statically-positioned table element,
+            // whose own offsetParent is the positioned container.
+            if (this.attributes.getNamedItem('data-testid')?.value === 'overlay') {
+              return tableElement;
+            } else if (this === tableElement) {
+              return document.querySelector('[data-testid="container"]');
+            }
+            return null;
+          }),
+        jest
+          .spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+          .mockImplementation(function (this: HTMLElement) {
+            return realGetBoundingClientRect.apply(this);
+          }),
+        jest.spyOn(window, 'getComputedStyle').mockImplementation(element => {
+          const sty = realGetComputedStyle(element);
+          if (element.attributes.getNamedItem('data-testid')?.value === 'container') {
+            sty.position = 'relative';
+          } else if (element === tableElement) {
+            sty.position = 'static';
+          }
+          return sty;
+        }),
+        jest
+          .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+          .mockImplementation(function (this: HTMLElement) {
+            return parseInt(this.style.width, 10) || 0;
+          }),
+        jest
+          .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+          .mockImplementation(function (this: HTMLElement) {
+            return parseInt(this.style.height, 10) || 0;
+          })
+      );
+
+      let res = render(<Example containerStyle={{top: 150, left: 0, width: 400, height: 400}} />);
+      let overlay = res.getByTestId('overlay');
+
+      // Identical to the positioned-container case: the static table element is
+      // transparent to positioning, so top is 200 (the container is offset by 150),
+      // not 350 as it would be if the table element were treated as the container.
+      expect(overlay).toHaveStyle(`
+        position: absolute;
+        z-index: 100000;
+        left: 12px;
+        top: 200px;
+        max-height: 406px;
+      `);
+    }
+  );
+});


### PR DESCRIPTION
Closes <!-- no existing issue; this resolves a TODO in the code -->

## Overview

This resolves the `// TODO(later): handle table elements?` in `getContainingBlock` (`packages/react-aria/src/overlays/calculatePosition.ts`).

Per the CSSOM View spec, `HTMLElement.offsetParent` can return a `<table>`, `<td>`, or `<th>` that is not the element's actual containing block. The change walks up past statically positioned table elements to the true `offsetParent`, so positioning resolves against the real containing block. Positioned table elements are kept, since those are valid containing blocks. This mirrors the equivalent guards in Popper.js (`getOffsetParent`) and Floating UI.

```ts
while (
  offsetParent &&
  (offsetParent.tagName === 'TABLE' ||
    offsetParent.tagName === 'TD' ||
    offsetParent.tagName === 'TH') &&
  window.getComputedStyle(offsetParent).position === 'static'
) {
  offsetParent = (offsetParent as HTMLElement).offsetParent;
}
```

Reachability, verified while addressing review feedback: the spec only takes the table branch of `offsetParent` when the element itself is statically positioned, and the overlay measured here is always `fixed` (before the first calculation) or `absolute` (afterward). Current engines therefore never report a static table `offsetParent` for this call site (verified in Chromium, WebKit, and Firefox). The walk is a zero cost defensive guard matching Popper and Floating UI, and the TODO could alternatively be resolved by documenting that table elements need no special handling here. Both options are laid out in the review thread.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Automated: `yarn jest packages/react-aria/test/overlays/useOverlayPosition.test.tsx`. A new `describe` block ("useOverlayPosition with a table element in the offsetParent chain") covers `table`, `td`, and `th`. It mocks `offsetParent` and `getComputedStyle` to insert a statically positioned table element into the overlay's `offsetParent` chain and asserts the overlay still resolves against the real positioned container (top is 200, not 350). These tests fail on `main` and pass with this change. The mocks are unavoidable: jsdom computes no layout, and current engines never report a static table `offsetParent` for a positioned element, so the branch cannot be reached in a real browser.

Manual: no visible difference can be demonstrated in current browsers for this call site, per the reachability note above.

## 🧢 Your Project:

Community contribution.
