### PR TITLE
feat(slider): add SliderMark and snapPoints for tick marks and pointer snapping

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Slider.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Slider.mdx
@@ -99,6 +99,46 @@ By default, slider values are percentages between 0 and 100. Use the `minValue`,
     fillOffset: 75
   }} />
 
+## Marks
+
+Render a `<SliderMark>` for each value you want to label along the track. Pressing a mark moves the nearest thumb to its value, so labels stay usable when they sit outside the track's bounds. Marks are not focusable — the thumb remains the keyboard interface — so keep their content short, or add `aria-hidden` where it would only repeat what the thumb already announces.
+
+```tsx render
+"use client";
+import {Slider} from 'vanilla-starter/Slider';
+
+<Slider
+  label="Brightness"
+  minValue={-100}
+  maxValue={100}
+  defaultValue={0}
+  /*- begin highlight -*/
+  marks={[-100, -50, 0, 50, 100]} />
+  {/*- end highlight -*/}
+```
+
+### Snapping
+
+Marks alone do not change how a thumb moves. Use `snapPoints` to make a pointer snap to values as it passes them, while leaving the values in between reachable. `snapThreshold` controls how close the pointer must get, as a fraction of the track length.
+
+Keyboard interactions are deliberately unaffected — arrow keys continue to move by `step` — so a snap point is a pointer affordance rather than a restriction on the value.
+
+<VisualExample
+  component={VanillaSlider}
+  docs={vanillaDocs.exports.Slider}
+  links={vanillaDocs.links}
+  props={['snapThreshold', 'step']}
+  initialProps={{
+    label: 'Brightness',
+    minValue: -100,
+    maxValue: 100,
+    defaultValue: 0,
+    marks: [-100, -50, 0, 50, 100],
+    snapPoints: [-100, -50, 0, 50, 100]
+  }} />
+
+Snap points do not have to be multiples of `step`. A value such as `0` on a slider that steps by 25 is only reachable with a pointer.
+
 ## Examples
 
 <ExampleList tag="slider" pages={props.pages} />
@@ -107,12 +147,13 @@ By default, slider values are percentages between 0 and 100. Use the `minValue`,
 
 <Anatomy />
 
-```tsx links={{Slider: '#slider', SliderOutput: '#slideroutput', SliderTrack: '#slidertrack', SliderFill: '#sliderfill', SliderThumb: '#sliderthumb'}}
+```tsx links={{Slider: '#slider', SliderOutput: '#slideroutput', SliderTrack: '#slidertrack', SliderFill: '#sliderfill', SliderMark: '#slidermark', SliderThumb: '#sliderthumb'}}
 <Slider>
   <Label />
   <SliderOutput />
   <SliderTrack>
     <SliderFill />
+    <SliderMark />
     <SliderThumb />
     <SliderThumb>
       <Label />
@@ -136,6 +177,10 @@ By default, slider values are percentages between 0 and 100. Use the `minValue`,
 ### SliderFill
 
 <PropTable component={docs.exports.SliderFill} links={docs.links} showDescription />
+
+### SliderMark
+
+<PropTable component={docs.exports.SliderMark} links={docs.links} showDescription />
 
 ### SliderThumb
 

--- a/packages/dev/s2-docs/pages/react-aria/Slider.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Slider.mdx
@@ -139,6 +139,8 @@ Keyboard interactions are deliberately unaffected — arrow keys continue to mov
 
 Snap points do not have to be multiples of `step`. A value such as `0` on a slider that steps by 25 is only reachable with a pointer.
 
+Marks and snap points cover the harder cases too. A macOS-style volume slider — ticks drawn across the track, a thumb that goes translucent while dragging, and a value readout that follows it — needs no other API: the thumb already exposes `isDragging` and `isHovered` as render props, and `SliderOutput` reads the live value. See the `SliderMarks` story for a worked example.
+
 ## Examples
 
 <ExampleList tag="slider" pages={props.pages} />

