### PR TITLE
fix: Minor PromptField styling fixes

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -160,6 +160,7 @@ const containerBackground = css(`
 
   &[data-state=generating] {
     box-shadow:
+      var(--prominent-outline-glow)
       inset 0 0 0 1px var(--border-color),
       inset 0 6px 15px 0 var(--inset-shadow-color),
       inset 0 -32px 100px -50px ${token('container.color.inner-shadow.generating')},

--- a/packages/@react-spectrum/ai/src/loader/react.tsx
+++ b/packages/@react-spectrum/ai/src/loader/react.tsx
@@ -214,7 +214,6 @@ export function PixelLoader(props: PixelLoaderProps) {
         width: size,
         height: size,
         lineHeight: 0,
-        overflow: 'clip',
         position: 'relative'
       }}
       {...rest}>


### PR DESCRIPTION
* Fixes loader animation being clipped
* Fixes transition between regular and generating states with variant=prominent, and preserves the outline glow shadow layer when generating (it was previously lost).