### PR TITLE
chore: remove renderProps from AI components

### DIFF
--- a/packages/@react-spectrum/ai/src/AttachmentList.tsx
+++ b/packages/@react-spectrum/ai/src/AttachmentList.tsx
@@ -60,11 +60,6 @@ import {useDOMRef} from './useDOMRef';
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 
-interface AttachmentRenderProps {
-  /** The size of the Card. */
-  size: 'XS' | 'S' | 'M' | 'L' | 'XL';
-}
-
 const controlSizeM = {
   default: 32,
   size: {
@@ -519,7 +514,7 @@ export interface AttachmentProps
     AriaLabelingProps,
     Pick<TagProps, 'id' | 'textValue' | 'render'> {
   /** The children of the Attachment. */
-  children: ReactNode | ((renderProps: AttachmentRenderProps) => ReactNode);
+  children: ReactNode;
   uploadProgress?: number;
   /** Whether the attachment has an error. */
   isInvalid?: boolean;
@@ -638,7 +633,7 @@ export const Attachment = forwardRef(function Attachment(
       <AttachmentCard size={size} isInvalid={isInvalid} isLoading={isLoading}>
         <AttachmentPreviewContext.Provider
           value={{isInvalid: !!isInvalid, uploadProgress: props.uploadProgress ?? 100, size}}>
-          {typeof children === 'function' ? children({size}) : children}
+          {children}
         </AttachmentPreviewContext.Provider>
       </AttachmentCard>
       {/** Definitely not a close button, though looks like one. */}

--- a/packages/@react-spectrum/ai/src/Chat.tsx
+++ b/packages/@react-spectrum/ai/src/Chat.tsx
@@ -375,7 +375,7 @@ const threadItemBase = style({
 
 export interface ThreadItemProps extends Pick<
   GridListItemProps,
-  'children' | 'textValue' | 'focusMode' | 'allowsArrowNavigation' | 'id'
+  'textValue' | 'focusMode' | 'allowsArrowNavigation' | 'id'
 > {
   /**
    * Spectrum-defined styles, returned by the `style()` macro.
@@ -385,6 +385,8 @@ export interface ThreadItemProps extends Pick<
   isStreaming?: boolean;
   /** Announce textValue on mount even when isStreaming is provided. */
   shouldAnnounceOnMount?: boolean;
+  /** The content to display in the ThreadItem. */
+  children: ReactNode;
 }
 
 /**

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -799,7 +799,10 @@ function PromptTokenFieldPopover(props: PromptTokenFieldPopoverProps) {
   );
 }
 
-export interface PromptTokenProps extends Omit<TokenProps, 'children' | 'render'> {
+export interface PromptTokenProps extends Omit<
+  TokenProps,
+  'children' | 'render' | 'className' | 'style'
+> {
   token: TokenSegment<PromptFieldTokenValue>;
   children: React.ReactNode;
 }

--- a/packages/dev/s2-docs/src/PropTable.tsx
+++ b/packages/dev/s2-docs/src/PropTable.tsx
@@ -146,6 +146,11 @@ export function PropTable({
     return null;
   }
 
+  let hasProps =
+    Object.values(properties).filter(
+      prop => prop.type === 'property' && prop.access !== 'private' && prop.access !== 'protected'
+    ).length > 0;
+
   let defaultClassName = properties.className?.default?.slice(1, -1);
   let renderProps: TType | null = null;
   let renderPropProperty = properties.className || properties.children;
@@ -177,12 +182,14 @@ export function PropTable({
           {renderHTMLfromMarkdown(component.description, {forceInline: false, forceBlock: true})}
         </div>
       )}
-      <GroupedPropTable
-        properties={properties}
-        links={links}
-        propGroups={GROUPS}
-        defaultExpanded={DEFAULT_EXPANDED}
-      />
+      {hasProps && (
+        <GroupedPropTable
+          properties={properties}
+          links={links}
+          propGroups={GROUPS}
+          defaultExpanded={DEFAULT_EXPANDED}
+        />
+      )}
       {defaultClassName ? <DefaultClassName defaultClassName={defaultClassName} /> : null}
       {renderProps && renderProps.type === 'interface' ? (
         <StateTable

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -827,7 +827,7 @@ export interface GridListLoadMoreItemProps
    * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the
    * element.
    * 
-   *  @default 'react-aria-GridListLoadingIndicator'
+   * @default 'react-aria-GridListLoadingIndicator'
    * 
    */
   className?: string;

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -826,6 +826,9 @@ export interface GridListLoadMoreItemProps
   /**
    * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the
    * element.
+   * 
+   *  @default 'react-aria-GridListLoadingIndicator'
+   * 
    */
   className?: string;
   /**

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -826,9 +826,8 @@ export interface GridListLoadMoreItemProps
   /**
    * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the
    * element.
-   * 
    * @default 'react-aria-GridListLoadingIndicator'
-   * 
+   *
    */
   className?: string;
   /**

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -826,8 +826,6 @@ export interface GridListLoadMoreItemProps
   /**
    * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the
    * element.
-   *
-   * @default 'react-aria-GridListLoadingIndicator'
    */
   className?: string;
   /**

--- a/packages/react-aria-components/src/GridList.tsx
+++ b/packages/react-aria-components/src/GridList.tsx
@@ -826,8 +826,8 @@ export interface GridListLoadMoreItemProps
   /**
    * The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the
    * element.
-   * @default 'react-aria-GridListLoadingIndicator'
    *
+   * @default 'react-aria-GridListLoadingIndicator'
    */
   className?: string;
   /**


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Check AI component docs page to make sure renderProps table doesn't appear anymore

## 🧢 Your Project:

<!--- Company/project for pull request -->
