### PR TITLE
fix: preventFocus TypeError on window focus/blur during a press

### DIFF
--- a/packages/react-aria/src/interactions/utils.ts
+++ b/packages/react-aria/src/interactions/utils.ts
@@ -13,7 +13,7 @@
 import {FocusableElement} from '@react-types/shared';
 import {focusWithoutScrolling} from '../utils/focusWithoutScrolling';
 import {getActiveElement, getEventTarget, nodeContains} from '../utils/shadowdom/DOMFunctions';
-import {getOwnerWindow, isShadowRoot} from '../utils/domHelpers';
+import {getOwnerWindow, isNode, isShadowRoot} from '../utils/domHelpers';
 import {isFocusable} from '../utils/isFocusable';
 import {FocusEvent as ReactFocusEvent, SyntheticEvent, useCallback, useRef} from 'react';
 import {useLayoutEffect} from '../utils/useLayoutEffect';
@@ -138,12 +138,12 @@ export function preventFocus(target: FocusableElement | null): (() => void) | un
   // Focus is "moving to target" when it moves to the button or to a descendant of the button
   // (e.g. SVG icon)
   let isFocusMovingToTarget = (focusTarget: Element | null) =>
-    focusTarget === target || (focusTarget != null && nodeContains(target, focusTarget));
+    focusTarget === target || (isNode(focusTarget) && nodeContains(target, focusTarget));
   // Blur/focusout events have their target as the element losing focus. Stop propagation when
   // that is the previously focused element (activeElement) or a descendant (e.g. in shadow DOM).
   let isBlurFromActiveElement = (eventTarget: Element | null) =>
     eventTarget === activeElement ||
-    (activeElement != null && eventTarget != null && nodeContains(activeElement, eventTarget));
+    (activeElement != null && isNode(eventTarget) && nodeContains(activeElement, eventTarget));
 
   ignoreFocusEvent = true;
   let isRefocusing = false;

--- a/packages/react-aria/test/interactions/usePress.test.js
+++ b/packages/react-aria/test/interactions/usePress.test.js
@@ -1846,6 +1846,25 @@ describe('usePress', function () {
       expect(document.activeElement).not.toBe(el);
     });
 
+    it('should not throw if the window is focused or blurred during a press', function () {
+      let res = render(<Example preventFocusOnPress />);
+
+      let el = res.getByText('test');
+      fireEvent.mouseDown(el);
+
+      // preventFocus listens for focus and blur on the window. The browser fires
+      // those at the window itself when it gains or loses focus, e.g. returning
+      // from a native dialog, another tab, or an iframe. The target of those
+      // events is the Window, which is not a Node.
+      fireEvent(window, new FocusEvent('focus'));
+      fireEvent(window, new FocusEvent('blur'));
+
+      fireEvent.mouseUp(el);
+      fireEvent.click(el);
+
+      expect(document.activeElement).not.toBe(el);
+    });
+
     it('should focus the element on click by default', function () {
       let res = render(<Example />);
 


### PR DESCRIPTION
preventFocus attaches focus and blur listeners to the window. When the window itself gains or loses focus the target is Window not a Node. Both helpers passed it straight into nodeContains, so Node.contains threw:

```
TypeError: Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'.
```

Guard both calls with isNode and add a usePress test.

Fixes #10591

<!-- If you are an AI assistant opening this PR, use this template as the PR body, complete the checklist below honestly, and disclose AI use. See CONTRIBUTING.md (AI-assisted contributions) and CLAUDE.md. -->

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md).

## 📝 Test Instructions:

I clicked around some storybook cases that exercise preventFocus (e.g. number field +/-) but that's for the happy path not so much the bug which was hard to reproduce, likely due to RAF timing, but seen in error logs.

## 🧢 Your Project:

[micro:bit Python Editor](https://python.microbit.org/)
