### PR TITLE
fix: PromptField max-height and scroll into view issues

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -369,10 +369,7 @@ export const PromptField = forwardRef(function PromptField(
         <div
           ref={domRef}
           {...focusWithinProps}
-          className={mergeStyles(
-            style({maxHeight: '40cqh', display: 'flex', flexDirection: 'column'}),
-            styles
-          )}>
+          className={mergeStyles(style({display: 'flex', flexDirection: 'column'}), styles)}>
           <PromptFieldContainer
             {...dropProps}
             role="group"
@@ -587,7 +584,6 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
         },
         flexGrow: 1,
         flexShrink: 1,
-        minHeight: 0,
         marginY: -16,
         marginEnd: -16,
         '--loader-color': {
@@ -626,7 +622,7 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
           value={prompt}
           onChange={setPrompt}
           allowsNewlines
-          className={style({flexGrow: 1, minHeight: 0, height: 'full'})}
+          className={style({flexGrow: 1})}
           aria-label={stringFormatter.format('promptfield.label')}
           isReadOnly={isListening}
           onSubmit={onSubmit}
@@ -713,7 +709,8 @@ export function PromptTokenField(props: PromptTokenFieldProps) {
                 },
                 width: 'full',
                 height: 'full',
-                minHeight: '1lh',
+                minHeight: 'calc(1lh + 32px)',
+                maxHeight: '30cqh',
                 overflow: 'auto',
                 paddingY: 16,
                 paddingEnd: 16,

--- a/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
+++ b/packages/@react-spectrum/ai/src/PromptFieldContainer.tsx
@@ -377,7 +377,7 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
       data-focused={isFocused || undefined}
       className={
         (size === 'M' ? outerBorder : '') +
-        style({containerType: 'inline-size', flexGrow: 1, minHeight: 0, display: 'flex'})
+        style({containerType: 'inline-size', flexGrow: 1, display: 'flex'})
       }
       style={{
         ...props.style,
@@ -426,7 +426,6 @@ export function PromptFieldContainer(props: PropFieldContainerProps) {
                 },
                 position: 'relative',
                 overflow: 'clip',
-                minHeight: 0,
                 width: 'full',
                 outlineStyle: 'solid',
                 outlineColor: {

--- a/packages/react-aria/src/tokenfield/useTokenField.ts
+++ b/packages/react-aria/src/tokenfield/useTokenField.ts
@@ -21,6 +21,7 @@ import {
   useRef
 } from 'react';
 import {getActiveElement, nodeContains} from '../utils/shadowdom/DOMFunctions';
+import {getInteractionModality, setInteractionModality} from '../interactions/useFocusVisible';
 import {getOwnerDocument} from '../utils/domHelpers';
 import {getScrollParents} from '../utils/getScrollParents';
 import {isMac} from '../utils/platform';
@@ -34,7 +35,6 @@ import {
   TokenFieldValue
 } from 'react-stately/useTokenFieldState';
 import {scrollRectIntoView} from '../utils/scrollIntoView';
-import {setInteractionModality} from '../interactions/useFocusVisible';
 import {useEvent} from '../utils/useEvent';
 import {useField} from '../label/useField';
 import {useFocusable} from '../interactions/useFocusable';
@@ -741,15 +741,16 @@ export function setTokenFieldSelection(
 // scrolling each scrollable ancestor of the field so it is visible.
 function scrollCaretIntoView(root: HTMLElement): void {
   let selection = window.getSelection();
-  if (!selection || selection.rangeCount === 0 || !nodeContains(root, selection.focusNode)) {
+  if (
+    getInteractionModality() !== 'keyboard' ||
+    !selection ||
+    selection.rangeCount === 0 ||
+    !nodeContains(root, selection.focusNode)
+  ) {
     return;
   }
 
   let range = selection.getRangeAt(0);
-  if (!range.collapsed) {
-    return;
-  }
-
   let rect = range.getBoundingClientRect();
 
   // A collapsed range doesn't always produce a client rect. This happens for empty lines.
@@ -760,6 +761,9 @@ function scrollCaretIntoView(root: HTMLElement): void {
       range = range.cloneRange();
       range.setEnd(node, range.endOffset + 1);
       rect = range.getBoundingClientRect();
+    } else if (root.firstChild == null) {
+      // If the root has no children, use its rect.
+      rect = root.getBoundingClientRect();
     } else {
       // Otherwise find the next sibling element (e.g. trailing <br>) and use its rect in this case.
       let nextSibling = node.nextSibling;


### PR DESCRIPTION
* Moves the max-height to the inner tokenfield element rather than the entire prompt field. Fixes prompt field shrinking to zero height and the plus overlapping the icon.
* Fixes if you backspace all the way to the beginning of the field the entire page scrolls up
* Fixes basic promptfield doesn't scroll at all
* Fixes placeholders don't scroll into view when you tab to them.