### PR TITLE
fix: `ResponseStatus` QA

### DIFF
--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -431,6 +431,20 @@ const executionTraceItemStyles = style({
       default: 'block',
       ':last-child': 'none'
     }
+  },
+  '--execution-trace-item-padding-bottom-disclosure': {
+    type: 'paddingBottom',
+    value: {
+      default: 12,
+      ':last-child': 0
+    }
+  },
+  '--execution-trace-item-padding-bottom-no-disclosure': {
+    type: 'paddingBottom',
+    value: {
+      default: 16,
+      ':last-child': 0
+    }
   }
 });
 
@@ -455,7 +469,7 @@ const executionTraceDisclosurePanelStyles = style({
 });
 
 const executionTraceDisclosureContainerStyles = style({
-  paddingBottom: 12,
+  paddingBottom: 'var(--execution-trace-item-padding-bottom-disclosure)',
   marginTop: -4
 });
 
@@ -463,7 +477,7 @@ const executionTraceWithoutDisclosureStyles = style({
   paddingStart: 8,
   display: 'flex',
   flexDirection: 'column',
-  minHeight: 24
+  paddingBottom: 'var(--execution-trace-item-padding-bottom-no-disclosure)'
 });
 
 /**

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -281,7 +281,7 @@ export interface ResponseStatusPanelProps
   styles?: StyleString;
 }
 
-const panelStyles = style({
+const panelStyle = {
   font: 'body',
   height: '--disclosure-panel-height',
   overflow: 'clip',
@@ -289,7 +289,7 @@ const panelStyles = style({
     default: '[height]',
     '@media (prefers-reduced-motion: reduce)': 'none'
   }
-});
+} as const;
 
 const panelInner = style({
   paddingTop: 8,
@@ -316,7 +316,10 @@ export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
   }, [registerPanel]);
 
   return (
-    <RACDisclosurePanel {...domProps} ref={panelRef} className={mergeStyles(panelStyles, styles)}>
+    <RACDisclosurePanel
+      {...domProps}
+      ref={panelRef}
+      className={mergeStyles(style(panelStyle), styles)}>
       <div className={panelInner}>{props.children}</div>
     </RACDisclosurePanel>
   );
@@ -446,19 +449,22 @@ const executionTraceItemDividerStyles = style({
   display: 'var(--divider-display, flex)'
 });
 
-const executionTraceItemBaseStyles = {
-  paddingBottom: 12,
+const executionTraceDisclosurePanelStyles = style({
+  ...panelStyle,
   paddingStart: 8
-} as const;
+});
+
+const executionTraceDisclosureContainerStyles = style({
+  paddingBottom: 12,
+  marginTop: -4
+});
 
 const executionTraceWithoutDisclosureStyles = style({
-  ...executionTraceItemBaseStyles,
+  paddingStart: 8,
   display: 'flex',
   flexDirection: 'column',
   minHeight: 24
 });
-
-const executionTraceDetailPanelStyles = style(executionTraceItemBaseStyles);
 
 /**
  * An ExecutionTraceItem represents a single step within an ExecutionTrace, such as
@@ -489,12 +495,14 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
         <div role="presentation" className={executionTraceItemDividerStyles} />
       </div>
       {hasDetail && !isAlwaysOpen ? (
-        <RACDisclosure>
-          <DetailTrigger>{children}</DetailTrigger>
-          <RACDisclosurePanel className={mergeStyles(panelStyles, executionTraceDetailPanelStyles)}>
-            {detail}
-          </RACDisclosurePanel>
-        </RACDisclosure>
+        <div className={executionTraceDisclosureContainerStyles}>
+          <RACDisclosure>
+            <DetailTrigger>{children}</DetailTrigger>
+            <RACDisclosurePanel className={executionTraceDisclosurePanelStyles}>
+              {detail}
+            </RACDisclosurePanel>
+          </RACDisclosure>
+        </div>
       ) : (
         <div className={executionTraceWithoutDisclosureStyles}>
           <span>{children}</span>

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -158,12 +158,11 @@ const buttonStyles = style({
     }
   },
   display: 'flex',
-  flexGrow: 1,
+  flexGrow: 0,
   alignItems: 'center',
   paddingX: 'calc(self(minHeight) * 3/8 - 1px)',
   gap: 'calc(self(minHeight) * 3/8 - 1px)',
   minHeight: 32,
-  width: 'full',
   backgroundColor: 'transparent',
   transition: 'default',
   borderWidth: 0,


### PR DESCRIPTION
## ✨ Changes:

- fix: move paddingBottom from disclosure panel to wrapper so that it doesn't impact the height transition
- fix: don't stretch disclosure so that focus ring hugs content
- don't apply paddingBottom to last `li` & also ensure that dislosure and non-disclosure items are the same height via padding size

## 📝 Test Instructions:

- content jump flicker no longer happening when expanding/collapsing `ExecutionTraceItem`s
- tab to parent `ResponseStatus` and child `ExecutionTraceItem`s and see focus ring hug content
- inspect last element to see no paddingBottom applied and both item types are 40px when no content wraps


