### PR TITLE
fix: remove invalid source package exports

### DIFF
--- a/packages/@adobe/react-spectrum/package.json
+++ b/packages/@adobe/react-spectrum/package.json
@@ -7,7 +7,6 @@
   "module": "./dist/exports/index.js",
   "exports": {
     ".": {
-      "source": "./exports/index.ts",
       "types": "./dist/types/exports/index.d.ts",
       "import": "./dist/exports/index.mjs",
       "require": "./dist/exports/index.cjs"
@@ -24,7 +23,6 @@
     },
     "./package.json": "./package.json",
     "./*": {
-      "source": "./exports/*.ts",
       "types": "./dist/types/exports/*.d.ts",
       "legacy-module": "./dist/exports/*.js",
       "import": "./dist/exports/*.mjs",

--- a/packages/react-aria-components/package.json
+++ b/packages/react-aria-components/package.json
@@ -26,7 +26,6 @@
   "types": "./dist/types/exports/index.d.ts",
   "exports": {
     ".": {
-      "source": "./exports/index.ts",
       "types": "./dist/types/exports/index.d.ts",
       "import": "./dist/exports/index.mjs",
       "require": "./dist/exports/index.cjs"
@@ -43,7 +42,6 @@
     },
     "./package.json": "./package.json",
     "./*": {
-      "source": "./exports/*.ts",
       "types": "./dist/types/exports/*.d.ts",
       "legacy-module": "./dist/exports/*.js",
       "import": "./dist/exports/*.mjs",

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -7,7 +7,6 @@
   "module": "./dist/exports/index.js",
   "exports": {
     ".": {
-      "source": "./exports/index.ts",
       "types": "./dist/types/exports/index.d.ts",
       "import": "./dist/exports/index.mjs",
       "require": "./dist/exports/index.cjs"
@@ -24,7 +23,6 @@
     },
     "./package.json": "./package.json",
     "./*": {
-      "source": "./exports/*.ts",
       "types": "./dist/types/exports/*.d.ts",
       "legacy-module": "./dist/exports/*.js",
       "import": "./dist/exports/*.mjs",

--- a/packages/react-stately/package.json
+++ b/packages/react-stately/package.json
@@ -7,14 +7,12 @@
   "module": "./dist/exports/index.js",
   "exports": {
     ".": {
-      "source": "./exports/index.ts",
       "types": "./dist/types/exports/index.d.ts",
       "import": "./dist/exports/index.mjs",
       "require": "./dist/exports/index.cjs"
     },
     "./package.json": "./package.json",
     "./*": {
-      "source": "./exports/*.ts",
       "types": "./dist/types/exports/*.d.ts",
       "legacy-module": "./dist/exports/*.js",
       "import": "./dist/exports/*.mjs",


### PR DESCRIPTION

## Summary

Removes invalid `source` conditional exports from packages that exclude
their `exports/**` source files from the published npm package.

Affected packages:

- `react-aria`
- `react-stately`
- `react-aria-components`
- `@adobe/react-spectrum`

When a bundler is configured with the `source` condition, these exports
can resolve to `./exports/*.ts` files that are not included in the
published package. Removing the invalid condition allows resolution to
fall back to the distributed `import` entry.

## Changes

- Remove the `source` export from the root export.
- Remove the `source` export from the wildcard export.
- No other package configuration or build files were changed.

## 🤖 AI Assistance

This PR was prepared with AI assistance. The changes were reviewed by me, and I understand the purpose and impact of
each change.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10397).
- [ ] Added/updated unit tests and storybook for this change (not applicable: this is a package export configuration fix).
- [ ] Filled out test instructions below.
- [ ] Updated documentation (not applicable).
- [ ] Looked at the Accessibility Practices for this feature (not applicable: this is a package resolution fix).
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our AI contribution guidance and pointed my assistant at https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md.

## 📝 Test Instructions:

Validation performed locally:

- `git diff --check` — passed.
- JSON parsing validation for all four modified `package.json` files — passed.

The repository's runtime/type-checking tests were not run because the
local `node_modules` state was not installed, so `yarn check-types` and
`yarn test:ssr` could not be executed.

Expected behavior:
1. Install the repository dependencies.
2. Run `yarn check-types`.
3. Run `yarn test:ssr`.
4. Run the relevant test suite for package resolution.
5. Verify that packages configured with the `source` condition resolve
   to their distributed `import` entry instead of the missing
   `exports/**/*.ts` files.

## 🧢 Your Project:

Personal open-source contribution.