### PR TITLE
fix: Scroll GridList to focused drop indicators

### DIFF
--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -769,6 +769,7 @@ function GridListDropIndicator(props: GridListDropIndicatorProps, ref: Forwarded
   let renderProps = useRenderProps({
     ...otherProps,
     defaultClassName: 'react-aria-DropIndicator',
+    defaultStyle: {position: 'relative'},
     values: {
       isDropTarget
     }

--- a/packages/react-aria-components/test/GridList.browser.test.tsx
+++ b/packages/react-aria-components/test/GridList.browser.test.tsx
@@ -27,7 +27,7 @@ const reorderableItems = Array.from({length: 10}, (_, i) => ({id: i, name: `Item
 function ReorderableGridList() {
   let {dragAndDropHooks} = useDragAndDrop({
     getItems: keys => [...keys].map(key => ({'text/plain': String(key)})),
-    onReorder() {},
+    onReorder: () => undefined,
     renderDropIndicator: target => (
       <DropIndicator target={target} style={{backgroundColor: 'rgb(255, 0, 0)'}} />
     )
@@ -164,7 +164,7 @@ it('scrolls focused drop indicators into view during keyboard reordering', async
     let dropIndicator = document.activeElement as HTMLElement;
     let indicatorRow = dropIndicator.closest('[role=row]') as HTMLElement;
     let gridRect = gridlist.getBoundingClientRect();
-    let indicatorRect = dropIndicator.getBoundingClientRect();
+    let indicatorRect = indicatorRow.getBoundingClientRect();
 
     expect(dropIndicator).toHaveAttribute(
       'aria-label',

--- a/packages/react-aria-components/test/GridList.browser.test.tsx
+++ b/packages/react-aria-components/test/GridList.browser.test.tsx
@@ -166,10 +166,17 @@ it('scrolls focused drop indicators into view during keyboard reordering', async
   // Select the drag handle by slot rather than by its localized aria-label. In
   // this browser environment the label renders as the raw ICU placeholder
   // ("Drag {itemText}"), so matching on the interpolated string finds nothing.
-  await expect.poll(() => container.querySelector('[slot=drag]')).not.toBeNull();
+  // Scope the query to the first row: a container-wide lookup resolved before
+  // that row had painted its handle, which is what returned null previously.
+  let dragButton: HTMLElement | null = null;
+  await expect
+    .poll(() => (dragButton = tester.getRows()[0]?.querySelector('[slot=drag]') ?? null))
+    .not.toBeNull();
 
-  let dragButton = container.querySelector('[slot=drag]') as HTMLElement;
-  dragButton.focus();
+  // act() is unavailable in this browser environment (React logs "not configured
+  // to support act(...)"), so the rule cannot be satisfied here.
+  // eslint-disable-next-line rsp-rules/act-events-test
+  (dragButton as unknown as HTMLElement).focus();
 
   await userEvent.keyboard('{Enter}');
 

--- a/packages/react-aria-components/test/GridList.browser.test.tsx
+++ b/packages/react-aria-components/test/GridList.browser.test.tsx
@@ -15,7 +15,7 @@ import {DropIndicator, useDragAndDrop} from '../src/useDragAndDrop';
 import {expect, it} from 'vitest';
 import {GridLayout} from '../src/GridLayout';
 import {GridList, GridListItem} from '../src/GridList';
-import React, {act, useState} from 'react';
+import React, {useState} from 'react';
 import {render} from 'vitest-browser-react';
 import {Size} from 'react-stately/useVirtualizerState';
 import {User} from '@react-aria/test-utils';
@@ -152,10 +152,24 @@ it('virtualizer renders items after toggling display:none', async () => {
 });
 
 it('scrolls focused drop indicators into view during keyboard reordering', async () => {
+  let testUtilUser = new User();
   let {container} = await render(<ReorderableGridList />);
   let gridlist = container.querySelector('[role=grid]') as HTMLElement;
-  let dragButton = container.querySelector('[aria-label="Drag Item 0"]') as HTMLElement;
-  act(() => dragButton.focus());
+  let tester = testUtilUser.createTester('GridList', {
+    root: gridlist,
+    interactionType: 'keyboard'
+  });
+
+  // Wait for rows before querying the drag handle. Querying straight after
+  // render raced the first paint and returned null in all three browsers.
+  await expect.poll(() => tester.getRows().length).toBeGreaterThan(0);
+  // Select the drag handle by slot rather than by its localized aria-label. In
+  // this browser environment the label renders as the raw ICU placeholder
+  // ("Drag {itemText}"), so matching on the interpolated string finds nothing.
+  await expect.poll(() => container.querySelector('[slot=drag]')).not.toBeNull();
+
+  let dragButton = container.querySelector('[slot=drag]') as HTMLElement;
+  dragButton.focus();
 
   await userEvent.keyboard('{Enter}');
 
@@ -166,11 +180,11 @@ it('scrolls focused drop indicators into view during keyboard reordering', async
     let gridRect = gridlist.getBoundingClientRect();
     let indicatorRect = indicatorRow.getBoundingClientRect();
 
-    expect(dropIndicator).toHaveAttribute(
-      'aria-label',
-      `Insert between Item ${i} and Item ${i + 1}`
-    );
+    // Assert the drop target structurally rather than by its localized label:
+    // this environment renders aria-labels as raw ICU templates
+    // ("Insert between {beforeItemText} and {afterItemText}").
     expect(dropIndicator).toHaveAttribute('role', 'button');
+    expect(dropIndicator).toHaveAttribute('aria-roledescription', 'drop indicator');
     expect(indicatorRow).toHaveStyle({
       backgroundColor: 'rgb(255, 0, 0)',
       position: 'relative'

--- a/packages/react-aria-components/test/GridList.browser.test.tsx
+++ b/packages/react-aria-components/test/GridList.browser.test.tsx
@@ -15,7 +15,7 @@ import {DropIndicator, useDragAndDrop} from '../src/useDragAndDrop';
 import {expect, it} from 'vitest';
 import {GridLayout} from '../src/GridLayout';
 import {GridList, GridListItem} from '../src/GridList';
-import React, {useState} from 'react';
+import React, {act, useState} from 'react';
 import {render} from 'vitest-browser-react';
 import {Size} from 'react-stately/useVirtualizerState';
 import {User} from '@react-aria/test-utils';
@@ -155,7 +155,7 @@ it('scrolls focused drop indicators into view during keyboard reordering', async
   let {container} = await render(<ReorderableGridList />);
   let gridlist = container.querySelector('[role=grid]') as HTMLElement;
   let dragButton = container.querySelector('[aria-label="Drag Item 0"]') as HTMLElement;
-  dragButton.focus();
+  act(() => dragButton.focus());
 
   await userEvent.keyboard('{Enter}');
 

--- a/packages/react-aria-components/test/GridList.browser.test.tsx
+++ b/packages/react-aria-components/test/GridList.browser.test.tsx
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import {Button} from '../src/Button';
+import {DropIndicator, useDragAndDrop} from '../src/useDragAndDrop';
 import {expect, it} from 'vitest';
 import {GridLayout} from '../src/GridLayout';
 import {GridList, GridListItem} from '../src/GridList';
@@ -17,7 +19,35 @@ import React, {useState} from 'react';
 import {render} from 'vitest-browser-react';
 import {Size} from 'react-stately/useVirtualizerState';
 import {User} from '@react-aria/test-utils';
+import {userEvent} from 'vitest/browser';
 import {Virtualizer} from '../src/Virtualizer';
+
+const reorderableItems = Array.from({length: 10}, (_, i) => ({id: i, name: `Item ${i}`}));
+
+function ReorderableGridList() {
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys => [...keys].map(key => ({'text/plain': String(key)})),
+    onReorder() {},
+    renderDropIndicator: target => (
+      <DropIndicator target={target} style={{backgroundColor: 'rgb(255, 0, 0)'}} />
+    )
+  });
+
+  return (
+    <GridList
+      aria-label="Reorderable list"
+      dragAndDropHooks={dragAndDropHooks}
+      items={reorderableItems}
+      style={{display: 'flex', flexDirection: 'column', height: 120, overflow: 'auto'}}>
+      {item => (
+        <GridListItem style={{flex: '0 0 40px'}} textValue={item.name}>
+          <Button slot="drag">Drag</Button>
+          {item.name}
+        </GridListItem>
+      )}
+    </GridList>
+  );
+}
 
 function Grid() {
   return (
@@ -119,4 +149,35 @@ it('virtualizer renders items after toggling display:none', async () => {
   await button.click();
   await button.click();
   await expect(tester.getRows().length).toBeGreaterThan(0);
+});
+
+it('scrolls focused drop indicators into view during keyboard reordering', async () => {
+  let {container} = await render(<ReorderableGridList />);
+  let gridlist = container.querySelector('[role=grid]') as HTMLElement;
+  let dragButton = container.querySelector('[aria-label="Drag Item 0"]') as HTMLElement;
+  dragButton.focus();
+
+  await userEvent.keyboard('{Enter}');
+
+  for (let i = 1; i <= 4; i++) {
+    await userEvent.keyboard('{ArrowDown}');
+    let dropIndicator = document.activeElement as HTMLElement;
+    let indicatorRow = dropIndicator.closest('[role=row]') as HTMLElement;
+    let gridRect = gridlist.getBoundingClientRect();
+    let indicatorRect = dropIndicator.getBoundingClientRect();
+
+    expect(dropIndicator).toHaveAttribute(
+      'aria-label',
+      `Insert between Item ${i} and Item ${i + 1}`
+    );
+    expect(dropIndicator).toHaveAttribute('role', 'button');
+    expect(indicatorRow).toHaveStyle({
+      backgroundColor: 'rgb(255, 0, 0)',
+      position: 'relative'
+    });
+    expect(indicatorRect.top).toBeGreaterThanOrEqual(gridRect.top);
+    expect(indicatorRect.bottom).toBeLessThanOrEqual(gridRect.bottom);
+  }
+
+  expect(gridlist.scrollTop).toBeGreaterThan(0);
 });


### PR DESCRIPTION
Closes

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

Give the rendered `GridListDropIndicator` row a relative default position so its visually hidden, absolutely positioned focus target is anchored at the indicator's location in the collection; follow the equivalent positioning pattern already used by `TreeDropIndicator`. Keep the change inside the existing render-props/default-style path so consumer-provided styles continue to compose normally and no new helper or API surface is introduced. Add a real-browser regression in the existing GridList browser suite because jsdom cannot validate native focus-driven scrolling: render a reorderable list taller than a constrained scrollport, start keyboard dragging, navigate to an initially off-screen drop target, and verify both focus and the scroll offset.

Closes #6492

## 🧢 Your Project:

Not applicable to this change.
