### PR TITLE
feat: add carousel overflow to AttachmentList

### DIFF
--- a/packages/@react-spectrum/ai/intl/ar-AE.json
+++ b/packages/@react-spectrum/ai/intl/ar-AE.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "جارٍ التحميل",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "ابدأ التسجيل",
-  "voicebutton.stopListening": "أوقف التسجيل"
+  "voicebutton.stopListening": "أوقف التسجيل",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/bg-BG.json
+++ b/packages/@react-spectrum/ai/intl/bg-BG.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Зареждане",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Започнете запис",
-  "voicebutton.stopListening": "Спри записа"
+  "voicebutton.stopListening": "Спри записа",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/cs-CZ.json
+++ b/packages/@react-spectrum/ai/intl/cs-CZ.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Načítání",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Začít nahrávat",
-  "voicebutton.stopListening": "Zastavit nahrávání"
+  "voicebutton.stopListening": "Zastavit nahrávání",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/da-DK.json
+++ b/packages/@react-spectrum/ai/intl/da-DK.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Indlæser",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start optagelsen",
-  "voicebutton.stopListening": "Stop optagelsen"
+  "voicebutton.stopListening": "Stop optagelsen",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/de-DE.json
+++ b/packages/@react-spectrum/ai/intl/de-DE.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Ladevorgang läuft",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Aufzeichnung starten",
-  "voicebutton.stopListening": "Aufzeichnung stoppen"
+  "voicebutton.stopListening": "Aufzeichnung stoppen",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/el-GR.json
+++ b/packages/@react-spectrum/ai/intl/el-GR.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Φόρτωση",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Ξεκινήστε την εγγραφή",
-  "voicebutton.stopListening": "Διακοπή εγγραφής"
+  "voicebutton.stopListening": "Διακοπή εγγραφής",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/en-US.json
+++ b/packages/@react-spectrum/ai/intl/en-US.json
@@ -16,5 +16,7 @@
   "promptfield.stopButton": "Stop",
   "promptfield.submitButton": "Send",
   "promptfield.insertButton": "Add",
-  "promptfield.uploading": "Uploading"
+  "promptfield.uploading": "Uploading",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/es-ES.json
+++ b/packages/@react-spectrum/ai/intl/es-ES.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Cargando",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Iniciar grabación",
-  "voicebutton.stopListening": "Detener grabación"
+  "voicebutton.stopListening": "Detener grabación",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/et-EE.json
+++ b/packages/@react-spectrum/ai/intl/et-EE.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Laadimine",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Alusta salvestamist",
-  "voicebutton.stopListening": "Lõpeta salvestamine"
+  "voicebutton.stopListening": "Lõpeta salvestamine",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/fi-FI.json
+++ b/packages/@react-spectrum/ai/intl/fi-FI.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Ladataan",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Aloita äänitys",
-  "voicebutton.stopListening": "Lopeta tallennus"
+  "voicebutton.stopListening": "Lopeta tallennus",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/fr-FR.json
+++ b/packages/@react-spectrum/ai/intl/fr-FR.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Chargement",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Démarrer l'enregistrement",
-  "voicebutton.stopListening": "Arrêter l'enregistrement"
+  "voicebutton.stopListening": "Arrêter l'enregistrement",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/he-IL.json
+++ b/packages/@react-spectrum/ai/intl/he-IL.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "בטעינה…",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "התחל להקליט",
-  "voicebutton.stopListening": "הפסק להקליט"
+  "voicebutton.stopListening": "הפסק להקליט",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/hr-HR.json
+++ b/packages/@react-spectrum/ai/intl/hr-HR.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Učitavanje",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
-  "voicebutton.stopListening": "Stop recording"
+  "voicebutton.stopListening": "Stop recording",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/hu-HU.json
+++ b/packages/@react-spectrum/ai/intl/hu-HU.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Betöltés folyamatban",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Kezdj el felvételt",
-  "voicebutton.stopListening": "Felvétel abbahagyása"
+  "voicebutton.stopListening": "Felvétel abbahagyása",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/it-IT.json
+++ b/packages/@react-spectrum/ai/intl/it-IT.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Caricamento",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Avvia registrazione",
-  "voicebutton.stopListening": "Interrompi registrazione"
+  "voicebutton.stopListening": "Interrompi registrazione",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/ja-JP.json
+++ b/packages/@react-spectrum/ai/intl/ja-JP.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "読み込み中",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "記録を開始",
-  "voicebutton.stopListening": "記録の停止"
+  "voicebutton.stopListening": "記録の停止",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/ko-KR.json
+++ b/packages/@react-spectrum/ai/intl/ko-KR.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "로드 중",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "기록 시작",
-  "voicebutton.stopListening": "기록 중지"
+  "voicebutton.stopListening": "기록 중지",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/lt-LT.json
+++ b/packages/@react-spectrum/ai/intl/lt-LT.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Įkeliama",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Pradėkite įrašinėti",
-  "voicebutton.stopListening": "Sustabdyti įrašymą"
+  "voicebutton.stopListening": "Sustabdyti įrašymą",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/lv-LV.json
+++ b/packages/@react-spectrum/ai/intl/lv-LV.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Notiek ielāde",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Sāciet ierakstīt",
-  "voicebutton.stopListening": "Pārtraukt ierakstu"
+  "voicebutton.stopListening": "Pārtraukt ierakstu",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/nb-NO.json
+++ b/packages/@react-spectrum/ai/intl/nb-NO.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Laster inn",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
-  "voicebutton.stopListening": "Stop recording"
+  "voicebutton.stopListening": "Stop recording",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/nl-NL.json
+++ b/packages/@react-spectrum/ai/intl/nl-NL.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Laden",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Opname starten",
-  "voicebutton.stopListening": "Opname stoppen"
+  "voicebutton.stopListening": "Opname stoppen",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/pl-PL.json
+++ b/packages/@react-spectrum/ai/intl/pl-PL.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Wczytywanie",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Rozpocznij nagrywanie",
-  "voicebutton.stopListening": "Zatrzymaj nagrywanie"
+  "voicebutton.stopListening": "Zatrzymaj nagrywanie",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/pt-BR.json
+++ b/packages/@react-spectrum/ai/intl/pt-BR.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Carregando",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Iniciar gravação",
-  "voicebutton.stopListening": "Parar gravação"
+  "voicebutton.stopListening": "Parar gravação",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/pt-PT.json
+++ b/packages/@react-spectrum/ai/intl/pt-PT.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "A carregar",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
-  "voicebutton.stopListening": "Stop recording"
+  "voicebutton.stopListening": "Stop recording",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/ro-RO.json
+++ b/packages/@react-spectrum/ai/intl/ro-RO.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Se încarcă",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Începe înregistrarea",
-  "voicebutton.stopListening": "Opriți înregistrarea"
+  "voicebutton.stopListening": "Opriți înregistrarea",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/ru-RU.json
+++ b/packages/@react-spectrum/ai/intl/ru-RU.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Загрузка",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Начать запись",
-  "voicebutton.stopListening": "Остановить запись"
+  "voicebutton.stopListening": "Остановить запись",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/sk-SK.json
+++ b/packages/@react-spectrum/ai/intl/sk-SK.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Načítava sa",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Začni nahrávať",
-  "voicebutton.stopListening": "Zastavte nahrávanie"
+  "voicebutton.stopListening": "Zastavte nahrávanie",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/sl-SI.json
+++ b/packages/@react-spectrum/ai/intl/sl-SI.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Nalaganje",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Začni snemati",
-  "voicebutton.stopListening": "Prenehajte snemati"
+  "voicebutton.stopListening": "Prenehajte snemati",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/sr-SP.json
+++ b/packages/@react-spectrum/ai/intl/sr-SP.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Učitavanje",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
-  "voicebutton.stopListening": "Stop recording"
+  "voicebutton.stopListening": "Stop recording",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/sv-SE.json
+++ b/packages/@react-spectrum/ai/intl/sv-SE.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Läser in",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Starta inspelning",
-  "voicebutton.stopListening": "Stoppa inspelning"
+  "voicebutton.stopListening": "Stoppa inspelning",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/tr-TR.json
+++ b/packages/@react-spectrum/ai/intl/tr-TR.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Yükleniyor",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Kayıtlara başlayın",
-  "voicebutton.stopListening": "Kaydı durdur"
+  "voicebutton.stopListening": "Kaydı durdur",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/uk-UA.json
+++ b/packages/@react-spectrum/ai/intl/uk-UA.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "Завантаження",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Починайте запис",
-  "voicebutton.stopListening": "Припиніть запис"
+  "voicebutton.stopListening": "Припиніть запис",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/zh-CN.json
+++ b/packages/@react-spectrum/ai/intl/zh-CN.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "加载",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "开始录制",
-  "voicebutton.stopListening": "停止录制"
+  "voicebutton.stopListening": "停止录制",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/intl/zh-TW.json
+++ b/packages/@react-spectrum/ai/intl/zh-TW.json
@@ -16,5 +16,7 @@
   "responsestatus.loading": "載入中",
   "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "開始錄製",
-  "voicebutton.stopListening": "停止錄製"
+  "voicebutton.stopListening": "停止錄製",
+  "attachmentlist.previousAttachments": "Show previous attachments",
+  "attachmentlist.nextAttachments": "Show next attachments"
 }

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {ActionButton} from '@react-spectrum/s2/ActionButton';
 import AlertTriangle from '@react-spectrum/s2/icons/AlertTriangle';
 import {
   AriaLabelingProps,
@@ -29,8 +30,10 @@ import {
 } from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Button} from 'react-aria-components/Button';
 import {CardProps} from '@react-spectrum/s2/Card';
+import ChevronLeft from '@react-spectrum/s2/icons/ChevronLeft';
+import ChevronRight from '@react-spectrum/s2/icons/ChevronRight';
 import {ContentContext} from '@react-spectrum/s2/Content';
-import {createContext, forwardRef, ReactNode, useContext, useRef} from 'react';
+import {createContext, forwardRef, ReactNode, useCallback, useContext, useRef, useState} from 'react';
 import Cross from '../ui-icons/Cross';
 import {DEFAULT_SLOT, Provider} from 'react-aria-components/slots';
 import File from '@react-spectrum/s2/icons/File';
