### PR TITLE
fix: Add button role to sortable column header text in Table starters

### DIFF
--- a/packages/react-aria-components/src/Group.tsx
+++ b/packages/react-aria-components/src/Group.tsx
@@ -87,10 +87,12 @@ export interface GroupProps
    * Use `'region'` when the contents of the group is important enough to be
    * included in the page table of contents. Use `'presentation'` if the group
    * is visual only and does not represent a semantic grouping of controls.
+   * Use `'button'` when the group wraps focusable text that forwards clicks
+   * to a parent control, such as the text of a sortable table column header.
    *
    * @default 'group'
    */
-  role?: 'group' | 'region' | 'presentation';
+  role?: 'group' | 'region' | 'presentation' | 'button';
 }
 
 export const GroupContext = createContext<ContextValue<GroupProps, HTMLDivElement>>({});

--- a/starters/docs/src/Table.tsx
+++ b/starters/docs/src/Table.tsx
@@ -41,7 +41,10 @@ export function Column(props: Omit<ColumnProps, 'children'> & {children?: React.
     <AriaColumn {...props} className="react-aria-Column button-base">
       {({allowsSorting, sortDirection}) => (
         <div className="column-header">
-          <Group role="presentation" tabIndex={-1} className="column-name">
+          <Group
+            role={allowsSorting ? 'button' : 'presentation'}
+            tabIndex={-1}
+            className="column-name">
             {props.children}
           </Group>
           {allowsSorting && (

--- a/starters/tailwind/src/Table.tsx
+++ b/starters/tailwind/src/Table.tsx
@@ -69,7 +69,10 @@ export function Column(props: ColumnProps) {
       )}>
       {composeRenderProps(props.children, (children, {allowsSorting, sortDirection}) => (
         <div className="flex items-center">
-          <Group role="presentation" tabIndex={-1} className={columnStyles}>
+          <Group
+            role={allowsSorting ? 'button' : 'presentation'}
+            tabIndex={-1}
+            className={columnStyles}>
             <span className="truncate">{children}</span>
             {allowsSorting && (
               <span


### PR DESCRIPTION
Closes #8502

The Table starters wrap the column header text in a `Group` with `tabIndex={-1}` so it can be focused independently from the `ColumnResizer`, but the group had `role="presentation"`. A focusable element with a presentation role hits the ARIA presentation conflict rule, and screen readers get no hint that clicking the text changes the sort order.

This change sets `role="button"` on that group when the column is sortable, which is when a screen reader click on it actually triggers an action. Non sortable columns keep the current behavior, since the first Table example in the docs uses plain columns and announcing an inert button there would be misleading. Happy to make it unconditional instead if that is the preference.

`GroupProps` only allowed `'group' | 'region' | 'presentation'` for `role`, so this also adds `'button'` to that union, with a short note in the prop description about when to use it.

Changed files:

- `starters/docs/src/Table.tsx` and `starters/tailwind/src/Table.tsx`, rendered by the Table docs
- `packages/react-aria-components/src/Group.tsx`, role type widened

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Open the Table sorting example in the docs (rendered from the vanilla or tailwind starter). Inspect a sortable column header: the inner group with `tabindex="-1"` should now have `role="button"`. With VoiceOver or NVDA, focus the column header text and confirm it is announced as a button, then activate it and confirm the sort order changes. Non sortable columns (for example the first Table example on the page) should be unchanged.

## 🧢 Your Project:

Personal open source contribution
