### PR TITLE
fix(react-aria): detect screen reader pointer events as virtual modality

### DIFF
--- a/packages/react-aria/src/interactions/useFocusVisible.ts
+++ b/packages/react-aria/src/interactions/useFocusVisible.ts
@@ -20,7 +20,7 @@ import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions'
 import {getOwnerDocument, getOwnerWindow} from '../utils/domHelpers';
 import {ignoreFocusEvent} from './utils';
 import {isMac} from '../utils/platform';
-import {isVirtualClick} from '../utils/isVirtualEvent';
+import {isVirtualClick, isVirtualPointerEvent} from '../utils/isVirtualEvent';
 import {openLink} from '../utils/openLink';
 import {PointerType} from '@react-types/shared';
 import {useEffect, useState} from 'react';
@@ -93,11 +93,21 @@ function handleKeyboardEvent(e: KeyboardEvent) {
 }
 
 function handlePointerEvent(e: PointerEvent | MouseEvent) {
-  currentModality = 'pointer';
-  currentPointerType = 'pointerType' in e ? (e.pointerType as PointerType) : 'mouse';
+  // JAWS and NVDA on Chromium synthesize a pointer event with pointerType 'mouse' rather than
+  // the empty string other screen readers use, so it is only distinguishable from a real mouse
+  // by its zero contact geometry. This is the same signal usePress relies on. The pointerType
+  // check keeps the mousedown fallback path, which has no width or height, out of this branch.
+  if ('pointerType' in e && isVirtualPointerEvent(e)) {
+    currentModality = 'virtual';
+    currentPointerType = 'virtual';
+  } else {
+    currentModality = 'pointer';
+    currentPointerType = 'pointerType' in e ? (e.pointerType as PointerType) : 'mouse';
+  }
+
   if (e.type === 'mousedown' || e.type === 'pointerdown') {
     hasEventBeforeFocus = true;
-    triggerChangeHandlers('pointer', e);
+    triggerChangeHandlers(currentModality, e);
   }
 }
 

--- a/packages/react-aria/test/interactions/useFocusVisible.test.js
+++ b/packages/react-aria/test/interactions/useFocusVisible.test.js
@@ -20,15 +20,24 @@ import {
 } from '@react-spectrum/test-utils-internal';
 import {
   addWindowFocusTracking,
+  getInteractionModality,
+  setInteractionModality,
   useFocusVisible,
-  useFocusVisibleListener
+  useFocusVisibleListener,
+  useInteractionModality
 } from '../../src/interactions/useFocusVisible';
 import {changeHandlers, hasSetupGlobalListeners} from '../../src/interactions/useFocusVisible';
 import {mergeProps} from '../../src/utils/mergeProps';
+import * as platform from '../../src/utils/platform';
 import React from 'react';
 import {useButton} from '../../src/button/useButton';
 import {useFocusRing} from '../../src/focus/useFocusRing';
 import userEvent from '@testing-library/user-event';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  isAndroid: jest.fn(() => false)
