### PR TITLE
chore: dedupe addEvent

### DIFF
--- a/packages/react-aria/src/overlays/usePreventScroll.ts
+++ b/packages/react-aria/src/overlays/usePreventScroll.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import {addEvent} from '../utils/domHelpers';
 import {chain} from '../utils/chain';
-
 import {getActiveElement, getEventTarget} from '../utils/shadowdom/DOMFunctions';
 import {getNonce} from '../utils/getNonce';
 import {getScrollParent} from '../utils/getScrollParent';
@@ -228,22 +228,6 @@ function setStyle(element: HTMLElement, style: string, value: string) {
 
   return () => {
     element.style[style] = cur;
-  };
-}
-
-// Adds an event listener to an element, and returns a function to remove it.
-function addEvent<K extends keyof GlobalEventHandlersEventMap>(
-  target: Document | Window,
-  event: K,
-  handler: (this: Document | Window, ev: GlobalEventHandlersEventMap[K]) => any,
-  options?: boolean | AddEventListenerOptions
-) {
-  // internal function, so it's ok to ignore the difficult to fix type error
-  // @ts-ignore
-  target.addEventListener(event, handler, options);
-  return () => {
-    // @ts-ignore
-    target.removeEventListener(event, handler, options);
   };
 }
 

--- a/packages/react-aria/src/utils/useEvent.ts
+++ b/packages/react-aria/src/utils/useEvent.ts
@@ -10,28 +10,25 @@
  * governing permissions and limitations under the License.
  */
 
-import {RefObject} from '@react-types/shared';
+import {addEvent} from './domHelpers';
+import {EventMapType, RefObject} from '@react-types/shared';
 import {useEffect} from 'react';
 import {useEffectEvent} from './useEffectEvent';
 
-export function useEvent<K extends keyof GlobalEventHandlersEventMap>(
-  ref: RefObject<EventTarget | null>,
-  event: K | (string & {}),
-  handler?: (this: Document, ev: GlobalEventHandlersEventMap[K]) => any,
+export function useEvent<T extends EventTarget, K extends keyof EventMapType<T>>(
+  ref: RefObject<T | null>,
+  event: Extract<K, string> | (string & {}),
+  listener?: (this: T, ev: EventMapType<Exclude<T, null>>[K]) => any,
   options?: boolean | AddEventListenerOptions
 ): void {
-  let handleEvent = useEffectEvent(handler);
-  let isDisabled = handler == null;
+  let handleEvent = useEffectEvent(listener);
+  let isDisabled = listener == null;
 
   useEffect(() => {
-    if (isDisabled || !ref.current) {
+    if (isDisabled || ref.current == null) {
       return;
     }
 
-    let element = ref.current;
-    element.addEventListener(event, handleEvent as EventListener, options);
-    return () => {
-      element.removeEventListener(event, handleEvent as EventListener, options);
-    };
+    return addEvent(ref.current, event, handleEvent, options);
   }, [ref, event, options, isDisabled]);
 }

--- a/packages/react-aria/test/utils/useEvent.test.tsx
+++ b/packages/react-aria/test/utils/useEvent.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {act, render} from '@react-spectrum/test-utils-internal';
+import React, {RefObject, useRef} from 'react';
+import {useEvent} from '../../src/utils/useEvent';
+
+interface ExampleProps {
+  event: string;
+  listener?: (e: Event) => void;
+  options?: boolean | AddEventListenerOptions;
+}
+
+function Example({event, listener, options}: ExampleProps) {
+  let ref = useRef<HTMLDivElement | null>(null);
+  useEvent(ref as RefObject<HTMLDivElement | null>, event, listener, options);
+  return <div ref={ref} data-testid="target" />;
+}
+
+describe('useEvent', () => {
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    let listener = jest.fn();
+    let {getByTestId, unmount} = render(<Example event="customevent" listener={listener} />);
+    let target = getByTestId('target');
+
+    act(() => {
+      target.dispatchEvent(new Event('customevent'));
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unmount();
+    act(() => {
+      target.dispatchEvent(new Event('customevent'));
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener when it becomes undefined', () => {
+    let listener = jest.fn();
+    let {getByTestId, rerender} = render(<Example event="customevent" listener={listener} />);
+    let target = getByTestId('target');
+
+    rerender(<Example event="customevent" listener={undefined} />);
+    act(() => {
+      target.dispatchEvent(new Event('customevent'));
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('re-subscribes when the event name changes', () => {
+    let listener = jest.fn();
+    let {getByTestId, rerender} = render(<Example event="first" listener={listener} />);
+    let target = getByTestId('target');
+
+    // Change the event name we're listening for to "second" and re-render the component
+    rerender(<Example event="second" listener={listener} />);
+
+    act(() => {
+      target.dispatchEvent(new Event('first'));
+    });
+    expect(listener).not.toHaveBeenCalled();
+
+    act(() => {
+      target.dispatchEvent(new Event('second'));
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards listener options such as once', () => {
+    let listener = jest.fn();
+    let {getByTestId} = render(
+      <Example event="customevent" listener={listener} options={{once: true}} />
+    );
+    let target = getByTestId('target');
+
+    act(() => {
+      target.dispatchEvent(new Event('customevent'));
+    });
+    act(() => {
+      target.dispatchEvent(new Event('customevent'));
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Pulled out of https://github.com/adobe/react-spectrum/pull/10102 in an effort to make it smaller an easier to review

This dedupes the usage of addEvent and refactors types so they work for all call sites. It also adds unit tests for useEvent which uses addEvent.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
