### PR TITLE
fix(table): decouple item drop target highlight from cell measurement state

### DIFF
--- a/packages/@adobe/react-spectrum/src/table/table.css
+++ b/packages/@adobe/react-spectrum/src/table/table.css
@@ -225,10 +225,14 @@
     /* forced-color-adjust: none, so that box-shadow style will render */
     forced-color-adjust: none;
   }
+}
 
-  .react-spectrum-Table-cellWrapper.react-spectrum-Table-cellWrapper--dropTarget {
-    background-color: var(--spectrum-table-droptarget-background-color);
-  }
+/* Deliberately not chained with .react-spectrum-Table-cellWrapper: that class is only applied while
+   the cell height is not an estimate, so chaining it here drops the drop target background whenever
+   the table is still measuring. The .react-spectrum-Table ancestor supplies the specificity instead,
+   so this still wins over .spectrum-Table--quiet .spectrum-Table-row .spectrum-Table-cellWrapper. */
+.react-spectrum-Table .react-spectrum-Table-row .react-spectrum-Table-cellWrapper--dropTarget {
+  background-color: var(--spectrum-table-droptarget-background-color);
 }
 
 @media (forced-colors: active) {

--- a/packages/@adobe/react-spectrum/test/table/TableDnd.test.js
+++ b/packages/@adobe/react-spectrum/test/table/TableDnd.test.js
@@ -3953,5 +3953,100 @@ describe('TableView', function () {
         fireEvent.keyUp(document.body, {key: 'Escape'});
       });
     });
+
+    describe('drop target highlight', function () {
+      // The highlight is painted on the row (border) and on each of its cell wrappers (background),
+      // because the cell wrappers are opaque and sit on top of the row. See issue #5404.
+      function getCellWrappers(row) {
+        return [...row.children];
+      }
+
+      function expectHighlighted(row, isHighlighted) {
+        expect(row.className.includes('react-spectrum-Table-row--dropTarget')).toBe(isHighlighted);
+        let wrappers = getCellWrappers(row);
+        expect(wrappers.length).toBeGreaterThan(0);
+        for (let wrapper of wrappers) {
+          expect(wrapper.className.includes('react-spectrum-Table-cellWrapper--dropTarget')).toBe(
+            isHighlighted
+          );
+        }
+      }
+
+      it('should highlight the row and its cells while dragging over an item drop target', async function () {
+        let {getByRole} = render(<DragOntoRowExample />);
+        let grid = getByRole('grid');
+        let rows = within(within(grid).getAllByRole('rowgroup')[1]).getAllByRole('row');
+
+        let dragCell = within(rows[1]).getAllByRole('rowheader')[0];
+        let dataTransfer = new DataTransfer();
+        fireEvent.pointerDown(dragCell, {
+          pointerType: 'mouse',
+          button: 0,
+          pointerId: 1,
+          clientX: 0,
+          clientY: 0
+        });
+        fireEvent(dragCell, new DragEvent('dragstart', {dataTransfer, clientX: 0, clientY: 0}));
+        act(() => jest.runAllTimers());
+        expectHighlighted(rows[0], false);
+
+        // Drop onto the middle of the first row, which is an "on" drop position.
+        fireEvent(rows[0], new DragEvent('dragover', {dataTransfer, clientX: 1, clientY: 20}));
+        act(() => {
+          jest.advanceTimersByTime(100);
+        });
+
+        expectHighlighted(rows[0], true);
+        expectHighlighted(rows[3], false);
+
+        // "Three" is not a folder, so it only accepts insert positions. Dragging over it must clear
+        // the highlight rather than leaving it behind on the previous target.
+        fireEvent(rows[3], new DragEvent('dragover', {dataTransfer, clientX: 1, clientY: 145}));
+        act(() => {
+          jest.advanceTimersByTime(100);
+        });
+
+        expectHighlighted(rows[0], false);
+        expectHighlighted(rows[3], false);
+
+        fireEvent.pointerUp(dragCell, {
+          pointerType: 'mouse',
+          button: 0,
+          pointerId: 1,
+          clientX: 1,
+          clientY: 145
+        });
+        fireEvent(rows[3], new DragEvent('drop', {dataTransfer, clientX: 1, clientY: 145}));
+        fireEvent(dragCell, new DragEvent('dragend', {dataTransfer, clientX: 1, clientY: 145}));
+        act(() => jest.runAllTimers());
+      });
+
+      it('should highlight the row and its cells when a keyboard drag targets an item', async function () {
+        let {getByRole} = render(<DragOntoRowExample />);
+        let grid = getByRole('grid');
+        // Rows other than the active drop target are aria-hidden during a keyboard drag, so the
+        // hidden option is needed to reach them.
+        let findRow = name =>
+          within(grid)
+            .getAllByRole('row', {hidden: true})
+            .find(row => within(row).queryByText(name));
+
+        // Start a keyboard drag from "Folder 1". "Folder 2" is the only other row that accepts an
+        // "on" drop, so it is the first drop target.
+        await user.tab();
+        await user.keyboard('{ArrowRight}');
+        await user.keyboard('{Enter}');
+        act(() => jest.runAllTimers());
+        expect(document.activeElement).toHaveAttribute('aria-label', 'Drop on Folder 2');
+
+        expectHighlighted(findRow('Folder 2'), true);
+        expectHighlighted(findRow('Six'), false);
+
+        fireEvent.keyDown(document.body, {key: 'Escape'});
+        fireEvent.keyUp(document.body, {key: 'Escape'});
+        act(() => jest.runAllTimers());
+        expectHighlighted(findRow('Folder 2'), false);
+      });
+    });
   });
 });


