### PR TITLE
Fix first drag interaction in Table

### DIFF
--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -1957,10 +1957,7 @@ export const Row = /*#__PURE__*/ createBranchComponent(
                     chevron: expandButtonProps,
                     drag: {
                       ...draggableItem?.dragButtonProps,
-                      ref: dragButtonRef,
-                      style: {
-                        pointerEvents: 'none'
-                      }
+                      ref: dragButtonRef
                     }
                   }
                 }

--- a/packages/react-aria-components/test/Table.test.js
+++ b/packages/react-aria-components/test/Table.test.js
@@ -1656,6 +1656,18 @@ describe('Table', () => {
       expect(button).toHaveAttribute('aria-label', 'Drag Games');
     });
 
+    it('should allow pointer interaction with the drag button on first attempt', async () => {
+      let {getAllByRole} = render(<DraggableTable />);
+      let dragButton = getAllByRole('button')[0];
+
+      expect(dragButton).toHaveAttribute('aria-label', 'Drag Games');
+
+      await user.pointer({
+        target: dragButton,
+        keys: '[MouseLeft]'
+      });
+    });
+
     it('should render drop indicators', async () => {
       let onReorder = jest.fn();
       let {getAllByRole} = render(


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes #10423

## ✅ Pull Request Checklist:

- [ X ] Included link to corresponding issue: https://github.com/adobe/react-spectrum/issues/10423
- [ X ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ X ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ X ] I understand every change in this PR and can explain why it's there.
- [ X ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Run the React Aria Components Table tests and verify that the drag button responds to pointer interaction on the first attempt.

## 🧢 Your Project:

<!--- Company/project for pull request -->
