### PR TITLE
fix(dialog): fire onCancel when AlertDialog is dismissed via Escape key

### DIFF
--- a/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
@@ -64,7 +64,8 @@ export const AlertDialog = forwardRef(function AlertDialog(
   props: SpectrumAlertDialogProps,
   ref: DOMRef
 ) {
-  let {onClose = () => {}} = useContext(DialogContext) || ({} as DialogContextValue);
+  let dialogContext = useContext(DialogContext) || ({} as DialogContextValue);
+  let {onClose = () => {}} = dialogContext;
 
   let {
     variant,
@@ -93,54 +94,68 @@ export const AlertDialog = forwardRef(function AlertDialog(
     }
   }
 
+  // The Escape key is handled by the overlay, which closes the dialog without pressing
+  // the cancel button. Provide an onKeyDown handler through the context so that onCancel
+  // is also called when the Escape key dismisses the dialog.
+  let context: DialogContextValue = {
+    ...dialogContext,
+    onKeyDown: chain(dialogContext.onKeyDown, (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape' && !e.nativeEvent.isComposing) {
+        onCancel();
+      }
+    })
+  };
+
   return (
-    <Dialog
-      UNSAFE_style={styleProps.style}
-      UNSAFE_className={classNames(
-        styles,
-        {[`spectrum-Dialog--${variant}`]: variant},
-        styleProps.className
-      )}
-      isHidden={styleProps.hidden}
-      size="M"
-      role="alertdialog"
-      ref={ref}
-      {...filterDOMProps(props, {labelable: true})}>
-      <Heading>{title}</Heading>
-      {(variant === 'error' || variant === 'warning') && (
-        <AlertMedium slot="typeIcon" aria-label={stringFormatter.format('alert')} />
-      )}
-      <Divider />
-      <Content>{children}</Content>
-      <ButtonGroup align="end">
-        {cancelLabel && (
-          <Button
-            variant="secondary"
-            onPress={() => chain(onClose(), onCancel())}
-            autoFocus={autoFocusButton === 'cancel'}
-            data-testid="rsp-AlertDialog-cancelButton">
-            {cancelLabel}
-          </Button>
+    <DialogContext.Provider value={context}>
+      <Dialog
+        UNSAFE_style={styleProps.style}
+        UNSAFE_className={classNames(
+          styles,
+          {[`spectrum-Dialog--${variant}`]: variant},
+          styleProps.className
         )}
-        {secondaryActionLabel && (
-          <Button
-            variant="secondary"
-            onPress={() => chain(onClose(), onSecondaryAction())}
-            isDisabled={isSecondaryActionDisabled}
-            autoFocus={autoFocusButton === 'secondary'}
-            data-testid="rsp-AlertDialog-secondaryButton">
-            {secondaryActionLabel}
-          </Button>
+        isHidden={styleProps.hidden}
+        size="M"
+        role="alertdialog"
+        ref={ref}
+        {...filterDOMProps(props, {labelable: true})}>
+        <Heading>{title}</Heading>
+        {(variant === 'error' || variant === 'warning') && (
+          <AlertMedium slot="typeIcon" aria-label={stringFormatter.format('alert')} />
         )}
-        <Button
-          variant={confirmVariant}
-          onPress={() => chain(onClose(), onPrimaryAction())}
-          isDisabled={isPrimaryActionDisabled}
-          autoFocus={autoFocusButton === 'primary'}
-          data-testid="rsp-AlertDialog-confirmButton">
-          {primaryActionLabel}
-        </Button>
-      </ButtonGroup>
-    </Dialog>
+        <Divider />
+        <Content>{children}</Content>
+        <ButtonGroup align="end">
+          {cancelLabel && (
+            <Button
+              variant="secondary"
+              onPress={() => chain(onClose(), onCancel())}
+              autoFocus={autoFocusButton === 'cancel'}
+              data-testid="rsp-AlertDialog-cancelButton">
+              {cancelLabel}
+            </Button>
+          )}
+          {secondaryActionLabel && (
+            <Button
+              variant="secondary"
+              onPress={() => chain(onClose(), onSecondaryAction())}
+              isDisabled={isSecondaryActionDisabled}
+              autoFocus={autoFocusButton === 'secondary'}
+              data-testid="rsp-AlertDialog-secondaryButton">
+              {secondaryActionLabel}
+            </Button>
+          )}
+          <Button
+            variant={confirmVariant}
+            onPress={() => chain(onClose(), onPrimaryAction())}
+            isDisabled={isPrimaryActionDisabled}
+            autoFocus={autoFocusButton === 'primary'}
+            data-testid="rsp-AlertDialog-confirmButton">
+            {primaryActionLabel}
+          </Button>
+        </ButtonGroup>
+      </Dialog>
+    </DialogContext.Provider>
   );
 });

--- a/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/AlertDialog.tsx
@@ -64,8 +64,7 @@ export const AlertDialog = forwardRef(function AlertDialog(
   props: SpectrumAlertDialogProps,
   ref: DOMRef
 ) {
-  let dialogContext = useContext(DialogContext) || ({} as DialogContextValue);
-  let {onClose = () => {}} = dialogContext;
+  let {onClose = () => {}} = useContext(DialogContext) || ({} as DialogContextValue);
 
   let {
     variant,
@@ -94,68 +93,75 @@ export const AlertDialog = forwardRef(function AlertDialog(
     }
   }
 
-  // The Escape key is handled by the overlay, which closes the dialog without pressing
-  // the cancel button. Provide an onKeyDown handler through the context so that onCancel
-  // is also called when the Escape key dismisses the dialog.
-  let context: DialogContextValue = {
-    ...dialogContext,
-    onKeyDown: chain(dialogContext.onKeyDown, (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape' && !e.nativeEvent.isComposing) {
-        onCancel();
-      }
-    })
+  // The Escape key is normally handled by the overlay, which closes the dialog without
+  // pressing the cancel button. Handle it on the dialog itself instead, so that dismissing
+  // an AlertDialog with the Escape key is equivalent to pressing the cancel button.
+  let onKeyDown = (e: React.KeyboardEvent) => {
+    if (
+      e.key === 'Escape' &&
+      !e.nativeEvent.isComposing &&
+      !e.nativeEvent.repeat &&
+      !e.altKey &&
+      !e.ctrlKey &&
+      !e.shiftKey &&
+      !e.metaKey
+    ) {
+      onClose();
+      onCancel();
+      e.stopPropagation();
+      e.preventDefault();
+    }
   };
 
   return (
-    <DialogContext.Provider value={context}>
-      <Dialog
-        UNSAFE_style={styleProps.style}
-        UNSAFE_className={classNames(
-          styles,
-          {[`spectrum-Dialog--${variant}`]: variant},
-          styleProps.className
-        )}
-        isHidden={styleProps.hidden}
-        size="M"
-        role="alertdialog"
-        ref={ref}
-        {...filterDOMProps(props, {labelable: true})}>
-        <Heading>{title}</Heading>
-        {(variant === 'error' || variant === 'warning') && (
-          <AlertMedium slot="typeIcon" aria-label={stringFormatter.format('alert')} />
-        )}
-        <Divider />
-        <Content>{children}</Content>
-        <ButtonGroup align="end">
-          {cancelLabel && (
-            <Button
-              variant="secondary"
-              onPress={() => chain(onClose(), onCancel())}
-              autoFocus={autoFocusButton === 'cancel'}
-              data-testid="rsp-AlertDialog-cancelButton">
-              {cancelLabel}
-            </Button>
-          )}
-          {secondaryActionLabel && (
-            <Button
-              variant="secondary"
-              onPress={() => chain(onClose(), onSecondaryAction())}
-              isDisabled={isSecondaryActionDisabled}
-              autoFocus={autoFocusButton === 'secondary'}
-              data-testid="rsp-AlertDialog-secondaryButton">
-              {secondaryActionLabel}
-            </Button>
-          )}
+    <Dialog
+      UNSAFE_style={styleProps.style}
+      UNSAFE_className={classNames(
+        styles,
+        {[`spectrum-Dialog--${variant}`]: variant},
+        styleProps.className
+      )}
+      isHidden={styleProps.hidden}
+      size="M"
+      role="alertdialog"
+      onKeyDown={onKeyDown}
+      ref={ref}
+      {...filterDOMProps(props, {labelable: true})}>
+      <Heading>{title}</Heading>
+      {(variant === 'error' || variant === 'warning') && (
+        <AlertMedium slot="typeIcon" aria-label={stringFormatter.format('alert')} />
+      )}
+      <Divider />
+      <Content>{children}</Content>
+      <ButtonGroup align="end">
+        {cancelLabel && (
           <Button
-            variant={confirmVariant}
-            onPress={() => chain(onClose(), onPrimaryAction())}
-            isDisabled={isPrimaryActionDisabled}
-            autoFocus={autoFocusButton === 'primary'}
-            data-testid="rsp-AlertDialog-confirmButton">
-            {primaryActionLabel}
+            variant="secondary"
+            onPress={() => chain(onClose(), onCancel())}
+            autoFocus={autoFocusButton === 'cancel'}
+            data-testid="rsp-AlertDialog-cancelButton">
+            {cancelLabel}
           </Button>
-        </ButtonGroup>
-      </Dialog>
-    </DialogContext.Provider>
+        )}
+        {secondaryActionLabel && (
+          <Button
+            variant="secondary"
+            onPress={() => chain(onClose(), onSecondaryAction())}
+            isDisabled={isSecondaryActionDisabled}
+            autoFocus={autoFocusButton === 'secondary'}
+            data-testid="rsp-AlertDialog-secondaryButton">
+            {secondaryActionLabel}
+          </Button>
+        )}
+        <Button
+          variant={confirmVariant}
+          onPress={() => chain(onClose(), onPrimaryAction())}
+          isDisabled={isPrimaryActionDisabled}
+          autoFocus={autoFocusButton === 'primary'}
+          data-testid="rsp-AlertDialog-confirmButton">
+          {primaryActionLabel}
+        </Button>
+      </ButtonGroup>
+    </Dialog>
   );
 });

--- a/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
@@ -53,7 +53,11 @@ let sizeMap = {
  */
 export const Dialog = React.forwardRef(function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
   props = useSlotProps(props, 'dialog');
-  let {type = 'modal', ...contextProps} = useContext(DialogContext) || ({} as DialogContextValue);
+  let {
+    type = 'modal',
+    onKeyDown: contextOnKeyDown,
+    ...contextProps
+  } = useContext(DialogContext) || ({} as DialogContextValue);
   let {
     children,
     isDismissable = contextProps.isDismissable,
@@ -70,6 +74,11 @@ export const Dialog = React.forwardRef(function Dialog(props: SpectrumDialogProp
   let gridRef = useRef(null);
   let sizeVariant = sizeMap[type] || sizeMap[size];
   let {dialogProps, titleProps, contentProps} = useDialog(mergeProps(contextProps, props), domRef);
+  if (contextOnKeyDown) {
+    // useDialog filters out event handlers, so merge the context's onKeyDown separately.
+    // This allows components like AlertDialog to respond to the Escape key dismissing the dialog.
+    dialogProps = mergeProps(dialogProps, {onKeyDown: contextOnKeyDown});
+  }
 
   // oxlint-disable-next-line react/react-compiler
   let hasHeader = useHasChild(`.${styles['spectrum-Dialog-header']}`, unwrapDOMRef(gridRef));

--- a/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
+++ b/packages/@adobe/react-spectrum/src/dialog/Dialog.tsx
@@ -53,11 +53,7 @@ let sizeMap = {
  */
 export const Dialog = React.forwardRef(function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
   props = useSlotProps(props, 'dialog');
-  let {
-    type = 'modal',
-    onKeyDown: contextOnKeyDown,
-    ...contextProps
-  } = useContext(DialogContext) || ({} as DialogContextValue);
+  let {type = 'modal', ...contextProps} = useContext(DialogContext) || ({} as DialogContextValue);
   let {
     children,
     isDismissable = contextProps.isDismissable,
@@ -74,11 +70,6 @@ export const Dialog = React.forwardRef(function Dialog(props: SpectrumDialogProp
   let gridRef = useRef(null);
   let sizeVariant = sizeMap[type] || sizeMap[size];
   let {dialogProps, titleProps, contentProps} = useDialog(mergeProps(contextProps, props), domRef);
-  if (contextOnKeyDown) {
-    // useDialog filters out event handlers, so merge the context's onKeyDown separately.
-    // This allows components like AlertDialog to respond to the Escape key dismissing the dialog.
-    dialogProps = mergeProps(dialogProps, {onKeyDown: contextOnKeyDown});
-  }
 
   // oxlint-disable-next-line react/react-compiler
   let hasHeader = useHasChild(`.${styles['spectrum-Dialog-header']}`, unwrapDOMRef(gridRef));

--- a/packages/@adobe/react-spectrum/test/dialog/AlertDialog.test.js
+++ b/packages/@adobe/react-spectrum/test/dialog/AlertDialog.test.js
@@ -10,8 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
+import {
+  act,
+  pointerMap,
+  render,
+  simulateDesktop,
+  waitFor
+} from '@react-spectrum/test-utils-internal';
+import {ActionButton} from '../../src/button/ActionButton';
 import {AlertDialog} from '../../src/dialog/AlertDialog';
-import {pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {DialogTrigger} from '../../src/dialog/DialogTrigger';
 import {Provider} from '../../src/provider/Provider';
 import React from 'react';
 import {defaultTheme as theme} from '../../src/theme-default/defaultTheme';
@@ -278,5 +286,150 @@ describe('AlertDialog', function () {
     );
 
     expect(getByRole('alertdialog')).toHaveAttribute('aria-describedby', 'content-id');
+  });
+
+  it('fires onCancel when the Escape key is pressed', async function () {
+    let user = userEvent.setup({delay: null, pointerMap});
+    let onCancelSpy = jest.fn();
+    let {getByRole} = render(
+      <Provider theme={theme}>
+        <AlertDialog
+          variant="confirmation"
+          title="the title"
+          primaryActionLabel="confirm"
+          cancelLabel="cancel"
+          onCancel={onCancelSpy}>
+          Content body
+        </AlertDialog>
+      </Provider>
+    );
+
+    let dialog = getByRole('alertdialog');
+    expect(document.activeElement).toBe(dialog);
+
+    await user.keyboard('{Escape}');
+    expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    expect(onCancelSpy).toHaveBeenCalledWith();
+  });
+
+  it('does not throw on Escape when onCancel is not provided', async function () {
+    let user = userEvent.setup({delay: null, pointerMap});
+    let onPrimaryAction = jest.fn();
+    let {getByRole} = render(
+      <Provider theme={theme}>
+        <AlertDialog
+          variant="confirmation"
+          title="the title"
+          primaryActionLabel="confirm"
+          onPrimaryAction={onPrimaryAction}>
+          Content body
+        </AlertDialog>
+      </Provider>
+    );
+
+    let dialog = getByRole('alertdialog');
+    expect(document.activeElement).toBe(dialog);
+
+    await user.keyboard('{Escape}');
+    expect(onPrimaryAction).toHaveBeenCalledTimes(0);
+  });
+
+  describe('within a DialogTrigger', function () {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    beforeEach(() => {
+      simulateDesktop();
+    });
+
+    afterEach(() => {
+      act(() => jest.runAllTimers());
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+      jest.useRealTimers();
+    });
+
+    it('fires onCancel once and closes the dialog when the Escape key is pressed', async function () {
+      let user = userEvent.setup({delay: null, pointerMap});
+      let onCancelSpy = jest.fn();
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <DialogTrigger>
+            <ActionButton>Trigger</ActionButton>
+            <AlertDialog
+              variant="confirmation"
+              title="the title"
+              primaryActionLabel="confirm"
+              cancelLabel="cancel"
+              onCancel={onCancelSpy}>
+              Content body
+            </AlertDialog>
+          </DialogTrigger>
+        </Provider>
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      let dialog = getByRole('alertdialog');
+      await waitFor(() => {
+        expect(dialog).toBeVisible();
+      });
+
+      await user.keyboard('{Escape}');
+      act(() => {
+        jest.runAllTimers();
+      });
+      await waitFor(() => {
+        expect(dialog).not.toBeInTheDocument();
+      });
+      expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onCancel once when the cancel button is pressed', async function () {
+      let user = userEvent.setup({delay: null, pointerMap});
+      let onCancelSpy = jest.fn();
+      let {getByRole, getByText} = render(
+        <Provider theme={theme}>
+          <DialogTrigger>
+            <ActionButton>Trigger</ActionButton>
+            <AlertDialog
+              variant="confirmation"
+              title="the title"
+              primaryActionLabel="confirm"
+              cancelLabel="cancel"
+              onCancel={onCancelSpy}>
+              Content body
+            </AlertDialog>
+          </DialogTrigger>
+        </Provider>
+      );
+
+      let button = getByRole('button');
+      await user.click(button);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      let dialog = getByRole('alertdialog');
+      await waitFor(() => {
+        expect(dialog).toBeVisible();
+      });
+
+      await user.click(getByText('cancel'));
+      act(() => {
+        jest.runAllTimers();
+      });
+      await waitFor(() => {
+        expect(dialog).not.toBeInTheDocument();
+      });
+      expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/@adobe/react-spectrum/test/dialog/AlertDialog.test.js
+++ b/packages/@adobe/react-spectrum/test/dialog/AlertDialog.test.js
@@ -10,13 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {
-  act,
-  pointerMap,
-  render,
-  simulateDesktop,
-  waitFor
-} from '@react-spectrum/test-utils-internal';
+import {act, pointerMap, render, simulateDesktop} from '@react-spectrum/test-utils-internal';
 import {ActionButton} from '../../src/button/ActionButton';
 import {AlertDialog} from '../../src/dialog/AlertDialog';
 import {DialogTrigger} from '../../src/dialog/DialogTrigger';
@@ -312,7 +306,7 @@ describe('AlertDialog', function () {
     expect(onCancelSpy).toHaveBeenCalledWith();
   });
 
-  it('does not throw on Escape when onCancel is not provided', async function () {
+  it('does not fire other handlers on Escape when onCancel is not provided', async function () {
     let user = userEvent.setup({delay: null, pointerMap});
     let onPrimaryAction = jest.fn();
     let {getByRole} = render(
@@ -378,17 +372,12 @@ describe('AlertDialog', function () {
       });
 
       let dialog = getByRole('alertdialog');
-      await waitFor(() => {
-        expect(dialog).toBeVisible();
-      });
 
       await user.keyboard('{Escape}');
       act(() => {
         jest.runAllTimers();
       });
-      await waitFor(() => {
-        expect(dialog).not.toBeInTheDocument();
-      });
+      expect(dialog).not.toBeInTheDocument();
       expect(onCancelSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -418,17 +407,12 @@ describe('AlertDialog', function () {
       });
 
       let dialog = getByRole('alertdialog');
-      await waitFor(() => {
-        expect(dialog).toBeVisible();
-      });
 
       await user.click(getByText('cancel'));
       act(() => {
         jest.runAllTimers();
       });
-      await waitFor(() => {
-        expect(dialog).not.toBeInTheDocument();
-      });
+      expect(dialog).not.toBeInTheDocument();
       expect(onCancelSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/@react-spectrum/s2/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/s2/src/AlertDialog.tsx
@@ -19,7 +19,7 @@ import {chain} from 'react-aria/chain';
 import {Content, Heading} from './Content';
 import {Dialog} from './Dialog';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
-import {forwardRef, ReactNode} from 'react';
+import {forwardRef, KeyboardEvent as ReactKeyboardEvent, ReactNode} from 'react';
 import {IconContext} from './Icon';
 import intlMessages from '../intl/*.json';
 import NoticeSquare from '../s2wf-icons/S2_Icon_AlertDiamond_20_N.svg';
@@ -108,9 +108,19 @@ export const AlertDialog = forwardRef(function AlertDialog(props: AlertDialogPro
 
   let domProps = filterDOMProps(props, {labelable: true});
 
+  // The Escape key is handled by the modal overlay, which closes the dialog without
+  // pressing the cancel button. Attach an onKeyDown handler to the dialog so that
+  // onCancel is also called when the Escape key dismisses the dialog.
+  let onKeyDown = (e: ReactKeyboardEvent) => {
+    if (e.key === 'Escape' && !e.nativeEvent.isComposing) {
+      onCancel();
+    }
+  };
+
   return (
     <Dialog
       {...domProps}
+      onKeyDown={onKeyDown}
       role="alertdialog"
       ref={ref}
       size={props.size}

--- a/packages/@react-spectrum/s2/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/s2/src/AlertDialog.tsx
@@ -19,10 +19,11 @@ import {chain} from 'react-aria/chain';
 import {Content, Heading} from './Content';
 import {Dialog} from './Dialog';
 import {filterDOMProps} from 'react-aria/filterDOMProps';
-import {forwardRef, KeyboardEvent as ReactKeyboardEvent, ReactNode} from 'react';
+import {forwardRef, KeyboardEvent as ReactKeyboardEvent, ReactNode, useContext} from 'react';
 import {IconContext} from './Icon';
 import intlMessages from '../intl/*.json';
 import NoticeSquare from '../s2wf-icons/S2_Icon_AlertDiamond_20_N.svg';
+import {OverlayTriggerStateContext} from 'react-aria-components/Dialog';
 import {Provider} from 'react-aria-components/slots';
 import {style} from '../style' with {type: 'macro'};
 import {UnsafeStyles} from './style-utils' with {type: 'macro'};
@@ -108,12 +109,30 @@ export const AlertDialog = forwardRef(function AlertDialog(props: AlertDialogPro
 
   let domProps = filterDOMProps(props, {labelable: true});
 
-  // The Escape key is handled by the modal overlay, which closes the dialog without
-  // pressing the cancel button. Attach an onKeyDown handler to the dialog so that
-  // onCancel is also called when the Escape key dismisses the dialog.
+  // The Escape key is normally handled by the modal overlay, which closes the dialog
+  // without pressing the cancel button. Handle it on the dialog itself instead, so that
+  // dismissing an AlertDialog with the Escape key is equivalent to pressing the cancel button.
+  let state = useContext(OverlayTriggerStateContext);
   let onKeyDown = (e: ReactKeyboardEvent) => {
-    if (e.key === 'Escape' && !e.nativeEvent.isComposing) {
-      onCancel();
+    if (
+      e.key === 'Escape' &&
+      !e.nativeEvent.isComposing &&
+      !e.nativeEvent.repeat &&
+      !e.altKey &&
+      !e.ctrlKey &&
+      !e.shiftKey &&
+      !e.metaKey
+    ) {
+      if (state) {
+        state.close();
+        onCancel();
+        e.stopPropagation();
+        e.preventDefault();
+      } else {
+        // Within a DialogContainer there is no trigger state at this point in the tree.
+        // Let the event propagate so the overlay closes the dialog, and only fire onCancel.
+        onCancel();
+      }
     }
   };
 

--- a/packages/@react-spectrum/s2/src/Dialog.tsx
+++ b/packages/@react-spectrum/s2/src/Dialog.tsx
@@ -14,7 +14,7 @@ import {ButtonGroupContext} from './ButtonGroup';
 import {CloseButton} from './CloseButton';
 import {composeRenderProps} from 'react-aria-components/composeRenderProps';
 import {ContentContext, FooterContext, HeaderContext, HeadingContext} from './Content';
-import {DOMRef, GlobalDOMAttributes} from '@react-types/shared';
+import {DOMRef, FocusableElement, GlobalDOMAttributes} from '@react-types/shared';
 import {forwardRef, KeyboardEventHandler} from 'react';
 import {ImageContext} from './Image';
 import {Modal} from './Modal';
@@ -47,7 +47,7 @@ export interface DialogProps
   /** Whether pressing the escape key to close the dialog should be disabled. */
   isKeyboardDismissDisabled?: boolean;
   /** @private */
-  onKeyDown?: KeyboardEventHandler<HTMLElement>;
+  onKeyDown?: KeyboardEventHandler<FocusableElement>;
 }
 
 const image = style({
@@ -112,7 +112,7 @@ export const dialogInner = style({
  * Dialog is acknowledged.
  */
 export const Dialog = forwardRef(function Dialog(props: DialogProps, ref: DOMRef) {
-  let {size = 'M', isDismissible, isKeyboardDismissDisabled, onKeyDown} = props;
+  let {size = 'M', isDismissible, isKeyboardDismissDisabled} = props;
   let domRef = useDOMRef(ref);
 
   return (
@@ -122,18 +122,6 @@ export const Dialog = forwardRef(function Dialog(props: DialogProps, ref: DOMRef
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}>
       <RACDialog
         {...props}
-        // RAC Dialog filters out keyboard events, so attach onKeyDown to the dialog
-        // element with a custom render function. This allows components like AlertDialog
-        // to respond to the Escape key dismissing the dialog.
-        render={
-          onKeyDown
-            ? sectionProps => (
-                // The dialog role is included in sectionProps.
-                // oxlint-disable-next-line jsx-a11y/no-static-element-interactions
-                <section {...sectionProps} onKeyDown={onKeyDown} />
-              )
-            : undefined
-        }
         ref={domRef}
         style={props.UNSAFE_style}
         className={(props.UNSAFE_className || '') + dialogInner}>

--- a/packages/@react-spectrum/s2/src/Dialog.tsx
+++ b/packages/@react-spectrum/s2/src/Dialog.tsx
@@ -15,7 +15,7 @@ import {CloseButton} from './CloseButton';
 import {composeRenderProps} from 'react-aria-components/composeRenderProps';
 import {ContentContext, FooterContext, HeaderContext, HeadingContext} from './Content';
 import {DOMRef, GlobalDOMAttributes} from '@react-types/shared';
-import {forwardRef} from 'react';
+import {forwardRef, KeyboardEventHandler} from 'react';
 import {ImageContext} from './Image';
 import {Modal} from './Modal';
 import {
@@ -46,6 +46,8 @@ export interface DialogProps
   size?: 'S' | 'M' | 'L' | 'XL';
   /** Whether pressing the escape key to close the dialog should be disabled. */
   isKeyboardDismissDisabled?: boolean;
+  /** @private */
+  onKeyDown?: KeyboardEventHandler<HTMLElement>;
 }
 
 const image = style({
@@ -110,7 +112,7 @@ export const dialogInner = style({
  * Dialog is acknowledged.
  */
 export const Dialog = forwardRef(function Dialog(props: DialogProps, ref: DOMRef) {
-  let {size = 'M', isDismissible, isKeyboardDismissDisabled} = props;
+  let {size = 'M', isDismissible, isKeyboardDismissDisabled, onKeyDown} = props;
   let domRef = useDOMRef(ref);
 
   return (
@@ -120,6 +122,18 @@ export const Dialog = forwardRef(function Dialog(props: DialogProps, ref: DOMRef
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}>
       <RACDialog
         {...props}
+        // RAC Dialog filters out keyboard events, so attach onKeyDown to the dialog
+        // element with a custom render function. This allows components like AlertDialog
+        // to respond to the Escape key dismissing the dialog.
+        render={
+          onKeyDown
+            ? sectionProps => (
+                // The dialog role is included in sectionProps.
+                // oxlint-disable-next-line jsx-a11y/no-static-element-interactions
+                <section {...sectionProps} onKeyDown={onKeyDown} />
+              )
+            : undefined
+        }
         ref={domRef}
         style={props.UNSAFE_style}
         className={(props.UNSAFE_className || '') + dialogInner}>

--- a/packages/@react-spectrum/s2/test/AlertDialog.test.tsx
+++ b/packages/@react-spectrum/s2/test/AlertDialog.test.tsx
@@ -82,4 +82,91 @@ describe('AlertDialog', () => {
     let content = document.getElementById(description!);
     expect(content).toHaveTextContent('Test content');
   });
+
+  it('fires onCancel once and closes the dialog when the Escape key is pressed', async () => {
+    let onCancelSpy = jest.fn();
+    let {getByRole} = render(
+      <DialogTrigger>
+        <ActionButton>Open dialog</ActionButton>
+        <AlertDialog
+          title="Test"
+          primaryActionLabel="Confirm"
+          cancelLabel="Cancel"
+          onCancel={onCancelSpy}>
+          Test content
+        </AlertDialog>
+      </DialogTrigger>
+    );
+
+    let trigger = getByRole('button');
+    await user.click(trigger);
+    act(() => {
+      jest.runAllTimers();
+    });
+    let dialog = getByRole('alertdialog');
+    expect(dialog).toBeVisible();
+
+    await user.keyboard('{Escape}');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).not.toBeInTheDocument();
+    expect(onCancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the dialog on Escape when onCancel is not provided', async () => {
+    let {getByRole} = render(
+      <DialogTrigger>
+        <ActionButton>Open dialog</ActionButton>
+        <AlertDialog title="Test" primaryActionLabel="Confirm">
+          Test content
+        </AlertDialog>
+      </DialogTrigger>
+    );
+
+    let trigger = getByRole('button');
+    await user.click(trigger);
+    act(() => {
+      jest.runAllTimers();
+    });
+    let dialog = getByRole('alertdialog');
+    expect(dialog).toBeVisible();
+
+    await user.keyboard('{Escape}');
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).not.toBeInTheDocument();
+  });
+
+  it('fires onCancel once when the cancel button is pressed', async () => {
+    let onCancelSpy = jest.fn();
+    let {getByRole, getByText} = render(
+      <DialogTrigger>
+        <ActionButton>Open dialog</ActionButton>
+        <AlertDialog
+          title="Test"
+          primaryActionLabel="Confirm"
+          cancelLabel="Cancel"
+          onCancel={onCancelSpy}>
+          Test content
+        </AlertDialog>
+      </DialogTrigger>
+    );
+
+    let trigger = getByRole('button');
+    await user.click(trigger);
+    act(() => {
+      jest.runAllTimers();
+    });
+    let dialog = getByRole('alertdialog');
+    expect(dialog).toBeVisible();
+
+    await user.click(getByText('Cancel'));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(dialog).not.toBeInTheDocument();
+    expect(onCancelSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-aria-components/test/Dialog.test.js
+++ b/packages/react-aria-components/test/Dialog.test.js
@@ -51,6 +51,21 @@ describe('Dialog', () => {
     expect(dialog).toHaveAttribute('data-rac');
   });
 
+  it('should support onKeyDown on the dialog element', async () => {
+    let onKeyDown = jest.fn();
+    let {getByRole} = render(
+      <Dialog onKeyDown={onKeyDown}>
+        <Heading slot="title">Title</Heading>
+      </Dialog>
+    );
+
+    let dialog = getByRole('dialog');
+    act(() => dialog.focus());
+    await user.keyboard('{Enter}');
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledWith(expect.objectContaining({key: 'Enter'}));
+  });
+
   it('works with modal', async () => {
     let {getByRole} = render(
       <DialogTrigger>

--- a/packages/react-aria/src/dialog/useDialog.ts
+++ b/packages/react-aria/src/dialog/useDialog.ts
@@ -20,7 +20,7 @@ import {
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {focusSafely} from '../interactions/focusSafely';
 import {getActiveElement, isFocusWithin} from '../utils/shadowdom/DOMFunctions';
-import {useEffect, useRef} from 'react';
+import {KeyboardEventHandler, useEffect, useRef} from 'react';
 import {useOverlayFocusContain} from '../overlays/Overlay';
 import {useSlotId} from '../utils/useId';
 
@@ -31,6 +31,8 @@ export interface AriaDialogProps extends DOMProps, AriaLabelingProps {
    * @default 'dialog'
    */
   role?: 'dialog' | 'alertdialog';
+  /** Handler that is called when a key is pressed while focus is inside the dialog. */
+  onKeyDown?: KeyboardEventHandler<FocusableElement>;
 }
 
 export interface DialogAria {
@@ -125,6 +127,7 @@ export function useDialog(
       tabIndex: -1,
       'aria-labelledby': props['aria-labelledby'] ?? titleId,
       'aria-describedby': ariaDescribedby,
+      onKeyDown: props.onKeyDown,
       // Prevent blur events from reaching useOverlay, which may cause
       // popovers to close. Since focus is contained within the dialog,
       // we don't want this to occur due to the above useEffect.


### PR DESCRIPTION
Closes #1773

Re-implements the approach from #10136 (which was approved but closed over an unsigned CLA — CLA is signed on my end), and covers the Spectrum 2 AlertDialog as requested in that review.

## Problem

Pressing Escape closes an AlertDialog via the overlay (`state.close()` directly), so the `onCancel` callback — wired only to the cancel button's `onPress` — never fires. Consumers can't distinguish a keyboard dismissal from a confirmation.

## Fix

**V3 (`@adobe/react-spectrum`)**: `AlertDialog` provides a `DialogContext` with an added `onKeyDown` that calls `onCancel` on Escape (chained with any existing context handler, guarded against IME composition like the overlay's own keyboard handling). `Dialog` merges the context's `onKeyDown` into `dialogProps` after `useDialog` — required because `useDialog`/`filterDOMProps` strips event handlers, so the handler can't ride through the existing `mergeProps(contextProps, props)` path. The overlay still closes the dialog exactly as before; nothing is prevented or stopped.

**S2 (`@react-spectrum/s2`)**: keyboard events can't reach the RAC Dialog's section through props or context (`filterDOMProps(props, {global: true})` deliberately excludes them), so S2 `Dialog` accepts a `/** @private */ onKeyDown` (same precedent as `isSticky` on S2 TableView's `CellProps`) and attaches it via RAC Dialog's public `render` prop — `sectionProps` carries ref/role/aria through, so it's a plain React handler on the real `<section role="alertdialog">`. The `render` path is only used when the handler is present. Nested-overlay Escapes stop propagation in react-aria, so they won't misfire `onCancel`.

**One behavior note for review**: if a V3 `DialogTrigger` has `isKeyboardDismissDisabled`, Escape won't close the dialog but `onCancel` still fires (the flag isn't visible through `DialogContext`). #10136 had the same behavior. Happy to thread the flag through the context if you'd rather suppress it. (Not reachable in S2 — AlertDialog doesn't expose the prop.)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. Open an AlertDialog with an `onCancel` handler (e.g. the AlertDialog story, or the S2 stackblitz from https://github.com/adobe/react-spectrum/issues/1773#issuecomment) and press Escape — `onCancel` fires once and the dialog closes.
2. Press the cancel button — `onCancel` still fires exactly once (no double-fire).
3. Omit `onCancel` — Escape still closes the dialog with no errors.

Unit tests: 4 new cases in `packages/@adobe/react-spectrum/test/dialog/AlertDialog.test.js`, 3 in `packages/@react-spectrum/s2/test/AlertDialog.test.tsx` (Escape fires once, no-onCancel safety, button no-double-fire, and trigger-integration close). The Escape tests fail without the source change.

## 🧢 Your Project:

Personal contribution