### PR TITLE
fix: table press and hold navigation

### DIFF
--- a/packages/react-aria/src/selection/useSelectableCollection.ts
+++ b/packages/react-aria/src/selection/useSelectableCollection.ts
@@ -415,22 +415,27 @@ export function useSelectableCollection(
     };
   };
   // oxlint-disable react/react-compiler
-  let {keyboardProps} = useKeyboard({
+  let {keyboardProps: repeatKeyboardProps} = useKeyboard({
     shortcuts: {
       ...withShiftSel('ArrowDown', arrowDown),
       ...withShiftSel('ArrowUp', arrowUp),
       ...withShiftSel('ArrowLeft', arrowLeft),
       ...withShiftSel('ArrowRight', arrowRight),
+      ...withShiftSel('PageDown', pageDown),
+      ...withShiftSel('PageUp', pageUp)
+    },
+    allowRepeats: true
+  });
+  // oxlint-disable react/react-compiler
+  let {keyboardProps} = useKeyboard({
+    shortcuts: {
       ...withShiftSel('Home', home),
       ...withShiftSel('End', end),
-      ...withShiftSel('PageDown', pageDown),
-      ...withShiftSel('PageUp', pageUp),
       'Mod+A': aHandler,
       Escape: escape,
       Tab: tab,
       'Tab+Shift': shiftTab
-    },
-    allowRepeats: true
+    }
   });
   // oxlint-enable react/react-compiler
 
@@ -699,7 +704,7 @@ export function useSelectableCollection(
   });
 
   let handlers = {
-    ...keyboardProps,
+    ...mergeProps(keyboardProps, repeatKeyboardProps),
     onFocus,
     onBlur,
     onMouseDown(e) {

--- a/packages/react-aria/src/selection/useSelectableCollection.ts
+++ b/packages/react-aria/src/selection/useSelectableCollection.ts
@@ -429,7 +429,8 @@ export function useSelectableCollection(
       Escape: escape,
       Tab: tab,
       'Tab+Shift': shiftTab
-    }
+    },
+    allowRepeats: true
   });
   // oxlint-enable react/react-compiler
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Reported https://github.com/adobe/react-spectrum/pull/9929#issuecomment-4855202487

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Go to a table and press and hold the arrow key to navigate quickly through a large table.

## 🧢 Your Project:

<!--- Company/project for pull request -->
