### PR TITLE
fix: update AttachmentList to latest design

### DIFF
--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -131,14 +131,8 @@ const attachmentCard = style({
   position: 'relative',
   borderRadius: 'lg',
   outlineStyle: 'solid',
-  outlineWidth: {
-    default: 1, // WHCM
-    isInvalid: 2
-  },
-  outlineOffset: {
-    default: -1,
-    isInvalid: -2
-  },
+  outlineWidth: 1,
+  outlineOffset: -1,
   outlineColor: {
     default: lightDark('black/3', 'white/3'),
     isLoading: lightDark('black/2', 'white/2'),
@@ -428,7 +422,7 @@ function AttachmentCard({
                     pointerEvents: 'none',
                     userSelect: 'none',
                     size: '--basic-thumb-size',
-                    borderRadius: '[3px]',
+                    borderRadius: 'inherit',
                     objectFit: 'cover',
                     outlineStyle: 'solid',
                     outlineWidth: 1,

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -91,14 +91,14 @@ const closeButton = style<{
   borderStyle: 'none',
   transition: 'default',
   backgroundColor: {
-    default: baseColor('gray-900'),
-    forcedColors: 'ButtonText'
+    default: baseColor('gray-200'),
+    forcedColors: 'ButtonFace'
   },
   color: {
-    default: baseColor('gray-25'),
+    default: baseColor('neutral'),
     isDisabled: 'disabled',
     forcedColors: {
-      default: 'ButtonFace',
+      default: 'ButtonText',
       isDisabled: 'GrayText'
     }
   },
@@ -117,10 +117,11 @@ const onlyPreview = ':not(:has([data-slot=content])):not(:has([data-slot=preview
 
 const container = {
   backgroundColor: {
-    default: lightDark('white/5', 'black/5'),
+    default: lightDark('black/3', 'white/3'),
+    isInvalid: 'red-700/8',
     forcedColors: 'ButtonFace'
   },
-  boxShadow: `[inset 0 0 0 1px light-dark(${color('black/5')}, ${color('white/5')}), 0 8px 32px 0 light-dark(${color('transparent-white-50')}, ${color('transparent-black-50')}), inset 0 -5px 21.6px 0 ${color('transparent-white-50')}, inset 0 24px 32px 0 ${color('transparent-white-50')}]`
+  boxShadow: `[0 8px 32px 0 light-dark(${color('transparent-black-50')}, ${color('transparent-white-50')})]`
 } as const;
 
 const attachmentCard = style({
@@ -139,7 +140,8 @@ const attachmentCard = style({
     isInvalid: -2
   },
   outlineColor: {
-    default: 'transparent',
+    default: lightDark('black/3', 'white/3'),
+    isLoading: lightDark('black/2', 'white/2'),
     forcedColors: 'ButtonBorder',
     isInvalid: {
       default: 'negative-900',
@@ -397,12 +399,20 @@ const tagStyles = style({
 interface AttachmentCardProps {
   size?: 'XS' | 'S' | 'M' | 'L' | 'XL';
   isInvalid?: boolean;
+  isLoading?: boolean;
   children: ReactNode;
 }
 
-function AttachmentCard({size = 'M', isInvalid = false, children}: AttachmentCardProps) {
+function AttachmentCard({
+  size = 'M',
+  isInvalid = false,
+  isLoading = false,
+  children
+}: AttachmentCardProps) {
   return (
-    <div aria-invalid={isInvalid || undefined} className={attachmentCard({size, isInvalid})}>
+    <div
+      aria-invalid={isInvalid || undefined}
+      className={attachmentCard({size, isInvalid, isLoading})}>
       <Provider
         values={[
           [
@@ -482,6 +492,7 @@ export const Attachment = forwardRef(function Attachment(
     size = 'M'
   } = props;
   let domRef = useDOMRef(ref);
+  let isLoading = props.uploadProgress != null && props.uploadProgress < 100;
   return (
     <Tag
       id={id}
@@ -491,7 +502,7 @@ export const Attachment = forwardRef(function Attachment(
       aria-describedby={ariaDescribedby}
       ref={domRef}
       className={renderProps => mergeStyles(tagStyles({...renderProps}), styles)}>
-      <AttachmentCard size={size} isInvalid={isInvalid}>
+      <AttachmentCard size={size} isInvalid={isInvalid} isLoading={isLoading}>
         <AttachmentPreviewContext.Provider
           value={{isInvalid: !!isInvalid, uploadProgress: props.uploadProgress ?? 100, size}}>
           {typeof children === 'function' ? children({size}) : children}

--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -35,8 +35,6 @@ import Cross from '../ui-icons/Cross';
 import {DEFAULT_SLOT, Provider} from 'react-aria-components/slots';
 import File from '@react-spectrum/s2/icons/File';
 import FileText from '@react-spectrum/s2/icons/FileText';
-// @ts-ignore
-import {IllustrationContext} from '@react-spectrum/s2/Icon';
 import {Image, ImageContext, ImageProps} from '@react-spectrum/s2/Image';
 import {ImageCoordinator} from '@react-spectrum/s2/ImageCoordinator';
 import ImageIcon from '@react-spectrum/s2/icons/Image';
@@ -195,7 +193,7 @@ const attachmentCard = style({
   justifyContent: {
     [onlyPreview]: 'center'
   },
-  '--basic-thumb-size': {
+  '--image-size': {
     type: 'height',
     value: {
       size: {
@@ -208,41 +206,13 @@ const attachmentCard = style({
       [onlyPreview]: 'full'
     }
   },
-  '--illust-thumb-size': {
-    type: 'height',
+  '--image-border-radius': {
+    type: 'borderTopStartRadius',
     value: {
-      size: {
-        XS: 48,
-        S: 44,
-        M: 48,
-        L: 52,
-        XL: 56
-      },
-      [onlyPreview]: 'full'
-    }
-  },
-  '--illust-margin-x': {
-    type: 'marginStart',
-    value: {
-      size: {
-        XS: -8,
-        S: -8,
-        M: -12,
-        L: -12,
-        XL: -12
-      }
+      default: '[3px]',
+      [onlyPreview]: 'lg'
     }
   }
-});
-
-const illustThumbnailStyles = style({
-  position: 'relative',
-  alignSelf: 'center',
-  flexShrink: 0,
-  pointerEvents: 'none',
-  userSelect: 'none',
-  size: '--illust-thumb-size',
-  marginX: '--illust-margin-x'
 });
 
 const attachmentTitle = style<{size: 'XS' | 'S' | 'M' | 'L' | 'XL'}>({
@@ -421,26 +391,14 @@ function AttachmentCard({
                     flexShrink: 0,
                     pointerEvents: 'none',
                     userSelect: 'none',
-                    size: '--basic-thumb-size',
-                    borderRadius: 'inherit',
+                    size: '--image-size',
+                    borderRadius: '--image-border-radius',
                     objectFit: 'cover',
                     outlineStyle: 'solid',
                     outlineWidth: 1,
                     outlineColor: 'gray-800/10',
                     outlineOffset: -1
                   })
-                }
-              }
-            }
-          ],
-          [
-            IllustrationContext,
-            {
-              slots: {
-                thumbnail: {
-                  styles: illustThumbnailStyles,
-                  // @ts-ignore
-                  'data-rsp-slot': 'illustration'
                 }
               }
             }


### PR DESCRIPTION
For release, based of latest designs. In particular:
- color of buttons changed from black to grey
- outline/box shadow/background color of the Attachment card updated
- Loading style changed slightly to match the design where the border gets lighter

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Test the AttachmentList stories in light/dark mode and sanity check its appearance in PromptField 

## 🧢 Your Project:

RSP
