### PR TITLE
fix: Ignore presses retargeted to the document element in dismissable modals

### DIFF
--- a/packages/react-aria/src/overlays/useModalOverlay.ts
+++ b/packages/react-aria/src/overlays/useModalOverlay.ts
@@ -53,9 +53,23 @@ export function useModalOverlay(
   state: OverlayTriggerState,
   ref: RefObject<HTMLElement | null>
 ): ModalOverlayAria {
+  let {shouldCloseOnInteractOutside} = props;
   let {overlayProps, underlayProps} = useOverlay(
     {
       ...props,
+      shouldCloseOnInteractOutside: (element) => {
+        // A modal's underlay covers the viewport, so the document element is never a
+        // legitimate outside-press target. It only appears as one when the browser
+        // retargets a press whose original target was removed from the DOM mid-press
+        // (e.g. a button swapped out after an async mutation), and dismissing then
+        // would close the modal under the user's pointer. Non-modal overlays must keep
+        // treating it as valid: on pages with a short body, presses below the body
+        // target the document element and should still dismiss (see #1367).
+        if (element === element.ownerDocument.documentElement) {
+          return false;
+        }
+        return shouldCloseOnInteractOutside ? shouldCloseOnInteractOutside(element) : true;
+      },
       isOpen: state.isOpen,
       onClose: state.close
     },

--- a/packages/react-aria/test/overlays/useModalOverlay.test.js
+++ b/packages/react-aria/test/overlays/useModalOverlay.test.js
@@ -62,5 +62,38 @@ describe('useModalOverlay', function () {
       fireEvent.click(document.body);
       expect(onOpenChange).not.toHaveBeenCalled();
     });
+
+    it('should not hide the overlay when a press is retargeted to the document element', function () {
+      // When the pressed element is removed from the DOM mid-press (e.g. a button swapped
+      // out after an async mutation), the browser retargets the press events to the
+      // document element. That must not be treated as a press outside the modal.
+      let onOpenChange = jest.fn();
+      render(
+        <Example
+          isOpen
+          onOpenChange={onOpenChange}
+          isDismissable />
+      );
+      pressStart(document.documentElement);
+      pressEnd(document.documentElement);
+      fireEvent.click(document.documentElement);
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('should ignore a retargeted press even if shouldCloseOnInteractOutside returns true', function () {
+      let onOpenChange = jest.fn();
+      render(
+        <Example
+          isOpen
+          onOpenChange={onOpenChange}
+          isDismissable
+          shouldCloseOnInteractOutside={() => true}
+        />
+      );
+      pressStart(document.documentElement);
+      pressEnd(document.documentElement);
+      fireEvent.click(document.documentElement);
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Closes #10510

## 🧢 Your Project

N/A — fixing a bug reported by a user of `react-aria-components`.

## 📝 Description

When the element being pressed inside a dismissable `ModalOverlay` is removed from the DOM mid-press (e.g. a row button swapped out when an async mutation resolves), the browser retargets the press events: both `pointerdown` and `click` arrive with the **document element** as their target. `isValidEvent` in `useInteractOutside` then treats the press as a genuine outside interaction:

- the not-in-document guard passes, because `documentElement.contains(documentElement)` is `true`, and
- `event.composedPath()` for a root-targeted event never includes the overlay ref.

Both events "look outside", so the modal dismisses under the user's pointer.

This PR scopes the fix to `useModalOverlay`: a modal's underlay covers the viewport, so the document element is **never** a legitimate outside-press target for a modal — it only shows up as one via mid-press retargeting. The hook now composes `shouldCloseOnInteractOutside` to reject the document element before delegating to a user-provided predicate (so the existing escape hatch keeps working).

The check deliberately does **not** live in `useInteractOutside`/`isValidEvent`: non-modal overlays must keep treating the document element as a valid outside target, because on pages with a short `<body>`, presses below the body target the document element and should still dismiss a popover — that's the reason the guard was widened from `body` to `documentElement` in #1369 (fixing #1367). This change leaves popovers untouched.

## 🧪 Test plan

Two new tests in `useModalOverlay.test.js`, parameterized over the existing Mouse/Pointer/Touch event matrix (6 cases):

1. A press fully retargeted to the document element does not close the modal.
2. It does not close even when a user-provided `shouldCloseOnInteractOutside` returns `true`.

Both fail on `main` (the modal closes) and pass with this change. No regressions: `packages/react-aria/test/overlays/` (197 tests) and `react-aria-components` `Dialog`/`Popover` suites (27 tests) pass.

## 🚀 How to test locally

```
yarn jest packages/react-aria/test/overlays/useModalOverlay.test.js
```

## ✅ PR Checklist

- [x] Included link to corresponding issue
- [x] Added/updated unit tests
- [ ] Filled out test instructions (above)
- [x] Updated documentation (no doc changes needed — no API change)
