### PR TITLE
Catch AbortError rejections from overlapping toast view transitions

### DIFF
--- a/packages/@adobe/react-spectrum/src/toast/ToastContainer.tsx
+++ b/packages/@adobe/react-spectrum/src/toast/ToastContainer.tsx
@@ -41,11 +41,14 @@ export type CloseFunction = () => void;
 
 function wrapInViewTransition(fn: () => void): void {
   if ('startViewTransition' in document) {
-    document
-      .startViewTransition(() => {
-        flushSync(fn);
-      })
-      .ready.catch(() => {});
+    let transition = document.startViewTransition(() => {
+      flushSync(fn);
+    });
+    // Prevents unhandled promise rejections when a transition is
+    // preempted by another (e.g. overlapping toasts).
+    transition.finished.catch(() => {});
+    transition.ready.catch(() => {});
+    transition.updateCallbackDone.catch(() => {});
   } else {
     fn();
   }

--- a/starters/docs/src/Toast.tsx
+++ b/starters/docs/src/Toast.tsx
@@ -25,9 +25,14 @@ export const queue = new ToastQueue<MyToastContent>({
   // Wrap state updates in a CSS view transition.
   wrapUpdate(fn) {
     if ('startViewTransition' in document) {
-      document.startViewTransition(() => {
+      let transition = document.startViewTransition(() => {
         flushSync(fn);
       });
+      // Prevents unhandled promise rejections when a transition is
+      // preempted by another (e.g. overlapping toasts).
+      transition.finished.catch(() => {});
+      transition.ready.catch(() => {});
+      transition.updateCallbackDone.catch(() => {});
     } else {
       fn();
     }

--- a/starters/tailwind/src/Toast.tsx
+++ b/starters/tailwind/src/Toast.tsx
@@ -26,9 +26,14 @@ export const queue = new ToastQueue<MyToastContent>({
   // Wrap state updates in a CSS view transition.
   wrapUpdate(fn) {
     if ('startViewTransition' in document) {
-      document.startViewTransition(() => {
+      let transition = document.startViewTransition(() => {
         flushSync(fn);
       });
+      // Prevents unhandled promise rejections when a transition is
+      // preempted by another (e.g. overlapping toasts).
+      transition.finished.catch(() => {});
+      transition.ready.catch(() => {});
+      transition.updateCallbackDone.catch(() => {});
     } else {
       fn();
     }


### PR DESCRIPTION
Fixes #10337

When overlapping toasts trigger back-to-back `document.startViewTransition()` calls, the skipped/preempted transition rejects its promises with `AbortError: Transition was skipped`. The starter templates and v1 ToastContainer only caught `.ready` (v1) or nothing at all (starters), resulting in unhandled promise rejections.

This fix adds `.catch(() => {})` on all three `ViewTransition` promises (`finished`, `ready`, `updateCallbackDone`) in all three locations:

- `starters/docs/src/Toast.tsx`
- `starters/tailwind/src/Toast.tsx`
- `packages/@adobe/react-spectrum/src/toast/ToastContainer.tsx`