@@ -54,7 +57,11 @@ import {
 } from 'react-aria-components/TagGroup';
 import {TextContext} from '@react-spectrum/s2/Text';
 import {useDOMRef} from './useDOMRef';
+import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
+import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
+import {useResizeObserver} from 'react-aria/private/utils/useResizeObserver';
+import {useValueEffect} from 'react-aria/private/utils/useValueEffect';
 
 interface AttachmentRenderProps {
   /** The size of the Card. */
@@ -309,27 +316,172 @@ export interface AttachmentListProps<T>
   styles?: StyleString;
 }
 
+// Caps growth so more attachments can't keep inflating an unsized ancestor; matches the Prompt
+// field's content width.
+const attachmentListStyles = style({
+  maxWidth: 700
+});
+
+const flexRow = {
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  width: 'full'
+} as const;
+
+const carouselContainer = style({
+  ...flexRow,
+  gap: 8
+});
+
+const tagListStyles = style<{isCarousel: boolean}>({
+  ...flexRow,
+  gap: 16,
+  minWidth: 0,
+  flexWrap: {default: 'wrap', isCarousel: 'nowrap'},
+  overflowX: {isCarousel: 'auto'},
+  // overflowX forces overflow-y into a clipping context too; hide the native scrollbar since the
+  // chevrons drive scrolling (same combo DateField's segmentContainer uses).
+  overflowY: {isCarousel: 'hidden'},
+  scrollbarWidth: {isCarousel: 'none'},
+  scrollSnapType: {isCarousel: 'x mandatory'},
+  flexGrow: {isCarousel: 1},
+  // Room for the close-button badge, which pokes past each card's corner.
+  padding: {isCarousel: 12}
+});
+
+// Fades the peeking edge attachment to read as more content, not a hard clip.
+const carouselMaskImage =
+  'linear-gradient(to right, transparent, black 32px, black calc(100% - 32px), transparent)';
+const carouselMask = {
+  WebkitMaskImage: carouselMaskImage,
+  maskImage: carouselMaskImage
+} as const;
+
+// borderRadius/transform aren't allowed ActionButton style overrides, so shape and RTL flip go on
+// this wrapper instead, same as Calendar's CalendarButton.
+const carouselNavButton = style({
+  flexShrink: 0,
+  borderRadius: 'full',
+  overflow: 'clip',
+  scale: {
+    direction: {
+      rtl: -1
+    }
+  }
+});
+
+function CarouselNavButton(
+  {side, onPress, isDisabled}: {side: 'start' | 'end', onPress: () => void, isDisabled: boolean}
+) {
+  let {direction} = useLocale();
+  let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
+  let Icon = side === 'start' ? ChevronLeft : ChevronRight;
+  return (
+    <div className={carouselNavButton({direction})}>
+      <ActionButton
+        isDisabled={isDisabled}
+        aria-label={stringFormatter.format(
+          side === 'start' ? 'attachmentlist.previousAttachments' : 'attachmentlist.nextAttachments'
+        )}
+        onPress={onPress}>
+        <Icon />
+      </ActionButton>
+    </div>
+  );
+}
+
 export const AttachmentList = (forwardRef as forwardRefType)(function AttachmentList<T>(
   props: AttachmentListProps<T>,
   ref: DOMRef<HTMLDivElement>
 ) {
   let {styles, items, children, dependencies, ...otherProps} = props;
   let domRef = useDOMRef(ref);
+  let scrollRef = useRef<HTMLDivElement>(null);
+
+  let [isCarousel, setIsCarousel] = useValueEffect(false);
+  // oxlint-disable react/react-compiler, react-hooks/exhaustive-deps
+  let checkForOverflow = useCallback(() => {
+    setIsCarousel(function* () {
+      yield true;
+      let el = scrollRef.current;
+      // Compare to domRef's width, not el's, so the nav buttons taking up their own share of the
+      // track can't feed back into this check.
+      yield !!el && !!domRef.current && el.scrollWidth > domRef.current.offsetWidth + 1;
+    });
+  }, [setIsCarousel]);
+  // oxlint-enable react/react-compiler, react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    checkForOverflow();
+  }, [checkForOverflow, items, children]);
+  // Observe the parent, not domRef: our own size changes when isCarousel toggles.
+  let parent = useRef<HTMLElement | null>(null);
+  // oxlint-disable react/react-compiler, react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    if (domRef.current) {
+      parent.current = domRef.current.parentElement as HTMLElement;
+    }
+  }, [domRef.current]);
+  // oxlint-enable react/react-compiler, react-hooks/exhaustive-deps
+  useResizeObserver({ref: parent, onResize: checkForOverflow});
+
+  let {direction} = useLocale();
+  let [canScrollPrev, setCanScrollPrev] = useState(false);
+  let [canScrollNext, setCanScrollNext] = useState(false);
+  // The track's own padding shifts the scroll-snap resting position away from 0; use the first
+  // read as the "start" baseline instead of assuming it's 0.
+  let startScrollRef = useRef<number | null>(null);
+  let updateScrollState = useCallback(() => {
+    let el = scrollRef.current;
+    if (el) {
+      // RTL reports scrollLeft as <= 0, the mirror of LTR; normalize with Math.abs.
+      let maxScroll = el.scrollWidth - el.clientWidth;
+      let scrolled = Math.abs(el.scrollLeft);
+      if (startScrollRef.current == null) {
+        startScrollRef.current = scrolled;
+      }
+      setCanScrollPrev(scrolled > startScrollRef.current + 1);
+      setCanScrollNext(scrolled < maxScroll - 1);
+    }
+  }, []);
+  useLayoutEffect(() => {
+    startScrollRef.current = null;
+    updateScrollState();
+  }, [updateScrollState, isCarousel]);
+  useResizeObserver({ref: scrollRef, onResize: updateScrollState});
+
+  let scroll = (dir: 1 | -1) => {
+    // RTL flips the scroll direction convention; flip the sign to match.
+    let sign = direction === 'rtl' ? -1 : 1;
+    scrollRef.current?.scrollBy({
+      left: sign * dir * scrollRef.current.clientWidth * 0.8,
+      behavior: 'smooth'
+    });
+  };
+
+  let tagList = (
+    <TagList
+      ref={scrollRef}
+      items={items}
+      dependencies={dependencies}
+      onScroll={updateScrollState}
+      className={tagListStyles({isCarousel})}
+      style={isCarousel ? carouselMask : undefined}>
+      {children}
+    </TagList>
+  );
+
   return (
-    <TagGroup {...otherProps} className={styles} ref={domRef}>
-      <TagList
-        items={items}
-        dependencies={dependencies}
-        className={style({
-          display: 'flex',
-          flexDirection: 'row',
-          gap: 16,
-          flexWrap: 'wrap',
-          alignItems: 'center',
-          width: 'full'
-        })}>
-        {children}
-      </TagList>
+    <TagGroup {...otherProps} className={mergeStyles(attachmentListStyles, styles)} ref={domRef}>
+      {isCarousel ? (
+        <div className={carouselContainer}>
+          <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />
+          {tagList}
+          <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />
+        </div>
+      ) : (
+        tagList
+      )}
     </TagGroup>
   );
 });
