### PR TITLE
fix: tooltip prop spread in s2 docs examples

### DIFF
--- a/packages/dev/s2-docs/pages/s2/Tooltip.mdx
+++ b/packages/dev/s2-docs/pages/s2/Tooltip.mdx
@@ -17,9 +17,9 @@ import {Tooltip, TooltipTrigger} from '@react-spectrum/s2/Tooltip';
 import {ActionButton} from '@react-spectrum/s2/ActionButton';
 import Edit from '@react-spectrum/s2/icons/Edit';
 
-<TooltipTrigger>
+<TooltipTrigger/* PROPS */>
   <ActionButton aria-label="Edit name"><Edit /></ActionButton>
-  <Tooltip/* PROPS */>Edit name</Tooltip>
+  <Tooltip>Edit name</Tooltip>
 </TooltipTrigger>
 ```
 

--- a/packages/dev/s2-docs/src/VisualExampleClient.tsx
+++ b/packages/dev/s2-docs/src/VisualExampleClient.tsx
@@ -447,7 +447,7 @@ function renderProp(name: string, value: any, control?: PropControl, indent = ''
       </>
     );
   } else if (typeof value === 'boolean') {
-    if (value === false && control?.optional) {
+    if (value === false && control?.optional && !control?.default) {
       return null;
     }
     if (name === 'contextualHelp') {


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10411

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Open example in stackblitz, no ts error
If you toggle the two default true boolean, they should render with 'false' explicitly in the example

## 🧢 Your Project:

<!--- Company/project for pull request -->
