### PR TITLE
fix(react-stately): set allowOverflow on TableLayout nodes for sticky columns

### DIFF
--- a/packages/react-stately/src/layout/TableLayout.ts
+++ b/packages/react-stately/src/layout/TableLayout.ts
@@ -232,6 +232,7 @@ export class TableLayout<T, O extends TableLayoutProps = TableLayoutProps> exten
     let layoutInfo = new LayoutInfo('header', collection.head?.key ?? 'header', rect);
     layoutInfo.isSticky = true;
     layoutInfo.zIndex = 1;
+    layoutInfo.allowOverflow = true;
 
     let y = this.padding;
     let width = 0;
@@ -259,6 +260,7 @@ export class TableLayout<T, O extends TableLayoutProps = TableLayoutProps> exten
   protected buildHeaderRow(headerRow: GridNode<T>, x: number, y: number): LayoutNode {
     let rect = new Rect(x, y, 0, 0);
     let row = new LayoutInfo('headerrow', headerRow.key, rect);
+    row.allowOverflow = true;
 
     let height = 0;
     let columns: LayoutNode[] = [];
@@ -358,6 +360,7 @@ export class TableLayout<T, O extends TableLayoutProps = TableLayoutProps> exten
     let layoutInfo = new LayoutInfo(node.type, node.key, rect);
     layoutInfo.isSticky = this.isStickyColumn(node);
     layoutInfo.zIndex = layoutInfo.isSticky ? 2 : 1;
+    layoutInfo.allowOverflow = true;
     layoutInfo.estimatedSize = isEstimated;
 
     return {
@@ -461,6 +464,7 @@ export class TableLayout<T, O extends TableLayoutProps = TableLayoutProps> exten
     let collection = this.virtualizer!.collection as TableCollection<T>;
     let rect = new Rect(x, y, 0, 0);
     let layoutInfo = new LayoutInfo('row', node.key, rect);
+    layoutInfo.allowOverflow = true;
 
     let children: LayoutNode[] = [];
     let height = 0;
@@ -511,6 +515,7 @@ export class TableLayout<T, O extends TableLayoutProps = TableLayoutProps> exten
     let layoutInfo = new LayoutInfo(node.type, node.key, rect);
     layoutInfo.isSticky = this.isStickyColumn(node);
     layoutInfo.zIndex = layoutInfo.isSticky ? 2 : 1;
+    layoutInfo.allowOverflow = true;
     layoutInfo.estimatedSize = isEstimated;
 
     return {


### PR DESCRIPTION
## Description
`TableLayout` exposes `isStickyColumn()` as a protected extension point to configure sticky columns. While overriding it sets `LayoutInfo.isSticky` and maintains persisted indices, `TableLayout` previously never set `LayoutInfo.allowOverflow = true` on its layout nodes. 

As a result, in `VirtualizerItem` (`layoutInfoToStyle`), sticky column cells were clipped and offset by parent scroll coordinates rather than remaining visually pinned in the viewport during virtualized horizontal scrolling.

## Solution
Updated `TableLayout.ts` across `buildTableHeader`, `buildHeaderRow`, `buildColumn`, `buildRow`, and `buildCell` to set `allowOverflow = true`, bringing `TableLayout` in line with sibling layouts (`ListLayout`, `GridLayout`, `WaterfallLayout`).

Fixes #10518