### PR TITLE
fix: ios26 address bar

### DIFF
--- a/packages/react-aria/src/overlays/calculatePosition.ts
+++ b/packages/react-aria/src/overlays/calculatePosition.ts
@@ -137,9 +137,10 @@ function getContainerDimensions(
     // The goal of the below is to get a top/left value that represents the top/left of the visual viewport with
     // respect to the layout viewport origin. This combined with the scrollTop/scrollLeft will allow us to calculate
     // coordinates/values with respect to the visual viewport or with respect to the layout viewport.
+    // Uses pageTop/pageLeft instead of offsetTop/offsetLeft because WebKit misreports those during pans.
     if (visualViewport) {
-      top = visualViewport.offsetTop;
-      left = visualViewport.offsetLeft;
+      top = Math.max(0, visualViewport.pageTop - (scroll.top ?? 0));
+      left = Math.max(0, visualViewport.pageLeft - (scroll.left ?? 0));
     }
   } else {
     ({width, height, top, left} = getOffset(containerNode, false));

--- a/packages/react-aria/src/overlays/useOverlayPosition.ts
+++ b/packages/react-aria/src/overlays/useOverlayPosition.ts
@@ -10,9 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import {addEvent} from '../utils/domHelpers';
 import {calculatePosition, getRect, PositionResult} from './calculatePosition';
 import {DOMAttributes, RefObject} from '@react-types/shared';
 import {getActiveElement, isFocusWithin} from '../utils/shadowdom/DOMFunctions';
+import {getPropagationTargets} from '../utils/shadowdom/DOMFunctions';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useCloseOnScroll} from './useCloseOnScroll';
 import {useLayoutEffect} from '../utils/useLayoutEffect';
@@ -368,9 +370,16 @@ export function useOverlayPosition(props: AriaPositionProps): PositionAria {
 
     visualViewport?.addEventListener('resize', onResize);
     visualViewport?.addEventListener('scroll', onScroll);
+    let cleanup = addEvent(
+      // @ts-expect-error
+      getPropagationTargets(window),
+      'scroll',
+      onScroll
+    );
     return () => {
       visualViewport?.removeEventListener('resize', onResize);
       visualViewport?.removeEventListener('scroll', onScroll);
+      cleanup();
     };
   }, [updatePosition]);
 


### PR DESCRIPTION
Fixes overlays being positioned underneath the address bar in iOS 26.

Pulled out of https://github.com/adobe/react-spectrum/pull/10102 to make the original PR smaller and easier to review.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