@@ -359,7 +511,8 @@ const tagStyles = style({
   position: 'relative',
   ...focusRing(),
   borderRadius: 'lg',
-  maxWidth: 'full'
+  maxWidth: 'full',
+  scrollSnapAlign: 'start'
 });
 interface AttachmentCardProps {
   size?: 'XS' | 'S' | 'M' | 'L' | 'XL';

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -261,6 +261,25 @@ const attachmentDescription = style<{size: 'XS' | 'S' | 'M' | 'L' | 'XL'}>({
   gridArea: 'description'
 });
 
+const attachmentContent = style({
+  display: 'grid',
+  gridTemplateColumns: ['minmax(0, 1fr)'],
+  gridTemplateAreas: ['title', 'description'],
+  columnGap: 4,
+  flexGrow: 1,
+  minWidth: 0,
+  alignItems: 'baseline',
+  alignContent: 'start',
+  paddingStart: {
+    default: '--card-spacing',
+    ':first-child': 0
+  },
+  paddingEnd: {
+    default: 'calc(var(--card-spacing) * 1.5 / 2)',
+    ':last-child': 0
+  }
+});
+
 const CloseButton = function CloseButton(props) {
   let ref = useRef(null);
   // oxlint-disable react/react-compiler
@@ -315,15 +334,11 @@ const flexRow = {
 
 const tagListStyles = style<{isCarousel: boolean}>({
   ...flexRow,
-  gap: 16,
-  minWidth: 0,
+  gap: 8,
   flexWrap: {default: 'wrap', isCarousel: 'nowrap'},
   overflowX: {isCarousel: 'auto'},
-  overflowY: {isCarousel: 'hidden'},
   scrollbarWidth: {isCarousel: 'none'},
   scrollSnapType: {isCarousel: 'x mandatory'},
-  flexGrow: {isCarousel: 1},
-  paddingX: {isCarousel: 12}
 });
 
 const carouselNavButton = style({
@@ -440,15 +455,11 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
 
   return (
     <TagGroup {...otherProps} className={styles} ref={domRef}>
-      {isCarousel ? (
-        <div className={style({...flexRow, gap: 8})}>
-          <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />
-          {tagList}
-          <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />
-        </div>
-      ) : (
-        tagList
-      )}
+      <div className={style({...flexRow, gap: 8, display: {default: 'contents', isCarousel: 'flex'}})({isCarousel})}>
+        {isCarousel && <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />}
+        {tagList}
+        {isCarousel && <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />}
+      </div>
     </TagGroup>
   );
 });
@@ -537,24 +548,7 @@ function AttachmentCard({
           [
             ContentContext,
             {
-              styles: style({
-                display: 'grid',
-                gridTemplateColumns: ['minmax(0, 1fr)'],
-                gridTemplateAreas: ['title', 'description'],
-                columnGap: 4,
-                flexGrow: 1,
-                minWidth: 0,
-                alignItems: 'baseline',
-                alignContent: 'start',
-                paddingStart: {
-                  default: '--card-spacing',
-                  ':first-child': 0
-                },
-                paddingEnd: {
-                  default: 'calc(var(--card-spacing) * 1.5 / 2)',
-                  ':last-child': 0
-                }
-              }),
+              styles: attachmentContent,
               // @ts-ignore
               'data-slot': 'content'
             }

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -54,6 +54,7 @@ import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
 import Play from '@react-spectrum/s2/icons/Play';
 import {pressScale} from '@react-spectrum/s2/pressScale';
 import {ProgressCircle} from '@react-spectrum/s2/ProgressCircle';
+import {scrollFade} from './tokens.macro' with {type: 'macro'};
 import {StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {
   Tag,
@@ -322,16 +323,8 @@ const tagListStyles = style<{isCarousel: boolean}>({
   scrollbarWidth: {isCarousel: 'none'},
   scrollSnapType: {isCarousel: 'x mandatory'},
   flexGrow: {isCarousel: 1},
-  padding: {isCarousel: 12}
+  paddingX: {isCarousel: 12}
 });
-
-// Fades the peeking edge attachment to read as more content, not a hard clip.
-const carouselMaskImage =
-  'linear-gradient(to right, transparent, black 32px, black calc(100% - 32px), transparent)';
-const carouselMask = {
-  WebkitMaskImage: carouselMaskImage,
-  maskImage: carouselMaskImage
-} as const;
 
 const carouselNavButton = style({
   flexShrink: 0,
@@ -440,14 +433,13 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
       items={items}
       dependencies={dependencies}
       onScroll={updateScrollState}
-      className={tagListStyles({isCarousel})}
-      style={isCarousel ? carouselMask : undefined}>
+      className={tagListStyles({isCarousel}) + ' ' + (isCarousel ? scrollFade({x: 32}) : '')}>
       {children}
     </TagList>
   );
 
   return (
-    <TagGroup {...otherProps} className={mergeStyles(style({maxWidth: 700}), styles)} ref={domRef}>
+    <TagGroup {...otherProps} className={styles} ref={domRef}>
       {isCarousel ? (
         <div className={style({...flexRow, gap: 8})}>
           <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />
@@ -612,7 +604,7 @@ export const Attachment = forwardRef(function Attachment(
           position: 'absolute',
           top: 0,
           insetEnd: 0,
-          transform: 'translate(50%, -50%)'
+          transform: 'translate(25%, -25%)'
         })}>
         <CloseButton size="XS" />
       </div>

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -318,16 +318,23 @@ const flexRow = {
   alignItems: 'center'
 } as const;
 
-const tagListStyles = style<{isCarousel: boolean}>({
+const tagListStyles = style({
   ...flexRow,
   gap: 8,
-  flexWrap: {default: 'wrap', isCarousel: 'nowrap'},
-  overflowX: {isCarousel: 'auto'},
-  scrollbarWidth: {isCarousel: 'none'},
-  scrollSnapType: {isCarousel: 'x mandatory'},
+  overflowX: 'auto',
+  overflowY: 'clip',
+  scrollbarWidth: {
+    '@supports (animation-timeline: scroll())': 'none'
+  },
+  scrollSnapType: 'x mandatory',
+  // padding for focus ring
   padding: 16,
+  margin: -16,
   boxSizing: 'border-box',
-  scrollPaddingX: 40
+  scrollPaddingX: {
+    default: 16,
+    '@supports (animation-timeline: scroll())': 64
+  }
 });
 
 const buttonFade = keyframes(`
@@ -353,7 +360,7 @@ const carouselNavButtonStyles = style<{
   borderStyle: 'none',
   transition: 'default',
   backgroundColor: {
-    default: baseColor('gray-100'),
+    default: baseColor('transparent-overlay-100'),
     forcedColors: 'ButtonFace'
   },
   color: {
@@ -441,10 +448,21 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
   let scrollRef = useRef<HTMLDivElement>(null);
   let {direction} = useLocale();
   let scroll = (dir: 1 | -1) => {
+    let el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+
     // RTL flips the scroll direction convention; flip the sign to match.
     let sign = direction === 'rtl' ? -1 : 1;
-    scrollRef.current?.scrollBy({
-      left: sign * dir * scrollRef.current.clientWidth,
+    el.scrollTo({
+      left: Math.max(
+        0,
+        Math.min(
+          el.scrollWidth - el.clientWidth,
+          el.scrollLeft + sign * dir * (el.clientWidth - 64 * 2)
+        )
+      ),
       behavior: 'smooth'
     });
   };
@@ -452,10 +470,7 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
   return (
     <TagGroup
       {...otherProps}
-      className={mergeStyles(
-        style({...flexRow, gap: 8, position: 'relative', marginX: -16}),
-        styles
-      )}
+      className={mergeStyles(style({...flexRow, gap: 8, position: 'relative'}), styles)}
       style={
         {
           timelineScope: '--carousel-scroll'
@@ -468,13 +483,14 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
         items={items}
         dependencies={dependencies}
         className={
-          tagListStyles({isCarousel: true}) +
+          tagListStyles +
           ' ' +
-          scrollFade({x: 32, inset: 40}) +
+          scrollFade({x: 32, inset: 56}) +
           ' ' +
           // Hack to keep scroll fade visible when the buttons are focused.
+          // 88px = 32 + 56
           css(
-            `&:is(button[data-focus-visible]+*){--scroll-fade-left: 72px !important} &:has(+ button[data-focus-visible]){--scroll-fade-right: calc(100% - 72px) !important}`
+            `&:is(button[data-focus-visible]+*){--scroll-fade-left: 88px !important} &:has(+ button[data-focus-visible]){--scroll-fade-right: calc(100% - 88px) !important}`
           )
         }
         style={
@@ -515,7 +531,7 @@ const tagStyles = style({
   position: 'relative',
   ...focusRing(),
   borderRadius: 'lg',
-  maxWidth: 'full',
+  maxWidth: 'calc(100% - 52px * 2)',
   scrollSnapAlign: 'start'
 });
 interface AttachmentCardProps {

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -260,25 +260,6 @@ const attachmentDescription = style<{size: 'XS' | 'S' | 'M' | 'L' | 'XL'}>({
   gridArea: 'description'
 });
 
-const attachmentContent = style({
-  display: 'grid',
-  gridTemplateColumns: ['minmax(0, 1fr)'],
-  gridTemplateAreas: ['title', 'description'],
-  columnGap: 4,
-  flexGrow: 1,
-  minWidth: 0,
-  alignItems: 'baseline',
-  alignContent: 'start',
-  paddingStart: {
-    default: '--card-spacing',
-    ':first-child': 0
-  },
-  paddingEnd: {
-    default: 'calc(var(--card-spacing) * 1.5 / 2)',
-    ':last-child': 0
-  }
-});
-
 const CloseButton = function CloseButton(props) {
   let ref = useRef(null);
   // oxlint-disable react/react-compiler
@@ -324,12 +305,6 @@ export interface AttachmentListProps<T>
   styles?: StyleString;
 }
 
-// Caps growth so more attachments can't keep inflating an unsized ancestor; matches the Prompt
-// field's content width.
-const attachmentListStyles = style({
-  maxWidth: 700
-});
-
 const flexRow = {
   display: 'flex',
   flexDirection: 'row',
@@ -337,24 +312,16 @@ const flexRow = {
   width: 'full'
 } as const;
 
-const carouselContainer = style({
-  ...flexRow,
-  gap: 8
-});
-
 const tagListStyles = style<{isCarousel: boolean}>({
   ...flexRow,
   gap: 16,
   minWidth: 0,
   flexWrap: {default: 'wrap', isCarousel: 'nowrap'},
   overflowX: {isCarousel: 'auto'},
-  // overflowX forces overflow-y into a clipping context too; hide the native scrollbar since the
-  // chevrons drive scrolling (same combo DateField's segmentContainer uses).
   overflowY: {isCarousel: 'hidden'},
   scrollbarWidth: {isCarousel: 'none'},
   scrollSnapType: {isCarousel: 'x mandatory'},
   flexGrow: {isCarousel: 1},
-  // Room for the close-button badge, which pokes past each card's corner.
   padding: {isCarousel: 12}
 });
 
@@ -366,8 +333,6 @@ const carouselMask = {
   maskImage: carouselMaskImage
 } as const;
 
-// borderRadius/transform aren't allowed ActionButton style overrides, so shape and RTL flip go on
-// this wrapper instead, same as Calendar's CalendarButton.
 const carouselNavButton = style({
   flexShrink: 0,
   borderRadius: 'full',
@@ -419,8 +384,6 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
     setIsCarousel(function* () {
       yield true;
       let el = scrollRef.current;
-      // Compare to domRef's width, not el's, so the nav buttons taking up their own share of the
-      // track can't feed back into this check.
       yield !!el && !!domRef.current && el.scrollWidth > domRef.current.offsetWidth + 1;
     });
   }, [setIsCarousel]);
@@ -442,13 +405,11 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
   let {direction} = useLocale();
   let [canScrollPrev, setCanScrollPrev] = useState(false);
   let [canScrollNext, setCanScrollNext] = useState(false);
-  // The track's own padding shifts the scroll-snap resting position away from 0; use the first
-  // read as the "start" baseline instead of assuming it's 0.
+  // Track padding can rest scroll-snap at a nonzero scrollLeft; treat the first read as "start".
   let startScrollRef = useRef<number | null>(null);
   let updateScrollState = useCallback(() => {
     let el = scrollRef.current;
     if (el) {
-      // RTL reports scrollLeft as <= 0, the mirror of LTR; normalize with Math.abs.
       let maxScroll = el.scrollWidth - el.clientWidth;
       let scrolled = Math.abs(el.scrollLeft);
       if (startScrollRef.current == null) {
@@ -486,9 +447,9 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
   );
 
   return (
-    <TagGroup {...otherProps} className={mergeStyles(attachmentListStyles, styles)} ref={domRef}>
+    <TagGroup {...otherProps} className={mergeStyles(style({maxWidth: 700}), styles)} ref={domRef}>
       {isCarousel ? (
-        <div className={carouselContainer}>
+        <div className={style({...flexRow, gap: 8})}>
           <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />
           {tagList}
           <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />
@@ -584,7 +545,24 @@ function AttachmentCard({
           [
             ContentContext,
             {
-              styles: attachmentContent,
+              styles: style({
+                display: 'grid',
+                gridTemplateColumns: ['minmax(0, 1fr)'],
+                gridTemplateAreas: ['title', 'description'],
+                columnGap: 4,
+                flexGrow: 1,
+                minWidth: 0,
+                alignItems: 'baseline',
+                alignContent: 'start',
+                paddingStart: {
+                  default: '--card-spacing',
+                  ':first-child': 0
+                },
+                paddingEnd: {
+                  default: 'calc(var(--card-spacing) * 1.5 / 2)',
+                  ':last-child': 0
+                }
+              }),
               // @ts-ignore
               'data-slot': 'content'
             }

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionButton} from '@react-spectrum/s2/ActionButton';
 import AlertTriangle from '@react-spectrum/s2/icons/AlertTriangle';
 import {
   AriaLabelingProps,
@@ -337,18 +336,52 @@ const tagListStyles = style<{isCarousel: boolean}>({
   flexWrap: {default: 'wrap', isCarousel: 'nowrap'},
   overflowX: {isCarousel: 'auto'},
   scrollbarWidth: {isCarousel: 'none'},
-  scrollSnapType: {isCarousel: 'x mandatory'}
+  scrollSnapType: {isCarousel: 'x mandatory'},
+  paddingY: 12
 });
 
-const carouselNavButton = style({
+const carouselNavButtonStyles = style<{
+  isDisabled: boolean;
+  isHovered: boolean;
+  isFocusVisible: boolean;
+  isPressed: boolean;
+  direction: 'ltr' | 'rtl';
+}>({
+  ...focusRing(),
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  size: controlSizeM,
   flexShrink: 0,
   borderRadius: 'full',
-  overflow: 'clip',
+  borderStyle: 'none',
+  transition: 'default',
+  backgroundColor: {
+    default: baseColor('gray-100'),
+    forcedColors: 'ButtonFace'
+  },
+  color: {
+    default: baseColor('neutral'),
+    isDisabled: 'disabled',
+    forcedColors: {
+      default: 'ButtonText',
+      isDisabled: 'GrayText'
+    }
+  },
+  '--iconPrimary': {
+    type: 'fill',
+    value: 'currentColor'
+  },
+  outlineColor: {
+    default: 'focus-ring',
+    forcedColors: 'Highlight'
+  },
   scale: {
     direction: {
       rtl: -1
     }
-  }
+  },
+  disableTapHighlight: true
 });
 
 function CarouselNavButton({
@@ -360,21 +393,25 @@ function CarouselNavButton({
   onPress: () => void;
   isDisabled: boolean;
 }) {
+  let ref = useRef(null);
   let {direction} = useLocale();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
   let Icon = side === 'start' ? ChevronLeft : ChevronRight;
+  // oxlint-disable react/react-compiler
   return (
-    <div className={carouselNavButton({direction})}>
-      <ActionButton
-        isDisabled={isDisabled}
-        aria-label={stringFormatter.format(
-          side === 'start' ? 'attachmentlist.previousAttachments' : 'attachmentlist.nextAttachments'
-        )}
-        onPress={onPress}>
-        <Icon />
-      </ActionButton>
-    </div>
+    <Button
+      ref={ref}
+      isDisabled={isDisabled}
+      aria-label={stringFormatter.format(
+        side === 'start' ? 'attachmentlist.previousAttachments' : 'attachmentlist.nextAttachments'
+      )}
+      style={pressScale(ref, {})}
+      onPress={onPress}
+      className={renderProps => carouselNavButtonStyles({...renderProps, direction})}>
+      <Icon />
+    </Button>
   );
+  // oxlint-enable react/react-compiler
 }
 
 export const AttachmentList = (forwardRef as forwardRefType)(function AttachmentList<T>(
@@ -601,7 +638,7 @@ export const Attachment = forwardRef(function Attachment(
           position: 'absolute',
           top: 0,
           insetEnd: 0,
-          transform: 'translate(25%, -25%)'
+          transform: 'translate(50%, -50%)'
         })}>
         <CloseButton size="XS" />
       </div>

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -33,7 +33,15 @@ import {CardProps} from '@react-spectrum/s2/Card';
 import ChevronLeft from '@react-spectrum/s2/icons/ChevronLeft';
 import ChevronRight from '@react-spectrum/s2/icons/ChevronRight';
 import {ContentContext} from '@react-spectrum/s2/Content';
-import {createContext, forwardRef, ReactNode, useCallback, useContext, useRef, useState} from 'react';
+import {
+  createContext,
+  forwardRef,
+  ReactNode,
+  useCallback,
+  useContext,
+  useRef,
+  useState
+} from 'react';
 import Cross from '../ui-icons/Cross';
 import {DEFAULT_SLOT, Provider} from 'react-aria-components/slots';
 import File from '@react-spectrum/s2/icons/File';
@@ -371,9 +379,15 @@ const carouselNavButton = style({
   }
 });
 
-function CarouselNavButton(
-  {side, onPress, isDisabled}: {side: 'start' | 'end', onPress: () => void, isDisabled: boolean}
-) {
+function CarouselNavButton({
+  side,
+  onPress,
+  isDisabled
+}: {
+  side: 'start' | 'end';
+  onPress: () => void;
+  isDisabled: boolean;
+}) {
   let {direction} = useLocale();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
   let Icon = side === 'start' ? ChevronLeft : ChevronRight;

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -21,26 +21,18 @@ import {
 import AudioWave from '@react-spectrum/s2/icons/AudioWave';
 import {
   baseColor,
-  color,
+  css,
   focusRing,
   iconStyle,
   lightDark,
   style
 } from '@react-spectrum/s2/style' with {type: 'macro'};
-import {Button} from 'react-aria-components/Button';
+import {Button, ButtonProps} from 'react-aria-components/Button';
 import {CardProps} from '@react-spectrum/s2/Card';
 import ChevronLeft from '@react-spectrum/s2/icons/ChevronLeft';
 import ChevronRight from '@react-spectrum/s2/icons/ChevronRight';
 import {ContentContext} from '@react-spectrum/s2/Content';
-import {
-  createContext,
-  forwardRef,
-  ReactNode,
-  useCallback,
-  useContext,
-  useRef,
-  useState
-} from 'react';
+import {createContext, CSSProperties, forwardRef, ReactNode, useContext, useRef} from 'react';
 import Cross from '../ui-icons/Cross';
 import {DEFAULT_SLOT, Provider} from 'react-aria-components/slots';
 import File from '@react-spectrum/s2/icons/File';
@@ -49,11 +41,11 @@ import {Image, ImageContext, ImageProps} from '@react-spectrum/s2/Image';
 import {ImageCoordinator} from '@react-spectrum/s2/ImageCoordinator';
 import ImageIcon from '@react-spectrum/s2/icons/Image';
 import intlMessages from '../intl/*.json';
+import {keyframes, scrollFade} from './tokens.macro' with {type: 'macro'};
 import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
 import Play from '@react-spectrum/s2/icons/Play';
 import {pressScale} from '@react-spectrum/s2/pressScale';
 import {ProgressCircle} from '@react-spectrum/s2/ProgressCircle';
-import {scrollFade} from './tokens.macro' with {type: 'macro'};
 import {StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {
   Tag,
@@ -65,11 +57,8 @@ import {
 } from 'react-aria-components/TagGroup';
 import {TextContext} from '@react-spectrum/s2/Text';
 import {useDOMRef} from './useDOMRef';
-import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
-import {useResizeObserver} from 'react-aria/private/utils/useResizeObserver';
-import {useValueEffect} from 'react-aria/private/utils/useValueEffect';
 
 interface AttachmentRenderProps {
   /** The size of the Card. */
@@ -133,8 +122,7 @@ const container = {
     default: lightDark('black/3', 'white/3'),
     isInvalid: 'red-700/8',
     forcedColors: 'ButtonFace'
-  },
-  boxShadow: `[0 8px 32px 0 light-dark(${color('transparent-black-50')}, ${color('transparent-white-50')})]`
+  }
 } as const;
 
 const attachmentCard = style({
@@ -337,8 +325,15 @@ const tagListStyles = style<{isCarousel: boolean}>({
   overflowX: {isCarousel: 'auto'},
   scrollbarWidth: {isCarousel: 'none'},
   scrollSnapType: {isCarousel: 'x mandatory'},
-  paddingY: 12
+  padding: 16,
+  boxSizing: 'border-box',
+  scrollPaddingX: 40
 });
+
+const buttonFade = keyframes(`
+  from { opacity: 0; visibility: hidden }
+  to { opacity: 1; visibility: visible }
+`);
 
 const carouselNavButtonStyles = style<{
   isDisabled: boolean;
@@ -346,6 +341,7 @@ const carouselNavButtonStyles = style<{
   isFocusVisible: boolean;
   isPressed: boolean;
   direction: 'ltr' | 'rtl';
+  side: 'start' | 'end';
 }>({
   ...focusRing(),
   display: 'flex',
@@ -381,18 +377,38 @@ const carouselNavButtonStyles = style<{
       rtl: -1
     }
   },
-  disableTapHighlight: true
+  disableTapHighlight: true,
+  position: 'absolute',
+  zIndex: 1,
+  insetEnd: {
+    side: {
+      end: 0
+    }
+  },
+  opacity: {
+    default: 0,
+    isFocusVisible: 1
+  },
+  visibility: {
+    default: 'hidden',
+    isFocusVisible: 'visible'
+  },
+  animation: {
+    '@supports (animation-timeline: scroll())': buttonFade,
+    isFocusVisible: 'none'
+  },
+  animationDuration: 1,
+  animationTimingFunction: 'in-out',
+  animationFillMode: 'both',
+  animationDirection: {
+    side: {
+      start: 'normal',
+      end: 'reverse'
+    }
+  }
 });
 
-function CarouselNavButton({
-  side,
-  onPress,
-  isDisabled
-}: {
-  side: 'start' | 'end';
-  onPress: () => void;
-  isDisabled: boolean;
-}) {
+function CarouselNavButton({side, ...otherProps}: ButtonProps & {side: 'start' | 'end'}) {
   let ref = useRef(null);
   let {direction} = useLocale();
   let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
@@ -400,14 +416,16 @@ function CarouselNavButton({
   // oxlint-disable react/react-compiler
   return (
     <Button
+      {...otherProps}
       ref={ref}
-      isDisabled={isDisabled}
       aria-label={stringFormatter.format(
         side === 'start' ? 'attachmentlist.previousAttachments' : 'attachmentlist.nextAttachments'
       )}
-      style={pressScale(ref, {})}
-      onPress={onPress}
-      className={renderProps => carouselNavButtonStyles({...renderProps, direction})}>
+      style={pressScale(ref, {
+        animationTimeline: '--carousel-scroll',
+        animationRange: side === 'start' ? '0px 32px' : 'calc(100% - 32px) 100%'
+      } as CSSProperties)}
+      className={renderProps => carouselNavButtonStyles({...renderProps, direction, side})}>
       <Icon />
     </Button>
   );
@@ -421,85 +439,53 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
   let {styles, items, children, dependencies, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let scrollRef = useRef<HTMLDivElement>(null);
-
-  let [isCarousel, setIsCarousel] = useValueEffect(false);
-  // oxlint-disable react/react-compiler, react-hooks/exhaustive-deps
-  let checkForOverflow = useCallback(() => {
-    setIsCarousel(function* () {
-      yield true;
-      let el = scrollRef.current;
-      yield !!el && !!domRef.current && el.scrollWidth > domRef.current.offsetWidth + 1;
-    });
-  }, [setIsCarousel]);
-  // oxlint-enable react/react-compiler, react-hooks/exhaustive-deps
-  useLayoutEffect(() => {
-    checkForOverflow();
-  }, [checkForOverflow, items, children]);
-  // Observe the parent, not domRef: our own size changes when isCarousel toggles.
-  let parent = useRef<HTMLElement | null>(null);
-  // oxlint-disable react/react-compiler, react-hooks/exhaustive-deps
-  useLayoutEffect(() => {
-    if (domRef.current) {
-      parent.current = domRef.current.parentElement as HTMLElement;
-    }
-  }, [domRef.current]);
-  // oxlint-enable react/react-compiler, react-hooks/exhaustive-deps
-  useResizeObserver({ref: parent, onResize: checkForOverflow});
-
   let {direction} = useLocale();
-  let [canScrollPrev, setCanScrollPrev] = useState(false);
-  let [canScrollNext, setCanScrollNext] = useState(false);
-  // Track padding can rest scroll-snap at a nonzero scrollLeft; treat the first read as "start".
-  let startScrollRef = useRef<number | null>(null);
-  let updateScrollState = useCallback(() => {
-    let el = scrollRef.current;
-    if (el) {
-      let maxScroll = el.scrollWidth - el.clientWidth;
-      let scrolled = Math.abs(el.scrollLeft);
-      if (startScrollRef.current == null) {
-        startScrollRef.current = scrolled;
-      }
-      setCanScrollPrev(scrolled > startScrollRef.current + 1);
-      setCanScrollNext(scrolled < maxScroll - 1);
-    }
-  }, []);
-  useLayoutEffect(() => {
-    startScrollRef.current = null;
-    updateScrollState();
-  }, [updateScrollState, isCarousel]);
-  useResizeObserver({ref: scrollRef, onResize: updateScrollState});
-
   let scroll = (dir: 1 | -1) => {
     // RTL flips the scroll direction convention; flip the sign to match.
     let sign = direction === 'rtl' ? -1 : 1;
     scrollRef.current?.scrollBy({
-      left: sign * dir * scrollRef.current.clientWidth * 0.8,
+      left: sign * dir * scrollRef.current.clientWidth,
       behavior: 'smooth'
     });
   };
 
-  let tagList = (
-    <TagList
-      ref={scrollRef}
-      items={items}
-      dependencies={dependencies}
-      onScroll={updateScrollState}
-      className={tagListStyles({isCarousel}) + ' ' + (isCarousel ? scrollFade({x: 32}) : '')}>
-      {children}
-    </TagList>
-  );
-
   return (
-    <TagGroup {...otherProps} className={styles} ref={domRef}>
-      {isCarousel ? (
-        <div className={style({...flexRow, gap: 8})}>
-          <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />
-          {tagList}
-          <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />
-        </div>
-      ) : (
-        tagList
+    <TagGroup
+      {...otherProps}
+      className={mergeStyles(
+        style({...flexRow, gap: 8, position: 'relative', marginX: -16}),
+        styles
       )}
+      style={
+        {
+          timelineScope: '--carousel-scroll'
+        } as CSSProperties
+      }
+      ref={domRef}>
+      <CarouselNavButton side="start" onPress={() => scroll(-1)} />
+      <TagList
+        ref={scrollRef}
+        items={items}
+        dependencies={dependencies}
+        className={
+          tagListStyles({isCarousel: true}) +
+          ' ' +
+          scrollFade({x: 32, inset: 40}) +
+          ' ' +
+          // Hack to keep scroll fade visible when the buttons are focused.
+          css(
+            `&:is(button[data-focus-visible]+*){--scroll-fade-left: 72px !important} &:has(+ button[data-focus-visible]){--scroll-fade-right: calc(100% - 72px) !important}`
+          )
+        }
+        style={
+          {
+            scrollTimelineName: '--carousel-scroll',
+            scrollTimelineAxis: 'inline'
+          } as CSSProperties
+        }>
+        {children}
+      </TagList>
+      <CarouselNavButton side="end" onPress={() => scroll(1)} />
     </TagGroup>
   );
 });
@@ -638,7 +624,7 @@ export const Attachment = forwardRef(function Attachment(
           position: 'absolute',
           top: 0,
           insetEnd: 0,
-          transform: 'translate(50%, -50%)'
+          transform: 'translate(30%, -30%)'
         })}>
         <CloseButton size="XS" />
       </div>

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -329,7 +329,6 @@ const flexRow = {
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  width: 'full'
 } as const;
 
 const tagListStyles = style<{isCarousel: boolean}>({

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -328,7 +328,7 @@ export interface AttachmentListProps<T>
 const flexRow = {
   display: 'flex',
   flexDirection: 'row',
-  alignItems: 'center',
+  alignItems: 'center'
 } as const;
 
 const tagListStyles = style<{isCarousel: boolean}>({
@@ -337,7 +337,7 @@ const tagListStyles = style<{isCarousel: boolean}>({
   flexWrap: {default: 'wrap', isCarousel: 'nowrap'},
   overflowX: {isCarousel: 'auto'},
   scrollbarWidth: {isCarousel: 'none'},
-  scrollSnapType: {isCarousel: 'x mandatory'},
+  scrollSnapType: {isCarousel: 'x mandatory'}
 });
 
 const carouselNavButton = style({
@@ -454,11 +454,15 @@ export const AttachmentList = (forwardRef as forwardRefType)(function Attachment
 
   return (
     <TagGroup {...otherProps} className={styles} ref={domRef}>
-      <div className={style({...flexRow, gap: 8, display: {default: 'contents', isCarousel: 'flex'}})({isCarousel})}>
-        {isCarousel && <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />}
-        {tagList}
-        {isCarousel && <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />}
-      </div>
+      {isCarousel ? (
+        <div className={style({...flexRow, gap: 8})}>
+          <CarouselNavButton side="start" isDisabled={!canScrollPrev} onPress={() => scroll(-1)} />
+          {tagList}
+          <CarouselNavButton side="end" isDisabled={!canScrollNext} onPress={() => scroll(1)} />
+        </div>
+      ) : (
+        tagList
+      )}
     </TagGroup>
   );
 });

--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -9,7 +9,7 @@ import {
   token
 } from './tokens.macro' with {type: 'macro'};
 import {color, css, style, StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {getEventTarget} from 'react-aria/private/utils/shadowdom/DOMFunctions';
+import {getEventTarget, nodeContains} from 'react-aria/private/utils/shadowdom/DOMFunctions';
 import {Group, GroupProps} from 'react-aria-components/Group';
 import {isFocusable} from 'react-aria/private/utils/isFocusable';
 import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
@@ -382,7 +382,7 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
         '--brand': brandColor
       }}
       onFocus={e => {
-        if (e.isTrusted) {
+        if (e.isTrusted && nodeContains(inputRef.current, getEventTarget(e))) {
           setFocused(true);
         }
       }}

--- a/packages/@react-spectrum/ai/src/tokens.macro.ts
+++ b/packages/@react-spectrum/ai/src/tokens.macro.ts
@@ -252,10 +252,11 @@ interface ScrollFadeOptions {
   end?: number;
   x?: number;
   y?: number;
+  inset?: number;
 }
 
 export function scrollFade(this: any | void, options: ScrollFadeOptions) {
-  let {x = 0, y = 0, top = y, bottom = y, start = x, end = x} = options;
+  let {x = 0, y = 0, top = y, bottom = y, start = x, end = x, inset = 0} = options;
 
   let blockMask = '',
     inlineMask = '';
@@ -263,10 +264,10 @@ export function scrollFade(this: any | void, options: ScrollFadeOptions) {
   if (top || bottom) {
     blockMask = `linear-gradient(
       to bottom,
-      transparent 0px,
-      black var(--scroll-fade-top, 0px),
-      black var(--scroll-fade-bottom, 100%),
-      transparent 100%
+      transparent 0px ${inset > 0 ? `calc(var(--scroll-fade-top, ${inset}px) - ${top}px)` : ''},
+      black var(--scroll-fade-top, ${inset}px),
+      black var(--scroll-fade-bottom, calc(100% - ${bottom}px)),
+      transparent ${inset > 0 ? `calc(var(--scroll-fade-bottom, 100%) + ${inset}px)` : ''} 100%
     )`;
   }
 
@@ -274,18 +275,24 @@ export function scrollFade(this: any | void, options: ScrollFadeOptions) {
     // TODO: rtl
     inlineMask = `linear-gradient(
       to right,
-      transparent 0px,
-      black var(--scroll-fade-left, 0px),
-      black var(--scroll-fade-right, 100%),
-      transparent 100%
+      transparent 0px ${inset > 0 ? `calc(var(--scroll-fade-left, ${inset}px) - ${start}px)` : ''},
+      black var(--scroll-fade-left, ${inset}px),
+      black var(--scroll-fade-right, calc(100% - ${end}px)),
+      transparent ${inset > 0 ? `calc(var(--scroll-fade-right, 100%) + ${end}px)` : ''} 100%
     )`;
   }
 
-  let topAnimation = scrollFadeKeyframes.call(this, 'top', '0px', top ? `${top}px` : '', '0px');
+  let topAnimation = scrollFadeKeyframes.call(
+    this,
+    'top',
+    '0px',
+    top ? `${top + inset}px` : '',
+    '0px'
+  );
   let bottomAnimation = scrollFadeKeyframes.call(
     this,
     'bottom',
-    bottom ? `calc(100% - ${bottom}px)` : '',
+    bottom ? `calc(100% - ${bottom + inset}px)` : '',
     '100%',
     '100%'
   );
@@ -293,13 +300,13 @@ export function scrollFade(this: any | void, options: ScrollFadeOptions) {
     this,
     'left',
     '0px',
-    start ? `${start}px` : '',
+    start ? `${start + inset}px` : '',
     '0px'
   );
   let rightAnimation = scrollFadeKeyframes.call(
     this,
     'right',
-    end ? `calc(100% - ${end}px)` : '',
+    end ? `calc(100% - ${end + inset}px)` : '',
     '100%',
     '100%'
   );

--- a/packages/@react-spectrum/ai/src/tokens.macro.ts
+++ b/packages/@react-spectrum/ai/src/tokens.macro.ts
@@ -304,7 +304,7 @@ export function scrollFade(this: any | void, options: ScrollFadeOptions) {
     '100%'
   );
   let animations = [topAnimation, bottomAnimation, leftAnimation, rightAnimation];
-  let timeline = ['scroll(self y)', 'scroll(self y)', 'scroll(self x)', 'scroll(self y)']
+  let timeline = ['scroll(self y)', 'scroll(self y)', 'scroll(self x)', 'scroll(self x)']
     .filter((_, i) => animations[i])
     .join(', ');
   let range = [

--- a/packages/@react-spectrum/ai/src/tokens.macro.ts
+++ b/packages/@react-spectrum/ai/src/tokens.macro.ts
@@ -344,16 +344,18 @@ function scrollFadeKeyframes(this: any, name: string, start: string, end: string
     return '';
   }
 
-  this.addAsset({
-    type: 'css',
-    content: `
+  if (this && typeof this.addAsset === 'function') {
+    this.addAsset({
+      type: 'css',
+      content: `
     @property --scroll-fade-${name} {
       syntax: "<length-percentage>";
       inherits: false;
       initial-value: ${initial};
     }
   `
-  });
+    });
+  }
 
   return keyframes.call(
     this,

--- a/packages/@react-spectrum/ai/stories/AttachmentList.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/AttachmentList.stories.tsx
@@ -272,7 +272,7 @@ export const Mixed: Story = {
 function CarouselRender(args) {
   let {isInvalid, size, uploadProgress, ...listArgs} = args;
   return (
-    <AttachmentList {...listArgs} styles={style({width: 500})}>
+    <AttachmentList {...listArgs} styles={style({width: 500, maxWidth: 'calc(100vw - 32px)'})}>
       {Array.from({length: 8}, (_, i) => (
         <AttachmentComponent
           key={i}
@@ -299,7 +299,7 @@ export const Carousel: Story = {
 function CarouselCardsRender(args) {
   let {isInvalid, size, uploadProgress, ...listArgs} = args;
   return (
-    <AttachmentList {...listArgs} styles={style({width: 500})}>
+    <AttachmentList {...listArgs} styles={style({width: 500, maxWidth: 'calc(100vw - 32px)'})}>
       {Array.from({length: 6}, (_, i) => (
         <AttachmentComponent
           key={i}

--- a/packages/@react-spectrum/ai/stories/AttachmentList.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/AttachmentList.stories.tsx
@@ -268,3 +268,61 @@ export const Mixed: Story = {
   name: 'Mixed attachements',
   render: args => <MixedAttachments {...args} />
 };
+
+function CarouselRender(args) {
+  let {isInvalid, size, uploadProgress, ...listArgs} = args;
+  return (
+    <AttachmentList {...listArgs} styles={style({width: 500})}>
+      {Array.from({length: 8}, (_, i) => (
+        <AttachmentComponent
+          key={i}
+          uploadProgress={uploadProgress}
+          isInvalid={isInvalid}
+          size={size}
+          aria-label={`file-${i + 1}.pdf`}>
+          <AttachmentPreview
+            mimeType="application/pdf"
+            slot="thumbnail"
+            src={new URL('../../s2/stories/assets/placeholder.png', import.meta.url).toString()}
+          />
+        </AttachmentComponent>
+      ))}
+    </AttachmentList>
+  );
+}
+
+export const Carousel: Story = {
+  name: 'Carousel (overflow)',
+  render: args => <CarouselRender {...args} />
+};
+
+function CarouselCardsRender(args) {
+  let {isInvalid, size, uploadProgress, ...listArgs} = args;
+  return (
+    <AttachmentList {...listArgs} styles={style({width: 500})}>
+      {Array.from({length: 6}, (_, i) => (
+        <AttachmentComponent
+          key={i}
+          uploadProgress={uploadProgress}
+          isInvalid={isInvalid}
+          size={size}
+          aria-label={`Card_file_${i + 1}.pdf`}>
+          <AttachmentPreview
+            mimeType="application/pdf"
+            slot="thumbnail"
+            src={new URL('../../s2/stories/assets/placeholder.png', import.meta.url).toString()}
+          />
+          <Content>
+            <Text slot="title">{`Card_file_${i + 1}.pdf`}</Text>
+            <Text slot="description">PDF</Text>
+          </Content>
+        </AttachmentComponent>
+      ))}
+    </AttachmentList>
+  );
+}
+
+export const CarouselCards: Story = {
+  name: 'Carousel with cards (overflow)',
+  render: args => <CarouselCardsRender {...args} />
+};

--- a/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
+++ b/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
@@ -11,204 +11,22 @@
  */
 
 import {Attachment, AttachmentList} from '@react-spectrum/ai';
-import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
 import {Image} from '@react-spectrum/s2/Image';
-import {Provider} from '@react-spectrum/s2/Provider';
 import React from 'react';
-import userEvent from '@testing-library/user-event';
+import {render} from '@react-spectrum/test-utils-internal';
 
 // Conditionally skip the suite
 const describeOrSkip = parseInt(React.version, 10) < 19 ? describe.skip : describe;
-
-function renderAttachments(count: number, wrap: (el: JSX.Element) => JSX.Element = el => el) {
-  return render(
-    wrap(
-      <AttachmentList aria-label="Uploaded files">
-        {Array.from({length: count}, (_, i) => (
-          <Attachment key={i} aria-label={`file-${i}.pdf`} textValue={`file-${i}.pdf`}>
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-        ))}
-      </AttachmentList>
-    )
-  );
-}
-
 describeOrSkip('AttachmentList', () => {
   it('should render', () => {
-    let {getByRole} = renderAttachments(1);
+    let {getByRole} = render(
+      <AttachmentList aria-label="Uploaded files">
+        <Attachment aria-label="Demo file.pdf" textValue="Demo file.pdf">
+          <Image slot="thumbnail" src="https://example.com/image.png" />
+        </Attachment>
+      </AttachmentList>
+    );
+
     expect(getByRole('grid')).toBeInTheDocument();
-  });
-
-  describe('carousel overflow', () => {
-    let offsetWidthSpy, clientWidthSpy, scrollWidthSpy, scrollLeftSpy;
-
-    afterEach(() => {
-      offsetWidthSpy?.mockRestore();
-      clientWidthSpy?.mockRestore();
-      scrollWidthSpy?.mockRestore();
-      scrollLeftSpy?.mockRestore();
-      delete window.HTMLElement.prototype.scrollBy;
-    });
-
-    it('should switch to a carousel once attachments overflow the container width', () => {
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => 200);
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 800);
-
-      let {getByRole} = renderAttachments(2);
-
-      expect(getByRole('button', {name: 'Show previous attachments'})).toBeInTheDocument();
-      expect(getByRole('button', {name: 'Show next attachments'})).toBeInTheDocument();
-    });
-
-    it('should not render carousel nav when attachments fit', () => {
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => 800);
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 200);
-
-      let {queryByRole} = renderAttachments(1);
-
-      expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
-    });
-
-    it("should not get stuck in carousel mode from the nav buttons shrinking the track's own width", () => {
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(function (this: HTMLElement) {
-          return this.getAttribute('role') === 'grid' ? 650 : 700;
-        });
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 690);
-
-      let {queryByRole} = renderAttachments(2);
-
-      expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
-    });
-
-    it('should disable "previous" at the natural resting start position, even when it is not scrollLeft 0', () => {
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => 200);
-      clientWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
-        .mockImplementation(() => 200);
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 800);
-      scrollLeftSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
-        .mockImplementation(() => 12);
-
-      let {getByRole} = renderAttachments(2);
-
-      expect(getByRole('button', {name: 'Show previous attachments'})).toBeDisabled();
-      expect(getByRole('button', {name: 'Show next attachments'})).not.toBeDisabled();
-    });
-
-    it('should disable "next" at the natural resting end position', () => {
-      // Mirror of the "previous"-at-start test above, for the end boundary.
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => 200);
-      clientWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
-        .mockImplementation(() => 200);
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 800);
-      scrollLeftSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
-        .mockImplementation(() => 600);
-
-      let {getByRole} = renderAttachments(2);
-
-      expect(getByRole('button', {name: 'Show next attachments'})).toBeDisabled();
-      expect(getByRole('button', {name: 'Show previous attachments'})).not.toBeDisabled();
-    });
-
-    it('should recalculate carousel mode when the container is resized', () => {
-      let fits = true;
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => (fits ? 800 : 200));
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 700);
-
-      let {queryByRole} = renderAttachments(2);
-
-      expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
-
-      fits = false;
-      fireEvent(window, new Event('resize'));
-
-      expect(queryByRole('button', {name: 'Show previous attachments'})).toBeInTheDocument();
-    });
-
-    it('should scroll toward the start (positive delta) when RTL and "previous" is pressed', async () => {
-      let user = userEvent.setup({delay: null, pointerMap});
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => 200);
-      clientWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
-        .mockImplementation(() => 200);
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 800);
-      // Simulate having scrolled in, so "previous" isn't disabled at the start boundary.
-      let scrollLeftValue = 0;
-      scrollLeftSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
-        .mockImplementation(() => scrollLeftValue);
-      let scrollBy = jest.fn();
-      window.HTMLElement.prototype.scrollBy = scrollBy;
-
-      let {getByRole} = renderAttachments(2, el => <Provider locale="ar-AE">{el}</Provider>);
-
-      scrollLeftValue = -300;
-      fireEvent.scroll(getByRole('grid'));
-
-      await user.click(getByRole('button', {name: 'Show previous attachments'}));
-      // RTL's negative-scrollLeft convention means "toward the start" is a positive delta,
-      // the opposite of LTR.
-      expect(scrollBy).toHaveBeenCalledWith(expect.objectContaining({left: expect.any(Number)}));
-      expect(scrollBy.mock.calls[0][0].left).toBeGreaterThan(0);
-    });
-
-    it('should scroll in the opposite direction for "previous" vs "next" when LTR', async () => {
-      let user = userEvent.setup({delay: null, pointerMap});
-      offsetWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
-        .mockImplementation(() => 200);
-      clientWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
-        .mockImplementation(() => 200);
-      scrollWidthSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
-        .mockImplementation(() => 800);
-      // Simulate having already scrolled in, so neither button is disabled at a boundary.
-      scrollLeftSpy = jest
-        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
-        .mockImplementation(() => 300);
-      let scrollBy = jest.fn();
-      window.HTMLElement.prototype.scrollBy = scrollBy;
-
-      let {getByRole} = renderAttachments(2);
-
-      await user.click(getByRole('button', {name: 'Show next attachments'}));
-      expect(scrollBy.mock.calls[0][0].left).toBeGreaterThan(0);
-
-      await user.click(getByRole('button', {name: 'Show previous attachments'}));
-      expect(scrollBy.mock.calls[1][0].left).toBeLessThan(0);
-    });
   });
 });

--- a/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
+++ b/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
@@ -12,8 +12,10 @@
 
 import {Attachment, AttachmentList} from '@react-spectrum/ai';
 import {Image} from '@react-spectrum/s2/Image';
+import {Provider} from '@react-spectrum/s2/Provider';
 import React from 'react';
-import {render} from '@react-spectrum/test-utils-internal';
+import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
+import userEvent from '@testing-library/user-event';
 
 // Conditionally skip the suite
 const describeOrSkip = parseInt(React.version, 10) < 19 ? describe.skip : describe;
@@ -28,5 +30,197 @@ describeOrSkip('AttachmentList', () => {
     );
 
     expect(getByRole('grid')).toBeInTheDocument();
+  });
+
+  describe('carousel overflow', () => {
+    let offsetWidthSpy, clientWidthSpy, scrollWidthSpy;
+
+    afterEach(() => {
+      offsetWidthSpy?.mockRestore();
+      clientWidthSpy?.mockRestore();
+      scrollWidthSpy?.mockRestore();
+    });
+
+    it('should switch to a carousel once attachments overflow the container width', () => {
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => 200);
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 800);
+
+      let {getByRole} = render(
+        <AttachmentList aria-label="Uploaded files">
+          <Attachment aria-label="one.pdf" textValue="one.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+          <Attachment aria-label="two.pdf" textValue="two.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+        </AttachmentList>
+      );
+
+      expect(getByRole('button', {name: 'Show previous attachments'})).toBeInTheDocument();
+      expect(getByRole('button', {name: 'Show next attachments'})).toBeInTheDocument();
+    });
+
+    it('should not render carousel nav when attachments fit', () => {
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => 800);
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 200);
+
+      let {queryByRole} = render(
+        <AttachmentList aria-label="Uploaded files">
+          <Attachment aria-label="one.pdf" textValue="one.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+        </AttachmentList>
+      );
+
+      expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
+    });
+
+    it('should not overflow just because the carousel nav buttons would take up their own space', () => {
+      // Regression test: comparing the track's own (post-button) width against itself, or against
+      // a container whose width shrinks once carousel mode reserves room for the nav buttons, can
+      // create a feedback loop - entering carousel mode eats just enough space that the content
+      // "still" doesn't fit, keeping it stuck on forever. Content that fits the *outer* box just
+      // fine (independent of whether buttons are shown) should never trigger the carousel.
+      // The track (role="grid") reports a smaller offsetWidth than the outer box, as it would once
+      // nav buttons reserve their own room - only comparing scrollWidth against the *outer* box's
+      // width (not the track's own) avoids the feedback loop, so this must mock them differently.
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(function (this: HTMLElement) {
+          return this.getAttribute('role') === 'grid' ? 650 : 700;
+        });
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 690);
+
+      let {queryByRole} = render(
+        <AttachmentList aria-label="Uploaded files">
+          <Attachment aria-label="one.pdf" textValue="one.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+          <Attachment aria-label="two.pdf" textValue="two.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+        </AttachmentList>
+      );
+
+      expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
+    });
+
+    it('should disable "previous" at the natural resting start position, even when it is not scrollLeft 0', () => {
+      // Browsers can rest scroll-snapped content at a nonzero scrollLeft (e.g. to account for the
+      // track's own padding) - the very first read should be treated as "the start", not literal 0.
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => 200);
+      clientWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
+        .mockImplementation(() => 200);
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 800);
+      let scrollLeftSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
+        .mockImplementation(() => 12);
+
+      let {getByRole} = render(
+        <AttachmentList aria-label="Uploaded files">
+          <Attachment aria-label="one.pdf" textValue="one.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+          <Attachment aria-label="two.pdf" textValue="two.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+        </AttachmentList>
+      );
+
+      expect(getByRole('button', {name: 'Show previous attachments'})).toBeDisabled();
+      expect(getByRole('button', {name: 'Show next attachments'})).not.toBeDisabled();
+
+      scrollLeftSpy.mockRestore();
+    });
+
+    it('should recalculate carousel mode when the container is resized', () => {
+      // ResizeObserver isn't implemented in jsdom, so this exercises the window resize fallback
+      // (useResizeObserver observes the parent element and falls back to a 'resize' listener).
+      let fits = true;
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => (fits ? 800 : 200));
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 700);
+
+      let {queryByRole} = render(
+        <AttachmentList aria-label="Uploaded files">
+          <Attachment aria-label="one.pdf" textValue="one.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+          <Attachment aria-label="two.pdf" textValue="two.pdf">
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+        </AttachmentList>
+      );
+
+      expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
+
+      fits = false;
+      fireEvent(window, new Event('resize'));
+
+      expect(queryByRole('button', {name: 'Show previous attachments'})).toBeInTheDocument();
+    });
+
+    it('should scroll toward the start (positive delta) when RTL and "previous" is pressed', async () => {
+      let user = userEvent.setup({delay: null, pointerMap});
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => 200);
+      clientWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
+        .mockImplementation(() => 200);
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 800);
+      // Starts at the resting position, then simulate having scrolled in, so "previous" isn't
+      // disabled at the start boundary when it's pressed.
+      let scrollLeftValue = 0;
+      let scrollLeftSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
+        .mockImplementation(() => scrollLeftValue);
+      let scrollBy = jest.fn();
+      window.HTMLElement.prototype.scrollBy = scrollBy;
+
+      let {getByRole} = render(
+        <Provider locale="ar-AE">
+          <AttachmentList aria-label="Uploaded files">
+            <Attachment aria-label="one.pdf" textValue="one.pdf">
+              <Image slot="thumbnail" src="https://example.com/image.png" />
+            </Attachment>
+            <Attachment aria-label="two.pdf" textValue="two.pdf">
+              <Image slot="thumbnail" src="https://example.com/image.png" />
+            </Attachment>
+          </AttachmentList>
+        </Provider>
+      );
+
+      scrollLeftValue = -300;
+      fireEvent.scroll(getByRole('grid'));
+
+      await user.click(getByRole('button', {name: 'Show previous attachments'}));
+      // RTL's negative-scrollLeft convention means "toward the start" is a positive delta,
+      // the opposite of LTR.
+      expect(scrollBy).toHaveBeenCalledWith(expect.objectContaining({left: expect.any(Number)}));
+      expect(scrollBy.mock.calls[0][0].left).toBeGreaterThan(0);
+
+      scrollLeftSpy.mockRestore();
+    });
   });
 });

