### PR TITLE
fix: clamp Time millisecond to a valid maximum of 999

### DIFF
--- a/packages/@internationalized/date/src/manipulation.ts
+++ b/packages/@internationalized/date/src/manipulation.ts
@@ -249,7 +249,7 @@ function balanceTime(time: Mutable<AnyTime>): number {
 }
 
 export function constrainTime(time: Mutable<AnyTime>): void {
-  time.millisecond = Math.max(0, Math.min(time.millisecond, 1000));
+  time.millisecond = Math.max(0, Math.min(time.millisecond, 999));
   time.second = Math.max(0, Math.min(time.second, 59));
   time.minute = Math.max(0, Math.min(time.minute, 59));
   time.hour = Math.max(0, Math.min(time.hour, 23));

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -968,4 +968,31 @@ describe('Time manipulation', function () {
   it('should leave a valid millisecond unchanged', function () {
     expect(new Time(1, 2, 3, 999).millisecond).toBe(999);
   });
+
+  it('should clamp an out of range second to 59', function () {
+    let time = new Time(1, 2, 100, 4);
+    expect(time.second).toBe(59);
+    expect(time.toString()).toBe('01:02:59.004');
+  });
+
+  it('should clamp an out of range minute to 59', function () {
+    let time = new Time(1, 100, 3, 4);
+    expect(time.minute).toBe(59);
+    expect(time.toString()).toBe('01:59:03.004');
+  });
+
+  it('should clamp an out of range hour to 23', function () {
+    let time = new Time(100, 2, 3, 4);
+    expect(time.hour).toBe(23);
+    expect(time.toString()).toBe('23:02:03.004');
+  });
+
+  it('should clamp negative fields to 0', function () {
+    let time = new Time(-1, -2, -3, -4);
+    expect(time.hour).toBe(0);
+    expect(time.minute).toBe(0);
+    expect(time.second).toBe(0);
+    expect(time.millisecond).toBe(0);
+    expect(time.toString()).toBe('00:00:00');
+  });
 });

--- a/packages/@internationalized/date/tests/manipulation.test.js
+++ b/packages/@internationalized/date/tests/manipulation.test.js
@@ -26,6 +26,7 @@ import {
   JapaneseCalendar,
   PersianCalendar,
   TaiwanCalendar,
+  Time,
   toCalendar,
   ZonedDateTime
 } from '..';
@@ -954,5 +955,17 @@ describe('ZonedDateTime manipulation', function () {
       let date = new ZonedDateTime(2020, 1, 1, 'UTC', 0, 5, 5, 5, 5);
       expect(date.subtract({[`${Unit}`]: 5})).toEqual(Expected);
     });
+  });
+});
+
+describe('Time manipulation', function () {
+  it('should clamp an out of range millisecond to 999', function () {
+    let time = new Time(1, 2, 3, 5000);
+    expect(time.millisecond).toBe(999);
+    expect(time.toString()).toBe('01:02:03.999');
+  });
+
+  it('should leave a valid millisecond unchanged', function () {
+    expect(new Time(1, 2, 3, 999).millisecond).toBe(999);
   });
 });


### PR DESCRIPTION
`constrainTime` clamps the millisecond field with
`Math.max(0, Math.min(time.millisecond, 1000))`, but a valid millisecond is in
the range 0 to 999. An out of range value is clamped to 1000, which is not a
representable millisecond.

`constrainTime` runs in the `Time` constructor, in `.set({millisecond})`, and in
`copy()`. So `new Time(1, 2, 3, 5000).millisecond` returns 1000, and
`new Time(1, 2, 3, 5000).toString()` returns "01:02:03" with the fraction
silently dropped, because the string builder computes `String(1000 / 1000)`.

The fix clamps to 999, matching the sibling clamps in the same function
(seconds to 59, minutes to 59, hours to 23) and `cycleTime`, which already bounds
the millisecond with 0 to 999.
