### PR TITLE
fix: run optimize-locales-plugin early in Vite

### DIFF
--- a/packages/dev/optimize-locales-plugin/LocalesPlugin.js
+++ b/packages/dev/optimize-locales-plugin/LocalesPlugin.js
@@ -16,6 +16,9 @@ module.exports = createUnplugin(({locales}) => {
   locales = locales.map(l => new Intl.Locale(l));
   return {
     name: 'locales-plugin',
+    vite: {
+      enforce: 'pre'
+    },
     resolveId(specifier, sourcePath, options) {
       if (
         !/[/\\](@react-stately|@react-aria|@react-spectrum|@adobe[/\\]react-spectrum|react-stately|react-aria|react-aria-components)[/\\]/.test(


### PR DESCRIPTION
Closes #10303

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Checked the generated Vite plugin shape locally:

```sh
node - <<'NODE'
const optimizeLocales = require('./packages/dev/optimize-locales-plugin/LocalesPlugin.js');
const plugin = optimizeLocales.vite({locales: ['en-US', 'pl-PL']});
console.log({name: plugin.name, enforce: plugin.enforce, hasResolveId: typeof plugin.resolveId === 'function'});
NODE
```

Output:

```js
{ name: 'locales-plugin', enforce: 'pre', hasResolveId: true }
```

Also ran:

```sh
yarn format packages/dev/optimize-locales-plugin/LocalesPlugin.js
```

Measured in two Vite apps by comparing direct plugin usage against the same config forced into the pre phase.

Rewardo app:

| Config | Build time | JS/CSS bytes | JS/CSS gzip |
|---|---:|---:|---:|
| Direct plugin | 1.717 s ± 0.077 | 1,365,198 | 461,842 |
| `enforce: 'pre'` | 1.705 s ± 0.158 | 1,364,284 | 461,216 |

POS simulator:

| Config | Build time | JS/CSS bytes | JS/CSS gzip |
|---|---:|---:|---:|
| Direct plugin | 650.5 ms ± 27.5 | 485,916 | 157,159 |
| `enforce: 'pre'` | 660.0 ms ± 22.4 | 476,387 | 151,989 |

Build time is basically unchanged, but the pre phase keeps excluded React Aria locale strings out of the bundle.

## 🧢 Your Project:

<!--- Company/project for pull request -->
