### PR TITLE
fix(PreviewTrigger): use independent state to avoid global tooltip registry interference

### DIFF
--- a/packages/react-aria-components/src/PreviewTrigger.tsx
+++ b/packages/react-aria-components/src/PreviewTrigger.tsx
@@ -13,12 +13,12 @@
 import {AriaPreviewTriggerProps, usePreviewTrigger} from 'react-aria/usePreviewTrigger';
 import {FocusableElement} from '@react-types/shared';
 import {FocusableProvider} from 'react-aria/private/interactions/useFocusable';
-import {OverlayTriggerState} from 'react-stately/useOverlayTriggerState';
+import {OverlayTriggerState, useOverlayTriggerState} from 'react-stately/useOverlayTriggerState';
 import {OverlayTriggerStateContext} from './Dialog';
 import {PopoverContext} from './Popover';
 import {Provider} from './utils';
-import React, {JSX, ReactNode, useMemo, useRef} from 'react';
-import {useTooltipTriggerState} from 'react-stately/useTooltipTriggerState';
+import React, {JSX, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {TooltipTriggerState} from 'react-stately/useTooltipTriggerState';
 
 export interface PreviewTriggerProps extends AriaPreviewTriggerProps {
   /** The trigger and Popover that make up the preview trigger. */
@@ -42,11 +42,7 @@ export interface PreviewTriggerProps extends AriaPreviewTriggerProps {
  * the popover may contain interactive content.
  */
 export function PreviewTrigger(props: PreviewTriggerProps): JSX.Element {
-  let state = useTooltipTriggerState({
-    ...props,
-    delay: props.delay ?? 600,
-    closeDelay: props.closeDelay ?? 200
-  });
+  let state = usePreviewTriggerState(props);
   let triggerRef = useRef<FocusableElement>(null);
   let popoverRef = useRef<HTMLElement>(null);
   let {triggerProps, popoverProps} = usePreviewTrigger({...props, triggerRef, popoverRef}, state);
@@ -88,4 +84,79 @@ export function PreviewTrigger(props: PreviewTriggerProps): JSX.Element {
       </FocusableProvider>
     </Provider>
   );
+}
+
+/**
+ * Provides the state for a preview trigger with warmup/cooldown delay behavior, without
+ * participating in the global tooltip trigger registry. This allows interactive content
+ * inside the preview popover (e.g. Tooltip, Select) to open without closing the preview,
+ * which would happen if useTooltipTriggerState were used directly (its closeOpenTooltips
+ * function closes all other tooltip states, including the preview's).
+ */
+function usePreviewTriggerState(props: PreviewTriggerProps): TooltipTriggerState {
+  let {delay = 600, closeDelay = 200} = props;
+  let {isOpen, open, close} = useOverlayTriggerState(props);
+  // Whether the current open/close transition should skip its animation. Set when swapping
+  // between previews during the warmup period.
+  let [shouldSkipAnimation, setShouldSkipAnimation] = useState(false);
+  let openTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  let closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  let showPreview = useCallback((immediate?: boolean) => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+    if (openTimeout.current) {
+      clearTimeout(openTimeout.current);
+      openTimeout.current = null;
+    }
+    setShouldSkipAnimation(!!immediate);
+    if (immediate || delay <= 0) {
+      open();
+    } else {
+      openTimeout.current = setTimeout(() => {
+        openTimeout.current = null;
+        setShouldSkipAnimation(false);
+        open();
+      }, delay);
+    }
+  }, [delay, open]);
+
+  let hidePreview = useCallback((immediate?: boolean) => {
+    if (openTimeout.current) {
+      clearTimeout(openTimeout.current);
+      openTimeout.current = null;
+    }
+    if (immediate || closeDelay <= 0) {
+      if (closeTimeout.current) {
+        clearTimeout(closeTimeout.current);
+        closeTimeout.current = null;
+      }
+      close();
+    } else if (!closeTimeout.current) {
+      closeTimeout.current = setTimeout(() => {
+        closeTimeout.current = null;
+        close();
+      }, closeDelay);
+    }
+  }, [closeDelay, close]);
+
+  useEffect(() => {
+    return () => {
+      if (openTimeout.current) {
+        clearTimeout(openTimeout.current);
+      }
+      if (closeTimeout.current) {
+        clearTimeout(closeTimeout.current);
+      }
+    };
+  }, []);
+
+  return {
+    isOpen,
+    shouldSkipAnimation,
+    open: showPreview,
+    close: hidePreview
+  };
 }

--- a/packages/react-aria-components/test/PreviewTrigger.test.js
+++ b/packages/react-aria-components/test/PreviewTrigger.test.js
@@ -21,6 +21,8 @@ import {Button} from '../src/Button';
 import {Link} from '../src/Link';
 import {Popover} from '../src/Popover';
 import {PreviewTrigger} from '../src/PreviewTrigger';
+import {Tooltip} from '../src/Tooltip';
+import {TooltipTrigger} from '../src/Tooltip';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
@@ -324,4 +326,34 @@ describe('PreviewTrigger', () => {
       }
     });
   });
+
+  it('stays open when a Tooltip inside the popover is hovered', async () => {
+    let {getByRole, getByTestId, getByText} = render(
+      <PreviewTrigger delay={0} closeDelay={0}>
+        <Link href="https://example.com">Example</Link>
+        <Popover data-testid="preview">
+          <TooltipTrigger>
+            <Button aria-label="Info">Info</Button>
+            <Tooltip>Tooltip content</Tooltip>
+          </TooltipTrigger>
+        </Popover>
+      </PreviewTrigger>
+    );
+    let link = getByRole('link');
+    let infoButton = getByRole('button', {name: 'Info'});
+
+    // Open the preview by hovering the trigger.
+    fireEvent.mouseMove(document.body);
+    await user.hover(link);
+    act(() => jest.runAllTimers());
+    let preview = getByTestId('preview');
+    expect(preview).toBeInTheDocument();
+
+    // Hovering a Tooltip trigger inside the popover opens the tooltip but the preview stays open.
+    await user.hover(infoButton);
+    act(() => jest.runAllTimers());
+    expect(getByText('Tooltip content')).toBeInTheDocument();
+    expect(preview).toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
## Summary

When a `Button` inside a `PreviewTrigger`'s `Popover` has a `Tooltip`, hovering the `Button` closes the `Popover` immediately.

### Root cause

`PreviewTrigger` was using `useTooltipTriggerState` from `react-stately`, which maintains a **module-level global tooltip registry**. When the inner `Tooltip` opens, its `showTooltip` → `closeOpenTooltips` iterates over the global registry and force-closes (`hideTooltip(true, true)`) all other registered tooltip states — including the `PreviewTrigger`'s state. This closes the preview popover.

### Fix

Replaced `useTooltipTriggerState` with a local `usePreviewTriggerState` hook that:
- Uses `useOverlayTriggerState` (no global registry) for the basic open/close state
- Implements the same warmup/cooldown delay behavior (`delay` and `closeDelay` props)
- Provides `shouldSkipAnimation` matching the `TooltipTriggerState` interface
- Does **not** participate in the global tooltip registry, so interactive content inside the preview popover (Tooltip, Select, etc.) can open without closing the preview

### Test

Added a test case that verifies:
1. Preview opens on hover
2. Hovering a Tooltip trigger inside the popover shows the tooltip
3. The preview stays open while the tooltip is visible

Fixes #10460