### PR TITLE
docs: fix agent skill links and update discovery index to RFC v0.2.0

### DIFF
--- a/.circleci/build-skills.sh
+++ b/.circleci/build-skills.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build agent skills for the current working tree and copy the resulting
-# .well-known/skills directories into $1 for later diffing.
+# .well-known/agent-skills directories into $1 for later diffing.
 #
 # Runs the two node scripts directly (rather than via yarn) so the command
 # works from a `git worktree` / `git archive` checkout that doesn't have
@@ -23,7 +23,7 @@ node packages/dev/s2-docs/scripts/generateAgentSkills.mjs
 rm -rf "$DEST"
 mkdir -p "$DEST"
 for lib in s2 react-aria; do
-  src="packages/dev/s2-docs/dist/$lib/.well-known/skills"
+  src="packages/dev/s2-docs/dist/$lib/.well-known/agent-skills"
   if [ -d "$src" ]; then
     mkdir -p "$DEST/$lib"
     cp -R "$src" "$DEST/$lib/"

--- a/.circleci/skills-diff.js
+++ b/.circleci/skills-diff.js
@@ -152,7 +152,7 @@ function colorCounts(counts) {
   return parts.join(' ');
 }
 
-// Map "s2/skills/<rest>" / "react-aria/skills/<rest>" (the layout produced
+// Map "s2/agent-skills/<rest>" / "react-aria/agent-skills/<rest>" (the layout produced
 // by build-skills.sh) to a cloudfront URL on the branch build.
 function fileUrl(relPath, sha) {
   if (!sha) {
@@ -161,7 +161,7 @@ function fileUrl(relPath, sha) {
   const parts = relPath.split(path.sep);
   const lib = parts[0];
   const rest = parts.slice(1).join('/');
-  // `rest` starts with "skills/...", the deploy lands it under /.well-known/
+  // `rest` starts with "agent-skills/...", the deploy lands it under /.well-known/
   let base;
   if (lib === 's2') {
     base = S2_BASE;

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -739,12 +739,89 @@ This skill does not edit code. Recommend:
 }
 
 /**
+ * Build a map from a doc's flat source-relative path (e.g. "forms.md",
+ * "internationalized/date/index.md") to the relative path it will be copied to
+ * inside a skill's `references/` directory (e.g. "guides/forms.md",
+ * "internationalized/date/index.md"). Used to rewrite cross-file links that were
+ * written for the docs site's flat URL structure so they resolve in the
+ * categorized `references/` layout the skill ships.
+ */
+function buildDestinationMap(categories, customGuideEntries) {
+  const destinationMap = new Map();
+
+  const addEntries = (entries, targetSubdir, stripPrefix = null) => {
+    for (const entry of entries) {
+      let targetRelPath = entry.path;
+      if (stripPrefix && targetRelPath.startsWith(stripPrefix)) {
+        targetRelPath = targetRelPath.slice(stripPrefix.length);
+      }
+      destinationMap.set(entry.path, path.posix.join(targetSubdir, targetRelPath));
+    }
+  };
+
+  addEntries(customGuideEntries, 'guides');
+  addEntries(categories.guides, 'guides');
+  addEntries(categories.components, 'components');
+  addEntries(categories.interactions, 'interactions');
+  addEntries(categories.utilities, 'utilities');
+  addEntries(categories.testing, 'testing');
+  addEntries(categories.internationalized, 'internationalized', 'internationalized/');
+  destinationMap.set('llms.txt', 'llms.txt');
+
+  return destinationMap;
+}
+
+const LINK_PATTERN = /(\]\()([^)\s]+)(\))/g;
+// Any URI with a scheme (http:, mailto:, cursor:, vscode:, s2:, etc.) is treated as opaque —
+// only extension-less/bare relative paths refer to files shipped inside the skill.
+const URI_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Rewrite relative Markdown links in `content` (a file whose flat source-relative
+ * path is `sourceRelPath`, being copied to `destRelPath` within `references/`) so
+ * that links pointing at other shipped docs resolve from the new, categorized
+ * location instead of the flat location they were authored for.
+ */
+function rewriteRelativeLinks(content, sourceRelPath, destRelPath, destinationMap) {
+  return content.replace(LINK_PATTERN, (match, prefix, href, suffix) => {
+    if (!href || href.startsWith('#') || URI_SCHEME_PATTERN.test(href)) {
+      return match;
+    }
+
+    const urlMatch = href.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/);
+    if (!urlMatch) {
+      return match;
+    }
+    const [, pathPart, queryPart = '', hashPart = ''] = urlMatch;
+    if (!pathPart) {
+      return match;
+    }
+
+    const resolvedSourcePath = path.posix.normalize(
+      path.posix.join(path.posix.dirname(sourceRelPath), pathPart)
+    );
+    const target = destinationMap.get(resolvedSourcePath);
+    if (!target) {
+      return match;
+    }
+
+    let newHref = path.posix.relative(path.posix.dirname(destRelPath), target);
+    if (!newHref.startsWith('.')) {
+      newHref = `./${newHref}`;
+    }
+
+    return `${prefix}${newHref}${queryPart}${hashPart}${suffix}`;
+  });
+}
+
+/**
  * Copy documentation files to the skill's references directory.
  */
 function copyDocsDocumentation(skillConfig, categories, skillDir, options = {}) {
   const refsDir = path.join(skillDir, 'references', options.referenceSubdir ?? '');
   const sourceDir = path.join(MARKDOWN_DOCS_DIST, skillConfig.sourceDir);
   const customGuideEntries = getCustomGuideEntries(skillConfig.name);
+  const destinationMap = buildDestinationMap(categories, customGuideEntries);
 
   // Create subdirectories only if they have content
   const subdirs = [
@@ -776,7 +853,11 @@ function copyDocsDocumentation(skillConfig, categories, skillDir, options = {}) 
 
     const targetPath = path.join(refsDir, targetSubdir, targetRelPath);
     fs.mkdirSync(path.dirname(targetPath), {recursive: true});
-    fs.copyFileSync(sourcePath, targetPath);
+
+    const destRelPath = path.posix.join(targetSubdir, targetRelPath);
+    const content = fs.readFileSync(sourcePath, 'utf8');
+    const rewritten = rewriteRelativeLinks(content, entry.path, destRelPath, destinationMap);
+    fs.writeFileSync(targetPath, rewritten);
   };
 
   // Copy guides
@@ -857,6 +938,8 @@ function copyAdditionalReferenceLibraries(skillConfig, skillDir) {
 }
 
 function copyFocusedDocs(sourceDir, skillDir, docs) {
+  const destinationMap = new Map(docs);
+
   for (const [sourceName, outputName] of docs) {
     const sourcePath = path.join(MARKDOWN_DOCS_DIST, sourceDir, sourceName);
     if (!fs.existsSync(sourcePath)) {
@@ -866,7 +949,10 @@ function copyFocusedDocs(sourceDir, skillDir, docs) {
 
     const outputPath = path.join(skillDir, 'references', outputName);
     fs.mkdirSync(path.dirname(outputPath), {recursive: true});
-    fs.copyFileSync(sourcePath, outputPath);
+
+    const content = fs.readFileSync(sourcePath, 'utf8');
+    const rewritten = rewriteRelativeLinks(content, sourceName, outputName, destinationMap);
+    fs.writeFileSync(outputPath, rewritten);
   }
 }
 
@@ -952,33 +1038,79 @@ function collectSkillFiles(skillDir) {
 }
 
 /**
- * Validate that all references/ links in SKILL.md resolve to actual files.
- * Throws if any broken links are found.
+ * Validate that all relative links in every Markdown file that ships with the skill
+ * (SKILL.md and everything under references/) resolve to actual files, relative to
+ * the file that contains the link. Throws if any broken links are found.
  */
 function validateSkillLinks(skillDir) {
+  const markdownFiles = [];
+  const walk = currentDir => {
+    for (const dirent of fs.readdirSync(currentDir, {withFileTypes: true})) {
+      const entryPath = path.join(currentDir, dirent.name);
+      if (dirent.isDirectory()) {
+        walk(entryPath);
+      } else if (dirent.isFile() && dirent.name.endsWith('.md')) {
+        markdownFiles.push(entryPath);
+      }
+    }
+  };
+
   const skillMdPath = path.join(skillDir, 'SKILL.md');
-  if (!fs.existsSync(skillMdPath)) {
-    return;
+  if (fs.existsSync(skillMdPath)) {
+    markdownFiles.push(skillMdPath);
+  }
+  const referencesDir = path.join(skillDir, 'references');
+  if (fs.existsSync(referencesDir)) {
+    walk(referencesDir);
   }
 
-  const content = fs.readFileSync(skillMdPath, 'utf8');
-  const linkPattern = /\[([^\]]*)\]\((references\/[^)]+)\)/g;
+  const linkPattern = /\[([^\]]*)\]\(([^)\s]+)\)/g;
   const broken = [];
 
-  let match;
-  while ((match = linkPattern.exec(content)) !== null) {
-    const linkText = match[1];
-    const linkPath = match[2];
-    const resolvedPath = path.join(skillDir, linkPath);
-    if (!fs.existsSync(resolvedPath)) {
-      broken.push(`"${linkText}" -> ${linkPath}`);
+  for (const filePath of markdownFiles) {
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    let match;
+    while ((match = linkPattern.exec(content)) !== null) {
+      const linkText = match[1];
+      let linkPath = match[2];
+
+      if (!linkPath || linkPath.startsWith('#') || URI_SCHEME_PATTERN.test(linkPath)) {
+        continue;
+      }
+
+      // Strip query params and hash fragments before resolving the file on disk
+      linkPath = linkPath.replace(/[?#].*$/, '');
+      if (!linkPath) {
+        continue;
+      }
+
+      // The legacy v3 docs site isn't part of this build, so its links can't be verified here.
+      if (/(^|\/)v3\//.test(linkPath)) {
+        continue;
+      }
+
+      const resolvedPath = path.resolve(path.dirname(filePath), linkPath);
+      if (fs.existsSync(resolvedPath)) {
+        continue;
+      }
+
+      // Some skills only bundle a curated subset of the full docs (e.g. blog posts, the site's
+      // own landing page, or a "focused" reference set). A link to a page that exists somewhere
+      // in the full generated docs corpus, just not in this skill's bundle, is a known, accepted
+      // gap rather than a broken/typo'd link.
+      const bareLinkPath = linkPath.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '');
+      const existsInFullCorpus = ['s2', 'react-aria'].some(lib =>
+        fs.existsSync(path.join(MARKDOWN_DOCS_DIST, lib, bareLinkPath))
+      );
+      if (!existsInFullCorpus) {
+        broken.push(`${path.relative(REPO_ROOT, filePath)}: "${linkText}" -> ${match[2]}`);
+      }
     }
   }
 
   if (broken.length > 0) {
-    throw new Error(
-      `Broken references in ${path.relative(REPO_ROOT, skillMdPath)}:\n  ${broken.join('\n  ')}`
-    );
+    throw new Error(`Broken links found:\n  ${broken.join('\n  ')}`);
   }
 }
 

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -4,18 +4,23 @@
  * Generates Agent Skills for React Spectrum (S2), migration, and React Aria.
  *
  * This script creates skills in the Agent Skills format (https://agentskills.io/specification)
+ * and publishes a discovery index per the Agent Skills Discovery via Well-Known URIs RFC
+ * (https://github.com/cloudflare/agent-skills-discovery-rfc), currently at v0.2.0.
  *
  * Usage:
  * node packages/dev/s2-docs/scripts/generateAgentSkills.mjs.
  *
  * The script will:
  * 1. Run the markdown docs generation if dist doesn't exist
- * 2. Create .well-known/skills directories inside the docs dist output
+ * 2. Create .well-known/agent-skills directories inside the docs dist output
  * 3. Copy relevant documentation to references/ subdirectories
- * 4. Generate .well-known/skills/index.json for discovery.
+ * 4. Package each skill with supporting files as a `.tar.gz` archive
+ * 5. Generate .well-known/agent-skills/index.json for discovery, with a `type`, `url`, and
+ *    SHA-256 `digest` per skill.
  */
 
-import {execSync} from 'child_process';
+import crypto from 'crypto';
+import {execFileSync, execSync} from 'child_process';
 import {fileURLToPath} from 'url';
 import fs from 'fs';
 import path from 'path';
@@ -30,7 +35,8 @@ const MARKDOWN_DOCS_SCRIPT = path.join(__dirname, 'generateMarkdownDocs.mjs');
 const MIGRATION_REFS_DIR = path.join(REPO_ROOT, 'packages/dev/s2-docs/migration-references');
 const AUDIT_SKILL_SOURCE_DIR = path.join(REPO_ROOT, 'packages/dev/s2-docs/skills/spectrum-audit');
 const WELL_KNOWN_DIR = '.well-known';
-const WELL_KNOWN_SKILLS_DIR = 'skills';
+const WELL_KNOWN_SKILLS_DIR = 'agent-skills';
+const DISCOVERY_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 
 // Skill definitions
 const SKILLS = {
@@ -1116,9 +1122,50 @@ function validateSkillLinks(skillDir) {
 
 function writeIndexJson(wellKnownRoot, skills) {
   const indexPath = path.join(wellKnownRoot, 'index.json');
-  const payload = {skills};
+  const payload = {$schema: DISCOVERY_SCHEMA, skills};
   fs.writeFileSync(indexPath, JSON.stringify(payload, null, 2) + '\n');
   console.log(`Generated ${path.relative(REPO_ROOT, indexPath)}`);
+}
+
+function sha256Digest(filePath) {
+  const hash = crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  return `sha256:${hash}`;
+}
+
+/**
+ * Package a skill directory as a `.tar.gz` archive at the well-known root, with `SKILL.md`
+ * and any supporting files (references/, etc.) at the archive root — per the Archive
+ * Distribution section of the Agent Skills Discovery RFC.
+ */
+function createSkillArchive(skillDir, skillName, wellKnownRoot) {
+  const archivePath = path.join(wellKnownRoot, `${skillName}.tar.gz`);
+  execFileSync('tar', ['--exclude=.DS_Store', '-czf', archivePath, '-C', skillDir, '.']);
+  return archivePath;
+}
+
+/**
+ * Build the discovery index entry's distribution fields (`type`, `url`, `digest`) for a
+ * generated skill. Skills consisting only of `SKILL.md` are published as `type: "skill-md"`;
+ * skills with supporting files (references/, etc.) are packaged as a `type: "archive"` tarball.
+ */
+function buildSkillArtifact(skillConfig, skillDir, wellKnownRoot, files) {
+  const wellKnownBase = `/${WELL_KNOWN_DIR}/${WELL_KNOWN_SKILLS_DIR}`;
+
+  if (files.length === 1 && files[0] === 'SKILL.md') {
+    return {
+      type: 'skill-md',
+      url: `${wellKnownBase}/${skillConfig.name}/SKILL.md`,
+      digest: sha256Digest(path.join(skillDir, 'SKILL.md'))
+    };
+  }
+
+  const archivePath = createSkillArchive(skillDir, skillConfig.name, wellKnownRoot);
+  console.log(`Generated ${path.relative(REPO_ROOT, archivePath)}`);
+  return {
+    type: 'archive',
+    url: `${wellKnownBase}/${skillConfig.name}.tar.gz`,
+    digest: sha256Digest(archivePath)
+  };
 }
 
 /**
@@ -1209,14 +1256,14 @@ function main() {
       const skillDir = generateSkill(config, wellKnownRoot);
       validateSkillLinks(skillDir);
       const files = collectSkillFiles(skillDir);
+      const artifact = buildSkillArtifact(config, skillDir, wellKnownRoot, files);
       const entry = {
         name: config.name,
+        type: artifact.type,
         description: config.description,
-        files
+        url: artifact.url,
+        digest: artifact.digest
       };
-      if (config.kind) {
-        entry.kind = config.kind;
-      }
       indexEntries.push(entry);
     }
 

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -16,7 +16,7 @@
  * 3. Copy relevant documentation to references/ subdirectories
  * 4. Package each skill with supporting files as a `.tar.gz` archive
  * 5. Generate .well-known/agent-skills/index.json for discovery, with a `type`, `url`, and
- *    SHA-256 `digest` per skill.
+ * SHA-256 `digest` per skill.
  */
 
 import crypto from 'crypto';

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -1149,12 +1149,10 @@ function createSkillArchive(skillDir, skillName, wellKnownRoot) {
  * skills with supporting files (references/, etc.) are packaged as a `type: "archive"` tarball.
  */
 function buildSkillArtifact(skillConfig, skillDir, wellKnownRoot, files) {
-  const wellKnownBase = `/${WELL_KNOWN_DIR}/${WELL_KNOWN_SKILLS_DIR}`;
-
   if (files.length === 1 && files[0] === 'SKILL.md') {
     return {
       type: 'skill-md',
-      url: `${wellKnownBase}/${skillConfig.name}/SKILL.md`,
+      url: `${skillConfig.name}/SKILL.md`,
       digest: sha256Digest(path.join(skillDir, 'SKILL.md'))
     };
   }
@@ -1163,7 +1161,7 @@ function buildSkillArtifact(skillConfig, skillDir, wellKnownRoot, files) {
   console.log(`Generated ${path.relative(REPO_ROOT, archivePath)}`);
   return {
     type: 'archive',
-    url: `${wellKnownBase}/${skillConfig.name}.tar.gz`,
+    url: `${skillConfig.name}.tar.gz`,
     digest: sha256Digest(archivePath)
   };
 }

--- a/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
+++ b/packages/dev/s2-docs/scripts/generateAgentSkills.mjs
@@ -1139,7 +1139,8 @@ function sha256Digest(filePath) {
  */
 function createSkillArchive(skillDir, skillName, wellKnownRoot) {
   const archivePath = path.join(wellKnownRoot, `${skillName}.tar.gz`);
-  execFileSync('tar', ['--exclude=.DS_Store', '-czf', archivePath, '-C', skillDir, '.']);
+  const entries = fs.readdirSync(skillDir).filter(name => name !== '.DS_Store');
+  execFileSync('tar', ['--exclude=.DS_Store', '-czf', archivePath, '-C', skillDir, ...entries]);
   return archivePath;
 }
 

--- a/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
+++ b/packages/dev/s2-docs/scripts/generateMarkdownDocs.mjs
@@ -992,17 +992,26 @@ function getTypeText(decl, fallbackContext) {
 }
 
 /**
+ * Resolve the `s2:` and `react-aria:` cross-library URL schemes (used to link from one
+ * doc site to another, e.g. from an S2 component page to its React Aria counterpart)
+ * into an absolute URL on the target site. Other URLs are returned unchanged.
+ */
+function resolveSchemeUrl(href) {
+  if (href && (href.startsWith('s2:') || href.startsWith('react-aria:'))) {
+    const url = new URL(href);
+    return getBaseUrl(url.protocol.slice(0, -1)) + '/' + url.pathname;
+  }
+  return href;
+}
+
+const URI_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
  * Transform relative URLs to use .md extension instead of .html or no extension.
  * Preserves query params and hash fragments.
  */
 function transformRelativeUrl(href) {
-  if (
-    !href ||
-    href.startsWith('http://') ||
-    href.startsWith('https://') ||
-    href.startsWith('mailto:') ||
-    href.startsWith('#')
-  ) {
+  if (!href || href.startsWith('#') || URI_SCHEME_PATTERN.test(href)) {
     return href;
   }
 
@@ -1017,6 +1026,9 @@ function transformRelativeUrl(href) {
   if (pathPart.endsWith('.html')) {
     // Replace .html with .md
     pathPart = pathPart.slice(0, -5) + '.md';
+  } else if (pathPart.endsWith('/')) {
+    // A trailing slash refers to that directory's index page
+    pathPart = pathPart + 'index.md';
   } else if (pathPart && !pathPart.match(/\.[a-zA-Z0-9]+$/)) {
     // Add .md to paths without an extension
     pathPart = pathPart + '.md';
@@ -2695,10 +2707,7 @@ function remarkDocsComponentsToMarkdown() {
           }
         }
 
-        if (href && (href.startsWith('s2:') || href.startsWith('react-aria:'))) {
-          let url = new URL(href);
-          href = getBaseUrl(url.protocol.slice(0, -1)) + '/' + url.pathname;
-        }
+        href = resolveSchemeUrl(href);
 
         // Convert .html links to .md for relative links
         if (href && !href.startsWith('http') && !href.startsWith('//') && href.endsWith('.html')) {
@@ -3283,7 +3292,7 @@ function remarkDocsComponentsToMarkdown() {
 
     // Transform relative links to use .md extension.
     visit(tree, 'link', node => {
-      node.url = transformRelativeUrl(node.url);
+      node.url = transformRelativeUrl(resolveSchemeUrl(node.url));
     });
 
     // Append "Related Types" section if we collected any.


### PR DESCRIPTION
Closes https://github.com/adobe/react-spectrum/issues/10466

- Fixes broken cross-file links inside `references/` (#10466).
- Updates the skills discovery output to match v0.2.0 of [Agent Skills Discovery via Well-Known URIs RFC](https://github.com/cloudflare/agent-skills-discovery-rfc)

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Confirm that it installs, and verify the output:

React Spectrum:

```
npx skills add https://d1pzu54gtk2aed.cloudfront.net/pr/250e7269629f551324337ffbc30d53beefa4c3d0/
```

React Aria:

```
npx skills add https://d5iwopk28bdhl.cloudfront.net/pr/250e7269629f551324337ffbc30d53beefa4c3d0/
```

## 🧢 Your Project:

<!--- Company/project for pull request -->
