### PR TITLE
fix: auto set static color auto and fix tokenfield docs regex for IME

### DIFF
--- a/packages/@react-spectrum/ai/chromatic/PromptField.stories.tsx
+++ b/packages/@react-spectrum/ai/chromatic/PromptField.stories.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {ActionButton} from '@react-spectrum/s2/ActionButton';
+import {AttachFileMenuItem, InsertMenuButton, PromptFieldVoiceButton} from '../src/PromptField';
+import {Button} from '@react-spectrum/s2/Button';
+import {
+  Header,
+  Heading,
+  Menu,
+  MenuItem,
+  MenuSection,
+  MenuTrigger,
+  Text
+} from '@react-spectrum/s2/Menu';
+import Keyboard from '@react-spectrum/s2/icons/Keyboard';
+import {LinkButton} from '@react-spectrum/s2/LinkButton';
+import ListMultiSelect from '@react-spectrum/s2/icons/ListMultiSelect';
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  PromptField,
+  PromptFieldSubmitButton,
+  PromptFieldToolbar,
+  PromptTokenField
+} from '@react-spectrum/ai';
+import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {ToggleButton} from '@react-spectrum/s2/ToggleButton';
+
+const meta: Meta = {
+  parameters: {
+    chromaticProvider: {
+      disableAnimations: true,
+      colorSchemes: ['light', 'dark'],
+      locales: ['en-US']
+    }
+  },
+  title: 'AI Chromatic/PromptField'
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function ToolbarButtons() {
+  return (
+    <div className={style({display: 'flex', gap: 8})}>
+      <ToggleButton isQuiet size="S">
+        <ListMultiSelect />
+        <Text>Plan mode</Text>
+      </ToggleButton>
+      <MenuTrigger>
+        <ActionButton isQuiet size="S">
+          <Keyboard />
+          <Text>Normal</Text>
+        </ActionButton>
+        <Menu>
+          <MenuSection>
+            <Header>
+              <Heading>Transcript view</Heading>
+            </Header>
+            <MenuItem>Normal</MenuItem>
+          </MenuSection>
+        </Menu>
+      </MenuTrigger>
+      <Button size="S" fillStyle="outline">
+        Model
+      </Button>
+      <LinkButton size="S" fillStyle="outline" href="#">
+        Terms and conditions
+      </LinkButton>
+    </div>
+  );
+}
+
+export const ToolbarButtonsStory: Story = {
+  render: () => (
+    <div className={style({width: 800, maxWidth: '90vw', marginX: 'auto'})}>
+      <PromptField>
+        <PromptTokenField />
+        <PromptFieldToolbar>
+          <div className={style({display: 'flex', gap: 8, alignItems: 'center'})}>
+            <InsertMenuButton>
+              <AttachFileMenuItem />
+            </InsertMenuButton>
+            <ToolbarButtons />
+          </div>
+          <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+            <PromptFieldVoiceButton />
+            <PromptFieldSubmitButton />
+          </div>
+        </PromptFieldToolbar>
+      </PromptField>
+      <PromptField variant="prominent">
+        <PromptTokenField />
+        <PromptFieldToolbar>
+          <div className={style({display: 'flex', gap: 8, alignItems: 'center'})}>
+            <InsertMenuButton>
+              <AttachFileMenuItem />
+            </InsertMenuButton>
+            <ToolbarButtons />
+          </div>
+          <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+            <PromptFieldVoiceButton />
+            <PromptFieldSubmitButton />
+          </div>
+        </PromptFieldToolbar>
+      </PromptField>
+      <PromptField variant="subtle">
+        <PromptTokenField />
+        <PromptFieldToolbar>
+          <div className={style({display: 'flex', gap: 8, alignItems: 'center'})}>
+            <InsertMenuButton>
+              <AttachFileMenuItem />
+            </InsertMenuButton>
+            <ToolbarButtons />
+          </div>
+          <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+            <PromptFieldVoiceButton />
+            <PromptFieldSubmitButton />
+          </div>
+        </PromptFieldToolbar>
+      </PromptField>
+    </div>
+  )
+};

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -10,11 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionButton} from '@react-spectrum/s2/ActionButton';
+import {ActionButton, ActionButtonContext} from '@react-spectrum/s2/ActionButton';
 import Attach from '@react-spectrum/s2/icons/Attach';
 import {Attachment, AttachmentList, AttachmentListProps} from './AttachmentList';
 import {Autocomplete} from 'react-aria-components/Autocomplete';
