### PR TITLE
fix: accept readonly array ComboBox values

### DIFF
--- a/packages/react-stately/src/combobox/useComboBoxState.ts
+++ b/packages/react-stately/src/combobox/useComboBoxState.ts
@@ -36,7 +36,7 @@ import {useControlledState} from '../utils/useControlledState';
 
 export type MenuTriggerAction = 'focus' | 'input' | 'manual';
 export type SelectionMode = 'single' | 'multiple';
-export type ValueType<M extends SelectionMode> = M extends 'single' ? Key | null : Key[];
+export type ValueType<M extends SelectionMode> = M extends 'single' ? Key | null : readonly Key[];
 export type ChangeValueType<M extends SelectionMode> = M extends 'single' ? Key | null : Key[];
 type ValidationType<M extends SelectionMode> = M extends 'single' ? Key | null : Key[];
 


### PR DESCRIPTION
## Summary

Re-applies the readonly array value type support from #9741 after the ComboBox state file was moved during the package consolidation work.

The consolidated `react-stately/src/combobox/useComboBoxState.ts` had kept most of the change, but `ValueType<'multiple'>` was restored to mutable `Key[]`. This updates it back to `readonly Key[]` so controlled multiple ComboBox values can use readonly arrays.

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->