### PR TITLE
feat: add isPressedWhenOpen prop to overlay trigger components

### DIFF
--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -131,6 +131,7 @@ export interface ComboBoxProps<T, M extends SelectionMode = 'single'>
   allowsEmptyCollection?: boolean;
   /**
    * Whether the trigger button appears pressed (e.g. `data-pressed`) while the popover is open.
+   *
    * @default true
    */
   isPressedWhenOpen?: boolean;
@@ -305,7 +306,14 @@ function ComboBoxInner<T>({props, collection, comboBoxRef: ref}: ComboBoxInnerPr
       values={[
         [ComboBoxStateContext, state],
         [LabelContext, {...labelProps, ref: labelRef}],
-        [ButtonContext, {...buttonProps, ref: buttonRef, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}],
+        [
+          ButtonContext,
+          {
+            ...buttonProps,
+            ref: buttonRef,
+            isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen
+          }
+        ],
         [InputContext, {...inputProps, ref: inputRef}],
         [OverlayTriggerStateContext, state],
         [

--- a/packages/react-aria-components/src/ComboBox.tsx
+++ b/packages/react-aria-components/src/ComboBox.tsx
@@ -129,6 +129,11 @@ export interface ComboBoxProps<T, M extends SelectionMode = 'single'>
   formValue?: 'text' | 'key';
   /** Whether the combo box allows the menu to be open when the collection is empty. */
   allowsEmptyCollection?: boolean;
+  /**
+   * Whether the trigger button appears pressed (e.g. `data-pressed`) while the popover is open.
+   * @default true
+   */
+  isPressedWhenOpen?: boolean;
 }
 
 export const ComboBoxContext =
@@ -300,7 +305,7 @@ function ComboBoxInner<T>({props, collection, comboBoxRef: ref}: ComboBoxInnerPr
       values={[
         [ComboBoxStateContext, state],
         [LabelContext, {...labelProps, ref: labelRef}],
-        [ButtonContext, {...buttonProps, ref: buttonRef, isPressed: state.isOpen}],
+        [ButtonContext, {...buttonProps, ref: buttonRef, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}],
         [InputContext, {...inputProps, ref: inputRef}],
         [OverlayTriggerStateContext, state],
         [

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -126,6 +126,11 @@ export interface DatePickerProps<T extends DateValue>
    * @default 'react-aria-DatePicker'
    */
   className?: ClassNameOrFunction<DatePickerRenderProps>;
+  /**
+   * Whether the trigger button appears pressed (e.g. `data-pressed`) while the popover is open.
+   * @default true
+   */
+  isPressedWhenOpen?: boolean;
 }
 export interface DateRangePickerProps<T extends DateValue>
   extends
@@ -145,6 +150,11 @@ export interface DateRangePickerProps<T extends DateValue>
    * @default 'react-aria-DateRangePicker'
    */
   className?: ClassNameOrFunction<DateRangePickerRenderProps>;
+  /**
+   * Whether the trigger button appears pressed (e.g. `data-pressed`) while the popover is open.
+   * @default true
+   */
+  isPressedWhenOpen?: boolean;
 }
 
 export const DatePickerContext =
@@ -219,7 +229,7 @@ export const DatePicker = /*#__PURE__*/ (forwardRef as forwardRefType)(function 
         [DatePickerStateContext, state],
         [GroupContext, {...groupProps, ref: groupRef, isInvalid: state.isInvalid}],
         [DateFieldContext, fieldProps],
-        [ButtonContext, {...buttonProps, isPressed: state.isOpen}],
+        [ButtonContext, {...buttonProps, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}],
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [CalendarContext, calendarProps as any],
         [OverlayTriggerStateContext, state],
@@ -330,7 +340,7 @@ export const DateRangePicker = /*#__PURE__*/ (forwardRef as forwardRefType)(
         values={[
           [DateRangePickerStateContext, state],
           [GroupContext, {...groupProps, ref: groupRef, isInvalid: state.isInvalid}],
-          [ButtonContext, {...buttonProps, isPressed: state.isOpen}],
+          [ButtonContext, {...buttonProps, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}],
           [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
           [RangeCalendarContext, calendarProps],
           [OverlayTriggerStateContext, state],

--- a/packages/react-aria-components/src/DatePicker.tsx
+++ b/packages/react-aria-components/src/DatePicker.tsx
@@ -128,6 +128,7 @@ export interface DatePickerProps<T extends DateValue>
   className?: ClassNameOrFunction<DatePickerRenderProps>;
   /**
    * Whether the trigger button appears pressed (e.g. `data-pressed`) while the popover is open.
+   *
    * @default true
    */
   isPressedWhenOpen?: boolean;
@@ -152,6 +153,7 @@ export interface DateRangePickerProps<T extends DateValue>
   className?: ClassNameOrFunction<DateRangePickerRenderProps>;
   /**
    * Whether the trigger button appears pressed (e.g. `data-pressed`) while the popover is open.
+   *
    * @default true
    */
   isPressedWhenOpen?: boolean;
@@ -229,7 +231,10 @@ export const DatePicker = /*#__PURE__*/ (forwardRef as forwardRefType)(function 
         [DatePickerStateContext, state],
         [GroupContext, {...groupProps, ref: groupRef, isInvalid: state.isInvalid}],
         [DateFieldContext, fieldProps],
-        [ButtonContext, {...buttonProps, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}],
+        [
+          ButtonContext,
+          {...buttonProps, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}
+        ],
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [CalendarContext, calendarProps as any],
         [OverlayTriggerStateContext, state],
@@ -340,7 +345,10 @@ export const DateRangePicker = /*#__PURE__*/ (forwardRef as forwardRefType)(
         values={[
           [DateRangePickerStateContext, state],
           [GroupContext, {...groupProps, ref: groupRef, isInvalid: state.isInvalid}],
-          [ButtonContext, {...buttonProps, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}],
+          [
+            ButtonContext,
+            {...buttonProps, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen}
+          ],
           [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
           [RangeCalendarContext, calendarProps],
           [OverlayTriggerStateContext, state],

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -49,6 +49,7 @@ export interface DialogTriggerProps extends OverlayTriggerProps {
   children: ReactNode;
   /**
    * Whether the trigger button appears pressed (e.g. `data-pressed`) while the dialog is open.
+   *
    * @default true
    */
   isPressedWhenOpen?: boolean;
@@ -115,7 +116,10 @@ export function DialogTrigger(props: DialogTriggerProps): JSX.Element {
           }
         ]
       ]}>
-      <PressResponder {...triggerProps} ref={buttonRef} isPressed={(props.isPressedWhenOpen ?? true) && state.isOpen}>
+      <PressResponder
+        {...triggerProps}
+        ref={buttonRef}
+        isPressed={(props.isPressedWhenOpen ?? true) && state.isOpen}>
         {props.children}
       </PressResponder>
     </Provider>

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -47,6 +47,11 @@ import {useOverlayTrigger} from 'react-aria/useOverlayTrigger';
 
 export interface DialogTriggerProps extends OverlayTriggerProps {
   children: ReactNode;
+  /**
+   * Whether the trigger button appears pressed (e.g. `data-pressed`) while the dialog is open.
+   * @default true
+   */
+  isPressedWhenOpen?: boolean;
 }
 
 export interface DialogRenderProps {
@@ -110,7 +115,7 @@ export function DialogTrigger(props: DialogTriggerProps): JSX.Element {
           }
         ]
       ]}>
-      <PressResponder {...triggerProps} ref={buttonRef} isPressed={state.isOpen}>
+      <PressResponder {...triggerProps} ref={buttonRef} isPressed={(props.isPressedWhenOpen ?? true) && state.isOpen}>
         {props.children}
       </PressResponder>
     </Provider>

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -118,6 +118,7 @@ export interface MenuTriggerProps extends BaseMenuTriggerProps {
   children: ReactNode;
   /**
    * Whether the trigger button appears pressed (e.g. `data-pressed`) while the menu is open.
+   *
    * @default true
    */
   isPressedWhenOpen?: boolean;
@@ -160,7 +161,10 @@ export function MenuTrigger(props: MenuTriggerProps): JSX.Element | null {
           }
         ]
       ]}>
-      <PressResponder {...menuTriggerProps} ref={ref} isPressed={(props.isPressedWhenOpen ?? true) && state.isOpen}>
+      <PressResponder
+        {...menuTriggerProps}
+        ref={ref}
+        isPressed={(props.isPressedWhenOpen ?? true) && state.isOpen}>
         {props.children}
       </PressResponder>
     </Provider>

--- a/packages/react-aria-components/src/Menu.tsx
+++ b/packages/react-aria-components/src/Menu.tsx
@@ -116,6 +116,11 @@ const SelectionManagerContext = createContext<SelectionManager | null>(null);
 
 export interface MenuTriggerProps extends BaseMenuTriggerProps {
   children: ReactNode;
+  /**
+   * Whether the trigger button appears pressed (e.g. `data-pressed`) while the menu is open.
+   * @default true
+   */
+  isPressedWhenOpen?: boolean;
 }
 
 export function MenuTrigger(props: MenuTriggerProps): JSX.Element | null {
@@ -155,7 +160,7 @@ export function MenuTrigger(props: MenuTriggerProps): JSX.Element | null {
           }
         ]
       ]}>
-      <PressResponder {...menuTriggerProps} ref={ref} isPressed={state.isOpen}>
+      <PressResponder {...menuTriggerProps} ref={ref} isPressed={(props.isPressedWhenOpen ?? true) && state.isOpen}>
         {props.children}
       </PressResponder>
     </Provider>

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -127,6 +127,11 @@ export interface SelectProps<T, M extends SelectionMode = 'single'>
    * @default 'Select an item' (localized)
    */
   placeholder?: string;
+  /**
+   * Whether the trigger button appears pressed (e.g. `data-pressed`) while the select is open.
+   * @default true
+   */
+  isPressedWhenOpen?: boolean;
 }
 
 export const SelectContext =
@@ -248,7 +253,7 @@ function SelectInner<T>({props, selectRef: ref, collection}: SelectInnerProps<T>
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [
           ButtonContext,
-          {...triggerProps, ref: buttonRef, isPressed: state.isOpen, autoFocus: props.autoFocus}
+          {...triggerProps, ref: buttonRef, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen, autoFocus: props.autoFocus}
         ],
         [OverlayTriggerStateContext, state],
         [

--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -129,6 +129,7 @@ export interface SelectProps<T, M extends SelectionMode = 'single'>
   placeholder?: string;
   /**
    * Whether the trigger button appears pressed (e.g. `data-pressed`) while the select is open.
+   *
    * @default true
    */
   isPressedWhenOpen?: boolean;
@@ -253,7 +254,12 @@ function SelectInner<T>({props, selectRef: ref, collection}: SelectInnerProps<T>
         [LabelContext, {...labelProps, ref: labelRef, elementType: 'span'}],
         [
           ButtonContext,
-          {...triggerProps, ref: buttonRef, isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen, autoFocus: props.autoFocus}
+          {
+            ...triggerProps,
+            ref: buttonRef,
+            isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen,
+            autoFocus: props.autoFocus
+          }
         ],
         [OverlayTriggerStateContext, state],
         [

--- a/packages/react-aria-components/test/ComboBox.test.js
+++ b/packages/react-aria-components/test/ComboBox.test.js
@@ -131,6 +131,15 @@ describe('ComboBox', () => {
     expect(button).toHaveAttribute('data-pressed');
   });
 
+  it('should not apply isPressed state to button when expanded with isPressedWhenOpen={false}', async () => {
+    let {getByRole} = render(<TestComboBox isPressedWhenOpen={false} />);
+    let button = getByRole('button');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).not.toHaveAttribute('data-pressed');
+  });
+
   it('should support filtering sections', async () => {
     let tree = render(
       <ComboBox>

--- a/packages/react-aria-components/test/DatePicker.test.js
+++ b/packages/react-aria-components/test/DatePicker.test.js
@@ -127,6 +127,15 @@ describe('DatePicker', () => {
     expect(button).toHaveAttribute('data-pressed');
   });
 
+  it('should not apply isPressed state to button when expanded with isPressedWhenOpen={false}', async () => {
+    let {getByRole} = render(<TestDatePicker isPressedWhenOpen={false} />);
+    let button = getByRole('button');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).not.toHaveAttribute('data-pressed');
+  });
+
   it('should support data-open state', async () => {
     let {getByRole} = render(<TestDatePicker />);
     let datePicker = document.querySelector('.react-aria-DatePicker');

--- a/packages/react-aria-components/test/DateRangePicker.test.js
+++ b/packages/react-aria-components/test/DateRangePicker.test.js
@@ -134,6 +134,15 @@ describe('DateRangePicker', () => {
     expect(button).toHaveAttribute('data-pressed');
   });
 
+  it('should not apply isPressed state to button when expanded with isPressedWhenOpen={false}', async () => {
+    let {getByRole} = render(<TestDateRangePicker isPressedWhenOpen={false} />);
+    let button = getByRole('button');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).not.toHaveAttribute('data-pressed');
+  });
+
   it('should support data-open state', async () => {
     let {getByRole} = render(<TestDateRangePicker />);
     let datePicker = document.querySelector('.react-aria-DateRangePicker');

--- a/packages/react-aria-components/test/Dialog.test.js
+++ b/packages/react-aria-components/test/Dialog.test.js
@@ -226,6 +226,26 @@ describe('Dialog', () => {
     expect(dialog).not.toBeInTheDocument();
   });
 
+  it('should not mark the trigger as pressed while open with isPressedWhenOpen={false}', async () => {
+    let {getByRole} = render(
+      <DialogTrigger isPressedWhenOpen={false}>
+        <Button aria-label="Help">?⃝</Button>
+        <Modal>
+          <Dialog>
+            <Heading slot="title">Help</Heading>
+            <p>For help accessing your account, please contact support.</p>
+          </Dialog>
+        </Modal>
+      </DialogTrigger>
+    );
+
+    let button = getByRole('button');
+    let dialogTester = testUtilUser.createTester('Dialog', {root: button, overlayType: 'modal'});
+    await dialogTester.open();
+    expect(dialogTester.getDialog()).toBeInTheDocument();
+    expect(button).not.toHaveAttribute('data-pressed');
+  });
+
   it('should get default aria label from trigger', async () => {
     let {getByRole} = render(
       <DialogTrigger>

--- a/packages/react-aria-components/test/Menu.test.tsx
+++ b/packages/react-aria-components/test/Menu.test.tsx
@@ -646,6 +646,25 @@ describe('Menu', () => {
     expect(onAction).toHaveBeenLastCalledWith('rename', undefined);
   });
 
+  it('should not mark the trigger as pressed while open with isPressedWhenOpen={false}', async () => {
+    let {getByRole} = render(
+      <MenuTrigger isPressedWhenOpen={false}>
+        <Button aria-label="Menu">☰</Button>
+        <Popover>
+          <Menu>
+            <MenuItem id="open">Open</MenuItem>
+            <MenuItem id="rename">Rename…</MenuItem>
+          </Menu>
+        </Popover>
+      </MenuTrigger>
+    );
+
+    let button = getByRole('button');
+    await user.click(button);
+    expect(getByRole('menu')).toBeInTheDocument();
+    expect(button).not.toHaveAttribute('data-pressed');
+  });
+
   it('should support onScroll', () => {
     let onScroll = jest.fn();
     let {getByRole} = renderMenu({onScroll});

--- a/packages/react-aria-components/test/Select.test.js
+++ b/packages/react-aria-components/test/Select.test.js
@@ -49,6 +49,16 @@ describe('Select', () => {
     user = userEvent.setup({delay: null, pointerMap});
   });
 
+  it('should not mark the trigger as pressed while open with isPressedWhenOpen={false}', async () => {
+    let {getByTestId} = render(<TestSelect isPressedWhenOpen={false} />);
+    let selectTester = testUtilUser.createTester('Select', {root: getByTestId('select')});
+    let trigger = selectTester.getTrigger();
+
+    await selectTester.open();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).not.toHaveAttribute('data-pressed');
+  });
+
   it('provides slots', async () => {
     let {getByTestId} = render(<TestSelect />);
     let wrapper = getByTestId('select');


### PR DESCRIPTION
closes #8339

## summary

adds an `isPressedWhenOpen` prop (default `true`) to the react-aria-components trigger components that currently force `isPressed` on the trigger button while their overlay is open: `DialogTrigger`, `MenuTrigger`, `Select`, `ComboBox`, `DatePicker`, and `DateRangePicker`.

passing `isPressedWhenOpen={false}` keeps the trigger's press state tied to actual presses, so `data-pressed` clears on release instead of persisting for as long as the overlay is open. this is the prop suggested in https://github.com/adobe/react-spectrum/issues/8339#issuecomment-2937553074 (name taken from the list there; happy to rename if the team prefers another option). the default is unchanged, so existing consumers and the s2 `DialogTrigger` workaround keep working as before.

## implementation

each of the six components passes `isPressed: state.isOpen` to either a `PressResponder` or `ButtonContext`. the change gates that value: `isPressed: (props.isPressedWhenOpen ?? true) && state.isOpen`. the prop is documented with jsdoc on each props interface so it lands in the generated prop tables.

a follow-up could migrate the s2 `DialogTrigger` workaround (`<PressResponder isPressed={false}>`) to this prop; left out of this pr to keep it scoped to the rac api.

## tests

one test per component: open the overlay via the existing test-util or click pattern, assert the overlay is open (`aria-expanded` or the dialog/menu is in the document), and assert `data-pressed` is absent. all six fail without the implementation. existing tests covering the default pressed-while-open behavior are untouched and still pass (228 tests across the six files).