-import {Button} from '@react-spectrum/s2/Button';
+import {Button, ButtonContext} from '@react-spectrum/s2/Button';
 import {Cell} from './loader/data';
 import {CenterBaseline} from '@react-spectrum/s2/CenterBaseline';
 import {color, css, space, style, StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
@@ -39,6 +39,7 @@ import {Image, Text} from '@react-spectrum/s2/Card';
 import intlMessages from '../intl/*.json';
 import {isFileDropItem, useDrop} from 'react-aria-components/useDrop';
 import {Link} from '@react-spectrum/s2/Link';
+import {LinkButtonContext} from '@react-spectrum/s2/LinkButton';
 import {Menu, MenuItem, MenuItemProps, MenuTrigger} from '@react-spectrum/s2/Menu';
 import Microphone from '@react-spectrum/s2/icons/Microphone';
 import {PixelLoader} from './loader/react';
@@ -53,10 +54,11 @@ import {
 } from 'react-stately/useTokenFieldState';
 import {PromptFieldContainer} from './PromptFieldContainer';
 import {PromptFocusContext} from './Chat';
+import {Provider} from 'react-aria-components/slots';
 import Send from '@react-spectrum/s2/icons/ArrowUpSend';
 import {setTokenFieldSelection} from 'react-aria/useTokenField';
 import Stop from '@react-spectrum/s2/icons/StopProcessing';
-import {ToggleButton} from '@react-spectrum/s2/ToggleButton';
+import {ToggleButton, ToggleButtonContext} from '@react-spectrum/s2/ToggleButton';
 import {
   Token,
   TokenField,
@@ -337,28 +339,36 @@ export const PromptField = forwardRef(function PromptField(
         onAddAttachments,
         onRemoveAttachments
       }}>
-      <div ref={domRef} {...focusWithinProps}>
-        <PromptFieldContainer
-          {...dropProps}
-          role="group"
-          variant={variant}
-          brandColor={brandColor}
-          isGenerating={isGenerating ?? false}
-          isDropTarget={isDropTarget}
-          styles={styles}
-          inputRef={inputRef}>
-          {children}
-        </PromptFieldContainer>
-        <p className={style({font: 'ui-sm', textAlign: 'center'})}>
-          {stringFormatter.format('promptfield.aiDisclaimer')}{' '}
-          <Link
-            variant="secondary"
-            href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html"
-            target="_blank">
-            {stringFormatter.format('promptfield.aiUserGuidlines')}
-          </Link>
-        </p>
-      </div>
+      <Provider
+        values={[
+          [ButtonContext, {staticColor: 'auto'}],
+          [LinkButtonContext, {staticColor: 'auto'}],
+          [ActionButtonContext, {staticColor: 'auto'}],
+          [ToggleButtonContext, {staticColor: 'auto'}]
+        ]}>
+        <div ref={domRef} {...focusWithinProps}>
+          <PromptFieldContainer
+            {...dropProps}
+            role="group"
+            variant={variant}
+            brandColor={brandColor}
+            isGenerating={isGenerating ?? false}
+            isDropTarget={isDropTarget}
+            styles={styles}
+            inputRef={inputRef}>
+            {children}
+          </PromptFieldContainer>
+          <p className={style({font: 'ui-sm', textAlign: 'center'})}>
+            {stringFormatter.format('promptfield.aiDisclaimer')}{' '}
+            <Link
+              variant="secondary"
+              href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html"
+              target="_blank">
+              {stringFormatter.format('promptfield.aiUserGuidlines')}
+            </Link>
+          </p>
+        </div>
+      </Provider>
     </PromptFieldContext.Provider>
   );
 });

