### PR TITLE
fix: NavigationTree updates from testing

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/NavigationTree.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/NavigationTree.mdx
@@ -17,20 +17,49 @@ export const description = 'A navigation component that displays a nested, hiera
 <ExampleSwitcher>
   ```tsx render docs={docs.exports.NavigationTree} links={docs.links} props={[]} type="vanilla" files={["starters/docs/src/NavigationTree.tsx", "starters/docs/src/NavigationTree.css", "packages/dev/s2-docs/pages/react-aria/RoutedNavigationTree.tsx"]}
   "use client";
-  import {NavigationTree, NavigationTreeItem} from 'vanilla-starter/NavigationTree';
+  import {NavigationTree, NavigationTreeItem, NavigationTreeItemContent, NavigationTreeItemLink} from 'vanilla-starter/NavigationTree';
+  import {Button} from 'vanilla-starter/Button';
+  import {MoreHorizontal} from 'lucide-react';
   import {RoutedNavigationTree} from './RoutedNavigationTree';
 
   <RoutedNavigationTree defaultSelectedRoute="/photos">
     {({selectedRoute}) => (
       <NavigationTree aria-label="Files" selectedRoute={selectedRoute} defaultExpandedKeys={['files']}>
-        <NavigationTreeItem id="home" href="/home" title="Home" />
-        <NavigationTreeItem id="files" href="/files" title="Files">
-          <NavigationTreeItem id="photos" href="/photos" title="Photos" />
-          <NavigationTreeItem id="videos" href="/videos" title="Videos" />
+        <NavigationTreeItem id="home" href="/home" textValue="Home">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
+          </NavigationTreeItemContent>
         </NavigationTreeItem>
-        <NavigationTreeItem id="shared" title="Shared">
-          <NavigationTreeItem id="food" href="/food" title="Food" />
-          <NavigationTreeItem id="drinks" href="/drinks" title="Drinks" />
+        <NavigationTreeItem id="files" href="/files" textValue="Files">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Files</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="photos" href="/photos" textValue="Photos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Photos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="videos" href="/videos" textValue="Videos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Videos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+        <NavigationTreeItem id="shared" textValue="Shared">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Shared</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="food" href="/food" textValue="Food">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Food</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="drinks" href="/drinks" textValue="Drinks">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Drinks</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
         </NavigationTreeItem>
       </NavigationTree>
     )}
@@ -39,20 +68,49 @@ export const description = 'A navigation component that displays a nested, hiera
 
   ```tsx render docs={docs.exports.NavigationTree} links={docs.links} props={[]} type="tailwind" files={["starters/tailwind/src/NavigationTree.tsx", "packages/dev/s2-docs/pages/react-aria/RoutedNavigationTree.tsx"]}
   "use client";
-  import {NavigationTree, NavigationTreeItem} from 'tailwind-starter/NavigationTree';
+  import {NavigationTree, NavigationTreeItem, NavigationTreeItemContent, NavigationTreeItemLink} from 'tailwind-starter/NavigationTree';
+  import {Button} from 'tailwind-starter/Button';
+  import {MoreHorizontal} from 'lucide-react';
   import {RoutedNavigationTree} from './RoutedNavigationTree';
 
   <RoutedNavigationTree defaultSelectedRoute="/photos">
     {({selectedRoute}) => (
       <NavigationTree aria-label="Files" selectedRoute={selectedRoute} defaultExpandedKeys={['files']}>
-        <NavigationTreeItem id="home" href="/home" title="Home" />
-        <NavigationTreeItem id="files" href="/files" title="Files">
-          <NavigationTreeItem id="photos" href="/photos" title="Photos" />
-          <NavigationTreeItem id="videos" href="/videos" title="Videos" />
+        <NavigationTreeItem id="home" href="/home" textValue="Home">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
+          </NavigationTreeItemContent>
         </NavigationTreeItem>
-        <NavigationTreeItem id="shared" title="Shared">
-          <NavigationTreeItem id="food" href="/food" title="Food" />
-          <NavigationTreeItem id="drinks" href="/drinks" title="Drinks" />
+        <NavigationTreeItem id="files" href="/files" textValue="Files">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Files</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="photos" href="/photos" textValue="Photos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Photos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="videos" href="/videos" textValue="Videos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Videos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+        <NavigationTreeItem id="shared" textValue="Shared">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Shared</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="food" href="/food" textValue="Food">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Food</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="drinks" href="/drinks" textValue="Drinks">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Drinks</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
         </NavigationTreeItem>
       </NavigationTree>
     )}
@@ -72,7 +130,7 @@ export const description = 'A navigation component that displays a nested, hiera
 
 ```tsx render files={["packages/dev/s2-docs/pages/react-aria/RoutedNavigationTree.tsx"]}
 "use client";
-import {NavigationTree, NavigationTreeItem} from 'vanilla-starter/NavigationTree';
+import {NavigationTree, NavigationTreeItem, NavigationTreeItemContent, NavigationTreeItemLink} from 'vanilla-starter/NavigationTree';
 import {RoutedNavigationTree} from './RoutedNavigationTree';
 
 function Example() {
@@ -87,7 +145,13 @@ function Example() {
       {({selectedRoute}) => (
         /*- begin highlight -*/
         <NavigationTree aria-label="Sections" items={items} selectedRoute={selectedRoute}>
-          {item => <NavigationTreeItem href={item.url} title={item.label} />}
+          {item => (
+            <NavigationTreeItem href={item.url} textValue={item.label}>
+              <NavigationTreeItemContent>
+                <NavigationTreeItemLink>{item.label}</NavigationTreeItemLink>
+              </NavigationTreeItemContent>
+            </NavigationTreeItem>
+          )}
         </NavigationTree>
         /*- end highlight -*/
       )}
@@ -102,7 +166,7 @@ Use `NavigationTreeSection` to group related items, with an optional `Navigation
 
 ```tsx render files={["packages/dev/s2-docs/pages/react-aria/RoutedNavigationTree.tsx"]}
 "use client";
-import {NavigationTree, NavigationTreeItem, NavigationTreeSection, NavigationTreeHeader} from 'vanilla-starter/NavigationTree';
+import {NavigationTree, NavigationTreeItem, NavigationTreeItemContent, NavigationTreeItemLink, NavigationTreeSection, NavigationTreeHeader} from 'vanilla-starter/NavigationTree';
 import {RoutedNavigationTree} from './RoutedNavigationTree';
 
 <RoutedNavigationTree defaultSelectedRoute="/projects/apollo">
@@ -111,14 +175,30 @@ import {RoutedNavigationTree} from './RoutedNavigationTree';
       {/*- begin highlight -*/}
       <NavigationTreeSection>
         <NavigationTreeHeader>Personal</NavigationTreeHeader>
-        <NavigationTreeItem href="/home" title="Home" />
-        <NavigationTreeItem href="/starred" title="Starred" />
+        <NavigationTreeItem href="/home" textValue="Home">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+        <NavigationTreeItem href="/starred" textValue="Starred">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Starred</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
       </NavigationTreeSection>
       {/*- end highlight -*/}
       <NavigationTreeSection>
         <NavigationTreeHeader>Projects</NavigationTreeHeader>
-        <NavigationTreeItem href="/projects/apollo" title="Apollo" />
-        <NavigationTreeItem href="/projects/gemini" title="Gemini" />
+        <NavigationTreeItem href="/projects/apollo" textValue="Apollo">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Apollo</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+        <NavigationTreeItem href="/projects/gemini" textValue="Gemini">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Gemini</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
       </NavigationTreeSection>
     </NavigationTree>
   )}
@@ -133,7 +213,7 @@ Combine `NavigationTree` with a client side router by wrapping your app in a [Ro
 
 ```tsx render
 "use client";
