### PR TITLE
fix: S2 Toast props

### DIFF
--- a/packages/@react-spectrum/s2/src/Toast.tsx
+++ b/packages/@react-spectrum/s2/src/Toast.tsx
@@ -579,7 +579,8 @@ export function SpectrumToast(props: SpectrumToastProps): ReactNode {
           index,
           isExpanded
         })
-      }>
+      }
+      {...filterDOMProps(toast.content)}>
       <div
         role="presentation"
         className={toastBody({isSingle: !isMain || visibleToasts.length <= 1 || isExpanded})}>

--- a/packages/@react-spectrum/s2/test/Toast.test.tsx
+++ b/packages/@react-spectrum/s2/test/Toast.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/@react-spectrum/s2/test/Toast.test.tsx
+++ b/packages/@react-spectrum/s2/test/Toast.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {act, installPointerEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import {Button} from '../src/Button';
+import {ToastContainer, ToastOptions, ToastQueue} from '../src/Toast';
+import userEvent from '@testing-library/user-event';
+
+function Example(options: ToastOptions = {}) {
+  return (
+    <>
+      <ToastContainer />
+      <Button variant="primary" onPress={() => ToastQueue.neutral('Toast', options)}>
+        Show Toast
+      </Button>
+    </>
+  );
+}
+
+describe('Toast', () => {
+  installPointerEvent();
+
+  let user;
+  beforeAll(() => {
+    user = userEvent.setup({delay: null, pointerMap});
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => jest.runAllTimers());
+  });
+
+  it('passes an id and data attribute through to the rendered toast', async () => {
+    let {getByRole, getByTestId} = render(
+      // @ts-ignore
+      <Example id="toast-1" data-testid="toast-1" />
+    );
+
+    let button = getByRole('button');
+    await user.click(button);
+
+    let toast = getByRole('alertdialog');
+    expect(toast).toBeVisible();
+    expect(toast).toHaveAttribute('id', 'toast-1');
+    expect(toast).toHaveAttribute('data-testid', 'toast-1');
+    expect(getByTestId('toast-1')).toBe(toast);
+  });
+});


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Reported in Slack

Our docs say that users can set `id` in the Toast options, however, it's not making it to the DOM despite our docs saying it's the html version of id.

The RAC Toast already does a filterDOMProps, so I assume we're meant to be able to send this through.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
