### PR TITLE
fix: support aria-current in LinkContext

### DIFF
--- a/packages/react-aria-components/src/Breadcrumbs.tsx
+++ b/packages/react-aria-components/src/Breadcrumbs.tsx
@@ -142,7 +142,7 @@ export const Breadcrumb = /*#__PURE__*/ createLeafComponent(
     let isCurrent = node.nextKey == null;
     let {isDisabled, onAction} = useSlottedContext(BreadcrumbsContext)!;
     let linkProps = {
-      'aria-current': isCurrent ? 'page' : null,
+      'aria-current': isCurrent ? ('page' as const) : undefined,
       isDisabled: isDisabled || isCurrent,
       onPress: () => onAction?.(node.key)
     };

--- a/packages/react-aria-components/src/NavigationTree.tsx
+++ b/packages/react-aria-components/src/NavigationTree.tsx
@@ -445,7 +445,7 @@ function NavigationTreeItemContentInner(props: NavigationTreeItemContentInnerPro
   // Provide onFocusChange so the link reports its focus up to NavigationTreeItem.
   let linkContextValue = {
     ...linkProps,
-    'aria-current': isCurrent ? 'page' : undefined,
+    'aria-current': isCurrent ? ('page' as const) : undefined,
     onFocusChange: setLinkFocused,
     onPress: linkProps.href == null && hasChildItems ? () => state.toggleKey(id) : undefined
   };

--- a/packages/react-aria-components/test/Link.test.js
+++ b/packages/react-aria-components/test/Link.test.js
@@ -48,6 +48,12 @@ describe('Link', () => {
     expect(link).toHaveAttribute('id', 'my-link-id');
   });
 
+  it('should support accessibility props', () => {
+    let {getByRole} = render(<Link aria-current="page">Test</Link>);
+    let link = getByRole('link');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
   it('should support render props', async () => {
     let {getByRole} = render(<Link>{({isHovered}) => (isHovered ? 'Hovered' : 'Test')}</Link>);
     let link = getByRole('link');

--- a/packages/react-aria/src/link/useLink.ts
+++ b/packages/react-aria/src/link/useLink.ts
@@ -28,7 +28,13 @@ import {usePress} from '../interactions/usePress';
 
 export interface LinkProps extends PressEvents, FocusableProps {}
 
-export interface AriaLinkProps extends LinkProps, LinkDOMProps, AriaLabelingProps {}
+export interface AriaLinkProps extends LinkProps, LinkDOMProps, AriaLabelingProps {
+  /**
+   * Indicates whether this element represents the current item within a container or set of related
+   * elements.
+   */
+  'aria-current'?: boolean | 'true' | 'false' | 'page' | 'step' | 'location' | 'date' | 'time';
+}
 
 export interface AriaLinkOptions extends AriaLinkProps {
   /** Whether the link is disabled. */


### PR DESCRIPTION
Closes #10572

## Summary

Adds `aria-current` to the Link hook props used by `LinkContext`, so context provider values can include the current-link state. A RAC regression test verifies that Link renders the attribute. This aligns Link with Button and preserves its existing runtime behavior.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10572).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it is there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Run `corepack yarn jest packages/react-aria-components/test/Link.test.js --runInBand`.

Verify that `<Link aria-current="page">` renders `aria-current="page"`.

## 🧢 Your Project:

N/A