### PR TITLE
fix: intl for new ResponseStatus strings and fix focus ring on long details

### DIFF
--- a/packages/@react-spectrum/ai/intl/ar-AE.json
+++ b/packages/@react-spectrum/ai/intl/ar-AE.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "أرسلني",
   "promptfield.uploading": "التحميل",
   "responsestatus.loading": "جارٍ التحميل",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "ابدأ التسجيل",
   "voicebutton.stopListening": "أوقف التسجيل"
 }

--- a/packages/@react-spectrum/ai/intl/bg-BG.json
+++ b/packages/@react-spectrum/ai/intl/bg-BG.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Изпрати",
   "promptfield.uploading": "Качване",
   "responsestatus.loading": "Зареждане",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Започнете запис",
   "voicebutton.stopListening": "Спри записа"
 }

--- a/packages/@react-spectrum/ai/intl/cs-CZ.json
+++ b/packages/@react-spectrum/ai/intl/cs-CZ.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Odeslat",
   "promptfield.uploading": "Nahrávání",
   "responsestatus.loading": "Načítání",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Začít nahrávat",
   "voicebutton.stopListening": "Zastavit nahrávání"
 }

--- a/packages/@react-spectrum/ai/intl/da-DK.json
+++ b/packages/@react-spectrum/ai/intl/da-DK.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Send",
   "promptfield.uploading": "Upload",
   "responsestatus.loading": "Indlæser",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start optagelsen",
   "voicebutton.stopListening": "Stop optagelsen"
 }

--- a/packages/@react-spectrum/ai/intl/de-DE.json
+++ b/packages/@react-spectrum/ai/intl/de-DE.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Senden",
   "promptfield.uploading": "Hochladen",
   "responsestatus.loading": "Ladevorgang läuft",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Aufzeichnung starten",
   "voicebutton.stopListening": "Aufzeichnung stoppen"
 }

--- a/packages/@react-spectrum/ai/intl/el-GR.json
+++ b/packages/@react-spectrum/ai/intl/el-GR.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Αποστολή",
   "promptfield.uploading": "Μεταφόρτωση",
   "responsestatus.loading": "Φόρτωση",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Ξεκινήστε την εγγραφή",
   "voicebutton.stopListening": "Διακοπή εγγραφής"
 }

--- a/packages/@react-spectrum/ai/intl/en-US.json
+++ b/packages/@react-spectrum/ai/intl/en-US.json
@@ -4,6 +4,7 @@
   "messagefeedback.thumbDown": "Bad response",
   "messagefeedback.thumbUp": "Good response",
   "responsestatus.loading": "Loading",
+  "responsestatus.processing": "Processing...",
   "voicebutton.stopListening": "Stop recording",
   "voicebutton.startListening": "Start recording",
   "promptfield.placeholder": "Ready to get started? Ask a question, share an idea, or add a task.",

--- a/packages/@react-spectrum/ai/intl/es-ES.json
+++ b/packages/@react-spectrum/ai/intl/es-ES.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Enviar",
   "promptfield.uploading": "Cargando",
   "responsestatus.loading": "Cargando",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Iniciar grabación",
   "voicebutton.stopListening": "Detener grabación"
 }

--- a/packages/@react-spectrum/ai/intl/et-EE.json
+++ b/packages/@react-spectrum/ai/intl/et-EE.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Saada",
   "promptfield.uploading": "Üleslaadimine",
   "responsestatus.loading": "Laadimine",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Alusta salvestamist",
   "voicebutton.stopListening": "Lõpeta salvestamine"
 }

--- a/packages/@react-spectrum/ai/intl/fi-FI.json
+++ b/packages/@react-spectrum/ai/intl/fi-FI.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Lähetä",
   "promptfield.uploading": "Lataaminen",
   "responsestatus.loading": "Ladataan",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Aloita äänitys",
   "voicebutton.stopListening": "Lopeta tallennus"
 }

--- a/packages/@react-spectrum/ai/intl/fr-FR.json
+++ b/packages/@react-spectrum/ai/intl/fr-FR.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Envoyer",
   "promptfield.uploading": "Téléchargement",
   "responsestatus.loading": "Chargement",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Démarrer l'enregistrement",
   "voicebutton.stopListening": "Arrêter l'enregistrement"
 }

