### PR TITLE
docs: don't animate pixel loader when not in view

### DIFF
--- a/packages/@react-spectrum/ai/src/loader/react.tsx
+++ b/packages/@react-spectrum/ai/src/loader/react.tsx
@@ -260,6 +260,19 @@ export function PixelLoader(props: PixelLoaderProps) {
   } = props;
   let isReducedMotion = useReducedMotion();
 
+  let ref = React.useRef<HTMLDivElement>(null);
+  let [isInView, setIsInView] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    let observer = new IntersectionObserver(([entry]) => setIsInView(entry.isIntersecting));
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
   // Normalize to a sequence.
   const sequence = React.useMemo(
     () => (Array.isArray(icon[0]) ? icon : [icon]) as Cell[][],
@@ -284,13 +297,14 @@ export function PixelLoader(props: PixelLoaderProps) {
 
   // Advance the sequence one icon per cycle while playing. Single-icon
   // loaders never start a timer — they're a pure infinite CSS loop.
+  let isAdvancing = isPlaying && isInView;
   React.useEffect(() => {
-    if (!isPlaying || !isSequence) {
+    if (!isAdvancing || !isSequence) {
       return undefined;
     }
     const id = setInterval(() => setTick(t => t + 1), duration);
     return () => clearInterval(id);
-  }, [isPlaying, isSequence, duration, sequence]);
+  }, [isAdvancing, isSequence, duration, sequence]);
 
   const animId = iconId(cells);
   const css = keyframesFor(cells, isReducedMotion);
@@ -314,6 +328,7 @@ export function PixelLoader(props: PixelLoaderProps) {
 
   return (
     <div
+      ref={ref}
       aria-hidden="true"
       className={className}
       style={{
@@ -326,7 +341,7 @@ export function PixelLoader(props: PixelLoaderProps) {
         forcedColorAdjust: 'none',
         willChange: 'opacity',
         ...(isPlaying && {
-          animation: `${animId}-group-o ${duration}ms linear ${iteration}`
+          animation: `${animId}-group-o ${duration}ms linear ${iteration} ${isInView ? 'running' : 'paused'}`
         })
       }}
       {...rest}>
@@ -368,8 +383,8 @@ export function PixelLoader(props: PixelLoaderProps) {
               ...(isPlaying &&
                 !isReducedMotion && {
                   animation:
-                    `${animId}-${i}-y ${duration}ms linear ${iteration}, ` +
-                    `${animId}-${i}-s ${duration}ms linear ${iteration}`,
+                    `${animId}-${i}-y ${duration}ms linear ${iteration} ${isInView ? 'running' : 'paused'}, ` +
+                    `${animId}-${i}-s ${duration}ms linear ${iteration} ${isInView ? 'running' : 'paused'}`,
                   willChange: 'transform'
                 })
             }}

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -581,7 +581,7 @@ function BasicChat() {
 
 The `icon` prop accepts either a single icon, which loops forever, or a themed preset, which cycles through several icons, one per loop. Icons and presets are exported individually from `@react-spectrum/ai/loader`.
 
-```tsx render type="s2" docs={docs.exports.PixelLoader} props={['icon']}
+```tsx render type="s2" docs={docs.exports.PixelLoader} props={['icon', 'isPlaying']} initialProps={{isPlaying: true}}
 "use client";
 import {PixelLoader} from '@react-spectrum/ai/loader';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
@@ -601,13 +601,17 @@ function PresetLoader(props) {
 
   return (
     <div ref={ref} className={style({height: 40})} >
-    {/*- begin highlight -*/}
-      <PixelLoader
-        {...props}
-        isPlaying={isInView}
-        /* PROPS */
-      />
-      {/*- end highlight -*/}
+      {isInView && (
+        <>
+          {/*- begin highlight -*/}
+          <PixelLoader
+            {...props}
+            /* PROPS */
+          />
+          {/*- end highlight -*/}
+        </>
+        )
+      }
     </div>
   );
 }
@@ -641,11 +645,15 @@ function LoadingStatus() {
 
   return (
     <div ref={ref} className={style({height: 40})} >
-      <ResponseStatus status={isInView ? 'pending' : 'success'}>
-        {/*- begin highlight -*/}
-        <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>
-        {/*- end highlight -*/}
-      </ResponseStatus>
+      {
+        isInView && (
+        <ResponseStatus status='pending'>
+          {/*- begin highlight -*/}
+          <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>
+          {/*- end highlight -*/}
+        </ResponseStatus>
+        )
+      }
     </div>
   );
 }

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -614,8 +614,8 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 
 function LoadingStatus() {
   return (
-    <div className={style({height: 40})} >
-      <ResponseStatus status='pending'>
+    <div className={style({height: 40})}>
+      <ResponseStatus status="pending">
         {/*- begin highlight -*/}
         <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>
         {/*- end highlight -*/}

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -602,7 +602,7 @@ function PresetLoader(props) {
 
 ### Usage
 
-Use the `pixelLoader` prop on `ResponseStatusTitle` and `PromptFieldToken` to display the pixel loader.
+Use the `pixelLoader` prop on `ResponseStatusTitle` and `PromptTokenField` to display the pixel loader.
 
 <ExampleSwitcher type={null} examples={['ResponseStatus', 'PromptField']}>
 

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -585,37 +585,16 @@ The `icon` prop accepts either a single icon, which loops forever, or a themed p
 "use client";
 import {PixelLoader} from '@react-spectrum/ai/loader';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {useRef, useState, useEffect} from 'react';
 
 function PresetLoader(props) {
-  let ref = useRef<HTMLDivElement>(null);
-  let [isInView, setIsInView] = useState(false);
-
-  useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-
-    let observer = new IntersectionObserver(([entry]) => {
-      setIsInView(entry.isIntersecting);
-    });
-    observer.observe(ref.current);
-    return () => observer.disconnect();
-  }, []);
-
   return (
-    <div ref={ref} className={style({height: 40})} >
-      {isInView && (
-        <>
-          {/*- begin highlight -*/}
-          <PixelLoader
-            {...props}
-            /* PROPS */
-          />
-          {/*- end highlight -*/}
-        </>
-        )
-      }
+    <div className={style({height: 40})} >
+      {/*- begin highlight -*/}
+      <PixelLoader
+        {...props}
+        /* PROPS */
+      />
+      {/*- end highlight -*/}
     </div>
   );
 }
@@ -632,34 +611,15 @@ Use the `pixelLoader` prop on `ResponseStatusTitle` and `PromptFieldToken` to di
 import {cc} from '@react-spectrum/ai/loader';
 import {ResponseStatus, ResponseStatusTitle} from '@react-spectrum/ai';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
-import {useRef, useState, useEffect} from 'react';
 
 function LoadingStatus() {
-  let ref = useRef<HTMLDivElement>(null);
-  let [isInView, setIsInView] = useState(false);
-
-  useEffect(() => {
-    if (!ref.current){
-      return;
-    }
-
-    let observer = new IntersectionObserver(
-      ([entry]) => setIsInView(entry.isIntersecting)
-    );
-    observer.observe(ref.current);
-    return () => observer.disconnect();
-  }, []);
-
   return (
-    <div ref={ref} className={style({height: 40})} >
-      {isInView && (
-        <ResponseStatus status='pending'>
-          {/*- begin highlight -*/}
-          <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>
-          {/*- end highlight -*/}
-        </ResponseStatus>
-        )
-      }
+    <div className={style({height: 40})} >
+      <ResponseStatus status='pending'>
+        {/*- begin highlight -*/}
+        <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>
+        {/*- end highlight -*/}
+      </ResponseStatus>
     </div>
   );
 }

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -592,7 +592,7 @@ function PresetLoader(props) {
   let [isInView, setIsInView] = useState(false);
 
   useEffect(() => {
-    let (!ref.current) {
+    if (!ref.current) {
       return;
     }
 

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -588,10 +588,14 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {useRef, useState, useEffect} from 'react';
 
 function PresetLoader(props) {
-  let ref = useRef(null);
+  let ref = useRef<HTMLDivElement>(null);
   let [isInView, setIsInView] = useState(false);
 
   useEffect(() => {
+    let (!ref.current) {
+      return;
+    }
+
     let observer = new IntersectionObserver(([entry]) => {
       setIsInView(entry.isIntersecting);
     });
@@ -631,10 +635,14 @@ import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
 import {useRef, useState, useEffect} from 'react';
 
 function LoadingStatus() {
-  let ref = useRef(null);
+  let ref = useRef<HTMLDivElement>(null);
   let [isInView, setIsInView] = useState(false);
 
   useEffect(() => {
+    if (!ref.current){
+      return;
+    }
+
     let observer = new IntersectionObserver(
       ([entry]) => setIsInView(entry.isIntersecting)
     );

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -581,39 +581,67 @@ function BasicChat() {
 
 The `icon` prop accepts either a single icon, which loops forever, or a themed preset, which cycles through several icons, one per loop. Icons and presets are exported individually from `@react-spectrum/ai/loader`.
 
-```tsx render type="s2" docs={docs.exports.PixelLoader} props={['icon', 'isPlaying']} initialProps={{isPlaying: true}}
+```tsx render type="s2" docs={docs.exports.PixelLoader} props={['icon']}
 "use client";
 import {PixelLoader} from '@react-spectrum/ai/loader';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {useRef, useState, useEffect} from 'react';
 
 function PresetLoader(props) {
+  let ref = useRef(null);
+  let [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    let observer = new IntersectionObserver(([entry]) => {
+      setIsInView(entry.isIntersecting);
+    });
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className={style({height: 40})}>
+    <div ref={ref} className={style({height: 40})} >
+    {/*- begin highlight -*/}
       <PixelLoader
         {...props}
+        isPlaying={isInView}
         /* PROPS */
       />
+      {/*- end highlight -*/}
     </div>
-  )
+  );
 }
 ```
 
 ### Usage
 
-Use the `pixelLoader` prop on `PromptTokenField` and `ResponseStatusTitle` to display the pixel loader.
+Use the `pixelLoader` prop on `ResponseStatusTitle` and `PromptFieldToken` to display the pixel loader.
 
 <ExampleSwitcher type={null} examples={['ResponseStatus', 'PromptField']}>
+
 
 ```tsx render type="s2"
 "use client";
 import {cc} from '@react-spectrum/ai/loader';
 import {ResponseStatus, ResponseStatusTitle} from '@react-spectrum/ai';
 import {style} from '@react-spectrum/s2/style' with {type: 'macro'};
+import {useRef, useState, useEffect} from 'react';
 
 function LoadingStatus() {
+  let ref = useRef(null);
+  let [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    let observer = new IntersectionObserver(
+      ([entry]) => setIsInView(entry.isIntersecting)
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className={style({height: 40})}>
-      <ResponseStatus status="pending">
+    <div ref={ref} className={style({height: 40})} >
+      <ResponseStatus status={isInView ? 'pending' : 'success'}>
         {/*- begin highlight -*/}
         <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>
         {/*- end highlight -*/}

--- a/packages/dev/s2-docs/pages/s2/ai-components.mdx
+++ b/packages/dev/s2-docs/pages/s2/ai-components.mdx
@@ -623,7 +623,6 @@ Use the `pixelLoader` prop on `ResponseStatusTitle` and `PromptFieldToken` to di
 
 <ExampleSwitcher type={null} examples={['ResponseStatus', 'PromptField']}>
 
-
 ```tsx render type="s2"
 "use client";
 import {cc} from '@react-spectrum/ai/loader';
@@ -645,8 +644,7 @@ function LoadingStatus() {
 
   return (
     <div ref={ref} className={style({height: 40})} >
-      {
-        isInView && (
+      {isInView && (
         <ResponseStatus status='pending'>
           {/*- begin highlight -*/}
           <ResponseStatusTitle pixelLoader={cc}>Analyzing campaign data...</ResponseStatusTitle>


### PR DESCRIPTION
<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

Go to ai components doc page, open chrome's task manager and compare it with the ai component doc page on prod. the cpu should be lower when you are not over the pixel loader section.

## 🧢 Your Project:

<!--- Company/project for pull request -->
