### PR TITLE
fix: preserve active FocusScope when sibling unmounts

### DIFF
--- a/packages/react-aria/src/focus/FocusScope.tsx
+++ b/packages/react-aria/src/focus/FocusScope.tsx
@@ -180,10 +180,8 @@ export function FocusScope(props: FocusScopeProps): JSX.Element {
       // Scope may have been re-parented.
       let parentScope = focusScopeTree.getTreeNode(scopeRef)?.parent?.scopeRef ?? null;
 
-      if (
-        (scopeRef === activeScope || isAncestorScope(scopeRef, activeScope)) &&
-        (!parentScope || focusScopeTree.getTreeNode(parentScope))
-      ) {
+      // A descendant may remain active while an ancestor scope is unmounted.
+      if (scopeRef === activeScope && (!parentScope || focusScopeTree.getTreeNode(parentScope))) {
         activeScope = parentScope;
       }
       focusScopeTree.removeTreeNode(scopeRef);

--- a/packages/react-aria/test/focus/FocusScope.browser.test.tsx
+++ b/packages/react-aria/test/focus/FocusScope.browser.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {expect, it} from 'vitest';
+import {FocusScope} from '../../src/focus/FocusScope';
+import React, {useState} from 'react';
+import ReactDOM from 'react-dom';
+import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
+
+function Portal({children}: {children: React.ReactNode}) {
+  return ReactDOM.createPortal(children, document.body);
+}
+
+function SiblingScopes() {
+  let [showFirst, setShowFirst] = useState(true);
+  let [showSecond, setShowSecond] = useState(false);
+
+  let openSecond = () => {
+    setShowSecond(true);
+    setTimeout(() => setShowFirst(false), 50);
+  };
+
+  return (
+    <FocusScope contain restoreFocus>
+      <button>Outside</button>
+      {showFirst && (
+        <Portal>
+          <FocusScope contain restoreFocus autoFocus>
+            <button onClick={openSecond}>Choose date and time</button>
+          </FocusScope>
+        </Portal>
+      )}
+      {showSecond && (
+        <Portal>
+          <FocusScope contain restoreFocus autoFocus>
+            <button>September</button>
+            <button>2026</button>
+            <button>Next month</button>
+          </FocusScope>
+        </Portal>
+      )}
+    </FocusScope>
+  );
+}
+
+it.each([
+  {direction: 'forward', shift: false, expected: '2026'},
+  {direction: 'reverse', shift: true, expected: 'Next month'}
+])(
+  'keeps $direction Tab navigation in a sibling scope after unmount',
+  async ({shift, expected}) => {
+    let {getByRole} = await render(<SiblingScopes />);
+
+    await userEvent.click(getByRole('button', {name: 'Choose date and time'}));
+    await expect
+      .element(getByRole('button', {name: 'Choose date and time'}))
+      .not.toBeInTheDocument();
+    await expect.element(getByRole('button', {name: 'September'})).toHaveFocus();
+
+    await userEvent.tab({shift});
+    await expect.element(getByRole('button', {name: expected})).toHaveFocus();
+  }
+);

--- a/packages/react-aria/test/focus/FocusScope.test.js
+++ b/packages/react-aria/test/focus/FocusScope.test.js
@@ -1927,6 +1927,52 @@ describe('FocusScope', function () {
       expect(document.activeElement).toBe(child3);
     });
 
+    it('should keep focus contained in a sibling scope when the previous scope unmounts', async function () {
+      function Portal({children}) {
+        return ReactDOM.createPortal(children, document.body);
+      }
+
+      function Test({showFirst, showSecond}) {
+        return (
+          <FocusScope contain restoreFocus>
+            <button data-testid="outside">Outside</button>
+            {showFirst && (
+              <Portal>
+                <FocusScope contain restoreFocus autoFocus>
+                  <button data-testid="first">First</button>
+                </FocusScope>
+              </Portal>
+            )}
+            {showSecond && (
+              <Portal>
+                <FocusScope contain restoreFocus autoFocus>
+                  <button data-testid="second1">September</button>
+                  <button data-testid="second2">2026</button>
+                  <button data-testid="second3">Next month</button>
+                </FocusScope>
+              </Portal>
+            )}
+          </FocusScope>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test showFirst />);
+      expect(document.activeElement).toBe(getByTestId('first'));
+
+      rerender(<Test showFirst showSecond />);
+      expect(document.activeElement).toBe(getByTestId('second1'));
+
+      rerender(<Test showSecond />);
+      expect(document.activeElement).toBe(getByTestId('second1'));
+
+      expect(focusScopeTree.size).toBe(3);
+      await user.tab();
+      expect(document.activeElement).toBe(getByTestId('second2'));
+      act(() => getByTestId('second1').focus());
+      await user.tab({shift: true});
+      expect(document.activeElement).toBe(getByTestId('second3'));
+    });
+
     it('should restore to the correct scope on unmount', async function () {
       function Test({show1, show2, show3}) {
         return (


### PR DESCRIPTION
Closes #10593

## Summary

When one portaled overlay opens another before the first finishes closing, the active `FocusScope` tree can temporarily reparent the new scope beneath the old one. The old cleanup treated an active descendant as a reason to reset `activeScope`, even when that descendant remained mounted. This left the surviving overlay without the correct containment owner, so keyboard navigation could skip a control or escape the overlay.

This change resets `activeScope` only when the scope being removed is itself active. Removing an ancestor now preserves a still-mounted active descendant while `removeTreeNode` reparents it. The existing nested whole-subtree unmount behavior remains covered and unchanged.

Regression coverage includes:

- a focused unit test for sibling portaled scopes and forward/reverse Tab navigation;
- a real-browser test matching the delayed sibling-overlay unmount sequence in the report, run in Chromium, Firefox, and WebKit.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues/10593).
- [x] Added/updated unit and browser tests. No Storybook change is needed because this is non-visual focus-management behavior.
- [x] Filled out test instructions.
- [x] Reviewed existing documentation; no update is needed because this fixes containment without changing the API or documented contract.
- [x] Looked at the [ARIA Authoring Practices dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), which requires Tab and Shift+Tab to remain within a modal dialog's tab sequence.
- [x] I understand every change in this PR and can explain why it's there.
- [x] This was AI-assisted. I followed the repository's AI contribution guidance and pointed the assistant at `AGENTS.md`, `CLAUDE.md`, and the relevant files under `docs/contributing/`.

## 📝 Test Instructions:

1. Run `yarn jest packages/react-aria/test/focus/FocusScope.test.js --runInBand`.
2. Run `yarn vitest run --config=vitest.browser.config.ts packages/react-aria/test/focus/FocusScope.browser.test.tsx`.
3. In the browser regression, activate **Choose date and time**, wait for that first scope to unmount, and verify:
   - Tab moves from **September** to **2026**.
   - Shift+Tab moves from **September** to **Next month**, not **Outside**.

Additional local validation:

- `yarn test:ssr`: 60 suites / 74 tests passed.
- `yarn test`: 373 suites and 7,989 tests passed; four unrelated Windows/locale/codemod suites failed (locale fixture path separator mismatch, empty generated locale sets, and a codemod package-manager e2e expectation).
- `yarn test:browser`: the target test passed in Chromium, Firefox, and WebKit; the full run later ended on an unrelated Firefox browser-session connection timeout while running `ListBox.browser.test.tsx`.
- `yarn lint`: type-check, oxlint, package lint, and Yarn constraints passed. The repository-wide format check reports checkout-wide CRLF differences on Windows; `yarn format:check` passes for all three changed files.

## 🧢 Your Project:

Open-source contribution by `dvd233`; no company project.
