### PR TITLE
fix: throw on invalid rgb() and rgba() color strings

### DIFF
--- a/packages/react-stately/src/color/Color.ts
+++ b/packages/react-stately/src/color/Color.ts
@@ -282,9 +282,13 @@ class RGBColor extends Color {
     // matching rgb(rrr, ggg, bbb), rgba(rrr, ggg, bbb, 0.a)
     const match = value.match(/^rgba?\((.*)\)$/);
     if (match?.[1]) {
-      colors = match[1].split(',').map(value => Number(value.trim()));
-      colors = colors.map((num, i) => {
-        return clamp(num ?? 0, 0, i < 3 ? 255 : 1);
+      const parts = match[1].split(',').map(value => value.trim());
+      // Number('') is 0 rather than NaN, so empty components need their own check.
+      if (parts.some(part => part === '' || !Number.isFinite(Number(part)))) {
+        return undefined;
+      }
+      colors = parts.map((part, i) => {
+        return clamp(Number(part), 0, i < 3 ? 255 : 1);
       });
     }
     if (colors[0] === undefined || colors[1] === undefined || colors[2] === undefined) {

--- a/packages/react-stately/test/color/Color.test.tsx
+++ b/packages/react-stately/test/color/Color.test.tsx
@@ -107,6 +107,20 @@ describe('Color', function () {
       expect(color.getChannelValue('alpha')).toBe(1);
       expect(color.toString('rgba')).toBe('rgba(255, 0, 0, 1)');
     });
+
+    it('should throw on non-numeric rgb channels', function () {
+      expect(() => parseColor('rgb(a, b, c)')).toThrow('Invalid color value: rgb(a, b, c)');
+    });
+
+    it('should throw on a non-numeric rgba alpha', function () {
+      expect(() => parseColor('rgba(0, 0, 0, abc)')).toThrow(
+        'Invalid color value: rgba(0, 0, 0, abc)'
+      );
+    });
+
+    it('should throw on empty rgb channels', function () {
+      expect(() => parseColor('rgb(, , )')).toThrow('Invalid color value: rgb(, , )');
+    });
   });
 
   describe('hsl', function () {


### PR DESCRIPTION
Closes <!-- no existing issue; found while auditing the color parsers -->

`parseColor` is documented as "Throws an error if the string could not be parsed", and the `hsl()`, `hsb()` and `#hex` branches all do. The `rgb()`/`rgba()` branch does not: it hands back a `Color` whose channels are `NaN`.

**Intent:** make the four parse branches agree on what an unparseable string is, so callers can keep relying on the documented throw. I picked the smallest change that does that rather than rewriting the rgb branch to a strict regex like the hsl/hsb ones, because the rgb branch also feeds the hex path and shares the `colors` array with it.

**Reproduction:**

```js
import {parseColor} from '@react-stately/color';

parseColor('rgb(a, b, c)');      // -> Color, toString('rgba') === 'rgba(NaN, NaN, NaN, 1)'
parseColor('rgba(0, 0, 0, abc)') // -> Color with alpha NaN
parseColor('rgb(, , )')          // -> rgba(0, 0, 0, 1)

parseColor('hsl(a, b, c)');      // -> throws 'Invalid color value: hsl(a, b, c)'
parseColor('hsb(a, b, c)');      // -> throws
parseColor('#ggg');              // -> throws
```

**Root cause:** `RGBColor.parse` matches with `/^rgba?\((.*)\)$/`, so anything between the parens is accepted and passed to `Number()`. `Number('a')` is `NaN`, `??` does not catch `NaN`, and `clamp(NaN, 0, 255)` is `NaN`, so the final guard (`colors[0] === undefined || ...`) never fires. `HSL_REGEX` and `HSB_REGEX` validate the numeric payload inside the regex instead, which is why those two behave correctly.

This matters beyond the direct call: `useColor` wraps `parseColor` in a try/catch and returns `undefined` for invalid input. Without the throw, a `NaN` `Color` flows into `useColorAreaState` / `useColorWheelState` / `useColorSliderState` and surfaces later as NaN thumb positions or an error thrown from a different stack.

**The fix** rejects components that are empty or do not parse to a finite number, so `RGBColor.parse` returns `undefined` and `parseColor` falls through to its existing `Invalid color value` error. The empty check is separate because `Number('')` is `0`, not `NaN`. Valid input is unaffected, including the existing out-of-range clamping test (`rgba(300, -10, 0, 4)`).

**What the tests assert:** three new cases in `packages/react-stately/test/color/Color.test.tsx` under the existing `rgb` describe, each asserting `parseColor` throws `Invalid color value: <input>` for non-numeric channels, a non-numeric alpha, and empty channels. They mirror the `should throw on invalid hex value` test already in the `hex` describe. Reverting only `Color.ts` turns all three red with "Received function did not throw"; the other 26 cases in the file stay green either way.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

No issue exists for this; I found it while reading the color parsers. Happy to open one first if you would prefer that.

Docs are unchanged: the `parseColor` docstring already promises the throw, so this makes the code match the existing documentation rather than changing it.

## 📝 Test Instructions:

```
yarn jest packages/react-stately/test/color/Color.test.tsx
```

29 passing, up from 26. To see the failure, revert `packages/react-stately/src/color/Color.ts` and rerun: the three new cases fail with "Received function did not throw".

I also ran the wider color surface (`packages/react-stately/test/color`, `packages/react-aria/test/color`, `packages/@adobe/react-spectrum/test/color`, `packages/react-aria-components/test/Color*`): 176 passing before, 179 after, no change in failures.

This is parser logic with no rendered output, so there was nothing to check for mouse/touch/keyboard/screen reader, LTR/RTL, light/dark, or sizing. AI-assisted, reviewed and verified by me.

## 🧢 Your Project:

Personal contribution.