--- a/packages/@react-spectrum/ai/stories/PromptField.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/PromptField.stories.tsx
@@ -11,6 +11,7 @@
  */
 
 import {action} from 'storybook/actions';
+import {ActionButton} from '@react-spectrum/s2/ActionButton';
 import {
   AttachFileMenuItem,
   CommandMenuItem,
@@ -30,6 +31,7 @@ import {
 } from '../src/PromptField';
 import {Attachment} from '../src/AttachmentList';
 import Brand from '@react-spectrum/s2/icons/Brand';
+import {Button} from '@react-spectrum/s2/Button';
 import {categorizeArgTypes, getActionArgs} from '../../s2/stories/utils';
 import {CenterBaseline} from '@react-spectrum/s2/CenterBaseline';
 import {
@@ -39,6 +41,7 @@ import {
   Menu,
   MenuItem,
   MenuSection,
+  MenuTrigger,
   SubmenuTrigger,
   Text
 } from '@react-spectrum/s2/Menu';
@@ -48,12 +51,16 @@ import * as data from '../src/loader/data';
 import type {FocusableRefValue} from '@react-types/shared';
 import {iconStyle, style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Image} from '@react-spectrum/s2/Image';
+import Keyboard from '@react-spectrum/s2/icons/Keyboard';
+import {LinkButton} from '@react-spectrum/s2/LinkButton';
 import LinkIcon from '@react-spectrum/s2/icons/Link';
+import ListMultiSelect from '@react-spectrum/s2/icons/ListMultiSelect';
 import {MessageSuggestion, MessageSuggestionList} from '../src/MessageSuggestion';
 import type {Meta, StoryObj} from '@storybook/react';
 import Plugin from '@react-spectrum/s2/icons/Plugin';
 import Prompt from '@react-spectrum/s2/icons/Prompt';
 import SocialNetwork from '@react-spectrum/s2/icons/SocialNetwork';
+import {ToggleButton} from '@react-spectrum/s2/ToggleButton';
 import {TokenFieldValue} from 'react-aria-components';
 import {TokenSegment} from 'react-stately';
 import {useRef, useState} from 'react';
@@ -285,6 +292,37 @@ function renderCompletions(filterValue: string, callbacks?: CompletionCallbacks)
   return null;
 }
 
+function ToolbarButtons() {
+  return (
+    <div className={style({display: 'flex', gap: 8})}>
+      <ToggleButton isQuiet size="S">
+        <ListMultiSelect />
+        <Text>Plan mode</Text>
+      </ToggleButton>
+      <MenuTrigger>
+        <ActionButton isQuiet size="S">
+          <Keyboard />
+          <Text>Normal</Text>
+        </ActionButton>
+        <Menu>
+          <MenuSection>
+            <Header>
+              <Heading>Transcript view</Heading>
+            </Header>
+            <MenuItem>Normal</MenuItem>
+          </MenuSection>
+        </Menu>
+      </MenuTrigger>
+      <Button size="S" fillStyle="outline">
+        Model
+      </Button>
+      <LinkButton size="S" fillStyle="outline" href="#">
+        Terms and conditions
+      </LinkButton>
+    </div>
+  );
+}
+
 interface UploadState {
   status: 'uploading' | 'completed';
   progress?: number;
@@ -508,36 +546,58 @@ function EverythingRender(args) {
           )}
         </PromptTokenField>
         <PromptFieldToolbar>
-          <InsertMenuButton>
-            <AttachFileMenuItem />
-            <SubmenuTrigger>
-              <MenuItem>
-                <Prompt />
-                <Text>Commands</Text>
-              </MenuItem>
-              <Menu items={slashCommands.filter(item => item.kind === 'command')}>
-                {item =>
-                  item.command === '/clear' ? (
-                    <MenuItem
-                      id={item.command}
-                      onAction={() => {
-                        setValue(new PromptFieldValue([]));
-                        setAttachments([]);
-                      }}>
-                      <Text slot="label">{item.command}</Text>
-                      <Text slot="description">{item.description}</Text>
-                    </MenuItem>
-                  ) : item.command === '/compact' ? (
-                    <MenuItem id={item.command} onAction={action('onCompact')}>
-                      <Text slot="label">{item.command}</Text>
-                      <Text slot="description">{item.description}</Text>
-                    </MenuItem>
-                  ) : item.command === '/feedback' || item.command === '/btw' ? (
-                    <InsertTextMenuItem id={item.command} text={item.command}>
-                      <Text slot="label">{item.command}</Text>
-                      <Text slot="description">{item.description}</Text>
-                    </InsertTextMenuItem>
-                  ) : (
+          <div className={style({display: 'flex', gap: 8, alignItems: 'center'})}>
+            <InsertMenuButton>
+              <AttachFileMenuItem />
+              <SubmenuTrigger>
+                <MenuItem>
+                  <Prompt />
+                  <Text>Commands</Text>
+                </MenuItem>
+                <Menu items={slashCommands.filter(item => item.kind === 'command')}>
+                  {item =>
+                    item.command === '/clear' ? (
+                      <MenuItem
+                        id={item.command}
+                        onAction={() => {
+                          setValue(new PromptFieldValue([]));
+                          setAttachments([]);
+                        }}>
+                        <Text slot="label">{item.command}</Text>
+                        <Text slot="description">{item.description}</Text>
+                      </MenuItem>
+                    ) : item.command === '/compact' ? (
+                      <MenuItem id={item.command} onAction={action('onCompact')}>
+                        <Text slot="label">{item.command}</Text>
+                        <Text slot="description">{item.description}</Text>
+                      </MenuItem>
+                    ) : item.command === '/feedback' || item.command === '/btw' ? (
+                      <InsertTextMenuItem id={item.command} text={item.command}>
+                        <Text slot="label">{item.command}</Text>
+                        <Text slot="description">{item.description}</Text>
+                      </InsertTextMenuItem>
+                    ) : (
+                      <InsertTokenMenuItem
+                        id={item.command}
+                        token={{
+                          type: 'token',
+                          text: item.command,
+                          value: {type: 'custom', anchor: '/', valueType: item.kind, data: item}
+                        }}>
+                        <Text slot="label">{item.command}</Text>
+                        <Text slot="description">{item.description}</Text>
+                      </InsertTokenMenuItem>
+                    )
+                  }
+                </Menu>
+              </SubmenuTrigger>
+              <SubmenuTrigger>
+                <MenuItem>
+                  <Plugin />
+                  <Text>Skills</Text>
+                </MenuItem>
+                <Menu items={slashCommands.filter(item => item.kind === 'skill')}>
+                  {item => (
                     <InsertTokenMenuItem
                       id={item.command}
                       token={{
@@ -548,59 +608,40 @@ function EverythingRender(args) {
                       <Text slot="label">{item.command}</Text>
                       <Text slot="description">{item.description}</Text>
                     </InsertTokenMenuItem>
-                  )
-                }
-              </Menu>
-            </SubmenuTrigger>
-            <SubmenuTrigger>
-              <MenuItem>
-                <Plugin />
-                <Text>Skills</Text>
-              </MenuItem>
-              <Menu items={slashCommands.filter(item => item.kind === 'skill')}>
-                {item => (
-                  <InsertTokenMenuItem
-                    id={item.command}
-                    token={{
-                      type: 'token',
-                      text: item.command,
-                      value: {type: 'custom', anchor: '/', valueType: item.kind, data: item}
-                    }}>
-                    <Text slot="label">{item.command}</Text>
-                    <Text slot="description">{item.description}</Text>
-                  </InsertTokenMenuItem>
-                )}
-              </Menu>
-            </SubmenuTrigger>
-            <SubmenuTrigger>
-              <MenuItem>
-                <Data />
-                <Text>Reference an object</Text>
-              </MenuItem>
-              <Menu items={objects}>
-                {item => (
-                  <MenuSection>
-                    <Header>
-                      <Heading>{item.section}</Heading>
-                    </Header>
-                    <Collection items={item.items}>
-                      {item => (
-                        <InsertTokenMenuItem
-                          id={item.title}
-                          token={{
-                            type: 'token',
-                            text: item.title,
-                            value: {type: 'custom', anchor: '@', valueType: item.kind, data: item}
-                          }}>
-                          {item.title}
-                        </InsertTokenMenuItem>
-                      )}
-                    </Collection>
-                  </MenuSection>
-                )}
-              </Menu>
-            </SubmenuTrigger>
-          </InsertMenuButton>
+                  )}
+                </Menu>
+              </SubmenuTrigger>
+              <SubmenuTrigger>
+                <MenuItem>
+                  <Data />
+                  <Text>Reference an object</Text>
+                </MenuItem>
+                <Menu items={objects}>
+                  {item => (
+                    <MenuSection>
+                      <Header>
+                        <Heading>{item.section}</Heading>
+                      </Header>
+                      <Collection items={item.items}>
+                        {item => (
+                          <InsertTokenMenuItem
+                            id={item.title}
+                            token={{
+                              type: 'token',
+                              text: item.title,
+                              value: {type: 'custom', anchor: '@', valueType: item.kind, data: item}
+                            }}>
+                            {item.title}
+                          </InsertTokenMenuItem>
+                        )}
+                      </Collection>
+                    </MenuSection>
+                  )}
+                </Menu>
+              </SubmenuTrigger>
+            </InsertMenuButton>
+            <ToolbarButtons />
+          </div>
           {/* TODO is this kind of styling expected from the user? Or should we have a slot that places the mic button next to the submit button? */}
           <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
             <PromptFieldVoiceButton onToggle={action('onToggle')} />

--- a/packages/@react-spectrum/s2/src/Menu.tsx
+++ b/packages/@react-spectrum/s2/src/Menu.tsx
@@ -37,7 +37,7 @@ import {box, iconStyles} from './Checkbox';
 import {centerBaseline} from './CenterBaseline';
 import CheckmarkIcon from '../ui-icons/Checkmark';
 import ChevronRightIcon from '../ui-icons/Chevron';
-import {ContextValue, DEFAULT_SLOT, Provider} from 'react-aria-components/slots';
+import {ContextValue, DEFAULT_SLOT, Provider, useSlottedContext} from 'react-aria-components/slots';
 import {
   control,
   controlFont,
@@ -747,12 +747,14 @@ function MenuTrigger(props: MenuTriggerProps): ReactNode {
       placement = `${direction} ${align}` as Placement;
   }
   let holdAffordance = trigger === 'longPress';
+  let actionButtonContext = useSlottedContext(ActionButtonContext) || {};
+  let toggleButtonContext = useSlottedContext(ToggleButtonContext) || {};
 
   return (
     <Provider
       values={[
-        [ActionButtonContext, {holdAffordance}],
-        [ToggleButtonContext, {holdAffordance}]
+        [ActionButtonContext, {...actionButtonContext, holdAffordance}],
+        [ToggleButtonContext, {...toggleButtonContext, holdAffordance}]
       ]}>
       <InternalMenuTriggerContext.Provider
         value={{

--- a/packages/@react-spectrum/s2/test/Menu.test.tsx
+++ b/packages/@react-spectrum/s2/test/Menu.test.tsx
@@ -17,7 +17,7 @@ import {
   render,
   User
 } from '@react-spectrum/test-utils-internal';
-import {ActionButton} from '../src/ActionButton';
+import {ActionButton, ActionButtonContext} from '../src/ActionButton';
 import {AriaMenuTests} from '../../../react-aria-components/test/AriaMenu.test-util';
 import {Button} from '../src/Button';
 import {Collection} from 'react-aria/Collection';
@@ -31,6 +31,7 @@ import {
   SubmenuTrigger,
   UnavailableMenuItemTrigger
 } from '../src/Menu';
+import {Provider, useSlottedContext} from 'react-aria-components/slots';
 import React from 'react';
 import {Selection} from '@react-types/shared';
 import {ToggleButton} from '../src/ToggleButton';
@@ -142,6 +143,32 @@ describe('Menu unavailable', () => {
     let menus = queryAllByRole('dialog');
     expect(menus).toHaveLength(0);
     expect(queryByText('Contact your administrator for permissions to delete.')).toBeNull();
+  });
+});
+
+describe('Context propagation', () => {
+  it('preserves the ActionButton context from its parent', () => {
+    function ContextActionButton() {
+      let {staticColor} = useSlottedContext(ActionButtonContext) || {};
+      return (
+        <ActionButton data-static-color={staticColor} aria-label="Menu button">
+          Menu button
+        </ActionButton>
+      );
+    }
+
+    let {getByRole} = render(
+      <Provider values={[[ActionButtonContext, {staticColor: 'auto'}]]}>
+        <MenuTrigger>
+          <ContextActionButton />
+          <Menu aria-label="Test">
+            <MenuItem id="item">Item</MenuItem>
+          </Menu>
+        </MenuTrigger>
+      </Provider>
+    );
+
+    expect(getByRole('button', {name: 'Menu button'})).toHaveAttribute('data-static-color', 'auto');
   });
 });
 

--- a/packages/dev/s2-docs/pages/react-aria/TagFieldValue.ts
+++ b/packages/dev/s2-docs/pages/react-aria/TagFieldValue.ts
@@ -2,7 +2,7 @@ import {type TokenFieldSegment, TokenFieldValue} from 'react-aria-components/Tok
 
 export class TagFieldValue extends TokenFieldValue {
   tokenize(text: string): TokenFieldSegment[] {
-    let parts = text.split(/[, \n]/);
+    let parts = text.split(/[,\s\u200B]/);
 
     let segments: TokenFieldSegment[] = parts.map((part, i) => {
       if (i === parts.length - 1 || part.length === 0) {

--- a/packages/dev/s2-docs/pages/react-aria/TokenField.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/TokenField.mdx
@@ -23,7 +23,7 @@ export const description = 'Allows users to enter text with inline tokens such a
     /* PROPS */
     defaultValue={TokenizingFieldValue.tokenize(
       'This example automatically tokenizes #hashtags and @usernames in the text.',
-      /(?<=\s|^)[#@]\S+(?=\s)/g
+      /(?<=[\s\u200B]|^)[#@][^\s\u200B]+(?=[\s\u200B])/g
     )}>
     {segment => <Token>{segment.text}</Token>}
   </TokenField>
@@ -38,7 +38,7 @@ export const description = 'Allows users to enter text with inline tokens such a
     /* PROPS */
     defaultValue={TokenizingFieldValue.tokenize(
       'This example automatically tokenizes #hashtags and @usernames in the text.',
-      /(?<=\s|^)[#@]\S+(?=\s)/g
+      /(?<=[\s\u200B]|^)[#@][^\s\u200B]+(?=[\s\u200B])/g
     )}>
     {segment => <Token>{segment.text}</Token>}
   </TokenField>
@@ -90,7 +90,7 @@ import {TokenizingFieldValue} from './TokenizingFieldValue';
   allowsNewlines
   defaultValue={TokenizingFieldValue.tokenize(
     'This example automatically tokenizes #hashtags and @usernames in the text.',
-    /(?<=\s|^)[#@]\S+(?=\s)/g
+    /(?<=[\s\u200B]|^)[#@][^\s\u200B]+(?=[\s\u200B])/g
   )}
   label="Message">
   {segment => <Token>{segment.text}</Token>}


### PR DESCRIPTION
From testing

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

1. Go to the TokenField RAC docs and make sure that you can insert japanese/other languages's words into the "Tag field" example and hit space to tokenize them
2. For the very first example in TokenField RAC docs, make sure you can type "@test" or "#test" and paste a zero width space after it to create a token
3. Check the "Everything" story in AI PromptField story and make sure all the buttons in the field's toolbar show up with the proper static color styling
<img width="882" height="238" alt="image" src="https://github.com/user-attachments/assets/49a143b6-0c77-4790-b6f3-9f9eb6fef4f0" />
<img width="873" height="234" alt="image" src="https://github.com/user-attachments/assets/c2125b2d-5fff-4990-9329-f5a7482e5453" />
 

## 🧢 Your Project:

RSP
