### PR TITLE
chore: simplifying keyboard navigation docs copy

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/GridList.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/GridList.mdx
@@ -736,64 +736,12 @@ let photos = [
     <GridListItem textValue={item.title}>
       <img src={item.src} alt="" />
       <Text>
-        <TextField style={{paddingTop: 2, paddingBottom: 2}} aria-label="title" defaultValue={item.title} />
+        <TextField style={{paddingTop: 2, paddingBottom: 2}} aria-label="title" defaultValue={item.title} placeholder="Enter a title" />
       </Text>
       <Text slot="description">{item.description}</Text>
     </GridListItem>
   )}
 </GridList>
-```
-
-You can further control if a row automatically focuses itself or its children on keyboard focus via `focusMode`. Futhermore, `allowsArrowNavigation` can be used to allow arrow key navigation from the row's children to adjacent rows.
-This allows keyboard users to navigate to the contents of the row without needing to tab in and out of the row even when in tab keyboard navigation.
-Be sure to only set `allowsArrowNavigation` on rows whose interactive content don't use arrow keys.
-
-```tsx render
-"use client";
-import {GridList, GridListItem, Text} from 'vanilla-starter/GridList';
-import {Button} from 'vanilla-starter/Button';
-import {useState} from 'react';
-
-///- begin collapse -///
-let initialItems = [
-  {id: 1, name: 'Apple', image: 'https://images.unsplash.com/photo-1630563451961-ac2ff27616ab?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.1.0'},
-  {id: 2, name: 'Peach', image: 'https://images.unsplash.com/photo-1642372849486-f88b963cb734?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.1.0'},
-  {id: 3, name: 'Blueberry', image: 'https://images.unsplash.com/photo-1606757389667-45c2024f9fa4?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.1.0'},
-  {id: 4, name: 'Broccoli', image: 'https://images.unsplash.com/photo-1685504445355-0e7bdf90d415?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.1.0'},
-  {id: 5, name: 'Brussels Sprouts', image: 'https://images.unsplash.com/photo-1685504507286-dc290728c01a?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.1.0'},
-  {id: 6, name: 'Peas', image: 'https://images.unsplash.com/photo-1587411768345-867e228218c8?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.1.0'},
-];
-///- end collapse -///
-
-function Example() {
-  let [items, setItems] = useState(initialItems);
-  return (
-    <GridList
-      items={items}
-      layout="stack"
-      orientation="vertical"
-      keyboardNavigationBehavior="tab"
-      aria-label="Shopping cart">
-      {item => (
-        <GridListItem
-          /*- begin highlight -*/
-          focusMode="child"
-          allowsArrowNavigation
-          /*- end highlight -*/
-          textValue={item.name}>
-          <img src={item.image} width={60} height={60} alt="" />
-          <Text>{item.name}</Text>
-          <Button
-            style={{width: 150, marginInlineStart: 10}}
-            variant="secondary"
-            onPress={() => setItems(prev => prev.filter(i => i.id !== item.id))}>
-            Remove from cart
-          </Button>
-        </GridListItem>
-      )}
-    </GridList>
-  );
-}
 ```
 
 ## Drag and drop

--- a/packages/dev/s2-docs/pages/react-aria/Table.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Table.mdx
@@ -762,17 +762,12 @@ let files = [
         <Cell>{item.name}</Cell>
         <Cell>{item.type}</Cell>
         <Cell>{item.date}</Cell>
-        <Cell><TextField aria-label={`${item.name} notes`} defaultValue="" /></Cell>
+        <Cell><TextField aria-label={`${item.name} notes`} placeholder="Enter notes" /></Cell>
       </Row>
     )}
   </TableBody>
 </Table>
 ```
-
-You can further control if a cell automatically focuses itself or its children on keyboard focus via `focusMode`. Futhermore, `allowsArrowNavigation` can be used to allow arrow key navigation from the cell's children to adjacent cells.
-This allows keyboard users to navigate to the selection checkboxes without needing to tab in and out of the selection cell even when in tab keyboard navigation.
-The vanilla CSS starter applies these to selection cells automatically, see the **Table.tsx** tab above.
-Be sure to only set `allowsArrowNavigation` on cells whose interactive content don't use arrow keys.
 
 ## Drag and drop
 

--- a/packages/dev/s2-docs/pages/s2/ListView.mdx
+++ b/packages/dev/s2-docs/pages/s2/ListView.mdx
@@ -412,7 +412,7 @@ let documents = [
     <ListViewItem textValue={item.name}>
       <File />
       <Text>
-        <TextField styles={style({margin: 4})} aria-label="title" defaultValue={item.name} />
+        <TextField styles={style({margin: 4})} aria-label="title" defaultValue={item.name} placeholder="Enter a name" />
       </Text>
     </ListViewItem>
   )}

--- a/packages/dev/s2-docs/pages/s2/TableView.mdx
+++ b/packages/dev/s2-docs/pages/s2/TableView.mdx
@@ -984,7 +984,7 @@ let files = [
         <Cell>{item.name}</Cell>
         <Cell>{item.type}</Cell>
         <Cell>{item.date}</Cell>
-        <Cell><TextField aria-label={`${item.name} notes`} defaultValue="" /></Cell>
+        <Cell><TextField aria-label={`${item.name} notes`} placeholder="Enter notes" /></Cell>
       </Row>
     )}
   </TableBody>

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -511,8 +511,8 @@ export interface GridListItemProps<T = object>
    */
   onAction?: () => void;
   /**
-   * Whether the row or its first focusable child element should be focused when the row is
-   * focused. Defaults to 'row'.
+   * Whether the row or its first focusable child element should be focused when navigating
+   * to the row. Defaults to 'row'.
    */
   focusMode?: 'child' | 'row';
   /**


### PR DESCRIPTION
followup from https://github.com/adobe/react-spectrum/pull/10159

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Check that there are placeholder in the textfields for RAC Table/Gridlist and S2 TableView/ListView keyboard navigation docs. That docs section should be simpler now too

## 🧢 Your Project:

RSP