### PR TITLE
chore: make sure Autocomplete docs doesnt have related pages and other docs fixes from testing

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Autocomplete.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Autocomplete.mdx
@@ -8,7 +8,6 @@ import {InlineAlert, Heading, Content} from '@react-spectrum/s2'
 
 export const tags = ['combobox', 'typeahead', 'input'];
 export const version = 'rc';
-export const relatedPages = [];
 export const description = 'Allows users to search or filter a list of suggestions.';
 
 # Autocomplete
@@ -1163,13 +1162,13 @@ function Example() {
   let updateFilter = () => {
     let {selectionStart, selectionEnd, value} = inputRef.current!;
     if (selectionStart === selectionEnd && document.activeElement === inputRef.current!) {
-      // The current filter value is the substring between 
+      // The current filter value is the substring between
       // the anchor character '@' and the caret position.
       let index = value.lastIndexOf('@', selectionStart);
       if (index >= 0) {
         let slice = value.slice(index + 1, selectionStart);
         // Spaces are not allowed in the filter value.
-        if (!slice.includes(' ')) { 
+        if (!slice.includes(' ')) {
           setAnchorIndex(index);
           setFilterValue(slice);
           return;
@@ -1177,11 +1176,11 @@ function Example() {
       }
     }
 
-    // Reset the anchor index, but not the filter value so 
+    // Reset the anchor index, but not the filter value so
     // that the menu does not flicker during the close animation.
     setAnchorIndex(-1);
   };
-  
+
   return (
     /*- begin highlight -*/
     // Pass the filter substring to Autocomplete.

--- a/packages/dev/s2-docs/pages/s2/SideNav.mdx
+++ b/packages/dev/s2-docs/pages/s2/SideNav.mdx
@@ -71,7 +71,7 @@ interface Item {
 let items: Item[] = [
   {id: 1, title: 'Documents', type: 'directory', children: [
     {id: 2, title: 'Project', type: 'directory', children: [
-      {id: 3, title: 'Weekly Report', type: 'file', href: '/weekly-report'},
+      {id: 3, title: 'Notes', type: 'file', href: '/notes'},
       {id: 4, title: 'Budget', type: 'file', href: '/budget'}
     ]}
   ]},
@@ -82,7 +82,7 @@ let items: Item[] = [
 ];
 ///- end collapse -///
 
-<RoutedSideNav defaultSelectedRoute="/weekly-report">
+<RoutedSideNav defaultSelectedRoute="/notes">
   {({selectedRoute}) => (
     <SideNav
       aria-label="Files"
@@ -110,7 +110,7 @@ let items: Item[] = [
 
 ### Slots
 
-`SideNavItemContent` supports icons, `Text`, [ActionMenu](ActionMenu), and [ActionButtonGroup](ActionButtonGroup) as children.
+`SideNavItemContent` supports icons, `Text`, [SideNavItemLink](#sidenavitemlink), [ActionMenu](ActionMenu), and [ActionButtonGroup](ActionButtonGroup) as children.
 
 ```tsx render type="s2" files={['packages/dev/s2-docs/pages/s2/RoutedSideNav.tsx']}
 "use client";
@@ -134,7 +134,7 @@ interface Item {
 let items: Item[] = [
   {id: 1, title: 'Documents', type: 'directory', children: [
     {id: 2, title: 'Project', type: 'directory', children: [
-      {id: 3, title: 'Weekly Report', type: 'file', href: '/weekly-report'},
+      {id: 3, title: 'Notes', type: 'file', href: '/notes'},
       {id: 4, title: 'Budget', type: 'file', href: '/budget'}
     ]}
   ]},
@@ -145,7 +145,7 @@ let items: Item[] = [
 ];
 ///- end collapse -///
 
-<RoutedSideNav defaultSelectedRoute="/weekly-report">
+<RoutedSideNav defaultSelectedRoute="/notes">
   {({selectedRoute}) => (
     <SideNav
       aria-label="Files"

--- a/starters/docs/src/Popover.css
+++ b/starters/docs/src/Popover.css
@@ -14,6 +14,7 @@
     opacity 200ms;
   font: var(--font-size) system-ui;
   padding: 8px;
+  overflow: auto;
 
   &[data-trigger='MenuTrigger'],
   &[data-trigger='SubmenuTrigger'] {

--- a/starters/hooks/src/Popover.css
+++ b/starters/hooks/src/Popover.css
@@ -14,6 +14,7 @@
     opacity 200ms;
   font: var(--font-size) system-ui;
   padding: 8px;
+  overflow: auto;
 
   &[data-trigger='MenuTrigger'],
   &[data-trigger='SubmenuTrigger'] {

--- a/starters/tailwind/src/Popover.tsx
+++ b/starters/tailwind/src/Popover.tsx
@@ -14,7 +14,7 @@ export interface PopoverProps extends Omit<AriaPopoverProps, 'children'> {
 }
 
 const styles = tv({
-  base: 'font-sans bg-white dark:bg-neutral-900/70 dark:backdrop-blur-2xl dark:backdrop-saturate-200 forced-colors:bg-[Canvas] shadow-2xl rounded-xl bg-clip-padding border border-black/10 dark:border-white/10 text-neutral-700 dark:text-neutral-300 outline-0',
+  base: 'font-sans bg-white dark:bg-neutral-900/70 dark:backdrop-blur-2xl dark:backdrop-saturate-200 forced-colors:bg-[Canvas] shadow-2xl rounded-xl bg-clip-padding border border-black/10 dark:border-white/10 text-neutral-700 dark:text-neutral-300 outline-0 overflow-auto',
   variants: {
     isEntering: {
       true: 'animate-in fade-in placement-bottom:slide-in-from-top-1 placement-top:slide-in-from-bottom-1 placement-left:slide-in-from-right-1 placement-right:slide-in-from-left-1 ease-out duration-200'


### PR DESCRIPTION
From testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Go to RAC Autocomplete docs page and make sure there isn't a "Related Pages" in the table of contents
Also fixes the Popover overflow issue for RAC starters (see DatePicker in small window, dates shouldn't overflow), and SideNav copy updates from testing

## 🧢 Your Project:

RSP
