### PR TITLE
fix(radio): allow native form onChange to fire for Radio selection

### DIFF
--- a/packages/react-aria-components/test/RadioGroup.test.js
+++ b/packages/react-aria-components/test/RadioGroup.test.js
@@ -397,6 +397,46 @@ describe.each(['RadioGroup', 'RadioField'])('%s', comp => {
     expect(onChange).toHaveBeenLastCalledWith('c');
   });
 
+  it('should fire a native form onChange event when a radio is clicked', async () => {
+    let formOnChange = jest.fn();
+    let onChange = jest.fn();
+    let {getAllByRole} = render(
+      <form onChange={formOnChange}>
+        <TestRadioGroup groupProps={{onChange}} />
+      </form>
+    );
+    let radios = getAllByRole('radio');
+
+    await user.click(radios[1]);
+    expect(radios[1]).toBeChecked();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith('b');
+    expect(formOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fire a native form onChange event when selection changes via the keyboard', async () => {
+    let formOnChange = jest.fn();
+    let onChange = jest.fn();
+    let {getAllByRole} = render(
+      <form onChange={formOnChange}>
+        <TestRadioGroup groupProps={{onChange}} />
+      </form>
+    );
+    let radios = getAllByRole('radio');
+
+    await user.tab();
+    expect(radios[0]).toHaveFocus();
+
+    // user-event implements its own radio-group arrow navigation, which bypasses our own code
+    fireEvent.keyDown(document.activeElement, {key: 'ArrowDown'});
+    fireEvent.keyUp(document.activeElement, {key: 'ArrowDown'});
+
+    expect(radios[1]).toBeChecked();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith('b');
+    expect(formOnChange).toHaveBeenCalledTimes(1);
+  });
+
   it('should support read only state', () => {
     let className = ({isReadOnly}) => (isReadOnly ? 'readonly' : '');
     let {getByRole, getAllByRole} = renderGroup({isReadOnly: true, className}, {className});

--- a/packages/react-aria/src/radio/useRadio.ts
+++ b/packages/react-aria/src/radio/useRadio.ts
@@ -101,8 +101,7 @@ export function useRadio(
 
   let checked = state.selectedValue === value;
 
-  let onChange = e => {
-    e.stopPropagation();
+  let onChange = () => {
     state.setSelectedValue(value);
   };
 

--- a/packages/react-aria/src/radio/useRadioGroup.ts
+++ b/packages/react-aria/src/radio/useRadioGroup.ts
@@ -114,6 +114,20 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
       // Call focus on nextElem so that keyboard navigation scrolls the radio into view
       nextElem.focus();
       state.setSelectedValue(nextElem.value);
+
+      // The state update above only changes the DOM `checked` property via React's controlled
+      // re-render — it does not dispatch any native event the way a real click does. React's own
+      // change detection for checkbox/radio inputs is keyed off the "click" event (a legacy
+      // browser-compat shim), not "change" or "input", so we replay a native click to make an
+      // ancestor <form onChange> (or any other native DOM listener) observe keyboard-driven
+      // selection the same way it observes a mouse click.
+      let checkedSetter = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(nextElem),
+        'checked'
+      )!.set!;
+      checkedSetter.call(nextElem, true);
+      nextElem.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+
       return true;
     }
     return false;


### PR DESCRIPTION
Closes #3799

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/3799).
- [x] Added/updated unit tests for this change.
- [x] Filled out test instructions.
- [ ] Updated documentation (no documented behavior needed updating; this restores documented-but-broken native form behavior).
- [x] Looked at the Accessibility Practices for this feature.

## Summary

`Radio`'s `onChange` handler called `e.stopPropagation()`, which prevented the native `change` event from ever bubbling to an ancestor `<form onChange>`. This matches a fix already identified and implemented by @devongovett on the `change-events` branch, which was never merged — this PR restores that fix for `useRadio`.

Separately, arrow-key navigation between radios in a `RadioGroup` only updates React state directly and never dispatches any native DOM event, so even with the above fix, keyboard-driven selection was still invisible to a native `<form onChange>`. This PR also replays a native `click` on the newly-selected radio when navigating via keyboard (React's own change-detection for checkbox/radio inputs is keyed off the `click` event, not `change`/`input`), so keyboard selection is observed the same way a mouse click already is.

### What changed

- `packages/react-aria/src/radio/useRadio.ts`: removed `e.stopPropagation()` from the input's `onChange` handler.
- `packages/react-aria/src/radio/useRadioGroup.ts`: after keyboard-driven selection in `getNextElement`, sets the native `checked` property (via the prototype's original setter, bypassing React's override) and dispatches a real, bubbling `click` event so native listeners observe the change.

## 📝 Test Instructions:

Two new tests in `packages/react-aria-components/test/RadioGroup.test.js`, run for both `RadioGroup` and `RadioField`:
- `should fire a native form onChange event when a radio is clicked`
- `should fire a native form onChange event when selection changes via the keyboard`

Both wrap the component in a real `<form onChange>` and assert it fires exactly once per interaction, alongside asserting the component's own `onChange` prop still fires exactly once (regression guard against double-firing).

Verified passing:
- `packages/react-aria-components/test/RadioGroup.test.js` — 74/74
- `packages/@adobe/react-spectrum/test/radio/Radio.test.js` (v3) — 34/34
- `packages/@react-spectrum/s2/test/RadioGroup.test.tsx` (S2) — 27/27
- `yarn oxfmt --check`, `yarn oxlint`, `yarn check-types` — all clean

## 🧢 Your Project:

Personal contribution.