### PR TITLE
fix(RangeCalendar): use getEventTarget for shadow DOM compatibility

### DIFF
--- a/packages/react-aria/src/calendar/useRangeCalendar.ts
+++ b/packages/react-aria/src/calendar/useRangeCalendar.ts
@@ -13,7 +13,7 @@
 import {AriaLabelingProps, DOMProps, FocusableElement, RefObject} from '@react-types/shared';
 import {CalendarAria, useCalendarBase} from './useCalendarBase';
 import {DateValue, RangeCalendarState} from 'react-stately/useRangeCalendarState';
-import {isFocusWithin, nodeContains} from '../utils/shadowdom/DOMFunctions';
+import {getEventTarget, isFocusWithin, nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {RangeCalendarProps} from 'react-stately/useRangeCalendarState';
 import {useEvent} from '../utils/useEvent';
 import {useRef} from 'react';
@@ -76,7 +76,7 @@ export function useRangeCalendar<T extends DateValue>(
       return;
     }
 
-    let target = e.target as Element;
+    let target = getEventTarget(e) as Element;
     if (
       ref.current &&
       isFocusWithin(ref.current) &&


### PR DESCRIPTION
## What changed

When `RangeCalendar` is rendered inside a shadow root, the window-level `pointerup` listener (`endDragging`) reads `e.target` directly. In shadow DOM, events are retargeted so `e.target` is the shadow **host**, not the actual calendar cell button. This causes `nodeContains(ref.current, target)` to always return `false`, and `commitSelection()` runs on every single click — immediately committing `start === end`.

## Fix

Used the existing `getEventTarget` helper from `@react-aria/src/utils/shadowdom/DOMFunctions` which reads `e.composedPath()[0]` from the event, giving the actual target element even inside shadow DOM.

## Related issue

Closes #10330