### PR TITLE
fix: restore selection indicator styles when transitions are interrupted

### DIFF
--- a/packages/react-aria-components/src/SharedElementTransition.tsx
+++ b/packages/react-aria-components/src/SharedElementTransition.tsx
@@ -96,6 +96,7 @@ export const SharedElement = forwardRef(function SharedElement(
     let scope = scopeRef.current;
     let prevSnapshot = scope[name];
     let frame: number | null = null;
+    let restoreStyles: (() => void) | null = null;
 
     if (element && isVisible && prevSnapshot) {
       // Element is transitioning from a previous instance.
@@ -125,11 +126,14 @@ export const SharedElement = forwardRef(function SharedElement(
       }
 
       // Remove overrides after one frame to animate to the current values.
-      frame = requestAnimationFrame(() => {
-        frame = null;
+      restoreStyles = () => {
         for (let [property, value] of values) {
           element.style[property] = value;
         }
+      };
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        restoreStyles?.();
       });
 
       delete scope[name];
@@ -160,6 +164,7 @@ export const SharedElement = forwardRef(function SharedElement(
     return () => {
       if (frame != null) {
         cancelAnimationFrame(frame);
+        restoreStyles?.();
       }
 
       if (element && element.isConnected && !element.hasAttribute('data-exiting')) {

--- a/packages/react-aria-components/stories/Tabs.stories.tsx
+++ b/packages/react-aria-components/stories/Tabs.stories.tsx
@@ -15,8 +15,9 @@ import {Button} from '../src/Button';
 import {Meta, StoryFn} from '@storybook/react';
 import {Orientation} from '@react-types/shared';
 import {OverlayArrow} from '../src/OverlayArrow';
-import React, {useState} from 'react';
+import React, {StrictMode, useState} from 'react';
 import {RouterProvider} from 'react-aria/private/utils/openLink';
+import {SelectionIndicator} from '../src/SelectionIndicator';
 import {Tab, TabList, TabPanel, TabProps, Tabs} from '../src/Tabs';
 import {Tooltip, TooltipTrigger} from '../src/Tooltip';
 import './styles.css';
@@ -27,6 +28,34 @@ export default {
 } as Meta<typeof Tabs>;
 
 export type TabsStory = StoryFn<typeof Tabs>;
+
+export const AnimatedSelectionIndicator: TabsStory = () => (
+  <StrictMode>
+    <Tabs defaultSelectedKey="settings">
+      <TabList aria-label="Sections" style={{display: 'flex', gap: 12}}>
+        {['overview', 'activity', 'settings'].map(key => (
+          <Tab key={key} id={key} style={{position: 'relative', padding: '12px 20px'}}>
+            <SelectionIndicator
+              style={{
+                position: 'absolute',
+                inset: 0,
+                border: '2px solid currentColor',
+                borderRadius: 4,
+                pointerEvents: 'none',
+                transitionProperty: 'translate, width, height',
+                transitionDuration: '200ms'
+              }}
+            />
+            {key}
+          </Tab>
+        ))}
+      </TabList>
+      <TabPanel id="overview">Overview</TabPanel>
+      <TabPanel id="activity">Activity</TabPanel>
+      <TabPanel id="settings">Settings</TabPanel>
+    </Tabs>
+  </StrictMode>
+);
 
 export const TabsExample: TabsStory = () => {
   let [url, setUrl] = useState('/FoR');

--- a/packages/react-aria-components/test/Tabs.browser.test.tsx
+++ b/packages/react-aria-components/test/Tabs.browser.test.tsx
@@ -11,8 +11,11 @@
  */
 
 import {expect, it} from 'vitest';
-import React from 'react';
+import {hydrateRoot} from 'react-dom/client';
+import React, {StrictMode, useEffect} from 'react';
 import {render} from 'vitest-browser-react';
+import {renderToString} from 'react-dom/server.browser';
+import {SelectionIndicator} from '../src/SelectionIndicator';
 import {Tab, TabList, TabPanel, Tabs} from '../src/Tabs';
 import {User} from '@react-aria/test-utils';
 
@@ -30,6 +33,82 @@ function TabsExample() {
     </Tabs>
   );
 }
+
+it.each([
+  {strict: false, selectedKey: 'one'},
+  {strict: false, selectedKey: 'five'},
+  {strict: true, selectedKey: 'one'},
+  {strict: true, selectedKey: 'five'}
+])(
+  'aligns the indicator after hydration (strict: $strict, selected: $selectedKey)',
+  async ({strict, selectedKey}) => {
+    let hydrated = false;
+    function HydrationMarker() {
+      useEffect(() => {
+        hydrated = true;
+      }, []);
+      return null;
+    }
+    let keys = ['one', 'two', 'three', 'four', 'five'];
+    let tree = (
+      <Tabs defaultSelectedKey={selectedKey}>
+        <HydrationMarker />
+        <TabList aria-label="Hydrated tabs" style={{display: 'flex', gap: 12}}>
+          {keys.map(key => (
+            <Tab key={key} id={key} style={{position: 'relative', padding: '12px 20px'}}>
+              <SelectionIndicator
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  transitionProperty: 'translate, width, height',
+                  transitionDuration: '200ms'
+                }}
+              />
+              {key}
+            </Tab>
+          ))}
+        </TabList>
+        {keys.map(key => (
+          <TabPanel key={key} id={key}>
+            {key}
+          </TabPanel>
+        ))}
+      </Tabs>
+    );
+    if (strict) {
+      tree = <StrictMode>{tree}</StrictMode>;
+    }
+    let container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = renderToString(tree);
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    try {
+      root = hydrateRoot(container, tree);
+      await expect.poll(() => hydrated).toBe(true);
+      await expect
+        .poll(() => container.querySelector('[role="tab"][aria-selected="true"]')?.textContent)
+        .toBe(selectedKey);
+      let selectedTab = container.querySelector(
+        '[role="tab"][aria-selected="true"]'
+      ) as HTMLElement;
+      let indicator = selectedTab.querySelector('.react-aria-SelectionIndicator') as HTMLElement;
+      expect(selectedTab.textContent).toBe(selectedKey);
+      await expect.poll(() => indicator.style.translate).toBe('');
+      await expect
+        .poll(() =>
+          Math.abs(
+            indicator.getBoundingClientRect().left - selectedTab.getBoundingClientRect().left
+          )
+        )
+        .toBeLessThan(1);
+      expect(indicator.style.width).toBe('');
+      expect(indicator.style.height).toBe('');
+    } finally {
+      root?.unmount();
+      container.remove();
+    }
+  }
+);
 
 it.each`
   interactionType


### PR DESCRIPTION
The goal is to keep the selection indicator aligned with the initially selected tab after SSR hydration in StrictMode, while preserving selection transitions.

SharedElement temporarily overrides inline transition properties and restores them in the next animation frame. If effect cleanup cancels that frame, the overrides can remain and contaminate the next snapshot. This change reuses the restoration callback during cleanup, before recording the next snapshot.

The browser regression tests cover hydration with and without StrictMode, with either the first or fifth tab initially selected. They wait for hydration to complete before checking alignment and restoration of inline styles. An additional Storybook example exercises animated selection from a non-first tab in StrictMode; the story is client-rendered, while hydration is covered by the browser tests.

AI assistance was used for investigation, implementation, and test preparation. The author review checklist below is intentionally not pre-checked.

Closes #10570

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [ ] I understand every change in this PR and can explain why it's there.
- [ ] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

1. Server-render Tabs with a non-first tab selected and a SelectionIndicator whose transition properties include translate, width, and height.
2. Hydrate under StrictMode and wait for hydration and the transition to finish.
3. Confirm the indicator remains aligned with the selected tab and temporary inline transition properties are restored.
4. Change tabs with the mouse and arrow keys and confirm transitions still work.
5. The new AnimatedSelectionIndicator story can be used to inspect client-rendered transitions. It is not itself an SSR reproduction.

Validation on Windows, Node 24.19.0:

- Full `yarn test --maxWorkers=2`: 372 suites passed, 4 failed; 7,967 tests passed, 16 failed, 16 skipped. The four failing suites were rerun in a separate, unmodified worktree at baseline commit 4dd44e0 and reproduced the same 16 failures: NumberField locale cases, NumberParser property-test initialization, codemod CLI fixture, and locale resolver Windows path expectations.
- Full `yarn test:ssr`: 60 suites / 74 tests passed on rerun. An earlier run had timeout failures.
- Full Chromium browser suite using the repository Vitest configuration with a local Chromium executable override: 149 passed, 1 failed, 9 skipped. The TokenField word-delete shortcut failure also reproduced in the unmodified baseline worktree. Firefox and WebKit have not been run.
- Full `yarn lint`: not clean because the Windows CRLF checkout triggers broad format-check failures. Type checking and oxlint passed. An untouched Tabs source file failed formatting in the CRLF checkout and passed in the LF baseline checkout. All three changed files were formatted and checked. No unrelated files were reformatted.
- Regression sensitivity: temporarily removing the cleanup restoration caused both StrictMode cases to fail on stale inline translate values; restoring it made all six Tabs browser tests pass.
- Independent Chromium UI checks covered mouse and keyboard interactions at narrow and wide viewport sizes. Touch, RTL, assistive technology, high contrast, and the Storybook runtime have not been manually verified.

## 🧢 Your Project:

Personal open-source contribution.