### PR TITLE
fix(react-aria): scope ariaHideOutside to target document

### DIFF
--- a/packages/react-aria/src/overlays/ariaHideOutside.ts
+++ b/packages/react-aria/src/overlays/ariaHideOutside.ts
@@ -50,7 +50,7 @@ let observerStack: Array<ObserverWrapper> = [];
 export function ariaHideOutside(targets: Element[], options?: AriaHideOutsideOptions | Element) {
   let windowObj = getOwnerWindow(targets?.[0]);
   let opts = options instanceof windowObj.Element ? {root: options} : options;
-  let root = opts?.root ?? document.body;
+  let root = opts?.root ?? windowObj.document.body;
   let shouldUseInert = opts?.shouldUseInert && supportsInert;
   let visibleNodes = new Set<Element>(targets);
   let hiddenNodes = new Set<Element>();

--- a/packages/react-aria/test/overlays/ariaHideOutside.test.js
+++ b/packages/react-aria/test/overlays/ariaHideOutside.test.js
@@ -49,6 +49,25 @@ describe('ariaHideOutside', function () {
     expect(() => getByRole('button')).not.toThrow();
   });
 
+  it('should use the target document as the default root', function () {
+    let iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    let iframeDocument = iframe.contentWindow.document;
+    iframeDocument.body.innerHTML = '<div id="outside"></div><div id="target"></div>';
+    let target = iframeDocument.getElementById('target');
+    let outside = iframeDocument.getElementById('outside');
+
+    let revert = ariaHideOutside([target]);
+
+    expect(outside).toHaveAttribute('aria-hidden', 'true');
+    expect(target).not.toHaveAttribute('aria-hidden');
+    expect(document.body).not.toHaveAttribute('aria-hidden');
+
+    revert();
+    expect(outside).not.toHaveAttribute('aria-hidden');
+    iframe.remove();
+  });
+
   it('should hide everything except multiple elements', function () {
     let {getByRole, getAllByRole, queryByRole, queryAllByRole} = render(
       <>


### PR DESCRIPTION
Closes #10581

## Summary

Scope `ariaHideOutside`'s default root to the document that owns its first target instead of the module-global `document`. This keeps modal and popover isolation within the secondary window/document where the overlay is rendered, while preserving the existing behavior when callers provide an explicit root or render in the main document.

The implementation uses the `windowObj` that `ariaHideOutside` already derives from the target. A regression test creates a second document, verifies that content beside the target is hidden there, and verifies that the opener document's body is not hidden.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10581).
- [x] Added/updated unit tests and storybook for this change (unit regression test added; no visual state requires a Storybook update).
- [x] Filled out test instructions.
- [ ] Updated documentation (not applicable; this corrects internal document scoping without changing the public API).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)
- [x] I understand every change in this PR and can explain why it's there.
- [x] If AI-assisted, I followed our [AI contribution guidance](https://github.com/adobe/react-spectrum/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and pointed my assistant at [CLAUDE.md](https://github.com/adobe/react-spectrum/blob/main/CLAUDE.md). I reviewed and verified the final change and test.

## 📝 Test Instructions:

Run:

```sh
corepack yarn jest packages/react-aria/test/overlays/ariaHideOutside.test.js --runInBand
```

The suite should pass all 25 tests. In the new `should use the target document as the default root` case, verify that:

- the sibling in the secondary document receives `aria-hidden="true"`;
- the target remains visible;
- the main document's `<body>` remains untouched; and
- cleanup restores the secondary document sibling.

Additional checks used locally:

```sh
corepack yarn format:check -- packages/react-aria/src/overlays/ariaHideOutside.ts packages/react-aria/test/overlays/ariaHideOutside.test.js
oxlint packages/react-aria/src/overlays/ariaHideOutside.ts packages/react-aria/test/overlays/ariaHideOutside.test.js
corepack yarn check-types
```

All three pass. A repo-wide Jest run passed 7,989 tests; its 16 failures are confined to existing Windows path-separator expectations in `packages/dev/parcel-resolver-optimize-locales/test/LocalesResolver.test.js`. The SSR run passed 59 of 60 suites, with the unrelated DatePicker SSR test timing out locally.

## 🧢 Your Project:

N/A
