### PR TITLE
fix: RangeCalendar range selection in shadow DOM

### DIFF
--- a/packages/react-aria-components/test/RangeCalendar.test.tsx
+++ b/packages/react-aria-components/test/RangeCalendar.test.tsx
@@ -10,7 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, pointerMap, render, within} from '@react-spectrum/test-utils-internal';
+import {
+  act,
+  createShadowRoot,
+  fireEvent,
+  installPointerEvent,
+  pointerMap,
+  render,
+  within
+} from '@react-spectrum/test-utils-internal';
 import {Button} from '../src/Button';
 
 import {
@@ -34,6 +42,7 @@ import {
   today
 } from '@internationalized/date';
 import {DateValue} from 'react-stately/useRangeCalendarState';
+import {enableShadowDOM} from 'react-stately/private/flags/flags';
 import {RangeValue} from '@react-types/shared';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -665,5 +674,85 @@ describe('RangeCalendar', () => {
     expect(tree.getAllByRole('gridcell')).toHaveLength(2);
     let heading = tree.container.querySelector('.react-aria-CalendarHeading');
     expect(heading).toHaveTextContent('April 1 – 2, 2026');
+  });
+
+  describe('shadow DOM', () => {
+    installPointerEvent();
+
+    beforeAll(() => {
+      enableShadowDOM();
+    });
+
+    let pointerOpts = {pointerType: 'mouse', pointerId: 1, width: 1, height: 1, detail: 1};
+    let clickCell = (cell: Element) => {
+      fireEvent.pointerDown(cell, pointerOpts);
+      fireEvent.pointerUp(cell, pointerOpts);
+      fireEvent.click(cell, {detail: 1});
+    };
+
+    it('should support selecting a range by clicking two dates', () => {
+      let {shadowRoot, cleanup} = createShadowRoot();
+      let container = document.createElement('div');
+      shadowRoot.appendChild(container);
+      let onChange = jest.fn();
+      render(
+        <TestCalendar
+          calendarProps={{onChange, defaultFocusedValue: new CalendarDate(2019, 6, 5)}}
+        />,
+        {container}
+      );
+
+      let grid = shadowRoot.querySelector<HTMLElement>('[role="grid"]')!;
+      let startCell = within(grid).getByText('17');
+      clickCell(startCell);
+
+      // The window pointerup listener receives an event retargeted to the shadow host.
+      // It must resolve the real target and not treat the click as a release outside
+      // the calendar, which would commit the selection early.
+      expect(startCell).toHaveAttribute('data-selection-start', 'true');
+      expect(startCell).toHaveAttribute('data-selection-end', 'true');
+      expect(onChange).not.toHaveBeenCalled();
+
+      let endCell = within(grid).getByText('23');
+      clickCell(endCell);
+
+      expect(startCell).toHaveAttribute('data-selection-start', 'true');
+      expect(endCell).toHaveAttribute('data-selection-end', 'true');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      cleanup();
+    });
+
+    it('should commit the selection when releasing a drag outside the calendar', () => {
+      let {shadowRoot, cleanup} = createShadowRoot();
+      let container = document.createElement('div');
+      shadowRoot.appendChild(container);
+      let onChange = jest.fn();
+      render(
+        <TestCalendar
+          calendarProps={{onChange, defaultFocusedValue: new CalendarDate(2019, 6, 5)}}
+        />,
+        {container}
+      );
+
+      let grid = shadowRoot.querySelector<HTMLElement>('[role="grid"]')!;
+      fireEvent.pointerDown(within(grid).getByText('17'), pointerOpts);
+      fireEvent.pointerEnter(within(grid).getByText('23'));
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Guards the inverse path: resolving the real target must not make releases
+      // outside the shadow root look like they are inside the calendar.
+      fireEvent.pointerUp(document.body, pointerOpts);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      cleanup();
+    });
   });
 });