--- a/packages/@react-spectrum/ai/intl/he-IL.json
+++ b/packages/@react-spectrum/ai/intl/he-IL.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "שלח",
   "promptfield.uploading": "העלאה",
   "responsestatus.loading": "בטעינה…",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "התחל להקליט",
   "voicebutton.stopListening": "הפסק להקליט"
 }

--- a/packages/@react-spectrum/ai/intl/hr-HR.json
+++ b/packages/@react-spectrum/ai/intl/hr-HR.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Send",
   "promptfield.uploading": "Uploading",
   "responsestatus.loading": "Učitavanje",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
   "voicebutton.stopListening": "Stop recording"
 }

--- a/packages/@react-spectrum/ai/intl/hu-HU.json
+++ b/packages/@react-spectrum/ai/intl/hu-HU.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Elküldöm",
   "promptfield.uploading": "Feltöltés",
   "responsestatus.loading": "Betöltés folyamatban",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Kezdj el felvételt",
   "voicebutton.stopListening": "Felvétel abbahagyása"
 }

--- a/packages/@react-spectrum/ai/intl/it-IT.json
+++ b/packages/@react-spectrum/ai/intl/it-IT.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Invia",
   "promptfield.uploading": "Caricamento",
   "responsestatus.loading": "Caricamento",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Avvia registrazione",
   "voicebutton.stopListening": "Interrompi registrazione"
 }

--- a/packages/@react-spectrum/ai/intl/ja-JP.json
+++ b/packages/@react-spectrum/ai/intl/ja-JP.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "送信",
   "promptfield.uploading": "アップロード中",
   "responsestatus.loading": "読み込み中",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "記録を開始",
   "voicebutton.stopListening": "記録の停止"
 }

--- a/packages/@react-spectrum/ai/intl/ko-KR.json
+++ b/packages/@react-spectrum/ai/intl/ko-KR.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "전송",
   "promptfield.uploading": "업로드",
   "responsestatus.loading": "로드 중",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "기록 시작",
   "voicebutton.stopListening": "기록 중지"
 }

--- a/packages/@react-spectrum/ai/intl/lt-LT.json
+++ b/packages/@react-spectrum/ai/intl/lt-LT.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Siųsti",
   "promptfield.uploading": "Įkėlimas",
   "responsestatus.loading": "Įkeliama",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Pradėkite įrašinėti",
   "voicebutton.stopListening": "Sustabdyti įrašymą"
 }

--- a/packages/@react-spectrum/ai/intl/lv-LV.json
+++ b/packages/@react-spectrum/ai/intl/lv-LV.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Sūtīt",
   "promptfield.uploading": "Augšupielāde",
   "responsestatus.loading": "Notiek ielāde",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Sāciet ierakstīt",
   "voicebutton.stopListening": "Pārtraukt ierakstu"
 }

--- a/packages/@react-spectrum/ai/intl/nb-NO.json
+++ b/packages/@react-spectrum/ai/intl/nb-NO.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Send",
   "promptfield.uploading": "Uploading",
   "responsestatus.loading": "Laster inn",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
   "voicebutton.stopListening": "Stop recording"
 }

--- a/packages/@react-spectrum/ai/intl/nl-NL.json
+++ b/packages/@react-spectrum/ai/intl/nl-NL.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Verzenden",
   "promptfield.uploading": "Uploaden",
   "responsestatus.loading": "Laden",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Opname starten",
   "voicebutton.stopListening": "Opname stoppen"
 }

--- a/packages/@react-spectrum/ai/intl/pl-PL.json
+++ b/packages/@react-spectrum/ai/intl/pl-PL.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Wyślij",
   "promptfield.uploading": "Przesyłanie",
   "responsestatus.loading": "Wczytywanie",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Rozpocznij nagrywanie",
   "voicebutton.stopListening": "Zatrzymaj nagrywanie"
 }

--- a/packages/@react-spectrum/ai/intl/pt-BR.json
+++ b/packages/@react-spectrum/ai/intl/pt-BR.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Enviar",
   "promptfield.uploading": "Carregando",
   "responsestatus.loading": "Carregando",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Iniciar gravação",
   "voicebutton.stopListening": "Parar gravação"
 }

--- a/packages/@react-spectrum/ai/intl/pt-PT.json
+++ b/packages/@react-spectrum/ai/intl/pt-PT.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Send",
   "promptfield.uploading": "Uploading",
   "responsestatus.loading": "A carregar",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
   "voicebutton.stopListening": "Stop recording"
 }

