### PR TITLE
fix: NavigationTree docs example's "Shared" row should expand on press

### DIFF
--- a/packages/dev/s2-docs/pages/react-aria/Router.tsx
+++ b/packages/dev/s2-docs/pages/react-aria/Router.tsx
@@ -9,8 +9,8 @@ export function Link(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   let navigate = useContext(NavigateContext);
 
   function handleNavigate(href: string | undefined, e: React.SyntheticEvent) {
-    e.preventDefault();
     if (href) {
+      e.preventDefault();
       navigate(href);
     }
   }

--- a/packages/dev/s2-docs/pages/react-aria/Router.tsx
+++ b/packages/dev/s2-docs/pages/react-aria/Router.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, {ReactNode, useState, createContext, useContext} from 'react';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps} from 'react-aria/mergeProps';
 
 // This is a fake router for documentation purposes. In a real app, you would
 // use a routing library like React Router or a framework like Next.js.

--- a/packages/dev/s2-docs/pages/react-aria/Router.tsx
+++ b/packages/dev/s2-docs/pages/react-aria/Router.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, {ReactNode, useState, createContext, useContext} from 'react';
+import {mergeProps} from '@react-aria/utils';
 
 // This is a fake router for documentation purposes. In a real app, you would
 // use a routing library like React Router or a framework like Next.js.
@@ -8,25 +9,21 @@ const NavigateContext = createContext<(href: string) => void>(() => {});
 export function Link(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   let navigate = useContext(NavigateContext);
 
-  return (
-    <a
-      {...props}
-      onClick={e => {
-        props.onClick?.(e);
-        if (props.href) {
-          e.preventDefault();
-          navigate(props.href);
-        }
-      }}
-      onKeyDown={e => {
-        props.onKeyDown?.(e);
-        if (e.key === 'Enter' && props.href) {
-          e.preventDefault();
-          navigate(props.href);
-        }
-      }}
-    />
-  );
+  let onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (props.href) {
+      e.preventDefault();
+      navigate(props.href);
+    }
+  };
+
+  let onKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === 'Enter' && props.href) {
+      e.preventDefault();
+      navigate(props.href);
+    }
+  };
+
+  return <a {...mergeProps(props, {onClick, onKeyDown})} />;
 }
 
 export function Router(props: {

--- a/packages/dev/s2-docs/pages/react-aria/Router.tsx
+++ b/packages/dev/s2-docs/pages/react-aria/Router.tsx
@@ -8,20 +8,21 @@ const NavigateContext = createContext<(href: string) => void>(() => {});
 export function Link(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   let navigate = useContext(NavigateContext);
 
-  function handleNavigate(href: string | undefined, e: React.SyntheticEvent) {
-    if (href) {
-      e.preventDefault();
-      navigate(href);
-    }
-  }
-
   return (
     <a
       {...props}
-      onClick={e => handleNavigate(props.href, e)}
+      onClick={e => {
+        props.onClick?.(e);
+        if (props.href) {
+          e.preventDefault();
+          navigate(props.href);
+        }
+      }}
       onKeyDown={e => {
-        if (e.key === 'Enter') {
-          handleNavigate(props.href, e);
+        props.onKeyDown?.(e);
+        if (e.key === 'Enter' && props.href) {
+          e.preventDefault();
+          navigate(props.href);
         }
       }}
     />


### PR DESCRIPTION
From testing. NavigationTree's doc example's "Shared" row should expand when pressing on its text, not just the chevron

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Test the NavigationTree docs. "Shared" row should expand when pressing on its text, not just the chevron

## 🧢 Your Project:

RSP
