### PR TITLE
fix(TableView): use correct color scheme in editable cell popover background

### DIFF
--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -25,6 +25,7 @@ import {
 } from '../style' with {type: 'macro'};
 import {Button, ButtonContext} from 'react-aria-components/Button';
 import {ButtonGroup} from './ButtonGroup';
+import {ColorSchemeContext} from './Provider';
 import {
   CellRenderProps,
   ColumnRenderProps,
@@ -1657,6 +1658,7 @@ function EditableCellInner(
   let dialogRef = useRef<DOMRefValue<HTMLElement>>(null);
 
   let {density, keyboardNavigationBehavior} = useContext(InternalTableContext);
+  let colorScheme = useContext(ColorSchemeContext);
   let size: 'XS' | 'S' | 'M' | 'L' | 'XL' | undefined = 'M';
   if (density === 'compact') {
     size = 'S';
@@ -1787,7 +1789,7 @@ function EditableCellInner(
               // Override default z-index from useOverlayPosition. We use isolation: isolate instead.
               zIndex: undefined
             }}
-            className={editPopover}>
+            className={renderProps => editPopover({...renderProps, colorScheme})}>
             <Provider values={[[OverlayTriggerStateContext, null]]}>
               <Form
                 ref={formRef}

--- a/packages/@react-spectrum/s2/src/TableView.tsx
+++ b/packages/@react-spectrum/s2/src/TableView.tsx
@@ -25,7 +25,6 @@ import {
 } from '../style' with {type: 'macro'};
 import {Button, ButtonContext} from 'react-aria-components/Button';
 import {ButtonGroup} from './ButtonGroup';
-import {ColorSchemeContext} from './Provider';
 import {
   CellRenderProps,
   ColumnRenderProps,
@@ -60,6 +59,7 @@ import {
   CollectionRendererContext,
   DefaultCollectionRenderer
 } from 'react-aria-components/CollectionBuilder';
+import {ColorSchemeContext} from './Provider';
 import {ColumnSize} from 'react-stately/useTableState';
 import {ContextValue, DEFAULT_SLOT, Provider, useSlottedContext} from 'react-aria-components/slots';
 import {


### PR DESCRIPTION
 Fixes S2 TableView's editable cell popover background to use the correct color scheme.

Before:
<img width="384" height="224" alt="Screenshot 2026-09-01 at 12 43 38 PM" src="https://github.com/user-attachments/assets/b6333fa8-fcf6-4af7-a5fd-2e436212cae3" />

After:
<img width="384" height="224" alt="Screenshot 2026-09-01 at 12 43 59 PM" src="https://github.com/user-attachments/assets/d0af0ac2-dffa-4075-834e-ff660e09a3d6" />



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Check editable cell popover background in both color schemes.

## 🧢 Your Project:

<!--- Company/project for pull request -->