--- a/packages/react-aria-components/test/RangeCalendar.test.tsx
+++ b/packages/react-aria-components/test/RangeCalendar.test.tsx
@@ -679,32 +679,49 @@ describe('RangeCalendar', () => {
   describe('shadow DOM', () => {
     installPointerEvent();
 
+    // enableShadowDOM() is a one way flag with no disable, so this describe has to stay
+    // last in the file — anything declared after it would run in shadow DOM mode too.
     beforeAll(() => {
       enableShadowDOM();
     });
 
     let pointerOpts = {pointerType: 'mouse', pointerId: 1, width: 1, height: 1, detail: 1};
-    let clickCell = (cell: Element) => {
-      fireEvent.pointerDown(cell, pointerOpts);
-      fireEvent.pointerUp(cell, pointerOpts);
-      fireEvent.click(cell, {detail: 1});
+    let pointerClick = (element: Element) => {
+      fireEvent.pointerDown(element, pointerOpts);
+      fireEvent.pointerUp(element, pointerOpts);
+      fireEvent.click(element, {detail: 1});
     };
 
-    it('should support selecting a range by clicking two dates', () => {
-      let {shadowRoot, cleanup} = createShadowRoot();
+    let renderInShadowRoot = (calendarProps = {}, attachTo?: HTMLElement) => {
+      let {shadowRoot, cleanup} = createShadowRoot(attachTo);
       let container = document.createElement('div');
       shadowRoot.appendChild(container);
       let onChange = jest.fn();
       render(
         <TestCalendar
-          calendarProps={{onChange, defaultFocusedValue: new CalendarDate(2019, 6, 5)}}
+          calendarProps={{
+            onChange,
+            defaultFocusedValue: new CalendarDate(2019, 6, 5),
+            ...calendarProps
+          }}
         />,
         {container}
       );
 
-      let grid = shadowRoot.querySelector<HTMLElement>('[role="grid"]')!;
+      return {
+        onChange,
+        shadowRoot,
+        cleanup,
+        calendar: shadowRoot.querySelector<HTMLElement>('[role="application"]')!,
+        grid: shadowRoot.querySelector<HTMLElement>('[role="grid"]')!
+      };
+    };
+
+    it('should support selecting a range by clicking two dates', () => {
+      let {grid, onChange, cleanup} = renderInShadowRoot();
+
       let startCell = within(grid).getByText('17');
-      clickCell(startCell);
+      pointerClick(startCell);
 
       // The window pointerup listener receives an event retargeted to the shadow host.
       // It must resolve the real target and not treat the click as a release outside
@@ -714,7 +731,7 @@ describe('RangeCalendar', () => {
       expect(onChange).not.toHaveBeenCalled();
 
       let endCell = within(grid).getByText('23');
-      clickCell(endCell);
+      pointerClick(endCell);
 
       expect(startCell).toHaveAttribute('data-selection-start', 'true');
       expect(endCell).toHaveAttribute('data-selection-end', 'true');
@@ -726,19 +743,121 @@ describe('RangeCalendar', () => {
       cleanup();
     });
 
-    it('should commit the selection when releasing a drag outside the calendar', () => {
-      let {shadowRoot, cleanup} = createShadowRoot();
-      let container = document.createElement('div');
-      shadowRoot.appendChild(container);
-      let onChange = jest.fn();
-      render(
-        <TestCalendar
-          calendarProps={{onChange, defaultFocusedValue: new CalendarDate(2019, 6, 5)}}
-        />,
-        {container}
-      );
+    it('should support selecting a range by dragging', () => {
+      let {grid, onChange, cleanup} = renderInShadowRoot();
 
-      let grid = shadowRoot.querySelector<HTMLElement>('[role="grid"]')!;
+      fireEvent.pointerDown(within(grid).getByText('17'), pointerOpts);
+      fireEvent.pointerEnter(within(grid).getByText('20'));
+      fireEvent.pointerEnter(within(grid).getByText('23'));
+      expect(onChange).not.toHaveBeenCalled();
+
+      let endCell = within(grid).getByText('23');
+      fireEvent.pointerUp(endCell, pointerOpts);
+      fireEvent.click(endCell, {detail: 1});
+
+      expect(within(grid).getByText('17')).toHaveAttribute('data-selection-start', 'true');
+      expect(endCell).toHaveAttribute('data-selection-end', 'true');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      cleanup();
+    });
+
+    it('should not commit the selection when pressing the month navigation buttons', () => {
+      let {calendar, grid, onChange, cleanup} = renderInShadowRoot();
+
+      pointerClick(within(grid).getByText('17'));
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Resolving the real target also feeds the `closest('button')` check: pressing
+      // the month navigation buttons must keep the in progress selection alive.
+      pointerClick(calendar.querySelector<HTMLElement>('button[slot="next"]')!);
+      expect(onChange).not.toHaveBeenCalled();
+
+      pointerClick(within(grid).getByText('5'));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 7, 5));
+
+      cleanup();
+    });
+
+    it('should not clear the selection when clicking a date with commitBehavior="clear"', () => {
+      let {grid, onChange, cleanup} = renderInShadowRoot({
+        commitBehavior: 'clear',
+        defaultValue: {start: new CalendarDate(2019, 6, 10), end: new CalendarDate(2019, 6, 20)}
+      });
+
+      let startCell = within(grid).getByText('17');
+      pointerClick(startCell);
+
+      // `clear` must only run for releases genuinely outside the calendar.
+      expect(startCell).toHaveAttribute('data-selection-start', 'true');
+      expect(onChange).not.toHaveBeenCalled();
+
+      pointerClick(within(grid).getByText('23'));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      cleanup();
+    });
+
+    it('should support selecting a range inside nested shadow roots', () => {
+      let outer = createShadowRoot();
+      let wrapper = document.createElement('div');
+      outer.shadowRoot.appendChild(wrapper);
+      let {grid, onChange, cleanup} = renderInShadowRoot({}, wrapper);
+
+      // The window listener only sees the outermost host, so the real target has to
+      // be resolved through both shadow boundaries.
+      pointerClick(within(grid).getByText('17'));
+      expect(onChange).not.toHaveBeenCalled();
+
+      pointerClick(within(grid).getByText('23'));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      cleanup();
+      outer.cleanup();
+    });
+
+    it('should commit the selection when focus leaves the shadow root', () => {
+      let outsideButton = document.createElement('button');
+      document.body.appendChild(outsideButton);
+      let {grid, onChange, cleanup} = renderInShadowRoot();
+
+      fireEvent.pointerDown(within(grid).getByText('17'), pointerOpts);
+      fireEvent.pointerEnter(within(grid).getByText('23'));
+      expect(onChange).not.toHaveBeenCalled();
+
+      // The blur path commits via `relatedTarget` rather than the pointerup target,
+      // so it should keep working across a shadow boundary.
+      act(() => {
+        outsideButton.focus();
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      document.body.removeChild(outsideButton);
+      cleanup();
+    });
+
+    it('should commit the selection when releasing a drag outside the calendar', () => {
+      let {grid, onChange, cleanup} = renderInShadowRoot();
+
       fireEvent.pointerDown(within(grid).getByText('17'), pointerOpts);
       fireEvent.pointerEnter(within(grid).getByText('23'));
       expect(onChange).not.toHaveBeenCalled();
@@ -746,6 +865,27 @@ describe('RangeCalendar', () => {
       // Guards the inverse path: resolving the real target must not make releases
       // outside the shadow root look like they are inside the calendar.
       fireEvent.pointerUp(document.body, pointerOpts);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      let {start, end} = onChange.mock.calls[0][0];
+      expect(start).toEqual(new CalendarDate(2019, 6, 17));
+      expect(end).toEqual(new CalendarDate(2019, 6, 23));
+
+      cleanup();
+    });
+
+    it('should commit the selection when releasing a drag outside the calendar but inside the shadow root', () => {
+      let {shadowRoot, grid, onChange, cleanup} = renderInShadowRoot();
+      let sibling = document.createElement('div');
+      shadowRoot.appendChild(sibling);
+
+      fireEvent.pointerDown(within(grid).getByText('17'), pointerOpts);
+      fireEvent.pointerEnter(within(grid).getByText('23'));
+      expect(onChange).not.toHaveBeenCalled();
+
+      // The resolved target is a sibling within the same shadow root — still outside
+      // the calendar, so the selection commits.
+      fireEvent.pointerUp(sibling, pointerOpts);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       let {start, end} = onChange.mock.calls[0][0];

--- a/packages/react-aria/src/calendar/useRangeCalendar.ts
+++ b/packages/react-aria/src/calendar/useRangeCalendar.ts
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, DOMProps, FocusableElement, RefObject} from '@react-types/shared';
 import {CalendarAria, useCalendarBase} from './useCalendarBase';
 import {DateValue, RangeCalendarState} from 'react-stately/useRangeCalendarState';
-import {isFocusWithin, nodeContains} from '../utils/shadowdom/DOMFunctions';
+import {getEventTarget, isFocusWithin, nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {RangeCalendarProps} from 'react-stately/useRangeCalendarState';
 import {useEvent} from '../utils/useEvent';
 import {useRef} from 'react';
@@ -76,7 +76,7 @@ export function useRangeCalendar<T extends DateValue>(
       return;
     }
 
-    let target = e.target as Element;
+    let target = getEventTarget(e) as Element;
     if (
       ref.current &&
       isFocusWithin(ref.current) &&


### PR DESCRIPTION
Closes #10330

When a `RangeCalendar` (including the calendar inside `DateRangePicker`) is rendered inside a shadow root with `enableShadowDOM()`, clicking a single date immediately committed a range where `start === end`, so a multi-day range could never be selected by clicking. Dragging a range had a second symptom from the same cause: `onChange` fired twice, once from the early commit and once from the cell's own press.

The window-level `pointerup` listener in `useRangeCalendar` read the raw `e.target`. For events coming from inside a shadow root the browser retargets that to the shadow host, so the calendar always believed the pointer was released outside of it and committed the in-progress selection on every click. The listener now resolves the real target with the existing shadow-safe `getEventTarget()` helper, as suggested by @snowystinger in the issue.

Resolving the real target also feeds the `closest('button, [role="button"]')` check on the line below, which is what stops the month navigation buttons from committing an in-progress selection. That path was broken inside a shadow root too, and is now covered.

Nested shadow roots work as well — the window listener only ever sees the outermost host, and `composedPath()[0]` resolves through every boundary. One known limit, unchanged by this PR and shared with `useInteractOutside` / `useToastRegion`: `closest()` does not pierce shadow boundaries, so it would still miss a navigation button living in a *deeper* shadow root than the calendar itself. That looked like a separate, wider change rather than something to fold in here.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10330).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1. `yarn jest packages/react-aria-components/test/RangeCalendar.test.tsx` — the new `shadow DOM` describe has eight tests. Five of them fail on `main` and pass with the fix:
   - selecting a range by clicking two dates — `onChange` fires with `start === end` on the first click
   - selecting a range by dragging — `onChange` fires twice
   - pressing the month navigation buttons mid-selection — commits early
   - `commitBehavior="clear"` — the first click wipes the selection instead of anchoring it
   - selecting a range inside nested shadow roots

   The other three pass with and without the fix and are there as guards on the inverse paths, so a future change can't over-correct: releasing outside the calendar, releasing outside the calendar but inside the same shadow root, and committing when focus leaves the shadow root.
2. Manual: call `enableShadowDOM()` from `@react-stately/flags`, render a `RangeCalendar` inside an open shadow root, and click two dates — the range commits only on the second click, matching light DOM behavior.

## 🧢 Your Project:

_No response_
