### PR TITLE
fix: commit ColorField value on Enter, matching NumberField behavior (Fixes #10445)

### DIFF
--- a/packages/react-aria/src/color/useColorField.ts
+++ b/packages/react-aria/src/color/useColorField.ts
@@ -20,9 +20,11 @@ import {
 } from '@react-types/shared';
 import {ColorFieldProps, ColorFieldState} from 'react-stately/useColorFieldState';
 import {InputHTMLAttributes, LabelHTMLAttributes, RefObject, useCallback, useState} from 'react';
+import {flushSync} from 'react-dom';
 import {mergeProps} from '../utils/mergeProps';
 import {privateValidationStateProp} from 'react-stately/private/form/useFormValidationState';
 import {useFocusWithin} from '../interactions/useFocusWithin';
+import {useKeyboard} from '../interactions/useKeyboard';
 import {useFormattedTextField} from '../textfield/useFormattedTextField';
 import {useFormReset} from '../utils/useFormReset';
 import {useId} from '../utils/useId';
@@ -70,7 +72,15 @@ export function useColorField(
   state: ColorFieldState,
   ref: RefObject<HTMLInputElement | null>
 ): ColorFieldAria {
-  let {isDisabled, isReadOnly, isRequired, isWheelDisabled, validationBehavior = 'aria'} = props;
+  let {
+    isDisabled,
+    isReadOnly,
+    isRequired,
+    isWheelDisabled,
+    validationBehavior = 'aria',
+    onKeyDown,
+    onKeyUp
+  } = props;
 
   let {colorValue, inputValue, increment, decrement, incrementToMax, decrementToMin, commit} =
     state;
@@ -110,6 +120,20 @@ export function useColorField(
   let scrollingDisabled = isWheelDisabled || isDisabled || isReadOnly || !focusWithin;
   useScrollWheel({onScroll: onWheel, isDisabled: scrollingDisabled}, ref);
 
+  let {keyboardProps} = useKeyboard({
+    isDisabled: isDisabled || isReadOnly,
+    shortcuts: {
+      Enter: () => {
+        flushSync(() => {
+          commit();
+        });
+        return {shouldPreventDefault: false};
+      }
+    },
+    onKeyDown,
+    onKeyUp
+  });
+
   let onChange = value => {
     if (state.validate(value)) {
       state.setInputValue(value);
@@ -136,7 +160,7 @@ export function useColorField(
 
   useFormReset(ref, state.defaultColorValue, state.setColorValue);
 
-  inputProps = mergeProps(inputProps, spinButtonProps, focusWithinProps, {
+  inputProps = mergeProps(keyboardProps, inputProps, spinButtonProps, focusWithinProps, {
     role: 'textbox',
     'aria-valuemax': null,
     'aria-valuemin': null,


### PR DESCRIPTION
## Summary

Pressing **Enter** in a `ColorField` now commits the typed value, matching the behavior of `NumberField`. Previously, typing a hex value and pressing Enter would silently retain the input display but not commit it to the color state — the value was only flushed on blur. If the user then closed a `ColorPicker` popover with **Escape**, the typed value was silently discarded and the previous color restored.

## Implementation

Mirrors the `useNumberField` Enter handling pattern (`useKeyboard` with `flushSync(() => commit())`):

- Added `flushSync` import from `react-dom`
- Added `useKeyboard` import from `../interactions/useKeyboard`
- Added `onKeyDown` and `onKeyUp` to props destructuring
- Added `useKeyboard` hook with an Enter shortcut that calls `flushSync(() => commit())`
- Merged `keyboardProps` first in the `mergeProps` chain so shortcuts run before other handlers

## Related

- Fixes #10445
- Sibling fix to #9748 / #9768 (the pointer-dismissal path was already fixed; this addresses the keyboard Enter/Escape path that React does not fire blur on unmount for)

## Test plan

- Type a hex value into a ColorField and press Enter — value should be committed immediately
- Type a hex value and press Escape — should NOT commit (cancel-on-Escape is conventional)
- Tab out of the field — value should commit on blur (existing behavior, unchanged)
- All existing tests should pass