--- a/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
+++ b/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
@@ -11,10 +11,10 @@
  */
 
 import {Attachment, AttachmentList} from '@react-spectrum/ai';
+import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
 import {Image} from '@react-spectrum/s2/Image';
 import {Provider} from '@react-spectrum/s2/Provider';
 import React from 'react';
-import {fireEvent, pointerMap, render} from '@react-spectrum/test-utils-internal';
 import userEvent from '@testing-library/user-event';
 
 // Conditionally skip the suite

--- a/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
+++ b/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
@@ -29,4 +29,30 @@ describeOrSkip('AttachmentList', () => {
 
     expect(getByRole('grid')).toBeInTheDocument();
   });
+
+  it('should switch to a carousel once attachments overflow the container width', () => {
+    let offsetWidthSpy = jest
+      .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockImplementation(() => 200);
+    let scrollWidthSpy = jest
+      .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+      .mockImplementation(() => 800);
+
+    let {getByRole} = render(
+      <AttachmentList aria-label="Uploaded files">
+        <Attachment aria-label="one.pdf" textValue="one.pdf">
+          <Image slot="thumbnail" src="https://example.com/image.png" />
+        </Attachment>
+        <Attachment aria-label="two.pdf" textValue="two.pdf">
+          <Image slot="thumbnail" src="https://example.com/image.png" />
+        </Attachment>
+      </AttachmentList>
+    );
+
+    expect(getByRole('button', {name: 'Show previous attachments'})).toBeInTheDocument();
+    expect(getByRole('button', {name: 'Show next attachments'})).toBeInTheDocument();
+
+    offsetWidthSpy.mockRestore();
+    scrollWidthSpy.mockRestore();
+  });
 });

