### PR TITLE
feat: support list of agent actions in ResponseStatus

### DIFF
--- a/packages/@react-spectrum/ai/exports/index.ts
+++ b/packages/@react-spectrum/ai/exports/index.ts
@@ -17,7 +17,13 @@ export {
   PromptToken,
   PromptFieldVoiceButton
 } from '../src/PromptField';
-export {ResponseStatus, ResponseStatusTitle, ResponseStatusPanel} from '../src/ResponseStatus';
+export {
+  ExecutionTrace,
+  ExecutionTraceItem,
+  ResponseStatus,
+  ResponseStatusTitle,
+  ResponseStatusPanel
+} from '../src/ResponseStatus';
 export {Chat, Thread, ThreadItem, ThreadScrollButton, PromptFocusContext} from '../src/Chat';
 export {TokenFieldValue} from 'react-aria-components/TokenField';
 export {UserMessage} from '../src/UserMessage';
@@ -39,6 +45,8 @@ export type {MessageFeedbackProps} from '../src/MessageFeedback';
 export type {MessageSourceProps, SourceListProps, SourceListItemProps} from '../src/MessageSource';
 export type {MessageSuggestionProps, MessageSuggestionListProps} from '../src/MessageSuggestion';
 export type {
+  ExecutionTraceProps,
+  ExecutionTraceItemProps,
   ResponseStatusProps,
   ResponseStatusTitleProps,
   ResponseStatusPanelProps

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -11,13 +11,7 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, GlobalDOMAttributes} from '@react-types/shared';
-import {
-  baseColor,
-  focusRing,
-  lightDark,
-  space,
-  style
-} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {baseColor, focusRing, space, style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Button} from 'react-aria-components/Button';
 import {CenterBaseline} from '@react-spectrum/s2/CenterBaseline';
 import CheckmarkCircle from '@react-spectrum/s2/icons/CheckmarkCircle';
@@ -217,14 +211,7 @@ const buttonStyles = style({
     }
   },
   width: 'full',
