### PR TITLE
Fix nested popover closing PreviewTrigger on hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ starters/docs/yarn.lock
 starters/tailwind/yarn.lock
 .scout/
 .codex/
+# Local AI/debug files
+IMPLEMENTATION-SUMMARY.md
+ISSUE-10443-FIX.md
+PULL-REQUEST-DESCRIPTION.md
+debug-storybook.log

--- a/LINT-FIX-REPORT.md
+++ b/LINT-FIX-REPORT.md
@@ -1,0 +1,155 @@
+# Lint and Format Fix Report
+
+## Issues Found
+
+### 1. Formatting Issues (3 files)
+```
+packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
+packages/react-aria-components/test/PreviewTrigger.test.js
+packages/react-aria/src/tooltip/useSafeArea.ts
+```
+
+### 2. Linting Warning
+```
+⚠ eslint(max-depth): Blocks are nested too deeply (5). Maximum allowed is 4.
+Location: packages/react-aria/src/tooltip/useSafeArea.ts:117:11
+```
+
+## Fixes Applied
+
+### Fix 1: Run Formatter
+```bash
+yarn format
+```
+✅ All 3 files formatted automatically
+
+### Fix 2: Reduce Nesting Depth
+
+**File:** `packages/react-aria/src/tooltip/useSafeArea.ts`
+
+**Problem:** The nested if statements inside the for loop created 5 levels of nesting (max allowed: 4)
+
+**Previous Code (5 levels):**
+```typescript
+if (overlayElement) {                                    // Level 2
+  let allPopovers = document.querySelectorAll('.react-aria-Popover');
+  for (let popover of allPopovers) {                     // Level 3
+    if (popover === overlayElement) {
+      continue;
+    }
+    
+    let popoverRect = popover.getBoundingClientRect();
+    if (popoverRect.width > 0 && popoverRect.height > 0 && rectContains(popoverRect, point)) { // Level 4
+      let popoverId = popover.id;
+      if (popoverId) {                                   // Level 5 ⚠️
+        let trigger = overlayElement.querySelector(`[aria-controls="${popoverId}"]`);
+        if (trigger) {                                   // Level 6 ⚠️⚠️
+          return true;
+        }
+      }
+    }
+  }
+}
+```
+
+**Refactored Code (4 levels max):**
+```typescript
+if (overlayElement) {                                    // Level 2
+  let allPopovers = document.querySelectorAll('.react-aria-Popover');
+  for (let popover of allPopovers) {                     // Level 3
+    // Skip the current overlay itself (already checked above)
+    if (popover === overlayElement) {
+      continue;
+    }
+
+    let popoverRect = popover.getBoundingClientRect();
+    // Check if this popover is visible and contains the pointer
+    let isVisible = popoverRect.width > 0 && popoverRect.height > 0;
+    if (!isVisible || !rectContains(popoverRect, point)) {
+      continue;  // ✅ Early exit reduces nesting
+    }
+
+    // Check if this popover was triggered from within the parent overlay
+    let popoverId = popover.id;
+    if (!popoverId) {
+      continue;  // ✅ Early exit reduces nesting
+    }
+
+    let trigger = overlayElement.querySelector(`[aria-controls="${popoverId}"]`);
+    if (trigger) {                                       // Level 4 ✅
+      return true;
+    }
+  }
+}
+```
+
+## Refactoring Strategy
+
+Used **guard clauses** (early returns/continues) to flatten the nesting:
+
+1. **Combined condition check:**
+   - Extracted `isVisible` variable
+   - Used inverted condition with early `continue`
+
+2. **Early exits:**
+   - Changed `if (popoverId)` to `if (!popoverId) continue`
+   - This eliminates one nesting level
+
+3. **Preserved logic:**
+   - Same behavior as before
+   - All checks still performed in correct order
+   - No functional changes
+
+## Benefits of Refactoring
+
+✅ **Compliance:** Max depth now 4 (was 5-6)  
+✅ **Readability:** Clearer flow with guard clauses  
+✅ **Maintainability:** Less indentation, easier to follow  
+✅ **Performance:** Same (no overhead added)  
+
+## Verification
+
+### Nesting Level Count
+
+**Before:**
+- Function → if → for → if → if → if = **6 levels** ❌
+
+**After:**
+- Function → if → for → if = **4 levels** ✅
+
+### Logic Verification
+
+Both versions execute the same checks:
+1. ✅ Skip if popover is the current overlay
+2. ✅ Skip if popover is not visible or doesn't contain point
+3. ✅ Skip if popover has no ID
+4. ✅ Return true if trigger with aria-controls is found
+
+### Commands to Verify Fix
+
+```bash
+# Format check
+yarn format:check
+
+# Lint check
+yarn lint
+
+# Or specifically:
+oxlint packages/react-aria/src/tooltip/useSafeArea.ts
+```
+
+## Summary
+
+**Files Modified:**
+1. `packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx` - Auto-formatted
+2. `packages/react-aria-components/test/PreviewTrigger.test.js` - Auto-formatted
+3. `packages/react-aria/src/tooltip/useSafeArea.ts` - Refactored + auto-formatted
+
+**Issues Resolved:**
+- ✅ Formatting issues in 3 files
+- ✅ Max-depth linting warning (reduced from 5/6 to 4)
+
+**Behavior:**
+- ✅ No functional changes
+- ✅ Same test coverage
+- ✅ Same performance characteristics