--- a/packages/react-aria-components/exports/Slider.ts
+++ b/packages/react-aria-components/exports/Slider.ts
@@ -20,6 +20,7 @@ export {
   SliderTrack,
   SliderThumb,
   SliderFill,
+  SliderMark,
   SliderContext,
   SliderOutputContext,
   SliderTrackContext,
@@ -35,7 +36,9 @@ export type {
   SliderTrackRenderProps,
   SliderThumbRenderProps,
   SliderFillProps,
-  SliderFillRenderProps
+  SliderFillRenderProps,
+  SliderMarkProps,
+  SliderMarkRenderProps
 } from '../src/Slider';
 export type {SliderState} from 'react-stately/useSliderState';
 

--- a/packages/react-aria-components/exports/index.ts
+++ b/packages/react-aria-components/exports/index.ts
@@ -188,6 +188,7 @@ export {
   SliderTrack,
   SliderThumb,
   SliderFill,
+  SliderMark,
   SliderContext,
   SliderOutputContext,
   SliderTrackContext,
@@ -457,7 +458,9 @@ export type {
   SliderTrackRenderProps,
   SliderFillProps,
   SliderFillRenderProps,
-  SliderThumbRenderProps
+  SliderThumbRenderProps,
+  SliderMarkProps,
+  SliderMarkRenderProps
 } from '../src/Slider';
 export type {
   SwitchProps,

--- a/packages/react-aria-components/src/Slider.tsx
+++ b/packages/react-aria-components/src/Slider.tsx
@@ -47,6 +47,7 @@ import React, {
 import {SliderState, useSliderState} from 'react-stately/useSliderState';
 import {useFocusRing} from 'react-aria/useFocusRing';
 import {useHover} from 'react-aria/useHover';
+import {useLocale} from 'react-aria/I18nProvider';
 import {useNumberFormatter} from 'react-aria/useNumberFormatter';
 import {VisuallyHidden} from 'react-aria/VisuallyHidden';
 
@@ -371,6 +372,133 @@ export const SliderThumb = /*#__PURE__*/ (forwardRef as forwardRefType)(function
         {renderProps.children}
       </Provider>
     </dom.div>
+  );
+});
+
+export interface SliderMarkRenderProps extends SliderRenderProps {
+  /**
+   * The value along the track that the mark is positioned at.
+   */
+  value: number;
+  /**
+   * Whether the mark is currently hovered with a mouse.
+   *
+   * @selector [data-hovered]
+   */
+  isHovered: boolean;
+}
+
+export interface SliderMarkProps
+  extends HoverEvents, RenderProps<SliderMarkRenderProps>, GlobalDOMAttributes<HTMLDivElement> {
+  /** The value along the track that the mark is positioned at. */
+  value: number;
+  /**
+   * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the
+   * element. A function may be provided to compute the class based on component state.
+   *
+   * @default 'react-aria-SliderMark'
+   */
+  className?: ClassNameOrFunction<SliderMarkRenderProps>;
+}
+
+/**
+ * A slider mark labels a value along the track. Pressing it moves the nearest thumb to that value.
+ */
+export const SliderMark = /*#__PURE__*/ (forwardRef as forwardRefType)(function SliderMark(
+  props: SliderMarkProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
+  let {value, onHoverStart, onHoverEnd, onHoverChange, ...otherProps} = props;
+  let state = useContext(SliderStateContext)!;
+  let {direction} = useLocale();
+  let {hoverProps, isHovered} = useHover({
+    onHoverStart,
+    onHoverEnd,
+    onHoverChange,
+    isDisabled: state.isDisabled
+  });
+
+  // Marks sit inside the track, which moves the nearest thumb to wherever the pointer went down.
+  // Stop that here so the thumb lands on the mark's exact value, including for labels rendered
+  // outside the track's bounds.
+  let onDown = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    let index = state.getClosestThumbIndex(value);
+    if (index < 0 || !state.isThumbEditable(index)) {
+      return;
+    }
+
+    e.preventDefault();
+    state.setFocusedThumb(index);
+    state.setThumbDragging(index, true);
+    state.setThumbPercent(index, state.getValuePercent(value));
+    state.setThumbDragging(index, false);
+  };
+
+  let isVertical = state.orientation === 'vertical';
+  let percent = state.getValuePercent(value);
+  if (isVertical || direction === 'rtl') {
+    percent = 1 - percent;
+  }
+
+  let renderProps = useRenderProps({
+    ...props,
+    defaultClassName: 'react-aria-SliderMark',
+    defaultStyle: {
+      position: 'absolute',
+      [isVertical ? 'top' : 'left']: `${percent * 100}%`,
+      transform: 'translate(-50%, -50%)'
+    },
+    values: {
+      orientation: state.orientation,
+      isDisabled: state.isDisabled,
+      isHovered,
+      value,
+      state
+    }
+  });
+
+  // Pointer events are dispatched before their mouse and touch equivalents, so only one handler
+  // acts on an interaction and the rest just stop propagation. JSDOM has no PointerEvent, so tests
+  // fall through to the mouse and touch handlers.
+  let hasPointerEvents = typeof PointerEvent !== 'undefined';
+  let interactions: HTMLAttributes<HTMLDivElement> = !state.isDisabled
+    ? {
+        onPointerDown: (e: React.PointerEvent) => {
+          if (e.pointerType === 'mouse' && (e.button !== 0 || e.altKey || e.ctrlKey || e.metaKey)) {
+            return;
+          }
+          onDown(e);
+        },
+        onMouseDown: (e: React.MouseEvent) => {
+          if (e.button !== 0 || e.altKey || e.ctrlKey || e.metaKey) {
+            return;
+          }
+          if (hasPointerEvents) {
+            e.stopPropagation();
+          } else {
+            onDown(e);
+          }
+        },
+        onTouchStart: (e: React.TouchEvent) => {
+          if (hasPointerEvents) {
+            e.stopPropagation();
+          } else {
+            onDown(e);
+          }
+        }
+      }
+    : {};
+
+  return (
+    <dom.div
+      {...mergeProps(otherProps, hoverProps, interactions)}
+      {...renderProps}
+      ref={ref}
+      data-hovered={isHovered || undefined}
+      data-orientation={state.orientation || undefined}
+      data-disabled={state.isDisabled || undefined}
+    />
   );
 });
 

--- a/packages/react-aria-components/stories/Slider.stories.tsx
+++ b/packages/react-aria-components/stories/Slider.stories.tsx
@@ -14,7 +14,7 @@ import {Label} from '../src/Label';
 
 import {Meta, StoryFn} from '@storybook/react';
 import React from 'react';
-import {Slider, SliderOutput, SliderThumb, SliderTrack} from '../src/Slider';
+import {Slider, SliderMark, SliderOutput, SliderThumb, SliderTrack} from '../src/Slider';
 import styles from '../example/index.css';
 import './styles.css';
 
@@ -103,7 +103,53 @@ SliderCSS.argTypes = {
   }
 };
 
