### PR TITLE
fix(react-stately): enable useControlledState early effect in React Native

### DIFF
--- a/packages/react-stately/src/utils/useControlledState.ts
+++ b/packages/react-stately/src/utils/useControlledState.ts
@@ -13,8 +13,9 @@
 import React, {SetStateAction, useCallback, useEffect, useReducer, useRef, useState} from 'react';
 
 // Use the earliest effect possible to reset the ref below.
+const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
 const useEarlyEffect: typeof React.useLayoutEffect =
-  typeof document !== 'undefined'
+  typeof document !== 'undefined' || isReactNative
     ? (React['useInsertionEffect'] ?? React.useLayoutEffect)
     : () => {};
 

--- a/packages/react-stately/src/utils/useControlledState.ts
+++ b/packages/react-stately/src/utils/useControlledState.ts
@@ -13,9 +13,8 @@
 import React, {SetStateAction, useCallback, useEffect, useReducer, useRef, useState} from 'react';
 
 // Use the earliest effect possible to reset the ref below.
-const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
 const useEarlyEffect: typeof React.useLayoutEffect =
-  typeof document !== 'undefined' || isReactNative
+  typeof document !== 'undefined' || parseInt(React.version, 10) >= 19
     ? (React['useInsertionEffect'] ?? React.useLayoutEffect)
     : () => {};
 


### PR DESCRIPTION
# Description

Closes #10512

## Summary

`useControlledState` uses an early synchronous effect to keep its internal value ref synchronized with controlled prop changes. The effect was previously enabled only when `document` was defined.

In React Native, `document` is not available, causing the early effect to become a no-op. As a result, parent-driven controlled value changes could be ignored.

Based on maintainer feedback, this PR introduces a specific check for React Native using `navigator.product === 'ReactNative'`. This ensures the synchronous effect runs in both standard DOM environments and React Native, without using `window` which would break Deno support.

## Changes

* Updated the environment check in `useControlledState.ts` to use `typeof document !== 'undefined' || isReactNative`.
* Removed the previous JS-DOM regression test, as it did not properly simulate the non-DOM environment condition and was deemed unnecessary.

## Why

React Native does not provide `document`, so the previous check incorrectly disabled the synchronization effect. Checking for `isReactNative` explicitly avoids regressions in other DOM-less environments like Deno.

## Pull Request Checklist

* [x] Included link to corresponding React Spectrum GitHub Issue.
* [x] Added/updated unit tests and storybook for this change (N/A).
* [x] Filled out test instructions.
* [x] Updated documentation (N/A).
* [x] Looked at the Accessibility Practices for this feature (N/A).
* [x] I understand every change in this PR and can explain why it's there.
* [x] If AI-assisted, I followed our AI contribution guidance and pointed my assistant at `CLAUDE.md`.
