### PR TITLE
fix: Reset internal CardView context to fix nested cards

### DIFF
--- a/packages/@react-spectrum/s2/src/Card.tsx
+++ b/packages/@react-spectrum/s2/src/Card.tsx
@@ -532,24 +532,27 @@ export const Card = forwardRef(function Card(props: CardProps, ref: DOMRef<HTMLD
         variant === 'quiet' ? UNSAFE_style : press(renderProps)
       }>
       {({selectionMode, selectionBehavior, isHovered, isFocusVisible, isSelected, isPressed}) => (
-        <InternalCardContext.Provider
-          value={{
-            size,
-            isQuiet,
-            isCheckboxSelection: selectionMode !== 'none' && selectionBehavior === 'toggle',
-            isHovered,
-            isFocusVisible,
-            isSelected,
-            isPressed
-          }}>
-          {/* Selection indicator and checkbox move inside the preview for quiet cards */}
-          {!isQuiet && <SelectionIndicator />}
-          {!isQuiet && selectionMode !== 'none' && selectionBehavior === 'toggle' && (
-            <CardCheckbox />
-          )}
-          {/* this makes the :first-child selector work even with the checkbox */}
-          <div className={style({display: 'contents'})}>{children}</div>
-        </InternalCardContext.Provider>
+        /* reset the element type to avoid error on nested GridListItems */
+        <InternalCardViewContext.Provider value={{ElementType: 'div', layout}}>
+          <InternalCardContext.Provider
+            value={{
+              size,
+              isQuiet,
+              isCheckboxSelection: selectionMode !== 'none' && selectionBehavior === 'toggle',
+              isHovered,
+              isFocusVisible,
+              isSelected,
+              isPressed
+            }}>
+            {/* Selection indicator and checkbox move inside the preview for quiet cards */}
+            {!isQuiet && <SelectionIndicator />}
+            {!isQuiet && selectionMode !== 'none' && selectionBehavior === 'toggle' && (
+              <CardCheckbox />
+            )}
+            {/* this makes the :first-child selector work even with the checkbox */}
+            <div className={style({display: 'contents'})}>{children}</div>
+          </InternalCardContext.Provider>
+        </InternalCardViewContext.Provider>
       )}
     </ElementType>
   );

--- a/packages/@react-spectrum/s2/stories/CardView.stories.tsx
+++ b/packages/@react-spectrum/s2/stories/CardView.stories.tsx
@@ -321,3 +321,80 @@ export const CardViewWithTextField: Story = {
     selectionMode: 'multiple'
   }
 };
+
+export function NestedCards() {
+  return (
+    <CardView aria-label="Nature photos" size="XL" styles={style({width: 'full', height: 600})}>
+      <ProjectCard />
+      <ProjectCard />
+    </CardView>
+  );
+}
+
+function ProjectCard() {
+  return (
+    <Card href="#">
+      <Content>
+        <Text slot="title">Firefly AI Acquisition</Text>
+        <Text slot="description">4 projects</Text>
+        <ActionMenu size="M">
+          <MenuItem>Test</MenuItem>
+        </ActionMenu>
+      </Content>
+      <div className={style({display: 'grid', gridTemplateColumns: ['auto', 'auto'], gap: 16})}>
+        <Card size="S" href="#" styles={style({width: 'auto'})}>
+          <CardPreview>
+            <Image
+              src="https://images.unsplash.com/photo-1705034598432-1694e203cdf3?q=80&w=600&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+              width={600}
+              height={400}
+            />
+          </CardPreview>
+          <Content>
+            <Text slot="title">Firefly launch hero</Text>
+            <Text slot="description">Stage 2 of 4</Text>
+          </Content>
+        </Card>
+        <Card size="S" href="#" styles={style({width: 'auto'})}>
+          <CardPreview>
+            <Image
+              src="https://images.unsplash.com/photo-1705034598432-1694e203cdf3?q=80&w=600&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+              width={600}
+              height={400}
+            />
+          </CardPreview>
+          <Content>
+            <Text slot="title">Firefly launch hero</Text>
+            <Text slot="description">Stage 2 of 4</Text>
+          </Content>
+        </Card>
+        <Card size="S" href="#" styles={style({width: 'auto'})}>
+          <CardPreview>
+            <Image
+              src="https://images.unsplash.com/photo-1705034598432-1694e203cdf3?q=80&w=600&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+              width={600}
+              height={400}
+            />
+          </CardPreview>
+          <Content>
+            <Text slot="title">Firefly launch hero</Text>
+            <Text slot="description">Stage 2 of 4</Text>
+          </Content>
+        </Card>
+        <Card size="S" href="#" styles={style({width: 'auto'})}>
+          <CardPreview>
+            <Image
+              src="https://images.unsplash.com/photo-1705034598432-1694e203cdf3?q=80&w=600&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+              width={600}
+              height={400}
+            />
+          </CardPreview>
+          <Content>
+            <Text slot="title">Firefly launch hero</Text>
+            <Text slot="description">Stage 2 of 4</Text>
+          </Content>
+        </Card>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
Previously if you tried to nest a Card inside another Card within a CardView, you'd get an error: `GridListItem cannot be rendered outside a collection`. We just need to reset the InternalCardViewContext's element type back to div at Card boundaries so nested cards don't inherit it. Added a storybook example for testing based on a coworker mock.