### PR TITLE
fix(calendar): support RangeCalendar selection inside shadow DOM

### DIFF
--- a/packages/react-aria/src/calendar/useRangeCalendar.ts
+++ b/packages/react-aria/src/calendar/useRangeCalendar.ts
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, DOMProps, FocusableElement, RefObject} from '@react-types/shared';
 import {CalendarAria, useCalendarBase} from './useCalendarBase';
 import {DateValue, RangeCalendarState} from 'react-stately/useRangeCalendarState';
-import {isFocusWithin, nodeContains} from '../utils/shadowdom/DOMFunctions';
+import {getEventTarget, isFocusWithin, nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {RangeCalendarProps} from 'react-stately/useRangeCalendarState';
 import {useEvent} from '../utils/useEvent';
 import {useRef} from 'react';
@@ -76,7 +76,7 @@ export function useRangeCalendar<T extends DateValue>(
       return;
     }
 
-    let target = e.target as Element;
+    let target = getEventTarget(e) as Element;
     if (
       ref.current &&
       isFocusWithin(ref.current) &&


### PR DESCRIPTION
Closes #10330 

## ✅ Pull Request Checklist:

- [X] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [X] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

- Go to the range calendar picker and click a date to set the start of the range, then click a second date to set the end in the Shadow DOM.
- Verify: The calendar should wait for the second click to commit the full multi-day range, rather than incorrectly committing start==end immediately on the first click.

## 🧢 Your Project:

<!--- Company/project for pull request -->
