### PR TITLE
fix: don't warn about a missing label when aria-hidden is set

### DIFF
--- a/packages/react-aria/src/label/useLabel.ts
+++ b/packages/react-aria/src/label/useLabel.ts
@@ -22,6 +22,12 @@ export interface LabelAriaProps extends LabelableProps, DOMProps, AriaLabelingPr
    * @default 'label'
    */
   labelElementType?: ElementType;
+  /**
+   * Whether the labeled element is hidden from assistive technology. When true, the
+   * missing-label development warning is suppressed: `aria-hidden` removes the element
+   * and its subtree from the accessibility tree, so an accessible name is not required.
+   */
+  'aria-hidden'?: boolean | 'false' | 'true';
 }
 
 export interface LabelAria {
@@ -43,6 +49,7 @@ export function useLabel(props: LabelAriaProps): LabelAria {
     label,
     'aria-labelledby': ariaLabelledby,
     'aria-label': ariaLabel,
+    'aria-hidden': ariaHidden,
     labelElementType = 'label'
   } = props;
 
@@ -55,7 +62,15 @@ export function useLabel(props: LabelAriaProps): LabelAria {
       id: labelId,
       htmlFor: labelElementType === 'label' ? id : undefined
     };
-  } else if (!ariaLabelledby && !ariaLabel && process.env.NODE_ENV !== 'production') {
+  } else if (
+    !ariaLabelledby &&
+    !ariaLabel &&
+    ariaHidden !== true &&
+    ariaHidden !== 'true' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
+    // An element with aria-hidden is removed from the accessibility tree, so it needs
+    // no accessible name — don't warn about a missing label in that case.
     console.warn(
       'If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility'
     );

--- a/packages/react-aria/test/label/useLabel.test.js
+++ b/packages/react-aria/test/label/useLabel.test.js
@@ -82,6 +82,21 @@ describe('useLabel hook', () => {
     );
   });
 
+  it('should not warn when no label is provided but aria-hidden is set', () => {
+    using spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    renderLabelHook({'aria-hidden': true});
+    renderLabelHook({'aria-hidden': 'true'});
+    expect(spyWarn).not.toHaveBeenCalled();
+  });
+
+  it('should still warn when no label is provided and aria-hidden is false', () => {
+    using spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    renderLabelHook({'aria-hidden': false});
+    expect(spyWarn).toHaveBeenCalledWith(
+      'If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility'
+    );
+  });
+
   it('should not return a `for` attribute when the label element type is not <label>', () => {
     let {labelProps, fieldProps} = renderLabelHook({label: 'Test', labelElementType: 'span'});
     expect(labelProps.id).toBeDefined();


### PR DESCRIPTION
Closes #9987

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/9987).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] ~Updated documentation~ — no documented API change; this only suppresses a dev-only console warning.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/).

`useLabel` emitted the development warning "If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility" even when `aria-hidden={true}` was set. Per the ARIA spec, `aria-hidden` removes the element and its subtree from the accessibility tree, so an accessible name is neither required nor meaningful — the warning is a false positive. Fixed at the root in `useLabel` (skipping the warning when `aria-hidden` is `true` or `"true"`), so every component built on it (ProgressBar, etc.) benefits. `aria-hidden={false}` still warns.

## 📝 Test Instructions:

- Render a labelable element with no visible label and `aria-hidden`, e.g. `<ProgressBar value={50} aria-hidden />` from `react-aria-components`, with `NODE_ENV !== 'production'`.
  - Before: a console warning is emitted.
  - After: no warning.
- `aria-hidden={false}` (or omitted) still warns as before.
- Added unit tests in `packages/react-aria/test/label/useLabel.test.js`: no warning for `aria-hidden` `true`/`"true"`, still warns for `false`.

## 🧢 Your Project:

Personal open-source contribution.