+}));
 
 function Example(props) {
   const {isFocusVisible} = useFocusVisible();
@@ -511,5 +520,155 @@ describe('useFocusVisibleListener', function () {
       changeHandlers.add = originalAdd;
       changeHandlers.delete = originalDelete;
     });
+  });
+});
+
+// Screen readers synthesize pointer events with zero contact geometry. Build the events
+// by hand rather than via the FakePointerEvent shim so width/height/pressure read back
+// exactly as written (the shim has no pressure getter, and returns undefined when unset).
+function pointerEvent(type, opts) {
+  let evt = new Event(type, {bubbles: true, cancelable: true, composed: true});
+  Object.assign(evt, {button: 0, width: 1, height: 1}, opts);
+  return evt;
+}
+
+describe('useInteractionModality with virtual (screen reader) pointer events', function () {
+  let cleanup;
+
+  beforeAll(() => {
+    // The module registered the mousedown fallback listeners at import time, since jsdom has
+    // no PointerEvent. Remove them while PointerEvent is still undefined, then define it and
+    // re-register so the real pointerdown/pointermove/pointerup listeners are attached.
+    addWindowFocusTracking()();
+    global.PointerEvent = class FakePointerEvent extends MouseEvent {};
+    cleanup = addWindowFocusTracking();
+  });
+
+  afterAll(() => {
+    cleanup();
+    delete global.PointerEvent;
+    addWindowFocusTracking();
+  });
+
+  beforeEach(() => {
+    setInteractionModality('keyboard');
+  });
+
+  it('reports virtual modality for a JAWS/NVDA Chromium screen reader pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+      );
+    });
+
+    expect(getInteractionModality()).toBe('virtual');
+  });
+
+  it('notifies useInteractionModality subscribers of virtual modality on a screen reader pointerdown', function () {
+    let {result} = renderHook(() => useInteractionModality());
+
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+      );
+    });
+
+    expect(result.current).toBe('virtual');
+  });
+
+  it('stays virtual through the pointerup paired with a screen reader pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+      );
+      fireEvent(
+        document.body,
+        pointerEvent('pointerup', {pointerType: 'mouse', width: 0, height: 0})
+      );
+    });
+
+    expect(getInteractionModality()).toBe('virtual');
+  });
+
+  it('reports virtual modality for an Android TalkBack pointerdown', function () {
+    platform.isAndroid.mockReturnValue(true);
+
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {
+          pointerType: 'mouse',
+          width: 1,
+          height: 1,
+          pressure: 0,
+          detail: 0
+        })
+      );
+    });
+
+    expect(getInteractionModality()).toBe('virtual');
+    platform.isAndroid.mockReturnValue(false);
+  });
+
+  it('reports pointer modality for a real mouse pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
+      );
+    });
+
+    expect(getInteractionModality()).toBe('pointer');
+  });
+
+  it('notifies useInteractionModality subscribers of pointer modality on a real mouse pointerdown', function () {
+    let {result} = renderHook(() => useInteractionModality());
+
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
+      );
+    });
+
+    expect(result.current).toBe('pointer');
+  });
+
+  it('reports pointer modality for a real touch pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'touch', width: 20, height: 20})
+      );
+    });
+
+    expect(getInteractionModality()).toBe('pointer');
+  });
+
+  it('reports virtual modality for a JAWS/VoiceOver click with no preceding pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
+      );
+    });
+    expect(getInteractionModality()).toBe('pointer');
+
+    act(() => {
+      fireEvent(document.body, pointerEvent('click', {pointerType: '', detail: 0}));
+    });
+
+    expect(getInteractionModality()).toBe('virtual');
+  });
+
+  it('reports keyboard modality for a keydown', function () {
+    act(() => {
+      fireEvent.keyDown(document.body, {key: 'Tab'});
+    });
+
+    expect(getInteractionModality()).toBe('keyboard');
   });
 });

--- a/packages/react-aria/test/interactions/useFocusVisible.test.js
+++ b/packages/react-aria/test/interactions/useFocusVisible.test.js
@@ -21,6 +21,7 @@ import {
 import {
   addWindowFocusTracking,
   getInteractionModality,
+  isFocusVisible,
   setInteractionModality,
   useFocusVisible,
   useFocusVisibleListener,
@@ -670,5 +671,48 @@ describe('useInteractionModality with virtual (screen reader) pointer events', f
     });
 
     expect(getInteractionModality()).toBe('keyboard');
+  });
+
+  it('keeps focus visible after a screen reader pointerdown', function () {
+    // The user-visible consequence of the modality: isFocusVisible() is false only
+    // for 'pointer', so a screen reader activation must not suppress the focus ring.
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+      );
+    });
+
+    expect(isFocusVisible()).toBe(true);
+  });
+
+  it('reports pointer modality for a pen pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'pen', width: 1, height: 1})
+      );
+    });
+
+    expect(getInteractionModality()).toBe('pointer');
+  });
+
+  it('returns to pointer modality when a real mouse moves after a screen reader pointerdown', function () {
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+      );
+    });
+    expect(getInteractionModality()).toBe('virtual');
+
+    act(() => {
+      fireEvent(
+        document.body,
+        pointerEvent('pointermove', {pointerType: 'mouse', width: 1, height: 1})
+      );
+    });
+
+    expect(getInteractionModality()).toBe('pointer');
   });
 });

