### PR TITLE
fix: ariaHideOutside ShadowDOM

### DIFF
--- a/packages/react-aria/src/overlays/ariaHideOutside.ts
+++ b/packages/react-aria/src/overlays/ariaHideOutside.ts
@@ -12,7 +12,7 @@
 
 import {createShadowTreeWalker} from '../utils/shadowdom/ShadowTreeWalker';
 
-import {getOwnerDocument, getOwnerWindow} from '../utils/domHelpers';
+import {getOwnerDocument, getOwnerWindow, isShadowRoot} from '../utils/domHelpers';
 import {nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {shadowDOM} from 'react-stately/private/flags/flags';
 
@@ -78,16 +78,16 @@ export function ariaHideOutside(targets: Element[], options?: AriaHideOutsideOpt
 
   let shadowRootsToWatch = new Set<ShadowRoot>();
   if (shadowDOM()) {
-    // find all shadow roots that are ancestors of the targets
-    // traverse upwards until the root is reached
+    // Find all shadow roots that enclose the targets, walking up the host chain
+    // until we reach the tree that `root` lives in. Each enclosing ShadowRoot
+    // needs its own MutationObserver because it does not cross shadow
+    // boundaries, so the observer on `root` cannot see mutations inside them.
+    let boundary = root.getRootNode();
     for (let target of targets) {
-      let node = target;
-      while (node && node !== root) {
-        let root = node.getRootNode();
-        if ('shadowRoot' in root) {
-          shadowRootsToWatch.add(root.shadowRoot as ShadowRoot);
-        }
-        node = root.parentNode as Element;
+      let current = target.getRootNode();
+      while (isShadowRoot(current) && current !== boundary) {
+        shadowRootsToWatch.add(current);
+        current = current.host.getRootNode();
       }
     }
   }

--- a/packages/react-aria/test/overlays/ariaHideOutside.test.js
+++ b/packages/react-aria/test/overlays/ariaHideOutside.test.js
@@ -336,12 +336,14 @@ describe('ariaHideOutside', function () {
 
     let {queryByRole, getAllByRole, getByTestId} = render(<Test />);
 
-    ariaHideOutside([getByTestId('test')]);
+    let revert = ariaHideOutside([getByTestId('test')]);
 
     queryByRole('button').click();
     await Promise.resolve(); // Wait for mutation observer tick
 
     expect(getAllByRole('listitem')).toHaveLength(1);
+
+    revert();
   });
 
   it('should handle when a new element is added and then reparented to a hidden container', async function () {
@@ -370,12 +372,14 @@ describe('ariaHideOutside', function () {
 
     let {queryByRole, queryAllByRole, getByTestId} = render(<Test />);
 
-    ariaHideOutside([getByTestId('test')]);
+    let revert = ariaHideOutside([getByTestId('test')]);
 
     queryByRole('button').click();
     await Promise.resolve(); // Wait for mutation observer tick
 
     expect(queryAllByRole('listitem')).toHaveLength(0);
+
+    revert();
   });
 
   it('work when called multiple times', function () {
@@ -585,12 +589,16 @@ describe('ariaHideOutside with shadow DOM', function () {
 
   describe('ariaHideOutside with Shadow DOM', () => {
     let cleanup;
-    afterEach(() => {
-      cleanup();
-      // iterate over anything leftover in the body and remove it
-      for (let element of document.body.children) {
-        document.body.removeChild(element);
+    afterEach(async () => {
+      cleanup?.();
+      cleanup = undefined;
+      // Remove anything leftover in the body. Use firstChild rather than iterating
+      // the live `children` collection, which skips elements as it mutates.
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
       }
+      // Close out any pending observers
+      await act(async () => Promise.resolve());
     });
 
     it('should not apply aria-hidden to direct parents of the shadow root', () => {
@@ -707,7 +715,7 @@ describe('ariaHideOutside with shadow DOM', function () {
       siblingContent.textContent = 'Sibling Content';
       outerShadowRoot.appendChild(siblingContent);
 
-      ariaHideOutside([modal], innerShadowRoot);
+      cleanup = ariaHideOutside([modal], innerShadowRoot);
 
       expect(isEffectivelyHidden(modal)).toBe(false);
 
@@ -797,10 +805,12 @@ describe('ariaHideOutside with shadow DOM', function () {
   describe('ariaHideOutside with nested Shadow DOMs', () => {
     let cleanup;
     afterEach(() => {
-      cleanup();
-      // iterate over anything leftover in the body and remove it
-      for (let element of document.body.children) {
-        document.body.removeChild(element);
+      cleanup?.();
+      cleanup = undefined;
+      // Remove anything leftover in the body. Use firstChild rather than iterating
+      // the live `children` collection, which skips elements as it mutates.
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
       }
     });
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Noticed while reviewing https://github.com/adobe/react-spectrum/pull/10188/changes#diff-29dcc007b6c87955ab3959f45722c6407485d9ca430d639b4394dbc351023a17R106 that our own logic in ariaHideOutside wasn't quite right. We had a test for it, but it was passing due to some global leaks from previous tests. I've corrected the leaks as well as the logic based on the other PR.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
