### PR TITLE
chore: Export PixelLoader and add brandColor prop to PromptField

### DIFF
--- a/packages/@react-spectrum/ai/exports/index.ts
+++ b/packages/@react-spectrum/ai/exports/index.ts
@@ -34,6 +34,7 @@ export {
 } from '../src/Chat';
 export {TokenFieldValue} from 'react-aria-components/TokenField';
 export {UserMessage} from '../src/UserMessage';
+export {PixelLoader} from '../src/loader/react';
 
 export type {AttachmentProps, AttachmentListProps} from '../src/AttachmentList';
 export type {

--- a/packages/@react-spectrum/ai/exports/index.ts
+++ b/packages/@react-spectrum/ai/exports/index.ts
@@ -68,3 +68,4 @@ export type {
 } from '../src/Chat';
 export type {TokenFieldValueOptions} from 'react-aria-components/TokenField';
 export type {UserMessageProps} from '../src/UserMessage';
+export type {PixelLoaderProps} from '../src/loader/react';

--- a/packages/@react-spectrum/ai/exports/loader.ts
+++ b/packages/@react-spectrum/ai/exports/loader.ts
@@ -1,1 +1,2 @@
+export {PixelLoader} from '../src/loader/react';
 export * from '../src/loader/data';

--- a/packages/@react-spectrum/ai/exports/loader.ts
+++ b/packages/@react-spectrum/ai/exports/loader.ts
@@ -1,2 +1,4 @@
 export {PixelLoader} from '../src/loader/react';
 export * from '../src/loader/data';
+
+export type {PixelLoaderProps} from '../src/loader/react';

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -404,7 +404,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
         width: 'full'
       })({isFocused: isFocused || prompt.segments.length > 0})}>
       <CenterBaseline>
-        <PixelLoader playing={isGenerating} icon={pixelLoader} />
+        <PixelLoader isPlaying={isGenerating} icon={pixelLoader} />
       </CenterBaseline>
       <Autocomplete>
         <TokenField

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -100,6 +100,7 @@ export interface PromptFieldProps {
   onRemoveAttachments?: (attachments: PromptFieldAttachment[]) => void;
   styles?: StyleString;
   variant?: 'balanced' | 'prominent' | 'subtle';
+  brandColor?: string;
   hideDisclaimer?: boolean;
 }
 
