### PR TITLE
fix: add suppressHydrationWarning to GlobalDOMAttributes and update f…

### DIFF
--- a/packages/@react-types/shared/src/dom.d.ts
+++ b/packages/@react-types/shared/src/dom.d.ts
@@ -301,6 +301,12 @@ export interface GlobalDOMAttributes<T = Element> extends GlobalDOMEvents<T> {
   hidden?: boolean | undefined;
   inert?: boolean | undefined;
   translate?: 'yes' | 'no' | undefined;
+  /**
+   * A React-only flag that suppresses the warning React normally logs when an element's
+   * server-rendered content doesn't match the client render during hydration. See [React
+   * docs](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors).
+   */
+  suppressHydrationWarning?: boolean | undefined;
 }
 
 /**

--- a/packages/react-aria/src/utils/filterDOMProps.ts
+++ b/packages/react-aria/src/utils/filterDOMProps.ts
@@ -32,7 +32,14 @@ const linkPropNames = new Set([
   'referrerPolicy'
 ]);
 
-const globalAttrs = new Set(['dir', 'lang', 'hidden', 'inert', 'translate']);
+const globalAttrs = new Set([
+  'dir',
+  'lang',
+  'hidden',
+  'inert',
+  'translate',
+  'suppressHydrationWarning'
+]);
 
 const globalEvents = new Set([
   'onClick',

--- a/packages/react-aria/test/utils/filterDOMProps.test.ts
+++ b/packages/react-aria/test/utils/filterDOMProps.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {filterDOMProps} from '../../src/utils/filterDOMProps';
+
+describe('filterDOMProps', () => {
+  it('always includes id', () => {
+    expect(filterDOMProps({id: 'foo'})).toEqual({id: 'foo'});
+  });
+
+  it('strips global attributes when global is not requested', () => {
+    let props = {dir: 'rtl', hidden: true, suppressHydrationWarning: true};
+    expect(filterDOMProps(props)).toEqual({});
+  });
+
+  it('includes global attributes when global is requested', () => {
+    let props = {
+      dir: 'rtl',
+      lang: 'en',
+      hidden: true,
+      inert: true,
+      translate: 'no',
+      suppressHydrationWarning: true
+    } as const;
+    expect(filterDOMProps(props, {global: true})).toEqual(props);
+  });
+
+  it('includes suppressHydrationWarning when global is requested', () => {
+    expect(filterDOMProps({suppressHydrationWarning: true}, {global: true})).toEqual({
+      suppressHydrationWarning: true
+    });
+  });
+
+  it('strips suppressHydrationWarning when global is not requested', () => {
+    expect(filterDOMProps({suppressHydrationWarning: true})).toEqual({});
+  });
+});


### PR DESCRIPTION
`filterDOMProps` did not forward `suppressHydrationWarning`, even though it is a valid React prop for handling unavoidable server/client hydration differences.

This change adds the prop to `GlobalDOMAttributes` and to the global attributes handled by `filterDOMProps`. Components using this utility can now forward it to the DOM only when `{global: true}` is specified. Unit tests cover both the inclusion and stripping behavior.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding React Spectrum GitHub Issue.
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component). Documentation is not applicable to this internal type/utility change.
- [x] Looked at the Accessibility Practices for this feature - Aria Practices. Not applicable; this does not change component interactions or ARIA behavior.
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed the AI contribution guidance and pointed my assistant at CLAUDE.md.

## 📝 Test Instructions:

Run the `filterDOMProps` unit tests and verify that:
- `suppressHydrationWarning` is retained with `{global: true}`.
- It is removed without `{global: true}`.
- Existing global-attribute filtering remains unchanged.


## AI assistance

I used an AI assistant to help draft the implementation and tests. I reviewed, understand, and take responsibility for every change in this PR.