### PR TITLE
feat: Response status update

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -416,6 +416,7 @@ export interface PromptTokenFieldProps {
   ) => React.ReactNode[] | null | Promise<React.ReactNode[] | null>;
   children?: (segment: TokenSegment<PromptFieldTokenValue>) => React.ReactElement;
   pixelLoader?: Cell[] | Cell[][];
+  disablePixelLoaderAnimation?: boolean;
   placeholder?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   // TODO: temp api for coworker so that the weird popover shrinking behavior
@@ -429,6 +430,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
     renderCompletions,
     children,
     pixelLoader,
+    disablePixelLoaderAnimation,
     placeholder,
     menuWidth,
     onKeyDown: onKeyDownProp
@@ -551,7 +553,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
       })({isFocused: isFocused || prompt.segments.length > 0})}>
       <CenterBaseline>
         <PixelLoader
-          isPlaying={isGenerating}
+          isPlaying={isGenerating && !disablePixelLoaderAnimation}
           icon={pixelLoader}
           color="var(--loader-color)"
           className={style({

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -416,7 +416,7 @@ export interface PromptTokenFieldProps {
   ) => React.ReactNode[] | null | Promise<React.ReactNode[] | null>;
   children?: (segment: TokenSegment<PromptFieldTokenValue>) => React.ReactElement;
   pixelLoader?: Cell[] | Cell[][];
-  disablePixelLoaderAnimation?: boolean;
+  shouldAnimatePixelLoader?: boolean;
   placeholder?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   // TODO: temp api for coworker so that the weird popover shrinking behavior
@@ -430,7 +430,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
     renderCompletions,
     children,
     pixelLoader,
-    disablePixelLoaderAnimation,
+    shouldAnimatePixelLoader = false,
     placeholder,
     menuWidth,
     onKeyDown: onKeyDownProp
@@ -553,7 +553,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
       })({isFocused: isFocused || prompt.segments.length > 0})}>
       <CenterBaseline>
         <PixelLoader
-          isPlaying={isGenerating && !disablePixelLoaderAnimation}
+          isPlaying={isGenerating && shouldAnimatePixelLoader}
           icon={pixelLoader}
           color="var(--loader-color)"
           className={style({

--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -423,7 +423,11 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
                 },
                 animationDuration: '2s, 3s, 4s',
                 animationTimingFunction: 'linear',
-                animationIterationCount: 'infinite'
+                animationIterationCount: 'infinite',
+                contain: 'strict',
+                willChange: {
+                  isGenerating: 'transform'
+                }
               })({isGenerating})
             }
           />

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -11,18 +11,13 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, GlobalDOMAttributes} from '@react-types/shared';
-import {
-  baseColor,
-  focusRing,
-  iconStyle,
-  space,
-  style
-} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Button} from 'react-aria-components/Button';
 import {CenterBaseline} from '@react-spectrum/s2/CenterBaseline';
 import CheckmarkCircle from '@react-spectrum/s2/icons/CheckmarkCircle';
 import Chevron from '../ui-icons/Chevron';
 import CloseCircle from '@react-spectrum/s2/icons/CloseCircle';
