### PR TITLE
fix: PromptField max-height

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -34,7 +34,6 @@ import {
 import {FocusableRef} from '@react-types/shared';
 import {getInteractionModality} from 'react-aria/private/interactions/useFocusVisible';
 import {IconContext, MenuTriggerProps} from '@react-spectrum/s2';
-import {Image, Text} from '@react-spectrum/s2/Card';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {isFileDropItem, useDrop} from 'react-aria-components/useDrop';
@@ -59,6 +58,7 @@ import {scrollFade} from './tokens.macro' with {type: 'macro'};
 import Send from '@react-spectrum/s2/icons/ArrowUpSend';
 import {setTokenFieldSelection} from 'react-aria/useTokenField';
 import Stop from '@react-spectrum/s2/icons/StopProcessing';
+import {Text} from '@react-spectrum/s2/Card';
 import {ToggleButton, ToggleButtonContext} from '@react-spectrum/s2/ToggleButton';
 import {
   Token,

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -12,7 +12,7 @@
 
 import {ActionButton, ActionButtonContext} from '@react-spectrum/s2/ActionButton';
 import Attach from '@react-spectrum/s2/icons/Attach';
-import {Attachment, AttachmentList, AttachmentListProps} from './AttachmentList';
+import {Attachment, AttachmentList, AttachmentListProps, AttachmentPreview} from './AttachmentList';
 import {Autocomplete} from 'react-aria-components/Autocomplete';
 import {Button, ButtonContext} from '@react-spectrum/s2/Button';
 import {Cell} from './loader/data';
@@ -424,7 +424,7 @@ export function PromptFieldAttachmentList(props: PromptFieldAttachmentListProps)
       {children ||
         (attachment => (
           <Attachment>
-            {attachment.image && <Image src={attachment.image} slot="thumbnail" />}
+            <AttachmentPreview mimeType={attachment.file.type} src={attachment.image} />
           </Attachment>
         ))}
     </AttachmentList>

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -55,6 +55,7 @@ import {
 import {PromptFieldContainer} from './PromptFieldContainer';
 import {PromptFocusContext} from './Chat';
 import {Provider} from 'react-aria-components/slots';
+import {scrollFade} from './tokens.macro' with {type: 'macro'};
 import Send from '@react-spectrum/s2/icons/ArrowUpSend';
 import {setTokenFieldSelection} from 'react-aria/useTokenField';
 import Stop from '@react-spectrum/s2/icons/StopProcessing';
@@ -75,7 +76,6 @@ import {useKeyboard} from 'react-aria/useKeyboard';
 import {useLocale} from 'react-aria/I18nProvider';
 import {useLocalizedStringFormatter} from 'react-aria/useLocalizedStringFormatter';
 import {useVoiceInput, VoiceInputErrorCode} from './useVoiceInput';
-
 export interface PromptFieldAttachment {
   id: string;
   file: File;
@@ -361,7 +361,10 @@ export const PromptField = forwardRef(function PromptField(
           [ActionButtonContext, {staticColor: 'auto', size}],
           [ToggleButtonContext, {staticColor: 'auto', size}]
         ]}>
-        <div ref={domRef} {...focusWithinProps}>
+        <div
+          ref={domRef}
+          {...focusWithinProps}
+          className={style({maxHeight: '40cqh', display: 'flex', flexDirection: 'column'})}>
           <PromptFieldContainer
             {...dropProps}
             role="group"
@@ -569,7 +572,11 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
             S: 2
           }
         },
-        width: 'full',
+        flexGrow: 1,
+        flexShrink: 1,
+        minHeight: 0,
+        marginY: -16,
+        marginEnd: -16,
         '--loader-color': {
           type: 'color',
           value: {
@@ -606,7 +613,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
           value={prompt}
           onChange={setPrompt}
           allowsNewlines
-          className={style({flexGrow: 1})}
+          className={style({flexGrow: 1, minHeight: 0, height: 'full'})}
           aria-label={stringFormatter.format('promptfield.label')}
           isReadOnly={isListening}
           onSubmit={onSubmit}
@@ -673,12 +680,14 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
             ref={inputRef}
             className={
               css('&:empty::before { content: attr(data-placeholder); }') +
+              ' ' +
+              scrollFade({y: 16}) +
               style<{size: 'S' | 'M'; isFocused: boolean}>({
                 font: {
-                  default: 'body',
+                  default: 'ui-lg',
                   size: {
-                    M: 'body',
-                    S: 'body-sm'
+                    M: 'ui-lg',
+                    S: 'ui'
                   }
                 },
                 color: {
@@ -690,6 +699,12 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
                   }
                 },
                 width: 'full',
+                height: 'full',
+                minHeight: '1lh',
+                overflow: 'auto',
+                paddingY: 16,
+                paddingEnd: 16,
+                boxSizing: 'border-box',
                 outlineStyle: 'none',
                 cursor: 'text',
                 transition: 'colors',
@@ -905,6 +920,7 @@ export function PromptFieldSubmitButton(props: PromptFieldSubmitButtonProps) {
     <Button
       variant="primary"
       staticColor="auto"
+      styles={style({alignSelf: 'end'})}
       // TODO: should it be possible to submit a prompt with only attachments?
       isDisabled={prompt.segments.length === 0 && !isGenerating}
       aria-label={

--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -704,6 +704,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
                 overflow: 'auto',
                 paddingY: 16,
                 paddingEnd: 16,
+                scrollPaddingY: 16,
                 boxSizing: 'border-box',
                 outlineStyle: 'none',
                 cursor: 'text',

--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -375,7 +375,10 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
       data-variant={variant}
       data-state={isGenerating ? 'generating' : 'idle'}
       data-focused={isFocused || undefined}
-      className={(size === 'M' ? outerBorder : '') + style({containerType: 'inline-size'})}
+      className={
+        (size === 'M' ? outerBorder : '') +
+        style({containerType: 'inline-size', flexGrow: 1, minHeight: 0, display: 'flex'})
+      }
       style={{
         ...props.style,
         // @ts-ignore
@@ -423,6 +426,8 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
                 },
                 position: 'relative',
                 overflow: 'clip',
+                minHeight: 0,
+                width: 'full',
                 outlineStyle: 'solid',
                 outlineColor: {
                   default: 'transparent', // for WHCM
@@ -503,7 +508,9 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
                 flexDirection: 'column',
                 gap: 16,
                 padding: 16,
-                cursor: 'text'
+                cursor: 'text',
+                height: 'full',
+                boxSizing: 'border-box'
               }) + (props.className || '')
             }>
             {props.children}

--- a/packages/@react-spectrum/ai/stories/Chat.stories.tsx
+++ b/packages/@react-spectrum/ai/stories/Chat.stories.tsx
@@ -29,6 +29,7 @@ import {
   MessageSuggestionList,
   PromptField,
   PromptFieldSubmitButton,
+  PromptFieldToolbar,
   PromptFieldValue,
   PromptTokenField,
   ResponseStatus,
@@ -502,7 +503,8 @@ export function VirtualizedStreamingChat() {
           gap: 16,
           paddingX: 16,
           boxSizing: 'border-box',
-          minWidth: 0
+          minWidth: 0,
+          containerType: 'size'
         })}>
         <div
           className={style({
@@ -596,41 +598,42 @@ export function VirtualizedStreamingChat() {
           }}
           isGenerating={isGenerating}
           onStop={handleStop}>
-          <div className={style({display: 'flex', gap: 16, alignItems: 'center'})}>
-            <PromptTokenField
-              placeholder={
-                isGenerating
-                  ? 'Type to steer (Enter) or queue a follow-up (Option+Enter) · Esc to stop'
-                  : undefined
+          <PromptTokenField
+            placeholder={
+              isGenerating
+                ? 'Type to steer (Enter) or queue a follow-up (Option+Enter) · Esc to stop'
+                : undefined
+            }
+            onKeyDown={e => {
+              if (!isGenerating) {
+                return;
               }
-              onKeyDown={e => {
-                if (!isGenerating) {
-                  return;
-                }
 
-                // TODO: we could make this even more realistic but for now just fire storybook event
-                // and add follow up message to queue
-                if (e.key === 'Enter' && !e.altKey) {
-                  e.preventDefault();
-                  if (promptValue.segments.length > 0) {
-                    action('onSteer')(promptValue.toString());
-                    setPromptValue(new PromptFieldValue([]));
-                  }
-                } else if (e.key === 'Enter' && e.altKey) {
-                  e.preventDefault();
-                  if (promptValue.segments.length > 0) {
-                    action('onFollowUp')(promptValue.toString());
-                    followUpMessage.current = promptValue;
-                    setPromptValue(new PromptFieldValue([]));
-                  }
-                } else if (e.key === 'Escape') {
-                  e.preventDefault();
-                  handleStop();
+              // TODO: we could make this even more realistic but for now just fire storybook event
+              // and add follow up message to queue
+              if (e.key === 'Enter' && !e.altKey) {
+                e.preventDefault();
+                if (promptValue.segments.length > 0) {
+                  action('onSteer')(promptValue.toString());
+                  setPromptValue(new PromptFieldValue([]));
                 }
-              }}
-            />
+              } else if (e.key === 'Enter' && e.altKey) {
+                e.preventDefault();
+                if (promptValue.segments.length > 0) {
+                  action('onFollowUp')(promptValue.toString());
+                  followUpMessage.current = promptValue;
+                  setPromptValue(new PromptFieldValue([]));
+                }
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                handleStop();
+              }
+            }}
+          />
+          <PromptFieldToolbar>
+            <div />
             <PromptFieldSubmitButton />
-          </div>
+          </PromptFieldToolbar>
         </PromptField>
       </Chat>
     </div>
@@ -711,7 +714,8 @@ export function EmptyChat() {
           gap: 16,
           paddingX: 16,
           boxSizing: 'border-box',
-          minWidth: 0
+          minWidth: 0,
+          containerType: 'size'
         })}>
         <div
           className={style({
@@ -798,7 +802,7 @@ export function EmptyChat() {
             timeouts.current.forEach(clearTimeout);
             timeouts.current = [];
           }}>
-          <div className={style({display: 'flex', gap: 16, alignItems: 'center'})}>
+          <div className={style({display: 'flex', gap: 16, height: 'full'})}>
             <PromptTokenField />
             <PromptFieldSubmitButton />
           </div>
@@ -879,7 +883,8 @@ export function ChatPopover() {
             height: 'full',
             gap: 16,
             boxSizing: 'border-box',
-            minWidth: 0
+            minWidth: 0,
+            containerType: 'size'
           })}>
           <Thread
             items={messages}
@@ -910,8 +915,8 @@ export function ChatPopover() {
               );
             }}
           </Thread>
-          <PromptField onSubmit={() => {}}>
-            <div className={style({display: 'flex', gap: 16, alignItems: 'center'})}>
+          <PromptField size="S" onSubmit={() => {}}>
+            <div className={style({display: 'flex', gap: 16, height: 'full'})}>
               <PromptTokenField />
               <PromptFieldSubmitButton />
             </div>
@@ -1249,7 +1254,8 @@ export function AsyncLoadingChat() {
           gap: 16,
           paddingX: 16,
           boxSizing: 'border-box',
-          minWidth: 0
+          minWidth: 0,
+          containerType: 'size'
         })}>
         <div
           className={style({
@@ -1295,7 +1301,7 @@ export function AsyncLoadingChat() {
           </Thread>
         </div>
         <PromptField>
-          <div className={style({display: 'flex', gap: 16, alignItems: 'center'})}>
+          <div className={style({display: 'flex', gap: 16, height: 'full'})}>
             <PromptTokenField />
             <PromptFieldSubmitButton />
           </div>

--- a/packages/dev/s2-docs/pages/s2/ai-component-helpers/chat.tsx
+++ b/packages/dev/s2-docs/pages/s2/ai-component-helpers/chat.tsx
@@ -247,7 +247,8 @@ export function VirtualizedStreamingChat(props: VirtualizedStreamingChatProps) {
           gap: 16,
           paddingX: 16,
           boxSizing: 'border-box',
-          minWidth: 0
+          minWidth: 0,
+          containerType: 'size'
         })}>
         <div
           className={style({

--- a/packages/react-aria/src/tokenfield/useTokenField.ts
+++ b/packages/react-aria/src/tokenfield/useTokenField.ts
@@ -22,6 +22,7 @@ import {
 } from 'react';
 import {getActiveElement, nodeContains} from '../utils/shadowdom/DOMFunctions';
 import {getOwnerDocument} from '../utils/domHelpers';
+import {getScrollParents} from '../utils/getScrollParents';
 import {isMac} from '../utils/platform';
 import {mergeProps} from '../utils/mergeProps';
 import {
@@ -32,6 +33,7 @@ import {
   TokenFieldState,
   TokenFieldValue
 } from 'react-stately/useTokenFieldState';
+import {scrollRectIntoView} from '../utils/scrollIntoView';
 import {setInteractionModality} from '../interactions/useFocusVisible';
 import {useEvent} from '../utils/useEvent';
 import {useField} from '../label/useField';
@@ -183,6 +185,9 @@ export function useTokenField<T extends TokenFieldValue = TokenFieldValue>(
       if (ref.current === getActiveElement(getOwnerDocument(ref.current))) {
         setTokenFieldSelection(ref.current, value.selectedRange);
         announceToken(value);
+        // We call preventDefault in the beforeinput handler below, which also prevents the
+        // browser's default behavior of scrolling the caret into view. Do it ourselves instead.
+        scrollCaretIntoView(ref.current);
       }
       selectedRange.current = value.selectedRange;
     }
@@ -411,7 +416,12 @@ export function useTokenField<T extends TokenFieldValue = TokenFieldValue>(
     }
 
     let selection = window.getSelection();
-    if (ref.current && selection && selection.containsNode(ref.current, true)) {
+    if (
+      ref.current &&
+      selection &&
+      selection.containsNode(ref.current, true) &&
+      !selection.isCollapsed
+    ) {
       selection.removeAllRanges();
       state.setValue(value =>
         value.withSelectedRange(new TokenFieldValue.SelectedRange(value.caretPosition))
@@ -721,6 +731,62 @@ export function setTokenFieldSelection(
       selection.focusOffset !== focusOffset
     ) {
       selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+    }
+  }
+}
+
+// Calling preventDefault in the beforeinput handler stops the browser from performing its
+// default edit action, which also suppresses its normal behavior of scrolling the caret into
+// view. Recreate that behavior by measuring the caret's position with a Range and
+// scrolling each scrollable ancestor of the field so it is visible.
+function scrollCaretIntoView(root: HTMLElement): void {
+  let selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || !nodeContains(root, selection.focusNode)) {
+    return;
+  }
+
+  let range = selection.getRangeAt(0);
+  if (!range.collapsed) {
+    return;
+  }
+
+  let rect = range.getBoundingClientRect();
+
+  // A collapsed range doesn't always produce a client rect. This happens for empty lines.
+  if (rect.top === 0 && rect.bottom === 0 && rect.left === 0 && rect.right === 0) {
+    let node: Node | null = range.endContainer;
+    if (node.nodeType === Node.TEXT_NODE && range.endOffset < node.nodeValue!.length) {
+      // If we are not at the end of the text node, extend the range to include the next character.
+      range = range.cloneRange();
+      range.setEnd(node, range.endOffset + 1);
+      rect = range.getBoundingClientRect();
+    } else {
+      // Otherwise find the next sibling element (e.g. trailing <br>) and use its rect in this case.
+      let nextSibling = node.nextSibling;
+      while (node && node !== root && !nextSibling) {
+        node = node.parentNode as Node | null;
+        nextSibling = node ? node.nextSibling : null;
+      }
+
+      if (nextSibling?.nodeType === Node.ELEMENT_NODE) {
+        rect = (nextSibling as HTMLElement).getBoundingClientRect();
+      }
+    }
+  }
+
+  for (let element of getScrollParents(root, true)) {
+    // scrollRectIntoView only scrolls a single scroll parent based on `rect`, which is a
+    // snapshot of the caret's position before any scrolling occurs. Scrolling an inner ancestor
+    // moves the caret within the viewport, so translate `rect` by however much we just scrolled
+    // before moving on to the next (outer) ancestor.
+    let scrollParent = element as HTMLElement;
+    let beforeTop = scrollParent.scrollTop;
+    let beforeLeft = scrollParent.scrollLeft;
+    scrollRectIntoView(scrollParent, root, rect, {block: 'nearest', inline: 'nearest'});
+    let dy = scrollParent.scrollTop - beforeTop;
+    let dx = scrollParent.scrollLeft - beforeLeft;
+    if (dy !== 0 || dx !== 0) {
+      rect = new DOMRect(rect.x - dx, rect.y - dy, rect.width, rect.height);
     }
   }
 }

--- a/packages/react-aria/src/utils/scrollIntoView.ts
+++ b/packages/react-aria/src/utils/scrollIntoView.ts
@@ -35,16 +35,24 @@ export function scrollIntoView(
   element: HTMLElement,
   opts: ScrollIntoViewOpts = {}
 ): void {
-  let {block = 'nearest', inline = 'nearest'} = opts;
-
   if (scrollView === element) {
     return;
   }
 
+  let target = element.getBoundingClientRect();
+  scrollRectIntoView(scrollView, element, target, opts);
+}
+
+export function scrollRectIntoView(
+  scrollView: HTMLElement,
+  element: HTMLElement,
+  target: DOMRect,
+  opts: ScrollIntoViewOpts = {}
+) {
+  let {block = 'nearest', inline = 'nearest'} = opts;
   let y = scrollView.scrollTop;
   let x = scrollView.scrollLeft;
 
-  let target = element.getBoundingClientRect();
   let view = scrollView.getBoundingClientRect();
   let itemStyle = window.getComputedStyle(element);
   let viewStyle = window.getComputedStyle(scrollView);


### PR DESCRIPTION
* Adds a max-height to PromptField of 40cqh, i.e. container units. This defaults to 40% of the viewport height, but if there is an ancestor container (e.g. Chat) it will be 40% of that. The token field becomes scrollable with an edge fade effect.
* Ensures that we scroll the caret into view when editing in TokenField.
* Fixes the default render function attachments in PromptField to render the new previews