### PR TITLE
fix: SideNav selectedRoute optional

### DIFF
--- a/packages/@react-spectrum/s2/src/SideNav.tsx
+++ b/packages/@react-spectrum/s2/src/SideNav.tsx
@@ -92,7 +92,7 @@ export interface SideNavProps<T>
     >,
     UnsafeStyles {
   /** The route that is currently selected. */
-  selectedRoute: string;
+  selectedRoute?: string | null;
   /** Spectrum-defined styles, returned by the `style()` macro. */
   styles?: StylesPropWithHeight;
 }

--- a/packages/@react-spectrum/s2/src/SideNav.tsx
+++ b/packages/@react-spectrum/s2/src/SideNav.tsx
@@ -153,7 +153,7 @@ const tree = style<TreeRenderProps>({
 
 interface InternalSideNavContextValue {
   /** The route that is currently selected. */
-  selectedRoute?: string;
+  selectedRoute?: string | null;
   /** The last route the focused key was synced to; dedupes the focus sync across items. */
   syncedRouteRef?: RefObject<string | undefined>;
 }

--- a/packages/@react-spectrum/s2/test/SideNav.test.tsx
+++ b/packages/@react-spectrum/s2/test/SideNav.test.tsx
@@ -237,6 +237,15 @@ describe('SideNav', () => {
     expect(queryByRole('link', {name: 'Projects 1'})).toBeNull();
   });
 
+  it('marks nothing if the selectedRoute is null', () => {
+    let {getAllByRole} = render(<SideNavExample selectedRoute={null} />);
+
+    let links = getAllByRole('link');
+    for (let link of links) {
+      expect(link).not.toHaveAttribute('aria-current');
+    }
+  });
+
   it('marks the link matching selectedRoute with aria-current="page"', () => {
     let {getByRole, rerender} = render(<SideNavExample selectedRoute="/files" />);
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Found while working on putting SideNav in our docs, we have pages like `useButton` which don't have a link in our SideNav but do display the SideNav when you visit those pages through `Button`'s ToC or through search.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