@@ -193,7 +194,8 @@ export const PromptField = forwardRef(function PromptField(
     onAddAttachments,
     onRemoveAttachments,
     hideDisclaimer,
-    variant = 'balanced'
+    variant = 'balanced',
+    brandColor
   } = props;
   let domRef = useDOMRef(ref);
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
@@ -277,6 +279,7 @@ export const PromptField = forwardRef(function PromptField(
           {...dropProps}
           role="group"
           variant={variant}
+          brandColor={brandColor}
           isGenerating={isGenerating ?? false}
           isDropTarget={isDropTarget}
           styles={styles}

--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -256,12 +256,13 @@ interface PropFieldContainerProps extends Omit<GroupProps, 'children'> {
   variant: 'balanced' | 'prominent' | 'subtle';
   isGenerating: boolean;
   isDropTarget: boolean;
+  brandColor?: string;
   styles?: StyleString;
   inputRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export function PromptFieldContainer(props: PropFieldContainerProps) {
-  let {variant, isGenerating, isDropTarget, styles, inputRef, ...otherProps} = props;
+  let {variant, isGenerating, isDropTarget, styles, inputRef, brandColor, ...otherProps} = props;
   let [isFocused, setFocused] = useState(false);
 
   return (
@@ -272,6 +273,11 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
       data-state={isGenerating ? 'generating' : 'idle'}
       data-focused={isFocused || undefined}
       className={outerBorder}
+      style={{
+        ...props.style,
+        // @ts-ignore
+        '--brand': brandColor
+      }}
       onFocus={e => {
         if (e.isTrusted) {
           setFocused(true);

--- a/packages/@react-spectrum/ai/src/loader/react.tsx
+++ b/packages/@react-spectrum/ai/src/loader/react.tsx
@@ -139,7 +139,7 @@ function keyframesFor(cells: Cell[]): string {
   return css;
 }
 
-interface PixelLoaderProps {
+export interface PixelLoaderProps {
   /**
    * Size of the loader in pixels. Multiples of 7 render evenly on the pixel grid.
    */

--- a/packages/@react-spectrum/ai/src/loader/react.tsx
+++ b/packages/@react-spectrum/ai/src/loader/react.tsx
@@ -140,20 +140,36 @@ function keyframesFor(cells: Cell[]): string {
 }
 
 interface PixelLoaderProps {
+  /**
+   * Size of the loader in pixels. Multiples of 7 render evenly on the pixel grid.
+   */
   size?: number;
-  playing?: boolean;
+  /**
+   * Whether the animation is playing.
+   */
+  isPlaying?: boolean;
+  /**
+   * The icon or sequence of icons to display. These should be imported from
+   * '@react-spectrum/ai/loader'.
+   */
   icon?: Cell[] | Cell[][];
-  speed?: number;
+  /**
+   * The color of the icon.
+   *
+   * @default 'currentColor'
+   */
   color?: string;
+  /**
+   * A custom CSS class to apply.
+   */
   className?: string;
 }
 
 export function PixelLoader(props: PixelLoaderProps) {
   const {
     size = 21,
-    playing = true,
+    isPlaying = true,
     icon = aiLogo,
-    speed = 1,
     color = 'currentColor',
     className,
     ...rest
@@ -165,7 +181,7 @@ export function PixelLoader(props: PixelLoaderProps) {
     [icon]
   );
   const isSequence = sequence.length > 1;
-  const duration = DURATION_MS / (speed || 1);
+  const duration = DURATION_MS;
 
   // `tick` increments once per cycle; the current icon is `tick % len`.
   const [tick, setTick] = React.useState(0);
@@ -180,12 +196,12 @@ export function PixelLoader(props: PixelLoaderProps) {
   // Advance the sequence one icon per cycle while playing. Single-icon
   // loaders never start a timer — they're a pure infinite CSS loop.
   React.useEffect(() => {
-    if (!playing || !isSequence) {
+    if (!isPlaying || !isSequence) {
       return undefined;
     }
     const id = setInterval(() => setTick(t => t + 1), duration);
     return () => clearInterval(id);
-  }, [playing, isSequence, duration, sequence]);
+  }, [isPlaying, isSequence, duration, sequence]);
 
   const cells = sequence[isSequence ? tick % sequence.length : 0];
   const animId = iconId(cells);
@@ -217,7 +233,7 @@ export function PixelLoader(props: PixelLoaderProps) {
         position: 'relative'
       }}
       {...rest}>
-      {playing ? <style>{css}</style> : null}
+      {isPlaying ? <style>{css}</style> : null}
       {cells.map((c, i) => {
         let x = (c.cx - 120) / CELL;
         let y = (c.cy - 120) / CELL;
@@ -250,7 +266,7 @@ export function PixelLoader(props: PixelLoaderProps) {
               height: cellSize + (isHighDPI && c.outer ? 0.5 : 0),
               borderRadius: `${corner(left, top)} ${corner(right, top)} ${corner(right, bottom)} ${corner(left, bottom)}`,
               backgroundColor: color,
-              ...(playing && {
+              ...(isPlaying && {
                 animation:
                   `${animId}-${i}-y ${duration}ms linear ${iteration}, ` +
                   `${animId}-${i}-o ${duration}ms linear ${iteration}`,

--- a/packages/@react-spectrum/ai/stories/PromptField.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/PromptField.stories.tsx
@@ -66,7 +66,7 @@ const meta: Meta<typeof PromptField> = {
   argTypes: {
     ...categorizeArgTypes('Events', events),
     children: {table: {disable: true}},
-    brand: {
+    brandColor: {
       control: 'color',
       description:
         'Sets the --brand custom property to retheme the PromptField. Only the hue is used; lightness and chroma come from the design tokens.',
@@ -92,7 +92,7 @@ const meta: Meta<typeof PromptField> = {
     }
   },
   args: {
-    brand: 'rgb(236, 105, 255)',
+    brandColor: 'rgb(236, 105, 255)',
     pixelLoader: 'aiLogo',
     attachmentVariant: 'thumbnail',
     attachmentInvalid: false,
@@ -101,14 +101,12 @@ const meta: Meta<typeof PromptField> = {
   },
   title: 'AI/PromptField',
   decorators: [
-    (Story, {args}) => (
+    Story => (
       <div
         style={{
           width: '800px',
           maxWidth: '90vw',
-          margin: '0 auto',
-          // @ts-ignore
-          '--brand': args.brand
+          margin: '0 auto'
         }}>
         <Story />
       </div>
@@ -351,7 +349,7 @@ function EverythingRender(args) {
   };
 
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
+    <div style={{display: 'flex', flexDirection: 'column', gap: 32}}>
       <MessageSuggestionList title="Suggestions">
         {prompts.map((prompt, i) => (
           <MessageSuggestion key={i} onPress={() => setValue(prompt)}>


### PR DESCRIPTION
Exports PixelLoader so it can be used outside PromptField. Also adds a `brandColor` prop to PromptField so it's easier to set instead of needing to know to use the `--brand` CSS variable.