--- a/packages/react-aria/test/interactions/useFocusVisible.test.js
+++ b/packages/react-aria/test/interactions/useFocusVisible.test.js
@@ -556,12 +556,10 @@ describe('useInteractionModality with virtual (screen reader) pointer events', f
   });
 
   it('reports virtual modality for a JAWS/NVDA Chromium screen reader pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+    );
 
     expect(getInteractionModality()).toBe('virtual');
   });
@@ -569,27 +567,23 @@ describe('useInteractionModality with virtual (screen reader) pointer events', f
   it('notifies useInteractionModality subscribers of virtual modality on a screen reader pointerdown', function () {
     let {result} = renderHook(() => useInteractionModality());
 
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+    );
 
     expect(result.current).toBe('virtual');
   });
 
   it('stays virtual through the pointerup paired with a screen reader pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
-      );
-      fireEvent(
-        document.body,
-        pointerEvent('pointerup', {pointerType: 'mouse', width: 0, height: 0})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+    );
+    fireEvent(
+      document.body,
+      pointerEvent('pointerup', {pointerType: 'mouse', width: 0, height: 0})
+    );
 
     expect(getInteractionModality()).toBe('virtual');
   });
@@ -597,30 +591,26 @@ describe('useInteractionModality with virtual (screen reader) pointer events', f
   it('reports virtual modality for an Android TalkBack pointerdown', function () {
     platform.isAndroid.mockReturnValue(true);
 
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {
-          pointerType: 'mouse',
-          width: 1,
-          height: 1,
-          pressure: 0,
-          detail: 0
-        })
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {
+        pointerType: 'mouse',
+        width: 1,
+        height: 1,
+        pressure: 0,
+        detail: 0
+      })
+    );
 
     expect(getInteractionModality()).toBe('virtual');
     platform.isAndroid.mockReturnValue(false);
   });
 
   it('reports pointer modality for a real mouse pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
+    );
 
     expect(getInteractionModality()).toBe('pointer');
   });
@@ -628,47 +618,37 @@ describe('useInteractionModality with virtual (screen reader) pointer events', f
   it('notifies useInteractionModality subscribers of pointer modality on a real mouse pointerdown', function () {
     let {result} = renderHook(() => useInteractionModality());
 
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
+    );
 
     expect(result.current).toBe('pointer');
   });
 
   it('reports pointer modality for a real touch pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'touch', width: 20, height: 20})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'touch', width: 20, height: 20})
+    );
 
     expect(getInteractionModality()).toBe('pointer');
   });
 
   it('reports virtual modality for a JAWS/VoiceOver click with no preceding pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 1, height: 1})
+    );
     expect(getInteractionModality()).toBe('pointer');
 
-    act(() => {
-      fireEvent(document.body, pointerEvent('click', {pointerType: '', detail: 0}));
-    });
+    fireEvent(document.body, pointerEvent('click', {pointerType: '', detail: 0}));
 
     expect(getInteractionModality()).toBe('virtual');
   });
 
   it('reports keyboard modality for a keydown', function () {
-    act(() => {
-      fireEvent.keyDown(document.body, {key: 'Tab'});
-    });
+    fireEvent.keyDown(document.body, {key: 'Tab'});
 
     expect(getInteractionModality()).toBe('keyboard');
   });