### PR DESCRIPTION
Re: #5404

## Intent

#5404 reports that a TableView item drop target shows no highlight while the root drop target does. I set out to fix it, but the first thing I did was try to reproduce it on `main` — and I can't. **I believe #5404 is already fixed**, incidentally, by the Virtualizer refactor in #6451.

So this PR does two things instead:

1. Adds the regression coverage that was missing (which is why this regressed silently and the issue sat open).
2. Fixes a separate, still-live defect in the same rule that reintroduces the exact same symptom under different conditions.

I'd rather bring you evidence than a speculative fix. If you disagree with the analysis below, I'm happy to keep digging — and if you agree, #5404 can be closed once this lands.

## Why I think #5404 is already fixed

The original diagnosis in the issue thread was @reidbarber's: [`dropState` is stale when used in `renderWrapper`](https://github.com/adobe/react-spectrum/issues/5404#issuecomment-1808806668).

The mechanism, for the record: TableView splits the drop highlight across two elements, because cell wrappers have opaque backgrounds (they have to, so sticky cells don't show other cells through them). The row carries the inset border (`react-spectrum-Table-row--dropTarget`), the cell wrappers carry the background tint (`react-spectrum-Table-cellWrapper--dropTarget`). At the time, the cell wrapper's `isDropTarget` was computed in a closure inside `renderWrapper`, which was handed to `useVirtualizerState` and whose output the old Virtualizer **cached** per `ReusableView`. Hovering a new drop target invalidates nothing — same collection, no scroll, no layout change — so the cached wrappers replayed a stale `dropState`. `TableRow`, being a real component reading `TableContext`, updated normally. The border was applied and then painted over by unchanged opaque white. That also explains why "the computed styles look right": the row *was* correct; the elements covering it were not. Root drops were unaffected because that highlight lives on `.react-spectrum-Table-body`, outside the cached tree.

#6451 removed both halves of that: `TableCellWrapper` is now a real component reading `dropState` from `TableContext`, and `TableVirtualizer` builds the wrapper tree inline on every render rather than consuming cached views.

I verified rather than assumed — a probe test firing a real `dragover` onto a folder row, dumping the classes on the row and its wrappers across four configurations:

```
[default]           row= … react-spectrum-Table-row--dropTarget
[default]       wrapper= … react-spectrum-Table-cellWrapper--dropTarget
[quiet]              … same
[overflowMode=wrap]  … same
[density=spacious]   … same
```

Both levels update in all of them.

## The defect this actually fixes

While confirming the above I found a live problem in the same CSS rule:

```css
.react-spectrum-Table-cellWrapper.react-spectrum-Table-cellWrapper--dropTarget {
  background-color: var(--spectrum-table-droptarget-background-color);
}
```

The chained base class is there purely for specificity — #4483 added it so the rule beats `.spectrum-Table--quiet .spectrum-Table-row .spectrum-Table-cellWrapper` at `(0,3,0)`. But `react-spectrum-Table-cellWrapper` is not a static hook. It's toggled by layout state:

```js
// TableViewBase.tsx
'react-spectrum-Table-cellWrapper': !layoutInfo.estimatedSize,
'react-spectrum-Table-cellWrapper--dropTarget': isDropTarget || isRootDroptarget
```

`estimatedSize` is true whenever a cell height is a guess rather than a measurement — initial layout, and again on any re-layout where the column width changed ([`TableLayout.ts#L332`](https://github.com/adobe/react-spectrum/blob/main/packages/react-stately/src/layout/TableLayout.ts#L332)). In those windows the modifier class is present, the JS is entirely correct, and the selector just stops matching. The item highlight disappears while the root highlight (on `.react-spectrum-Table-body`) keeps working — the same confusing signature as #5404, with nothing in the DOM to explain it.

The fix takes the specificity from an ancestor that can't be toggled off:

```css
.react-spectrum-Table .react-spectrum-Table-row .react-spectrum-Table-cellWrapper--dropTarget {
  background-color: var(--spectrum-table-droptarget-background-color);
}
```

Still `(0,3,0)`, and `table.css` is imported after `@adobe/spectrum-css-temp` in `TableViewBase.tsx`, so it still wins the tie against the quiet variant.

Happy to be told the right call is instead to make the base class unconditional and give the "height is measured" case its own class — that's the other way to break the coupling, it's just a wider change.

## Tests

Nothing anywhere asserted these classes, which is how this regressed unnoticed. Two tests in `TableDnd.test.js`, pointer and keyboard, asserting the row **and every one of its cell wrappers**:

- the targeted row and all its wrappers get the drop target classes
- the highlight follows the target rather than being left behind on a stale one
- it clears when the drag ends

I mutation-tested them: stubbing the cell wrapper's `isDropTarget` to `false` fails both, so they would have caught the original #5404 bug.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests). — tests added; no new story, the existing `DragOntoRowExample` already covers this visual state and no new state is introduced.
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component). — no docs change; no API surface change.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.

## 📝 Test Instructions:

Storybook → `TableView/Drag and Drop` → **Drag onto row**.

1. Drag a row over "Folder 1" or "Folder 2". The row should show a blue inset border *and* a blue tint across all of its cells.
2. Drag between a folder row and a non-folder row — the highlight should move/clear rather than sticking to the previous target.
3. Repeat with `isQuiet`, and with `overflowMode="wrap"` (the case the CSS fix targets — resize a column mid-drag to force a re-estimate).
4. Keyboard: focus a row, <kbd>→</kbd> to the drag handle, <kbd>Enter</kbd> to start a drag, then arrow through drop targets.

Tested: mouse + keyboard, light + dark, LTR, default/quiet/wrap/spacious. **Not** tested: RTL, high-contrast (the `forced-colors` block sets the drop target background to transparent, so this rule is a no-op there), screen reader, zoom.

`yarn jest packages/@adobe/react-spectrum/test/table/TableDnd.test.js` — 80/80 pass locally. I was not able to run the React 16/17 matrix locally (unrelated local node_modules corruption), so I'm relying on CI for those.

## 🧢 Your Project:

Personal / open source contribution