--- a/packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
+++ b/packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
@@ -20,7 +20,7 @@
  */
 
 import {Button} from '../src/Button';
-import {ComboBox, ComboBoxItem} from '../src/ComboBox';
+import {ComboBox} from '../src/ComboBox';
 import {Input} from '../src/Input';
 import {Label} from '../src/Label';
 import {Link} from '../src/Link';
@@ -116,11 +116,11 @@ export function PreviewWithComboBox() {
             </div>
             <Popover>
               <ListBox>
-                <ComboBoxItem>Getting Started</ComboBoxItem>
-                <ComboBoxItem>Components</ComboBoxItem>
-                <ComboBoxItem>Hooks</ComboBoxItem>
-                <ComboBoxItem>Accessibility</ComboBoxItem>
-                <ComboBoxItem>Internationalization</ComboBoxItem>
+                <ListBoxItem>Getting Started</ListBoxItem>
+                <ListBoxItem>Components</ListBoxItem>
+                <ListBoxItem>Hooks</ListBoxItem>
+                <ListBoxItem>Accessibility</ListBoxItem>
+                <ListBoxItem>Internationalization</ListBoxItem>
               </ListBox>
             </Popover>
           </ComboBox>

--- a/packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
+++ b/packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Example demonstrating the fix for GitHub issue #10443:
+ * "Nested Popover closes PreviewTrigger when hovered"
+ * 
+ * This example shows a PreviewTrigger with interactive content (Select/ComboBox)
+ * inside the preview popover. The preview should stay open while interacting with
+ * the nested overlay.
+ */
+
+import {Button} from '../src/Button';
+import {ComboBox, ComboBoxItem} from '../src/ComboBox';
+import {Input} from '../src/Input';
+import {Label} from '../src/Label';
+import {Link} from '../src/Link';
+import {ListBox, ListBoxItem} from '../src/ListBox';
+import {Popover} from '../src/Popover';
+import {PreviewTrigger} from '../src/PreviewTrigger';
+import React from 'react';
+import {Select, SelectValue} from '../src/Select';
+
+export function PreviewWithSelect() {
+  return (
+    <div style={{padding: '50px'}}>
+      <p>Hover over the link below to see a preview with a Select inside:</p>
+      
+      <PreviewTrigger delay={200} closeDelay={100}>
+        <Link href="https://example.com" target="_blank">
+          Example Product
+        </Link>
+        <Popover
+          style={{
+            background: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            padding: '16px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            minWidth: '300px'
+          }}>
+          <h3 style={{margin: '0 0 12px 0'}}>Product Details</h3>
+          <p style={{margin: '0 0 12px 0', color: '#666'}}>
+            Select an option to see more information.
+          </p>
+          
+          {/* This Select opens a nested Popover - the preview should stay open */}
+          <Select placeholder="Choose a variant" style={{marginBottom: '12px'}}>
+            <Label>Product Variant</Label>
+            <Button>
+              <SelectValue />
+              <span aria-hidden="true">▼</span>
+            </Button>
+            <Popover>
+              <ListBox>
+                <ListBoxItem id="small">Small</ListBoxItem>
+                <ListBoxItem id="medium">Medium</ListBoxItem>
+                <ListBoxItem id="large">Large</ListBoxItem>
+                <ListBoxItem id="xl">Extra Large</ListBoxItem>
+              </ListBox>
+            </Popover>
+          </Select>
+
+          <Button
+            style={{
+              background: '#0074e0',
+              color: 'white',
+              border: 'none',
+              padding: '8px 16px',
+              borderRadius: '4px',
+              cursor: 'pointer'
+            }}>
+            Add to Cart
+          </Button>
+        </Popover>
+      </PreviewTrigger>
+    </div>
+  );
+}
+
+export function PreviewWithComboBox() {
+  return (
+    <div style={{padding: '50px'}}>
+      <p>Hover over the link below to see a preview with a ComboBox inside:</p>
+      
+      <PreviewTrigger delay={200} closeDelay={100}>
+        <Link href="https://example.com" target="_blank">
+          Search Documentation
+        </Link>
+        <Popover
+          style={{
+            background: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            padding: '16px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            minWidth: '300px'
+          }}>
+          <h3 style={{margin: '0 0 12px 0'}}>Quick Search</h3>
+          
+          {/* This ComboBox opens a nested Popover - the preview should stay open */}
+          <ComboBox>
+            <Label>Search topics</Label>
+            <div style={{display: 'flex', gap: '8px'}}>
+              <Input placeholder="Type to search..." />
+              <Button>▼</Button>
+            </div>
+            <Popover>
+              <ListBox>
+                <ComboBoxItem>Getting Started</ComboBoxItem>
+                <ComboBoxItem>Components</ComboBoxItem>
+                <ComboBoxItem>Hooks</ComboBoxItem>
+                <ComboBoxItem>Accessibility</ComboBoxItem>
+                <ComboBoxItem>Internationalization</ComboBoxItem>
+              </ListBox>
+            </Popover>
+          </ComboBox>
+        </Popover>
+      </PreviewTrigger>
+    </div>
+  );
+}
+
+export function NestedPreviewTriggers() {
+  return (
+    <div style={{padding: '50px'}}>
+      <p>Edge case: PreviewTrigger inside another PreviewTrigger:</p>
+      
+      <PreviewTrigger delay={200} closeDelay={100}>
+        <Link href="https://example.com" target="_blank">
+          Parent Link
+        </Link>
+        <Popover
+          style={{
+            background: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            padding: '16px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            minWidth: '250px'
+          }}>
+          <h3 style={{margin: '0 0 12px 0'}}>Parent Preview</h3>
+          <p style={{margin: '0 0 12px 0'}}>
+            This preview contains another link with its own preview:
+          </p>
+          
+          <PreviewTrigger delay={200} closeDelay={100}>
+            <Link href="https://example.com/nested" target="_blank">
+              Nested Link
+            </Link>
+            <Popover
+              style={{
+                background: 'white',
+                border: '1px solid #0074e0',
+                borderRadius: '4px',
+                padding: '12px',
+                boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                minWidth: '200px'
+              }}>
+              <p style={{margin: 0}}>
+                This is a nested preview! Both should stay open while hovering.
+              </p>
+            </Popover>
+          </PreviewTrigger>
+        </Popover>
+      </PreviewTrigger>
+    </div>
+  );
+}

--- a/packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
+++ b/packages/react-aria-components/stories/PreviewTrigger-NestedOverlay.example.tsx
@@ -13,7 +13,7 @@
 /**
  * Example demonstrating the fix for GitHub issue #10443:
  * "Nested Popover closes PreviewTrigger when hovered"
- * 
+ *
  * This example shows a PreviewTrigger with interactive content (Select/ComboBox)
  * inside the preview popover. The preview should stay open while interacting with
  * the nested overlay.
@@ -34,7 +34,7 @@ export function PreviewWithSelect() {
   return (
     <div style={{padding: '50px'}}>
       <p>Hover over the link below to see a preview with a Select inside:</p>
-      
+
       <PreviewTrigger delay={200} closeDelay={100}>
         <Link href="https://example.com" target="_blank">
           Example Product
@@ -52,7 +52,7 @@ export function PreviewWithSelect() {
           <p style={{margin: '0 0 12px 0', color: '#666'}}>
             Select an option to see more information.
           </p>
-          
+
           {/* This Select opens a nested Popover - the preview should stay open */}
           <Select placeholder="Choose a variant" style={{marginBottom: '12px'}}>
             <Label>Product Variant</Label>
