### PR TITLE
fix: menu example typeahead

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Menu.mdx
+++ b/packages/dev/s2-docs/pages/react-aria/Menu.mdx
@@ -30,41 +30,41 @@ export const description = 'Displays a list of actions or options that a user ca
     </Button>
     <Menu>
       <MenuSection>
-        <MenuItem onAction={() => alert('open')}>
+        <MenuItem onAction={() => alert('open')} textValue="Open">
           <FolderOpen />
           <Text slot="label">Open</Text>
           <Keyboard>⌘O</Keyboard>
         </MenuItem>
-        <MenuItem onAction={() => alert('rename')}>
+        <MenuItem onAction={() => alert('rename')} textValue="Rename">
           <Pencil />
           <Text slot="label">Rename…</Text>
           <Keyboard>⌘R</Keyboard>
         </MenuItem>
-        <MenuItem onAction={() => alert('duplicate')}>
+        <MenuItem onAction={() => alert('duplicate')} textValue="Duplicate">
           <Copy />
           <Text slot="label">Duplicate</Text>
           <Keyboard>⌘D</Keyboard>
         </MenuItem>
-        <MenuItem onAction={() => alert('delete')}>
+        <MenuItem onAction={() => alert('delete')} textValue="Delete">
           <Trash />
           <Text slot="label">Delete…</Text>
           <Keyboard>⌘⌫</Keyboard>
         </MenuItem>
         <SubmenuTrigger>
-          <MenuItem>
+          <MenuItem textValue="Share">
             <Share />
             <Text slot="label">Share</Text>
           </MenuItem>
           <Menu>
-            <MenuItem>
+            <MenuItem textValue="Email">
               <Mail />
               <Text slot="label">Email</Text>
             </MenuItem>
-            <MenuItem>
+            <MenuItem textValue="SMS">
               <Smartphone />
               <Text slot="label">SMS</Text>
             </MenuItem>
-            <MenuItem>
+            <MenuItem textValue="Instagram">
               <Instagram />
               <Text slot="label">Instagram</Text>
             </MenuItem>


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->
https://github.com/adobe/react-spectrum/issues/10501#issuecomment-5404811466

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Go to RAC Menu docs and use type ahead in the first example, everything should be accessible

## 🧢 Your Project:

<!--- Company/project for pull request -->
