### PR TITLE
fix: properly wire up user provided onKeydown in PromptField

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -73,7 +73,6 @@ import {useControlledState} from 'react-stately/useControlledState';
 import {useEffectEvent} from 'react-aria/private/utils/useEffectEvent';
 import {useFocusableRef} from './useDOMRef';
 import {useFocusWithin} from 'react-aria/useFocusWithin';
-import {useKeyboard} from 'react-aria/useKeyboard';
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useVoiceInput, VoiceInputErrorCode} from './useVoiceInput';
@@ -354,9 +353,8 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
     pixelLoader,
     placeholder,
     menuWidth,
-    onKeyDown: onKeyDownProp
+    onKeyDown
   } = props;
-  let {keyboardProps} = useKeyboard({onKeyDown: onKeyDownProp});
   let {
     prompt,
     setPrompt,
@@ -453,6 +451,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
               setFocused(false);
             }
           }}
+          onKeyDown={onKeyDown}
           onPaste={
             acceptedAttachmentTypes
               ? e => {
@@ -476,7 +475,6 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
               : undefined
           }>
           <TokenInput
-            {...keyboardProps}
             data-placeholder={placeholder || stringFormatter.format('promptfield.placeholder')}
             ref={inputRef}
             className={renderProps =>

--- a/packages/@react-spectrum/ai/test/PromptField.test.tsx
+++ b/packages/@react-spectrum/ai/test/PromptField.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {PromptField, PromptTokenField} from '../src/PromptField';
+import React from 'react';
+import {render} from '@react-spectrum/test-utils-internal';
+import userEvent from '@testing-library/user-event';
+
+const describeOrSkip = parseInt(React.version, 10) < 19 ? describe.skip : describe;
+describeOrSkip('PromptField', () => {
+  let user;
+
+  beforeAll(() => {
+    user = userEvent.setup({delay: null});
+  });
+
+  it('fires onKeyDown when a key is pressed in the token field', async () => {
+    let onKeyDown = jest.fn();
+    let {getByRole} = render(
+      <PromptField>
+        <PromptTokenField onKeyDown={onKeyDown} />
+      </PromptField>
+    );
+
+    let input = getByRole('textbox');
+    await user.click(input);
+    await user.keyboard('a');
+
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
due to a bad merge it seems when we moved TokenField out into RAC

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Test the PromptField "Everything" story and make sure you can submit several prompts and then use ArrowUp/Down to cycle through the prompt history.

## 🧢 Your Project:

RSP
