### PR TITLE
fix: select the autofocused item when selectOnFocus is true

### DIFF
--- a/packages/react-aria-components/test/GridList.test.js
+++ b/packages/react-aria-components/test/GridList.test.js
@@ -226,6 +226,51 @@ describe('GridList', () => {
     expect(document.activeElement).toBe(gridList);
   });
 
+  describe('autoFocus with selectOnFocus (selectionBehavior="replace")', () => {
+    it.each`
+      autoFocus  | index
+      ${'first'} | ${0}
+      ${'last'}  | ${2}
+    `(
+      'selects the autofocused row when selectOnFocus with autoFocus=$autoFocus',
+      ({autoFocus, index}) => {
+        let {getAllByRole} = renderGridList({
+          selectionMode: 'single',
+          selectionBehavior: 'replace',
+          autoFocus
+        });
+        let rows = getAllByRole('row');
+        expect(document.activeElement).toBe(rows[index]);
+        expect(rows[index]).toHaveAttribute('aria-selected', 'true');
+      }
+    );
+
+    it('does not select the autofocused row when selectionMode="none"', () => {
+      let {getAllByRole} = renderGridList({
+        selectionMode: 'none',
+        selectionBehavior: 'replace',
+        autoFocus: 'first'
+      });
+      let rows = getAllByRole('row');
+      expect(document.activeElement).toBe(rows[0]);
+      expect(rows[0]).not.toHaveAttribute('aria-selected');
+    });
+
+    it('does not change an existing "all" selection when autofocusing', () => {
+      let {getAllByRole} = renderGridList({
+        selectionMode: 'multiple',
+        selectionBehavior: 'replace',
+        defaultSelectedKeys: 'all',
+        autoFocus: 'first'
+      });
+      let rows = getAllByRole('row');
+      expect(document.activeElement).toBe(rows[0]);
+      for (let row of rows) {
+        expect(row).toHaveAttribute('aria-selected', 'true');
+      }
+    });
+  });
+
   it('should support hover', async () => {
     let onHoverStart = jest.fn();
     let onHoverChange = jest.fn();

--- a/packages/react-aria/src/selection/useSelectableCollection.ts
+++ b/packages/react-aria/src/selection/useSelectableCollection.ts
@@ -625,6 +625,15 @@ export function useSelectableCollection(
       manager.setFocused(true);
       manager.setFocusedKey(focusedKey);
 
+      if (
+        focusedKey != null &&
+        selectOnFocus &&
+        !selectedKeys.size &&
+        manager.canSelectItem(focusedKey)
+      ) {
+        manager.replaceSelection(focusedKey);
+      }
+
       // If no default focus key is selected, focus the collection itself.
       if (focusedKey == null && !shouldUseVirtualFocus && ref.current) {
         focusSafely(ref.current);

--- a/packages/react-aria/stories/selection/List.tsx
+++ b/packages/react-aria/stories/selection/List.tsx
@@ -1,6 +1,7 @@
 import {
   AsyncLoadable,
   CollectionBase,
+  FocusStrategy,
   MultipleSelection,
   Node,
   SelectionBehavior
@@ -56,4 +57,5 @@ export function List<T extends object>(props: ListProps<T>): JSX.Element {
 
 export interface ListProps<T> extends CollectionBase<T>, AsyncLoadable, MultipleSelection {
   selectionBehavior?: SelectionBehavior;
+  autoFocus?: boolean | FocusStrategy;
 }

--- a/packages/react-aria/test/selection/useSelectableCollection.test.js
+++ b/packages/react-aria/test/selection/useSelectableCollection.test.js
@@ -49,6 +49,39 @@ describe('useSelectableCollection', () => {
     expect(options[0]).toHaveAttribute('aria-selected', 'true');
   });
 
+  it.each`
+    autoFocus  | index
+    ${'first'} | ${0}
+    ${'last'}  | ${2}
+  `(
+    'selects the autofocused item if selectOnFocus with autoFocus=$autoFocus',
+    ({autoFocus, index}) => {
+      let {getAllByRole} = render(
+        <List selectionMode="single" autoFocus={autoFocus}>
+          <Item>Paco de Lucia</Item>
+          <Item>Vicente Amigo</Item>
+          <Item>Gerardo Nunez</Item>
+        </List>
+      );
+      let options = getAllByRole('option');
+      expect(document.activeElement).toBe(options[index]);
+      expect(options[index]).toHaveAttribute('aria-selected', 'true');
+    }
+  );
+
+  it('does not change the selection when autofocusing an already selected collection', () => {
+    let {getAllByRole} = render(
+      <List selectionMode="single" autoFocus="first" defaultSelectedKeys={['Gerardo Nunez']}>
+        <Item key="Paco de Lucia">Paco de Lucia</Item>
+        <Item key="Vicente Amigo">Vicente Amigo</Item>
+        <Item key="Gerardo Nunez">Gerardo Nunez</Item>
+      </List>
+    );
+    let options = getAllByRole('option');
+    expect(options[2]).toHaveAttribute('aria-selected', 'true');
+    expect(options[0]).not.toHaveAttribute('aria-selected');
+  });
+
   it('can navigate without replacing the selection in multiple selection selectOnFocus', async () => {
     let {getAllByRole} = render(
       <List selectionMode="multiple" selectionBehavior="replace">


### PR DESCRIPTION
Closes #4391

The autoFocus effect in `useSelectableCollection` calls `setFocused`/`setFocusedKey` but never touches the selection, which makes it the only focus path in the file that ignores `selectOnFocus`; the focus-in handler, the Home and End handlers, and item navigation all call `replaceSelection`. With `autoFocus="first"` or `"last"` plus `selectOnFocus`, the item is focused but not selected.

The fix mirrors the guard item navigation already uses: after `setFocusedKey`, call `replaceSelection` when `selectOnFocus` is set, nothing is selected yet, and `manager.canSelectItem` allows it. The `!selectedKeys.size` guard is load-bearing because the effect has no dependency array and re-runs until the collection is populated, so it must not clobber an existing selection or the restore-selected-key branch above it. As LFDanLu noted on the issue, no Spectrum component currently combines these props, so the `List` test harness gained an `autoFocus` prop to make the combination testable.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Run `yarn jest packages/react-aria/test/selection/useSelectableCollection.test.js`. The two new `selects the autofocused item if selectOnFocus` cases (autoFocus="first" and "last") fail without the `useSelectableCollection.ts` change and pass with it; the third new case checks that autofocusing a collection with a default selection does not change that selection. Also ran the react-aria selection, menu, and grid suites and the react-aria-components ListBox, Select, ComboBox, and Menu suites (172 tests) with no regressions, plus oxlint and tsc on the touched files.

## 🧢 Your Project:

Personal contribution.
