### PR TITLE
fix: don't resolve drops past the last table row to the TableBody

### DIFF
--- a/packages/react-aria-components/src/TreeDropTargetDelegate.ts
+++ b/packages/react-aria-components/src/TreeDropTargetDelegate.ts
@@ -209,14 +209,19 @@ export class TreeDropTargetDelegate<T> {
       let isLastChildAtLevel = !nextItem || nextItem.parentKey !== parentKey;
 
       if (isLastChildAtLevel) {
-        let afterParentTarget = {
-          type: 'item',
-          key: parentKey,
-          dropPosition: 'after'
-        } as const;
+        // Only items can be drop targets. Ancestors such as a Table's <TableBody> or a
+        // <TreeSection> are part of the collection, but their keys are generated rather than
+        // provided by the user, so dropping "after" them is not something the user can handle.
+        if (parentItem?.type === 'item') {
+          let afterParentTarget = {
+            type: 'item',
+            key: parentKey,
+            dropPosition: 'after'
+          } as const;
 
-        if (isValidDropTarget(afterParentTarget)) {
-          ancestorTargets.push(afterParentTarget);
+          if (isValidDropTarget(afterParentTarget)) {
+            ancestorTargets.push(afterParentTarget);
+          }
         }
         if (nextItem) {
           break;

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -332,6 +332,38 @@ let DraggableTable = props => {
   return <TestTable tableProps={{dragAndDropHooks}} />;
 };
 
+// A table that both accepts drops from other tables and supports reordering within itself,
+// like the "Multiple positions" example in the docs.
+let ReorderableTable = ({items, onInsert, ...props}) => {
+  let {dragAndDropHooks} = useDragAndDrop({
+    getItems: keys => [...keys].map(key => ({'custom-app-type': String(key)})),
+    acceptedDragTypes: ['custom-app-type'],
+    getDropOperation: () => 'move',
+    onInsert: onInsert ?? (() => {}),
+    onReorder: () => {},
+    onRootDrop: () => {}
+  });
+
+  return (
+    <Table {...props} dragAndDropHooks={dragAndDropHooks}>
+      <TableHeader>
+        <Column />
+        <Column isRowHeader>Name</Column>
+      </TableHeader>
+      <TableBody items={items}>
+        {item => (
+          <Row>
+            <Cell>
+              <Button slot="drag">≡</Button>
+            </Cell>
+            <Cell>{item.name}</Cell>
+          </Row>
+        )}
+      </TableBody>
+    </Table>
+  );
+};
+
 let DisabledRowDraggableTable = () => {
   let {dragAndDropHooks} = useDragAndDrop({
     getItems: keys => [...keys].map(key => ({'text/plain': String(key)})),
@@ -1939,6 +1971,50 @@ describe('Table', () => {
       act(() => jest.runAllTimers());
       expect(tableTester.getRows()).toHaveLength(8);
       expect(tableTester.getSelectedRows()).toHaveLength(1);
+    });
+
+    it('should target the last row when dragging past the end of the table', async () => {
+      let onInsert = jest.fn();
+      let {getAllByRole} = render(
+        <>
+          <ReorderableTable aria-label="First table" items={[{id: 'a1', name: 'One'}]} />
+          <ReorderableTable
+            aria-label="Second table"
+            items={[
+              {id: 'b1', name: 'Two'},
+              {id: 'b2', name: 'Three'}
+            ]}
+            onInsert={onInsert}
+          />
+        </>
+      );
+      let grids = getAllByRole('grid');
+      let draggedRow = within(grids[0]).getAllByRole('row')[1];
+
+      let dataTransfer = new DataTransfer();
+      fireEvent(draggedRow, new DragEvent('dragstart', {dataTransfer, clientX: 5, clientY: 5}));
+      act(() => jest.runAllTimers());
+
+      // Drag below the last row. Past the end of the table the drop target used to escalate to
+      // the <TableBody>, whose key is generated rather than provided by the user, so the item
+      // was never inserted. Several pointer paths reach that state; moving downward and moving
+      // horizontally each suffice, so exercise both.
+      fireEvent(grids[1], new DragEvent('dragenter', {dataTransfer, clientX: 100, clientY: 50}));
+      fireEvent(grids[1], new DragEvent('dragover', {dataTransfer, clientX: 100, clientY: 50}));
+      fireEvent(grids[1], new DragEvent('dragover', {dataTransfer, clientX: 70, clientY: 50}));
+      fireEvent(grids[1], new DragEvent('dragover', {dataTransfer, clientX: 70, clientY: 75}));
+
+      await act(async () =>
+        fireEvent(grids[1], new DragEvent('drop', {dataTransfer, clientX: 70, clientY: 75}))
+      );
+      act(() => jest.runAllTimers());
+
+      expect(onInsert).toHaveBeenCalledTimes(1);
+      expect(onInsert.mock.calls[0][0].target).toEqual({
+        type: 'item',
+        key: 'b2',
+        dropPosition: 'after'
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10463

## What and why

Dragging a row from one Table into another and dropping it below the last row silently destroys the item — it vanishes from both tables, with no error. The goal is that dropping past the end of a table inserts at the end, the same as dropping just above the last row does.

The drop target handed to `onInsert` in that case is not a row at all: it's the `<TableBody>` collection node, identified by an internal generated key (`react-aria-27` and similar). Application code has no way to act on that key — `useListData.insertAfter` treats an unknown key as a no-op — so nothing is inserted, while `onDragEnd` still fires with `dropOperation: 'move'` and removes the item from the source list.

The approach here is to stop the delegate from ever proposing a non-row as a drop target, rather than to make consumers defend against generated keys. A drop target that application code cannot map back to its own data is not a valid target, so it should not escape the delegate.

## How it works

`TreeDropTargetDelegate.getPotentialTargets` walks up the parent chain of the target row and offers "after the parent" as an alternative drop target. That's the mechanism that lets you drop past the last child of an expanded tree row and land after the parent instead of inside it, and it's genuinely needed there.

It never checked that the ancestor was an item. In a flat Table, the last row's parent is the `<TableBody>` node, so it became a second potential target. Once there are two targets, `selectTarget` treats the position as an ambiguous boundary and can switch to the outermost one — the `<TableBody>`.

The fix adds a `parentItem?.type === 'item'` guard before pushing an ancestor target. Nested rows and tree items are unaffected, since their ancestors are real items. It also covers `<TreeSection>`, whose key is likewise generated.

### Which pointer paths trigger it

Worth being precise, because it is easy to conclude the bug is intermittent. I measured the resolved target across three paths on the pre-fix code (`b2` is the correct last-row key):

| path | pre-fix result |
| --- | --- |
| single hover below the last row, first drag of the session | `b2` — correct |
| two hovers, purely leftward, zero vertical movement | `react-aria-N` — wrong |
| single hover below the last row, second drag of the session | `react-aria-N` — wrong |

Vertical movement is not required: the `X_SWITCH_THRESHOLD` branch in `selectTarget` escalates to the outer target on horizontal movement alone. And a single hover is enough after the first drag, because the delegate is constructed once via `useState` in `Table.tsx` while `pointerTracking.boundaryContext` and `yDirection` are never reset when a drag ends — so an escalated `preferredTargetIndex` persists into subsequent drags. Only the very first drag of a page session reliably resolves correctly.

That stickiness across drags looks like a separate robustness problem in `selectTarget`, but it is not addressed here: with the bogus ancestor removed there is only one potential target for a flat table, so the boundary logic is never entered. It could still matter for trees.

### Scope of the bug

Only drops between two collections are affected. In a same-collection reorder the bogus target is still proposed, but `isValidDropTarget` rejects it: `isValidInsert` requires `!isInternal`, and `isValidReorder` requires `isDraggingWithinParent`, which fails because the `<TableBody>` node's `parentKey` is `null` while the dragged rows' `parentKey` is the body's key. `isValidInsert` has no equivalent parent-consistency check, which is what lets it through on the cross-collection path.

A table whose `<TableBody>` ends with a `TableLoadMoreItem` is also immune, because the loader gives the last row a non-null `nextKey` and `getPotentialTargets` returns early. Worth knowing when reproducing: the existing `DndTableExample` story has such a loader and therefore cannot show this bug. The docs' "Multiple positions" Table example has no loader and does reproduce it.

### Alternative considered

Adding an existence/parent check to `isValidInsert` in `useDroppableCollectionState` would also block this, and would harden every delegate at once. I did not do it here because it treats the symptom: the delegate would still be manufacturing targets that refer to nothing. It may be worth adding as defense in depth, and I'm happy to include it if you'd prefer.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

This PR was written with AI assistance (Claude Code). No storybook change: this is a bug fix with no new API or visual surface, and the behavior is covered by a unit test. Happy to add a story if you'd like one.

## 📝 Test Instructions:

Manual repro, using the "Multiple positions" example on the [drag and drop docs](https://react-spectrum.adobe.com/react-aria/dnd.html) with the **Table** variant:

1. Drag a row from the first table over the second table.
2. Move the pointer below the last row. If this is the first drag of the session, wiggle horizontally or keep moving downward; on any later drag a plain hover below the last row is enough.
3. Drop.
4. The row should be appended to the end of the second table. Before this change it disappeared from both tables.

### What I tested

- **Mouse** — the three pointer paths in the table above, plus the new unit test.
- **RTL** — verified separately under `I18nProvider locale="ar-AE"`: the bug reproduces identically and the fix holds. The change is direction-independent, so I did not add a duplicate RTL test.
- **Keyboard / screen reader** — not affected by this code path; keyboard drag and drop resolves targets through the keyboard delegate, not `getDropTargetFromPoint`. Not manually retested.
- **Not covered:** touch, light/dark/high-contrast, sizes/zoom, and text-length variations — this is drop-target resolution logic with no visual surface of its own.

`yarn test` and `yarn test:ssr` both produce a failure set byte-identical to the base commit (this checkout has pre-existing environment failures from generated code that needs a build — icons, `intl/**/*.json` glob imports); the only delta is the one test this PR adds. `yarn lint` and `yarn format` report nothing on the changed files.

## 🧢 Your Project:

react-aria-components