### PR TITLE
fix: prevent Android Chrome taps from being detected as drag event

### DIFF
--- a/packages/react-aria/src/dnd/useDrag.ts
+++ b/packages/react-aria/src/dnd/useDrag.ts
@@ -40,7 +40,7 @@ import {
   writeToDataTransfer
 } from './utils';
 import intlMessages from '../../intl/dnd/*.json';
-import {isIOS} from '../utils/platform';
+import {isIOS, isWebKit} from '../utils/platform';
 import {isVirtualClick, isVirtualPointerEvent} from '../utils/isVirtualEvent';
 import {useDescription} from '../utils/useDescription';
 import {useGlobalListeners} from '../utils/useGlobalListeners';
@@ -369,7 +369,7 @@ export function useDrag(options: DragOptions): DragResult {
           : e.pointerType;
 
         // Try to detect virtual drag passthrough gestures.
-        if (e.width < 1 && e.height < 1 && isIOS()) {
+        if (e.width < 1 && e.height < 1 && isIOS() && isWebKit()) {
           // iOS VoiceOver.
           modalityOnPointerDown.current = 'virtual';
         } else {

--- a/packages/react-aria/src/dnd/useDrag.ts
+++ b/packages/react-aria/src/dnd/useDrag.ts
@@ -40,6 +40,7 @@ import {
   writeToDataTransfer
 } from './utils';
 import intlMessages from '../../intl/dnd/*.json';
+import {isIOS} from '../utils/platform';
 import {isVirtualClick, isVirtualPointerEvent} from '../utils/isVirtualEvent';
 import {useDescription} from '../utils/useDescription';
 import {useGlobalListeners} from '../utils/useGlobalListeners';
@@ -360,7 +361,6 @@ export function useDrag(options: DragOptions): DragResult {
     // events such as selection from also occurring. We attempt to infer whether a
     // pointer event (e.g. long press) came from a touch screen reader, and then initiate
     // dragging in the native onDragStart listener above.
-
     interactions = {
       ...descriptionProps,
       onPointerDown(e) {
@@ -369,7 +369,7 @@ export function useDrag(options: DragOptions): DragResult {
           : e.pointerType;
 
         // Try to detect virtual drag passthrough gestures.
-        if (e.width < 1 && e.height < 1) {
+        if (e.width < 1 && e.height < 1 && isIOS()) {
           // iOS VoiceOver.
           modalityOnPointerDown.current = 'virtual';
         } else {

--- a/packages/react-aria/test/dnd/dnd.test.js
+++ b/packages/react-aria/test/dnd/dnd.test.js
@@ -2710,12 +2710,21 @@ describe('useDrag and useDrop', function () {
   });
 
   describe('screen reader', () => {
+    let platformGetter;
+    let userAgentGetter;
+
     beforeEach(async () => {
+      platformGetter = jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'iPhone');
+      userAgentGetter = jest
+        .spyOn(navigator, 'userAgent', 'get')
+        .mockImplementation(() => 'AppleWebKit');
       // reset focus visible state
       fireEvent.click(document.body, {detail: 0, pointerType: null});
     });
 
     afterEach(async () => {
+      platformGetter.mockRestore();
+      userAgentGetter.mockRestore();
       await user.keyboard('{Escape}');
     });
 
@@ -2952,7 +2961,11 @@ describe('useDrag and useDrop', function () {
         draggable,
         pointerEvent('pointerup', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0})
       );
-      await user.pointer({target: draggable, keys: '[MouseLeft]', coords: {width: 0, height: 0}});
+      await user.pointer({
+        target: draggable,
+        keys: '[MouseLeft]',
+        coords: {clientX: 50, clientY: 25, width: 1, height: 1}
+      });
       act(() => jest.runAllTimers());
       expect(draggable).toHaveAttribute('data-dragging', 'true');
       expect(draggable).toHaveAttribute('aria-describedby');
@@ -3017,7 +3030,11 @@ describe('useDrag and useDrop', function () {
         draggable,
         pointerEvent('pointerup', {pointerId: 1, width: 1, height: 1, pressure: 0, detail: 0})
       );
-      await user.pointer({target: draggable, keys: '[MouseLeft]', coords: {width: 0, height: 0}});
+      await user.pointer({
+        target: draggable,
+        keys: '[MouseLeft]',
+        coords: {clientX: 50, clientY: 25, width: 1, height: 1}
+      });
       act(() => jest.runAllTimers());
       expect(draggable).toHaveAttribute('data-dragging', 'true');
 

--- a/packages/react-aria/test/dnd/useDraggableCollection.test.js
+++ b/packages/react-aria/test/dnd/useDraggableCollection.test.js
@@ -1037,6 +1037,8 @@ describe('useDraggableCollection', () => {
     });
 
     it('should work with a listbox without a drag button', async () => {
+      let platformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+      platformGetter.mockReturnValue('iPhone');
       setMedia({pointer: 'coarse'});
       let onDragStart = jest.fn();
       let onDragEnd = jest.fn();
@@ -1125,10 +1127,14 @@ describe('useDraggableCollection', () => {
         keys: new Set(['foo', 'bar']),
         isInternal: false
       });
+
+      platformGetter.mockRestore();
     });
 
     it('should support row actions', async () => {
       setMedia({pointer: 'coarse'});
+      let platformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+      platformGetter.mockReturnValue('iPhone');
       let onDragStart = jest.fn();
       let onDragEnd = jest.fn();
       let onDrop = jest.fn();
@@ -1232,6 +1238,8 @@ describe('useDraggableCollection', () => {
         keys: new Set(['foo', 'bar']),
         isInternal: false
       });
+
+      platformGetter.mockRestore();
     });
   });
 });

--- a/packages/react-aria/test/dnd/useDraggableCollection.test.js
+++ b/packages/react-aria/test/dnd/useDraggableCollection.test.js
@@ -1037,8 +1037,12 @@ describe('useDraggableCollection', () => {
     });
 
     it('should work with a listbox without a drag button', async () => {
-      let platformGetter = jest.spyOn(window.navigator, 'platform', 'get');
-      platformGetter.mockReturnValue('iPhone');
+      let platformGetter = jest
+        .spyOn(navigator, 'platform', 'get')
+        .mockImplementation(() => 'iPhone');
+      let userAgentGetter = jest
+        .spyOn(navigator, 'userAgent', 'get')
+        .mockImplementation(() => 'AppleWebKit');
       setMedia({pointer: 'coarse'});
       let onDragStart = jest.fn();
       let onDragEnd = jest.fn();
@@ -1129,12 +1133,17 @@ describe('useDraggableCollection', () => {
       });
 
       platformGetter.mockRestore();
+      userAgentGetter.mockRestore();
     });
 
     it('should support row actions', async () => {
       setMedia({pointer: 'coarse'});
-      let platformGetter = jest.spyOn(window.navigator, 'platform', 'get');
-      platformGetter.mockReturnValue('iPhone');
+      let platformGetter = jest
+        .spyOn(navigator, 'platform', 'get')
+        .mockImplementation(() => 'iPhone');
+      let userAgentGetter = jest
+        .spyOn(navigator, 'userAgent', 'get')
+        .mockImplementation(() => 'AppleWebKit');
       let onDragStart = jest.fn();
       let onDragEnd = jest.fn();
       let onDrop = jest.fn();
@@ -1240,6 +1249,7 @@ describe('useDraggableCollection', () => {
       });
 
       platformGetter.mockRestore();
+      userAgentGetter.mockRestore();
     });
   });
 });


### PR DESCRIPTION
slack reported issue

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to the S1 storybook -> Drag and Drop default story. Make sure tapping on the "Drag me" button doesn't start drag in Android Chrome. Make sure you can still drag and drop in iOS VoiceOver via double tapping said button and smoke check drag and drop on all other device/OS combos 

NOTE: NVDA/JAWS keyboard drag and drop is broken due to https://github.com/adobe/react-spectrum/issues/10310 it seems, unrelated to the changes in this PR

## 🧢 Your Project:

RSP