-const CustomThumb = ({index, children}: {index: number; children: React.ReactNode}) => {
+const MARKS = [-100, -50, 0, 50, 100];
+
+export const SliderMarks: SliderStory = props => (
+  <Slider
+    {...props}
+    aria-label="Balance"
+    defaultValue={0}
+    minValue={-100}
+    maxValue={100}
+    snapPoints={MARKS}
+    style={{position: 'relative', width: 300}}>
+    <SliderOutput />
+    <SliderTrack style={{position: 'relative', height: 30, width: '100%'}}>
+      <div
+        style={{position: 'absolute', backgroundColor: 'gray', height: 3, top: 13, width: '100%'}}
+      />
+      {MARKS.map(value => (
+        <SliderMark key={value} value={value} style={{top: 14}}>
+          {({isHovered}) => (
+            <>
+              <div style={{width: 2, height: 10, backgroundColor: 'gray'}} />
+              <span
+                style={{
+                  position: 'absolute',
+                  top: 12,
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  fontSize: 12,
+                  textDecoration: isHovered ? 'underline' : undefined
+                }}>
+                {value}
+              </span>
+            </>
+          )}
+        </SliderMark>
+      ))}
+      <CustomThumb index={0} />
+    </SliderTrack>
+  </Slider>
+);
+
+SliderMarks.args = {
+  isDisabled: false,
+  snapThreshold: 0.03
+};
+
+const CustomThumb = ({index, children}: {index: number; children?: React.ReactNode}) => {
   return (
     <SliderThumb
       index={index}

--- a/packages/react-aria-components/stories/Slider.stories.tsx
+++ b/packages/react-aria-components/stories/Slider.stories.tsx
@@ -103,23 +103,83 @@ SliderCSS.argTypes = {
   }
 };
 
-const MARKS = [-100, -50, 0, 50, 100];
+// Seven ticks over six intervals, matching the macOS Sound output volume slider that
+// https://github.com/adobe/react-spectrum/issues/8285 asks for.
+const VOLUME_TICKS = [0, 100 / 6, 200 / 6, 50, 400 / 6, 500 / 6, 100];
 
 export const SliderMarks: SliderStory = props => (
+  <Slider
+    {...props}
+    aria-label="Volume"
+    defaultValue={70}
+    snapPoints={VOLUME_TICKS}
+    style={{display: 'flex', alignItems: 'center', gap: 10, width: 360}}>
+    <SliderTrack
+      style={{position: 'relative', flex: 1, height: 22, display: 'flex', alignItems: 'center'}}>
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          height: 4,
+          background: '#d4d4d4',
+          borderRadius: 2
+        }}
+      />
+      {VOLUME_TICKS.map((value, i) => (
+        <SliderMark key={i} value={value}>
+          {({isHovered}) => (
+            <div
+              style={{
+                width: 2,
+                height: 11,
+                borderRadius: 1,
+                background: isHovered ? '#8a8a8a' : '#bdbdbd'
+              }}
+            />
+          )}
+        </SliderMark>
+      ))}
+      <SliderThumb
+        style={({isDragging}) => ({
+          width: 11,
+          height: 22,
+          top: '50%',
+          borderRadius: 5.5,
+          // The thumb goes translucent while dragging, as the macOS slider does.
+          background: isDragging ? 'rgba(255, 255, 255, 0.45)' : '#fff',
+          boxShadow: isDragging
+            ? '0 0 0 0.5px rgba(0, 0, 0, 0.09)'
+            : '0 0 0 0.5px rgba(0, 0, 0, 0.18), 0 1px 3px rgba(0, 0, 0, 0.28)'
+        })}
+      />
+    </SliderTrack>
+    <SliderOutput style={{width: 40, textAlign: 'end', fontVariantNumeric: 'tabular-nums'}} />
+  </Slider>
+);
+
+SliderMarks.args = {
+  isDisabled: false,
+  snapThreshold: 0.02
+};
+
+const LABELLED_MARKS = [-100, -50, 0, 50, 100];
+
+export const SliderMarksWithLabels: SliderStory = props => (
   <Slider
     {...props}
     aria-label="Balance"
     defaultValue={0}
     minValue={-100}
     maxValue={100}
-    snapPoints={MARKS}
+    snapPoints={LABELLED_MARKS}
     style={{position: 'relative', width: 300}}>
     <SliderOutput />
     <SliderTrack style={{position: 'relative', height: 30, width: '100%'}}>
       <div
         style={{position: 'absolute', backgroundColor: 'gray', height: 3, top: 13, width: '100%'}}
       />
-      {MARKS.map(value => (
+      {LABELLED_MARKS.map(value => (
         <SliderMark key={value} value={value} style={{top: 14}}>
           {({isHovered}) => (
             <>
@@ -144,7 +204,7 @@ export const SliderMarks: SliderStory = props => (
   </Slider>
 );
 
-SliderMarks.args = {
+SliderMarksWithLabels.args = {
   isDisabled: false,
   snapThreshold: 0.03
 };

--- a/packages/react-aria-components/test/Slider.test.js
+++ b/packages/react-aria-components/test/Slider.test.js
@@ -17,6 +17,7 @@ import {
   Slider,
   SliderContext,
   SliderFill,
+  SliderMark,
   SliderOutput,
   SliderThumb,
   SliderTrack
@@ -455,5 +456,134 @@ describe('Slider', () => {
       <TestSlider sliderProps={{value: 80, orientation: 'vertical'}} fillProps={{offset: 50}} />
     );
     expect(fill).toHaveStyle({position: 'absolute', bottom: '50%', height: '30%', width: '100%'});
+  });
+
+  describe('SliderMark', () => {
+    let renderMarks = (sliderProps = {}, markProps, markValues = [0, 25, 50]) => {
+      let values = [].concat(sliderProps.defaultValue ?? 0);
+      return render(
+        <Slider defaultValue={0} {...sliderProps}>
+          <Label>Opacity</Label>
+          <SliderTrack>
+            {markValues.map(value => (
+              <SliderMark key={value} value={value} {...markProps}>
+                {value}
+              </SliderMark>
+            ))}
+            {values.map((_, i) => (
+              <SliderThumb key={i} index={i} aria-label={`thumb ${i}`} />
+            ))}
+          </SliderTrack>
+        </Slider>
+      );
+    };
+
+    it('should render marks positioned along the track', () => {
+      let {getByRole} = renderMarks();
+      let marks = getByRole('group').querySelectorAll('.react-aria-SliderMark');
+
+      expect(marks).toHaveLength(3);
+      expect(marks[1]).toHaveTextContent('25');
+      expect(marks[1]).toHaveAttribute('data-orientation', 'horizontal');
+      expect(marks[1]).toHaveStyle({
+        position: 'absolute',
+        left: '25%',
+        transform: 'translate(-50%, -50%)'
+      });
+    });
+
+    it('should position marks from the end when vertical', () => {
+      let {getByRole} = renderMarks({orientation: 'vertical'});
+      let marks = getByRole('group').querySelectorAll('.react-aria-SliderMark');
+
+      expect(marks[1]).toHaveAttribute('data-orientation', 'vertical');
+      expect(marks[1]).toHaveStyle({position: 'absolute', top: '75%'});
+    });
+
+    it('should support render props', () => {
+      let {getByRole} = renderMarks(
+        {},
+        {className: ({value, isDisabled}) => `mark-${value} ${isDisabled ? 'disabled' : ''}`.trim()}
+      );
+      let marks = getByRole('group').querySelectorAll('[class^="mark-"]');
+
+      expect(marks[1]).toHaveClass('mark-25');
+    });
+
+    it('should move the nearest thumb to the mark value when pressed', () => {
+      let onChange = jest.fn();
+      let onChangeEnd = jest.fn();
+      let {getByRole} = renderMarks({onChange, onChangeEnd});
+      let marks = getByRole('group').querySelectorAll('.react-aria-SliderMark');
+
+      fireEvent.mouseDown(marks[2]);
+      expect(getByRole('slider')).toHaveValue('50');
+      expect(onChange).toHaveBeenCalledWith(50);
+      expect(onChangeEnd).toHaveBeenCalledWith(50);
+    });
+
+    it('should not let the track handle a press on a mark', () => {
+      let {getByRole} = renderMarks({}, {style: {width: 200}});
+      let marks = getByRole('group').querySelectorAll('.react-aria-SliderMark');
+
+      // The track has no layout in JSDOM, so if it handled the press the thumb would land on 0.
+      fireEvent.mouseDown(marks[1]);
+      expect(getByRole('slider')).toHaveValue('25');
+    });
+
+    it('should move the closest of multiple thumbs', () => {
+      let {getAllByRole, getByRole} = renderMarks({defaultValue: [10, 80]});
+      let marks = getByRole('group').querySelectorAll('.react-aria-SliderMark');
+      let sliders = getAllByRole('slider');
+
+      fireEvent.mouseDown(marks[2]);
+      expect(sliders[0]).toHaveValue('10');
+      expect(sliders[1]).toHaveValue('50');
+    });
+
+    it('should round a mark that is not a snap point to the nearest step', () => {
+      let onChange = jest.fn();
+      let {getByRole} = renderMarks({onChange, step: 5}, undefined, [12.5]);
+
+      fireEvent.mouseDown(getByRole('group').querySelector('.react-aria-SliderMark'));
+      expect(onChange).toHaveBeenCalledWith(15);
+    });
+
+    it('should land exactly on a mark that is also a snap point', () => {
+      let onChange = jest.fn();
+      let {getByRole} = renderMarks({onChange, step: 5, snapPoints: [12.5]}, undefined, [12.5]);
+
+      fireEvent.mouseDown(getByRole('group').querySelector('.react-aria-SliderMark'));
+      expect(onChange).toHaveBeenCalledWith(12.5);
+    });
+
+    it('should do nothing when the slider is disabled', () => {
+      let onChange = jest.fn();
+      let {getByRole} = renderMarks({onChange, isDisabled: true});
+      let marks = getByRole('group').querySelectorAll('.react-aria-SliderMark');
+
+      expect(marks[1]).toHaveAttribute('data-disabled', 'true');
+      fireEvent.mouseDown(marks[1]);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should support hover state', async () => {
+      let onHoverChange = jest.fn();
+      let {getByRole} = renderMarks(
+        {},
+        {onHoverChange, className: ({isHovered}) => (isHovered ? 'mark hovered' : 'mark')}
+      );
+      let mark = getByRole('group').querySelector('.mark');
+
+      expect(mark).not.toHaveAttribute('data-hovered');
+
+      await user.hover(mark);
+      expect(mark).toHaveAttribute('data-hovered', 'true');
+      expect(mark).toHaveClass('hovered');
+      expect(onHoverChange).toHaveBeenCalledWith(true);
+
+      await user.unhover(mark);
+      expect(mark).not.toHaveAttribute('data-hovered');
+    });
   });
 });

--- a/packages/react-aria/src/slider/useSlider.ts
+++ b/packages/react-aria/src/slider/useSlider.ts
@@ -80,9 +80,6 @@ export function useSlider<T extends number | number[]>(
   const reverseX = direction === 'rtl';
   const currentPosition = useRef<number | null>(null);
   const {moveProps} = useMove({
-    onMoveStart() {
-      currentPosition.current = null;
-    },
     onMove({deltaX, deltaY}) {
       if (!trackRef.current) {
         return;
@@ -137,27 +134,7 @@ export function useSlider<T extends number | number[]>(
       if (direction === 'rtl' || isVertical) {
         percent = 1 - percent;
       }
-      let value = state.getPercentValue(percent);
-
-      // to find the closet thumb we split the array based on the first thumb position to the "right/end" of the click.
-      let closestThumb;
-      let split = state.values.findIndex(v => value - v < 0);
-      if (split === 0) {
-        // If the index is zero then the closetThumb is the first one
-        closestThumb = split;
-      } else if (split === -1) {
-        // If no index is found they've clicked past all the thumbs
-        closestThumb = state.values.length - 1;
-      } else {
-        let lastLeft = state.values[split - 1];
-        let firstRight = state.values[split];
-        // Pick the last left/start thumb, unless they are stacked on top of each other, then pick the right/end one
-        if (Math.abs(lastLeft - value) < Math.abs(firstRight - value)) {
-          closestThumb = split - 1;
-        } else {
-          closestThumb = split;
-        }
-      }
+      let closestThumb = state.getClosestThumbIndex(state.getPercentValue(percent));
 
       // Confirm that the found closest thumb is editable, not disabled, and move it
       if (closestThumb >= 0 && state.isThumbEditable(closestThumb)) {
@@ -167,15 +144,19 @@ export function useSlider<T extends number | number[]>(
         realTimeTrackDraggingIndex.current = closestThumb;
         state.setFocusedThumb(closestThumb);
         currentPointer.current = id;
+        // Track the pointer rather than the thumb, so that the rest of the drag stays under the
+        // cursor even when the value was adjusted to fit the step or a snap point.
+        currentPosition.current = clamp(percent, 0, 1) * size;
 
         state.setThumbDragging(realTimeTrackDraggingIndex.current!, true);
-        state.setThumbValue(closestThumb, value);
+        state.setThumbPercent(closestThumb, percent);
 
         addGlobalListener(window, 'mouseup', onUpTrack, false);
         addGlobalListener(window, 'touchend', onUpTrack, false);
         addGlobalListener(window, 'pointerup', onUpTrack, false);
       } else {
         realTimeTrackDraggingIndex.current = null;
+        currentPosition.current = null;
       }
     }
   };

--- a/packages/react-aria/test/slider/useSlider.test.js
+++ b/packages/react-aria/test/slider/useSlider.test.js
@@ -146,6 +146,27 @@ describe('useSlider', () => {
       expect(stateRef.current.values).toEqual([40, 80]);
     });
 
+    it('should snap to snapPoints when clicking and dragging on the track', () => {
+      let onChangeSpy = jest.fn();
+      render(
+        <Example onChange={onChangeSpy} aria-label="Slider" defaultValue={[10]} snapPoints={[50]} />
+      );
+
+      // The track is 100px wide, so the default threshold of 2% reaches roughly 2px either side.
+      let track = screen.getByTestId('track');
+      fireEvent.mouseDown(track, {clientX: 49, pageX: 49});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([50]);
+
+      fireEvent.mouseMove(track, {clientX: 51, pageX: 51});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([50]);
+
+      // Dragging out of range picks up where the pointer is, not where the snap left the thumb.
+      fireEvent.mouseMove(track, {clientX: 55, pageX: 55});
+      expect(onChangeSpy).toHaveBeenLastCalledWith([55]);
+
+      fireEvent.mouseUp(track, {clientX: 55, pageX: 55});
+    });
+
     it('should not allow you to set value if disabled', () => {
       let onChangeSpy = jest.fn();
       let onChangeEndSpy = jest.fn();

--- a/packages/react-stately/src/slider/useSliderState.ts
+++ b/packages/react-stately/src/slider/useSliderState.ts
@@ -47,6 +47,17 @@ export interface SliderProps<T = number | number[]>
    * @default 1
    */
   step?: number;
+  /**
+   * A list of values that a thumb magnetically snaps to while dragging or clicking with a pointer.
+   * Values in between remain reachable, and keyboard interactions are unaffected.
+   */
+  snapPoints?: number[];
+  /**
+   * How close a pointer must be to a snap point for it to snap, as a fraction of the track length.
+   *
+   * @default 0.02
+   */
+  snapThreshold?: number;
 }
 
 export interface SliderState {
@@ -158,6 +169,14 @@ export interface SliderState {
   getPercentValue(percent: number): number;
 
   /**
+   * Returns the index of the thumb nearest to the given value. When two thumbs are
+   * stacked on the same value, the one after the value is returned.
+   *
+   * @param value
+   */
+  getClosestThumbIndex(value: number): number;
+
+  /**
    * Returns if the specified thumb is editable.
    *
    * @param index
@@ -201,6 +220,7 @@ export interface SliderState {
 const DEFAULT_MIN_VALUE = 0;
 const DEFAULT_MAX_VALUE = 100;
 const DEFAULT_STEP_VALUE = 1;
+const DEFAULT_SNAP_THRESHOLD = 0.02;
 
 export interface SliderStateOptions<T> extends SliderProps<T> {
   numberFormatter: Intl.NumberFormat;
@@ -223,7 +243,9 @@ export function useSliderState<T extends number | number[]>(
     maxValue = DEFAULT_MAX_VALUE,
     numberFormatter: formatter,
     step = DEFAULT_STEP_VALUE,
-    orientation = 'horizontal'
+    orientation = 'horizontal',
+    snapPoints,
+    snapThreshold = DEFAULT_SNAP_THRESHOLD
   } = props;
 
   // Page step should be at least equal to step and always a multiple of the step.
@@ -294,17 +316,24 @@ export function useSliderState<T extends number | number[]>(
     isEditablesRef.current[index] = editable;
   }
 
-  function updateValue(index: number, value: number) {
+  function commitValue(index: number, value: number) {
     if (isDisabled || !isThumbEditable(index)) {
       return;
     }
-    const thisMin = getThumbMinValue(index);
-    const thisMax = getThumbMaxValue(index);
-
-    // Round value to multiple of step, clamp value between min and max
-    value = snapValueToStep(value, thisMin, thisMax, step);
-    let newValues = replaceIndex(valuesRef.current, index, value);
+    let newValues = replaceIndex(
+      valuesRef.current,
+      index,
+      clamp(value, getThumbMinValue(index), getThumbMaxValue(index))
+    );
     setValues(newValues);
+  }
+
+  function updateValue(index: number, value: number) {
+    // Round value to multiple of step, clamp value between min and max
+    commitValue(
+      index,
+      snapValueToStep(value, getThumbMinValue(index), getThumbMaxValue(index), step)
+    );
   }
 
   function updateDragging(index: number, dragging: boolean) {
@@ -356,8 +385,50 @@ export function useSliderState<T extends number | number[]>(
     }
   }
 
+  // Pointer interactions run through percentages, so snapping is applied here rather than in
+  // updateValue. That leaves keyboard interactions, which move by step, unaffected.
   function setThumbPercent(index: number, percent: number) {
-    updateValue(index, getPercentValue(percent));
+    let snapPoint = getSnapPoint(percent);
+    if (snapPoint != null) {
+      commitValue(index, snapPoint);
+    } else {
+      updateValue(index, getPercentValue(percent));
+    }
+  }
+
+  function getSnapPoint(percent: number) {
+    if (!snapPoints || snapThreshold <= 0) {
+      return undefined;
+    }
+
+    let closest: number | undefined;
+    let closestDistance = snapThreshold;
+    for (let snapPoint of snapPoints) {
+      let distance = Math.abs(getValuePercent(snapPoint) - percent);
+      if (distance <= closestDistance) {
+        closest = snapPoint;
+        closestDistance = distance;
+      }
+    }
+
+    return closest;
+  }
+
+  function getClosestThumbIndex(value: number) {
+    // Split the array on the first thumb positioned after the value.
+    let split = values.findIndex(v => value - v < 0);
+    if (split === 0) {
+      return split;
+    }
+    if (split === -1) {
+      // The value is past all of the thumbs.
+      return values.length - 1;
+    }
+
+    // Pick the thumb before the value, unless the one after it is closer or they are stacked.
+    return Math.abs(values[split - 1] - value) < Math.abs(values[split] - value)
+      ? split - 1
+      : split;
   }
 
   function getRoundedValue(value: number) {
@@ -396,6 +467,7 @@ export function useSliderState<T extends number | number[]>(
     getThumbMinValue,
     getThumbMaxValue,
     getPercentValue,
+    getClosestThumbIndex,
     isThumbEditable,
     setThumbEditable,
     incrementThumb,

--- a/packages/react-stately/test/slider/useSliderState.test.js
+++ b/packages/react-stately/test/slider/useSliderState.test.js
@@ -193,4 +193,93 @@ describe('useSliderState', () => {
     expect(onChangeSpy).not.toHaveBeenCalled();
     expect(onChangeEndSpy).not.toHaveBeenCalled();
   });
+
+  it('should return the closest thumb to a value', () => {
+    let result = renderHook(() =>
+      useSliderState({defaultValue: [20, 50, 80], numberFormatter})
+    ).result;
+
+    expect(result.current.getClosestThumbIndex(0)).toBe(0);
+    expect(result.current.getClosestThumbIndex(34)).toBe(0);
+    expect(result.current.getClosestThumbIndex(36)).toBe(1);
+    expect(result.current.getClosestThumbIndex(50)).toBe(1);
+    expect(result.current.getClosestThumbIndex(100)).toBe(2);
+  });
+
+  it('should return the last of two stacked thumbs as the closest', () => {
+    let result = renderHook(() => useSliderState({defaultValue: [50, 50], numberFormatter})).result;
+
+    expect(result.current.getClosestThumbIndex(50)).toBe(1);
+  });
+
+  describe('snapPoints', () => {
+    let renderSnapSlider = props =>
+      renderHook(() =>
+        useSliderState({defaultValue: [0], snapPoints: [0, 25, 50], numberFormatter, ...props})
+      ).result;
+
+    it('should snap to the nearest snap point within the threshold', () => {
+      let result = renderSnapSlider();
+
+      act(() => result.current.setThumbPercent(0, 0.49));
+      expect(result.current.getThumbValue(0)).toBe(50);
+
+      act(() => result.current.setThumbPercent(0, 0.515));
+      expect(result.current.getThumbValue(0)).toBe(50);
+    });
+
+    it('should leave values outside the threshold alone', () => {
+      let result = renderSnapSlider();
+
+      act(() => result.current.setThumbPercent(0, 0.45));
+      expect(result.current.getThumbValue(0)).toBe(45);
+
+      act(() => result.current.setThumbPercent(0, 0.56));
+      expect(result.current.getThumbValue(0)).toBe(56);
+    });
+
+    it('should pick the closest snap point when two are in range', () => {
+      let result = renderSnapSlider({snapPoints: [49, 51], snapThreshold: 0.5});
+
+      act(() => result.current.setThumbPercent(0, 0.4));
+      expect(result.current.getThumbValue(0)).toBe(49);
+
+      act(() => result.current.setThumbPercent(0, 0.6));
+      expect(result.current.getThumbValue(0)).toBe(51);
+    });
+
+    it('should snap to points that are not multiples of step', () => {
+      let result = renderSnapSlider({snapPoints: [12.5], step: 5});
+
+      act(() => result.current.setThumbPercent(0, 0.13));
+      expect(result.current.getThumbValue(0)).toBe(12.5);
+    });
+
+    it('should keep snapped values within the thumb bounds', () => {
+      let result = renderSnapSlider({defaultValue: [0, 40], snapPoints: [50]});
+
+      act(() => result.current.setThumbPercent(0, 0.5));
+      expect(result.current.values).toEqual([40, 40]);
+    });
+
+    it('should not affect keyboard interactions', () => {
+      let result = renderSnapSlider({defaultValue: [45]});
+
+      act(() => result.current.incrementThumb(0));
+      expect(result.current.getThumbValue(0)).toBe(46);
+
+      act(() => result.current.setThumbValue(0, 49));
+      expect(result.current.getThumbValue(0)).toBe(49);
+
+      act(() => result.current.decrementThumb(0));
+      expect(result.current.getThumbValue(0)).toBe(48);
+    });
+
+    it('should not snap when snapThreshold is 0', () => {
+      let result = renderSnapSlider({snapThreshold: 0});
+
+      act(() => result.current.setThumbPercent(0, 0.49));
+      expect(result.current.getThumbValue(0)).toBe(49);
+    });
+  });
 });

--- a/starters/docs/src/Slider.css
+++ b/starters/docs/src/Slider.css
@@ -40,6 +40,41 @@
     }
   }
 
+  .react-aria-SliderMark {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    .tick {
+      display: block;
+      background: var(--border-color);
+      border-radius: 9999px;
+    }
+
+    .tick-label {
+      position: absolute;
+      font-size: var(--font-size-sm);
+      color: var(--gray-800);
+      white-space: nowrap;
+    }
+
+    &[data-hovered] .tick-label {
+      color: var(--text-color);
+    }
+
+    &[data-disabled] {
+      cursor: default;
+
+      .tick {
+        background: var(--border-color-disabled);
+      }
+
+      .tick-label {
+        color: var(--text-color-disabled);
+      }
+    }
+  }
+
   .react-aria-SliderThumb {
     width: calc(var(--spacing) * 5.5);
     height: calc(var(--spacing) * 5.5);
@@ -92,6 +127,25 @@
     .react-aria-SliderThumb {
       top: 50%;
     }
+
+    .react-aria-SliderMark {
+      top: 50%;
+
+      .tick {
+        width: 2px;
+        height: var(--spacing-2);
+      }
+
+      .tick-label {
+        top: calc(100% + var(--spacing-1));
+        left: 50%;
+        transform: translateX(-50%);
+      }
+    }
+
+    .react-aria-SliderTrack:has(.react-aria-SliderMark) {
+      margin-bottom: var(--spacing-5);
+    }
   }
 
   &[data-orientation='vertical'] {
@@ -138,6 +192,21 @@
 
     .react-aria-SliderThumb {
       left: 50%;
+    }
+
+    .react-aria-SliderMark {
+      left: 50%;
+
+      .tick {
+        width: var(--spacing-2);
+        height: 2px;
+      }
+
+      .tick-label {
+        left: calc(100% + var(--spacing-1));
+        top: 50%;
+        transform: translateY(-50%);
+      }
     }
   }
 

--- a/starters/docs/src/Slider.tsx
+++ b/starters/docs/src/Slider.tsx
@@ -1,6 +1,7 @@
 'use client';
 import {
   Slider as AriaSlider,
+  SliderMark,
   SliderOutput,
   type SliderProps as AriaSliderProps,
   SliderThumb,
@@ -21,12 +22,15 @@ export interface SliderProps<T> extends AriaSliderProps<T> {
    * @default 0
    */
   fillOffset?: number;
+  /** Values to render tick marks at along the track. */
+  marks?: number[];
 }
 
 export function Slider<T extends number | number[]>({
   label,
   thumbLabels,
   fillOffset,
+  marks,
   ...props
 }: SliderProps<T>) {
   return (
@@ -39,6 +43,12 @@ export function Slider<T extends number | number[]>({
             <div className="track inset" data-disabled={isDisabled || undefined}>
               <SliderFill offset={fillOffset} />
             </div>
+            {marks?.map(value => (
+              <SliderMark key={value} value={value}>
+                <span className="tick" />
+                <span className="tick-label">{state.getFormattedValue(value)}</span>
+              </SliderMark>
+            ))}
             {state.values.map((_, i) => (
               <SliderThumb
                 key={i}

--- a/starters/hooks/src/Slider.css
+++ b/starters/hooks/src/Slider.css
@@ -40,6 +40,41 @@
     }
   }
 
+  .react-aria-SliderMark {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    .tick {
+      display: block;
+      background: var(--border-color);
+      border-radius: 9999px;
+    }
+
+    .tick-label {
+      position: absolute;
+      font-size: var(--font-size-sm);
+      color: var(--gray-800);
+      white-space: nowrap;
+    }
+
+    &[data-hovered] .tick-label {
+      color: var(--text-color);
+    }
+
+    &[data-disabled] {
+      cursor: default;
+
+      .tick {
+        background: var(--border-color-disabled);
+      }
+
+      .tick-label {
+        color: var(--text-color-disabled);
+      }
+    }
+  }
+
   .react-aria-SliderThumb {
     width: calc(var(--spacing) * 5.5);
     height: calc(var(--spacing) * 5.5);
@@ -92,6 +127,25 @@
     .react-aria-SliderThumb {
       top: 50%;
     }
+
+    .react-aria-SliderMark {
+      top: 50%;
+
+      .tick {
+        width: 2px;
+        height: var(--spacing-2);
+      }
+
+      .tick-label {
+        top: calc(100% + var(--spacing-1));
+        left: 50%;
+        transform: translateX(-50%);
+      }
+    }
+
+    .react-aria-SliderTrack:has(.react-aria-SliderMark) {
+      margin-bottom: var(--spacing-5);
+    }
   }
 
   &[data-orientation='vertical'] {
@@ -138,6 +192,21 @@
 
     .react-aria-SliderThumb {
       left: 50%;
+    }
+
+    .react-aria-SliderMark {
+      left: 50%;
+
+      .tick {
+        width: var(--spacing-2);
+        height: 2px;
+      }
+
+      .tick-label {
+        left: calc(100% + var(--spacing-1));
+        top: 50%;
+        transform: translateY(-50%);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #8285

## Intent

#8285 asks for five things: ticks along the track, optional labels, clicking a label to set the value, snapping to ticks under the pointer, and keyboard interactions left alone.

Four of those are already buildable on top of RAC. The fifth is not, and @lixiaoyan named the reason in the thread: `onChange` carries no indication of *why* the value changed, so userland can't apply one rule for the pointer and another for the keyboard without re-implementing the pointer handling RAC already owns.

The library does know the difference, and `useSliderState` already has a clean seam for it. So this adds the primitive that can't be built outside, plus the one component needed to compose the rest — and nothing else.

## The advanced use case works, and it needed nothing extra

@reidbarber's read was that this is an advanced use case better served by a controlled value. That was fair, so rather than argue it I rebuilt the reference from the issue — the macOS Sound volume slider — end to end, and checked what the API actually had to grow by.

| Behaviour in the reference | What it needed |
| --- | --- |
| Ticks drawn across the track | **`SliderMark`** (new) |
| Magnetic snapping to ticks | **`snapPoints`** (new) |
| Thumb goes translucent while dragging | `[data-dragging]` — already there |
| Value readout following the thumb | `SliderOutput` / thumb render props — already there |
| Level-reactive speaker icon, mute glyph | the `value` you already hold |
| Keyboard stepping straight through ticks | falls out of where snapping lives |



https://github.com/user-attachments/assets/8dce3cdd-24ec-4dfd-8ff9-ff62ff1029b6



**Two additions.** Everything else came off render props that already exist. If finishing the demo had needed a third or fourth prop, that would have been a signal the design was wrong; it didn't.

That result is also why the tooltip, the translucency and the icon logic are **not** in this PR. They are app-level styling, and RAC ships unstyled on purpose.

<!-- video of the advanced use case goes here -->

## How it works

**`setThumbPercent` is the pointer door.** Every pointer path goes through it (`useSliderThumb`'s move handler, `useSlider`'s track drag and press); no keyboard path does — arrows and Page Up/Down use `incrementThumb`/`decrementThumb`, Home/End and the range input use `setThumbValue`. Putting snapping there makes "keyboard is unaffected" structural rather than a flag someone can forget.

**`snapPoints` / `snapThreshold` on `useSliderState`.** The threshold is a fraction of the track rather than pixels, so `@react-stately` stays free of geometry — it already works in percentages and never measures the DOM.

**Snap points deliberately bypass step rounding.** `updateValue` splits into `commitValue` (clamp to the thumb's neighbours, write) and `updateValue` (`snapValueToStep`, then `commitValue`). Snapping calls `commitValue` directly, because otherwise a snap point at `12.5` on a `step={5}` slider would round to `15` and defeat the point. Every non-snapping path keeps its original behaviour, and `getSnapPoint` returns on its first line when `snapPoints` is undefined.

**`getClosestThumbIndex` moves onto the state.** `useSlider` had this search inline and `SliderMark` needs the same answer, so it moved rather than got duplicated. Same algorithm, same tie-breaking for stacked thumbs — the existing stacked-thumb tests cover it and are untouched.

## A pre-existing drag bug this surfaced

`useSlider`'s track drag is delta-based and seeded its running position from the **thumb**:

```js
currentPosition.current = state.getThumbPercent(index) * size;
```

Press the track at 49px, the value adjusts to 50, and the seed becomes 50 while the cursor is at 49 — the thumb then runs 1px ahead of the pointer for the rest of the drag. Snapping made it obvious, but it already exists on `main`: press at 49.6 with `step={5}` and you are 0.4px out for the remainder. `useSliderThumb` never had it, because it seeds before any rounding.

Fixed by seeding from the pointer at mousedown, where the raw percent is already computed. There is a regression assertion for it in the new track test. This is the one change that alters existing behaviour, so it is the part worth reviewing hardest.

## Two decisions worth arguing with

**Pressing a mark doesn't start a drag.** A mark sits inside `SliderTrack`, which moves the nearest thumb to wherever the pointer landed — so without intercepting, the track overwrites the mark's exact value a moment later, and a label rendered outside the track's bounds gets no handling at all. The mark stops propagation and sets the value itself, which costs drag-from-a-tick. That matches the issue ("clicking on the label should move the slider to the corresponding value"), and a purely decorative tick is `pointer-events: none` plus an entry in `snapPoints`. Happy to revisit if you would rather keep drag-through.

**Marks are not focusable.** The thumb is the keyboard interface; a tab stop per tick would be a regression for keyboard users. They are plain elements, so authors can `aria-hidden` them where the content only repeats what the thumb announces — the docs say so.

## Blast radius

`useSliderState` and `useSlider` are shared by every slider in the repo, so this reaches RSP v3 `Slider`/`RangeSlider`/`ColorSlider`, S2 `Slider`/`RangeSlider`/`ColorSlider`, RAC `Slider`/`ColorSlider`/`ColorArea`/`ColorWheel`, and `useColorSliderState` (which spreads the base state, so it inherits everything). **116 suites / 2584 tests pass.**

Two things to flag rather than leave you to find:

- **`SliderState` gained a required method.** Anyone hand-rolling a `SliderState` rather than calling `useSliderState` gets a TypeScript error. Rare, and type-only, but real.
- **`setThumbPercent` is on the hot drag path** and now calls `getSnapPoint` on every pointer move. It returns on the first line without `snapPoints`, so existing sliders pay one property check per move.

## What this doesn't cover

- **Speed-sensitive snapping** ("the behavior may vary depending on movement speed"). macOS does this, but it is unspecified and I would be inventing a heuristic. Distance-based only.
- **Spectrum v3 / S2 tick marks.** There is no design spec in the repo for what a Spectrum tick looks like, and inventing the design system's visuals isn't a contributor's call. Happy to follow up if design weighs in.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Storybook: **React Aria Components → Slider → SliderMarks** (the macOS volume slider, with a `snapThreshold` control) and **SliderMarksWithLabels**.

1. **Drag the thumb** across the ticks — it should catch briefly at each one, then release and keep tracking the cursor with **no offset**. Drag past several and confirm the thumb stays under the pointer.
2. **Press a tick label** (SliderMarksWithLabels) — the thumb jumps to exactly that value and `onChangeEnd` fires once.
3. **Press the track** just beside a mark — snaps to the mark; continuing into a drag stays under the cursor.
4. **Keyboard** — focus the thumb and hold an arrow key. Movement is by `step` throughout, including across snap points.
5. **`snapThreshold: 0`** — snapping fully off.
6. **`isDisabled`** — marks get `data-disabled` and ignore presses.

### What I tested

- **Mouse and keyboard**, via the unit tests (143 existing slider tests unchanged and passing, 24 added) and by hand in a browser.
- **RTL and vertical**: unit tests assert position (`top: 75%` for a vertical mark at 25). The positioning expression is the one `SliderThumb` already uses, so marks and thumbs cannot drift apart.
- **Not verified by me**: real touch hardware, screen readers, forced-colors. The touch path is where I would most value a second pair of eyes — `pointerdown` and `touchstart` both fire, so one handler acts and the others stop propagation to keep the track from handling the press twice.

### On the default for `snapThreshold`

`0.02` of the track — roughly 6px on a 300px track. It is a judgement call about feel rather than something derived, and it is a published default, so if it reads wrong to you I would rather change it now than in a follow-up.

## 🧢 Your Project:

Personal / open source contribution.
