### PR TITLE
Fix useTreeData subtree move validation

### DIFF
--- a/packages/react-stately/src/data/useTreeData.ts
+++ b/packages/react-stately/src/data/useTreeData.ts
@@ -378,6 +378,14 @@ export function useTreeData<T extends object>(options: TreeOptions<T>): TreeData
     },
     move(key: Key, toParentKey: Key | null, index: number) {
       setItems(({items, nodeMap: originalMap}) => {
+        let current = toParentKey;
+        while (current != null) {
+          if (current === key) {
+            throw new Error('Cannot move an item to be a child of itself.');
+          }
+          current = originalMap.get(current)?.parentKey ?? null;
+        }
+
         let node = originalMap.get(key);
         if (!node) {
           return {items, nodeMap: originalMap};
@@ -496,6 +504,9 @@ function moveItems<T extends object>(
       throw new Error('Cannot move an item to be a child of itself.');
     }
     parent = nodeMap.get(parent.parentKey!) ?? null;
+  }
+  if (parent != null && removeKeys.has(parent.key)) {
+    throw new Error('Cannot move an item to be a child of itself.');
   }
 
   let originalToIndex = toIndex;

--- a/packages/react-stately/src/data/useTreeData.ts
+++ b/packages/react-stately/src/data/useTreeData.ts
@@ -499,14 +499,11 @@ function moveItems<T extends object>(
 
   let parent = toParent;
   let removeKeys = new Set(keys);
-  while (parent?.parentKey != null) {
+  while (parent != null) {
     if (removeKeys.has(parent.key)) {
       throw new Error('Cannot move an item to be a child of itself.');
     }
-    parent = nodeMap.get(parent.parentKey!) ?? null;
-  }
-  if (parent != null && removeKeys.has(parent.key)) {
-    throw new Error('Cannot move an item to be a child of itself.');
+    parent = parent.parentKey != null ? (nodeMap.get(parent.parentKey) ?? null) : null;
   }
 
   let originalToIndex = toIndex;

--- a/packages/react-stately/test/data/useTreeData.test.js
+++ b/packages/react-stately/test/data/useTreeData.test.js
@@ -903,7 +903,7 @@ describe('useTreeData', function () {
     expect(result.current.items[0].children[0].children.length).toEqual(3);
   });
 
-  describe('moveBefore error', function () {
+  describe('move errors', function () {
     const consoleError = console.error;
     beforeEach(() => {
       console.error = jest.fn();
@@ -913,15 +913,56 @@ describe('useTreeData', function () {
       console.error = consoleError;
     });
 
-    it('cannot move an item within itself', function () {
-      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
-
-      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+    let expectToThrow = cb => {
+      let didThrow = false;
       try {
-        act(() => result.current.moveBefore('Suzie', ['John', 'Sam', 'Eli']));
+        cb();
       } catch (e) {
+        didThrow = true;
         expect(e.toString()).toContain('Cannot move an item to be a child of itself.');
       }
+
+      if (!didThrow) {
+        expect(console.error).toHaveBeenCalled();
+        const errorString = console.error.mock.calls.flat().join(' ');
+        expect(errorString).toContain('Cannot move an item to be a child of itself.');
+      }
+    };
+
+    it('cannot move an item before itself', function () {
+      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+      expectToThrow(() => act(() => result.current.moveBefore('Suzie', ['John', 'Sam', 'Eli'])));
+    });
+
+    it('cannot move a root-level item before itself', function () {
+      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+      expectToThrow(() => act(() => result.current.moveBefore('Suzie', ['David'])));
+    });
+
+    it('cannot move an item after itself', function () {
+      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+      expectToThrow(() => act(() => result.current.moveAfter('Suzie', ['John'])));
+    });
+
+    it('cannot move a root-level item after itself', function () {
+      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+      expectToThrow(() => act(() => result.current.moveAfter('Suzie', ['David'])));
+    });
+
+    it('cannot move an item into itself', function () {
+      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+      expectToThrow(() => act(() => result.current.move('John', 'Suzie', 0)));
+    });
+
+    it('cannot move a root-level item into itself', function () {
+      const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
+      let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
+      expectToThrow(() => act(() => result.current.move('David', 'Suzie', 0)));
     });
   });
 

--- a/packages/react-stately/test/data/useTreeData.test.js
+++ b/packages/react-stately/test/data/useTreeData.test.js
@@ -913,44 +913,50 @@ describe('useTreeData', function () {
       console.error = consoleError;
     });
 
-    let expectToThrow = cb => {
-      expect(cb).toThrow('Cannot move an item to be a child of itself.');
+    let reactMajor = parseInt(React.version, 10);
+    let expectMoveError = (result, action) => {
+      if (reactMajor >= 18) {
+        expect(() => act(action)).toThrow('Cannot move an item to be a child of itself.');
+      } else {
+        act(action);
+        expect(result.error?.message).toContain('Cannot move an item to be a child of itself.');
+      }
     };
 
     it('cannot move an item before a child inside itself', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
-      expectToThrow(() => act(() => result.current.moveBefore('Suzie', ['John', 'Sam', 'Eli'])));
+      expectMoveError(result, () => result.current.moveBefore('Suzie', ['John', 'Sam', 'Eli']));
     });
 
     it('cannot move a root-level item before any of its children', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
-      expectToThrow(() => act(() => result.current.moveBefore('Suzie', ['David'])));
+      expectMoveError(result, () => result.current.moveBefore('Suzie', ['David']));
     });
 
     it('cannot move an item after a child inside itself', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
-      expectToThrow(() => act(() => result.current.moveAfter('Suzie', ['John'])));
+      expectMoveError(result, () => result.current.moveAfter('Suzie', ['John']));
     });
 
     it('cannot move a root-level item after any of its children', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
-      expectToThrow(() => act(() => result.current.moveAfter('Suzie', ['David'])));
+      expectMoveError(result, () => result.current.moveAfter('Suzie', ['David']));
     });
 
     it('cannot move an item into itself', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
-      expectToThrow(() => act(() => result.current.move('John', 'Suzie', 0)));
+      expectMoveError(result, () => result.current.move('John', 'Suzie', 0));
     });
 
     it('cannot move a root-level item into itself', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
-      expectToThrow(() => act(() => result.current.move('David', 'Suzie', 0)));
+      expectMoveError(result, () => result.current.move('David', 'Suzie', 0));
     });
   });
 

--- a/packages/react-stately/test/data/useTreeData.test.js
+++ b/packages/react-stately/test/data/useTreeData.test.js
@@ -914,40 +914,28 @@ describe('useTreeData', function () {
     });
 
     let expectToThrow = cb => {
-      let didThrow = false;
-      try {
-        cb();
-      } catch (e) {
-        didThrow = true;
-        expect(e.toString()).toContain('Cannot move an item to be a child of itself.');
-      }
-
-      if (!didThrow) {
-        expect(console.error).toHaveBeenCalled();
-        const errorString = console.error.mock.calls.flat().join(' ');
-        expect(errorString).toContain('Cannot move an item to be a child of itself.');
-      }
+      expect(cb).toThrow('Cannot move an item to be a child of itself.');
     };
 
-    it('cannot move an item before itself', function () {
+    it('cannot move an item before a child inside itself', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
       expectToThrow(() => act(() => result.current.moveBefore('Suzie', ['John', 'Sam', 'Eli'])));
     });
 
-    it('cannot move a root-level item before itself', function () {
+    it('cannot move a root-level item before any of its children', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
       expectToThrow(() => act(() => result.current.moveBefore('Suzie', ['David'])));
     });
 
-    it('cannot move an item after itself', function () {
+    it('cannot move an item after a child inside itself', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
       expectToThrow(() => act(() => result.current.moveAfter('Suzie', ['John'])));
     });
 
-    it('cannot move a root-level item after itself', function () {
+    it('cannot move a root-level item after any of its children', function () {
       const initialItems = [...initial, {name: 'Emily'}, {name: 'Eli'}];
       let {result} = renderHook(() => useTreeData({initialItems, getChildren, getKey}));
       expectToThrow(() => act(() => result.current.moveAfter('Suzie', ['David'])));


### PR DESCRIPTION
# Description

Closes #10539

## Summary

Prevent `useTreeData` from silently dropping nodes when an item is moved into its own subtree.

This adds validation to the imperative `move`, `moveBefore`, and `moveAfter` APIs so that moves targeting a node's own descendants throw:

`Cannot move an item to be a child of itself.`

The validation also covers root-level nodes, which were previously missed by `moveBefore` and `moveAfter`.

## Changes

* Added ancestor validation to `move()`.
* Fixed root-level ancestor validation in `moveBefore()` and `moveAfter()`.
* Added isolated regression tests covering nested and root-level self-subtree moves for all three APIs.
* No changes to drag-and-drop behavior.

## Pull Request Checklist:

* [x] Included link to corresponding [[React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10539)](https://github.com/adobe/react-spectrum/issues/10539).
* [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
* [x] Filled out test instructions.
* [x] Updated documentation (if it already exists for this component).
* [x] Looked at the Accessibility Practices for this feature - [[Aria Practices](https://www.w3.org/WAI/ARIA/apg/)](https://www.w3.org/WAI/ARIA/apg/).
* [x] I understand every change in this PR and can explain why it's there.
* [x] If AI-assisted, I followed our [[AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions)](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md.

## Test Instructions:

Run the `useTreeData` test suite:

```bash
yarn jest useTreeData
```

The regression tests verify that `move`, `moveBefore`, and `moveAfter` throw when attempting to move an item into its own subtree, including root-level ancestor cases.

## Your Project:

None