### PR TITLE
fix: Include full URL when stringifying PromptFieldValue

### DIFF
--- a/packages/@react-spectrum/ai/src/PromptField.tsx
+++ b/packages/@react-spectrum/ai/src/PromptField.tsx
@@ -231,6 +231,12 @@ export class PromptFieldValue extends TokenFieldValue<PromptFieldTokenValue> {
     }
     return super.replaceRangeWithSegments(start, end, segments, coalesce);
   }
+
+  toString() {
+    return this.segments
+      .map(s => (s.type === 'token' && s.value?.type === 'url' ? s.value.url : s.text))
+      .join('');
+  }
 }
 
 const PromptFieldContext = createContext<PromptFieldState & {size: 'S' | 'M'}>({

--- a/packages/@react-spectrum/ai/test/PromptField.test.tsx
+++ b/packages/@react-spectrum/ai/test/PromptField.test.tsx
@@ -507,4 +507,19 @@ describeOrSkip('PromptField', () => {
     await user.click(screen.getByRole('link', {name: 'AI User Guidelines'}));
     expect(onAITermsPress).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps the full URL when stringifying', async () => {
+    let {user, textbox, getValue} = renderPromptField();
+    await user.click(textbox);
+    await user.keyboard('visit https://www.test.com now');
+
+    await waitFor(() =>
+      expect(getValue().segments.some(s => s.type === 'token' && s.value?.type === 'url')).toBe(
+        true
+      )
+    );
+    let urlToken = getValue().segments.find(s => s.type === 'token' && s.value?.type === 'url');
+    expect(urlToken?.text).toBe('test.com');
+    expect(getValue().toString()).toContain('https://www.test.com');
+  });
 });


### PR DESCRIPTION
Alternative to #10565. When submitting a prompt we should include full URLs without stripping https://www. (which we do for display purposes).