--- a/packages/@react-spectrum/ai/intl/ro-RO.json
+++ b/packages/@react-spectrum/ai/intl/ro-RO.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Trimite",
   "promptfield.uploading": "Încărcare",
   "responsestatus.loading": "Se încarcă",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Începe înregistrarea",
   "voicebutton.stopListening": "Opriți înregistrarea"
 }

--- a/packages/@react-spectrum/ai/intl/ru-RU.json
+++ b/packages/@react-spectrum/ai/intl/ru-RU.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Отправить",
   "promptfield.uploading": "Отправка",
   "responsestatus.loading": "Загрузка",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Начать запись",
   "voicebutton.stopListening": "Остановить запись"
 }

--- a/packages/@react-spectrum/ai/intl/sk-SK.json
+++ b/packages/@react-spectrum/ai/intl/sk-SK.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Odoslať",
   "promptfield.uploading": "Nahrávanie",
   "responsestatus.loading": "Načítava sa",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Začni nahrávať",
   "voicebutton.stopListening": "Zastavte nahrávanie"
 }

--- a/packages/@react-spectrum/ai/intl/sl-SI.json
+++ b/packages/@react-spectrum/ai/intl/sl-SI.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Pošlji",
   "promptfield.uploading": "Nalaganje",
   "responsestatus.loading": "Nalaganje",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Začni snemati",
   "voicebutton.stopListening": "Prenehajte snemati"
 }

--- a/packages/@react-spectrum/ai/intl/sr-SP.json
+++ b/packages/@react-spectrum/ai/intl/sr-SP.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Send",
   "promptfield.uploading": "Uploading",
   "responsestatus.loading": "Učitavanje",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Start recording",
   "voicebutton.stopListening": "Stop recording"
 }

--- a/packages/@react-spectrum/ai/intl/sv-SE.json
+++ b/packages/@react-spectrum/ai/intl/sv-SE.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Skicka",
   "promptfield.uploading": "Överför",
   "responsestatus.loading": "Läser in",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Starta inspelning",
   "voicebutton.stopListening": "Stoppa inspelning"
 }

--- a/packages/@react-spectrum/ai/intl/tr-TR.json
+++ b/packages/@react-spectrum/ai/intl/tr-TR.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Gönder",
   "promptfield.uploading": "Yükleme",
   "responsestatus.loading": "Yükleniyor",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Kayıtlara başlayın",
   "voicebutton.stopListening": "Kaydı durdur"
 }

--- a/packages/@react-spectrum/ai/intl/uk-UA.json
+++ b/packages/@react-spectrum/ai/intl/uk-UA.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "Відправити",
   "promptfield.uploading": "Завантаження",
   "responsestatus.loading": "Завантаження",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "Починайте запис",
   "voicebutton.stopListening": "Припиніть запис"
 }

--- a/packages/@react-spectrum/ai/intl/zh-CN.json
+++ b/packages/@react-spectrum/ai/intl/zh-CN.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "发送",
   "promptfield.uploading": "正在上载",
   "responsestatus.loading": "加载",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "开始录制",
   "voicebutton.stopListening": "停止录制"
 }

--- a/packages/@react-spectrum/ai/intl/zh-TW.json
+++ b/packages/@react-spectrum/ai/intl/zh-TW.json
@@ -13,6 +13,7 @@
   "promptfield.submitButton": "傳送",
   "promptfield.uploading": "上傳中",
   "responsestatus.loading": "載入中",
+  "responsestatus.processing": "Processing...",
   "voicebutton.startListening": "開始錄製",
   "voicebutton.stopListening": "停止錄製"
 }

