### PR TITLE
fix: use hook filters in optimize-locales-plugin

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.js
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.js
@@ -12,6 +12,10 @@
 const {createUnplugin} = require('unplugin');
 const path = require('path');
 
+const localeSpecifierRegex = /[a-z]{2}-[A-Z]{2}/;
+const sourcePathRegex =
+  /[/\\](@react-stately|@react-aria|@react-spectrum|@adobe[/\\]react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/;
+
 module.exports = createUnplugin(({locales}) => {
   locales = locales.map(l => new Intl.Locale(l));
   return {
@@ -19,25 +23,25 @@ module.exports = createUnplugin(({locales}) => {
     vite: {
       enforce: 'pre'
     },
-    resolveId(specifier, sourcePath, options) {
-      if (
-        !/[/\\](@react-stately|@react-aria|@react-spectrum|@adobe[/\\]react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/.test(
-          sourcePath
-        ) ||
-        options?.ssr
-      ) {
-        return;
-      }
-
-      let match = specifier.match(/[a-z]{2}-[A-Z]{2}/);
-      if (match) {
-        let locale = new Intl.Locale(match[0]);
-        if (!locales.some(l => localeMatches(locale, l))) {
-          return path.join(__dirname, 'empty.js');
+    resolveId: {
+      filter: {
+        id: localeSpecifierRegex
+      },
+      handler(specifier, sourcePath, options) {
+        if (!sourcePathRegex.test(sourcePath) || options?.ssr) {
+          return;
         }
-      }
 
-      return null;
+        let match = specifier.match(localeSpecifierRegex);
+        if (match) {
+          let locale = new Intl.Locale(match[0]);
+          if (!locales.some(l => localeMatches(locale, l))) {
+            return path.join(__dirname, 'empty.js');
+          }
+        }
+
+        return null;
+      }
     }
   };
 });

--- a/packages/dev/optimize-locales-plugin/test/LocalesPlugin.test.js
+++ b/packages/dev/optimize-locales-plugin/test/LocalesPlugin.test.js
@@ -22,7 +22,18 @@ function fakeImporter(pkgName) {
   return `/repo/node_modules/${pkgName}/dist/intlStrings.mjs`;
 }
 
+function resolveId(plugin, ...args) {
+  return plugin.resolveId.handler(...args);
+}
+
 describe('@react-aria/optimize-locales-plugin', () => {
+  test('resolveId filters locale-looking specifiers', () => {
+    const plugin = createPlugin(['en-US']);
+
+    expect(plugin.resolveId.filter.id.test('./fr-FR.json')).toBe(true);
+    expect(plugin.resolveId.filter.id.test('./helpers')).toBe(false);
+  });
+
   describe('resolveId redirects non-included locales to empty.js for', () => {
     const cases = [
       ['@react-stately/combobox', fakeImporter('@react-stately/combobox')],
@@ -36,7 +47,7 @@ describe('@react-aria/optimize-locales-plugin', () => {
 
     test.each(cases)('importer under %s', (_label, sourcePath) => {
       const plugin = createPlugin(['en-US']);
-      const resolved = plugin.resolveId('./fr-FR.json', sourcePath, {});
+      const resolved = resolveId(plugin, './fr-FR.json', sourcePath, {});
       expect(resolved).toBe(EMPTY_JS);
     });
   });
@@ -44,32 +55,32 @@ describe('@react-aria/optimize-locales-plugin', () => {
   describe('resolveId leaves things alone when', () => {
     test('importer is outside React Spectrum / React Aria scopes', () => {
       const plugin = createPlugin(['en-US']);
-      const resolved = plugin.resolveId('./fr-FR.json', fakeImporter('some-other-pkg'), {});
+      const resolved = resolveId(plugin, './fr-FR.json', fakeImporter('some-other-pkg'), {});
       expect(resolved).toBeUndefined();
     });
 
     test('specifier targets an included locale', () => {
       const plugin = createPlugin(['en-US', 'fr-FR']);
-      const resolved = plugin.resolveId('./fr-FR.json', fakeImporter('@adobe/react-spectrum'), {});
+      const resolved = resolveId(plugin, './fr-FR.json', fakeImporter('@adobe/react-spectrum'), {});
       expect(resolved).toBeNull();
     });
 
     test('specifier targets a regional locale whose language is included without a region', () => {
       // Including a bare language ("fr") should keep every regional variant.
       const plugin = createPlugin(['en-US', 'fr']);
-      const resolved = plugin.resolveId('./fr-CA.json', fakeImporter('@react-aria/button'), {});
+      const resolved = resolveId(plugin, './fr-CA.json', fakeImporter('@react-aria/button'), {});
       expect(resolved).toBeNull();
     });
 
     test('specifier does not look like a locale', () => {
       const plugin = createPlugin(['en-US']);
-      const resolved = plugin.resolveId('./helpers', fakeImporter('@adobe/react-spectrum'), {});
+      const resolved = resolveId(plugin, './helpers', fakeImporter('@adobe/react-spectrum'), {});
       expect(resolved).toBeNull();
     });
 
     test('options.ssr is true', () => {
       const plugin = createPlugin(['en-US']);
-      const resolved = plugin.resolveId('./fr-FR.json', fakeImporter('@adobe/react-spectrum'), {
+      const resolved = resolveId(plugin, './fr-FR.json', fakeImporter('@adobe/react-spectrum'), {
         ssr: true
       });
       expect(resolved).toBeUndefined();
@@ -79,7 +90,7 @@ describe('@react-aria/optimize-locales-plugin', () => {
   test('handles Windows-style importer paths', () => {
     const plugin = createPlugin(['en-US']);
     const windowsImporter = 'C:\\repo\\node_modules\\@adobe\\react-spectrum\\dist\\intlStrings.mjs';
-    const resolved = plugin.resolveId('./fr-FR.json', windowsImporter, {});
+    const resolved = resolveId(plugin, './fr-FR.json', windowsImporter, {});
     expect(resolved).toBe(EMPTY_JS);
   });
 });


### PR DESCRIPTION
Closes #10301

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Monkey patch any project using optimize-locales-plugin with the same patch. Observe:

Before:
```
Benchmark 1: yarn build
  Time (mean ± σ):      2.251 s ±  0.041 s    [User: 3.505 s, System: 0.859 s]
  Range (min … max):    2.201 s …  2.315 s    5 runs
```

After:
```
Benchmark 1: yarn build
  Time (mean ± σ):      2.198 s ±  0.041 s    [User: 3.328 s, System: 0.819 s]
  Range (min … max):    2.160 s …  2.267 s    5 runs
```

This was originally spotted thanks to Rolldown perfshaming us:

```
[PLUGIN_TIMINGS] Your build spent significant time in plugins. Here is a breakdown:
  - locales-plugin (76%)
  - vite:handlebars (12%)
  - sentry-vite-plugin (6%)
See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
```

Also ran locally:

```
yarn format packages/dev/optimize-locales-plugin/LocalesPlugin.js
node -e "require('./packages/dev/optimize-locales-plugin/LocalesPlugin.js')"
```

Not exactly earth-shattering, but hey, less perfshaming.

## 🧢 Your Project:

<!--- Company/project for pull request -->