-import {NavigationTree, NavigationTreeItem} from 'vanilla-starter/NavigationTree';
+import {NavigationTree, NavigationTreeItem, NavigationTreeItemContent, NavigationTreeItemLink} from 'vanilla-starter/NavigationTree';
 import {RouterProvider} from 'react-aria-components';
 import {useState} from 'react';
 
@@ -144,9 +224,21 @@ function Example() {
     <RouterProvider navigate={setRoute}>
       {/*- end highlight -*/}
       <NavigationTree aria-label="Mail" selectedRoute={route}>
-        <NavigationTreeItem href="/inbox" title="Inbox" />
-        <NavigationTreeItem href="/drafts" title="Drafts" />
-        <NavigationTreeItem href="/sent" title="Sent" />
+        <NavigationTreeItem href="/inbox" textValue="Inbox">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Inbox</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+        <NavigationTreeItem href="/drafts" textValue="Drafts">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Drafts</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+        <NavigationTreeItem href="/sent" textValue="Sent">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Sent</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
       </NavigationTree>
     </RouterProvider>
   );

--- a/packages/dev/s2-docs/pages/react-aria/NavigationTree.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/NavigationTree.mdx
@@ -34,30 +34,36 @@ export const description = 'A navigation component that displays a nested, hiera
         <NavigationTreeItem id="files" href="/files" textValue="Files">
           <NavigationTreeItemContent>
             <NavigationTreeItemLink>Files</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
           </NavigationTreeItemContent>
           <NavigationTreeItem id="photos" href="/photos" textValue="Photos">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Photos</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
           <NavigationTreeItem id="videos" href="/videos" textValue="Videos">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Videos</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
         </NavigationTreeItem>
         <NavigationTreeItem id="shared" textValue="Shared">
           <NavigationTreeItemContent>
             <NavigationTreeItemLink>Shared</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
           </NavigationTreeItemContent>
           <NavigationTreeItem id="food" href="/food" textValue="Food">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Food</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
           <NavigationTreeItem id="drinks" href="/drinks" textValue="Drinks">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Drinks</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
         </NavigationTreeItem>
@@ -85,30 +91,36 @@ export const description = 'A navigation component that displays a nested, hiera
         <NavigationTreeItem id="files" href="/files" textValue="Files">
           <NavigationTreeItemContent>
             <NavigationTreeItemLink>Files</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
           </NavigationTreeItemContent>
           <NavigationTreeItem id="photos" href="/photos" textValue="Photos">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Photos</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
           <NavigationTreeItem id="videos" href="/videos" textValue="Videos">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Videos</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
         </NavigationTreeItem>
         <NavigationTreeItem id="shared" textValue="Shared">
           <NavigationTreeItemContent>
             <NavigationTreeItemLink>Shared</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
           </NavigationTreeItemContent>
           <NavigationTreeItem id="food" href="/food" textValue="Food">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Food</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
           <NavigationTreeItem id="drinks" href="/drinks" textValue="Drinks">
             <NavigationTreeItemContent>
               <NavigationTreeItemLink>Drinks</NavigationTreeItemLink>
+              <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
             </NavigationTreeItemContent>
           </NavigationTreeItem>
         </NavigationTreeItem>

--- a/packages/dev/s2-docs/pages/react-aria/NavigationTree.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/NavigationTree.mdx
@@ -119,11 +119,6 @@ export const description = 'A navigation component that displays a nested, hiera
 
 </ExampleSwitcher>
 
-<InlineAlert variant="notice">
-  <Heading>Accessibility</Heading>
-  <Content>`NavigationTree` renders as a tree so keyboard users can navigate and expand the hierarchy. When it acts as the main navigation for a page, place it inside a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html): wrap the `NavigationTree` in a `<nav>` element with an `aria-label` so assistive technology users can quickly find it.</Content>
-</InlineAlert>
-
 ## Content
 
 `NavigationTree` follows the [Collection Components API](collections?component=NavigationTree), accepting both static and dynamic collections. The example above shows a static collection. This example shows a dynamic collection, passing a list of objects to the `items` prop and a function to render the children.