-  backgroundColor: {
-    default: 'transparent',
-    isFocusVisible: lightDark('transparent-black-100', 'transparent-white-100'),
-    isHovered: lightDark('transparent-black-100', 'transparent-white-100'),
-    isPressed: lightDark('transparent-black-300', 'transparent-white-300'),
-    isLoading: 'transparent',
-    isOnlyText: 'transparent'
-  },
+  backgroundColor: 'transparent',
   transition: 'default',
   borderWidth: 0,
   borderRadius: 'default',

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -57,12 +57,6 @@ export interface ResponseStatusProps extends Omit<
   'className' | 'style' | 'render' | 'children' | keyof GlobalDOMAttributes
 > {
   /**
-   * The size of the response status.
-   *
-   * @default 'M'
-   */
-  size?: 'S' | 'M' | 'L' | 'XL';
-  /**
    * The amount of space between stacked response statuses.
    *
    * @default 'regular'
@@ -86,7 +80,6 @@ export interface ResponseStatusProps extends Omit<
 }
 
 const ResponseStatusContext = createContext<{
-  size?: 'S' | 'M' | 'L' | 'XL';
   density?: 'compact' | 'regular' | 'spacious';
   status: 'loading' | 'failed' | 'success';
   hasPanelContent: boolean;
@@ -111,7 +104,7 @@ export const ResponseStatus = forwardRef(function ResponseStatus(
   props: ResponseStatusProps,
   ref: DOMRef<HTMLDivElement>
 ) {
-  let {size = 'M', density = 'regular', status = 'loading', styles} = props;
+  let {density = 'regular', status = 'loading', styles} = props;
   let domRef = useDOMRef(ref);
   let [hasPanelContent, setHasPanelContent] = useState(false);
   let registerPanel = useCallback((mounted: boolean) => setHasPanelContent(mounted), []);
@@ -123,8 +116,7 @@ export const ResponseStatus = forwardRef(function ResponseStatus(
   }
 
   return (
-    <Provider
-      values={[[ResponseStatusContext, {size, density, status, hasPanelContent, registerPanel}]]}>
+    <Provider values={[[ResponseStatusContext, {density, status, hasPanelContent, registerPanel}]]}>
       <RACDisclosure
         {...props}
         {...disclosureProps}
@@ -162,14 +154,7 @@ const headingStyle = style({
 const buttonStyles = style({
   ...focusRing(),
   outlineOffset: -2,
-  font: {
-    size: {
-      S: 'body-sm',
-      M: 'body',
-      L: 'body-lg',
-      XL: 'body-xl'
-    }
-  },
+  font: 'body',
   color: {
     default: baseColor('neutral'),
     isLoading: 'neutral',
@@ -185,35 +170,10 @@ const buttonStyles = style({
   paddingX: 'calc(self(minHeight) * 3/8 - 1px)',
   gap: 'calc(self(minHeight) * 3/8 - 1px)',
   minHeight: {
-    size: {
-      S: {
-        density: {
-          compact: 18,
-          regular: 24,
-          spacious: 32
-        }
-      },
-      M: {
-        density: {
-          compact: 24,
-          regular: 32,
-          spacious: 40
-        }
-      },
-      L: {
-        density: {
-          compact: 32,
-          regular: 40,
-          spacious: 48
-        }
-      },
-      XL: {
-        density: {
-          compact: 40,
-          regular: 48,
-          spacious: 56
-        }
-      }
+    density: {
+      compact: 24,
+      regular: 32,
+      spacious: 40
     }
   },
   width: 'full',
@@ -239,22 +199,8 @@ const chevronStyles = style({
 });
 
 const progressCircleStyles = style({
-  width: {
-    size: {
-      S: 16,
-      M: 18,
-      L: 20,
-      XL: 22
-    }
-  },
-  height: {
-    size: {
-      S: 16,
-      M: 18,
-      L: 20,
-      XL: 22
-    }
-  }
+  width: 18,
+  height: 18
 });
 
 /**
@@ -271,7 +217,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
   const domProps = filterDOMProps(otherProps);
   let {direction} = useLocale();
   let {isExpanded} = useContext(DisclosureStateContext)!;
-  let {size = 'M', density, status, hasPanelContent} = useContext(ResponseStatusContext)!;
+  let {density, status, hasPanelContent} = useContext(ResponseStatusContext)!;
   let isRTL = direction === 'rtl';
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
 
@@ -283,7 +229,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
       {isLoading ? (
         <CenterBaseline>
           <ProgressCircle
-            styles={progressCircleStyles({size})}
+            styles={progressCircleStyles}
             isIndeterminate
             aria-label={stringFormatter.format('responsestatus.loading')}
           />
@@ -297,19 +243,12 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
                 styles: style({
                   marginStart: 'auto',
                   flexShrink: 0,
-                  size: {
-                    size: {
-                      S: 16,
-                      M: 20,
-                      L: 24,
-                      XL: 28
-                    }
-                  },
+                  size: 20,
                   '--iconPrimary': {
                     type: 'fill',
                     value: 'currentColor'
                   }
-                })({size})
+                })
               }
             ]
           ]}>
@@ -325,7 +264,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
       {props.children}
       {isInteractive ? (
         <CenterBaseline styles={chevronStyles({isExpanded, isRTL})}>
-          <Chevron size={size} />
+          <ChevronRight styles={iconStyle({size: 'M'})} />
         </CenterBaseline>
       ) : null}
     </>
@@ -335,7 +274,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
     <Heading {...domProps} level={level} ref={domRef} className={mergeStyles(headingStyle, styles)}>
       <Button
         className={renderProps =>
-          buttonStyles({...renderProps, size, density, isLoading, isOnlyText: !isInteractive})
+          buttonStyles({...renderProps, density, isLoading, isOnlyText: !isInteractive})
         }
         slot={isInteractive ? 'trigger' : undefined}>
         {rowContent}
@@ -369,14 +308,7 @@ const panelStyles = style({
 const panelInner = style({
   paddingTop: 8,
   paddingBottom: 16,
-  paddingX: {
-    size: {
-      S: 8,
-      M: space(9),
-      L: 12,
-      XL: space(15)
-    }
-  }
+  paddingX: space(9)
 });
 
 /**
@@ -388,7 +320,7 @@ export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
   ref: DOMRef<HTMLDivElement>
 ) {
   let {styles} = props;
-  let {size = 'M', registerPanel} = useContext(ResponseStatusContext)!;
+  let {registerPanel} = useContext(ResponseStatusContext)!;
   const domProps = filterDOMProps(props);
   let panelRef = useDOMRef(ref);
 
@@ -399,7 +331,7 @@ export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
 
   return (
     <RACDisclosurePanel {...domProps} ref={panelRef} className={mergeStyles(panelStyles, styles)}>
-      <div className={panelInner({size})}>{props.children}</div>
+      <div className={panelInner}>{props.children}</div>
     </RACDisclosurePanel>
   );
 });
@@ -475,14 +407,11 @@ function DetailTrigger(props: DetailTriggerProps) {
 
   return (
     <Button
-      className={renderProps =>
-        // TODO: remove size conditional once size is also removed from ResponseStatus
-        mergeStyles(buttonStyles({...renderProps, size: 'M'}), detailTriggerStyles)
-      }
+      className={renderProps => mergeStyles(buttonStyles({...renderProps}), detailTriggerStyles)}
       slot="trigger">
       {children}
       <CenterBaseline styles={detailTriggerChevronStyles({isExpanded, isRTL})}>
-        <Chevron size="S" />
+        <ChevronRight styles={iconStyle({size: 'S'})} />
       </CenterBaseline>
     </Button>
   );

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -264,7 +264,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
       {props.children}
       {isInteractive ? (
         <CenterBaseline styles={chevronStyles({isExpanded, isRTL})}>
-          <ChevronRight styles={iconStyle({size: 'M'})} />
+          <Chevron size="M" />
         </CenterBaseline>
       ) : null}
     </>
@@ -387,7 +387,7 @@ const detailTriggerStyles = style({
 
 const detailTriggerChevronStyles = style({
   display: 'inline-flex',
-  marginStart: 4,
+  marginStart: 8,
   rotate: {
     isRTL: 180,
     isExpanded: 90
@@ -407,7 +407,7 @@ function DetailTrigger(props: DetailTriggerProps) {
       slot="trigger">
       {children}
       <CenterBaseline styles={detailTriggerChevronStyles({isExpanded, isRTL})}>
-        <ChevronRight styles={iconStyle({size: 'S'})} />
+        <Chevron size="M" />
       </CenterBaseline>
     </Button>
   );

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -11,7 +11,13 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, GlobalDOMAttributes} from '@react-types/shared';
-import {baseColor, focusRing, space, style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {
+  baseColor,
+  focusRing,
+  iconStyle,
+  space,
+  style
+} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Button} from 'react-aria-components/Button';
 import {CenterBaseline} from '@react-spectrum/s2/CenterBaseline';
 import CheckmarkCircle from '@react-spectrum/s2/icons/CheckmarkCircle';
@@ -395,5 +401,206 @@ export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
     <RACDisclosurePanel {...domProps} ref={panelRef} className={mergeStyles(panelStyles, styles)}>
       <div className={panelInner({size})}>{props.children}</div>
     </RACDisclosurePanel>
+  );
+});
+
+export interface ExecutionTraceProps extends DOMProps, AriaLabelingProps {
+  /**
+   * The ExecutionTraceItem elements to render as a timeline. Typically placed inside a
+   * ResponseStatusPanel.
+   */
+  children: ReactNode;
+  /**
+   * Spectrum-defined styles, returned by the `style()` macro.
+   */
+  styles?: StyleString;
+}
+
+const executionTraceStyles = style({
+  display: 'flex',
+  flexDirection: 'column',
+  margin: 0,
+  padding: 0,
+  paddingStart: 4,
+  listStyleType: 'none'
+});
+
+/**
+ * An ExecutionTrace displays a timeline of the steps taken while generating a
+ * response, such as tool calls or searches.
+ */
+export const ExecutionTrace = forwardRef(function ExecutionTrace(
+  props: ExecutionTraceProps,
+  ref: DOMRef<HTMLOListElement>
+) {
+  let {styles, children, ...otherProps} = props;
+  let domRef = useDOMRef(ref);
+  let domProps = filterDOMProps(otherProps);
+
+  return (
+    <ol {...domProps} ref={domRef} className={mergeStyles(executionTraceStyles, styles)}>
+      {children}
+    </ol>
+  );
+});
+
+interface DetailTriggerProps {
+  children: ReactNode;
+}
+
+const detailTriggerStyles = style({
+  display: 'block',
+  paddingY: 4,
+  marginTop: -2,
+  textAlign: 'start'
+});
+
+const detailTriggerChevronStyles = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  verticalAlign: 'middle',
+  marginStart: 4,
+  rotate: {
+    isRTL: 180,
+    isExpanded: 90
+  },
+  transition: 'default'
+});
+
+function DetailTrigger(props: DetailTriggerProps) {
+  let {children} = props;
+  let {direction} = useLocale();
+  let isRTL = direction === 'rtl';
+  let {isExpanded} = useContext(DisclosureStateContext)!;
+
+  return (
+    <Button
+      className={renderProps =>
+        // TODO: remove size conditional once size is also removed from ResponseStatus
+        mergeStyles(buttonStyles({...renderProps, size: 'M'}), detailTriggerStyles)
+      }
+      slot="trigger">
+      {children}
+      <CenterBaseline styles={detailTriggerChevronStyles({isExpanded, isRTL})}>
+        <Chevron size="S" />
+      </CenterBaseline>
+    </Button>
+  );
+}
+
+export interface ExecutionTraceItemProps extends DOMProps, AriaLabelingProps {
+  /** Allows detail content to render but prevents the row from being collapsible. */
+  isDetailNotCollapsible?: boolean;
+  /**
+   * The label describing the step.
+   */
+  children: ReactNode;
+  /**
+   * An icon shown at the leading edge of the row. If omitted, a checkmark is rendered by default.
+   */
+  icon?: ReactNode;
+  /**
+   * Additional detail revealed when the step is expanded, such as tool call input or output.
+   * If omitted, the row is static and cannot be expanded.
+   */
+  detail?: ReactNode;
+  /**
+   * Spectrum-defined styles, returned by the `style()` macro.
+   */
+  styles?: StyleString;
+}
+
+const executionTraceItemStyles = style({
+  font: 'body',
+  display: 'flex',
+  gap: 8,
+  marginTop: {
+    isDetailed: -2
+  },
+  '--divider-display': {
+    type: 'display',
+    value: {
+      default: 'flex',
+      ':last-child': 'none'
+    }
+  }
+});
+
+const itemIconContainerStyles = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  flexShrink: 0,
+  paddingTop: {
+    isDetailed: 2
+  }
+});
+
+const executionTraceItemDividerStyles = style({
+  width: 1,
+  flexGrow: 1,
+  marginY: 2,
+  backgroundColor: 'gray-500',
+  display: 'var(--divider-display, flex)'
+});
+
+const executionTraceItemContentStyles = style({
+  display: 'flex',
+  flexDirection: 'column',
+  paddingBottom: 12,
+  paddingX: 8
+});
+
+const executionTraceItemNoCollapseStyles = style({
+  minHeight: 24
+});
+
+/**
+ * An ExecutionTraceItem represents a single step within an ExecutionTrace, such as
+ * a tool call or search. When a `detail` is provided, the row can be expanded to reveal it.
+ */
+export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
+  props: ExecutionTraceItemProps,
+  ref: DOMRef<HTMLLIElement>
+) {
+  let {
+    isDetailNotCollapsible,
+    detail,
+    icon = <CheckmarkCircle aria-hidden="true" />,
+    children,
+    styles,
+    ...otherProps
+  } = props;
+  let domRef = useDOMRef(ref);
+  let domProps = filterDOMProps(otherProps);
+  let hasDetail = detail != null;
+
+  return (
+    <li
+      {...domProps}
+      ref={domRef}
+      className={mergeStyles(executionTraceItemStyles({isDetailed: hasDetail}), styles)}>
+      <div className={itemIconContainerStyles({isDetailed: hasDetail && !isDetailNotCollapsible})}>
+        <Provider values={[[IconContext, {styles: iconStyle({size: 'M'})}]]}>
+          <CenterBaseline>{icon}</CenterBaseline>
+        </Provider>
+        <div className={executionTraceItemDividerStyles} />
+      </div>
+      {hasDetail && !isDetailNotCollapsible ? (
+        <RACDisclosure className={executionTraceItemContentStyles}>
+          <DetailTrigger>{children}</DetailTrigger>
+          <RACDisclosurePanel className={panelStyles}>{detail}</RACDisclosurePanel>
+        </RACDisclosure>
+      ) : (
+        <div
+          className={mergeStyles(
+            executionTraceItemContentStyles,
+            executionTraceItemNoCollapseStyles
+          )}>
+          <span>{children}</span>
+          {hasDetail && isDetailNotCollapsible ? <div>{detail}</div> : null}
+        </div>
+      )}
+    </li>
   );
 });

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -295,13 +295,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
             aria-label={stringFormatter.format('responsestatus.loading')}
           />
         </CenterBaseline>
