### PR TITLE
fix: include final constrained year in CalendarYearPicker

### DIFF
--- a/packages/react-aria-components/test/Calendar.test.js
+++ b/packages/react-aria-components/test/Calendar.test.js
@@ -924,7 +924,7 @@ describe('Calendar', () => {
                   value={value}
                   onChange={e => onChange(e.target.value)}>
                   {items.map(item => (
-                    <option key={item.id} value={item.id}>
+                    <option key={item.id} value={item.id} data-date={item.date.toString()}>
                       {item.formatted}
                     </option>
                   ))}
@@ -967,6 +967,22 @@ describe('Calendar', () => {
         .getAllByRole('option')
         .map(o => o.textContent)
     ).toEqual(Array.from({length: 7}, (_, i) => String(i + 2020)));
+
+    tree.rerender(
+      <YearPickerExample
+        key="cross-year-range"
+        calendarProps={{
+          minValue: new CalendarDate(2024, 8, 3),
+          maxValue: new CalendarDate(2025, 2, 3),
+          focusedValue: new CalendarDate(2025, 2, 1)
+        }}
+      />
+    );
+    let yearPicker = tree.getByLabelText('year');
+    let options = within(yearPicker).getAllByRole('option');
+    expect(options.map(o => o.textContent)).toEqual(['2024', '2025']);
+    expect(yearPicker).toHaveValue('1');
+    expect(options[1]).toHaveAttribute('data-date', '2025-02-03');
 
     tree.rerender(
       <YearPickerExample

--- a/packages/react-aria/src/calendar/useCalendarYearPicker.ts
+++ b/packages/react-aria/src/calendar/useCalendarYearPicker.ts
@@ -85,8 +85,9 @@ export function useCalendarYearPicker(
   let years: CalendarYearPickerItem[] = [];
   let date = minDate;
   let value = 0;
-  while (date.compare(maxDate) <= 0) {
-    if (isSameYear(date, state.focusedDate)) {
+  while (date.compare(maxDate) <= 0 || isSameYear(date, maxDate)) {
+    let itemDate = date.compare(maxDate) > 0 ? maxDate : date;
+    if (isSameYear(itemDate, state.focusedDate)) {
       value = years.length;
     }
 
@@ -96,8 +97,8 @@ export function useCalendarYearPicker(
       // store the year number, because in some calendars, such
       // as the Japanese, the era may also change.
       id: years.length,
-      date,
-      formatted: formatter.format(date.toDate(state.timeZone))
+      date: itemDate,
+      formatted: formatter.format(itemDate.toDate(state.timeZone))
     });
 
     date = date.add({years: 1});


### PR DESCRIPTION
Closes #10531

When both `minValue` and `maxValue` are set, the year picker steps forward from the exact month and day in `minValue`. If the month and day in the final year fall after `maxValue`, that step overshoots the range and omits a year that still contains selectable dates.

This includes the final overlapping calendar year and clamps its item date to `maxValue`, so selecting the option cannot focus a date outside the allowed range. The regression test covers a range from August 3, 2024 through February 3, 2025 and verifies that 2025 is present, selected for a focused date in 2025, and backed by the clamped February 3 date.

## Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10531).
- [x] Added/updated unit tests and storybook for this change (unit coverage added; no storybook change is needed for this logic fix).
- [x] Filled out test instructions.
- [x] Updated documentation (no documentation change is needed because the public API and intended behavior are unchanged).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/) (the existing select interaction and semantics are unchanged).
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

AI assistance disclosure: I used OpenAI Codex to investigate the root cause, implement the change, and run validation. I reviewed and understand the resulting code and test.

## Test Instructions:

1. Render a `Calendar` with `minValue={new CalendarDate(2024, 8, 3)}`, `maxValue={new CalendarDate(2025, 2, 3)}`, and `focusedValue={new CalendarDate(2025, 2, 1)}`.
2. Open the `CalendarYearPicker`.
3. Verify that the options are 2024 and 2025, and that 2025 is selected.
4. Select 2025 and verify that focus remains within the allowed range rather than moving to August 3, 2025.

Automated validation:

- `yarn test packages/react-aria-components/test/Calendar.test.js --runInBand` — 37 tests passed.
- `yarn test:ssr --runInBand` — 60 suites and 74 tests passed.
- Constraints, package lint, TypeScript checks, oxlint, targeted formatting, and `git diff --check` passed.
- The full Jest run was also attempted. The changed Calendar suite passed; unrelated existing Windows failures remained in locale fixture resolution, path separator assertions, and codemod temporary-directory handling.
- The repository-wide format check reports CRLF differences across 6481 untouched files in this Windows checkout; both changed files pass `oxfmt --check`.

## Your Project:

Personal contribution.
