### PR TITLE
fix: skip visibility check in Focusable and Pressable dev warnings

### DIFF
--- a/packages/react-aria/src/interactions/Pressable.tsx
+++ b/packages/react-aria/src/interactions/Pressable.tsx
@@ -44,7 +44,7 @@ export const Pressable: React.ForwardRefExoticComponent<
         return;
       }
 
-      if (!props.isDisabled && !isFocusable(el)) {
+      if (!props.isDisabled && !isFocusable(el, {skipVisibilityCheck: true})) {
         console.warn(
           '<Pressable> child must be focusable. Please ensure the tabIndex prop is passed through.'
         );

--- a/packages/react-aria/src/interactions/useFocusable.tsx
+++ b/packages/react-aria/src/interactions/useFocusable.tsx
@@ -151,7 +151,7 @@ export const Focusable: React.ForwardRefExoticComponent<
         return;
       }
 
-      if (!props.isDisabled && !isFocusable(el)) {
+      if (!props.isDisabled && !isFocusable(el, {skipVisibilityCheck: true})) {
         console.warn(
           '<Focusable> child must be focusable. Please ensure the tabIndex prop is passed through.'
         );

--- a/packages/react-aria/test/interactions/Focusable.test.js
+++ b/packages/react-aria/test/interactions/Focusable.test.js
@@ -148,6 +148,21 @@ describe('Focusable', function () {
     );
   });
 
+  it('should not warn if focusable child is inside a hidden subtree', async function () {
+    using spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <div hidden>
+        <Focusable>
+          <span role="button">Button</span>
+        </Focusable>
+      </div>
+    );
+
+    expect(spy).not.toHaveBeenCalledWith(
+      '<Focusable> child must be focusable. Please ensure the tabIndex prop is passed through.'
+    );
+  });
+
   it('should warn if child does not have a role', async function () {
     using spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     render(

--- a/packages/react-aria/test/interactions/Pressable.test.js
+++ b/packages/react-aria/test/interactions/Pressable.test.js
@@ -123,6 +123,21 @@ describe('Pressable', function () {
     );
   });
 
+  it('should not warn if focusable child is inside a hidden subtree', async function () {
+    using spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <div hidden>
+        <Pressable>
+          <span role="button">Button</span>
+        </Pressable>
+      </div>
+    );
+
+    expect(spy).not.toHaveBeenCalledWith(
+      '<Pressable> child must be focusable. Please ensure the tabIndex prop is passed through.'
+    );
+  });
+
   it('supports isDisabled', async function () {
     using spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     let {getByRole} = render(


### PR DESCRIPTION
## 📖 Summary

The dev-only mount check in `Focusable` and `Pressable` asks whether `tabIndex` reached the DOM child, but `isFocusable` also walks ancestors for visibility. A correct child mounted inside a hidden subtree - e.g. a collapsed `DisclosurePanel` - warned even though `tabIndex` was applied.

Both call sites now pass `{skipVisibilityCheck: true}`, as the tree walk in `interactions/utils.ts` already does. `matches()` still catches a child that drops its props, and the other two checks in the effect are untouched.

Closes #10546

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests). — tests added; no storybook, dev-mode warning with no visual surface.
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component). — none needed.
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/) - dev warning only, no behaviour change.
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md). - AI-assisted; I reviewed every line and tested the result in our own repository to see the warning no longer prints.

## 📝 Test Instructions:

```
yarn jest packages/react-aria/test/interactions/Focusable.test.js packages/react-aria/test/interactions/Pressable.test.js
```

One test per file: a correct child inside `<div hidden>` must not warn. Both fail on `main` and pass with this change. The existing "child is not focusable" tests are unchanged and still pass.

## 🧢 Your Project:

N/A