-      ) : isInteractive ? (
-        <CenterBaseline styles={chevronStyles({isExpanded, isRTL})}>
-          <Chevron size={size} />
-        </CenterBaseline>
-      ) : null}
-      {props.children}
-      {!isLoading && (
+      ) : (
         <Provider
           values={[
             [
@@ -335,6 +329,12 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
           </CenterBaseline>
         </Provider>
       )}
+      {props.children}
+      {isInteractive ? (
+        <CenterBaseline styles={chevronStyles({isExpanded, isRTL})}>
+          <Chevron size={size} />
+        </CenterBaseline>
+      ) : null}
     </>
   );
 

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -414,24 +414,25 @@ function DetailTrigger(props: DetailTriggerProps) {
 }
 
 export interface ExecutionTraceItemProps extends DOMProps, AriaLabelingProps {
-  /** Allows detail content to render but prevents the row from being collapsible. */
-  isDetailNotCollapsible?: boolean;
   /**
    * The label describing the step.
    */
   children: ReactNode;
-  /**
-   * An icon shown at the leading edge of the row. If omitted, a checkmark is rendered by default.
-   */
-  icon?: ReactNode;
-  /**
-   * Additional detail revealed when the step is expanded, such as tool call input or output.
-   * If omitted, the row is static and cannot be expanded.
-   */
   detail?: ReactNode;
   /**
    * Spectrum-defined styles, returned by the `style()` macro.
    */
+  /**
+   * An icon shown at the leading edge of the row. If omitted, a checkmark is rendered by default.
+   */
+  icon?: ReactNode;
+  /** Allows detail content to render but prevents the row from being collapsible. */
+  isAlwaysOpen?: boolean;
+  /**
+   * Additional detail revealed when the step is expanded, such as tool call input or output.
+   * If omitted, the row is static and cannot be expanded.
+   */
+
   styles?: StyleString;
 }
 
@@ -486,7 +487,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   ref: DOMRef<HTMLLIElement>
 ) {
   let {
-    isDetailNotCollapsible,
+    isAlwaysOpen,
     detail,
     icon = <CheckmarkCircle aria-hidden="true" />,
     children,
@@ -505,7 +506,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
         </Provider>
         <div role="presentation" className={executionTraceItemDividerStyles} />
       </div>
-      {hasDetail && !isDetailNotCollapsible ? (
+      {hasDetail && !isAlwaysOpen ? (
         <RACDisclosure>
           <DetailTrigger>{children}</DetailTrigger>
           <RACDisclosurePanel className={mergeStyles(panelStyles, executionTraceDetailPanelStyles)}>
@@ -515,7 +516,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
       ) : (
         <div className={executionTraceWithoutDisclosureStyles}>
           <span>{children}</span>
-          {hasDetail && isDetailNotCollapsible ? <div>{detail}</div> : null}
+          {hasDetail && isAlwaysOpen ? <div>{detail}</div> : null}
         </div>
       )}
     </li>

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -382,15 +382,11 @@ interface DetailTriggerProps {
 
 const detailTriggerStyles = style({
   display: 'block',
-  paddingY: 4,
-  marginTop: -2,
-  textAlign: 'start'
+  paddingStart: 8
 });
 
 const detailTriggerChevronStyles = style({
   display: 'inline-flex',
-  alignItems: 'center',
-  verticalAlign: 'middle',
   marginStart: 4,
   rotate: {
     isRTL: 180,
@@ -440,29 +436,23 @@ export interface ExecutionTraceItemProps extends DOMProps, AriaLabelingProps {
 }
 
 const executionTraceItemStyles = style({
-  font: 'body',
   display: 'flex',
-  gap: 8,
-  marginTop: {
-    isDetailed: -2
-  },
+  font: 'body',
+  gap: 4,
   '--divider-display': {
     type: 'display',
     value: {
-      default: 'flex',
+      default: 'block',
       ':last-child': 'none'
     }
   }
 });
 
-const itemIconContainerStyles = style({
+const executionTraceItemIconContainerStyles = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  flexShrink: 0,
-  paddingTop: {
-    isDetailed: 2
-  }
+  flexShrink: 0
 });
 
 const executionTraceItemDividerStyles = style({
@@ -473,16 +463,19 @@ const executionTraceItemDividerStyles = style({
   display: 'var(--divider-display, flex)'
 });
 
-const executionTraceItemContentStyles = style({
+const executionTraceItemBaseStyles = {
+  paddingBottom: 12,
+  paddingStart: 8
+} as const;
+
+const executionTraceWithoutDisclosureStyles = style({
+  ...executionTraceItemBaseStyles,
   display: 'flex',
   flexDirection: 'column',
-  paddingBottom: 12,
-  paddingX: 8
-});
-
-const executionTraceItemNoCollapseStyles = style({
   minHeight: 24
 });
+
+const executionTraceDetailPanelStyles = style(executionTraceItemBaseStyles);
 
 /**
  * An ExecutionTraceItem represents a single step within an ExecutionTrace, such as
@@ -505,27 +498,22 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   let hasDetail = detail != null;
 
   return (
-    <li
-      {...domProps}
-      ref={domRef}
-      className={mergeStyles(executionTraceItemStyles({isDetailed: hasDetail}), styles)}>
-      <div className={itemIconContainerStyles({isDetailed: hasDetail && !isDetailNotCollapsible})}>
+    <li {...domProps} ref={domRef} className={mergeStyles(executionTraceItemStyles, styles)}>
+      <div className={executionTraceItemIconContainerStyles}>
         <Provider values={[[IconContext, {styles: iconStyle({size: 'M'})}]]}>
           <CenterBaseline>{icon}</CenterBaseline>
         </Provider>
-        <div className={executionTraceItemDividerStyles} />
+        <div role="presentation" className={executionTraceItemDividerStyles} />
       </div>
       {hasDetail && !isDetailNotCollapsible ? (
-        <RACDisclosure className={executionTraceItemContentStyles}>
+        <RACDisclosure>
           <DetailTrigger>{children}</DetailTrigger>
-          <RACDisclosurePanel className={panelStyles}>{detail}</RACDisclosurePanel>
+          <RACDisclosurePanel className={mergeStyles(panelStyles, executionTraceDetailPanelStyles)}>
+            {detail}
+          </RACDisclosurePanel>
         </RACDisclosure>
       ) : (
-        <div
-          className={mergeStyles(
-            executionTraceItemContentStyles,
-            executionTraceItemNoCollapseStyles
-          )}>
+        <div className={executionTraceWithoutDisclosureStyles}>
           <span>{children}</span>
           {hasDetail && isDetailNotCollapsible ? <div>{detail}</div> : null}
         </div>

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -10,11 +10,25 @@
  * governing permissions and limitations under the License.
  */
 
+import AlertTriangle from '@react-spectrum/s2/icons/AlertTriangle';
 import {categorizeArgTypes, getActionArgs} from '../../s2/stories/utils';
+import {Content} from '@react-spectrum/s2/Content';
+import {
+  ExecutionTrace,
+  ExecutionTraceItem,
+  ResponseStatus,
+  ResponseStatusPanel,
+  ResponseStatusTitle
+} from '@react-spectrum/ai';
+import {InlineAlert} from '@react-spectrum/s2/InlineAlert';
+import {Link} from '@react-spectrum/s2/Link';
+import MagicWand from '@react-spectrum/s2/icons/MagicWand';
 import type {Meta, StoryObj} from '@storybook/react';
+import Plugin from '@react-spectrum/s2/icons/Plugin';
+import PluginGear from '@react-spectrum/s2/icons/PluginGear';
 import React from 'react';
-import {ResponseStatus, ResponseStatusPanel, ResponseStatusTitle} from '@react-spectrum/ai';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import Tools from '@react-spectrum/s2/icons/Tools';
 
 const events = ['onExpandedChange'];
 
@@ -81,6 +95,121 @@ export const NoResponseContent: Story = {
               ? 'Response generated'
               : 'Response failed'}
         </ResponseStatusTitle>
+      </ResponseStatus>
+    </div>
+  )
+};
+
+export const WithExecutionTrace: Story = {
+  args: {
+    defaultExpanded: true,
+    status: 'success',
+    size: 'M'
+  },
+  render: args => (
+    <div className={style({width: 800, minHeight: 240})}>
+      <ResponseStatus {...args}>
+        <ResponseStatusTitle>Used 6 tools</ResponseStatusTitle>
+        <ResponseStatusPanel>
+          <ExecutionTrace>
+            {/** Rendered detail that doesn't offer user the option to collapse. */}
+            <ExecutionTraceItem
+              isDetailNotCollapsible
+              icon={<MagicWand />}
+              detail="The user wants to 'parse the data' with their existing audiences. This is a bit vague - they want to create a new audience based on/combining their existing audiences. Let me search for their existing audiences first to see what we have to work with, then we can brainstorm something creative.">
+              Thought
+            </ExecutionTraceItem>
+
+            {/** Custom icon and text, complex detail content. */}
+            <ExecutionTraceItem
+              icon={<Plugin />}
+              detail={
+                <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
+                  <div>
+                    <span className={style({color: 'gray-600'})}>skill_name: </span>
+                    <span className={style({font: 'code-sm'})}>operational-insights</span>
+                  </div>
+                  <div>
+                    <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
+                    <div className={style({font: 'code-sm'})}>
+                      Loaded skill: operational-insights
+                    </div>
+                  </div>
+                </div>
+              }>
+              Loaded skill Operational Insights
+            </ExecutionTraceItem>
+
+            {/** No icon, text only (default icon renders) */}
+            <ExecutionTraceItem>
+              Read file packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+            </ExecutionTraceItem>
+
+            {/** Custom icon and text, complex detail content and error. */}
+            <ExecutionTraceItem
+              icon={<AlertTriangle />}
+              detail={
+                <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
+                  <div>
+                    <span className={style({color: 'gray-600'})}>db_name: </span>
+                    <span>hkg_db</span>
+                  </div>
+                  <div>
+                    <div className={style({color: 'gray-600', marginBottom: 4})}>sql:</div>
+                    <div className={style({font: 'code-sm', whiteSpace: 'pre-wrap'})}>
+                      {'SELECT DISTINCT a.audienceId AS audience_id, a.name AS audience_name, CASE WHEN a.isEdge = true ' +
+                        "THEN 'Edge' WHEN a.isStreaming = true THEN 'Streaming' WHEN a.isBatch = true THEN 'Batch' ELSE " +
+                        "'Unknown' END AS evaluation_type, a.totalProfiles AS profile_count, ARRAY_AGG(DISTINCT d.name) A" +
+                        'S activation_destinations FROM hkg_dim_audience a LEFT JOIN hkg_br_audience_destination ad ON a.' +
+                        'audienceId = ad.audienceId LEFT JOIN hkg_dim_destination d ON ad.destinationId = d.destinationId' +
+                        ' WHERE a.totalProfiles IS NOT NULL GROUP BY a.audienceId, a.name, a.isEdge, a.isStreaming, a.isBa' +
+                        'tch, a.totalProfiles ORDER BY a.totalProfiles DESC LIMIT 10'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
+                    <InlineAlert
+                      variant="negative"
+                      fillStyle="subtleFill"
+                      styles={style({width: 'full'})}>
+                      <Content>
+                        It looks like this isn't available for your organization right now, so I
+                        wasn't able to look that up for you. If you believe your organization should
+                        have access, your Adobe account team can help get you set up.
+                        <br />
+                        <br />
+                        <span className={style({font: 'code-sm'})}>
+                          {'<system-reminder>\n' +
+                            'The underlying response was HTTP 403 (access denied) — usually because the organization is not ' +
+                            'entitled to this Adobe Experience Platform capability. Reply to the user with the message above ' +
+                            'as your complete response for this turn and then stop. Do not show the status code or raw error ' +
+                            'text, do not invent fixes such as refreshing the session or changing region or profile settings, and...'}
+                        </span>
+                      </Content>
+                    </InlineAlert>
+                  </div>
+                </div>
+              }>
+              Attempted running SQL – Querying top 10 largest audiences.
+            </ExecutionTraceItem>
+
+            {/** Custon icon and text, no detail. */}
+            <ExecutionTraceItem icon={<PluginGear />}>
+              Attempted to call list items tool
+            </ExecutionTraceItem>
+
+            <ExecutionTraceItem icon={<Tools />}>
+              Searched the{' '}
+              <Link variant="secondary" href="https://react-spectrum.adobe.com" target="_blank">
+                React Spectrum
+              </Link>{' '}
+              docs
+            </ExecutionTraceItem>
+          </ExecutionTrace>
+          {/* <div>
+            This example has isOpen hard coded, so only the inner disclosures are collapsable
+          </div> */}
+        </ResponseStatusPanel>
       </ResponseStatus>
     </div>
   )

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -40,10 +40,6 @@ const meta: Meta<typeof ResponseStatus> = {
   tags: ['autodocs'],
   argTypes: {
     ...categorizeArgTypes('Events', events),
-    size: {
-      control: 'radio',
-      options: ['S', 'M', 'L', 'XL']
-    },
     density: {
       control: 'radio',
       options: ['compact', 'regular', 'spacious']
@@ -103,8 +99,7 @@ export const NoResponseContent: Story = {
 export const WithExecutionTrace: Story = {
   args: {
     defaultExpanded: true,
-    status: 'success',
-    size: 'M'
+    status: 'success'
   },
   render: args => (
     <div className={style({width: 800, minHeight: 240})}>
@@ -206,9 +201,6 @@ export const WithExecutionTrace: Story = {
               docs
             </ExecutionTraceItem>
           </ExecutionTrace>
-          {/* <div>
-            This example has isOpen hard coded, so only the inner disclosures are collapsable
-          </div> */}
         </ResponseStatusPanel>
       </ResponseStatus>
     </div>

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -109,15 +109,14 @@ export const WithExecutionTrace: Story = {
           <ExecutionTrace>
             {/** Rendered detail that doesn't offer user the option to collapse. */}
             <ExecutionTraceItem
-              isDetailNotCollapsible
+              detail="The user wants to 'parse the data' with their existing audiences. This is a bit vague - they want to create a new audience based on/combining their existing audiences. Let me search for their existing audiences first to see what we have to work with, then we can brainstorm something creative."
               icon={<MagicWand />}
-              detail="The user wants to 'parse the data' with their existing audiences. This is a bit vague - they want to create a new audience based on/combining their existing audiences. Let me search for their existing audiences first to see what we have to work with, then we can brainstorm something creative.">
+              isAlwaysOpen>
               Thought
             </ExecutionTraceItem>
 
             {/** Custom icon and text, complex detail content. */}
             <ExecutionTraceItem
-              icon={<Plugin />}
               detail={
                 <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
                   <div>
@@ -131,7 +130,8 @@ export const WithExecutionTrace: Story = {
                     </div>
                   </div>
                 </div>
-              }>
+              }
+              icon={<Plugin />}>
               Loaded skill Operational Insights
             </ExecutionTraceItem>
 
@@ -142,7 +142,6 @@ export const WithExecutionTrace: Story = {
 
             {/** Custom icon and text, complex detail content and error. */}
             <ExecutionTraceItem
-              icon={<AlertTriangle />}
               detail={
                 <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
                   <div>
@@ -184,7 +183,8 @@ export const WithExecutionTrace: Story = {
                     </InlineAlert>
                   </div>
                 </div>
-              }>
+              }
+              icon={<AlertTriangle />}>
               Attempted running SQL – Querying top 10 largest audiences.
             </ExecutionTraceItem>
 


### PR DESCRIPTION
This PR introduces `<ExecutionTrace>` and `<ExecutionTraceItem>` - components that render inside a `<ResponseStatus>` in order to highlight the steps an agent took while crafting its response. 

<img width="629" height="375" alt="image" src="https://github.com/user-attachments/assets/71e49c76-7fe3-4b05-b108-010c6869fb83" />


