### PR TITLE
fix: preserve ComboBox selection when a controlled value is applied asynchronously

### DIFF
--- a/packages/react-aria-components/test/ComboBox.test.js
+++ b/packages/react-aria-components/test/ComboBox.test.js
@@ -368,6 +368,70 @@ describe('ComboBox', () => {
     }
   );
 
+  it('should not clear the selection when a fully controlled value is applied asynchronously', async () => {
+    let onSelectionChange = jest.fn();
+    let keyToText = {
+      1: 'Cat',
+      2: 'Dog',
+      3: 'Kangaroo'
+    };
+
+    // Form libraries such as Formik and react-hook-form apply the controlled value after
+    // running validation, so it lands in a later render than the one that reported it.
+    function ControlledComboBox() {
+      let [selectedKey, setSelectedKey] = useState(null);
+      let [inputValue, setInputValue] = useState('');
+
+      return (
+        <>
+          <ComboBox
+            selectedKey={selectedKey}
+            inputValue={inputValue}
+            onSelectionChange={key => {
+              onSelectionChange(key);
+              setTimeout(() => {
+                setSelectedKey(key);
+                setInputValue(key != null ? keyToText[key] : '');
+              }, 10);
+            }}
+            onInputChange={setInputValue}>
+            <Label>Favorite Animal</Label>
+            <Input />
+            <Button />
+            <Popover>
+              <ListBox>
+                <ListBoxItem id="1">Cat</ListBoxItem>
+                <ListBoxItem id="2">Dog</ListBoxItem>
+                <ListBoxItem id="3">Kangaroo</ListBoxItem>
+              </ListBox>
+            </Popover>
+          </ComboBox>
+          <button type="button">Next</button>
+        </>
+      );
+    }
+
+    let tree = render(<ControlledComboBox />);
+    let input = tree.getByRole('combobox');
+
+    await user.tab();
+    await user.keyboard('Do');
+    act(() => jest.runAllTimers());
+
+    // Select without letting the deferred update land first, so focus moves away while the
+    // controlled value still reports the previous selection.
+    await user.click(within(tree.getByRole('listbox')).getByRole('option', {name: 'Dog'}));
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange).toHaveBeenCalledWith('2');
+
+    await user.tab();
+    act(() => jest.runAllTimers());
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(input).toHaveValue('Dog');
+    expect(tree.queryByRole('listbox')).toBeNull();
+  });
+
   it('should support form reset', async () => {
     const tree = render(
       <form>

--- a/packages/react-stately/src/combobox/useComboBoxState.ts
+++ b/packages/react-stately/src/combobox/useComboBoxState.ts
@@ -228,11 +228,17 @@ export function useComboBoxState<T, M extends SelectionMode = 'single'>(
       ? controlledValue[0]
       : controlledValue;
 
+  // Tracks a selection that has been reported to the user but that the controlled value hasn't
+  // reflected back yet. Form libraries commonly apply the update asynchronously (e.g. after running
+  // validation), so the rendered selection is stale until then and must not be reported back.
+  let pendingValueRef = useRef<Key | null | undefined>(undefined);
+
   let setValue = (value: Key | Key[] | null) => {
     if (selectionMode === 'single') {
       let key = Array.isArray(value) ? (value[0] ?? null) : value;
       setControlledValue(key);
       if (key !== displayValue) {
+        pendingValueRef.current = key;
         props.onSelectionChange?.(key);
       }
     } else {
@@ -491,6 +497,10 @@ export function useComboBoxState<T, M extends SelectionMode = 'single'>(
       }
     }
 
+    if (displayValue !== lastValueRef.current) {
+      pendingValueRef.current = undefined;
+    }
+
     lastValueRef.current = displayValue;
     lastSelectedKeyText.current = selectedItemText;
   });
@@ -534,6 +544,13 @@ export function useComboBoxState<T, M extends SelectionMode = 'single'>(
     // If multiple things are controlled, call onSelectionChange only when selecting the focused item,
     // or when inputValue needs to be synced back to the selected item on commit/blur.
     if (value !== undefined && props.inputValue !== undefined) {
+      if (pendingValueRef.current !== undefined) {
+        // Stop menu from reopening from useEffect
+        setLastValue(inputValue);
+        closeMenu();
+        return;
+      }
+
       let itemText = selectedKey != null ? (collection.getItem(selectedKey)?.textValue ?? '') : '';
       if (shouldForceSelectionChange || selectionMode === 'multiple' || inputValue !== itemText) {
         props.onSelectionChange?.(selectedKey);
@@ -565,7 +582,11 @@ export function useComboBoxState<T, M extends SelectionMode = 'single'>(
     if (triggerState.isOpen && selectionManager.focusedKey != null) {
       // Reset inputValue and close menu here if the selected key is already the focused key. Otherwise
       // fire onSelectionChange to allow the application to control the closing.
-      if (selectionManager.isSelected(selectionManager.focusedKey) && selectionMode === 'single') {
+      if (
+        (selectionManager.isSelected(selectionManager.focusedKey) ||
+          pendingValueRef.current === selectionManager.focusedKey) &&
+        selectionMode === 'single'
+      ) {
         commitSelection(true);
       } else {
         selectionManager.select(selectionManager.focusedKey);


### PR DESCRIPTION
Closes #4621

## 🎯 Intent

When a ComboBox is driven by a form library (Formik, react-hook-form), `onSelectionChange` fires a
spurious extra call — the selected key, then immediately `null` — and the selection the user just
made is thrown away. The goal is that one user selection produces exactly one `onSelectionChange`
call, regardless of how quickly the app feeds the controlled value back.

## 🔍 What was happening

A fully controlled ComboBox (both `selectedKey`/`value` and `inputValue` owned by the app) reads the
selection out of the last rendered props. Form libraries run validation before they apply the new
value, so the update lands in a *later* render than the one that reported it. In the window in
between, the ComboBox still renders the previous selection.

If the field is committed during that window — blurring or tabbing away right after picking an
option — two things go wrong:

- `commit()` doesn't recognise the focused option as selected (the rendered selection hasn't caught
  up), so it re-selects it and fires `onSelectionChange` a second time with the same key.
- `commitSelection()` then reports the *rendered* selection back to the app to nudge it to re-sync
  `inputValue`. That rendered selection is stale — `null` — so it clobbers the pending selection.

Net result for one click: `onSelectionChange('2')`, `onSelectionChange('2')`, `onSelectionChange(null)`,
and an empty input. This is the "called twice, first with the selected value and immediately after
with null" from the issue, and why the reported workarounds (`setTimeout`, disabling validation,
keying the component off the error) all worked — each one removes the deferred update.

## 🔧 How this fixes it

`useComboBoxState` now remembers, in `pendingValueRef`, a selection it has already reported but that
the controlled value hasn't reflected back yet. The ref is set when `setValue` reports a new key and
cleared as soon as the controlled value changes, so it is only ever set during that in-between window
(and never in multiple selection mode, where the value isn't reported this way).

With that memory in place:

- `commit()` treats the focused option as already selected, so it stops re-selecting it.
- `commitSelection()` skips reporting the selection back while an update is pending — the app already
  knows about it — and just closes the menu.

Nothing changes when the app applies the value synchronously: the ref is cleared by the time anything
reads it, so the existing behaviour (including the "sync inputValue back on blur" nudge for unmatched
text) is untouched.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

New Jest test in `packages/react-aria-components/test/ComboBox.test.js`: "should not clear the
selection when a fully controlled value is applied asynchronously". It renders a fully controlled
ComboBox whose handler applies `selectedKey`/`inputValue` on a timer (standing in for a form
library's validation pass), picks an option, and tabs away before the update lands. Without the fix
it records 3 `onSelectionChange` calls and an empty input; with it, 1 call and `Dog` in the input.

To check by hand: wire a ComboBox to Formik or react-hook-form with `mode: 'onChange'` and a
controlled `selectedKey` + `inputValue`, pick an option from the menu, and immediately tab out of the
field. The selection should stick, and `onSelectionChange` should fire once.

Tested with mouse and keyboard. No visual, RTL, or styling changes — this is state-layer only.

## 🧢 Your Project:

N/A
