### PR TITLE
fix: Select type default

### DIFF
--- a/packages/react-aria-components/src/Select.tsx
+++ b/packages/react-aria-components/src/Select.tsx
@@ -98,7 +98,7 @@ export interface SelectRenderProps {
   isRequired: boolean;
 }
 
-export interface SelectProps<T, M extends SelectionMode = 'single'>
+export interface SelectProps<T = {}, M extends SelectionMode = 'single'>
   extends
     Omit<
       AriaSelectProps<T, M>,


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10358

Looks like we can reinstate the default

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