--- a/packages/@react-spectrum/ai/src/ResponseStatus.tsx
+++ b/packages/@react-spectrum/ai/src/ResponseStatus.tsx
@@ -37,6 +37,8 @@ import {
 import {filterDOMProps} from 'react-aria/filterDOMProps';
 import {Heading} from 'react-aria-components/Heading';
 import {IconContext} from '@react-spectrum/s2/Icon';
+// @ts-ignore
+import intlMessages from '../intl/*.json';
 import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
 import {PixelLoader} from '../exports';
 import {Provider} from 'react-aria-components/slots';
@@ -52,8 +54,10 @@ import React, {
 import {scrollFade} from './tokens.macro' with {type: 'macro'};
 import {StyleString} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {useDOMRef} from './useDOMRef';
+import {useFocusRing} from 'react-aria/useFocusRing';
 import {useLayoutEffect} from 'react-aria/private/utils/useLayoutEffect';
 import {useLocale} from 'react-aria/I18nProvider';
+import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 
 export interface ResponseStatusProps extends Omit<
   RACDisclosureProps,
@@ -169,6 +173,7 @@ const disclosureStyles = style({
   color: {
     default: baseColor('neutral-subdued'),
     isExpanded: 'gray-1000',
+    isOnlyText: 'gray-1000',
     forcedColors: 'ButtonText',
     isDisabled: {
       default: 'disabled',
@@ -210,6 +215,7 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
   let {level = 3, styles, pixelLoader, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   const domProps = filterDOMProps(otherProps);
+  let stringFormatter = useLocalizedStringFormatter(intlMessages, '@react-spectrum/ai');
   let {direction} = useLocale();
   let {isExpanded} = useContext(DisclosureStateContext)!;
   let {status, hasPanelContent} = useContext(ResponseStatusContext)!;
@@ -263,8 +269,9 @@ export const ResponseStatusTitle = forwardRef(function ResponseStatusTitle(
                 </CenterBaseline>
               </Provider>
             )}
-            {/* TODO: translation */}
-            {isLoading && isExpanded ? 'Processing...' : props.children}
+            {isLoading && isExpanded
+              ? stringFormatter.format('responsestatus.processing')
+              : props.children}
             {isInteractive ? (
               <CenterBaseline styles={style(chevronStyles)({isExpanded, isRTL})}>
                 <Chevron size="M" />
@@ -308,7 +315,7 @@ const panelInner = style({
 
 /**
  * A response status panel is a collapsible section of content that is hidden until the
- * response status is expanded. The panel cannot be expanded while `status` is `'pending'`.
+ * response status is expanded.
  */
 export const ResponseStatusPanel = forwardRef(function ResponseStatusPanel(
   props: ResponseStatusPanelProps,
@@ -401,7 +408,7 @@ const shimmer = css(`
   @media (prefers-reduced-motion: reduce) {
     display: none;
   }
-  
+
   @supports (-webkit-mask-clip: text) {
     mask-image: linear-gradient(white, white);
     -webkit-mask-clip: text;
@@ -579,6 +586,9 @@ const executationTradeDetailWrapperStyle = style({
 });
 
 const executionTraceDetailStyle = style({
+  // focus ring needs to be here instead of child detail div since the fade fades the focus ring
+  ...focusRing(),
+  outlineOffset: -2,
   backgroundColor: 'layer-1',
   borderRadius: 'lg',
   font: 'body-2xs',
@@ -596,6 +606,7 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
   let {detail, detailMaxHeight, icon, children, styles, status = 'success', ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let domProps = filterDOMProps(otherProps);
+  let {isFocusVisible, focusProps} = useFocusRing();
   let hasDetail = detail != null;
 
   return (
@@ -654,11 +665,18 @@ export const ExecutionTraceItem = forwardRef(function ExecutionTraceItem(
           <DetailTrigger isPending={status === 'pending'}>{children}</DetailTrigger>
           <RACDisclosurePanel className={style(panelStyle)}>
             <div className={executationTradeDetailWrapperStyle}>
-              <div className={executionTraceDetailStyle}>
+              <div className={executionTraceDetailStyle({isFocusVisible})}>
                 <div
+                  {...focusProps}
                   className={
                     scrollFade({y: 24}) +
-                    style({maxHeight: 120, overflow: 'auto', paddingX: 12, paddingY: 8})
+                    style({
+                      outlineStyle: 'none',
+                      maxHeight: 120,
+                      overflow: 'auto',
+                      paddingX: 12,
+                      paddingY: 8
+                    })
                   }
                   style={{maxHeight: detailMaxHeight}}>
                   {detail}


### PR DESCRIPTION
Followup from https://github.com/adobe/react-spectrum/pull/10524

Updates the intl files with the english fallback of "processing", fixes focus ring for long details in the ResponseStatus that become scrollable, and makes the hover style of the "No response content" ResponseStatus button not change on hover 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Test the Response Status "No Response Content" story by hovering it and verify the color doesn't change. Keyboard nav to and open the "Attempted running SQL" detail in the "With execution trace" story and tab to the details. A focus ring should render there. Sanity check that switching locale doesn't crash the story

## 🧢 Your Project:

RSP
