### PR TITLE
fix: commit ColorField value on Enter

### DIFF
--- a/packages/react-aria-components/test/ColorField.test.js
+++ b/packages/react-aria-components/test/ColorField.test.js
@@ -130,6 +130,44 @@ describe('ColorField', () => {
     expect(outerEl[0]).toHaveClass('react-aria-ColorField');
   });
 
+  it('should commit the typed value on Enter', async () => {
+    let onChange = jest.fn();
+    let {getByRole} = render(<TestColorField onChange={onChange} />);
+    let input = getByRole('textbox');
+
+    await user.tab();
+    await user.clear(input);
+    await user.keyboard('#0000ff');
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(parseColor('#0000ff'));
+    expect(input).toHaveValue('#0000FF');
+  });
+
+  it('should restore the previous value on Enter if the typed value cannot be parsed', async () => {
+    let onChange = jest.fn();
+    let {getByRole} = render(<TestColorField onChange={onChange} />);
+    let input = getByRole('textbox');
+
+    await user.tab();
+    await user.clear(input);
+    await user.keyboard('ab');
+    await user.keyboard('{Enter}');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue('#FF0000');
+  });
+
+  it('should call a user onKeyDown handler exactly once per key press', async () => {
+    let onKeyDown = jest.fn();
+    render(<TestColorField onKeyDown={onKeyDown} />);
+
+    await user.tab();
+    await user.keyboard('a');
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
   it('supports validation errors', async () => {
     let {getByRole, getByTestId} = render(
       <form data-testid="form">

--- a/packages/react-aria/src/color/useColorField.ts
+++ b/packages/react-aria/src/color/useColorField.ts
@@ -19,6 +19,7 @@ import {
   ValidationResult
 } from '@react-types/shared';
 import {ColorFieldProps, ColorFieldState} from 'react-stately/useColorFieldState';
+import {flushSync} from 'react-dom';
 import {InputHTMLAttributes, LabelHTMLAttributes, RefObject, useCallback, useState} from 'react';
 import {mergeProps} from '../utils/mergeProps';
 import {privateValidationStateProp} from 'react-stately/private/form/useFormValidationState';
@@ -26,6 +27,7 @@ import {useFocusWithin} from '../interactions/useFocusWithin';
 import {useFormattedTextField} from '../textfield/useFormattedTextField';
 import {useFormReset} from '../utils/useFormReset';
 import {useId} from '../utils/useId';
+import {useKeyboard} from '../interactions/useKeyboard';
 import {useScrollWheel} from '../interactions/useScrollWheel';
 import {useSpinButton} from '../spinbutton/useSpinButton';
 
@@ -70,10 +72,26 @@ export function useColorField(
   state: ColorFieldState,
   ref: RefObject<HTMLInputElement | null>
 ): ColorFieldAria {
-  let {isDisabled, isReadOnly, isRequired, isWheelDisabled, validationBehavior = 'aria'} = props;
+  let {
+    isDisabled,
+    isReadOnly,
+    isRequired,
+    isWheelDisabled,
+    validationBehavior = 'aria',
+    onKeyDown,
+    onKeyUp
+  } = props;
 
-  let {colorValue, inputValue, increment, decrement, incrementToMax, decrementToMin, commit} =
-    state;
+  let {
+    colorValue,
+    inputValue,
+    increment,
+    decrement,
+    incrementToMax,
+    decrementToMin,
+    commit,
+    commitValidation
+  } = state;
 
   let inputId = useId();
   let {spinButtonProps} = useSpinButton({
@@ -110,6 +128,21 @@ export function useColorField(
   let scrollingDisabled = isWheelDisabled || isDisabled || isReadOnly || !focusWithin;
   useScrollWheel({onScroll: onWheel, isDisabled: scrollingDisabled}, ref);
 
+  let {keyboardProps} = useKeyboard({
+    isDisabled: isDisabled || isReadOnly,
+    shortcuts: {
+      Enter: () => {
+        flushSync(() => {
+          commit();
+        });
+        commitValidation();
+        return {shouldPreventDefault: false};
+      }
+    },
+    onKeyDown,
+    onKeyUp
+  });
+
   let onChange = value => {
     if (state.validate(value)) {
       state.setInputValue(value);
@@ -128,7 +161,9 @@ export function useColorField(
       [privateValidationStateProp]: state,
       type: 'text',
       autoComplete: 'off',
-      onChange
+      onChange,
+      onKeyDown: undefined,
+      onKeyUp: undefined
     },
     state,
     ref
@@ -136,7 +171,7 @@ export function useColorField(
 
   useFormReset(ref, state.defaultColorValue, state.setColorValue);
 
-  inputProps = mergeProps(inputProps, spinButtonProps, focusWithinProps, {
+  inputProps = mergeProps(keyboardProps, inputProps, spinButtonProps, focusWithinProps, {
     role: 'textbox',
     'aria-valuemax': null,
     'aria-valuemin': null,


### PR DESCRIPTION
Closes #10445

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component). *(The docs don't describe the Enter behavior for NumberField either, so there is nothing to update.)*
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## Summary

Pressing <kbd>Enter</kbd> in a `ColorField` now commits the typed value, the same way `NumberField` does. Previously the value was only flushed on blur: after typing a hex and pressing Enter, the input displayed the new value while the color state (`onChange`, swatch, sliders) kept the old one, and dismissing a `ColorPicker` popover with <kbd>Escape</kbd> silently discarded it.

## Implementation

Mirrors the `useNumberField` Enter handling (`useKeyboard` shortcut):

- On Enter: `flushSync(() => commit())`, then `commitValidation()`, returning `{shouldPreventDefault: false}` so implicit form submission still works.
- `commitValidation()` is needed on top of `state.commit()` because the empty and unparseable input paths in `useColorFieldState.commit()` return early without committing validation. Without it, an empty required field would not be marked invalid before an implicit form submission (as noted in review on #10446).
- `onKeyDown`/`onKeyUp` are destructured out of props, passed to `useKeyboard`, and explicitly excluded from the props forwarded to `useFormattedTextField`. `useTextField` already wires the user's key handlers through `useFocusable`, so forwarding them down both paths makes them fire twice per key press. `useNumberField` avoids this the same way.
- `keyboardProps` is merged first, matching the ordering comment in `useNumberField`.

Tests are based on the RAC NumberField ones as suggested in review: Enter commits (`onChange` + reformat), Enter on an unparseable value restores the previous value, and a regression test that a user `onKeyDown` fires exactly once per key press. The two Enter tests fail without the `useColorField` change.

## Relationship to #10446

I reported #10445. #10446 was opened for it, but it doesn't address the review feedback there (missing `commitValidation`, no tests), and it forwards the user's `onKeyDown`/`onKeyUp` both into `useKeyboard` and, via `...props`, into `useFormattedTextField`, which double-invokes user key handlers. This PR is an independent implementation covering those points.

Separately: that author's account looks a bit odd to me (a crypto wallet address in the bio, and a burst of near-simultaneous PRs across several unrelated repos today), so I wanted the fix for this issue to be in good shape either way. Mentioning it for maintainer awareness; happy to defer if you'd rather land #10446 with fixes.

## 📝 Test Instructions:

- `yarn jest packages/react-aria-components/test/ColorField.test.js` runs the three new tests.
- Manual: in any `ColorPicker` + `ColorField` composition (e.g. the docs example), type a different hex value and press <kbd>Enter</kbd>. `onChange` fires and the swatch/area update immediately; closing the popover with <kbd>Escape</kbd> afterwards keeps the color. Tabbing out still commits on blur as before.
- Related suites pass locally: react-aria `useColorField`, react-stately `useColorFieldState`, S2 `ColorField`, v3 `ColorField`, RAC `NumberField` (97 tests).

## 🧢 Your Project:

Umoh