@@ -159,6 +154,11 @@ function Example() {
   );
 }
 ```
+
+<InlineAlert variant="notice">
+  <Heading>Accessibility</Heading>
+  <Content>`NavigationTree` renders as a tree so keyboard users can navigate and expand the hierarchy. When it acts as the main navigation for a page, place it inside a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html): wrap the `NavigationTree` in a `<nav>` element with an `aria-label` so assistive technology users can quickly find it.</Content>
+</InlineAlert>
 
 ### Sections
 

--- a/packages/dev/s2-docs/src/ComponentCard.tsx
+++ b/packages/dev/s2-docs/src/ComponentCard.tsx
@@ -268,6 +268,7 @@ const componentIllustrations: Record<string, [string, string] | undefined> = {
   Meter: [MeterLight, MeterDark],
   'Migrating to Spectrum 2': [MigratingLight, MigratingDark],
   Modal: [DialogLight, DialogDark],
+  NavigationTree: [SideNavLight, SideNavDark],
   NumberField: [NumberFieldLight, NumberFieldDark],
   Picker: [PickerLight, PickerDark],
   Popover: [PopoverLight, PopoverDark],

--- a/packages/react-aria-components/src/NavigationTree.tsx
+++ b/packages/react-aria-components/src/NavigationTree.tsx
@@ -22,6 +22,7 @@ import {
 import {Collection, forwardRefType, Key, Node, RouterOptions} from '@react-types/shared';
 import {getScrollParent} from 'react-aria/private/utils/getScrollParent';
 import {LinkContext} from './Link';
+import {nodeContains} from 'react-aria/private/utils/shadowdom/DOMFunctions';
 import React, {
   createContext,
   ForwardedRef,
@@ -133,10 +134,7 @@ export const NavigationTree = /*#__PURE__*/ (forwardRef as forwardRefType)(funct
   let {className, style, children, selectedRoute, ...rest} = props;
   let syncedRouteRef = useRef<string | undefined>(undefined);
   let treeRef = useObjectRef(ref);
-  let context = useMemo(
-    () => ({selectedRoute, syncedRouteRef, treeRef}),
-    [selectedRoute, treeRef]
-  );
+  let context = useMemo(() => ({selectedRoute, syncedRouteRef, treeRef}), [selectedRoute, treeRef]);
 
   return (
     <InternalNavigationTreeContext.Provider value={context}>
@@ -242,7 +240,7 @@ export const NavigationTreeItem = /*#__PURE__*/ (forwardRef as forwardRefType)(
         // page. When the tree isn't its own scroll container the nearest scroll parent is outside the
         // tree, so we skip rather than hijack the surrounding scroll position.
         let treeRoot = treeRef?.current;
-        if (treeRoot && treeRoot.contains(scrollParent)) {
+        if (treeRoot && nodeContains(treeRoot, scrollParent)) {
           scrollIntoView(scrollParent, objRef.current, {block: 'center'});
         }
       }

--- a/packages/react-aria-components/src/NavigationTree.tsx
+++ b/packages/react-aria-components/src/NavigationTree.tsx
@@ -60,6 +60,8 @@ interface InternalNavigationTreeContextValue {
   selectedRoute?: string | null;
   /** The last route the focused key was synced to; dedupes the focus sync across items. */
   syncedRouteRef?: RefObject<string | undefined>;
+  /** The NavigationTree's root element, used to keep current-route scrolling inside the tree. */
+  treeRef?: RefObject<HTMLDivElement | null>;
 }
 const InternalNavigationTreeContext = createContext<InternalNavigationTreeContextValue>({});
 
@@ -130,13 +132,17 @@ export const NavigationTree = /*#__PURE__*/ (forwardRef as forwardRefType)(funct
   [props, ref] = useContextProps(props, ref, NavigationTreeContext);
   let {className, style, children, selectedRoute, ...rest} = props;
   let syncedRouteRef = useRef<string | undefined>(undefined);
-  let context = useMemo(() => ({selectedRoute, syncedRouteRef}), [selectedRoute]);
+  let treeRef = useObjectRef(ref);
+  let context = useMemo(
+    () => ({selectedRoute, syncedRouteRef, treeRef}),
+    [selectedRoute, treeRef]
+  );
 
   return (
     <InternalNavigationTreeContext.Provider value={context}>
       <Tree
         {...rest}
-        ref={ref}
+        ref={treeRef}
         className={className ?? 'react-aria-NavigationTree'}
         style={style}
         selectionMode="none"
@@ -213,7 +219,7 @@ export const NavigationTreeItem = /*#__PURE__*/ (forwardRef as forwardRefType)(
       render,
       ...rest
     } = props;
-    let {selectedRoute} = useContext(InternalNavigationTreeContext);
+    let {selectedRoute, treeRef} = useContext(InternalNavigationTreeContext);
     let hasLink = href != null && href.length > 0;
     let isCurrent = hasLink && href === selectedRoute;
     let [isLinkFocused, setLinkFocused] = useState(false);
@@ -232,9 +238,15 @@ export const NavigationTreeItem = /*#__PURE__*/ (forwardRef as forwardRefType)(
     useEffect(() => {
       if (isCurrent && objRef.current) {
         let scrollParent = getScrollParent(objRef.current, true) as HTMLElement;
-        scrollIntoView(scrollParent, objRef.current, {block: 'center'});
+        // Only scroll the tree's own scroll container into view — never an outer ancestor such as the
+        // page. When the tree isn't its own scroll container the nearest scroll parent is outside the
+        // tree, so we skip rather than hijack the surrounding scroll position.
+        let treeRoot = treeRef?.current;
+        if (treeRoot && treeRoot.contains(scrollParent)) {
+          scrollIntoView(scrollParent, objRef.current, {block: 'center'});
+        }
       }
-    }, [isCurrent, objRef]);
+    }, [isCurrent, objRef, treeRef]);
 
     return (
       <NavigationTreeItemLinkContext.Provider
@@ -427,7 +439,7 @@ interface NavigationTreeItemContentInnerProps {
 function NavigationTreeItemContentInner(props: NavigationTreeItemContentInnerProps): ReactNode {
   let {treeRenderProps, linkCtx, children} = props;
   let {isCurrent, isLinkFocused, setLinkFocused, ...linkProps} = linkCtx;
-  let {state, isFocusVisible, isFocusVisibleWithin} = treeRenderProps;
+  let {state, isFocusVisible, isFocusVisibleWithin, id, hasChildItems} = treeRenderProps;
   let {isCurrentAncestor} = useContext(NavigationTreeItemStateContext);
 
   useRouteFocusSync({state});
@@ -446,7 +458,8 @@ function NavigationTreeItemContentInner(props: NavigationTreeItemContentInnerPro
   let linkContextValue = {
     ...linkProps,
     'aria-current': isCurrent ? 'page' : undefined,
-    onFocusChange: setLinkFocused
+    onFocusChange: setLinkFocused,
+    onPress: linkProps.href == null && hasChildItems ? () => state.toggleKey(id) : undefined
   };
   return <Provider values={[[LinkContext, linkContextValue]]}>{renderChildren}</Provider>;
 }

--- a/packages/react-aria-components/test/NavigationTree.test.tsx
+++ b/packages/react-aria-components/test/NavigationTree.test.tsx
@@ -112,6 +112,26 @@ function NoLinkActionMenuNavigationTreeExample(props: Partial<NavigationTreeProp
   );
 }
 
+function NoHrefLinkNavigationTreeExample(props: Partial<NavigationTreeProps<unknown>>) {
+  return (
+    <NavigationTree aria-label="Test NavigationTree" {...props}>
+      <NavigationTreeItem id="section" textValue="Section">
+        <NavigationTreeItemContent>
+          <Link>Section</Link>
+          <Button slot="chevron" aria-label="expand">
+            ▶
+          </Button>
+        </NavigationTreeItemContent>
+        <NavigationTreeItem id="section-2" href="/section-2" textValue="Section 2">
+          <NavigationTreeItemContent>
+            <Link>Section 2</Link>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+      </NavigationTreeItem>
+    </NavigationTree>
+  );
+}
+
 // Section 1 has an aria-label instead of a NavigationTreeHeader (as is allowed by the underlying
 // TreeSection); Section 2 uses a NavigationTreeHeader so both default classes get covered.
 function SectionNavigationTreeExample(props: Partial<NavigationTreeProps<unknown>>) {
@@ -346,6 +366,18 @@ describe('NavigationTree', () => {
     let sectionRow = getByRole('row', {name: 'Section'});
     expect(sectionRow).toHaveFocus();
     expect(within(sectionRow).getByRole('button', {name: 'More actions'})).not.toHaveFocus();
+  });
+
+  it('toggles expansion when pressing the label (a no-href Link) of a parent row', async () => {
+    let {getByRole} = render(<NoHrefLinkNavigationTreeExample />);
+    let sectionRow = getByRole('row', {name: 'Section'});
+    expect(sectionRow).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(within(sectionRow).getByRole('link', {name: 'Section'}));
+    expect(sectionRow).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(within(sectionRow).getByRole('link', {name: 'Section'}));
+    expect(sectionRow).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('arrow left from a deep leaf steps to parent, collapses it, then moves to the grandparent', async () => {

--- a/starters/docs/src/NavigationTree.css
+++ b/starters/docs/src/NavigationTree.css
@@ -45,19 +45,24 @@
   /* Indent each nested level. --tree-item-level is set on the row by React Aria (1-based). */
   padding-inline-start: calc((var(--tree-item-level, 1) - 1) * var(--padding));
 
-  /* The hover indicator lights up for any interactable row (links and expandable categories),
-   * matching React Aria's data-hovered, which is only set on actionable rows. */
-  &[data-hovered] a.react-aria-Link:before {
+  .react-aria-Link:before {
+    display: none;
     content: '';
     position: absolute;
     inset-inline-start: 2px;
     top: 50%;
-    width: 4px;
+    width: 2px;
     transform: translateY(-50%);
     height: 1lh;
     background: var(--text-color-hover);
     font-weight: 600;
     border-radius: 9999px;
+  }
+
+  /* The hover indicator lights up for any interactable row (links and expandable categories),
+   * matching React Aria's data-hovered, which is only set on actionable rows. */
+  &[data-hovered] a.react-aria-Link:before {
+    display: block;
   }
 
   /* When a current-route ancestor is collapsed, tint it and show a small dot where the pill would be.
@@ -67,30 +72,16 @@
    * row renders as a link or a plain span. */
   &[data-current-ancestor]:not([data-expanded]) {
     .react-aria-Link:before {
-      content: '';
-      position: absolute;
-      inset-inline-start: 2px;
-      top: 50%;
-      width: 4px;
+      display: block;
       height: 4px;
-      transform: translateY(-50%);
-      background: var(--text-color-hover);
-      border-radius: 9999px;
+      width: 4px;
     }
   }
 
   /* React Aria sets data-current on the link matching the NavigationTree's selectedRoute. */
-  &[data-current]:not([data-hovered]) .react-aria-Link:before {
-    content: '';
-    position: absolute;
-    inset-inline-start: 2px;
-    top: 50%;
-    width: 4px;
-    transform: translateY(-50%);
-    height: 1lh;
+  &[data-current] .react-aria-Link:before {
+    display: block;
     background: var(--highlight-background);
-    font-weight: 600;
-    border-radius: 9999px;
   }
 
   &[data-focus-visible] {

--- a/starters/docs/src/NavigationTree.css
+++ b/starters/docs/src/NavigationTree.css
@@ -42,6 +42,7 @@
   outline: none;
   color: var(--text-color);
   font: var(--font-size) system-ui;
+  -webkit-tap-highlight-color: transparent;
   /* Indent each nested level. --tree-item-level is set on the row by React Aria (1-based). */
   padding-inline-start: calc((var(--tree-item-level, 1) - 1) * var(--padding));
 
@@ -59,9 +60,7 @@
     border-radius: 9999px;
   }
 
-  /* The hover indicator lights up for any interactable row (links and expandable categories),
-   * matching React Aria's data-hovered, which is only set on actionable rows. */
-  &[data-hovered] a.react-aria-Link:before {
+  a.react-aria-Link[data-hovered]:before {
     display: block;
   }
 

--- a/starters/docs/src/NavigationTree.tsx
+++ b/starters/docs/src/NavigationTree.tsx
@@ -2,6 +2,7 @@
 import {
   Button,
   Link,
+  type LinkProps,
   NavigationTree as AriaNavigationTree,
   NavigationTreeHeader as AriaNavigationTreeHeader,
   type NavigationTreeHeaderProps,
@@ -26,39 +27,21 @@ export function NavigationTreeItemContent(props: {children?: React.ReactNode}) {
     <AriaNavigationTreeItemContent>
       {({hasChildItems}: NavigationTreeItemContentRenderProps) => (
         <>
-          {/* The label is rendered as a Link so it becomes the row's focusable child. It picks up
-           * href + aria-current automatically from the NavigationTree. Rows without an href render as a
-           * span instead of an anchor. */}
-          <Link>{props.children}</Link>
-          {hasChildItems && (
-            <Button slot="chevron">
-              <ChevronRight aria-hidden />
-            </Button>
-          )}
+          {props.children}
+          <Button
+            slot="chevron"
+            isDisabled={!hasChildItems}
+            style={{visibility: hasChildItems ? undefined : 'hidden'}}>
+            <ChevronRight aria-hidden />
+          </Button>
         </>
       )}
     </AriaNavigationTreeItemContent>
   );
 }
 
-export interface NavigationTreeItemProps extends Partial<AriaNavigationTreeItemProps> {
-  title?: React.ReactNode;
-}
-
-export function NavigationTreeItem(props: NavigationTreeItemProps) {
-  let textValue = typeof props.title === 'string' ? props.title : '';
-  return (
-    <AriaNavigationTreeItem textValue={textValue} {...props}>
-      {props.title != null ? (
-        <>
-          <NavigationTreeItemContent>{props.title}</NavigationTreeItemContent>
-          {props.children}
-        </>
-      ) : (
-        props.children
-      )}
-    </AriaNavigationTreeItem>
-  );
+export function NavigationTreeItem(props: AriaNavigationTreeItemProps) {
+  return <AriaNavigationTreeItem {...props} />;
 }
 
 export function NavigationTreeSection<T extends object>(props: NavigationTreeSectionProps<T>) {
@@ -67,4 +50,8 @@ export function NavigationTreeSection<T extends object>(props: NavigationTreeSec
 
 export function NavigationTreeHeader(props: NavigationTreeHeaderProps) {
   return <AriaNavigationTreeHeader {...props} />;
+}
+
+export function NavigationTreeItemLink(props: LinkProps) {
+  return <Link {...props} />;
 }

--- a/starters/docs/stories/NavigationTree.stories.tsx
+++ b/starters/docs/stories/NavigationTree.stories.tsx
@@ -25,11 +25,13 @@ export default meta;
 type Story = StoryFn<typeof NavigationTree>;
 
 function RoutedNavigationTree(props: {
-  children: ({selectedRoute}: {selectedRoute: string}) => ReactNode,
-  defaultSelectedRoute: string
+  children: ({selectedRoute}: {selectedRoute: string}) => ReactNode;
+  defaultSelectedRoute: string;
 }) {
   let [selectedRoute, setSelectedRoute] = useState(props.defaultSelectedRoute);
-  return <RouterProvider navigate={setSelectedRoute}>{props.children({selectedRoute})}</RouterProvider>;
+  return (
+    <RouterProvider navigate={setSelectedRoute}>{props.children({selectedRoute})}</RouterProvider>
+  );
 }
 
 export const Example: Story = args => (
@@ -43,7 +45,9 @@ export const Example: Story = args => (
         <NavigationTreeItem id="home" href="/home" textValue="Home">
           <NavigationTreeItemContent>
             <NavigationTreeItemLink>Home</NavigationTreeItemLink>
-            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
+            <Button variant="quiet" aria-label="More options">
+              <MoreHorizontal size={16} aria-hidden />
+            </Button>
           </NavigationTreeItemContent>
         </NavigationTreeItem>
         <NavigationTreeItem id="files" href="/files" textValue="Files">

--- a/starters/docs/stories/NavigationTree.stories.tsx
+++ b/starters/docs/stories/NavigationTree.stories.tsx
@@ -1,0 +1,117 @@
+import {Button} from '../src/Button';
+import type {Meta, StoryFn} from '@storybook/react';
+import {MoreHorizontal} from 'lucide-react';
+import {
+  NavigationTree,
+  NavigationTreeItem,
+  NavigationTreeItemContent,
+  NavigationTreeItemLink,
+  NavigationTreeSection,
+  NavigationTreeHeader
+} from '../src/NavigationTree';
+import React, {type ReactNode, useState} from 'react';
+import {RouterProvider} from 'react-aria-components';
+
+const meta: Meta<typeof NavigationTree> = {
+  component: NavigationTree,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryFn<typeof NavigationTree>;
+
+function RoutedNavigationTree(props: {
+  children: ({selectedRoute}: {selectedRoute: string}) => ReactNode,
+  defaultSelectedRoute: string
+}) {
+  let [selectedRoute, setSelectedRoute] = useState(props.defaultSelectedRoute);
+  return <RouterProvider navigate={setSelectedRoute}>{props.children({selectedRoute})}</RouterProvider>;
+}
+
+export const Example: Story = args => (
+  <RoutedNavigationTree defaultSelectedRoute="/photos">
+    {({selectedRoute}) => (
+      <NavigationTree
+        aria-label="Files"
+        selectedRoute={selectedRoute}
+        defaultExpandedKeys={['files']}
+        {...args}>
+        <NavigationTreeItem id="home" href="/home" textValue="Home">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+        <NavigationTreeItem id="files" href="/files" textValue="Files">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Files</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="photos" href="/photos" textValue="Photos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Photos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="videos" href="/videos" textValue="Videos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Videos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+        <NavigationTreeItem id="shared" textValue="Shared">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Shared</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="food" href="/food" textValue="Food">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Food</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="drinks" href="/drinks" textValue="Drinks">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Drinks</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+      </NavigationTree>
+    )}
+  </RoutedNavigationTree>
+);
+
+export const Sections: Story = args => (
+  <RoutedNavigationTree defaultSelectedRoute="/projects/apollo">
+    {({selectedRoute}) => (
+      <NavigationTree aria-label="Workspace" selectedRoute={selectedRoute} {...args}>
+        <NavigationTreeSection>
+          <NavigationTreeHeader>Personal</NavigationTreeHeader>
+          <NavigationTreeItem href="/home" textValue="Home">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem href="/starred" textValue="Starred">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Starred</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeSection>
+        <NavigationTreeSection>
+          <NavigationTreeHeader>Projects</NavigationTreeHeader>
+          <NavigationTreeItem href="/projects/apollo" textValue="Apollo">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Apollo</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem href="/projects/gemini" textValue="Gemini">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Gemini</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeSection>
+      </NavigationTree>
+    )}
+  </RoutedNavigationTree>
+);

--- a/starters/tailwind/src/NavigationTree.tsx
+++ b/starters/tailwind/src/NavigationTree.tsx
@@ -123,7 +123,8 @@ export function NavigationTreeItemContent(props: {children?: React.ReactNode}) {
               slot="chevron"
               isDisabled={!hasChildItems}
               className={({isFocusVisible}) =>
-                expandButton({isFocusVisible, className: hasChildItems ? undefined : 'invisible'})}>
+                expandButton({isFocusVisible, className: hasChildItems ? undefined : 'invisible'})
+              }>
               <ChevronRight aria-hidden className={chevron({isExpanded})} />
             </Button>
           </>
@@ -133,11 +134,7 @@ export function NavigationTreeItemContent(props: {children?: React.ReactNode}) {
   );
 }
 
-export interface NavigationTreeItemProps extends Partial<AriaNavigationTreeItemProps> {
-  title?: React.ReactNode;
-}
-
-export function NavigationTreeItem(props: NavigationTreeItemProps) {
+export function NavigationTreeItem(props: AriaNavigationTreeItemProps) {
   return <AriaNavigationTreeItem className={itemStyles} {...props} />;
 }
 
@@ -154,7 +151,11 @@ export function NavigationTreeHeader(props: NavigationTreeHeaderProps) {
   );
 }
 
-export function NavigationTreeItemLink(props: LinkProps) {
+export interface NavigationTreeItemLinkProps extends Omit<LinkProps, 'children'> {
+  children?: React.ReactNode;
+}
+
+export function NavigationTreeItemLink(props: NavigationTreeItemLinkProps) {
   let {indicator} = React.useContext(NavTreeLinkContext);
   return (
     <Link {...props} className={({isDisabled}) => linkStyles({isDisabled})}>

--- a/starters/tailwind/src/NavigationTree.tsx
+++ b/starters/tailwind/src/NavigationTree.tsx
@@ -2,6 +2,7 @@
 import {
   Button,
   Link,
+  type LinkProps,
   NavigationTree as AriaNavigationTree,
   NavigationTreeHeader as AriaNavigationTreeHeader,
   type NavigationTreeHeaderProps,
@@ -31,8 +32,8 @@ export function NavigationTree<T>({children, ...props}: NavigationTreeProps<T>) 
 }
 
 // The focus ring lives on the row (not the link) so it spans the whole item. Hover/current/ancestor
-// state is surfaced as a leading-edge indicator on the Link (see linkStyles) rather than a full-row
-// background. The row is a `group` so the Link can react to the row's data-* attributes. isFocusVisible
+// state is surfaced as a leading-edge indicator (see indicatorStyles) rather than a full-row
+// background. The row is a `group` so the indicator can react to the row's data-* attributes. isFocusVisible
 // comes from the render props; RAC's isFocusVisible already follows the link (it is not true when
 // another child, e.g. a button, is focused).
 const itemStyles = tv({
@@ -45,33 +46,34 @@ const itemStyles = tv({
   }
 });
 
-// A single `before` pseudo-element on the Link is the leading-edge indicator; the row's data-*
-// attributes (via `group-[...]`) decide how it looks so the three states never overlap:
-//   - Hover pill (neutral, full height): only rows that render as a link (`data-href`) light up on
-//     hover, matching RAC's data-hovered on actionable rows.
-//   - Current pill (blue, full height): the selected row, but only when it is not also hovered, so
-//     hovering the selected row shows the neutral hover pill instead (never both).
-//   - Ancestor dot (neutral, short): a collapsed ancestor of the current route shows a small dot in
-//     the same spot. It shortens the height (higher specificity than the base) and shares the neutral
-//     color with hover, so hovering a collapsed ancestor still reads as the dot, not a full pill.
-// Works for ancestors that render as a link or a plain span since it keys off the row, not the element.
 const linkStyles = tv({
   base:
     'relative flex-1 min-w-0 flex items-center gap-2 py-1.5 px-2 text-sm no-underline text-current cursor-pointer outline-none ' +
     // A row without an href renders its label as a non-interactive span, so it should not look clickable.
-    'group-[:not([data-href])]:cursor-default ' +
-    "before:content-[''] before:absolute before:start-0.5 before:top-1/2 before:h-[1lh] before:w-1 before:-translate-y-1/2 before:rounded-full before:forced-color-adjust-none " +
-    'group-[[data-hovered][data-href]]:before:bg-neutral-400 dark:group-[[data-hovered][data-href]]:before:bg-neutral-500 ' +
-    'group-[[data-current]:not([data-hovered])]:before:bg-blue-600 dark:group-[[data-current]:not([data-hovered])]:before:bg-blue-400 ' +
-    'group-[[data-current-ancestor]:not([data-expanded])]:before:h-1 group-[[data-current-ancestor]:not([data-expanded])]:before:bg-neutral-400 dark:group-[[data-current-ancestor]:not([data-expanded])]:before:bg-neutral-500 ' +
-    // In forced-colors mode authored backgrounds are dropped, so whenever the indicator is showing
-    // (any of the three states above) render it as the system Highlight color instead.
-    'forced-colors:group-[:is([data-hovered][data-href],[data-current]:not([data-hovered]),[data-current-ancestor]:not([data-expanded]))]:before:bg-[Highlight]',
+    'group-[:not([data-href])]:cursor-default',
   variants: {
     isDisabled: {
       true: 'cursor-default'
     }
   }
+});
+
+// The leading-edge indicator is a real, presentational element (aria-hidden). Its variant is chosen in
+// JS (see NavigationTreeItemContent) and surfaced as a single `data-indicator` attribute, so the styles
+// stay flat and precedence lives in one place instead of relying on CSS specificity:
+//   - current (blue pill): the selected row. Because the variant is picked in JS, it keeps this color
+//     even while hovered.
+//   - ancestor (neutral dot): a collapsed ancestor of the current route.
+//   - hover (neutral pill): any actionable row on hover.
+const indicatorStyles = tv({
+  base:
+    'absolute start-0.5 top-1/2 -translate-y-1/2 w-0.5 h-[1lh] rounded-full forced-color-adjust-none ' +
+    // Only real link rows (the group row has data-href) get the hover pill.
+    'group-[[data-href]]:data-[indicator=hover]:bg-neutral-400 dark:group-[[data-href]]:data-[indicator=hover]:bg-neutral-500 ' +
+    'data-[indicator=current]:bg-blue-600 dark:data-[indicator=current]:bg-blue-400 ' +
+    'data-[indicator=ancestor]:h-1 data-[indicator=ancestor]:w-1 data-[indicator=ancestor]:bg-neutral-400 dark:data-[indicator=ancestor]:bg-neutral-500 ' +
+    // In forced-colors mode authored backgrounds are dropped, so render any visible state as Highlight.
+    'forced-colors:data-[indicator]:bg-[Highlight]'
 });
 
 const expandButton = tv({
@@ -88,25 +90,45 @@ const chevron = tv({
   }
 });
 
+const NavTreeLinkContext = React.createContext<{
+  indicator: 'current' | 'ancestor' | 'hover' | undefined;
+}>({indicator: undefined});
+
 export function NavigationTreeItemContent(props: {children?: React.ReactNode}) {
   return (
     <AriaNavigationTreeItemContent>
-      {({level, hasChildItems, isDisabled, isExpanded}) => (
-        <>
-          {level > 1 && (
-            <div
-              className="shrink-0"
-              style={{width: `calc((${level} - 1) * calc(var(--spacing) * 4))`}}
-            />
-          )}
-          <Link className={linkStyles({isDisabled})}>{props.children}</Link>
-          {hasChildItems && (
-            <Button slot="chevron" className={({isFocusVisible}) => expandButton({isFocusVisible})}>
+      {({level, hasChildItems, isExpanded, isHovered, isCurrent, isCurrentAncestor}) => {
+        // Pick the indicator variant here so precedence is explicit: a current row keeps its color even
+        // while hovered, then a collapsed current-route ancestor, then hover on any actionable row.
+        let indicator: 'current' | 'ancestor' | 'hover' | undefined;
+        if (isCurrent) {
+          indicator = 'current';
+        } else if (isCurrentAncestor && !isExpanded) {
+          indicator = 'ancestor';
+        } else if (isHovered) {
+          indicator = 'hover';
+        }
+        return (
+          <>
+            {level > 1 && (
+              <div
+                className="shrink-0"
+                style={{width: `calc((${level} - 1) * calc(var(--spacing) * 4))`}}
+              />
+            )}
+            <NavTreeLinkContext.Provider value={{indicator}}>
+              {props.children}
+            </NavTreeLinkContext.Provider>
+            <Button
+              slot="chevron"
+              isDisabled={!hasChildItems}
+              className={({isFocusVisible}) =>
+                expandButton({isFocusVisible, className: hasChildItems ? undefined : 'invisible'})}>
               <ChevronRight aria-hidden className={chevron({isExpanded})} />
             </Button>
-          )}
-        </>
-      )}
+          </>
+        );
+      }}
     </AriaNavigationTreeItemContent>
   );
 }
@@ -116,13 +138,7 @@ export interface NavigationTreeItemProps extends Partial<AriaNavigationTreeItemP
 }
 
 export function NavigationTreeItem(props: NavigationTreeItemProps) {
-  let textValue = typeof props.title === 'string' ? props.title : '';
-  return (
-    <AriaNavigationTreeItem className={itemStyles} textValue={textValue} {...props}>
-      <NavigationTreeItemContent>{props.title}</NavigationTreeItemContent>
-      {props.children}
-    </AriaNavigationTreeItem>
-  );
+  return <AriaNavigationTreeItem className={itemStyles} {...props} />;
 }
 
 export function NavigationTreeSection<T extends object>(props: NavigationTreeSectionProps<T>) {
@@ -135,5 +151,15 @@ export function NavigationTreeHeader(props: NavigationTreeHeaderProps) {
       {...props}
       className="px-2 py-1 text-sm font-semibold text-neutral-700 dark:text-neutral-300"
     />
+  );
+}
+
+export function NavigationTreeItemLink(props: LinkProps) {
+  let {indicator} = React.useContext(NavTreeLinkContext);
+  return (
+    <Link {...props} className={({isDisabled}) => linkStyles({isDisabled})}>
+      <span aria-hidden data-indicator={indicator} className={indicatorStyles()} />
+      {props.children}
+    </Link>
   );
 }

--- a/starters/tailwind/src/NavigationTree.tsx
+++ b/starters/tailwind/src/NavigationTree.tsx
@@ -38,7 +38,7 @@ export function NavigationTree<T>({children, ...props}: NavigationTreeProps<T>) 
 // another child, e.g. a button, is focused).
 const itemStyles = tv({
   extend: focusRing,
-  base: 'group relative font-sans flex items-center rounded-md cursor-default select-none text-neutral-800 dark:text-neutral-200 -outline-offset-2',
+  base: 'group relative font-sans flex items-center rounded-md cursor-default select-none text-neutral-800 dark:text-neutral-200 -outline-offset-2 [-webkit-tap-highlight-color:transparent]',
   variants: {
     isDisabled: {
       true: 'text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]'
@@ -91,22 +91,18 @@ const chevron = tv({
 });
 
 const NavTreeLinkContext = React.createContext<{
-  indicator: 'current' | 'ancestor' | 'hover' | undefined;
+  indicator: 'current' | 'ancestor' | undefined;
 }>({indicator: undefined});
 
 export function NavigationTreeItemContent(props: {children?: React.ReactNode}) {
   return (
     <AriaNavigationTreeItemContent>
-      {({level, hasChildItems, isExpanded, isHovered, isCurrent, isCurrentAncestor}) => {
-        // Pick the indicator variant here so precedence is explicit: a current row keeps its color even
-        // while hovered, then a collapsed current-route ancestor, then hover on any actionable row.
-        let indicator: 'current' | 'ancestor' | 'hover' | undefined;
+      {({level, hasChildItems, isExpanded, isCurrent, isCurrentAncestor}) => {
+        let indicator: 'current' | 'ancestor' | undefined;
         if (isCurrent) {
           indicator = 'current';
         } else if (isCurrentAncestor && !isExpanded) {
           indicator = 'ancestor';
-        } else if (isHovered) {
-          indicator = 'hover';
         }
         return (
           <>
@@ -159,8 +155,16 @@ export function NavigationTreeItemLink(props: NavigationTreeItemLinkProps) {
   let {indicator} = React.useContext(NavTreeLinkContext);
   return (
     <Link {...props} className={({isDisabled}) => linkStyles({isDisabled})}>
-      <span aria-hidden data-indicator={indicator} className={indicatorStyles()} />
-      {props.children}
+      {({isHovered}) => (
+        <>
+          <span
+            aria-hidden
+            data-indicator={indicator ?? (isHovered ? 'hover' : undefined)}
+            className={indicatorStyles()}
+          />
+          {props.children}
+        </>
+      )}
     </Link>
   );
 }

--- a/starters/tailwind/stories/NavigationTree.stories.tsx
+++ b/starters/tailwind/stories/NavigationTree.stories.tsx
@@ -1,0 +1,115 @@
+import {Button} from '../src/Button';
+import {type Meta} from '@storybook/react';
+import {MoreHorizontal} from 'lucide-react';
+import {
+  NavigationTree,
+  NavigationTreeItem,
+  NavigationTreeItemContent,
+  NavigationTreeItemLink,
+  NavigationTreeSection,
+  NavigationTreeHeader
+} from '../src/NavigationTree';
+import React, {type ReactNode, useState} from 'react';
+import {RouterProvider} from 'react-aria-components';
+
+const meta: Meta<typeof NavigationTree> = {
+  component: NavigationTree,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+function RoutedNavigationTree(props: {
+  children: ({selectedRoute}: {selectedRoute: string}) => ReactNode,
+  defaultSelectedRoute: string
+}) {
+  let [selectedRoute, setSelectedRoute] = useState(props.defaultSelectedRoute);
+  return <RouterProvider navigate={setSelectedRoute}>{props.children({selectedRoute})}</RouterProvider>;
+}
+
+export const Example = (args: any) => (
+  <RoutedNavigationTree defaultSelectedRoute="/photos">
+    {({selectedRoute}) => (
+      <NavigationTree
+        aria-label="Files"
+        selectedRoute={selectedRoute}
+        defaultExpandedKeys={['files']}
+        {...args}>
+        <NavigationTreeItem id="home" href="/home" textValue="Home">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
+          </NavigationTreeItemContent>
+        </NavigationTreeItem>
+        <NavigationTreeItem id="files" href="/files" textValue="Files">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Files</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="photos" href="/photos" textValue="Photos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Photos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="videos" href="/videos" textValue="Videos">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Videos</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+        <NavigationTreeItem id="shared" textValue="Shared">
+          <NavigationTreeItemContent>
+            <NavigationTreeItemLink>Shared</NavigationTreeItemLink>
+          </NavigationTreeItemContent>
+          <NavigationTreeItem id="food" href="/food" textValue="Food">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Food</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem id="drinks" href="/drinks" textValue="Drinks">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Drinks</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+      </NavigationTree>
+    )}
+  </RoutedNavigationTree>
+);
+
+export const Sections = (args: any) => (
+  <RoutedNavigationTree defaultSelectedRoute="/projects/apollo">
+    {({selectedRoute}) => (
+      <NavigationTree aria-label="Workspace" selectedRoute={selectedRoute} {...args}>
+        <NavigationTreeSection>
+          <NavigationTreeHeader>Personal</NavigationTreeHeader>
+          <NavigationTreeItem href="/home" textValue="Home">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Home</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem href="/starred" textValue="Starred">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Starred</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeSection>
+        <NavigationTreeSection>
+          <NavigationTreeHeader>Projects</NavigationTreeHeader>
+          <NavigationTreeItem href="/projects/apollo" textValue="Apollo">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Apollo</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+          <NavigationTreeItem href="/projects/gemini" textValue="Gemini">
+            <NavigationTreeItemContent>
+              <NavigationTreeItemLink>Gemini</NavigationTreeItemLink>
+            </NavigationTreeItemContent>
+          </NavigationTreeItem>
+        </NavigationTreeSection>
+      </NavigationTree>
+    )}
+  </RoutedNavigationTree>
+);

--- a/starters/tailwind/stories/NavigationTree.stories.tsx
+++ b/starters/tailwind/stories/NavigationTree.stories.tsx
@@ -23,11 +23,13 @@ const meta: Meta<typeof NavigationTree> = {
 export default meta;
 
 function RoutedNavigationTree(props: {
-  children: ({selectedRoute}: {selectedRoute: string}) => ReactNode,
-  defaultSelectedRoute: string
+  children: ({selectedRoute}: {selectedRoute: string}) => ReactNode;
+  defaultSelectedRoute: string;
 }) {
   let [selectedRoute, setSelectedRoute] = useState(props.defaultSelectedRoute);
-  return <RouterProvider navigate={setSelectedRoute}>{props.children({selectedRoute})}</RouterProvider>;
+  return (
+    <RouterProvider navigate={setSelectedRoute}>{props.children({selectedRoute})}</RouterProvider>
+  );
 }
 
 export const Example = (args: any) => (
@@ -41,7 +43,9 @@ export const Example = (args: any) => (
         <NavigationTreeItem id="home" href="/home" textValue="Home">
           <NavigationTreeItemContent>
             <NavigationTreeItemLink>Home</NavigationTreeItemLink>
-            <Button variant="quiet" aria-label="More options"><MoreHorizontal size={16} aria-hidden /></Button>
+            <Button variant="quiet" aria-label="More options">
+              <MoreHorizontal size={16} aria-hidden />
+            </Button>
           </NavigationTreeItemContent>
         </NavigationTreeItem>
         <NavigationTreeItem id="files" href="/files" textValue="Files">


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->

Fixes from testing:
- add starter storybook stories
- add test for opening a non-href item that contains children
  - as a result of this, add property to context so that we can open on a link click and not rely on the the events which were stopped by the link that wasn't doing anything
- move inline alert down to content
- fix page auto scroll, page will no longer scroll down to the last example in the navigation tree docs page
- make indicator smaller and no longer change selected one's colour on hover
- change structure of starters to support adding buttons as children
- fix webkit tap highlight

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