+import {color, focusRing, space, style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import Cross from '../ui-icons/Cross';
 import {
   DisclosureStateContext,
   Disclosure as RACDisclosure,
@@ -33,10 +28,10 @@ import {
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {Heading} from 'react-aria-components/Heading';
 import {IconContext} from '@react-spectrum/s2/Icon';
-// @ts-ignore
-import intlMessages from '../intl/*.json';
+import {keyframes} from './tokens.macro' with {type: 'macro'};
 import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
-import {ProgressCircle} from '@react-spectrum/s2/ProgressCircle';
+import {PixelLoader} from '../exports';
+import {pressScale} from '@react-spectrum/s2';
 import {Provider} from 'react-aria-components/slots';
 import React, {
   createContext,
@@ -44,13 +39,13 @@ import React, {
   ReactNode,
   useCallback,
   useContext,
+  useRef,
   useState
 } from 'react';
 import {StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {useDOMRef} from './useDOMRef';
 import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
 import {useLocale} from 'react-aria/I18nProvider';
-import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 
 export interface ResponseStatusProps extends Omit<
   RACDisclosureProps,
@@ -102,19 +97,9 @@ export const ResponseStatus = forwardRef(function ResponseStatus(
   let [hasPanelContent, setHasPanelContent] = useState(false);
   let registerPanel = useCallback((mounted: boolean) => setHasPanelContent(mounted), []);
 
-  let disclosureProps: Partial<RACDisclosureProps> = {};
-  if (status === 'loading') {
-    disclosureProps.isExpanded = false;
-    disclosureProps.onExpandedChange = () => {};
-  }
-
   return (
     <Provider values={[[ResponseStatusContext, {status, hasPanelContent, registerPanel}]]}>
-      <RACDisclosure
-        {...props}
-        {...disclosureProps}
-        ref={domRef}
-        className={mergeStyles(responseStatus, styles)}>
+      <RACDisclosure {...props} ref={domRef} className={mergeStyles(responseStatus, styles)}>
         {props.children}
       </RACDisclosure>
     </Provider>
@@ -146,10 +131,9 @@ const headingStyle = style({
 
 const buttonStyles = style({
   ...focusRing(),
-  outlineOffset: -2,
-  font: 'body',
+  font: 'ui-sm',
   color: {
-    default: baseColor('neutral'),
+    default: 'gray-600',
     isLoading: 'neutral',
     forcedColors: 'ButtonText',
     isDisabled: {
@@ -160,15 +144,21 @@ const buttonStyles = style({
   display: 'flex',
   flexGrow: 0,
   alignItems: 'center',
-  paddingX: 'calc(self(minHeight) * 3/8 - 1px)',
-  gap: 'calc(self(minHeight) * 3/8 - 1px)',
-  minHeight: 32,
-  backgroundColor: 'transparent',
+  paddingX: 12,
+  paddingY: 4,
+  gap: 8,
+  backgroundColor: {
+    default: 'transparent',
+    isHovered: 'gray-75',
+    isFocusVisible: 'gray-75',
+    isPressed: 'gray-75'
+  },
   transition: 'default',
   borderWidth: 0,
   borderRadius: 'default',
   textAlign: 'start',
-  disableTapHighlight: true
+  disableTapHighlight: true,
+  truncate: true
 });
 
 const chevronStyles = {
@@ -183,11 +173,6 @@ const chevronStyles = {
   },
   flexShrink: 0
 } as const;
-
-const progressCircleStyles = style({
-  width: 18,
-  height: 18
-});
 
 /**
  * A response status title consisting of a heading and a trigger button. The leading icon is a
@@ -205,20 +190,17 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
   let {isExpanded} = useContext(DisclosureStateContext)!;
   let {status, hasPanelContent} = useContext(ResponseStatusContext)!;
   let isRTL = direction === 'rtl';
-  let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
+  // let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
 
   let isLoading = status === 'loading';
-  let isInteractive = hasPanelContent && !isLoading;
+  let isInteractive = hasPanelContent;
 
   let rowContent = (
     <>
       {isLoading ? (
-        <CenterBaseline>
-          <ProgressCircle
-            styles={progressCircleStyles}
-            isIndeterminate
-            aria-label={stringFormatter.format('responsestatus.loading')}
-          />
+        // 1px padding to center the loader in a 16px box, aligning with the other status icons.
+        <CenterBaseline styles={style({padding: '[1px]', size: 14})}>
+          <PixelLoader size={14} />
         </CenterBaseline>
       ) : (
         <Provider
@@ -229,7 +211,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
                 styles: style({
                   marginStart: 'auto',
                   flexShrink: 0,
-                  size: 20,
+                  size: 16,
                   '--iconPrimary': {
                     type: 'fill',
                     value: 'currentColor'
@@ -256,11 +238,19 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
     </>
   );
 
+  let buttonRef = useRef<HTMLButtonElement | null>(null);
+
   return (
     <Heading {...domProps} level={level} ref={domRef} className={mergeStyles(headingStyle, styles)}>
       <Button
+        ref={buttonRef}
+        // eslint-disable-next-line react/react-compiler
+        style={pressScale(buttonRef)}
         className={renderProps =>
-          buttonStyles({...renderProps, isLoading, isOnlyText: !isInteractive})
+          mergeStyles(
+            buttonStyles({...renderProps, isLoading, isOnlyText: !isInteractive}),
+            style({font: 'body-sm', color: 'gray-1000'})
+          )
         }
         slot={isInteractive ? 'trigger' : undefined}>
         {rowContent}
@@ -282,7 +272,8 @@ export interface ResponseStatusPanelProps
 }
 
 const panelStyle = {
-  font: 'body',
+  font: 'body-2xs',
+  color: 'gray-600',
   height: '--disclosure-panel-height',
   overflow: 'clip',
   transition: {
@@ -319,7 +310,7 @@ export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
     <RACDisclosurePanel
       {...domProps}
       ref={panelRef}
-      className={mergeStyles(style(panelStyle), styles)}>
+      className={mergeStyles(style({...panelStyle, marginStart: 24}), styles)}>
       <div className={panelInner}>{props.children}</div>
     </RACDisclosurePanel>
   );
@@ -367,33 +358,60 @@ export const ExecutionTrace = forwardRef(function ExecutionTrace(
 
 interface DetailTriggerProps {
   children: ReactNode;
+  isPending: boolean;
 }
 
 const detailTriggerStyles = style({
-  display: 'block',
-  paddingStart: 8
+  display: 'block'
 });
 
-const detailTriggerChevronStyles = style({
-  ...chevronStyles,
-  display: 'inline-flex',
-  marginStart: 8
+const shimmerAnimation = keyframes(`
+  from {
+    background-position: 100% 0%;
+  }
+
+  to {
+    background-position: 0% 0%;
+  }
+`);
+
+const SPREAD = '4ch';
+
+const shimmer = style({
+  backgroundImage: {
+    isPending: `linear-gradient(90deg, currentColor calc(50% - ${SPREAD}), ${color('gray-1000')} 50%, currentColor calc(50% + ${SPREAD}))`
+  },
+  backgroundClip: 'text',
+  backgroundSize: `[calc(200% + ${SPREAD} * 2) 100%]`,
+  animation: {
+    isPending: shimmerAnimation
+  },
+  animationDuration: 2000,
+  animationIterationCount: 'infinite'
 });
+
+function ShimmerText(props: DetailTriggerProps) {
+  let {children, isPending} = props;
+  return (
+    <span
+      className={shimmer({isPending})}
+      style={{WebkitTextFillColor: isPending ? 'transparent' : undefined}}>
+      {children}
+    </span>
+  );
+}
 
 function DetailTrigger(props: DetailTriggerProps) {
-  let {children} = props;
-  let {direction} = useLocale();
-  let isRTL = direction === 'rtl';
-  let {isExpanded} = useContext(DisclosureStateContext)!;
+  let ref = useRef<HTMLButtonElement | null>(null);
 
   return (
     <Button
+      ref={ref}
+      // eslint-disable-next-line react/react-compiler
+      style={pressScale(ref)}
       className={renderProps => mergeStyles(buttonStyles({...renderProps}), detailTriggerStyles)}
       slot="trigger">
-      {children}
-      <CenterBaseline styles={detailTriggerChevronStyles({isExpanded, isRTL})}>
-        <Chevron size="M" />
-      </CenterBaseline>
+      <ShimmerText {...props} />
     </Button>
   );
 }
@@ -403,21 +421,19 @@ export interface ExecutionTraceItemProps extends DOMProps, AriaLabelingProps {
    * The label describing the step.
    */
   children: ReactNode;
-  detail?: ReactNode;
+  status?: 'pending' | 'failed' | 'success';
   /**
-   * Spectrum-defined styles, returned by the `style()` macro.
+   * Additional detail revealed when the step is expanded, such as tool call input or output.
+   * If omitted, the row is static and cannot be expanded.
    */
+  detail?: ReactNode;
   /**
    * An icon shown at the leading edge of the row. If omitted, a checkmark is rendered by default.
    */
   icon?: ReactNode;
   /** Allows detail content to render but prevents the row from being collapsible. */
   isAlwaysOpen?: boolean;
-  /**
-   * Additional detail revealed when the step is expanded, such as tool call input or output.
-   * If omitted, the row is static and cannot be expanded.
-   */
-
+  /** Spectrum-defined styles, returned by the `style()` macro. */
   styles?: StyleString;
 }
 
@@ -458,26 +474,29 @@ const executionTraceItemIconContainerStyles = style({
 const executionTraceItemDividerStyles = style({
   width: 1,
   flexGrow: 1,
-  marginY: 2,
-  backgroundColor: 'gray-500',
+  marginY: 0,
+  minHeight: 12,
+  backgroundColor: 'gray-200',
   display: 'var(--divider-display, flex)'
 });
 
 const executionTraceDisclosurePanelStyles = style({
-  ...panelStyle,
-  paddingStart: 8
+  ...panelStyle
 });
 
-const executionTraceDisclosureContainerStyles = style({
-  paddingBottom: 'var(--execution-trace-item-padding-bottom-disclosure)',
-  marginTop: -4
+// Extra wrapper for padding to avoid transition jump
+const executationTradeDetailWrapperStyle = style({
+  paddingTop: 4,
+  paddingBottom: 20
 });
 
-const executionTraceWithoutDisclosureStyles = style({
-  paddingStart: 8,
-  display: 'flex',
-  flexDirection: 'column',
-  paddingBottom: 'var(--execution-trace-item-padding-bottom-no-disclosure)'
+const executionTraceDetailStyle = style({
+  paddingX: 12,
+  paddingY: 8,
+  backgroundColor: 'layer-1',
+  borderRadius: 'lg',
+  font: 'body-2xs',
+  color: 'gray-600'
 });
 
 /**
@@ -491,9 +510,10 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   let {
     isAlwaysOpen,
     detail,
-    icon = <CheckmarkCircle aria-hidden="true" />,
+    // icon = <CheckmarkCircle aria-hidden="true" />,
     children,
     styles,
+    status = 'success',
     ...otherProps
   } = props;
   let domRef = useDOMRef(ref);
@@ -503,24 +523,62 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   return (
     <li {...domProps} ref={domRef} className={mergeStyles(executionTraceItemStyles, styles)}>
       <div className={executionTraceItemIconContainerStyles}>
-        <Provider values={[[IconContext, {styles: iconStyle({size: 'M'})}]]}>
+        {/* <Provider values={[[IconContext, {styles: iconStyle({size: 'M'})}]]}>
           <CenterBaseline>{icon}</CenterBaseline>
-        </Provider>
+        </Provider> */}
+        <CenterBaseline>
+          {status === 'failed' && (
+            <Cross className={style({'--iconPrimary': {type: 'fill', value: 'gray-600'}})} />
+          )}
+          {status !== 'failed' && (
+            <svg
+              viewBox="0 0 8 8"
+              className={style({
+                size: 8,
+                fill: {
+                  default: 'none',
+                  status: {
+                    success: 'gray-500'
+                  }
+                },
+                stroke: {
+                  default: 'none',
+                  status: {
+                    pending: 'gray-600'
+                  }
+                },
+                strokeWidth: {
+                  default: 0,
+                  status: {
+                    pending: 1
+                  }
+                }
+              })({status})}>
+              <circle cx={4} cy={4} r={status === 'pending' ? 3.5 : 4} />
+            </svg>
+          )}
+        </CenterBaseline>
         <div role="presentation" className={executionTraceItemDividerStyles} />
       </div>
       {hasDetail && !isAlwaysOpen ? (
-        <div className={executionTraceDisclosureContainerStyles}>
-          <RACDisclosure>
-            <DetailTrigger>{children}</DetailTrigger>
-            <RACDisclosurePanel className={executionTraceDisclosurePanelStyles}>
-              {detail}
-            </RACDisclosurePanel>
-          </RACDisclosure>
-        </div>
+        <RACDisclosure className="">
+          <DetailTrigger isPending={status === 'pending'}>{children}</DetailTrigger>
+          <RACDisclosurePanel className={executionTraceDisclosurePanelStyles}>
+            <div className={executationTradeDetailWrapperStyle}>
+              <div className={executionTraceDetailStyle}>{detail}</div>
+            </div>
+          </RACDisclosurePanel>
+        </RACDisclosure>
       ) : (
-        <div className={executionTraceWithoutDisclosureStyles}>
-          <span>{children}</span>
-          {hasDetail && isAlwaysOpen ? <div>{detail}</div> : null}
+        <div>
+          <span className={mergeStyles(buttonStyles({}), detailTriggerStyles)}>
+            <ShimmerText isPending={status === 'pending'}>{children}</ShimmerText>
+          </span>
+          {hasDetail && isAlwaysOpen ? (
+            <div className={executationTradeDetailWrapperStyle}>
+              <div className={executionTraceDetailStyle}>{detail}</div>
+            </div>
+          ) : null}
         </div>
       )}
     </li>

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -16,6 +16,7 @@ import {
   color,
   css,
   focusRing,
+  iconStyle,
   space,
   style
 } from '@react-spectrum/s2/style' with {type: 'macro'};
@@ -47,10 +48,10 @@ import React, {
   RefObject,
   useCallback,
   useContext,
-  useId,
   useRef,
   useState
 } from 'react';
+import {scrollFade} from './tokens.macro' with {type: 'macro'};
 import {StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {useDOMRef} from './useDOMRef';
 import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
@@ -307,7 +308,7 @@ const panelStyle = {
 const panelInner = style({
   paddingTop: 8,
   paddingBottom: 16,
-  paddingX: space(9)
+  paddingX: space(6)
 });
 
 /**
@@ -385,8 +386,15 @@ interface DetailTriggerProps {
 
 const SPREAD = '4ch';
 
-/* Only supported in Chrome/Safari, not Firefox for performance reasons.
-   Tried using `mask-image: -moz-element(#id)` but this disables GPU acceleration. */
+/* Inert clone positioned above original text.
+ * This element acts as a mask for the actual shimmer
+ * in the ::after pseudo element.
+ *
+ * NOTE: It is possible to add the ::after shimmer
+ * directly to the original text instead of a clone,
+ * but this can cause the text to appear thinner than
+ * expected due to masking of sub-pixels. The clone
+ * fixes that problem. */
 const shimmer = css(`
   position: relative;
   position: absolute;
@@ -420,10 +428,10 @@ const shimmer = css(`
 
 const shimmerSym = Symbol('shimmer');
 
+// TODO: make this component a reusable utility?
 function ShimmerText(props: DetailTriggerProps) {
   let {children, isPending} = props;
   let {isExpanded, responseStatusRef} = useContext(ResponseStatusContext)!;
-  let id = useId();
 
   // Do the animation in JS rather than CSS so we can synchronize across elements.
   let shimmerRef = useCallback(
@@ -451,9 +459,7 @@ function ShimmerText(props: DetailTriggerProps) {
 
   return (
     <span className={style({position: 'relative', display: 'inline-block'})}>
-      <span id={id} className={style({display: 'inline-block'})}>
-        {children}
-      </span>
+      <span className={style({display: 'inline-block'})}>{children}</span>
       {/* inert clone of the children with shimmer effect mask. */}
       {isPending && isExpanded && (
         <span inert ref={shimmerRef} className={shimmer}>
@@ -581,8 +587,6 @@ const executationTradeDetailWrapperStyle = style({
 });
 
 const executionTraceDetailStyle = style({
-  paddingX: 12,
-  paddingY: 8,
   backgroundColor: 'layer-1',
   borderRadius: 'lg',
   font: 'body-2xs',
@@ -597,16 +601,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   props: ExecutionTraceItemProps,
   ref: DOMRef<HTMLLIElement>
 ) {
-  let {
-    isAlwaysOpen,
-    detail,
-    // TODO: do we still support icons?
-    // icon = <CheckmarkCircle aria-hidden="true" />,
-    children,
-    styles,
-    status = 'success',
-    ...otherProps
-  } = props;
+  let {isAlwaysOpen, detail, icon, children, styles, status = 'success', ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let domProps = filterDOMProps(otherProps);
   let hasDetail = detail != null;
@@ -614,40 +609,50 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   return (
     <li {...domProps} ref={domRef} className={mergeStyles(executionTraceItemStyles, styles)}>
       <div className={executionTraceItemIconContainerStyles}>
-        {/* <Provider values={[[IconContext, {styles: iconStyle({size: 'M'})}]]}>
-          <CenterBaseline>{icon}</CenterBaseline>
-        </Provider> */}
         <CenterBaseline>
           {status === 'failed' && (
-            <Cross className={style({'--iconPrimary': {type: 'fill', value: 'gray-600'}})} />
-          )}
-          {status !== 'failed' && (
-            <svg
-              viewBox="0 0 8 8"
+            <div
               className={style({
-                size: 8,
-                fill: {
-                  default: 'none',
-                  status: {
-                    success: 'gray-500'
-                  }
-                },
-                stroke: {
-                  default: 'none',
-                  status: {
-                    pending: 'gray-600'
-                  }
-                },
-                strokeWidth: {
-                  default: 0,
-                  status: {
-                    pending: 1
-                  }
-                }
-              })({status})}>
-              <circle cx={4} cy={4} r={status === 'pending' ? 3.5 : 4} />
-            </svg>
+                size: 16,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              })}>
+              <Cross className={style({'--iconPrimary': {type: 'fill', value: 'gray-600'}})} />
+            </div>
           )}
+          {status !== 'failed' &&
+            (icon ? (
+              <IconContext.Provider value={{styles: iconStyle({size: 'S'})}}>
+                {icon}
+              </IconContext.Provider>
+            ) : (
+              <svg
+                viewBox="0 0 16 16"
+                className={style({
+                  size: 16,
+                  fill: {
+                    default: 'none',
+                    status: {
+                      success: 'gray-500'
+                    }
+                  },
+                  stroke: {
+                    default: 'none',
+                    status: {
+                      pending: 'gray-600'
+                    }
+                  },
+                  strokeWidth: {
+                    default: 0,
+                    status: {
+                      pending: 2
+                    }
+                  }
+                })({status})}>
+                <circle cx={8} cy={8} r={status === 'pending' ? 3 : 4} />
+              </svg>
+            ))}
         </CenterBaseline>
         <div role="presentation" className={executionTraceItemDividerStyles} />
       </div>
@@ -656,7 +661,15 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
           <DetailTrigger isPending={status === 'pending'}>{children}</DetailTrigger>
           <RACDisclosurePanel className={style(panelStyle)}>
             <div className={executationTradeDetailWrapperStyle}>
-              <div className={executionTraceDetailStyle}>{detail}</div>
+              <div className={executionTraceDetailStyle}>
+                <div
+                  className={
+                    scrollFade({y: 24}) +
+                    style({maxHeight: 120, overflow: 'auto', paddingX: 12, paddingY: 8})
+                  }>
+                  {detail}
+                </div>
+              </div>
             </div>
           </RACDisclosurePanel>
         </RACDisclosure>

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -11,12 +11,20 @@
  */
 
 import {AriaLabelingProps, DOMProps, DOMRef, GlobalDOMAttributes} from '@react-types/shared';
+import {
+  baseColor,
+  color,
+  css,
+  focusRing,
+  space,
+  style
+} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {Button} from 'react-aria-components/Button';
+import {Cell} from './loader/data';
 import {CenterBaseline} from '@react-spectrum/s2/CenterBaseline';
 import CheckmarkCircle from '@react-spectrum/s2/icons/CheckmarkCircle';
 import Chevron from '../ui-icons/Chevron';
 import CloseCircle from '@react-spectrum/s2/icons/CloseCircle';
-import {color, focusRing, space, style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import Cross from '../ui-icons/Cross';
 import {
   DisclosureStateContext,
@@ -28,7 +36,6 @@ import {
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {Heading} from 'react-aria-components/Heading';
 import {IconContext} from '@react-spectrum/s2/Icon';
-import {keyframes} from './tokens.macro' with {type: 'macro'};
 import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
 import {PixelLoader} from '../exports';
 import {pressScale} from '@react-spectrum/s2';
@@ -39,6 +46,7 @@ import React, {
   ReactNode,
   useCallback,
   useContext,
+  useId,
   useRef,
   useState
 } from 'react';
@@ -54,9 +62,9 @@ export interface ResponseStatusProps extends Omit<
   /**
    * The current status of the response.
    *
-   * @default 'loading'
+   * @default 'pending'
    */
-  status?: 'loading' | 'failed' | 'success';
+  status?: 'pending' | 'failed' | 'success';
   /**
    * The contents of the response status, consisting of a ResponseStatusTitle and
    * ResponseStatusPanel.
@@ -69,11 +77,11 @@ export interface ResponseStatusProps extends Omit<
 }
 
 const ResponseStatusContext = createContext<{
-  status: 'loading' | 'failed' | 'success';
+  status: 'pending' | 'failed' | 'success';
   hasPanelContent: boolean;
   registerPanel: (mounted: boolean) => void;
 }>({
-  status: 'loading',
+  status: 'pending',
   hasPanelContent: false,
   registerPanel: () => {}
 });
@@ -92,7 +100,7 @@ export const ResponseStatus = forwardRef(function ResponseStatus(
   props: ResponseStatusProps,
   ref: DOMRef<HTMLDivElement>
 ) {
-  let {status = 'loading', styles} = props;
+  let {status = 'pending', styles} = props;
   let domRef = useDOMRef(ref);
   let [hasPanelContent, setHasPanelContent] = useState(false);
   let registerPanel = useCallback((mounted: boolean) => setHasPanelContent(mounted), []);
@@ -119,6 +127,8 @@ export interface ResponseStatusTitleProps extends DOMProps {
    * Spectrum-defined styles, returned by the `style()` macro.
    */
   styles?: StyleString;
+  /** Pixel loader icon or sequence to display. */
+  pixelLoader?: Cell[] | Cell[][];
 }
 
 const headingStyle = style({
@@ -129,12 +139,12 @@ const headingStyle = style({
   minWidth: 0
 });
 
-const buttonStyles = style({
+// Top-level disclosure.
+const disclosureStyles = style({
   ...focusRing(),
-  font: 'ui-sm',
+  font: 'body-sm',
   color: {
-    default: 'gray-600',
-    isLoading: 'neutral',
+    default: baseColor('gray-800'),
     forcedColors: 'ButtonText',
     isDisabled: {
       default: 'disabled',
@@ -144,21 +154,11 @@ const buttonStyles = style({
   display: 'flex',
   flexGrow: 0,
   alignItems: 'center',
-  paddingX: 12,
-  paddingY: 4,
   gap: 8,
-  backgroundColor: {
-    default: 'transparent',
-    isHovered: 'gray-75',
-    isFocusVisible: 'gray-75',
-    isPressed: 'gray-75'
-  },
   transition: 'default',
-  borderWidth: 0,
   borderRadius: 'default',
   textAlign: 'start',
-  disableTapHighlight: true,
-  truncate: true
+  width: 'fit'
 });
 
 const chevronStyles = {
@@ -183,60 +183,15 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
   props: ResponseStatusTitleProps,
   ref: DOMRef<HTMLDivElement>
 ) {
-  let {level = 3, styles, ...otherProps} = props;
+  let {level = 3, styles, pixelLoader, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   const domProps = filterDOMProps(otherProps);
   let {direction} = useLocale();
   let {isExpanded} = useContext(DisclosureStateContext)!;
   let {status, hasPanelContent} = useContext(ResponseStatusContext)!;
   let isRTL = direction === 'rtl';
-  // let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
-
-  let isLoading = status === 'loading';
+  let isLoading = status === 'pending';
   let isInteractive = hasPanelContent;
-
-  let rowContent = (
-    <>
-      {isLoading ? (
-        // 1px padding to center the loader in a 16px box, aligning with the other status icons.
-        <CenterBaseline styles={style({padding: '[1px]', size: 14})}>
-          <PixelLoader size={14} />
-        </CenterBaseline>
-      ) : (
-        <Provider
-          values={[
-            [
-              IconContext,
-              {
-                styles: style({
-                  marginStart: 'auto',
-                  flexShrink: 0,
-                  size: 16,
-                  '--iconPrimary': {
-                    type: 'fill',
-                    value: 'currentColor'
-                  }
-                })
-              }
-            ]
-          ]}>
-          <CenterBaseline slot="icon">
-            {status === 'failed' ? (
-              <CloseCircle aria-hidden="true" />
-            ) : (
-              <CheckmarkCircle aria-hidden="true" />
-            )}
-          </CenterBaseline>
-        </Provider>
-      )}
-      {props.children}
-      {isInteractive ? (
-        <CenterBaseline styles={style(chevronStyles)({isExpanded, isRTL})}>
-          <Chevron size="M" />
-        </CenterBaseline>
-      ) : null}
-    </>
-  );
 
   let buttonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -246,14 +201,57 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
         ref={buttonRef}
         // eslint-disable-next-line react/react-compiler
         style={pressScale(buttonRef)}
-        className={renderProps =>
-          mergeStyles(
-            buttonStyles({...renderProps, isLoading, isOnlyText: !isInteractive}),
-            style({font: 'body-sm', color: 'gray-1000'})
-          )
-        }
+        className={style({
+          padding: 0,
+          backgroundColor: 'transparent',
+          width: 'full',
+          disableTapHighlight: true,
+          borderWidth: 0,
+          outlineStyle: 'none',
+          transition: 'default'
+        })}
         slot={isInteractive ? 'trigger' : undefined}>
-        {rowContent}
+        {renderProps => (
+          <span className={disclosureStyles({...renderProps, isOnlyText: !isInteractive})}>
+            {isLoading ? (
+              <CenterBaseline>
+                <PixelLoader size={21} icon={pixelLoader} />
+              </CenterBaseline>
+            ) : (
+              <Provider
+                values={[
+                  [
+                    IconContext,
+                    {
+                      styles: style({
+                        flexShrink: 0,
+                        size: 20,
+                        '--iconPrimary': {
+                          type: 'fill',
+                          value: 'currentColor'
+                        }
+                      })
+                    }
+                  ]
+                ]}>
+                <CenterBaseline slot="icon" styles={style({size: 21})}>
+                  {status === 'failed' ? (
+                    <CloseCircle aria-hidden="true" />
+                  ) : (
+                    <CheckmarkCircle aria-hidden="true" />
+                  )}
+                </CenterBaseline>
+              </Provider>
+            )}
+            {/* TODO: translation */}
+            {isLoading && isExpanded ? 'Processing...' : props.children}
+            {isInteractive ? (
+              <CenterBaseline styles={style(chevronStyles)({isExpanded, isRTL})}>
+                <Chevron size="M" />
+              </CenterBaseline>
+            ) : null}
+          </span>
+        )}
       </Button>
     </Heading>
   );
@@ -290,7 +288,7 @@ const panelInner = style({
 
 /**
  * A response status panel is a collapsible section of content that is hidden until the
- * response status is expanded. The panel cannot be expanded while `status` is `'loading'`.
+ * response status is expanded. The panel cannot be expanded while `status` is `'pending'`.
  */
 export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
   props: ResponseStatusPanelProps,
@@ -310,7 +308,7 @@ export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
     <RACDisclosurePanel
       {...domProps}
       ref={panelRef}
-      className={mergeStyles(style({...panelStyle, marginStart: 24}), styles)}>
+      className={mergeStyles(style({...panelStyle, marginStart: 16}), styles)}>
       <div className={panelInner}>{props.children}</div>
     </RACDisclosurePanel>
   );
@@ -361,45 +359,104 @@ interface DetailTriggerProps {
   isPending: boolean;
 }
 
-const detailTriggerStyles = style({
-  display: 'block'
-});
+const SPREAD = '4ch';
 
-const shimmerAnimation = keyframes(`
-  from {
-    background-position: 100% 0%;
+/* Only supported in Chrome/Safari, not Firefox for performance reasons.
+   Tried using `mask-image: -moz-element(#id)` but this disables GPU acceleration. */
+const shimmer = css(`
+  position: relative;
+  position: absolute;
+  inset: 0;
+  overflow: clip;
+  color: transparent;
+  contain: strict;
+
+  @media (prefers-reduced-motion: reduce) {
+    display: none;
+  }
+  
+  @supports (-webkit-mask-clip: text) {
+    mask-image: linear-gradient(white, white);
+    -webkit-mask-clip: text;
   }
 
-  to {
-    background-position: 0% 0%;
+  @supports not (-webkit-mask-clip: text) {
+    display: none;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent calc(50% - ${SPREAD}), ${color('gray-1000')} 50%, transparent calc(50% + ${SPREAD}));
+    will-change: transform;
+    pointer-events: none;
   }
 `);
 
-const SPREAD = '4ch';
-
-const shimmer = style({
-  backgroundImage: {
-    isPending: `linear-gradient(90deg, currentColor calc(50% - ${SPREAD}), ${color('gray-1000')} 50%, currentColor calc(50% + ${SPREAD}))`
-  },
-  backgroundClip: 'text',
-  backgroundSize: `[calc(200% + ${SPREAD} * 2) 100%]`,
-  animation: {
-    isPending: shimmerAnimation
-  },
-  animationDuration: 2000,
-  animationIterationCount: 'infinite'
-});
-
 function ShimmerText(props: DetailTriggerProps) {
   let {children, isPending} = props;
+  let {isExpanded} = useContext(DisclosureStateContext)!;
+  let id = useId();
+
+  // Do the animation in JS rather than CSS so we can synchronize across elements.
+  let shimmerRef = useCallback((el: HTMLSpanElement | null) => {
+    if (el && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      let animation = el.animate(
+        [{transform: 'translateX(-100%)'}, {transform: 'translateX(100%)'}],
+        {duration: 2500, iterations: Infinity, easing: 'ease-in-out', pseudoElement: '::after'}
+      );
+      animation.startTime = 0;
+      return () => animation.cancel();
+    }
+  }, []);
+
   return (
-    <span
-      className={shimmer({isPending})}
-      style={{WebkitTextFillColor: isPending ? 'transparent' : undefined}}>
-      {children}
+    <span className={style({position: 'relative', display: 'inline-block'})}>
+      <span id={id} className={style({display: 'inline-block'})}>
+        {children}
+      </span>
+      {/* inert clone of the children with shimmer effect mask. */}
+      {isPending && isExpanded && (
+        <span inert ref={shimmerRef} className={shimmer}>
+          {children}
+        </span>
+      )}
     </span>
   );
 }
+
+// Inner disclosure.
+const detailTriggerStyles = style({
+  ...focusRing(),
+  display: 'block',
+  font: 'ui-sm',
+  color: {
+    default: 'gray-600',
+    forcedColors: 'ButtonText',
+    isDisabled: {
+      default: 'disabled',
+      forcedColors: 'GrayText'
+    }
+  },
+  flexGrow: 0,
+  alignItems: 'center',
+  paddingX: 12,
+  paddingY: 4,
+  gap: 8,
+  backgroundColor: {
+    default: 'transparent',
+    isHovered: 'gray-75',
+    isFocusVisible: 'gray-75',
+    isPressed: 'gray-75'
+  },
+  transition: 'default',
+  borderWidth: 0,
+  borderRadius: 'default',
+  textAlign: 'start',
+  disableTapHighlight: true,
+  truncate: true
+});
 
 function DetailTrigger(props: DetailTriggerProps) {
   let ref = useRef<HTMLButtonElement | null>(null);
@@ -409,7 +466,7 @@ function DetailTrigger(props: DetailTriggerProps) {
       ref={ref}
       // eslint-disable-next-line react/react-compiler
       style={pressScale(ref)}
-      className={renderProps => mergeStyles(buttonStyles({...renderProps}), detailTriggerStyles)}
+      className={detailTriggerStyles}
       slot="trigger">
       <ShimmerText {...props} />
     </Button>
@@ -421,6 +478,7 @@ export interface ExecutionTraceItemProps extends DOMProps, AriaLabelingProps {
    * The label describing the step.
    */
   children: ReactNode;
+  /** The status of this step. */
   status?: 'pending' | 'failed' | 'success';
   /**
    * Additional detail revealed when the step is expanded, such as tool call input or output.
@@ -448,19 +506,11 @@ const executionTraceItemStyles = style({
       ':last-child': 'none'
     }
   },
-  '--execution-trace-item-padding-bottom-disclosure': {
-    type: 'paddingBottom',
-    value: {
-      default: 12,
-      ':last-child': 0
-    }
-  },
-  '--execution-trace-item-padding-bottom-no-disclosure': {
-    type: 'paddingBottom',
-    value: {
-      default: 16,
-      ':last-child': 0
-    }
+  transition: 'opacity',
+  transitionDuration: 300,
+  opacity: {
+    default: 1,
+    '@starting-style': 0
   }
 });
 
@@ -477,11 +527,13 @@ const executionTraceItemDividerStyles = style({
   marginY: 0,
   minHeight: 12,
   backgroundColor: 'gray-200',
-  display: 'var(--divider-display, flex)'
-});
-
-const executionTraceDisclosurePanelStyles = style({
-  ...panelStyle
+  display: 'var(--divider-display, flex)',
+  transition: 'opacity',
+  transitionDuration: 300,
+  opacity: {
+    default: 1,
+    '@starting-style': 0
+  }
 });
 
 // Extra wrapper for padding to avoid transition jump
@@ -510,6 +562,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   let {
     isAlwaysOpen,
     detail,
+    // TODO: do we still support icons?
     // icon = <CheckmarkCircle aria-hidden="true" />,
     children,
     styles,
@@ -563,7 +616,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
       {hasDetail && !isAlwaysOpen ? (
         <RACDisclosure className="">
           <DetailTrigger isPending={status === 'pending'}>{children}</DetailTrigger>
-          <RACDisclosurePanel className={executionTraceDisclosurePanelStyles}>
+          <RACDisclosurePanel className={style(panelStyle)}>
             <div className={executationTradeDetailWrapperStyle}>
               <div className={executionTraceDetailStyle}>{detail}</div>
             </div>
@@ -571,7 +624,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
         </RACDisclosure>
       ) : (
         <div>
-          <span className={mergeStyles(buttonStyles({}), detailTriggerStyles)}>
+          <span className={detailTriggerStyles({})}>
             <ShimmerText isPending={status === 'pending'}>{children}</ShimmerText>
           </span>
           {hasDetail && isAlwaysOpen ? (

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -39,7 +39,6 @@ import {Heading} from 'react-aria-components/Heading';
 import {IconContext} from '@react-spectrum/s2/Icon';
 import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
 import {PixelLoader} from '../exports';
-import {pressScale} from '@react-spectrum/s2';
 import {Provider} from 'react-aria-components/slots';
 import React, {
   createContext,
@@ -48,7 +47,6 @@ import React, {
   RefObject,
   useCallback,
   useContext,
-  useRef,
   useState
 } from 'react';
 import {scrollFade} from './tokens.macro' with {type: 'macro'};
@@ -169,7 +167,8 @@ const disclosureStyles = style({
   ...focusRing(),
   font: 'body-sm',
   color: {
-    default: baseColor('gray-800'),
+    default: baseColor('neutral-subdued'),
+    isExpanded: 'gray-1000',
     forcedColors: 'ButtonText',
     isDisabled: {
       default: 'disabled',
@@ -218,14 +217,9 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
   let isLoading = status === 'pending';
   let isInteractive = hasPanelContent;
 
-  let buttonRef = useRef<HTMLButtonElement | null>(null);
-
   return (
     <Heading {...domProps} level={level} ref={domRef} className={mergeStyles(headingStyle, styles)}>
       <Button
-        ref={buttonRef}
-        // eslint-disable-next-line react/react-compiler
-        style={pressScale(buttonRef)}
         className={style({
           padding: 0,
           backgroundColor: 'transparent',
@@ -237,7 +231,8 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
         })}
         slot={isInteractive ? 'trigger' : undefined}>
         {renderProps => (
-          <span className={disclosureStyles({...renderProps, isOnlyText: !isInteractive})}>
+          <span
+            className={disclosureStyles({...renderProps, isExpanded, isOnlyText: !isInteractive})}>
             {isLoading ? (
               <CenterBaseline>
                 <PixelLoader size={21} icon={pixelLoader} />
@@ -476,7 +471,7 @@ const detailTriggerStyles = style({
   display: 'block',
   font: 'ui-sm',
   color: {
-    default: 'gray-600',
+    default: baseColor('gray-600'),
     forcedColors: 'ButtonText',
     isDisabled: {
       default: 'disabled',
@@ -492,7 +487,7 @@ const detailTriggerStyles = style({
     default: 'transparent',
     isHovered: 'gray-75',
     isFocusVisible: 'gray-75',
-    isPressed: 'gray-75'
+    isPressed: 'gray-100'
   },
   transition: 'default',
   borderWidth: 0,
@@ -503,15 +498,8 @@ const detailTriggerStyles = style({
 });
 
 function DetailTrigger(props: DetailTriggerProps) {
-  let ref = useRef<HTMLButtonElement | null>(null);
-
   return (
-    <Button
-      ref={ref}
-      // eslint-disable-next-line react/react-compiler
-      style={pressScale(ref)}
-      className={detailTriggerStyles}
-      slot="trigger">
+    <Button className={detailTriggerStyles} slot="trigger">
       <ShimmerText {...props} />
     </Button>
   );
@@ -530,11 +518,15 @@ export interface ExecutionTraceItemProps extends DOMProps, AriaLabelingProps {
    */
   detail?: ReactNode;
   /**
+   * Maximum height for the detail panel.
+   *
+   * @default 120
+   */
+  detailMaxHeight?: number;
+  /**
    * An icon shown at the leading edge of the row. If omitted, a checkmark is rendered by default.
    */
   icon?: ReactNode;
-  /** Allows detail content to render but prevents the row from being collapsible. */
-  isAlwaysOpen?: boolean;
   /** Spectrum-defined styles, returned by the `style()` macro. */
   styles?: StyleString;
 }
@@ -601,7 +593,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   props: ExecutionTraceItemProps,
   ref: DOMRef<HTMLLIElement>
 ) {
-  let {isAlwaysOpen, detail, icon, children, styles, status = 'success', ...otherProps} = props;
+  let {detail, detailMaxHeight, icon, children, styles, status = 'success', ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let domProps = filterDOMProps(otherProps);
   let hasDetail = detail != null;
@@ -611,6 +603,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
       <div className={executionTraceItemIconContainerStyles}>
         <CenterBaseline>
           {status === 'failed' && (
+            /* 16px box so it lines up with other icons */
             <div
               className={style({
                 size: 16,
@@ -656,7 +649,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
         </CenterBaseline>
         <div role="presentation" className={executionTraceItemDividerStyles} />
       </div>
-      {hasDetail && !isAlwaysOpen ? (
+      {hasDetail ? (
         <RACDisclosure className="">
           <DetailTrigger isPending={status === 'pending'}>{children}</DetailTrigger>
           <RACDisclosurePanel className={style(panelStyle)}>
@@ -666,7 +659,8 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
                   className={
                     scrollFade({y: 24}) +
                     style({maxHeight: 120, overflow: 'auto', paddingX: 12, paddingY: 8})
-                  }>
+                  }
+                  style={{maxHeight: detailMaxHeight}}>
                   {detail}
                 </div>
               </div>
@@ -678,11 +672,6 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
           <span className={detailTriggerStyles({})}>
             <ShimmerText isPending={status === 'pending'}>{children}</ShimmerText>
           </span>
-          {hasDetail && isAlwaysOpen ? (
-            <div className={executationTradeDetailWrapperStyle}>
-              <div className={executionTraceDetailStyle}>{detail}</div>
-            </div>
-          ) : null}
         </div>
       )}
     </li>

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -44,6 +44,7 @@ import React, {
   createContext,
   forwardRef,
   ReactNode,
+  RefObject,
   useCallback,
   useContext,
   useId,
@@ -80,10 +81,14 @@ const ResponseStatusContext = createContext<{
   status: 'pending' | 'failed' | 'success';
   hasPanelContent: boolean;
   registerPanel: (mounted: boolean) => void;
+  isExpanded: boolean;
+  responseStatusRef: RefObject<HTMLDivElement | null> | null;
 }>({
   status: 'pending',
   hasPanelContent: false,
-  registerPanel: () => {}
+  registerPanel: () => {},
+  isExpanded: false,
+  responseStatusRef: null
 });
 
 const responseStatus = style({
@@ -102,17 +107,36 @@ export const ResponseStatus = forwardRef(function ResponseStatus(
 ) {
   let {status = 'pending', styles} = props;
   let domRef = useDOMRef(ref);
-  let [hasPanelContent, setHasPanelContent] = useState(false);
-  let registerPanel = useCallback((mounted: boolean) => setHasPanelContent(mounted), []);
 
   return (
-    <Provider values={[[ResponseStatusContext, {status, hasPanelContent, registerPanel}]]}>
-      <RACDisclosure {...props} ref={domRef} className={mergeStyles(responseStatus, styles)}>
+    <RACDisclosure {...props} ref={domRef} className={mergeStyles(responseStatus, styles)}>
+      <ResponseStatusContextProvider status={status} responseStatusRef={domRef}>
         {props.children}
-      </RACDisclosure>
-    </Provider>
+      </ResponseStatusContextProvider>
+    </RACDisclosure>
   );
 });
+
+function ResponseStatusContextProvider({
+  status,
+  children,
+  responseStatusRef
+}: {
+  status: 'pending' | 'success' | 'failed';
+  children: ReactNode;
+  responseStatusRef: RefObject<HTMLDivElement | null> | null;
+}) {
+  let [hasPanelContent, setHasPanelContent] = useState(false);
+  let registerPanel = useCallback((mounted: boolean) => setHasPanelContent(mounted), []);
+  let {isExpanded} = useContext(DisclosureStateContext)!;
+
+  return (
+    <ResponseStatusContext.Provider
+      value={{status, hasPanelContent, registerPanel, isExpanded, responseStatusRef}}>
+      {children}
+    </ResponseStatusContext.Provider>
+  );
+}
 
 export interface ResponseStatusTitleProps extends DOMProps {
   /**
@@ -394,22 +418,36 @@ const shimmer = css(`
   }
 `);
 
+const shimmerSym = Symbol('shimmer');
+
 function ShimmerText(props: DetailTriggerProps) {
   let {children, isPending} = props;
-  let {isExpanded} = useContext(DisclosureStateContext)!;
+  let {isExpanded, responseStatusRef} = useContext(ResponseStatusContext)!;
   let id = useId();
 
   // Do the animation in JS rather than CSS so we can synchronize across elements.
-  let shimmerRef = useCallback((el: HTMLSpanElement | null) => {
-    if (el && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      let animation = el.animate(
-        [{transform: 'translateX(-100%)'}, {transform: 'translateX(100%)'}],
-        {duration: 2500, iterations: Infinity, easing: 'ease-in-out', pseudoElement: '::after'}
-      );
-      animation.startTime = 0;
-      return () => animation.cancel();
-    }
-  }, []);
+  let shimmerRef = useCallback(
+    (el: HTMLSpanElement | null) => {
+      if (el && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        let animation = el.animate(
+          [{transform: 'translateX(-100%)'}, {transform: 'translateX(100%)'}],
+          {duration: 2500, iterations: Infinity, easing: 'ease-in-out', pseudoElement: '::after'}
+        );
+        animation[shimmerSym] = true;
+
+        // If there is an existing shimmer animation already happening, synchronize with it.
+        // If there is only one, then start from the beginning of the animation.
+        let existingAnim = responseStatusRef?.current
+          ?.getAnimations({subtree: true})
+          .find(anim => anim[shimmerSym] && anim !== animation);
+        if (existingAnim) {
+          animation.startTime = existingAnim.startTime;
+        }
+        return () => animation.cancel();
+      }
+    },
+    [responseStatusRef]
+  );
 
   return (
     <span className={style({position: 'relative', display: 'inline-block'})}>

--- a/packages/@react-spectrum/ai/src/tokens.macro.ts
+++ b/packages/@react-spectrum/ai/src/tokens.macro.ts
@@ -1,4 +1,4 @@
-import {color} from '@react-spectrum/s2/style';
+import {color, css} from '@react-spectrum/s2/style';
 import tokens from './tokens.merged.json';
 
 // Colors below this OKLCH chroma are treated as neutral (white/black/gray) and
@@ -239,4 +239,123 @@ function hash(v: string) {
     hash = ((hash << 5) + hash + v.charCodeAt(i)) >>> 0;
   }
   return hash;
+}
+
+interface ScrollFadeOptions {
+  top?: number;
+  bottom?: number;
+  start?: number;
+  end?: number;
+  x?: number;
+  y?: number;
+}
+
+export function scrollFade(this: any | void, options: ScrollFadeOptions) {
+  let {x = 0, y = 0, top = y, bottom = y, start = x, end = x} = options;
+
+  let blockMask = '',
+    inlineMask = '';
+
+  if (top || bottom) {
+    blockMask = `linear-gradient(
+      to bottom,
+      transparent 0px,
+      black var(--scroll-fade-top, 0px),
+      black var(--scroll-fade-bottom, 100%),
+      transparent 100%
+    )`;
+  }
+
+  if (start || end) {
+    // TODO: rtl
+    inlineMask = `linear-gradient(
+      to right,
+      transparent 0px,
+      black var(--scroll-fade-left, 0px),
+      black var(--scroll-fade-right, 100%),
+      transparent 100%
+    )`;
+  }
+
+  let topAnimation = scrollFadeKeyframes.call(this, 'top', '0px', top ? `${top}px` : '', '0px');
+  let bottomAnimation = scrollFadeKeyframes.call(
+    this,
+    'bottom',
+    bottom ? `calc(100% - ${bottom}px)` : '',
+    '100%',
+    '100%'
+  );
+  let leftAnimation = scrollFadeKeyframes.call(
+    this,
+    'left',
+    '0px',
+    start ? `${start}px` : '',
+    '0px'
+  );
+  let rightAnimation = scrollFadeKeyframes.call(
+    this,
+    'right',
+    end ? `calc(100% - ${end}px)` : '',
+    '100%',
+    '100%'
+  );
+  let animations = [topAnimation, bottomAnimation, leftAnimation, rightAnimation];
+  let timeline = ['scroll(self y)', 'scroll(self y)', 'scroll(self x)', 'scroll(self y)']
+    .filter((_, i) => animations[i])
+    .join(', ');
+  let range = [
+    `0px ${top}px`,
+    `calc(100% - ${bottom}px) 100%`,
+    `0px ${start}px`,
+    `calc(100% - ${end}px) 100%`
+  ]
+    .filter((_, i) => animations[i])
+    .join(', ');
+
+  if (blockMask || inlineMask) {
+    return css.call(
+      this,
+      `
+      mask-image: ${[blockMask, inlineMask].filter(Boolean).join(', ')};
+      mask-composite: intersect;
+      mask-repeat: no-repeat;
+
+      @supports (animation-timeline: scroll()) {
+        animation: ${animations.filter(Boolean).join(', ')};
+        animation-duration: 1ms;
+        animation-timing-function: ease-in-out;
+        animation-timeline: ${timeline};
+        animation-range: ${range};
+        animation-fill-mode: both;
+      }
+    `
+    );
+  }
+
+  return '';
+}
+
+function scrollFadeKeyframes(this: any, name: string, start: string, end: string, initial: string) {
+  if (!start || !end) {
+    return '';
+  }
+
+  this.addAsset({
+    type: 'css',
+    content: `
+    @property --scroll-fade-${name} {
+      syntax: "<length-percentage>";
+      inherits: false;
+      initial-value: ${initial};
+    }
+  `
+  });
+
+  return keyframes.call(
+    this,
+    `
+      from { --scroll-fade-${name}: ${start}; }
+      to { --scroll-fade-${name}: ${end}; }
+    `
+  );
 }

--- a/packages/@react-spectrum/ai/stories/Chat.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/Chat.stories.tsx
@@ -510,7 +510,7 @@ export function VirtualizedStreamingChat() {
                     textValue={announcement}
                     isStreaming={msg.isStreaming}
                     shouldAnnounceOnMount>
-                    <ResponseStatus status={msg.isStreaming ? 'loading' : 'success'}>
+                    <ResponseStatus status={msg.isStreaming ? 'pending' : 'success'}>
                       <ResponseStatusTitle>{title}</ResponseStatusTitle>
                       <ResponseStatusPanel>
                         {msg.details && (
@@ -734,7 +734,7 @@ export function EmptyChat() {
                     textValue={announcement}
                     isStreaming={msg.isStreaming}
                     shouldAnnounceOnMount>
-                    <ResponseStatus status={msg.isStreaming ? 'loading' : 'success'}>
+                    <ResponseStatus status={msg.isStreaming ? 'pending' : 'success'}>
                       <ResponseStatusTitle>{title}</ResponseStatusTitle>
                       <ResponseStatusPanel>
                         {msg.details && (

--- a/packages/@react-spectrum/ai/stories/PromptField.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/PromptField.stories.tsx
@@ -498,6 +498,7 @@ function EverythingRender(args) {
             });
           }}
           pixelLoader={data[args.pixelLoader]}
+          shouldAnimatePixelLoader
           placeholder={placeholder}
           menuWidth={menuWidth}>
           {token => (
@@ -622,7 +623,7 @@ function BasicRender({placeholder, ...args}: any) {
   return (
     <PromptField {...args}>
       <div className={style({display: 'flex', gap: 16, alignItems: 'center'})}>
-        <PromptTokenField placeholder={placeholder} />
+        <PromptTokenField placeholder={placeholder} shouldAnimatePixelLoader />
         <PromptFieldSubmitButton />
       </div>
     </PromptField>
@@ -637,6 +638,7 @@ export const AsyncCompletions = () => (
   <PromptField>
     <div className={style({display: 'flex', gap: 16, alignItems: 'center'})}>
       <PromptTokenField
+        shouldAnimatePixelLoader
         completionTrigger={/(?<=^|\s)[@/]/}
         renderCompletions={async filterValue => {
           await new Promise(resolve => setTimeout(resolve, 500));

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -219,7 +219,7 @@ function WithExecutionTraceRender(args) {
       return;
     }
     let timers = [...executionTraceSteps, null].map((_, i) =>
-      setTimeout(() => setVisibleCount(i + 1), i * 2500)
+      setTimeout(() => setVisibleCount(i + 1), i * 2000 + Math.random() * 500)
     );
     return () => timers.forEach(clearTimeout);
   }, [args.static, args.status]);

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -120,11 +120,11 @@ export const WithExecutionTrace: Story = {
                 <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
                   <div>
                     <span className={style({color: 'gray-600'})}>skill_name: </span>
-                    <span className={style({font: 'code-sm'})}>operational-insights</span>
+                    <span className={style({font: 'code-xs'})}>operational-insights</span>
                   </div>
                   <div>
                     <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
-                    <div className={style({font: 'code-sm'})}>
+                    <div className={style({font: 'code-xs'})}>
                       Loaded skill: operational-insights
                     </div>
                   </div>
@@ -149,7 +149,7 @@ export const WithExecutionTrace: Story = {
                   </div>
                   <div>
                     <div className={style({color: 'gray-600', marginBottom: 4})}>sql:</div>
-                    <div className={style({font: 'code-sm', whiteSpace: 'pre-wrap'})}>
+                    <div className={style({font: 'code-xs', whiteSpace: 'pre-wrap'})}>
                       {'SELECT DISTINCT a.audienceId AS audience_id, a.name AS audience_name, CASE WHEN a.isEdge = true ' +
                         "THEN 'Edge' WHEN a.isStreaming = true THEN 'Streaming' WHEN a.isBatch = true THEN 'Batch' ELSE " +
                         "'Unknown' END AS evaluation_type, a.totalProfiles AS profile_count, ARRAY_AGG(DISTINCT d.name) A" +
@@ -171,7 +171,7 @@ export const WithExecutionTrace: Story = {
                         have access, your Adobe account team can help get you set up.
                         <br />
                         <br />
-                        <span className={style({font: 'code-sm'})}>
+                        <span className={style({font: 'code-xs'})}>
                           {'<system-reminder>\n' +
                             'The underlying response was HTTP 403 (access denied) — usually because the organization is not ' +
                             'entitled to this Adobe Experience Platform capability. Reply to the user with the message above ' +
@@ -192,8 +192,10 @@ export const WithExecutionTrace: Story = {
               Attempted to call list items tool
             </ExecutionTraceItem>
 
-            <ExecutionTraceItem icon={<Tools />}>
-              Searched the{' '}
+            <ExecutionTraceItem
+              icon={<Tools />}
+              status={args.status === 'loading' ? 'pending' : args.status}>
+              {args.status === 'loading' ? 'Searching' : 'Searched'} the{' '}
               <Link variant="secondary" href="https://react-spectrum.adobe.com" target="_blank">
                 React Spectrum
               </Link>{' '}

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -105,7 +105,8 @@ export const WithExecutionTrace: Story = {
     defaultExpanded: false,
     status: 'success',
     static: false,
-    parallelTasks: 1
+    parallelTasks: 1,
+    showIcons: false
   } as any,
   argTypes: {
     pixelLoader: {
@@ -126,7 +127,7 @@ const executionTraceSteps: Array<Omit<ExecutionTraceItemProps, 'status'>> = [
     detail:
       "The user wants to 'parse the data' with their existing audiences. This is a bit vague - they want to create a new audience based on/combining their existing audiences. Let me search for their existing audiences first to see what we have to work with, then we can brainstorm something creative.",
     icon: <MagicWand />,
-    isAlwaysOpen: true,
+    // isAlwaysOpen: true,
     children: 'Thought'
   },
   {
@@ -219,7 +220,7 @@ function WithExecutionTraceRender(args) {
       return;
     }
     let timers = [...executionTraceSteps, null].map((_, i) =>
-      setTimeout(() => setVisibleCount(i + 1), i * 2000 + Math.random() * 500)
+      setTimeout(() => setVisibleCount(i + 1), i * 2000 + Math.random() * 1000)
     );
     return () => timers.forEach(clearTimeout);
   }, [args.static, args.status]);
@@ -249,7 +250,11 @@ function WithExecutionTraceRender(args) {
             {executionTraceSteps.slice(0, visibleCount).map((step, i) => {
               let isLast = i >= visibleCount - args.parallelTasks;
               return (
-                <ExecutionTraceItem key={i} {...step} status={isLast ? status : 'success'}>
+                <ExecutionTraceItem
+                  key={i}
+                  {...step}
+                  icon={args.showIcons ? step.icon : null}
+                  status={isLast ? status : 'success'}>
                   {step.children}
                 </ExecutionTraceItem>
               );

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -264,7 +264,7 @@ function WithExecutionTraceRender(args) {
       </ResponseStatus>
       <p className={style({font: 'body', flexGrow: 1})}>This is an example response.</p>
       <PromptField isGenerating={isStreaming}>
-        <PromptTokenField pixelLoader={data[args.pixelLoader]} disablePixelLoaderAnimation>
+        <PromptTokenField pixelLoader={data[args.pixelLoader]}>
           {token => <PromptToken token={token}>{token.text}</PromptToken>}
         </PromptTokenField>
         <PromptFieldToolbar>

--- a/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
@@ -11,17 +11,25 @@
  */
 
 import AlertTriangle from '@react-spectrum/s2/icons/AlertTriangle';
-import {categorizeArgTypes, getActionArgs} from '../../s2/stories/utils';
-import {Content} from '@react-spectrum/s2/Content';
 import {
+  AttachFileMenuItem,
   ExecutionTrace,
   ExecutionTraceItem,
+  ExecutionTraceItemProps,
+  InsertMenuButton,
+  PromptField,
+  PromptFieldSubmitButton,
+  PromptFieldToolbar,
+  PromptToken,
+  PromptTokenField,
   ResponseStatus,
   ResponseStatusPanel,
   ResponseStatusTitle
 } from '@react-spectrum/ai';
+import {categorizeArgTypes, getActionArgs} from '../../s2/stories/utils';
+import {Content} from '@react-spectrum/s2/Content';
+import * as data from '../src/loader/data';
 import {InlineAlert} from '@react-spectrum/s2/InlineAlert';
-import {Link} from '@react-spectrum/s2/Link';
 import MagicWand from '@react-spectrum/s2/icons/MagicWand';
 import type {Meta, StoryObj} from '@storybook/react';
 import Plugin from '@react-spectrum/s2/icons/Plugin';
@@ -42,12 +50,12 @@ const meta: Meta<typeof ResponseStatus> = {
     ...categorizeArgTypes('Events', events),
     status: {
       control: 'radio',
-      options: ['loading', 'failed', 'success']
+      options: ['pending', 'failed', 'success']
     },
     children: {table: {disable: true}}
   },
   args: {
-    status: 'loading',
+    status: 'pending',
     ...getActionArgs(events)
   },
   title: 'AI/ResponseStatus'
@@ -61,7 +69,7 @@ export const Example: Story = {
     <div className={style({width: 320, minHeight: 240})}>
       <ResponseStatus {...args}>
         <ResponseStatusTitle>
-          {args.status === 'loading'
+          {args.status === 'pending'
             ? 'Generating response'
             : args.status === 'success'
               ? 'Response generated'
@@ -69,7 +77,7 @@ export const Example: Story = {
         </ResponseStatusTitle>
         <ResponseStatusPanel>
           Here is the generated response content. This area is hidden until the disclosure is
-          expanded, and cannot be expanded while loading.
+          expanded.
         </ResponseStatusPanel>
       </ResponseStatus>
     </div>
@@ -81,7 +89,7 @@ export const NoResponseContent: Story = {
     <div className={style({width: 320, minHeight: 240})}>
       <ResponseStatus {...args}>
         <ResponseStatusTitle>
-          {args.status === 'loading'
+          {args.status === 'pending'
             ? 'Generating response'
             : args.status === 'success'
               ? 'Response generated'
@@ -94,116 +102,173 @@ export const NoResponseContent: Story = {
 
 export const WithExecutionTrace: Story = {
   args: {
-    defaultExpanded: true,
-    status: 'success'
-  },
+    defaultExpanded: false,
+    status: 'success',
+    static: false,
+    parallelTasks: 1
+  } as any,
+  argTypes: {
+    pixelLoader: {
+      control: 'select',
+      options: Object.keys(data),
+      description: 'Sets the icon to use for the pixel loader.'
+    }
+  } as any,
   parameters: {
     layout: 'fullscreen'
   },
-  render: args => (
-    <div className={style({maxWidth: 600, minHeight: 240})}>
-      <ResponseStatus {...args}>
-        <ResponseStatusTitle>Used 6 tools</ResponseStatusTitle>
+  render: args => <WithExecutionTraceRender {...args} />
+};
+
+const executionTraceSteps: Array<Omit<ExecutionTraceItemProps, 'status'>> = [
+  {
+    // Rendered detail that doesn't offer user the option to collapse.
+    detail:
+      "The user wants to 'parse the data' with their existing audiences. This is a bit vague - they want to create a new audience based on/combining their existing audiences. Let me search for their existing audiences first to see what we have to work with, then we can brainstorm something creative.",
+    icon: <MagicWand />,
+    isAlwaysOpen: true,
+    children: 'Thought'
+  },
+  {
+    // Custom icon and text, complex detail content.
+    detail: (
+      <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
+        <div>
+          <span className={style({color: 'gray-600'})}>skill_name: </span>
+          <span className={style({font: 'code-xs'})}>operational-insights</span>
+        </div>
+        <div>
+          <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
+          <div className={style({font: 'code-xs'})}>Loaded skill: operational-insights</div>
+        </div>
+      </div>
+    ),
+    icon: <Plugin />,
+    children: 'Loaded skill Operational Insights'
+  },
+  {
+    // No icon, text only (default icon renders).
+    children: 'Read file packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx'
+  },
+  {
+    // Custom icon and text, complex detail content and error.
+    detail: (
+      <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
+        <div>
+          <span className={style({color: 'gray-600'})}>db_name: </span>
+          <span>hkg_db</span>
+        </div>
+        <div>
+          <div className={style({color: 'gray-600', marginBottom: 4})}>sql:</div>
+          <div className={style({font: 'code-xs', whiteSpace: 'pre-wrap'})}>
+            {'SELECT DISTINCT a.audienceId AS audience_id, a.name AS audience_name, CASE WHEN a.isEdge = true ' +
+              "THEN 'Edge' WHEN a.isStreaming = true THEN 'Streaming' WHEN a.isBatch = true THEN 'Batch' ELSE " +
+              "'Unknown' END AS evaluation_type, a.totalProfiles AS profile_count, ARRAY_AGG(DISTINCT d.name) A" +
+              'S activation_destinations FROM hkg_dim_audience a LEFT JOIN hkg_br_audience_destination ad ON a.' +
+              'audienceId = ad.audienceId LEFT JOIN hkg_dim_destination d ON ad.destinationId = d.destinationId' +
+              ' WHERE a.totalProfiles IS NOT NULL GROUP BY a.audienceId, a.name, a.isEdge, a.isStreaming, a.isBa' +
+              'tch, a.totalProfiles ORDER BY a.totalProfiles DESC LIMIT 10'}
+          </div>
+        </div>
+        <div>
+          <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
+          <InlineAlert variant="negative" fillStyle="subtleFill" styles={style({width: 'full'})}>
+            <Content>
+              It looks like this isn't available for your organization right now, so I wasn't able
+              to look that up for you. If you believe your organization should have access, your
+              Adobe account team can help get you set up.
+              <br />
+              <br />
+              <span className={style({font: 'code-xs'})}>
+                {'<system-reminder>\n' +
+                  'The underlying response was HTTP 403 (access denied) — usually because the organization is not ' +
+                  'entitled to this Adobe Experience Platform capability. Reply to the user with the message above ' +
+                  'as your complete response for this turn and then stop. Do not show the status code or raw error ' +
+                  'text, do not invent fixes such as refreshing the session or changing region or profile settings, and...'}
+              </span>
+            </Content>
+          </InlineAlert>
+        </div>
+      </div>
+    ),
+    icon: <AlertTriangle />,
+    children: 'Attempted running SQL – Querying top 10 largest audiences.'
+  },
+  {
+    // Custom icon and text, no detail.
+    icon: <PluginGear />,
+    children: 'Attempted to call list items tool'
+  },
+  {
+    icon: <Tools />,
+    children: 'Searched the React Spectrum docs'
+  }
+];
+
+function WithExecutionTraceRender(args) {
+  let [visibleCountState, setVisibleCount] = React.useState(1);
+  let status = args.status;
+  if (!args.static && status === 'pending' && visibleCountState > executionTraceSteps.length) {
+    status = 'success';
+  }
+  let isStreaming = status === 'pending';
+  let visibleCount = isStreaming && !args.static ? visibleCountState : executionTraceSteps.length;
+
+  React.useEffect(() => {
+    if (args.static) {
+      return;
+    }
+    let timers = [...executionTraceSteps, null].map((_, i) =>
+      setTimeout(() => setVisibleCount(i + 1), i * 2500)
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [args.static, args.status]);
+
+  return (
+    <div
+      className={style({
+        maxWidth: 800,
+        minHeight: 240,
+        marginX: 'auto',
+        paddingY: 40,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        boxSizing: 'border-box'
+      })}>
+      <ResponseStatus {...args} status={status}>
+        <ResponseStatusTitle pixelLoader={data[args.pixelLoader]}>
+          {isStreaming
+            ? executionTraceSteps[Math.min(visibleCount, executionTraceSteps.length - 1)].children
+            : status === 'success'
+              ? 'Loaded skill, ran SQL query, and 3 more steps'
+              : 'Response failed'}
+        </ResponseStatusTitle>
         <ResponseStatusPanel>
           <ExecutionTrace>
-            {/** Rendered detail that doesn't offer user the option to collapse. */}
-            <ExecutionTraceItem
-              detail="The user wants to 'parse the data' with their existing audiences. This is a bit vague - they want to create a new audience based on/combining their existing audiences. Let me search for their existing audiences first to see what we have to work with, then we can brainstorm something creative."
-              icon={<MagicWand />}
-              isAlwaysOpen>
-              Thought
-            </ExecutionTraceItem>
-
-            {/** Custom icon and text, complex detail content. */}
-            <ExecutionTraceItem
-              detail={
-                <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
-                  <div>
-                    <span className={style({color: 'gray-600'})}>skill_name: </span>
-                    <span className={style({font: 'code-xs'})}>operational-insights</span>
-                  </div>
-                  <div>
-                    <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
-                    <div className={style({font: 'code-xs'})}>
-                      Loaded skill: operational-insights
-                    </div>
-                  </div>
-                </div>
-              }
-              icon={<Plugin />}>
-              Loaded skill Operational Insights
-            </ExecutionTraceItem>
-
-            {/** No icon, text only (default icon renders) */}
-            <ExecutionTraceItem>
-              Read file packages/@react-spectrum/ai/stories/ResponseStatus.stories.tsx
-            </ExecutionTraceItem>
-
-            {/** Custom icon and text, complex detail content and error. */}
-            <ExecutionTraceItem
-              detail={
-                <div className={style({display: 'flex', flexDirection: 'column', gap: 12})}>
-                  <div>
-                    <span className={style({color: 'gray-600'})}>db_name: </span>
-                    <span>hkg_db</span>
-                  </div>
-                  <div>
-                    <div className={style({color: 'gray-600', marginBottom: 4})}>sql:</div>
-                    <div className={style({font: 'code-xs', whiteSpace: 'pre-wrap'})}>
-                      {'SELECT DISTINCT a.audienceId AS audience_id, a.name AS audience_name, CASE WHEN a.isEdge = true ' +
-                        "THEN 'Edge' WHEN a.isStreaming = true THEN 'Streaming' WHEN a.isBatch = true THEN 'Batch' ELSE " +
-                        "'Unknown' END AS evaluation_type, a.totalProfiles AS profile_count, ARRAY_AGG(DISTINCT d.name) A" +
-                        'S activation_destinations FROM hkg_dim_audience a LEFT JOIN hkg_br_audience_destination ad ON a.' +
-                        'audienceId = ad.audienceId LEFT JOIN hkg_dim_destination d ON ad.destinationId = d.destinationId' +
-                        ' WHERE a.totalProfiles IS NOT NULL GROUP BY a.audienceId, a.name, a.isEdge, a.isStreaming, a.isBa' +
-                        'tch, a.totalProfiles ORDER BY a.totalProfiles DESC LIMIT 10'}
-                    </div>
-                  </div>
-                  <div>
-                    <div className={style({color: 'gray-600', marginBottom: 4})}>RESULT</div>
-                    <InlineAlert
-                      variant="negative"
-                      fillStyle="subtleFill"
-                      styles={style({width: 'full'})}>
-                      <Content>
-                        It looks like this isn't available for your organization right now, so I
-                        wasn't able to look that up for you. If you believe your organization should
-                        have access, your Adobe account team can help get you set up.
-                        <br />
-                        <br />
-                        <span className={style({font: 'code-xs'})}>
-                          {'<system-reminder>\n' +
-                            'The underlying response was HTTP 403 (access denied) — usually because the organization is not ' +
-                            'entitled to this Adobe Experience Platform capability. Reply to the user with the message above ' +
-                            'as your complete response for this turn and then stop. Do not show the status code or raw error ' +
-                            'text, do not invent fixes such as refreshing the session or changing region or profile settings, and...'}
-                        </span>
-                      </Content>
-                    </InlineAlert>
-                  </div>
-                </div>
-              }
-              icon={<AlertTriangle />}>
-              Attempted running SQL – Querying top 10 largest audiences.
-            </ExecutionTraceItem>
-
-            {/** Custon icon and text, no detail. */}
-            <ExecutionTraceItem icon={<PluginGear />}>
-              Attempted to call list items tool
-            </ExecutionTraceItem>
-
-            <ExecutionTraceItem
-              icon={<Tools />}
-              status={args.status === 'loading' ? 'pending' : args.status}>
-              {args.status === 'loading' ? 'Searching' : 'Searched'} the{' '}
-              <Link variant="secondary" href="https://react-spectrum.adobe.com" target="_blank">
-                React Spectrum
-              </Link>{' '}
-              docs
-            </ExecutionTraceItem>
+            {executionTraceSteps.slice(0, visibleCount).map((step, i) => {
+              let isLast = i >= visibleCount - args.parallelTasks;
+              return (
+                <ExecutionTraceItem key={i} {...step} status={isLast ? status : 'success'}>
+                  {step.children}
+                </ExecutionTraceItem>
+              );
+            })}
           </ExecutionTrace>
         </ResponseStatusPanel>
       </ResponseStatus>
+      <p className={style({font: 'body', flexGrow: 1})}>This is an example response.</p>
+      <PromptField isGenerating={isStreaming}>
+        <PromptTokenField pixelLoader={data[args.pixelLoader]} disablePixelLoaderAnimation>
+          {token => <PromptToken token={token}>{token.text}</PromptToken>}
+        </PromptTokenField>
+        <PromptFieldToolbar>
+          <InsertMenuButton>
+            <AttachFileMenuItem />
+          </InsertMenuButton>
+          <PromptFieldSubmitButton />
+        </PromptFieldToolbar>
+      </PromptField>
     </div>
-  )
-};
+  );
+}


### PR DESCRIPTION
Updates the response status component with latest design changes.

* Animated AI icon moves to the response status - it does not animate in the prompt field. Added a prop to opt-out of the animation in PromptField - to be discussed.
* Using dots instead of icons in the execution trace
* Top-level disclosure shows the current in-progress item when collapsed, and "Processing..." when expanded.
* New shimmer animation on the currently in progress trace item. If multiple are in progress at once the animations are synchronized.
* Response status content has a max-height and a scroll fade effect (a reusable macro)
* New trace items fade in when they arrive
* Updated typography

Note that there are breaking API changes here. Since this is in alpha, it's ok for now.