### PR TITLE
fix: DialogTrigger inside Tabs

### DIFF
--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -83,13 +83,6 @@ export function DialogTrigger(props: DialogTriggerProps): JSX.Element | null {
   // This is needed to handle submenus.
   let state = useMenuTriggerState(props);
 
-  // If within a collection (e.g. Tabs), render nothing.
-  // Not using createHideableComponent for this because that also creates a forwardRef.
-  let isHidden = useIsHidden();
-  if (isHidden) {
-    return null;
-  }
-
   let buttonRef = useRef<HTMLButtonElement>(null);
   let {triggerProps, overlayProps} = useOverlayTrigger({type: 'dialog'}, state, buttonRef);
 
@@ -101,6 +94,13 @@ export function DialogTrigger(props: DialogTriggerProps): JSX.Element | null {
   triggerProps.id = useId();
   // oxlint-disable-next-line react/react-compiler
   overlayProps['aria-labelledby'] = triggerProps.id;
+
+  // If within a collection (e.g. Tabs), render nothing.
+  // Not using createHideableComponent for this because that also creates a forwardRef.
+  let isHidden = useIsHidden();
+  if (isHidden) {
+    return null;
+  }
 
   return (
     <Provider

--- a/packages/react-aria-components/src/Dialog.tsx
+++ b/packages/react-aria-components/src/Dialog.tsx
@@ -42,6 +42,7 @@ import React, {
 import {RootMenuTriggerStateContext} from './Menu';
 import {TextContext} from './Text';
 import {useId} from 'react-aria/useId';
+import {useIsHidden} from 'react-aria/private/collections/Hidden';
 import {useMenuTriggerState} from 'react-stately/useMenuTriggerState';
 import {useOverlayTrigger} from 'react-aria/useOverlayTrigger';
 
@@ -77,10 +78,17 @@ export const OverlayTriggerStateContext = createContext<OverlayTriggerState | nu
 /**
  * A DialogTrigger opens a dialog when a trigger element is pressed.
  */
-export function DialogTrigger(props: DialogTriggerProps): JSX.Element {
+export function DialogTrigger(props: DialogTriggerProps): JSX.Element | null {
   // Use useMenuTriggerState instead of useOverlayTriggerState in case a menu is embedded in the dialog.
   // This is needed to handle submenus.
   let state = useMenuTriggerState(props);
+
+  // If within a collection (e.g. Tabs), render nothing.
+  // Not using createHideableComponent for this because that also creates a forwardRef.
+  let isHidden = useIsHidden();
+  if (isHidden) {
+    return null;
+  }
 
   let buttonRef = useRef<HTMLButtonElement>(null);
   let {triggerProps, overlayProps} = useOverlayTrigger({type: 'dialog'}, state, buttonRef);

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -20,7 +20,7 @@ import {
 } from '@react-spectrum/test-utils-internal';
 import {Button} from '../src/Button';
 import {ComboBox} from '../src/ComboBox';
-import {Dialog, DialogTrigger} from '../src/Dialog';
+import {DialogTrigger} from '../src/Dialog';
 import {Input} from '../src/Input';
 import {Label} from '../src/Label';
 import {ListBox, ListBoxItem} from '../src/ListBox';

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -1091,13 +1091,11 @@ describe('Tabs', () => {
           </TabList>
           <DialogTrigger>
             <Button>Dialog button</Button>
-            <Popover>
-              <Dialog aria-label="Filters">
-                <Menu aria-label="Filter options">
-                  <MenuItem>Item 1</MenuItem>
-                  <MenuItem>Item 2</MenuItem>
-                </Menu>
-              </Dialog>
+            <Popover aria-label="Filters">
+              <Menu aria-label="Filter options">
+                <MenuItem>Item 1</MenuItem>
+                <MenuItem>Item 2</MenuItem>
+              </Menu>
             </Popover>
           </DialogTrigger>
         </div>

--- a/packages/react-aria-components/test/Tabs.test.js
+++ b/packages/react-aria-components/test/Tabs.test.js
@@ -20,6 +20,7 @@ import {
 } from '@react-spectrum/test-utils-internal';
 import {Button} from '../src/Button';
 import {ComboBox} from '../src/ComboBox';
+import {Dialog, DialogTrigger} from '../src/Dialog';
 import {Input} from '../src/Input';
 import {Label} from '../src/Label';
 import {ListBox, ListBoxItem} from '../src/ListBox';
@@ -1078,5 +1079,40 @@ describe('Tabs', () => {
     await menu.open();
     expect(menu.getOptions()).toHaveLength(3);
     await menu.close();
+  });
+
+  it('supports DialogTrigger inside Tabs', async () => {
+    let tree = render(
+      <Tabs>
+        <div>
+          <TabList>
+            <Tab id="key1">First Tab</Tab>
+            <Tab id="key2">Second Tab</Tab>
+          </TabList>
+          <DialogTrigger>
+            <Button>Dialog button</Button>
+            <Popover>
+              <Dialog aria-label="Filters">
+                <Menu aria-label="Filter options">
+                  <MenuItem>Item 1</MenuItem>
+                  <MenuItem>Item 2</MenuItem>
+                </Menu>
+              </Dialog>
+            </Popover>
+          </DialogTrigger>
+        </div>
+        <TabPanel id="key1">First Tab content</TabPanel>
+        <TabPanel id="key2">Second Tab content</TabPanel>
+      </Tabs>
+    );
+
+    let tester = testUtilUser.createTester('Tabs', {root: tree.getByRole('tablist')});
+    expect(tester.getTabs().length).toBe(2);
+
+    let trigger = tree.getByRole('button');
+    await user.click(trigger);
+
+    let dialog = tree.getByRole('dialog');
+    expect(within(dialog).getAllByRole('menuitem')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Follow-up to #10019, which made collection triggers hideable "so that the parent collection doesn't try to inherit the items from the child collection". `MenuTrigger`, `Select` and `ComboBox` were covered there; `DialogTrigger` was not.

(No issue to close — #9011 and its duplicate #9067 are already closed, and the cases they reported are fixed by #10019. This is the remaining trigger.)

A `DialogTrigger` inside a collection still renders during that collection's hidden pass. Its `Popover` preserves children there, so collection content inside the dialog renders detached from its own providers. With a `Menu` in the dialog this throws:

```
TypeError: Cannot read properties of null (reading 'isDisabled')
    at useMenuItem
```

That shape shows up in real UIs — a popover panel that holds a menu, rendered next to a `TabList` in the tab row. In our case the panel has two modes (a searchable list of filters, and a set of filter editors), so it's legitimately a dialog rather than a `MenuTrigger`.

This applies the same treatment `MenuTrigger` got, in the same place and with the same comment. The check sits after the hooks so they stay unconditional.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/9011).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

`yarn jest packages/react-aria-components/test/Tabs.test.js`

The added test `supports DialogTrigger inside Tabs` sits alongside the Menu/Select/ComboBox cases from #10019. It fails on `main` with the TypeError above and passes with this change. The full `packages/react-aria-components` suite passes (55 suites, 1568 tests).

## 🧢 Your Project:

[Metaview](https://www.metaview.ai)
