### PR TITLE
chore: fix weekly TSDiffer when running against baseline that has a version mismatch against latest commit

### DIFF
--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -148,7 +148,7 @@ jobs:
             raise SystemExit(f"Missing required environment variables: {', '.join(missing)}")
 
           today = os.environ['TODAY']
-          channel = os.environ['SLACK_CHANNEL_ID']
+          channel = os.environ['TEST_SLACK_ID']
           snapshots_repo = os.environ['SNAPSHOTS_REPO']
           slack_token = os.environ['SLACK_TSDIFF_CHROMATIC_BOT_TOKEN']
           github_token = os.environ['GITHUB_TOKEN']

--- a/.github/workflows/weekly-api-diff.yml
+++ b/.github/workflows/weekly-api-diff.yml
@@ -148,7 +148,7 @@ jobs:
             raise SystemExit(f"Missing required environment variables: {', '.join(missing)}")
 
           today = os.environ['TODAY']
-          channel = os.environ['TEST_SLACK_ID']
+          channel = os.environ['SLACK_CHANNEL_ID']
           snapshots_repo = os.environ['SNAPSHOTS_REPO']
           slack_token = os.environ['SLACK_TSDIFF_CHROMATIC_BOT_TOKEN']
           github_token = os.environ['GITHUB_TOKEN']

--- a/scripts/buildBranchAPI.js
+++ b/scripts/buildBranchAPI.js
@@ -180,6 +180,34 @@ async function build() {
       .filter(Boolean)
   );
 
+  // similar to above, dev/* packages may contain pinned dependency versions (e.g. codemods pins to specific S2 versions)
+  // problem that arises is if we do a patch release since our weekly tsdiffer looks for the last MINOR instead
+  // this causes a miss match in the versions since the dev/* package gets copied over and might still have the updated S2 patch
+  // version whereas the workspace (aka the last minor baseline we checked out) has the last S2 minor version
+  // handle this by deleting the pinned versions so we resolve to the workspace's version
+  let devPackageJsons = glob.sync('dev/**/package.json', {
+    cwd: path.join(dir, 'packages'),
+    ignore: ['**/node_modules/**']
+  });
+  for (let p of devPackageJsons) {
+    let fullPath = path.join(dir, 'packages', p);
+    let json = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+    let changed = false;
+    for (let depField of ['dependencies', 'devDependencies']) {
+      if (json[depField]) {
+        for (let dep of Object.keys(json[depField])) {
+          if (workspacePackageNames.has(dep)) {
+            delete json[depField][dep];
+            changed = true;
+          }
+        }
+      }
+    }
+    if (changed) {
+      fs.writeFileSync(fullPath, JSON.stringify(json, false, 2));
+    }
+  }
+
   let excludeList = ['@react-spectrum/story-utils'];
   // Copy packages over to temp dir
   console.log('copying over');


### PR DESCRIPTION
tsdiffer job fails right now since the detected baseline (aka last minor release) doesn't match what is on main (aka patch release version) since we deliberately only look for minor versions to compare against. We do only want to only compare against last minor release so this fixes buildBranchAPI to handle cases like this

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

RSP