--- a/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
+++ b/packages/@react-spectrum/ai/test/AttachmentList.test.tsx
@@ -19,26 +19,36 @@ import userEvent from '@testing-library/user-event';
 
 // Conditionally skip the suite
 const describeOrSkip = parseInt(React.version, 10) < 19 ? describe.skip : describe;
+
+function renderAttachments(count: number, wrap: (el: JSX.Element) => JSX.Element = el => el) {
+  return render(
+    wrap(
+      <AttachmentList aria-label="Uploaded files">
+        {Array.from({length: count}, (_, i) => (
+          <Attachment key={i} aria-label={`file-${i}.pdf`} textValue={`file-${i}.pdf`}>
+            <Image slot="thumbnail" src="https://example.com/image.png" />
+          </Attachment>
+        ))}
+      </AttachmentList>
+    )
+  );
+}
+
 describeOrSkip('AttachmentList', () => {
   it('should render', () => {
-    let {getByRole} = render(
-      <AttachmentList aria-label="Uploaded files">
-        <Attachment aria-label="Demo file.pdf" textValue="Demo file.pdf">
-          <Image slot="thumbnail" src="https://example.com/image.png" />
-        </Attachment>
-      </AttachmentList>
-    );
-
+    let {getByRole} = renderAttachments(1);
     expect(getByRole('grid')).toBeInTheDocument();
   });
 
   describe('carousel overflow', () => {
-    let offsetWidthSpy, clientWidthSpy, scrollWidthSpy;
+    let offsetWidthSpy, clientWidthSpy, scrollWidthSpy, scrollLeftSpy;
 
     afterEach(() => {
       offsetWidthSpy?.mockRestore();
       clientWidthSpy?.mockRestore();
       scrollWidthSpy?.mockRestore();
+      scrollLeftSpy?.mockRestore();
+      delete window.HTMLElement.prototype.scrollBy;
     });
 
     it('should switch to a carousel once attachments overflow the container width', () => {
@@ -49,16 +59,7 @@ describeOrSkip('AttachmentList', () => {
         .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
         .mockImplementation(() => 800);
 
-      let {getByRole} = render(
-        <AttachmentList aria-label="Uploaded files">
-          <Attachment aria-label="one.pdf" textValue="one.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-          <Attachment aria-label="two.pdf" textValue="two.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-        </AttachmentList>
-      );
+      let {getByRole} = renderAttachments(2);
 
       expect(getByRole('button', {name: 'Show previous attachments'})).toBeInTheDocument();
       expect(getByRole('button', {name: 'Show next attachments'})).toBeInTheDocument();
@@ -72,26 +73,12 @@ describeOrSkip('AttachmentList', () => {
         .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
         .mockImplementation(() => 200);
 
-      let {queryByRole} = render(
-        <AttachmentList aria-label="Uploaded files">
-          <Attachment aria-label="one.pdf" textValue="one.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-        </AttachmentList>
-      );
+      let {queryByRole} = renderAttachments(1);
 
       expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
     });
 
-    it('should not overflow just because the carousel nav buttons would take up their own space', () => {
-      // Regression test: comparing the track's own (post-button) width against itself, or against
-      // a container whose width shrinks once carousel mode reserves room for the nav buttons, can
-      // create a feedback loop - entering carousel mode eats just enough space that the content
-      // "still" doesn't fit, keeping it stuck on forever. Content that fits the *outer* box just
-      // fine (independent of whether buttons are shown) should never trigger the carousel.
-      // The track (role="grid") reports a smaller offsetWidth than the outer box, as it would once
-      // nav buttons reserve their own room - only comparing scrollWidth against the *outer* box's
-      // width (not the track's own) avoids the feedback loop, so this must mock them differently.
+    it("should not get stuck in carousel mode from the nav buttons shrinking the track's own width", () => {
       offsetWidthSpy = jest
         .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
         .mockImplementation(function (this: HTMLElement) {
@@ -101,23 +88,12 @@ describeOrSkip('AttachmentList', () => {
         .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
         .mockImplementation(() => 690);
 
-      let {queryByRole} = render(
-        <AttachmentList aria-label="Uploaded files">
-          <Attachment aria-label="one.pdf" textValue="one.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-          <Attachment aria-label="two.pdf" textValue="two.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-        </AttachmentList>
-      );
+      let {queryByRole} = renderAttachments(2);
 
       expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
     });
 
     it('should disable "previous" at the natural resting start position, even when it is not scrollLeft 0', () => {
-      // Browsers can rest scroll-snapped content at a nonzero scrollLeft (e.g. to account for the
-      // track's own padding) - the very first read should be treated as "the start", not literal 0.
       offsetWidthSpy = jest
         .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
         .mockImplementation(() => 200);
@@ -127,30 +103,38 @@ describeOrSkip('AttachmentList', () => {
       scrollWidthSpy = jest
         .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
         .mockImplementation(() => 800);
-      let scrollLeftSpy = jest
+      scrollLeftSpy = jest
         .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
         .mockImplementation(() => 12);
 
-      let {getByRole} = render(
-        <AttachmentList aria-label="Uploaded files">
-          <Attachment aria-label="one.pdf" textValue="one.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-          <Attachment aria-label="two.pdf" textValue="two.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-        </AttachmentList>
-      );
+      let {getByRole} = renderAttachments(2);
 
       expect(getByRole('button', {name: 'Show previous attachments'})).toBeDisabled();
       expect(getByRole('button', {name: 'Show next attachments'})).not.toBeDisabled();
+    });
 
-      scrollLeftSpy.mockRestore();
+    it('should disable "next" at the natural resting end position', () => {
+      // Mirror of the "previous"-at-start test above, for the end boundary.
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => 200);
+      clientWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
+        .mockImplementation(() => 200);
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 800);
+      scrollLeftSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
+        .mockImplementation(() => 600);
+
+      let {getByRole} = renderAttachments(2);
+
+      expect(getByRole('button', {name: 'Show next attachments'})).toBeDisabled();
+      expect(getByRole('button', {name: 'Show previous attachments'})).not.toBeDisabled();
     });
 
     it('should recalculate carousel mode when the container is resized', () => {
-      // ResizeObserver isn't implemented in jsdom, so this exercises the window resize fallback
-      // (useResizeObserver observes the parent element and falls back to a 'resize' listener).
       let fits = true;
       offsetWidthSpy = jest
         .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
@@ -159,16 +143,7 @@ describeOrSkip('AttachmentList', () => {
         .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
         .mockImplementation(() => 700);
 
-      let {queryByRole} = render(
-        <AttachmentList aria-label="Uploaded files">
-          <Attachment aria-label="one.pdf" textValue="one.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-          <Attachment aria-label="two.pdf" textValue="two.pdf">
-            <Image slot="thumbnail" src="https://example.com/image.png" />
-          </Attachment>
-        </AttachmentList>
-      );
+      let {queryByRole} = renderAttachments(2);
 
       expect(queryByRole('button', {name: 'Show previous attachments'})).not.toBeInTheDocument();
 
@@ -189,27 +164,15 @@ describeOrSkip('AttachmentList', () => {
       scrollWidthSpy = jest
         .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
         .mockImplementation(() => 800);
-      // Starts at the resting position, then simulate having scrolled in, so "previous" isn't
-      // disabled at the start boundary when it's pressed.
+      // Simulate having scrolled in, so "previous" isn't disabled at the start boundary.
       let scrollLeftValue = 0;
-      let scrollLeftSpy = jest
+      scrollLeftSpy = jest
         .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
         .mockImplementation(() => scrollLeftValue);
       let scrollBy = jest.fn();
       window.HTMLElement.prototype.scrollBy = scrollBy;
 
-      let {getByRole} = render(
-        <Provider locale="ar-AE">
-          <AttachmentList aria-label="Uploaded files">
-            <Attachment aria-label="one.pdf" textValue="one.pdf">
-              <Image slot="thumbnail" src="https://example.com/image.png" />
-            </Attachment>
-            <Attachment aria-label="two.pdf" textValue="two.pdf">
-              <Image slot="thumbnail" src="https://example.com/image.png" />
-            </Attachment>
-          </AttachmentList>
-        </Provider>
-      );
+      let {getByRole} = renderAttachments(2, el => <Provider locale="ar-AE">{el}</Provider>);
 
       scrollLeftValue = -300;
       fireEvent.scroll(getByRole('grid'));
@@ -219,8 +182,33 @@ describeOrSkip('AttachmentList', () => {
       // the opposite of LTR.
       expect(scrollBy).toHaveBeenCalledWith(expect.objectContaining({left: expect.any(Number)}));
       expect(scrollBy.mock.calls[0][0].left).toBeGreaterThan(0);
+    });
 
-      scrollLeftSpy.mockRestore();
+    it('should scroll in the opposite direction for "previous" vs "next" when LTR', async () => {
+      let user = userEvent.setup({delay: null, pointerMap});
+      offsetWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockImplementation(() => 200);
+      clientWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'clientWidth', 'get')
+        .mockImplementation(() => 200);
+      scrollWidthSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollWidth', 'get')
+        .mockImplementation(() => 800);
+      // Simulate having already scrolled in, so neither button is disabled at a boundary.
+      scrollLeftSpy = jest
+        .spyOn(window.HTMLElement.prototype, 'scrollLeft', 'get')
+        .mockImplementation(() => 300);
+      let scrollBy = jest.fn();
+      window.HTMLElement.prototype.scrollBy = scrollBy;
+
+      let {getByRole} = renderAttachments(2);
+
+      await user.click(getByRole('button', {name: 'Show next attachments'}));
+      expect(scrollBy.mock.calls[0][0].left).toBeGreaterThan(0);
+
+      await user.click(getByRole('button', {name: 'Show previous attachments'}));
+      expect(scrollBy.mock.calls[1][0].left).toBeLessThan(0);
     });
   });
 });

--- a/scripts/setupTests.js
+++ b/scripts/setupTests.js
@@ -41,7 +41,10 @@ const ERROR_PATTERNS_WE_SHOULD_FIX_BUT_ALLOW = [
   '`ReactDOMTestUtils.act` is deprecated in favor of `React.act`'
 ];
 
-const WARNING_PATTERNS_WE_SHOULD_FIX_BUT_ALLOW = ['Browserslist: caniuse-lite is outdated'];
+const WARNING_PATTERNS_WE_SHOULD_FIX_BUT_ALLOW = [
+  'Browserslist: caniuse-lite is outdated',
+  'Browserslist: browsers data (caniuse-lite) is 6 months old.'
+];
 
 function failTestOnConsoleError() {
   const error = console.error;


### PR DESCRIPTION
Closes https://github.com/orgs/adobe/projects/19/views/4?pane=issue&itemId=217105801 (draft issue)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Run Tests, Open the storybook for `AttachmentList` there are two new stories to display the new feature. Also run locally, go over to the `PromptField` story and try dragging attachments into it until it overflows the field.

## 🧢 Your Project:

Adobe
