### PR TITLE
fix: breadcrumbs href undefined causing an empty string

### DIFF
--- a/packages/react-aria/src/utils/openLink.tsx
+++ b/packages/react-aria/src/utils/openLink.tsx
@@ -205,7 +205,7 @@ export function useLinkProps(props?: LinkDOMProps): LinkDOMProps {
   let linkProps: LinkDOMProps = {};
   if (props) {
     for (let key of ['href', 'target', 'rel', 'download', 'ping', 'referrerPolicy']) {
-      if (key in props) {
+      if (key in props && props[key] !== undefined) {
         linkProps[key] = key === 'href' ? href : props[key];
       }
     }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Noticed while debugging the Breadcrumbs chromatic story snapshot change. If you are on main and run `yarn chromatic`, then go to the S2 Breadcrumb story, after it loads, it'll error with 
"Error: An empty string ("") was passed to the href attribute. To fix this, either do not render the element at all or pass null to href instead of an empty string."

This is because open link checks if a key in in the props but doesn't check if it's undefined value. In React, undefined in the props object is considered the same as the key not being present. So I've updated our check to match React behaviour.
The reason that it was an issue is because of this change https://github.com/adobe/react-spectrum/pull/7032/changes which now always calls useHref. However, it would return an empty string, and that was what was used.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
