### PR TITLE
fix(ActionBar): fix icon color in close button in emphasized ActionBar

### DIFF
--- a/packages/@react-spectrum/s2/chromatic/ActionBar.stories.tsx
+++ b/packages/@react-spectrum/s2/chromatic/ActionBar.stories.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {ActionBar, ActionBarProps} from '../src/ActionBar';
+import {ActionButton} from '../src/ActionButton';
+import {generatePowerset} from '@react-spectrum/story-utils';
+import type {Meta, StoryObj} from '@storybook/react';
+import {ReactNode} from 'react';
+import {shortName} from './utils';
+import {style} from '../style' with {type: 'macro'};
+
+const meta: Meta<typeof ActionBar> = {
+  component: ActionBar,
+  parameters: {
+    chromaticProvider: {disableAnimations: true}
+  },
+  title: 'S2 Chromatic/ActionBar'
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ActionBar>;
+
+let states = [{isEmphasized: [false, true]}];
+let combinations = generatePowerset(states);
+
+const Template = (args: ActionBarProps): ReactNode => {
+  return (
+    <div className={style({display: 'flex', flexDirection: 'column', gap: 24, width: 960})}>
+      {combinations.map(c => {
+        let key =
+          Object.keys(c)
+            .map(k => shortName(k, c[k]))
+            .join(' ') || 'default';
+
+        return (
+          <div key={key} className={style({position: 'relative', height: 96})}>
+            <ActionBar {...args} {...c} selectedItemCount={3}>
+              <ActionButton>Edit</ActionButton>
+              <ActionButton>Copy</ActionButton>
+              <ActionButton>Delete</ActionButton>
+            </ActionBar>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: args => <Template {...args} />
+};

--- a/packages/@react-spectrum/s2/src/CloseButton.tsx
+++ b/packages/@react-spectrum/s2/src/CloseButton.tsx
@@ -76,7 +76,7 @@ const styles = style<
         default: baseColor('neutral'),
         isDisabled: 'disabled',
         isStaticColor: {
-          default: 'white',
+          default: 'transparent-overlay-1000',
           isDisabled: 'transparent-overlay-400'
         },
         forcedColors: {


### PR DESCRIPTION
Fixes a contrast failure in the S2 ActionBar's clear button. In dark mode with `isEmphasized`, the close button's icon was hardcoded to white, which failed contrast against the ActionBar background color.

Changed to `transparent-overlay-1000`, which auto-computes black or white based on the `--s2-container-bg` inherited from the container.

Also added a chromatic story.

Before:

<img width="576" height="273" alt="Screenshot 2026-08-05 at 5 28 23 PM" src="https://github.com/user-attachments/assets/c1ad14c1-4db3-41e6-b890-e4eb11fdf5e2" />

After:

<img width="576" height="273" alt="Screenshot 2026-08-05 at 5 30 35 PM" src="https://github.com/user-attachments/assets/92be0fe1-263c-4f0a-b9c1-c6cbf29ad134" />


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Verify in docs/storybook and check new Chromatic story.

## 🧢 Your Project:

<!--- Company/project for pull request -->
