### PR TITLE
fix: update AI promptfield dropzone colors

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -1,5 +1,6 @@
 import {
   brand,
+  convertColor,
   defaultBrand,
   defineProperties,
   keyframes,
@@ -449,11 +450,15 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
                 height: '100%',
                 boxSizing: 'border-box',
                 borderRadius: 'inherit',
-                backgroundColor: 'indigo-800/10',
+                backgroundColor: {
+                  variant: {
+                    subtle: `[${convertColor(color('indigo-800'), 10)}]`
+                  }
+                },
                 borderStyle: 'solid',
                 borderWidth: 2,
-                borderColor: 'indigo-800'
-              })}
+                borderColor: `[${convertColor(color('indigo-800'))}]`
+              })({variant})}
             />
           )}
           <div

--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -449,10 +449,10 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
                 height: '100%',
                 boxSizing: 'border-box',
                 borderRadius: 'inherit',
-                backgroundColor: 'blue-800/10',
+                backgroundColor: 'indigo-800/10',
                 borderStyle: 'solid',
                 borderWidth: 2,
-                borderColor: 'blue-800'
+                borderColor: 'indigo-800'
               })}
             />
           )}

--- a/packages/@react-spectrum/ai/src/tokens.macro.ts
+++ b/packages/@react-spectrum/ai/src/tokens.macro.ts
@@ -68,7 +68,9 @@ export function brand(l: number, c: number, hueOffset: number, alpha = 1) {
 
 // Converts a single token color value to a brand-relative color, unless it's a
 // neutral (kept as-is) or not a color at all (e.g. an opacity number, kept as-is).
-export function convertColor(value: any) {
+// An optional opacity (0-100) overrides the color's own alpha. Note: neutral
+// colors are returned untouched, so opacity is ignored for them.
+export function convertColor(value: any, opacity?: number) {
   if (typeof value !== 'string') {
     return value;
   }
@@ -78,7 +80,7 @@ export function convertColor(value: any) {
   }
   let parts = match[1].split(',').map(x => parseFloat(x.trim()));
   let [r, g, b] = parts;
-  let alpha = parts[3] ?? 1;
+  let alpha = opacity != null ? opacity / 100 : parts[3] ?? 1;
   let [L, C, H] = rgbToOklch(r, g, b);
   if (C < NEUTRAL_CHROMA) {
     return value;

--- a/packages/@react-spectrum/ai/src/tokens.macro.ts
+++ b/packages/@react-spectrum/ai/src/tokens.macro.ts
@@ -74,19 +74,21 @@ export function convertColor(value: any, opacity?: number) {
   if (typeof value !== 'string') {
     return value;
   }
-  let match = value.match(/rgba?\(([^)]+)\)/);
-  if (!match) {
-    return value;
-  }
-  let parts = match[1].split(',').map(x => parseFloat(x.trim()));
-  let [r, g, b] = parts;
-  let alpha = opacity != null ? opacity / 100 : parts[3] ?? 1;
-  let [L, C, H] = rgbToOklch(r, g, b);
-  if (C < NEUTRAL_CHROMA) {
-    return value;
-  }
-  let offset = Math.round((H - BRAND_REF_HUE) * 10) / 10;
-  return brand(Math.round(L * 1e4) / 1e4, Math.round(C * 1e4) / 1e4, offset, alpha);
+  return value.replace(/rgba?\([^)]+\)/g, value => {
+    let match = value.match(/rgba?\(([^)]+)\)/);
+    if (!match) {
+      return value;
+    }
+    let parts = match[1].split(',').map(x => parseFloat(x.trim()));
+    let [r, g, b] = parts;
+    let alpha = opacity != null ? opacity / 100 : (parts[3] ?? 1);
+    let [L, C, H] = rgbToOklch(r, g, b);
+    if (C < NEUTRAL_CHROMA) {
+      return value;
+    }
+    let offset = Math.round((H - BRAND_REF_HUE) * 10) / 10;
+    return brand(Math.round(L * 1e4) / 1e4, Math.round(C * 1e4) / 1e4, offset, alpha);
+  });
 }
 
 export function token(name: string) {


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->

changes to convertColor are to support opacity + light-dark

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Try dropping on the "Everything" Promptfield story. The dropzone should respond to brand colors. There is no dropzone background for balanced and prominent variants. 


## 🧢 Your Project:

<!--- Company/project for pull request -->
