### PR TITLE
fix: pasting into promptfield and promptfield classname handling

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -40,6 +40,7 @@ import {isFileDropItem, useDrop} from 'react-aria-components/useDrop';
 import {Link} from '@react-spectrum/s2/Link';
 import {LinkButtonContext} from '@react-spectrum/s2/LinkButton';
 import {Menu, MenuItem, MenuItemProps, MenuTrigger} from '@react-spectrum/s2/Menu';
+import {mergeStyles} from '@react-spectrum/s2/mergeStyles';
 import Microphone from '@react-spectrum/s2/icons/Microphone';
 import {PixelLoader} from './loader/react';
 import Plus from '@react-spectrum/s2/icons/Add';
@@ -364,7 +365,10 @@ export const PromptField = forwardRef(function PromptField(
         <div
           ref={domRef}
           {...focusWithinProps}
-          className={style({maxHeight: '40cqh', display: 'flex', flexDirection: 'column'})}>
+          className={mergeStyles(
+            style({maxHeight: '40cqh', display: 'flex', flexDirection: 'column'}),
+            styles
+          )}>
           <PromptFieldContainer
             {...dropProps}
             role="group"
@@ -373,7 +377,6 @@ export const PromptField = forwardRef(function PromptField(
             brandColor={brandColor}
             isGenerating={isGenerating ?? false}
             isDropTarget={isDropTarget}
-            styles={styles}
             inputRef={inputRef}>
             {children}
           </PromptFieldContainer>
@@ -654,7 +657,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
                   let clipboardData = e.clipboardData as DataTransfer;
                   let attachments: PromptFieldAttachment[] = [];
                   for (let item of clipboardData.items) {
-                    if (matchMimeType(item.type, acceptedAttachmentTypes)) {
+                    if (item.kind === 'file' && matchMimeType(item.type, acceptedAttachmentTypes)) {
                       let file = item.getAsFile()!;
                       attachments.push({
                         id: crypto.randomUUID(),

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -257,35 +257,32 @@ function BasicPrompt(props) {
   let [value, setValue] = useState<PromptFieldValue>(() => new PromptFieldValue([]));
 
   return (
-    <div
-      className={style({
+    /*- begin highlight -*/
+    <PromptField
+      {...props}
+      /* PROPS */
+      value={value}
+      onChange={setValue}
+      onSubmit={value => {
+        console.log(value.toString());
+        setValue(new PromptFieldValue([]));
+      }}
+      styles={style({
         minWidth: 190,
         width: {
           default: 'full',
           size: {
             S: '50%'
           }
-        }
-      })({size: props.size})}>
-      {/*- begin highlight -*/}
-      <PromptField
-        {...props}
-        /* PROPS */
-        value={value}
-        onChange={setValue}
-        onSubmit={value => {
-          console.log(value.toString());
-          setValue(new PromptFieldValue([]));
-        }}>
-        {/*- end highlight -*/}
-        <PromptTokenField />
-        <PromptFieldToolbar>
-          <div style={{marginInlineStart: 'auto'}}>
-            <PromptFieldSubmitButton />
-          </div>
-        </PromptFieldToolbar>
-      </PromptField>
-    </div>
+        }})({size: props.size})}>
+      {/*- end highlight -*/}
+      <PromptTokenField />
+      <PromptFieldToolbar>
+        <div style={{marginInlineStart: 'auto'}}>
+          <PromptFieldSubmitButton />
+        </div>
+      </PromptFieldToolbar>
+    </PromptField>
   );
 }
 ```


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

Go to storybook `?path=/docs/ai-promptfield--docs` and paste "ع, ج, ح, خ" into the field. It shouldn't crash.

Go to docs `/s2/ai-components#prompt-fields` and check that the promptfield example with controls S|M changes size with its legal text and doesn't have a wrapper div to handle it anymore

## 🧢 Your Project:

<!--- Company/project for pull request -->