@@ -676,42 +656,34 @@ describe('useInteractionModality with virtual (screen reader) pointer events', f
   it('keeps focus visible after a screen reader pointerdown', function () {
     // The user-visible consequence of the modality: isFocusVisible() is false only
     // for 'pointer', so a screen reader activation must not suppress the focus ring.
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+    );
 
     expect(isFocusVisible()).toBe(true);
   });
 
   it('reports pointer modality for a pen pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'pen', width: 1, height: 1})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'pen', width: 1, height: 1})
+    );
 
     expect(getInteractionModality()).toBe('pointer');
   });
 
   it('returns to pointer modality when a real mouse moves after a screen reader pointerdown', function () {
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointerdown', {pointerType: 'mouse', width: 0, height: 0})
+    );
     expect(getInteractionModality()).toBe('virtual');
 
-    act(() => {
-      fireEvent(
-        document.body,
-        pointerEvent('pointermove', {pointerType: 'mouse', width: 1, height: 1})
-      );
-    });
+    fireEvent(
+      document.body,
+      pointerEvent('pointermove', {pointerType: 'mouse', width: 1, height: 1})
+    );
 
     expect(getInteractionModality()).toBe('pointer');
   });


### PR DESCRIPTION
Closes #10310

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 🐛 Bug

`useInteractionModality()` reports `pointer` when a JAWS or NVDA user activates a control in Chromium. Screen reader users are treated as mouse users, so focus rings are suppressed and modality-dependent behavior misfires.

## 🔍 Root cause

`handlePointerEvent` in `useFocusVisible.ts` set `currentModality = 'pointer'` for every `pointerdown` without consulting `isVirtualPointerEvent`. Chromium's screen-reader-synthesized `pointerdown` reports `pointerType: 'mouse'` — not the empty string JAWS/Firefox and VoiceOver use — so `isVirtualClick` on the trailing `click` can't catch it either. Firefox and VoiceOver only work by accident: they emit no `pointerdown` at all.

This makes `useFocusVisible` the only hook that never adopted the virtual-pointer heuristic the rest of the library has used since #3524 (`usePress`, `useDrag`, `DragManager`, `useRangeCalendar`).

## ✅ Fix

Reuse the existing `isVirtualPointerEvent` helper. Per the [Pointer Events spec](https://www.w3.org/TR/pointerevents/#dom-pointerevent-width), a UA **MUST** report `width`/`height` of `1` for inputs without contact geometry, so a zero-size `pointerdown` cannot originate from a real mouse. Also broadcasts the resolved modality rather than the literal `'pointer'`.

## 📝 Test Instructions:

Automated: `yarn jest packages/react-aria/test/interactions/useFocusVisible.test.js` — twelve tests in the `useInteractionModality with virtual (screen reader) pointer events` block. Three prove virtual detection (including subscriber broadcast and that the paired `pointerup` doesn't reset modality), plus `isFocusVisible()` staying true after a screen-reader pointerdown; the rest guard real mouse, touch, pen, Android TalkBack, Firefox/VoiceOver empty-`pointerType` click, keyboard, and recovery to `pointer` on a real mouse move. Full `react-aria` (1163) and `react-aria-components` (1522) suites pass.

Manual (Windows + JAWS or NVDA + Chrome): start the screen reader, activate any React Aria button with Enter, and observe `useInteractionModality()` / `getInteractionModality()` now reports `virtual` instead of `pointer`.

## ⚠️ Verification needed

I don't have access to JAWS or NVDA. The fix assumes Chromium's synthesized `pointerdown` reports `width: 0, height: 0`. This is inferred from (a) the spec forbidding `0` for real pointers, and (b) `usePress` having relied on this exact signal for JAWS/NVDA browse mode since #3524 — if the geometry were different, that shipped code would already be broken. A maintainer or @jesusgalhub confirming the geometry on real hardware would close this gap.

## 📋 Out of scope (follow-ups)

- `handleClickEvent` sets `currentModality = 'virtual'` but never calls `triggerChangeHandlers`, so the Firefox/VoiceOver virtual *click* never re-broadcasts to subscribers. Latent, separate.
- The zero-geometry heuristic has drifted into several spellings across the codebase; unifying them belongs in its own PR.

## 🧢 Your Project:

Individual contributor