### PR TITLE
fix: properly position the loading spinner using  illustration as its thumbnail

### DIFF
--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -593,10 +593,10 @@ export const Attachment = forwardRef(function Attachment(
               insetStart: {
                 default: '50%',
                 // this checks that there is text content in the attachment + a Image as a thumbnail
-                ':has(~ [data-slot=content]):not(:has(~ [data-rsp-slot=thumbnail]))':
+                ':has(~ [data-slot=content]):not(:has(~ [data-rsp-slot=illustration]))':
                   '[calc(var(--card-padding-x) + var(--basic-thumb-size) / 2)]',
                 // this checks that there is text content in the attachment + a Illustration as a thumbnail
-                ':has(~ [data-slot=content]):has(~ [data-rsp-slot=thumbnail])':
+                ':has(~ [data-slot=content]):has(~ [data-rsp-slot=illustration])':
                   '[calc(var(--card-padding-x) + var(--illust-margin-x) + var(--illust-thumb-size) / 2)]'
               },
               transform: 'translate(-50%, -50%)'


### PR DESCRIPTION
From coworker testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Go to the AttachmentList mixed content story and set a upload progress via the controls. Check that the progress circles are placed inside the Thumbnail

## 🧢 Your Project:

RSP