@@ -91,7 +91,7 @@ export function PreviewWithComboBox() {
   return (
     <div style={{padding: '50px'}}>
       <p>Hover over the link below to see a preview with a ComboBox inside:</p>
-      
+
       <PreviewTrigger delay={200} closeDelay={100}>
         <Link href="https://example.com" target="_blank">
           Search Documentation
@@ -106,7 +106,7 @@ export function PreviewWithComboBox() {
             minWidth: '300px'
           }}>
           <h3 style={{margin: '0 0 12px 0'}}>Quick Search</h3>
-          
+
           {/* This ComboBox opens a nested Popover - the preview should stay open */}
           <ComboBox>
             <Label>Search topics</Label>
@@ -134,7 +134,7 @@ export function NestedPreviewTriggers() {
   return (
     <div style={{padding: '50px'}}>
       <p>Edge case: PreviewTrigger inside another PreviewTrigger:</p>
-      
+
       <PreviewTrigger delay={200} closeDelay={100}>
         <Link href="https://example.com" target="_blank">
           Parent Link
@@ -152,7 +152,7 @@ export function NestedPreviewTriggers() {
           <p style={{margin: '0 0 12px 0'}}>
             This preview contains another link with its own preview:
           </p>
-          
+
           <PreviewTrigger delay={200} closeDelay={100}>
             <Link href="https://example.com/nested" target="_blank">
               Nested Link

--- a/packages/react-aria-components/test/PreviewTrigger.test.js
+++ b/packages/react-aria-components/test/PreviewTrigger.test.js
@@ -264,6 +264,99 @@ describe('PreviewTrigger', () => {
     expect(getByTestId('preview')).toBeInTheDocument();
   });
 
+  describe('nested overlays', () => {
+    installPointerEvent();
+
+    let mockRect = (el, rect) => {
+      el.getBoundingClientRect = () => ({
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+        width: rect.right - rect.left,
+        height: rect.bottom - rect.top,
+        x: rect.left,
+        y: rect.top,
+        toJSON() {}
+      });
+    };
+
+    it('stays open when hovering over a nested popover', async () => {
+      // Need to create a proper nested popover with a trigger that sets aria-controls
+      function NestedPopoverTrigger() {
+        let [isOpen, setIsOpen] = React.useState(false);
+        let triggerId = 'nested-trigger';
+        let popoverId = 'nested-popover-id';
+        
+        return (
+          <>
+            <Button 
+              id={triggerId}
+              aria-controls={isOpen ? popoverId : undefined}
+              onPress={() => setIsOpen(true)}>
+              Open Nested
+            </Button>
+            {isOpen && (
+              <Popover 
+                data-testid="nested-popover"
+                id={popoverId}
+                isOpen
+                style={{position: 'absolute'}}>
+                <p>Nested content</p>
+              </Popover>
+            )}
+          </>
+        );
+      }
+      
+      let {getByRole, getByTestId, queryByTestId} = render(
+        <PreviewTrigger delay={0} closeDelay={0}>
+          <Link href="https://example.com">Example</Link>
+          <Popover data-testid="preview">
+            <p>Preview content</p>
+            <NestedPopoverTrigger />
+          </Popover>
+        </PreviewTrigger>
+      );
+      let link = getByRole('link');
+
+      // Open the preview
+      fireEvent.mouseMove(document.body);
+      await user.hover(link);
+      act(() => jest.runAllTimers());
+
+      let preview = getByTestId('preview');
+      expect(preview).toBeInTheDocument();
+
+      // Click to open the nested popover
+      let nestedTrigger = getByRole('button', {name: 'Open Nested'});
+      await user.click(nestedTrigger);
+      act(() => jest.runAllTimers());
+
+      let nestedPopover = getByTestId('nested-popover');
+      expect(nestedPopover).toBeInTheDocument();
+
+      // Mock positions: link at top, preview below it, nested popover to the side
+      mockRect(link, {left: 0, right: 100, top: 0, bottom: 20});
+      mockRect(preview, {left: 0, right: 100, top: 40, bottom: 140});
+      mockRect(nestedPopover, {left: 120, right: 220, top: 40, bottom: 140});
+
+      // Move pointer into the nested popover - the preview should stay open
+      fireEvent.pointerMove(document.body, {clientX: 150, clientY: 80, pointerType: 'mouse'});
+      act(() => jest.runAllTimers());
+      expect(queryByTestId('preview')).toBeInTheDocument();
+
+      // Move pointer well outside - both should close
+      fireEvent.pointerMove(document.body, {clientX: 500, clientY: 500, pointerType: 'mouse'});
+      act(() => jest.runAllTimers());
+      expect(queryByTestId('preview')).not.toBeInTheDocument();
+    });
+      fireEvent.pointerMove(document.body, {clientX: 500, clientY: 500, pointerType: 'mouse'});
+      act(() => jest.runAllTimers());
+      expect(queryByTestId('preview')).not.toBeInTheDocument();
+    });
+  });
+
   describe('long press (touch)', () => {
     installPointerEvent();
 

--- a/packages/react-aria-components/test/PreviewTrigger.test.js
+++ b/packages/react-aria-components/test/PreviewTrigger.test.js
@@ -351,10 +351,6 @@ describe('PreviewTrigger', () => {
       act(() => jest.runAllTimers());
       expect(queryByTestId('preview')).not.toBeInTheDocument();
     });
-      fireEvent.pointerMove(document.body, {clientX: 500, clientY: 500, pointerType: 'mouse'});
-      act(() => jest.runAllTimers());
-      expect(queryByTestId('preview')).not.toBeInTheDocument();
-    });
   });
 
   describe('long press (touch)', () => {

--- a/packages/react-aria-components/test/PreviewTrigger.test.js
+++ b/packages/react-aria-components/test/PreviewTrigger.test.js
@@ -287,17 +287,17 @@ describe('PreviewTrigger', () => {
         let [isOpen, setIsOpen] = React.useState(false);
         let triggerId = 'nested-trigger';
         let popoverId = 'nested-popover-id';
-        
+
         return (
           <>
-            <Button 
+            <Button
               id={triggerId}
               aria-controls={isOpen ? popoverId : undefined}
               onPress={() => setIsOpen(true)}>
               Open Nested
             </Button>
             {isOpen && (
-              <Popover 
+              <Popover
                 data-testid="nested-popover"
                 id={popoverId}
                 isOpen
@@ -308,7 +308,7 @@ describe('PreviewTrigger', () => {
           </>
         );
       }
-      
+
       let {getByRole, getByTestId, queryByTestId} = render(
         <PreviewTrigger delay={0} closeDelay={0}>
           <Link href="https://example.com">Example</Link>

--- a/packages/react-aria/src/tooltip/useSafeArea.ts
+++ b/packages/react-aria/src/tooltip/useSafeArea.ts
@@ -82,7 +82,12 @@ export function useSafeArea(options: SafeAreaOptions): void {
   }, [isDisabled, isOpen, triggerRef, overlayRef]);
 }
 
-function isPointInSafeArea(point: Point, triggerRect: DOMRect, overlayRect?: DOMRect, overlayElement?: Element | null): boolean {
+function isPointInSafeArea(
+  point: Point,
+  triggerRect: DOMRect,
+  overlayRect?: DOMRect,
+  overlayElement?: Element | null
+): boolean {
   if (rectContains(triggerRect, point)) {
     return true;
   }
@@ -92,7 +97,7 @@ function isPointInSafeArea(point: Point, triggerRect: DOMRect, overlayRect?: DOM
   if (rectContains(overlayRect, point)) {
     return true;
   }
-  
+
   // Check if the pointer is within any descendant overlays (e.g. a Select opened inside a
   // PreviewTrigger). Descendant overlays are portaled outside the parent overlay's DOM tree, but
   // we want to keep the parent open while interacting with them.
@@ -105,23 +110,28 @@ function isPointInSafeArea(point: Point, triggerRect: DOMRect, overlayRect?: DOM
       if (popover === overlayElement) {
         continue;
       }
-      
+
       let popoverRect = popover.getBoundingClientRect();
       // Check if this popover is visible and contains the pointer
-      if (popoverRect.width > 0 && popoverRect.height > 0 && rectContains(popoverRect, point)) {
-        // Check if this popover was triggered from within the parent overlay by checking if any
-        // element within the parent overlay has aria-controls pointing to this popover's ID.
-        let popoverId = popover.id;
-        if (popoverId) {
-          let trigger = overlayElement.querySelector(`[aria-controls="${popoverId}"]`);
-          if (trigger) {
-            return true;
-          }
-        }
+      let isVisible = popoverRect.width > 0 && popoverRect.height > 0;
+      if (!isVisible || !rectContains(popoverRect, point)) {
+        continue;
+      }
+
+      // Check if this popover was triggered from within the parent overlay by checking if any
+      // element within the parent overlay has aria-controls pointing to this popover's ID.
+      let popoverId = popover.id;
+      if (!popoverId) {
+        continue;
+      }
+
+      let trigger = overlayElement.querySelector(`[aria-controls="${popoverId}"]`);
+      if (trigger) {
+        return true;
       }
     }
   }
-  
+
   // Otherwise, check whether the point is within the convex hull connecting the two rects.
   let hull = convexHull([...rectCorners(triggerRect), ...rectCorners(overlayRect)]);
   return hull.length >= 3 && isPointInPolygon(point, hull);

--- a/packages/react-aria/src/tooltip/useSafeArea.ts
+++ b/packages/react-aria/src/tooltip/useSafeArea.ts
@@ -65,7 +65,7 @@ export function useSafeArea(options: SafeAreaOptions): void {
       let point = {x: e.clientX, y: e.clientY};
       let triggerRect = trigger!.getBoundingClientRect();
       let overlayRect = overlayRef.current?.getBoundingClientRect();
-      onSafeAreaChange(isPointInSafeArea(point, triggerRect, overlayRect));
+      onSafeAreaChange(isPointInSafeArea(point, triggerRect, overlayRect, overlayRef.current));
     };
 
     // If the pointer leaves the document entirely, it is no longer in the safe area.
@@ -82,7 +82,7 @@ export function useSafeArea(options: SafeAreaOptions): void {
   }, [isDisabled, isOpen, triggerRef, overlayRef]);
 }
 
-function isPointInSafeArea(point: Point, triggerRect: DOMRect, overlayRect?: DOMRect): boolean {
+function isPointInSafeArea(point: Point, triggerRect: DOMRect, overlayRect?: DOMRect, overlayElement?: Element | null): boolean {
   if (rectContains(triggerRect, point)) {
     return true;
   }
@@ -92,6 +92,36 @@ function isPointInSafeArea(point: Point, triggerRect: DOMRect, overlayRect?: DOM
   if (rectContains(overlayRect, point)) {
     return true;
   }
+  
+  // Check if the pointer is within any descendant overlays (e.g. a Select opened inside a
+  // PreviewTrigger). Descendant overlays are portaled outside the parent overlay's DOM tree, but
+  // we want to keep the parent open while interacting with them.
+  // To determine if a popover is a descendant, we check if the pointer is in it AND some element
+  // within the parent overlay has focus or aria-controls pointing to it.
+  if (overlayElement) {
+    let allPopovers = document.querySelectorAll('.react-aria-Popover');
+    for (let popover of allPopovers) {
+      // Skip the current overlay itself (already checked above)
+      if (popover === overlayElement) {
+        continue;
+      }
+      
+      let popoverRect = popover.getBoundingClientRect();
+      // Check if this popover is visible and contains the pointer
+      if (popoverRect.width > 0 && popoverRect.height > 0 && rectContains(popoverRect, point)) {
+        // Check if this popover was triggered from within the parent overlay by checking if any
+        // element within the parent overlay has aria-controls pointing to this popover's ID.
+        let popoverId = popover.id;
+        if (popoverId) {
+          let trigger = overlayElement.querySelector(`[aria-controls="${popoverId}"]`);
+          if (trigger) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  
   // Otherwise, check whether the point is within the convex hull connecting the two rects.
   let hull = convexHull([...rectCorners(triggerRect), ...rectCorners(overlayRect)]);
   return hull.length >= 3 && isPointInPolygon(point, hull);


### PR DESCRIPTION
Closes #10443

## Summary

Fixes an issue where a nested Popover opened from inside a `PreviewTrigger` popover caused the parent `PreviewTrigger` popover to close when moving the pointer into the nested overlay.

The issue happened because the nested overlay is rendered outside of the `PreviewTrigger` popover boundary, causing the hover interaction to be interpreted as leaving the preview area.

This change adds regression coverage for nested overlays inside `PreviewTrigger` and ensures the parent preview remains open while interacting with child overlays.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10443).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [ARIA Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md.

## 📝 Test Instructions:

### Automated tests

Run:

```bash
yarn jest packages/react-aria-components/test/PreviewTrigger.test.js

## 🧢 Your Project:
N/A

